### PR TITLE
[IMP] web, account, sale: support sections, notes, and subsections in list views

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -17,7 +17,8 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
 
     get sectionAndNoteClasses() {
         return {
-            "fw-bold": this.isSection(),
+            "fw-bolder": this.isTopSection(),
+            "fw-bold": this.isSection() && !this.isTopSection(),
             "fst-italic": this.isNote(),
             "text-warning": this.shouldShowWarning(),
         };
@@ -33,6 +34,11 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
     }
 
     isSection(record = null) {
+        record = record || this.props.record;
+        return ["line_section", "line_subsection"].includes(record.data.display_type);
+    }
+
+    isTopSection(record = null) {
         record = record || this.props.record;
         return record.data.display_type === "line_section";
     }

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -13,18 +13,20 @@
                     t-att-value="label"
                     t-on-change="(ev) => this.updateLabel(ev.target.value)"
                     t-ref="labelNodeRef"
+                    t-key="props.readonly"
                 />
             </t>
             <t t-elif="isSection()">
                 <input
                     type="text"
-                    class="o_input text-wrap border-0 fst-italic fw-bold"
+                    class="o_input text-wrap border-0 fst-italic"
                     placeholder="Enter a description"
                     t-att-class="sectionAndNoteClasses"
                     t-att-readonly="sectionAndNoteIsReadonly"
                     t-att-value="label"
                     t-on-change="(ev) => this.updateLabel(ev.target.value)"
                     t-ref="labelNodeRef"
+                    t-key="props.readonly"
                 />
             </t>
             <t t-else="">
@@ -50,6 +52,7 @@
                     t-att-value="label"
                     t-on-change="(ev) => this.updateLabel(ev.target.value)"
                     t-ref="labelNodeRef"
+                    t-key="props.readonly"
                 />
             </t>
             <t t-if="isPrintMode.value">

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
@@ -2,24 +2,35 @@
 // The goal of this file is to contain CSS hacks related to allowing
 // section and note on sale order and invoice.
 
-table.o_section_and_note_list_view tr.o_data_row.o_is_line_note,
-table.o_section_and_note_list_view tr.o_data_row.o_is_line_note textarea[name="name"],
-div.o_is_line_note {
-    font-style: italic;
-}
-table.o_section_and_note_list_view tr.o_data_row.o_is_line_section,
-div.o_is_line_section {
-    font-weight: bold;
-    background-color: #DDDDDD;
-}
-table.o_section_and_note_list_view tr.o_data_row.o_is_line_section {
-    border-top: 1px solid #BBB;
-    border-bottom: 1px solid #BBB;
-}
-
 table.o_section_and_note_list_view tr.o_data_row {
-    &.o_is_line_note,
+    &.o_is_line_note {
+        font-style: italic;
+    }
     &.o_is_line_section {
+        font-weight: bold;
+        background-color: #DDDDDD;
+        --table-bg: var(--300);
+    }
+    &.o_is_line_subsection {
+        --table-bg: var(--200);
+    }
+    &.o_is_line_section, &.o_is_line_subsection {
+        border-top: 1px solid #BBB;
+        border-bottom: 1px solid #BBB;
+        .o_list_section_options {
+            width: 1px;  // to prevent the column to expand
+            button {
+                padding: 0px;
+                background: none;
+                border-style: none;
+                display: table-cell;
+                cursor: pointer;
+            }
+        }
+    }
+    &.o_is_line_note,
+    &.o_is_line_section,
+    &.o_is_line_subsection {
         td {
             // There is an undeterministic CSS behaviour in Chrome related to
             // the combination of the row's and its children's borders.

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -1,13 +1,71 @@
+import { Component, useEffect } from "@odoo/owl";
+import { x2ManyCommands } from "@web/core/orm_service";
 import { registry } from "@web/core/registry";
-import { ListRenderer } from "@web/views/list/list_renderer";
-import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
-import { TextField, ListTextField } from "@web/views/fields/text/text_field";
 import { CharField } from "@web/views/fields/char/char_field";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-import { Component, useEffect } from "@odoo/owl";
+import { ListTextField, TextField } from "@web/views/fields/text/text_field";
+import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
+import { ListRenderer } from "@web/views/list/list_renderer";
+
+const DISPLAY_TYPES = {
+    NOTE: "line_note",
+    SECTION: "line_section",
+    SUBSECTION: "line_subsection",
+};
+
+function getPreviousSectionRecords(list, record) {
+    const { sectionRecords } = getRecordsUntilSection(list, record, false);
+    return sectionRecords;
+}
+
+function getSectionRecords(list, record, subSection) {
+    const { sectionRecords } = getRecordsUntilSection(list, record, true, subSection);
+    return sectionRecords;
+}
+
+function hasNextSection(list, record) {
+    const { indexAtEnd } = getRecordsUntilSection(list, record, true);
+    return indexAtEnd < list.records.length && list.records[indexAtEnd].data.display_type === record.data.display_type;
+}
+
+function hasPreviousSection(list, record) {
+    const { indexAtEnd } = getRecordsUntilSection(list, record, false);
+    return indexAtEnd >= 0 && list.records[indexAtEnd].data.display_type === record.data.display_type;
+}
+
+function getRecordsUntilSection(list, record, asc, subSection) {
+    const stopAtTypes = [DISPLAY_TYPES.SECTION];
+    if (subSection ?? record.data.display_type === DISPLAY_TYPES.SUBSECTION) {
+        stopAtTypes.push(DISPLAY_TYPES.SUBSECTION);
+    }
+
+    const sectionRecords = [];
+    let index = list.records.indexOf(record);
+    if (asc) {
+        sectionRecords.push(list.records[index]);
+        index++;
+        while (index < list.records.length && !stopAtTypes.includes(list.records[index].data.display_type)) {
+            sectionRecords.push(list.records[index]);
+            index++;
+        }
+    } else {
+        index--;
+        while (index >= 0 && !stopAtTypes.includes(list.records[index].data.display_type)) {
+            sectionRecords.unshift(list.records[index]);
+            index--;
+        }
+        sectionRecords.unshift(list.records[index]);
+    }
+
+    return {
+        sectionRecords,
+        indexAtEnd: index,
+    };
+}
 
 export class SectionAndNoteListRenderer extends ListRenderer {
-    static template = "account.sectionAndNoteListRenderer";
+    static template = "account.SectionAndNoteListRenderer";
+    static recordRowTemplate = "account.SectionAndNoteListRenderer.RecordRow";
 
     /**
      * The purpose of this extension is to allow sections and notes in the one2many list
@@ -21,7 +79,105 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         useEffect(
             (editedRecord) => this.focusToName(editedRecord),
             () => [this.editedRecord]
-        )
+        );
+    }
+
+    async addRowAfterSection(record, addSubSection) {
+        const canProceed = await this.props.list.leaveEditMode();
+        if (!canProceed) {
+            return;
+        }
+
+        const index =
+            this.props.list.records.indexOf(record) +
+            getSectionRecords(this.props.list, record).length -
+            1;
+        const context = {
+            default_display_type: addSubSection ? DISPLAY_TYPES.SUBSECTION : DISPLAY_TYPES.SECTION,
+        };
+        await this.props.list.addNewRecordAtIndex(index, { context });
+    }
+
+    async addNoteInSection(record) {
+        const canProceed = await this.props.list.leaveEditMode();
+        if (!canProceed) {
+            return;
+        }
+
+        const index =
+            this.props.list.records.indexOf(record) +
+            getSectionRecords(this.props.list, record, true).length -
+            1;
+        const context = {
+            default_display_type: DISPLAY_TYPES.NOTE,
+        };
+        await this.props.list.addNewRecordAtIndex(index, { context });
+    }
+
+    async addRowInSection(record, addSubSection) {
+        const canProceed = await this.props.list.leaveEditMode();
+        if (!canProceed) {
+            return;
+        }
+
+        const index =
+            this.props.list.records.indexOf(record) +
+            getSectionRecords(this.props.list, record, !addSubSection).length -
+            1;
+        const context = {};
+        if (addSubSection) {
+            context["default_display_type"] = DISPLAY_TYPES.SUBSECTION;
+        }
+        await this.props.list.addNewRecordAtIndex(index, { context });
+    }
+
+    canAddSubSection() {
+        const selection = new Map(this.props.list.fields.display_type.selection);
+        return selection.has(DISPLAY_TYPES.SUBSECTION);
+    }
+
+    async deleteSection(record) {
+        if (this.editedRecord && this.editedRecord !== record) {
+            const left = await this.props.list.leaveEditMode();
+            if (!left) {
+                return;
+            }
+        }
+        if (this.activeActions.onDelete) {
+            const method = this.activeActions.unlink ? "unlink" : "delete";
+            const commands = [];
+            const sectionRecords = getSectionRecords(this.props.list, record);
+            for (const sectionRecord of sectionRecords) {
+                commands.push(
+                    x2ManyCommands[method](sectionRecord.resId || sectionRecord._virtualId)
+                );
+            }
+            await this.props.list.applyCommands(commands);
+        }
+    }
+
+    async duplicateSection(record) {
+        const left = await this.props.list.leaveEditMode();
+        if (!left) {
+            return;
+        }
+
+        const sectionRecords = getSectionRecords(this.props.list, record);
+        await this.props.list.duplicateRecords(sectionRecords);
+    }
+
+    async editNextRecord(record, group) {
+        const canProceed = await this.props.list.leaveEditMode({ validate: true });
+        if (!canProceed) {
+            return;
+        }
+
+        const iter = getRecordsUntilSection(this.props.list, record, true, true);
+        if (this.isSection(record) || iter.sectionRecords.length === 1) {
+            return this.props.list.addNewRecordAtIndex(iter.indexAtEnd - 1);
+        } else {
+            return super.editNextRecord(record, group);
+        }
     }
 
     focusToName(editRec) {
@@ -31,9 +187,32 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         }
     }
 
-    isSectionOrNote(record=null) {
+    hasNextSection(record) {
+        return hasNextSection(this.props.list, record);
+    }
+
+    hasPreviousSection(record) {
+        return hasPreviousSection(this.props.list, record);
+    }
+
+    isSectionOrNote(record = null) {
         record = record || this.record;
-        return ['line_section', 'line_note'].includes(record.data.display_type);
+        return [DISPLAY_TYPES.SECTION, DISPLAY_TYPES.SUBSECTION, DISPLAY_TYPES.NOTE].includes(
+            record.data.display_type
+        );
+    }
+
+    isSection(record = null) {
+        record = record || this.record;
+        return [DISPLAY_TYPES.SECTION, DISPLAY_TYPES.SUBSECTION].includes(record.data.display_type);
+    }
+
+    isSortable() {
+        return false;
+    }
+
+    isTopSection(record) {
+        return record.data.display_type === DISPLAY_TYPES.SECTION;
     }
 
     getRowClass(record) {
@@ -43,7 +222,11 @@ export class SectionAndNoteListRenderer extends ListRenderer {
 
     getCellClass(column, record) {
         const classNames = super.getCellClass(column, record);
-        if (this.isSectionOrNote(record) && column.widget !== "handle" && column.name !== this.titleField) {
+        if (
+            this.isSectionOrNote(record) &&
+            column.widget !== "handle" &&
+            column.name !== this.titleField
+        ) {
             return `${classNames} o_hidden`;
         }
         return classNames;
@@ -58,7 +241,10 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     getSectionColumns(columns) {
-        const sectionCols = columns.filter((col) => col.widget === "handle" || col.type === "field" && col.name === this.titleField);
+        const sectionCols = columns.filter(
+            (col) =>
+                col.widget === "handle" || (col.type === "field" && col.name === this.titleField)
+        );
         return sectionCols.map((col) => {
             if (col.name === this.titleField) {
                 return { ...col, colspan: columns.length - sectionCols.length + 1 };
@@ -66,6 +252,45 @@ export class SectionAndNoteListRenderer extends ListRenderer {
                 return { ...col };
             }
         });
+    }
+
+    async moveSectionDown(record) {
+        const canProceed = await this.props.list.leaveEditMode();
+        if (!canProceed) {
+            return;
+        }
+
+        const sectionRecords = getSectionRecords(this.props.list, record);
+        const index = this.props.list.records.indexOf(record) + sectionRecords.length;
+        const nextSectionRecords = getSectionRecords(this.props.list, this.props.list.records[index]);
+        return this.swapSections(sectionRecords, nextSectionRecords);
+    }
+
+    async moveSectionUp(record) {
+        const canProceed = await this.props.list.leaveEditMode();
+        if (!canProceed) {
+            return;
+        }
+
+        const previousSectionRecords = getPreviousSectionRecords(this.props.list, record);
+        const sectionRecords = getSectionRecords(this.props.list, record);
+        return this.swapSections(previousSectionRecords, sectionRecords);
+    }
+
+    async swapSections(sectionRecords1, sectionRecords2) {
+        const commands = [];
+        let sequence = sectionRecords1[0].data[this.props.list.handleField];
+        for (const record of sectionRecords2) {
+            commands.push(x2ManyCommands.update(record.resId || record._virtualId, {
+                [this.props.list.handleField]: sequence++,
+            }));
+        }
+        for (const record of sectionRecords1) {
+            commands.push(x2ManyCommands.update(record.resId || record._virtualId, {
+                [this.props.list.handleField]: sequence++,
+            }));
+        }
+        await this.props.list.applyCommands(commands, { sort: true });
     }
 }
 
@@ -81,7 +306,7 @@ export class SectionAndNoteText extends Component {
     static props = { ...standardFieldProps };
 
     get componentToUse() {
-        return this.props.record.data.display_type === 'line_section' ? CharField : TextField;
+        return this.props.record.data.display_type === "line_section" ? CharField : TextField;
     }
 }
 
@@ -96,7 +321,7 @@ export class ListSectionAndNoteText extends SectionAndNoteText {
 export const sectionAndNoteFieldOne2Many = {
     ...x2ManyField,
     component: SectionAndNoteFieldOne2Many,
-    additionalClasses: [...x2ManyField.additionalClasses || [], "o_field_one2many"],
+    additionalClasses: [...(x2ManyField.additionalClasses || []), "o_field_one2many"],
 };
 
 export const sectionAndNoteText = {

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -1,8 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
-    <t t-name="account.sectionAndNoteListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
+    <t t-name="account.SectionAndNoteListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
         <xpath expr="//table" position="attributes">
             <attribute name="class" add="o_section_and_note_list_view" separator=" "/>
+        </xpath>
+    </t>
+    <t t-name="account.SectionAndNoteListRenderer.RecordRow" t-inherit="web.ListRenderer.RecordRow">
+        <xpath expr="//td[hasclass('o_list_record_remove')]" position="attributes">
+            <attribute name="t-if">!isSection(record) or props.list.count gt props.list.limit</attribute>
+        </xpath>
+        <xpath expr="//td[hasclass('o_list_record_remove')]" position="after">
+            <td t-else="" class="o_list_section_options w-print-0 p-print-0 text-center">
+                <Dropdown position="'bottom-end'" t-if="!props.readonly">
+                    <button class="btn px-1">
+                        <i class="fa fa-ellipsis-v"/>
+                    </button>
+                    <t t-set-slot="content">
+                        <DropdownItem onSelected="() => this.addRowInSection(record, false)">
+                            <i class="me-1 fa fa-fw fa-plus"/><span>Add a product</span>
+                        </DropdownItem>
+                        <t t-if="this.isTopSection(record)">
+                            <DropdownItem onSelected="() => this.addRowAfterSection(record, false)">
+                                <i class="me-1 fa fa-fw fa-level-down"/><span>Add a section</span>
+                            </DropdownItem>
+                            <t t-if="this.canAddSubSection()">
+                                <DropdownItem onSelected="() => this.addRowInSection(record, true)">
+                                    <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
+                                </DropdownItem>
+                            </t>
+                        </t>
+                        <t t-elif="this.canAddSubSection()">
+                            <DropdownItem onSelected="() => this.addRowAfterSection(record, true)">
+                                <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
+                            </DropdownItem>
+                        </t>
+                        <DropdownItem onSelected="() => this.addNoteInSection(record)">
+                            <i class="me-1 fa fa-fw fa-sticky-note-o"/><span>Add a note</span>
+                        </DropdownItem>
+                        <DropdownItem t-if="this.hasPreviousSection(record)" onSelected="() => this.moveSectionUp(record)">
+                            <i class="me-1 fa fa-fw fa-arrow-up"/><span>Move Up</span>
+                        </DropdownItem>
+                        <DropdownItem t-if="this.hasNextSection(record)" onSelected="() => this.moveSectionDown(record)">
+                            <i class="me-1 fa fa-fw fa-arrow-down"/><span>Move Down</span>
+                        </DropdownItem>
+                        <DropdownItem onSelected="() => this.duplicateSection(record)">
+                            <i class="me-1 fa fa-fw fa-clone"/><span>Duplicate</span>
+                        </DropdownItem>
+                        <t t-if="hasDeleteButton">
+                            <DropdownItem class="'text-danger'" onSelected="() => this.deleteSection(record)">
+                                <i class="me-1 fa fa-fw fa-trash"/><span>Delete</span>
+                            </DropdownItem>
+                        </t>
+                    </t>
+                </Dropdown>
+            </td>
         </xpath>
     </t>
 

--- a/addons/account/static/tests/section_and_note.test.js
+++ b/addons/account/static/tests/section_and_note.test.js
@@ -1,25 +1,40 @@
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
-import { expect, test } from "@odoo/hoot";
-import { queryAll, queryAllTexts, queryOne } from "@odoo/hoot-dom";
-import { contains, defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
-
-class Invoice extends models.Model {
-    invoice_line_ids = fields.One2many({
-        string: "Lines",
-        relation: "invoice_line",
-        relation_field: "invoice_id",
-    });
-    _records = [{ id: 1, invoice_line_ids: [1, 2, 3] }];
-}
+import { expect, getFixture, test } from "@odoo/hoot";
+import { animationFrame, edit, press, queryAllTexts } from "@odoo/hoot-dom";
+import {
+    clickSave,
+    contains,
+    defineModels,
+    fields,
+    models,
+    mountView,
+    onRpc,
+} from "@web/../tests/web_test_helpers";
 
 class InvoiceLine extends models.Model {
     _name = "invoice_line";
+    _records = [
+        { id: 1, name: "r1", display_type: false, sequence: 1, m2m: [1] },
+        { id: 2, name: "r2", display_type: false, sequence: 2, m2m: [2] },
+        { id: 3, name: "A", display_type: "line_section", sequence: 3, m2m: [1] },
+        { id: 4, name: "A1", display_type: false, sequence: 4, m2m: [1, 3] },
+        { id: 5, name: "A2", display_type: false, sequence: 5, m2m: [1, 2] },
+        { id: 6, name: "B", display_type: "line_section", sequence: 6, m2m: [2] },
+        { id: 7, name: "B1", display_type: false, sequence: 7, m2m: [1, 3] },
+        { id: 8, name: "B2", display_type: false, sequence: 8, m2m: [] },
+        { id: 9, name: "Ba", display_type: "line_subsection", sequence: 9, m2m: [3] },
+        { id: 10, name: "Ba1", display_type: false, sequence: 10, m2m: [2, 3] },
+        { id: 11, name: "Ba2", display_type: false, sequence: 11, m2m: [3] },
+        { id: 12, name: "C", display_type: "line_section", sequence: 12, m2m: [1] },
+        { id: 13, name: "C1", display_type: false, sequence: 13, m2m: [] },
+    ];
 
-    sequence = fields.Integer();
+    name = fields.Char();
     display_type = fields.Selection({
-        string: "Type",
+        default: false,
         selection: [
             ["line_section", "Section"],
+            ["line_subsection", "Subsection"],
             ["line_note", "Note"],
         ],
     });
@@ -27,65 +42,1330 @@ class InvoiceLine extends models.Model {
         string: "Invoice",
         relation: "invoice",
     });
-    name = fields.Text();
-    price = fields.Monetary({ currency_field: "" });
+    sequence = fields.Integer();
+    m2m = fields.Many2many({ relation: "bar" });
+}
+class Invoice extends models.Model {
     _records = [
-        { id: 1, display_type: false, invoice_id: 1, name: "product\n2 lines", price: 123.45 },
-        { id: 2, display_type: "line_section", invoice_id: 1, name: "section" },
-        { id: 3, display_type: "line_note", invoice_id: 1, name: "note" },
+        {
+            id: 1,
+            invoice_line_ids: Array.from({ length: InvoiceLine._records.length }, (_, i) => i + 1),
+        },
+    ];
+
+    invoice_line_ids = fields.One2many({ relation: "invoice_line" });
+}
+
+class Bar extends models.Model {
+    name = fields.Char();
+
+    _records = [
+        { id: 1, name: "Value 1" },
+        { id: 2, name: "Value 2" },
+        { id: 3, name: "Value 3" },
     ];
 }
 
-defineModels([Invoice, InvoiceLine]);
+defineModels([Invoice, InvoiceLine, Bar]);
 defineMailModels();
 
-test("correct display of section and note fields", async () => {
+onRpc("has_group", () => true);
+
+test("can add a product in a section", async () => {
     await mountView({
         type: "form",
         resModel: "invoice",
+        resId: 1,
         arch: `
             <form>
-                <field name="invoice_line_ids" widget="section_and_note_one2many">
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
                     <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
                         <field name="sequence" widget="handle"/>
+                        <field name="name"/>
                         <field name="display_type" column_invisible="1"/>
-                        <field name="name" widget="section_and_note_text"/>
-                        <field name="price"/>
                     </list>
                 </field>
-            </form>`,
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_list_section_options:eq(0) button").click();
+    await contains(".o-dropdown-item:contains(Add a product)").click();
+    await edit("A3");
+    await contains(getFixture()).click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "A3",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+});
+
+test("can add a product in a subsection", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
         resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_list_section_options:last button").click();
+    await contains(".o-dropdown-item:contains(Add a product)").click();
+    await edit("Ca3");
+    await contains(getFixture()).click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+        "Ca3",
+    ]);
+});
+
+test("can add a subsection in a section", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_list_section_options:eq(0) button").click();
+    await contains(".o-dropdown-item:contains(Add a subsection)").click();
+    await edit("Aa");
+    await contains(getFixture()).click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "Aa",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    expect(".o_is_line_subsection:contains(Aa)").toHaveCount(1);
+});
+
+test("can't add a subsection if value not in selection", async () => {
+    InvoiceLine._records[10].display_type = "line_section";
+    InvoiceLine._fields.display_type = fields.Selection({
+        default: false,
+        selection: [
+            ["line_section", "Section"],
+            ["line_note", "Note"],
+        ],
     });
 
-    expect('[name="invoice_line_ids"] table').toHaveClass("o_section_and_note_list_view");
-    expect("tr.o_data_row:nth-child(1)").not.toHaveClass("o_is_line_section", {
-        message: "should not have a section class",
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    await contains(".o_list_section_options:last button").click();
+    expect(".o-dropdown-item:contains(Add a subsection)").toHaveCount(0);
+});
+
+test("can add a section after another", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_list_section_options:eq(0) button").click();
+    await contains(".o-dropdown-item:contains(Add a section)").click();
+    await edit("D");
+    await contains(getFixture()).click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "D",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    expect(`.o_is_line_section:contains(D)`).toHaveCount(1);
+});
+
+test("can add a subsection after another", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_is_line_subsection .o_list_section_options button").click();
+    await contains(".o-dropdown-item:contains(Add a subsection)").click();
+    await edit("Bb");
+    await contains(getFixture()).click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "Bb",
+        "C",
+        "C1",
+    ]);
+    expect(`.o_is_line_subsection:contains(Bb)`).toHaveCount(1);
+});
+
+test("can delete sections", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_list_section_options:eq(1) button").click();
+    await contains(".o-dropdown-item:contains(Delete)").click();
+    expect(queryAllTexts(".o_data_row")).toEqual(["r1", "r2", "A", "A1", "A2", "C", "C1"]);
+});
+
+test("can delete subsections", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_is_line_subsection .o_list_section_options button").click();
+    await contains(".o-dropdown-item:contains(Delete)").click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "C",
+        "C1",
+    ]);
+});
+
+test("can duplicate sections", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_list_section_options:eq(1) button").click();
+    await contains(".o-dropdown-item:contains(Duplicate)").click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+});
+
+test("can duplicate subsections", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_is_line_subsection .o_list_section_options button").click();
+    await contains(".o-dropdown-item:contains(Duplicate)").click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+});
+
+test("can resequence records inside sections", async () => {
+    onRpc("web_save", ({ args }) => {
+        expect.step("web_save");
+        expect(args[1]).toEqual({
+            invoice_line_ids: [
+                [1, 4, { sequence: 1 }],
+                [1, 1, { sequence: 2 }],
+                [1, 2, { sequence: 3 }],
+                [1, 3, { sequence: 4 }],
+                [1, 6, { sequence: 6 }],
+                [1, 7, { sequence: 7 }],
+                [1, 8, { sequence: 8 }],
+                [1, 9, { sequence: 9 }],
+                [1, 10, { sequence: 10 }],
+                [1, 11, { sequence: 11 }],
+                [1, 5, { sequence: 12 }],
+                [1, 13, { sequence: 5 }],
+                [1, 12, { sequence: 13 }],
+            ],
+        });
+    });
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
     });
 
-    const sectionLine = queryOne("tr.o_data_row:nth-child(2)");
-    const sectionCell = queryOne("td.o_section_and_note_text_cell", { root: sectionLine });
-    expect(sectionLine).toHaveClass("o_is_line_section", {
-        message: "should have a section class",
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_data_row:eq(3) .o_row_handle").dragAndDrop(".o_data_row:eq(0)");
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "A1",
+        "r1",
+        "r2",
+        "A",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_data_row:eq(4) .o_row_handle").dragAndDrop(".o_data_row:eq(10)");
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "A1",
+        "r1",
+        "r2",
+        "A",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "A2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_data_row:last .o_row_handle").dragAndDrop(".o_data_row:eq(4)");
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "A1",
+        "r1",
+        "r2",
+        "A",
+        "C1",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "A2",
+        "C",
+    ]);
+    await clickSave();
+    expect.verifySteps(["web_save"]);
+});
+
+test("resequence can be discarded", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
     });
-    expect(sectionCell).toHaveAttribute("colspan", "2");
 
-    const noteLine = queryOne("tr.o_data_row:nth-child(3)");
-    const noteCell = queryOne("td.o_section_and_note_text_cell", { root: noteLine });
-    expect(noteLine).toHaveClass("o_is_line_note", { message: "should have a note class" });
-    expect(noteCell).toHaveAttribute("colspan", "2");
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_data_row:eq(3) .o_row_handle").dragAndDrop(".o_data_row:eq(0)");
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "A1",
+        "r1",
+        "r2",
+        "A",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_form_button_cancel").click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+});
 
-    await contains(noteCell).click();
-    expect(queryAll('div[name="name"] textarea', { root: noteCell })).toHaveCount(1);
-    await contains(sectionCell).click();
-    expect(queryAll('div[name="name"] input', { root: sectionCell })).toHaveCount(1);
+test("can resequence sections", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
 
-    // Drag and drop the second line in first position
-    await contains("tbody tr:nth-child(2) .o_row_handle", { visible: false }).dragAndDrop(
-        "tbody tr:nth-child(1)"
+    await contains(".o_data_row:eq(11) .o_row_handle").dragAndDrop(".o_data_row:eq(0)");
+    expect(queryAllTexts(".o_data_row")).toEqual(
+        ["C", "r1", "r2", "A", "A1", "A2", "B", "B1", "B2", "Ba", "Ba1", "Ba2", "C1"],
+        {
+            message: "With C on top, B becomes the top section for all records starting from B1",
+        }
     );
-    expect(queryAllTexts(".o_data_cell.o_list_text")).toEqual([
-        "section",
-        "product\n2 lines",
-        "note",
+    await contains(".o_list_section_options:eq(2) button").click();
+    await contains(".o-dropdown-item:contains(Delete)").click();
+    expect(queryAllTexts(".o_data_row")).toEqual(["C", "r1", "r2", "A", "A1", "A2"], {
+        message: "Deleting B will then remove all records starting from B1",
+    });
+});
+
+test("add a section", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    expect(`.o_note_row`).toHaveCount(0);
+    await contains(".o_field_x2many_list_row_add a:eq(1)").click();
+    await edit("D");
+    await contains(getFixture()).click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+        "D",
+    ]);
+    expect(`.o_is_line_section`).toHaveCount(4);
+});
+
+test("add note", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    expect(`.o_note_row`).toHaveCount(0);
+    await contains(".o_field_x2many_list_row_add a:last").click();
+    await edit("this is a note");
+    await contains(getFixture()).click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+        "this is a note",
+    ]);
+    expect(`.o_is_line_note`).toHaveCount(1);
+});
+
+test("section_and_note_text widget", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name" widget="section_and_note_text"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    expect(`.o_note_row`).toHaveCount(0);
+    await contains(".o_field_x2many_list_row_add a:last").click();
+    expect(`.o_is_line_note textarea`).toHaveCount(1);
+    await edit("this is a note\non 2 lines");
+    await contains(getFixture()).click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+        "this is a note\non 2 lines",
+    ]);
+});
+
+test("sections with required content field", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name" required="1"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(".o_data_row").toHaveCount(13);
+    await contains(".o_list_section_options:eq(0) button").click();
+    await contains(".o-dropdown-item:contains(Add a subsection)").click();
+    expect(".o_data_row").toHaveCount(14);
+    await contains(".o_list_section_options:eq(1) button").click();
+    await contains(".o-dropdown-item:contains(Delete)").click();
+    expect(".o_data_row").toHaveCount(13);
+    await contains(".o_list_section_options:eq(0) button").click();
+    await contains(".o-dropdown-item:contains(Add a subsection)").click();
+    expect(".o_invalid_cell").toHaveCount(0);
+    await press("Enter");
+    await animationFrame();
+    expect(".o_invalid_cell").toHaveCount(1);
+    expect(".o_data_row").toHaveCount(14);
+    await contains(".o_form_button_cancel").click();
+    expect(".o_data_row").toHaveCount(13);
+    await contains(".o_field_x2many_list_row_add a:eq(1)").click();
+    expect(".o_data_row").toHaveCount(14);
+    expect(".o_invalid_cell").toHaveCount(0);
+    await press("Enter");
+    await animationFrame();
+    expect(".o_invalid_cell").toHaveCount(1);
+    await edit("D");
+    await press("Enter");
+    await animationFrame();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+        "D",
+        "",
+    ]);
+});
+
+test("sections duplicate with many2many", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="m2m" widget="many2many_tags"/>
+                        <field name="sequence"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual(
+        [
+            "r1 \nValue 1\n 1",
+            "r2 \nValue 2\n 2",
+            "A",
+            "A1 \nValue 1\nValue 3\n 4",
+            "A2 \nValue 1\nValue 2\n 5",
+            "B",
+            "B1 \nValue 1\nValue 3\n 7",
+            "B2 \n 8",
+            "Ba",
+            "Ba1 \nValue 2\nValue 3\n 10",
+            "Ba2 \nValue 3\n 11",
+            "C",
+            "C1 \n 13",
+        ],
+        { message: "m2m values are not shown inside (sub-)section rows" }
+    );
+    await contains(".o_list_section_options:eq(1) button").click();
+    await contains(".o-dropdown-item:contains(Duplicate)").click();
+    expect(queryAllTexts(".o_data_row")).toEqual(
+        [
+            "r1 \nValue 1\n 1",
+            "r2 \nValue 2\n 2",
+            "A",
+            "A1 \nValue 1\nValue 3\n 4",
+            "A2 \nValue 1\nValue 2\n 5",
+            "B",
+            "B1 \nValue 1\nValue 3\n 7",
+            "B2 \n 8",
+            "Ba",
+            "Ba1 \nValue 2\nValue 3\n 10",
+            "Ba2 \nValue 3\n 11",
+            "B",
+            "B1 \nValue 1\nValue 3\n 13",
+            "B2 \n 14",
+            "Ba",
+            "Ba1 \nValue 2\nValue 3\n 16",
+            "Ba2 \nValue 3\n 17",
+            "C",
+            "C1 \n 19",
+        ],
+        { message: "m2m values are copied as well" }
+    );
+    await contains(".o_list_section_options:eq(2) button").click();
+    await contains(".o-dropdown-item:contains(Duplicate)").click();
+    expect(queryAllTexts(".o_data_row")).toEqual(
+        [
+            "r1 \nValue 1\n 1",
+            "r2 \nValue 2\n 2",
+            "A",
+            "A1 \nValue 1\nValue 3\n 4",
+            "A2 \nValue 1\nValue 2\n 5",
+            "B",
+            "B1 \nValue 1\nValue 3\n 7",
+            "B2 \n 8",
+            "Ba",
+            "Ba1 \nValue 2\nValue 3\n 10",
+            "Ba2 \nValue 3\n 11",
+            "Ba",
+            "Ba1 \nValue 2\nValue 3\n 13",
+            "Ba2 \nValue 3\n 14",
+            "B",
+            "B1 \nValue 1\nValue 3\n 16",
+            "B2 \n 17",
+            "Ba",
+            "Ba1 \nValue 2\nValue 3\n 19",
+            "Ba2 \nValue 3\n 20",
+            "C",
+            "C1 \n 22",
+        ],
+        { message: "m2m values are copied as well" }
+    );
+});
+
+test("swap sections and subsections", async () => {
+    await mountView({
+        type: "form",
+        resModel: "invoice",
+        resId: 1,
+        arch: `
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    widget="section_and_note_one2many"
+                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                >
+                    <list editable="bottom">
+                        <control>
+                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                        </control>
+                        <field name="sequence" widget="handle"/>
+                        <field name="name"/>
+                        <field name="display_type" column_invisible="1"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    });
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_list_section_options:eq(2) button").click();
+    await contains(".o-dropdown-item:contains(Add a subsection)").click();
+    await edit("Bb");
+    await contains(getFixture()).click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "A",
+        "A1",
+        "A2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "Bb",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_list_section_options:eq(1) button").click();
+    expect(".o-dropdown-item:contains(Move Down)").toHaveCount(1);
+    expect(".o-dropdown-item:contains(Move Up)").toHaveCount(1);
+    await contains(".o_list_section_options:eq(0) button").click();
+    expect(".o-dropdown-item:contains(Move Down)").toHaveCount(1);
+    expect(".o-dropdown-item:contains(Move Up)").toHaveCount(0);
+    await contains(".o_list_section_options:eq(4) button").click();
+    expect(".o-dropdown-item:contains(Move Down)").toHaveCount(0);
+    expect(".o-dropdown-item:contains(Move Up)").toHaveCount(1);
+    await contains(".o_list_section_options:eq(1) button").click();
+    await contains(".o-dropdown-item:contains(Move Up)").click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "B",
+        "B1",
+        "B2",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "Bb",
+        "A",
+        "A1",
+        "A2",
+        "C",
+        "C1",
+    ]);
+    await contains(".o_list_section_options:eq(1) button").click();
+    expect(".o-dropdown-item:contains(Move Down)").toHaveCount(1);
+    expect(".o-dropdown-item:contains(Move Up)").toHaveCount(0);
+    await contains(".o_list_section_options:eq(2) button").click();
+    expect(".o-dropdown-item:contains(Move Down)").toHaveCount(0);
+    expect(".o-dropdown-item:contains(Move Up)").toHaveCount(1);
+    await contains(".o_list_section_options:eq(1) button").click();
+    await contains(".o-dropdown-item:contains(Move Down)").click();
+    expect(queryAllTexts(".o_data_row")).toEqual([
+        "r1",
+        "r2",
+        "B",
+        "B1",
+        "B2",
+        "Bb",
+        "Ba",
+        "Ba1",
+        "Ba2",
+        "A",
+        "A1",
+        "A2",
+        "C",
+        "C1",
     ]);
 });

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
@@ -2,7 +2,7 @@
 <templates>
     <t
         t-name="sale.ListRenderer.RecordRow"
-        t-inherit="web.ListRenderer.RecordRow"
+        t-inherit="account.SectionAndNoteListRenderer.RecordRow"
         t-inherit-mode="primary"
     >
         <!-- Remove the drag-and-drop handle for combo lines and combo item lines. -->

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1606,6 +1606,33 @@ export class ListRenderer extends Component {
         return false;
     }
 
+    editNextRecord(record, group) {
+        const list = this.props.list;
+        const topReCreate = this.props.editable === "top" && record.isNew;
+        const index = list.records.indexOf(record);
+        let futureRecord = list.records[index + 1];
+        if (topReCreate && index === 0) {
+            futureRecord = null;
+        }
+
+        if (!futureRecord && !this.canCreate) {
+            futureRecord = list.records[0];
+        }
+
+        if (futureRecord) {
+            list.leaveEditMode({ validate: true }).then((canProceed) => {
+                if (canProceed) {
+                    list.enterEditMode(futureRecord);
+                }
+            });
+        } else if (this.lastIsDirty || !record.canBeAbandoned || this.displayRowCreates) {
+            this.add({ group });
+        } else {
+            futureRecord = list.records.at(0);
+            list.enterEditMode(futureRecord);
+        }
+    }
+
     /**
      * @param {string} hotkey
      * @param {HTMLTableCellElement} cell
@@ -1699,28 +1726,7 @@ export class ListRenderer extends Component {
                 break;
             }
             case "enter": {
-                const index = list.records.indexOf(record);
-                let futureRecord = list.records[index + 1];
-                if (topReCreate && index === 0) {
-                    futureRecord = null;
-                }
-
-                if (!futureRecord && !this.canCreate) {
-                    futureRecord = list.records[0];
-                }
-
-                if (futureRecord) {
-                    list.leaveEditMode({ validate: true }).then((canProceed) => {
-                        if (canProceed) {
-                            list.enterEditMode(futureRecord);
-                        }
-                    });
-                } else if (this.lastIsDirty || !record.canBeAbandoned || this.displayRowCreates) {
-                    this.add({ group });
-                } else {
-                    futureRecord = list.records.at(0);
-                    list.enterEditMode(futureRecord);
-                }
+                this.editNextRecord(record, group);
                 break;
             }
             case "escape": {


### PR DESCRIPTION
This commit introduces a new feature for the section & note field: subsections, allowing for one additional layer of structured hierarchy beneath a section (nesting beyond one level is not supported).

The update also includes several contextual actions on sections and subsections:

-Add a product
-Add a subsection
-Add a note
-Move up/down the current section
-Duplicate
-Delete

The duplicate and delete actions now apply to the section or subsection and all of its child records.

task-4920305

Co-authored-by: Michaël Mattiello <mcm@odoo.com>
Co-authored-by: Julien Carion <juca@odoo.com>