### PR TITLE
[FIX] html_editor: keep relative urls in link tools

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -46,11 +46,12 @@ export class LinkPopover extends Component {
 
         const textContent = cleanZWChars(this.props.linkElement.textContent);
         const labelEqualsUrl =
-            textContent === this.props.linkElement.href ||
-            textContent + "/" === this.props.linkElement.href;
+            textContent === this.props.linkElement.getAttribute("href") ||
+            textContent + "/" === this.props.linkElement.getAttribute("href");
         this.state = useState({
             editing: this.props.LinkPopoverState.editing,
-            url: this.props.linkElement.href || "",
+            // `.getAttribute("href")` instead of `.href` to keep relative url
+            url: this.props.linkElement.getAttribute("href") || this.deduceUrl(textContent),
             label: labelEqualsUrl ? "" : textContent,
             previewIcon: {
                 /** @type {'fa'|'imgSrc'|'mimetype'} */
@@ -65,7 +66,8 @@ export class LinkPopover extends Component {
                 this.props.type ||
                 this.props.linkElement.className
                     .match(/btn(-[a-z0-9_-]*)(primary|secondary)/)
-                    ?.pop() || "",
+                    ?.pop() ||
+                "",
             isImage: this.props.isImage,
             showLabel: !this.props.linkElement.childElementCount,
         });
@@ -100,7 +102,12 @@ export class LinkPopover extends Component {
 
     onChange() {
         // Apply changes to update the link preview.
-        this.props.onChange(this.state.url, this.state.label, this.classes, this.state.attachmentId);
+        this.props.onChange(
+            this.state.url,
+            this.state.label,
+            this.classes,
+            this.state.attachmentId
+        );
     }
     onClickApply() {
         this.state.editing = false;
@@ -111,22 +118,17 @@ export class LinkPopover extends Component {
         this.state.url = deducedUrl
             ? this.correctLink(deducedUrl)
             : this.correctLink(this.state.url);
-        this.props.onApply(
-            this.state.url,
-            this.state.label,
-            this.classes,
-            this.state.attachmentId
-        );
+        this.props.onApply(this.state.url, this.state.label, this.classes, this.state.attachmentId);
     }
     onClickEdit() {
         this.state.editing = true;
         this.props.onEdit();
-        this.state.url = this.props.linkElement.href;
+        this.state.url = this.props.linkElement.getAttribute("href");
 
         const textContent = cleanZWChars(this.props.linkElement.textContent);
         const labelEqualsUrl =
-            textContent === this.props.linkElement.href ||
-            textContent + "/" === this.props.linkElement.href;
+            textContent === this.props.linkElement.getAttribute("href") ||
+            textContent + "/" === this.props.linkElement.getAttribute("href");
         this.state.label = labelEqualsUrl ? "" : textContent;
     }
     async onClickCopy(ev) {
@@ -212,7 +214,7 @@ export class LinkPopover extends Component {
         }
 
         try {
-            url = new URL(this.state.url); // relative to absolute
+            url = new URL(this.state.url, this.props.linkElement.href); // relative to absolute
         } catch {
             // Invalid URL, might happen with editor unsuported protocol. eg type
             // `geo:37.786971,-122.399677`, become `http://geo:37.786971,-122.399677`
@@ -255,7 +257,7 @@ export class LinkPopover extends Component {
             // Set state based on cached link meta data
             // for record missing errors, we push a warning that the url is likely invalid
             // for other errors, we log them to not block the ui
-            const internalMetadata = await this.props.getInternalMetaData(this.state.url);
+            const internalMetadata = await this.props.getInternalMetaData(url.href);
             if (internalMetadata.favicon) {
                 this.state.previewIcon = {
                     type: "imgSrc",

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -497,7 +497,7 @@ describe("Selection collapsed", () => {
         });
         test("should delete only the button", async () => {
             await testEditor({
-                contentBefore: `<p>a<a class="btn" href="#">[]</a></p>`,
+                contentBefore: `<p>a<a class="btn" href="http://test.test/">[]</a></p>`,
                 stepFunction: deleteBackward,
                 contentAfter: `<p>a[]</p>`,
             });

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -348,7 +348,7 @@ describe("Selection collapsed", () => {
 
         test("should delete only the button", async () => {
             await testEditor({
-                contentBefore: `<p><a class="btn" href="#">[]</a>a</p>`,
+                contentBefore: `<p><a class="btn" href="http://test.test/">[]</a>a</p>`,
                 stepFunction: deleteForward,
                 contentAfter: `<p>[]a</p>`,
             });

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -928,7 +928,7 @@ test("link preview in Link Popover", async () => {
     Partner._records = [
         {
             id: 1,
-            txt: "<p class='test_target'>abc<a href='/test'>This website</a></p>",
+            txt: "<p class='test_target'>abc<a href='http://test.test'>This website</a></p>",
         },
     ];
     await mountView({

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -333,7 +333,9 @@ test("Image transformation disappears on backspace/delete", async () => {
     `);
     click("img.test-image");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     press("backspace");
     await expectElementCount(".transfo-container", 0);
@@ -341,12 +343,13 @@ test("Image transformation disappears on backspace/delete", async () => {
     click("img.test-image");
     await waitFor(".o-we-toolbar");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     press("delete");
     await expectElementCount(".transfo-container", 0);
 });
-
 
 test("Image transformation disappears on character key press", async () => {
     const { editor } = await setupEditor(`
@@ -354,7 +357,9 @@ test("Image transformation disappears on character key press", async () => {
     `);
     click("img.test-image");
     await expectElementCount(".o-we-toolbar", 1);
-    await contains(".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']").click();
+    await contains(
+        ".o-we-toolbar div[name='image_modifiers'] button[name='image_transform']"
+    ).click();
     await expectElementCount(".transfo-container", 1);
     insertText(editor, "a");
     await expectElementCount(".transfo-container", 0);
@@ -531,7 +536,7 @@ test("can undo adding link to image", async () => {
 
 test("can remove the link of an image", async () => {
     await setupEditor(`
-        <a href="#"><img src="${base64Img}"></a>
+        <a href="http://test.test/"><img src="${base64Img}"></a>
     `);
     const img = queryOne("img");
     await click("img");
@@ -545,7 +550,7 @@ test("can remove the link of an image", async () => {
 
 test("can undo link removing of an image", async () => {
     const { editor } = await setupEditor(`
-        <a href="#"><img src="${base64Img}"></a>
+        <a href="http://test.test/"><img src="${base64Img}"></a>
     `);
     const img = queryOne("img");
     await click("img");

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -476,73 +476,75 @@ describe("Selection collapsed", () => {
         // see `anchor.nodeName === "A" && brEls.includes(anchor.firstChild)` in line_break_plugin.js
         test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable">ab<a href="#">[]cd</a></div>`,
+                contentBefore: `<div class="oe_unbreakable">ab<a href="http://test.test/">[]cd</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable">ab<br><a href="#">[]cd</a></div>`,
+                contentAfter: `<div class="oe_unbreakable">ab<br><a href="http://test.test/">[]cd</a></div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#">a[]b</a></div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">a[]b</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#">a<br>[]b</a></div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">a<br>[]b</a></div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#">ab[]</a></div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#">ab</a><br><br>[]</div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br><br>[]</div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#">ab[]</a>cd</div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a>cd</div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#">ab</a><br>[]cd</div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br>[]cd</div>`,
             });
             await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="#" style="display: block;">ab[]</a></div>`,
+                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab[]</a></div>`,
                 stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="#" style="display: block;">ab</a>[]<br></div>`,
+                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab</a>[]<br></div>`,
             });
         });
 
         test("should insert a paragraph break outside the starting edge of an anchor at start of block", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]ab</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]ab</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p><br></p><p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
-                contentAfter: '<p><br></p><p><a href="#">[]ab</a></p>',
+                    '<p><br></p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
+                contentAfter: '<p><br></p><p><a href="http://test.test/">[]ab</a></p>',
             });
         });
         test("should insert a paragraph break outside the starting edge of an anchor after some text", async () => {
             await testEditor({
-                contentBefore: '<p>ab<a href="#">[]cd</a></p>',
+                contentBefore: '<p>ab<a href="http://test.test/">[]cd</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p>ab</p><p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
-                contentAfter: '<p>ab</p><p><a href="#">[]cd</a></p>',
+                    '<p>ab</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
+                contentAfter: '<p>ab</p><p><a href="http://test.test/">[]cd</a></p>',
             });
         });
         test("should insert a paragraph break in the middle of an anchor", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">a[]b</a></p>',
+                contentBefore: '<p><a href="http://test.test/">a[]b</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p>\ufeff<a href="#">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
-                contentAfter: '<p><a href="#">a</a></p><p><a href="#">[]b</a></p>',
+                    '<p>\ufeff<a href="http://test.test/">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
+                contentAfter:
+                    '<p><a href="http://test.test/">a</a></p><p><a href="http://test.test/">[]b</a></p>',
             });
         });
         test("should insert a paragraph break outside the ending edge of an anchor", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">ab[]</a></p>',
+                contentBefore: '<p><a href="http://test.test/">ab[]</a></p>',
                 stepFunction: splitBlockA,
-                contentAfterEdit: `<p>\ufeff<a href="#">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
-                contentAfter: `<p><a href="#">ab</a></p><p>[]<br></p>`,
+                contentAfterEdit: `<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                contentAfter: `<p><a href="http://test.test/">ab</a></p><p>[]<br></p>`,
             });
         });
         test("should insert a paragraph break outside the ending edge of an anchor (2)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">ab[]</a>cd</p>',
+                contentBefore: '<p><a href="http://test.test/">ab[]</a>cd</p>',
                 stepFunction: splitBlockA,
-                contentAfterEdit: '<p>\ufeff<a href="#">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
-                contentAfter: '<p><a href="#">ab</a></p><p>[]cd</p>',
+                contentAfterEdit:
+                    '<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
+                contentAfter: '<p><a href="http://test.test/">ab</a></p><p>[]cd</p>',
             });
         });
     });

--- a/addons/html_editor/static/tests/keyboard/arrow.test.js
+++ b/addons/html_editor/static/tests/keyboard/arrow.test.js
@@ -298,11 +298,11 @@ describe("Around links", () => {
 
     test("should move out of a link (ArrowRight)", async () => {
         await testEditor({
-            contentBefore: '<p>ab<a href="#">cd[]</a>ef</p>',
+            contentBefore: '<p>ab<a href="http://test.test/">cd[]</a>ef</p>',
             contentBeforeEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="http://test.test/" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "cd[]" + // content
                 "\ufeff" + // end zwnbsp
@@ -313,24 +313,24 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="http://test.test/">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "[]ef</p>",
-            contentAfter: '<p>ab<a href="#">cd</a>[]ef</p>',
+            contentAfter: '<p>ab<a href="http://test.test/">cd</a>[]ef</p>',
         });
     });
 
     test("should move out of a link (ArrowLeft)", async () => {
         await testEditor({
-            contentBefore: '<p>ab<a href="#">[]cd</a>ef</p>',
+            contentBefore: '<p>ab<a href="http://test.test/">[]cd</a>ef</p>',
             contentBeforeEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="http://test.test/" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "[]cd" + // content
                 "\ufeff" + // end zwnbsp
@@ -341,14 +341,14 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab[]" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="http://test.test/">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "ef</p>",
-            contentAfter: '<p>ab[]<a href="#">cd</a>ef</p>',
+            contentAfter: '<p>ab[]<a href="http://test.test/">cd</a>ef</p>',
         });
     });
 });

--- a/addons/html_editor/static/tests/keyboard/arrow.test.js
+++ b/addons/html_editor/static/tests/keyboard/arrow.test.js
@@ -242,11 +242,11 @@ describe("Around ZWS", () => {
 describe("Around links", () => {
     test("should move into a link (ArrowRight)", async () => {
         await testEditor({
-            contentBefore: '<p>ab[]<a href="#">cd</a>ef</p>',
+            contentBefore: '<p>ab[]<a href="http://test.test/">cd</a>ef</p>',
             contentBeforeEdit:
                 "<p>ab[]" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="http://test.test/">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
@@ -257,24 +257,24 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="http://test.test/" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "[]cd" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "ef</p>",
-            contentAfter: '<p>ab<a href="#">[]cd</a>ef</p>',
+            contentAfter: '<p>ab<a href="http://test.test/">[]cd</a>ef</p>',
         });
     });
 
     test("should move into a link (ArrowLeft)", async () => {
         await testEditor({
-            contentBefore: '<p>ab<a href="#">cd</a>[]ef</p>',
+            contentBefore: '<p>ab<a href="http://test.test/">cd</a>[]ef</p>',
             contentBeforeEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="http://test.test/">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
@@ -285,14 +285,14 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="http://test.test/" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "cd[]" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "ef</p>",
-            contentAfter: '<p>ab<a href="#">cd[]</a>ef</p>',
+            contentAfter: '<p>ab<a href="http://test.test/">cd[]</a>ef</p>',
         });
     });
 
@@ -555,8 +555,9 @@ describe("Around invisible chars in RTL languages", () => {
     });
 
     describe("ZWNBSP", () => {
-        const content = "<p>" + "الرجال" + '<a href="#">اءيتجنب</a>' + "هؤلاء" + "</p>";
-        // Displayed as "هؤلاء<a href="#">اءيتجنب</a>الرجال" in the editor:
+        const content =
+            "<p>" + "الرجال" + '<a href="http://test.test/">اءيتجنب</a>' + "هؤلاء" + "</p>";
+        // Displayed as "هؤلاء<a href="http://test.test/">اءيتجنب</a>الرجال" in the editor:
         //                third +         link      + first
         test("should move into a link (ArrowLeft)", async () => {
             const { editor, el } = await setupEditor(content, { config: { direction: "rtl" } });
@@ -564,7 +565,7 @@ describe("Around invisible chars in RTL languages", () => {
             // childNodes[1] and childNodes[3] are the ZWNBSP text nodes
             const link = el.firstChild.childNodes[2];
             // Place cursor at the end of first child (before the FEFF char)
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]الرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]الرجال
             setSelection({ anchorNode: pFirstChild, anchorOffset: pFirstChild.length });
 
             await keyPress("ArrowLeft")(editor);
@@ -572,9 +573,9 @@ describe("Around invisible chars in RTL languages", () => {
             const selection = editor.document.getSelection();
             expect(selection.anchorNode).toBe(link.firstChild); // FEFF node
             expect(selection.anchorOffset).toBe(1);
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFالرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال\uFEFF<a href="#" class="o_link_in_selection">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
+                '<p>الرجال\uFEFF<a href="http://test.test/" class="o_link_in_selection">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
             );
         });
         test("should move into a link (ArrowRight)", async () => {
@@ -584,7 +585,7 @@ describe("Around invisible chars in RTL languages", () => {
             const pFifthChild = el.firstChild.childNodes[4]; // "هؤلاء"
             const link2ndChild = link.childNodes[1]; // اءيتجنب
             // Place cursor at the beginning of fifth child (after the FEFF char)
-            // Displayed as هؤلاء[]\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء[]\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFFالرجال
             setSelection({ anchorNode: pFifthChild, anchorOffset: 0 });
 
             await keyPress("ArrowRight")(editor);
@@ -592,9 +593,9 @@ describe("Around invisible chars in RTL languages", () => {
             const selection = editor.document.getSelection();
             expect(selection.anchorNode).toBe(link2ndChild);
             expect(selection.anchorOffset).toBe(link2ndChild.length);
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFالرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال\uFEFF<a href="#" class="o_link_in_selection">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFهؤلاء</p>'
+                '<p>الرجال\uFEFF<a href="http://test.test/" class="o_link_in_selection">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFهؤلاء</p>'
             );
         });
         test("should move out of a link (ArrowLeft)", async () => {
@@ -603,7 +604,7 @@ describe("Around invisible chars in RTL languages", () => {
             const link = el.firstChild.childNodes[2];
             const link2ndChild = link.childNodes[1]; // text content inside link: اءيتجنب
             // Place cursor at the end of link's content (before the FEFF char)
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFالرجال
             setSelection({ anchorNode: link2ndChild, anchorOffset: link2ndChild.length });
 
             await keyPress("ArrowLeft")(editor);
@@ -611,9 +612,9 @@ describe("Around invisible chars in RTL languages", () => {
             const selection = editor.document.getSelection();
             expect(selection.anchorNode).toBe(el.firstChild.childNodes[3]); // FEFF node outside link
             expect(selection.anchorOffset).toBe(1);
-            // Displayed as هؤلاء[]\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء[]\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFFالرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]هؤلاء</p>'
+                '<p>الرجال\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]هؤلاء</p>'
             );
         });
         test("should move out of a link (ArrowRight)", async () => {
@@ -623,7 +624,7 @@ describe("Around invisible chars in RTL languages", () => {
             const link = el.firstChild.childNodes[2];
             const link2ndChild = link.childNodes[1]; // text content inside link: اءيتجنب
             // Place cursor at the beginning of link's content (after the FEFF char)
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFالرجال
             setSelection({ anchorNode: link2ndChild, anchorOffset: 0 });
 
             await keyPress("ArrowRight")(editor);
@@ -631,9 +632,9 @@ describe("Around invisible chars in RTL languages", () => {
             const selection = editor.document.getSelection();
             expect(selection.anchorNode).toBe(pFirstChild);
             expect(selection.anchorOffset).toBe(pFirstChild.length);
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]الرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]الرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال[]\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
+                '<p>الرجال[]\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
             );
         });
     });

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -33,16 +33,22 @@ describe("button style", () => {
 
 describe("button edit", () => {
     test("button link should be editable with double click select", async () => {
-        const { el, editor } = await setupEditor('<p>this is a <a href="#">link</a></p>');
+        const { el, editor } = await setupEditor(
+            '<p>this is a <a href="http://test.test/">link</a></p>'
+        );
         await waitForNone(".o-we-linkpopover");
         const button = el.querySelector("a");
         // simulate double click selection
         await simulateDoubleClickSelect(button);
         expect(getContent(el)).toBe(
-            '<p>this is a \ufeff<a href="#" class="o_link_in_selection">[\ufefflink]\ufeff</a>\ufeff</p>'
+            '<p>this is a \ufeff<a href="http://test.test/" class="o_link_in_selection">[\ufefflink]\ufeff</a>\ufeff</p>'
         );
-        expect(cleanLinkArtifacts(getContent(el))).toBe('<p>this is a <a href="#">[link]</a></p>');
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.test/">[link]</a></p>'
+        );
         await insertText(editor, "X");
-        expect(cleanLinkArtifacts(getContent(el))).toBe('<p>this is a <a href="#">X[]</a></p>');
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.test/">X[]</a></p>'
+        );
     });
 });

--- a/addons/html_editor/static/tests/link/existing.test.js
+++ b/addons/html_editor/static/tests/link/existing.test.js
@@ -8,85 +8,85 @@ import { contains } from "@web/../tests/_framework/dom_test_helpers";
 
 test("should parse correctly a span inside a Link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b[]</span></a>c</p>',
-        contentAfter: '<p>a<a href="exist"><span class="a">b[]</span></a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b[]</span></a>c</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">b[]</span></a>c</p>',
     });
 });
 
 test("should parse correctly an empty span inside a Link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]<span class="a"></span></a>c</p>',
-        contentAfter: '<p>a<a href="exist">b[]<span class="a"></span></a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]<span class="a"></span></a>c</p>',
+        contentAfter: '<p>a<a href="http://test.test/">b[]<span class="a"></span></a>c</p>',
     });
 });
 
 test("should parse correctly a span inside a Link 2", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b[]</span>c</a>d</p>',
-        contentAfter: '<p>a<a href="exist"><span class="a">b[]</span>c</a>d</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b[]</span>c</a>d</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">b[]</span>c</a>d</p>',
     });
 });
 
 test("should parse correctly an empty span inside a Link then add a char", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]<span class="a"></span></a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]<span class="a"></span></a>c</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        contentAfter: '<p>a<a href="exist">bc[]<span class="a"></span></a>c</p>',
+        contentAfter: '<p>a<a href="http://test.test/">bc[]<span class="a"></span></a>c</p>',
     });
 });
 
 test("should parse correctly a span inside a Link then add a char", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b[]</span></a>d</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b[]</span></a>d</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        // JW cAfter: '<p>a<span><a href="exist">b</a>c[]</span>d</p>',
-        contentAfter: '<p>a<a href="exist"><span class="a">bc[]</span></a>d</p>',
+        // JW cAfter: '<p>a<span><a href="http://test.test/">b</a>c[]</span>d</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">bc[]</span></a>d</p>',
     });
 });
 
 test("should parse correctly a span inside a Link then add a char 2", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b[]</span>d</a>e</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b[]</span>d</a>e</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        contentAfter: '<p>a<a href="exist"><span class="a">bc[]</span>d</a>e</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">bc[]</span>d</a>e</p>',
     });
 });
 
 test("should parse correctly a span inside a Link then add a char 3", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist"><span class="a">b</span>c[]</a>e</p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b</span>c[]</a>e</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "d");
         },
-        // JW cAfter: '<p>a<a href="exist"><span class="a">b</span>c</a>d[]e</p>',
-        contentAfter: '<p>a<a href="exist"><span class="a">b</span>cd[]</a>e</p>',
+        // JW cAfter: '<p>a<a href="http://test.test/"><span class="a">b</span>c</a>d[]e</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">b</span>cd[]</a>e</p>',
     });
 });
 
 test("should add a character after the link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]</a>d</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>d</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        // JW cAfter: '<p>a<a href="exist">b</a>c[]d</p>',
-        contentAfter: '<p>a<a href="exist">bc[]</a>d</p>',
+        // JW cAfter: '<p>a<a href="http://test.test/">b</a>c[]d</p>',
+        contentAfter: '<p>a<a href="http://test.test/">bc[]</a>d</p>',
     });
 });
 
 test("should add two character after the link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]</a>e</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>e</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "cd");
         },
-        contentAfter: '<p>a<a href="exist">bcd[]</a>e</p>',
+        contentAfter: '<p>a<a href="http://test.test/">bcd[]</a>e</p>',
     });
 });
 
@@ -102,28 +102,28 @@ test("should add a character after the link if range just after link", async () 
 
 test("should add a character in the link after a br tag", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b<br>[]</a>d</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b<br>[]</a>d</p>',
         stepFunction: async (editor) => {
             await insertText(editor, "c");
         },
-        contentAfter: '<p>a<a href="exist">b<br>c[]</a>d</p>',
+        contentAfter: '<p>a<a href="http://test.test/">b<br>c[]</a>d</p>',
     });
 });
 
 test("should remove an empty link on save", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="exist">b[]</a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>c</p>',
         contentBeforeEdit:
-            '<p>a\ufeff<a href="exist" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffc</p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffc</p>',
         stepFunction: deleteBackward,
         contentAfterEdit:
-            '<p>a\ufeff<a href="exist" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffc</p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffc</p>',
         contentAfter: "<p>a[]c</p>",
     });
     await testEditor({
-        contentBefore: '<p>a<a href="exist"></a>b</p>',
-        contentBeforeEdit: '<p>a\ufeff<a href="exist">\ufeff</a>\ufeffb</p>',
-        contentAfterEdit: '<p>a\ufeff<a href="exist">\ufeff</a>\ufeffb</p>',
+        contentBefore: '<p>a<a href="http://test.test/"></a>b</p>',
+        contentBeforeEdit: '<p>a\ufeff<a href="http://test.test/">\ufeff</a>\ufeffb</p>',
+        contentAfterEdit: '<p>a\ufeff<a href="http://test.test/">\ufeff</a>\ufeffb</p>',
         contentAfter: "<p>ab</p>",
     });
 });

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -41,46 +41,46 @@ test("should pad a link with ZWNBSPs and add visual indication (2)", async () =>
 
 test("should keep link padded with ZWNBSPs after a delete", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/">b[]</a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>c</p>',
         stepFunction: deleteBackward,
         contentAfterEdit:
-            '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffc</p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffc</p>',
         contentAfter: "<p>a[]c</p>",
     });
 });
 
 test("should keep isolated link after a delete and typing", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/">b[]</a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b[]</a>c</p>',
         stepFunction: async (editor) => {
             deleteBackward(editor);
             await insertText(editor, "a");
             await insertText(editor, "b");
             await insertText(editor, "c");
         },
-        contentAfter: '<p>a<a href="#/">abc[]</a>c</p>',
+        contentAfter: '<p>a<a href="http://test.test/">abc[]</a>c</p>',
     });
 });
 
 test("should delete the content from the link when popover is active", async () => {
-    const { editor, el } = await setupEditor('<p><a href="#/">abc[]abc</a></p>');
+    const { editor, el } = await setupEditor('<p><a href="http://test.test/">abc[]abc</a></p>');
     await expectElementCount(".o-we-linkpopover", 1);
     deleteBackward(editor);
     deleteBackward(editor);
     deleteBackward(editor);
     const content = getContent(el);
     expect(content).toBe(
-        '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]abc\ufeff</a>\ufeff</p>'
+        '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]abc\ufeff</a>\ufeff</p>'
     );
-    expect(cleanLinkArtifacts(content)).toBe('<p><a href="#/">[]abc</a></p>');
+    expect(cleanLinkArtifacts(content)).toBe('<p><a href="http://test.test/">[]abc</a></p>');
 });
 
 describe.tags("desktop");
 describe("should position the cursor outside the link", () => {
     test("clicking at the start of the link", async () => {
-        const { el } = await setupEditor('<p><a href="#/">te[]st</a></p>');
+        const { el } = await setupEditor('<p><a href="http://test.test/">te[]st</a></p>');
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
         );
 
         const aElement = queryOne("p a");
@@ -88,31 +88,39 @@ describe("should position the cursor outside the link", () => {
         // Simulate the selection with mousedown
         setSelection({ anchorNode: aElement.childNodes[0], anchorOffset: 0 });
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">[]\ufefftest\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">[]\ufefftest\ufeff</a>\ufeff</p>'
         );
         await animationFrame(); // selection change
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</p>');
+        expect(getContent(el)).toBe(
+            '<p>[]\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff</p>'
+        );
     });
 
     test("clicking at the start of the link when format is applied on link", async () => {
         const { el } = await setupEditor('<p><strong><a href="#/">test</a></strong></p>');
-        expect(getContent(el)).toBe('<p><strong>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>');
+        expect(getContent(el)).toBe(
+            '<p><strong>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>'
+        );
 
         const aElement = queryOne("p a");
         await pointerDown(el);
         // Simulate the selection with mousedown
         setSelection({ anchorNode: aElement.childNodes[0], anchorOffset: 0 });
-        expect(getContent(el)).toBe('<p><strong>\ufeff<a href="#/">[]\ufefftest\ufeff</a>\ufeff</strong></p>');
+        expect(getContent(el)).toBe(
+            '<p><strong>\ufeff<a href="#/">[]\ufefftest\ufeff</a>\ufeff</strong></p>'
+        );
         await animationFrame(); // selection change
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p><strong>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>');
+        expect(getContent(el)).toBe(
+            '<p><strong>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>'
+        );
     });
 
     test("clicking at the end of the link", async () => {
-        const { el } = await setupEditor('<p><a href="#/">te[]st</a></p>');
+        const { el } = await setupEditor('<p><a href="http://test.test/">te[]st</a></p>');
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
         );
 
         const aElement = queryOne("p a");
@@ -123,17 +131,19 @@ describe("should position the cursor outside the link", () => {
             anchorOffset: nodeSize(aElement.childNodes[2]),
         });
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefftest\ufeff[]</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefftest\ufeff[]</a>\ufeff</p>'
         );
         await animationFrame(); // selectionChange
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff[]</p>');
+        expect(getContent(el)).toBe(
+            '<p>\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff[]</p>'
+        );
     });
 
     test("clicking before the link's text content", async () => {
-        const { el, editor } = await setupEditor('<p><a href="#/">te[]st</a></p>');
+        const { el, editor } = await setupEditor('<p><a href="http://test.test/">te[]st</a></p>');
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffte[]st\ufeff</a>\ufeff</p>'
         );
 
         const aElement = queryOne("p a");
@@ -141,30 +151,34 @@ describe("should position the cursor outside the link", () => {
         // Simulate the selection with mousedown
         setSelection({ anchorNode: aElement.childNodes[1], anchorOffset: 0 });
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]test\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]test\ufeff</a>\ufeff</p>'
         );
         await animationFrame(); // selection change
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p>[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</p>');
+        expect(getContent(el)).toBe(
+            '<p>[]\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff</p>'
+        );
 
         await insertText(editor, "link");
-        expect(getContent(el)).toBe('<p>link[]\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</p>');
+        expect(getContent(el)).toBe(
+            '<p>link[]\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff</p>'
+        );
 
         setSelection({ anchorNode: aElement.childNodes[1], anchorOffset: 0 });
         await animationFrame(); // selectionChange
         expect(getContent(el)).toBe(
-            '<p>link\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]test\ufeff</a>\ufeff</p>'
+            '<p>link\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]test\ufeff</a>\ufeff</p>'
         );
         await insertText(editor, "content");
         expect(getContent(el)).toBe(
-            '<p>link\ufeff<a href="#/" class="o_link_in_selection">\ufeffcontent[]test\ufeff</a>\ufeff</p>'
+            '<p>link\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffcontent[]test\ufeff</a>\ufeff</p>'
         );
     });
 
     test(" clicking after the link's text content", async () => {
-        const { el, editor } = await setupEditor('<p><a href="#/">t[]est</a></p>');
+        const { el, editor } = await setupEditor('<p><a href="http://test.test/">t[]est</a></p>');
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefft[]est\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefft[]est\ufeff</a>\ufeff</p>'
         );
 
         const aElement = queryOne("p a");
@@ -175,14 +189,18 @@ describe("should position the cursor outside the link", () => {
             anchorOffset: nodeSize(aElement.childNodes[1]),
         });
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefftest[]\ufeff</a>\ufeff</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefftest[]\ufeff</a>\ufeff</p>'
         );
         await animationFrame(); // selection change
         await pointerUp(el);
-        expect(getContent(el)).toBe('<p>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff[]</p>');
+        expect(getContent(el)).toBe(
+            '<p>\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufeff[]</p>'
+        );
 
         await insertText(editor, "link");
-        expect(getContent(el)).toBe('<p>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufefflink[]</p>');
+        expect(getContent(el)).toBe(
+            '<p>\ufeff<a href="http://test.test/">\ufefftest\ufeff</a>\ufefflink[]</p>'
+        );
 
         setSelection({
             anchorNode: aElement.childNodes[1],
@@ -190,11 +208,11 @@ describe("should position the cursor outside the link", () => {
         });
         await animationFrame(); // selectionChange
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefftest[]\ufeff</a>\ufefflink</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefftest[]\ufeff</a>\ufefflink</p>'
         );
         await insertText(editor, "content");
         expect(getContent(el)).toBe(
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufefftestcontent[]\ufeff</a>\ufefflink</p>'
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufefftestcontent[]\ufeff</a>\ufefflink</p>'
         );
     });
 });
@@ -224,9 +242,9 @@ describe("should zwnbsp-pad simple text link", () => {
     });
     test("should zwnbsp-pad simple text link (2)", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="#/">[]bc</a>d</p>',
+            contentBefore: '<p>a<a href="http://test.test/">[]bc</a>d</p>',
             contentBeforeEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
             stepFunction: async (editor) => {
                 removeZwnbsp(editor);
                 const a = editor.editable.querySelector("a");
@@ -237,14 +255,14 @@ describe("should zwnbsp-pad simple text link", () => {
                 dispatchNormalize(editor);
             },
             contentAfterEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]bc\ufeff</a>\ufeffd</p>',
         });
     });
     test("should zwnbsp-pad simple text link (3)", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="#/">b[]</a>d</p>',
+            contentBefore: '<p>a<a href="http://test.test/">b[]</a>d</p>',
             contentBeforeEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffb[]\ufeff</a>\ufeffd</p>',
             stepFunction: async (editor) => {
                 const a = editor.editable.querySelector("a");
                 // Insert an extra character as a text node so we can set
@@ -259,14 +277,14 @@ describe("should zwnbsp-pad simple text link", () => {
                 dispatchNormalize(editor);
             },
             contentAfterEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffb[]c\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffb[]c\ufeff</a>\ufeffd</p>',
         });
     });
     test("should zwnbsp-pad simple text link (4)", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="#/">bc[]</a>d</p>',
+            contentBefore: '<p>a<a href="http://test.test/">bc[]</a>d</p>',
             contentBeforeEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
             stepFunction: async (editor) => {
                 removeZwnbsp(editor);
                 const a = editor.editable.querySelector("a");
@@ -277,7 +295,7 @@ describe("should zwnbsp-pad simple text link", () => {
                 dispatchNormalize(editor);
             },
             contentAfterEdit:
-                '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
+                '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffbc[]\ufeff</a>\ufeffd</p>',
         });
     });
     test("should zwnbsp-pad simple text link (5)", async () => {
@@ -300,31 +318,32 @@ describe("should zwnbsp-pad simple text link", () => {
 
 test("should not zwnbsp-pad nav-link", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/" class="nav-link">[]b</a>c</p>',
-        contentBeforeEdit: '<p>a<a href="#/" class="nav-link">[]b</a>c</p>',
+        contentBefore: '<p>a<a href="http://test.test/" class="nav-link">[]b</a>c</p>',
+        contentBeforeEdit: '<p>a<a href="http://test.test/" class="nav-link">[]b</a>c</p>',
     });
 });
 
 test("should not zwnbsp-pad in nav", async () => {
     await testEditor({
-        contentBefore: '<nav>a<a href="#/">[]b</a>c</nav>',
-        contentBeforeEdit: '<nav>a<a href="#/">[]b</a>c</nav>',
+        contentBefore: '<nav>a<a href="http://test.test/">[]b</a>c</nav>',
+        contentBeforeEdit: '<nav>a<a href="http://test.test/">[]b</a>c</nav>',
     });
 });
 
 test("should not zwnbsp-pad link with block fontawesome", async () => {
     await testEditor({
         contentBefore:
-            '<p>a<a href="#/">[]<i style="display: flex;" class="fa fa-star"></i></a>b</p>',
+            '<p>a<a href="http://test.test/">[]<i style="display: flex;" class="fa fa-star"></i></a>b</p>',
         contentBeforeEdit:
-            '<p>a<a href="#/">\ufeff[]<i style="display: flex;" class="fa fa-star" contenteditable="false">\u200b</i>\ufeff</a>b</p>',
+            '<p>a<a href="http://test.test/">\ufeff[]<i style="display: flex;" class="fa fa-star" contenteditable="false">\u200b</i>\ufeff</a>b</p>',
     });
 });
 
 test("should not zwnbsp-pad link with image", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/">[]<img style="display: inline;"></a>b</p>',
-        contentBeforeEdit: '<p>a<a href="#/">[]<img style="display: inline;"></a>b</p>',
+        contentBefore: '<p>a<a href="http://test.test/">[]<img style="display: inline;"></a>b</p>',
+        contentBeforeEdit:
+            '<p>a<a href="http://test.test/">[]<img style="display: inline;"></a>b</p>',
     });
 });
 
@@ -370,7 +389,8 @@ test("should zwnbps-pad links with .btn class", async () => {
 
 test("should not add visual indication to a button", async () => {
     await testEditor({
-        contentBefore: '<p><a href="#" class="btn">[]content</a></p>',
-        contentBeforeEdit: '<p>\ufeff<a href="#" class="btn">\ufeff[]content\ufeff</a>\ufeff</p>',
+        contentBefore: '<p><a href="http://test.test/" class="btn">[]content</a></p>',
+        contentBeforeEdit:
+            '<p>\ufeff<a href="http://test.test/" class="btn">\ufeff[]content\ufeff</a>\ufeff</p>',
     });
 });

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -12,30 +12,30 @@ import { expectElementCount } from "../_helpers/ui_expectations";
 
 test("should pad a link with ZWNBSPs and add visual indication", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/">b</a>c</p>',
-        contentBeforeEdit: '<p>a\ufeff<a href="#/">\ufeffb\ufeff</a>\ufeffc</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b</a>c</p>',
+        contentBeforeEdit: '<p>a\ufeff<a href="http://test.test/">\ufeffb\ufeff</a>\ufeffc</p>',
         stepFunction: async (editor) => {
             setSelection({ anchorNode: editor.editable.querySelector("a"), anchorOffset: 1 });
             await tick();
         },
         contentAfterEdit:
-            '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeffc</p>',
-        contentAfter: '<p>a<a href="#/">[]b</a>c</p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeffc</p>',
+        contentAfter: '<p>a<a href="http://test.test/">[]b</a>c</p>',
     });
 });
 
 test("should pad a link with ZWNBSPs and add visual indication (2)", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/"><span class="a">b</span></a></p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b</span></a></p>',
         contentBeforeEdit:
-            '<p>a\ufeff<a href="#/">\ufeff<span class="a">b</span>\ufeff</a>\ufeff</p>',
+            '<p>a\ufeff<a href="http://test.test/">\ufeff<span class="a">b</span>\ufeff</a>\ufeff</p>',
         stepFunction: async (editor) => {
             setSelection({ anchorNode: editor.editable.querySelector("a span"), anchorOffset: 0 });
             await tick();
         },
         contentAfterEdit:
-            '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff<span class="a">[]b</span>\ufeff</a>\ufeff</p>',
-        contentAfter: '<p>a<a href="#/"><span class="a">[]b</span></a></p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff<span class="a">[]b</span>\ufeff</a>\ufeff</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">[]b</span></a></p>',
     });
 });
 

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -196,6 +196,18 @@ describe("popover should edit,copy,remove the link", () => {
             '<p>this is a <a href="http://test.com/">http://test.com/[]</a></p>'
         );
     });
+    test("relative URLs should be kept relative URLs", async () => {
+        onRpc("/html_editor/link_preview_internal", () => ({}));
+        onRpc("/contactus", () => ({}));
+        const { el } = await setupEditor('<p>this is a <a href="/contactus">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_apply_link");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="/contactus">li[]nk</a></p>'
+        );
+    });
     test("after clicking on copy button, the url should be copied to clipboard", async () => {
         await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -36,7 +36,9 @@ describe("should open a popover", () => {
         await expectElementCount(".o-we-linkpopover", 0);
     });
     test("should open a popover when the selection is inside a link and stay open if selection move in the same link", async () => {
-        const { el } = await setupEditor('<p>this []is a <a href="exist">l<b>in</b>k</a></p>');
+        const { el } = await setupEditor(
+            '<p>this []is a <a href="http://test.test/">l<b>in</b>k</a></p>'
+        );
         await expectElementCount(".o-we-linkpopover", 0);
         // selection inside a link
         const aNode = queryOne("a");
@@ -49,7 +51,7 @@ describe("should open a popover", () => {
         await expectElementCount(".o-we-linkpopover", 1);
         // FEFF is taken into account in the index
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p>this is a <a href="exist">l<b>in</b>[]k</a></p>'
+            '<p>this is a <a href="http://test.test/">l<b>in</b>[]k</a></p>'
         );
         // Another selection in the same link
         setSelection({
@@ -61,7 +63,7 @@ describe("should open a popover", () => {
         await animationFrame();
         await expectElementCount(".o-we-linkpopover", 1);
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p>this is a <a href="exist">[]l<b>in</b>k</a></p>'
+            '<p>this is a <a href="http://test.test/">[]l<b>in</b>k</a></p>'
         );
     });
     test("link popover should have input field for href when the link doesn't have href", async () => {
@@ -71,7 +73,7 @@ describe("should open a popover", () => {
         expect(".o_we_href_input_link").toHaveValue("");
     });
     test("link popover should have buttons for link operation when the link has href", async () => {
-        await setupEditor('<p>this is a <a href="test.com">li[]nk</a></p>');
+        await setupEditor('<p>this is a <a href="http://test.test/">li[]nk</a></p>');
         await expectElementCount(".o-we-linkpopover", 1);
         expect(".o_we_copy_link").toHaveCount(1);
         expect(".o_we_edit_link").toHaveCount(1);
@@ -329,8 +331,12 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
 
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">#[]</a></p>');
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p><a href="http://test.test/">http://test.test/[]</a></p>'
+            );
         });
         test("Should be able to insert button on empty p", async () => {
             const { editor, el } = await setupEditor("<p>[]</p>");
@@ -338,9 +344,11 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
 
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p><a href="#" class="btn btn-fill-primary">#[]</a></p>'
+                '<p><a href="http://test.test/" class="btn btn-fill-primary">http://test.test/[]</a></p>'
             );
         });
         test("Should keep http protocol on valid http url", async () => {
@@ -362,9 +370,11 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>a <a href="#">link[]</a>&nbsp;&nbsp;b</p>'
+                '<p>a <a href="http://test.test/">link[]</a>&nbsp;&nbsp;b</p>'
             );
         });
         test("should insert a link then create a new <p>", async () => {
@@ -373,11 +383,13 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             // press("Enter");
             splitBlock(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                `<p>ab<a href="#">link</a></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+                `<p>ab<a href="http://test.test/">link</a></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
             );
         });
         test("should insert a link then create a new <p>, and another character", async () => {
@@ -386,12 +398,14 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             // press("Enter");
             splitBlock(editor);
             await insertText(editor, "D");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>a<a href="#">link</a></p><p>D[]b</p>'
+                '<p>a<a href="http://test.test/">link</a></p><p>D[]b</p>'
             );
         });
         test("should insert a link then insert a <br>", async () => {
@@ -400,10 +414,14 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             // press("Enter");
             insertLineBreak(editor);
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>a<a href="#">link</a><br>[]b</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>a<a href="http://test.test/">link</a><br>[]b</p>'
+            );
         });
         test("should insert a link then insert a <br> and another character", async () => {
             const { editor, el } = await setupEditor("<p>a[]b</p>");
@@ -411,11 +429,15 @@ describe("Link creation", () => {
             await animationFrame();
             await click(".o-we-command-name:first");
             await contains(".o-we-linkpopover input.o_we_label_link").fill("link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").fill("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").fill(
+                "http://test.test/"
+            );
             // press("Enter");
             insertLineBreak(editor);
             await insertText(editor, "D");
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>a<a href="#">link</a><br>D[]b</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>a<a href="http://test.test/">link</a><br>D[]b</p>'
+            );
         });
     });
     describe("Creation by toolbar", () => {
@@ -424,9 +446,11 @@ describe("Link creation", () => {
             await waitFor(".o-we-toolbar");
             await click(".o-we-toolbar .fa-link");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "http://test.test/"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">Hello[]</a></p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p><a href="http://test.test/">Hello[]</a></p>'
+            );
         });
         test("should convert valid url to https link", async () => {
             const { el } = await setupEditor("<p>[Hello]</p>");
@@ -456,9 +480,11 @@ describe("Link creation", () => {
             );
             await waitFor(".o-we-toolbar");
             click(".o-we-toolbar .fa-link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>Hello this is <a href="#">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
+                '<p>Hello this is <a href="http://test.test/">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
             );
         });
         test("should convert all selected text to link and keep style except bgclor", async () => {
@@ -467,9 +493,11 @@ describe("Link creation", () => {
             );
             await waitFor(".o-we-toolbar");
             click(".o-we-toolbar .fa-link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>Hello this is <a href="#">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
+                '<p>Hello this is <a href="http://test.test/">a <b>new</b> <u>link</u> keeping style[]</a>!</p>'
             );
         });
         test("should convert all selected text to link and keep style except color (2)", async () => {
@@ -478,9 +506,11 @@ describe("Link creation", () => {
             );
             await waitFor(".o-we-toolbar");
             click(".o-we-toolbar .fa-link");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p>Hello this is a <b>ne</b><a href="#"><b>w</b> <u>link</u> keep[]</a><span style="color:red">ing</span> style!</p>'
+                '<p>Hello this is a <b>ne</b><a href="http://test.test/"><b>w</b> <u>link</u> keep[]</a><span style="color:red">ing</span> style!</p>'
             );
         });
         test("should set the link on two existing characters", async () => {
@@ -491,9 +521,11 @@ describe("Link creation", () => {
             expect('.o-we-toolbar button[name="link"]').not.toHaveAttribute("disabled");
             await click(".o-we-toolbar .fa-link");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "http://test.test/"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>H<a href="#">el[]</a>lo</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>H<a href="http://test.test/">el[]</a>lo</p>'
+            );
         });
         test("should not allow to create a link if selection span multiple block", async () => {
             const { el } = await setupEditor("<p>H[ello</p><p>wor]ld</p>");
@@ -547,9 +579,11 @@ describe("Link creation", () => {
             await waitFor(".o-we-toolbar");
             await click(".o-we-toolbar .fa-link");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "http://test.test/"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p>aaa<a href="#">ab[]</a>cdef</p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p>aaa<a href="http://test.test/">ab[]</a>cdef</p>'
+            );
         });
         test("should remove link when click away without inputting url", async () => {
             const { el } = await setupEditor("<p>H[el]lo</p>");
@@ -604,9 +638,11 @@ describe("Link creation", () => {
             // not validated link shouldn't affect the DOM yet
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[Hello]</p>");
             await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
-                "#"
+                "http://test.test/"
             );
-            expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">Hello[]</a></p>');
+            expect(cleanLinkArtifacts(getContent(el))).toBe(
+                '<p><a href="http://test.test/">Hello[]</a></p>'
+            );
 
             undo(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[Hello]</p>");
@@ -617,9 +653,11 @@ describe("Link creation", () => {
             await click(".o-we-toolbar .fa-link");
             // not validated link shouldn't affect the DOM yet
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p><b>[Hello]</b></p>");
-            await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#");
+            await contains(".o-we-linkpopover input.o_we_href_input_link").edit(
+                "http://test.test/"
+            );
             expect(cleanLinkArtifacts(getContent(el))).toBe(
-                '<p><b><a href="#">Hello[]</a></b></p>'
+                '<p><b><a href="http://test.test/">Hello[]</a></b></p>'
             );
             undo(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p><b>[Hello]</b></p>");
@@ -960,7 +998,8 @@ describe("link preview", () => {
     });
     test("test external metadata cached correctly", async () => {
         const title = "Open Source ERP and CRM | Odoo";
-        const description = "From ERP to CRM, eCommerce and CMS. Download Odoo or use it in the cloud. Grow Your Business.";
+        const description =
+            "From ERP to CRM, eCommerce and CMS. Download Odoo or use it in the cloud. Grow Your Business.";
         onRpc("/html_editor/link_preview_external", () => {
             expect.step("/html_editor/link_preview_external");
             return {
@@ -1040,73 +1079,79 @@ describe("links with inline image", () => {
         const { el } = await setupEditor(`<p>ab[cd<img src="${base64Img}">ef]g</p>`);
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit("#");
+        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
+            "http://test.test/"
+        );
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">cd<img src="${base64Img}">ef[]</a>g</p>`
+            `<p>ab<a href="http://test.test/">cd<img src="${base64Img}">ef[]</a>g</p>`
         );
     });
     test("can undo add link to inline image + text", async () => {
         const { editor, el } = await setupEditor(`<p>ab[cd<img src="${base64Img}">ef]g</p>`);
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit("#");
+        await contains(".o-we-linkpopover input.o_we_href_input_link", { timeout: 1500 }).edit(
+            "http://test.test/"
+        );
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">cd<img src="${base64Img}">ef[]</a>g</p>`
+            `<p>ab<a href="http://test.test/">cd<img src="${base64Img}">ef[]</a>g</p>`
         );
         undo(editor);
         await animationFrame();
         expect(cleanLinkArtifacts(getContent(el))).toBe(`<p>ab[cd<img src="${base64Img}">ef]g</p>`);
     });
     test("can remove link from an inline image", async () => {
-        const { el } = await setupEditor(`<p>ab<a href="#">cd<img src="${base64Img}">ef</a>g</p>`);
+        const { el } = await setupEditor(
+            `<p>ab<a href="http://test.test/">cd<img src="${base64Img}">ef</a>g</p>`
+        );
         await click("img");
         await waitFor(".o-we-toolbar");
         expect("button[name='unlink']").toHaveCount(1);
         await click("button[name='unlink']");
         await animationFrame();
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">cd[</a><img src="${base64Img}"><a href="#">]ef</a>g</p>`
+            `<p>ab<a href="http://test.test/">cd[</a><img src="${base64Img}"><a href="http://test.test/">]ef</a>g</p>`
         );
         await expectElementCount(".o-we-linkpopover", 0);
     });
     test("can remove link from a selection of an inline image + text", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c[d<img src="${base64Img}">e]f</a>g</p>`
+            `<p>ab<a href="http://test.test/">c[d<img src="${base64Img}">e]f</a>g</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>[d<img src="${base64Img}">e]<a href="#">f</a>g</p>`
+            `<p>ab<a href="http://test.test/">c</a>[d<img src="${base64Img}">e]<a href="http://test.test/">f</a>g</p>`
         );
     });
     test("can remove link from a selection (ltr) with multiple inline images", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c[d<img src="${base64Img}">e<img src="${base64Img}">f]g</a>h</p>`
+            `<p>ab<a href="http://test.test/">c[d<img src="${base64Img}">e<img src="${base64Img}">f]g</a>h</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>[d<img src="${base64Img}">e<img src="${base64Img}">f]<a href="#">g</a>h</p>`
+            `<p>ab<a href="http://test.test/">c</a>[d<img src="${base64Img}">e<img src="${base64Img}">f]<a href="http://test.test/">g</a>h</p>`
         );
     });
     test("can remove link from a selection (rtl) with multiple inline images", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c]d<img src="${base64Img}">e<img src="${base64Img}">f[g</a>h</p>`
+            `<p>ab<a href="http://test.test/">c]d<img src="${base64Img}">e<img src="${base64Img}">f[g</a>h</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>]d<img src="${base64Img}">e<img src="${base64Img}">f[<a href="#">g</a>h</p>`
+            `<p>ab<a href="http://test.test/">c</a>]d<img src="${base64Img}">e<img src="${base64Img}">f[<a href="http://test.test/">g</a>h</p>`
         );
     });
     test("can remove link from a selection (ltr) with multiple inline images acrossing different links", async () => {
         const { el } = await setupEditor(
-            `<p>ab<a href="#">c[d<img src="${base64Img}">e</a>xx<a href="#">f<img src="${base64Img}">g]h</a>i</p>`
+            `<p>ab<a href="http://test.test/">c[d<img src="${base64Img}">e</a>xx<a href="http://test.test/">f<img src="${base64Img}">g]h</a>i</p>`
         );
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-unlink");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p>ab<a href="#">c</a>[d<img src="${base64Img}">exxf<img src="${base64Img}">g]<a href="#">h</a>i</p>`
+            `<p>ab<a href="http://test.test/">c</a>[d<img src="${base64Img}">exxf<img src="${base64Img}">g]<a href="http://test.test/">h</a>i</p>`
         );
     });
     test("can remove link from a selection (rtl) with multiple inline images acrossing different links", async () => {
@@ -1119,8 +1164,10 @@ describe("links with inline image", () => {
             `<p>ab<a href="#">c</a>]d<img src="${base64Img}">exxf<img src="${base64Img}">g[<a href="#">h</a>i</p>`
         );
     });
-    test("link elelment should be removed and popover should close when image is deleted from a image link ", async () => {
-        const { el } = await setupEditor(`<p>ab<a href="#"><img src="${base64Img}">[]</a>c</p>`);
+    test("link element should be removed and popover should close when image is deleted from a image link", async () => {
+        const { el } = await setupEditor(
+            `<p>ab<a href="http://test.test/"><img src="${base64Img}"></a>c[]</p>`
+        );
         await click("img");
         await waitFor(".o-we-toolbar");
         await waitFor(".o-we-linkpopover");
@@ -1261,7 +1308,7 @@ describe("apply button should be disabled when the URL is empty", () => {
         expect(".o_we_apply_link").toHaveAttribute("disabled");
     });
     test("when URL on link is empty, the apply link button should be disabled (3)", async () => {
-        await setupEditor('<p>this is a <a href="exiting">li[]nk</a></p>');
+        await setupEditor('<p>this is a <a href="http://test.test/">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");
         await click(".o_we_edit_link");
         await contains(".o-we-linkpopover input.o_we_href_input_link").edit("");

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1204,7 +1204,7 @@ describe("links with inline image", () => {
 
 describe("readonly mode", () => {
     test("popover should not display edit buttons in readonly mode", async () => {
-        await setupEditor('<p><a class="o_link_readonly" href="#">link[]</a></p>');
+        await setupEditor('<p><a class="o_link_readonly" href="http://test.test/">link[]</a></p>');
         await waitFor(".o-we-linkpopover");
         // Copy link button should be available
         expect(".o-we-linkpopover .o_we_copy_link").toHaveCount(1);

--- a/addons/html_editor/static/tests/link/remove.test.js
+++ b/addons/html_editor/static/tests/link/remove.test.js
@@ -6,28 +6,28 @@ import { getContent, setSelection } from "../_helpers/selection";
 describe("range collapsed, remove by popover unlink button", () => {
     test("should remove the link if collapsed range at the end of a link", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="exist">bcd[]</a>e</p>',
+            contentBefore: '<p>a<a href="http://test.test/">bcd[]</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: "<p>abcd[]e</p>",
         });
         // With fontawesome at the start of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>bcd[]</a>e</p>',
+                '<p>a<a href="http://test.test/"><span class="fa fa-music" contenteditable="false">\u200B</span>bcd[]</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a<span class="fa fa-music"></span>bcd[]e</p>',
         });
         // With fontawesome at the middle of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">bc<span class="fa fa-music" contenteditable="false">\u200B</span>d[]</a>e</p>',
+                '<p>a<a href="http://test.test/">bc<span class="fa fa-music" contenteditable="false">\u200B</span>d[]</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>abc<span class="fa fa-music"></span>d[]e</p>',
         });
         // With fontawesome at the end of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">bcd[]<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
+                '<p>a<a href="http://test.test/">bcd[]<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>abcd[]<span class="fa fa-music"></span>e</p>',
         });
@@ -35,28 +35,28 @@ describe("range collapsed, remove by popover unlink button", () => {
 
     test("should remove the link if collapsed range in the middle a link", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="exist">b[]cd</a>e</p>',
+            contentBefore: '<p>a<a href="http://test.test/">b[]cd</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: "<p>ab[]cde</p>",
         });
         // With fontawesome at the start of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>b[]cd</a>e</p>',
+                '<p>a<a href="http://test.test/"><span class="fa fa-music" contenteditable="false">\u200B</span>b[]cd</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a<span class="fa fa-music"></span>b[]cde</p>',
         });
         // With fontawesome at the middle of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">b[]c<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
+                '<p>a<a href="http://test.test/">b[]c<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>ab[]c<span class="fa fa-music"></span>de</p>',
         });
         // With fontawesome at the end of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">b[]cd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
+                '<p>a<a href="http://test.test/">b[]cd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>ab[]cd<span class="fa fa-music"></span>e</p>',
         });
@@ -64,28 +64,28 @@ describe("range collapsed, remove by popover unlink button", () => {
 
     test("should remove the link if collapsed range at the start of a link", async () => {
         await testEditor({
-            contentBefore: '<p>a<a href="exist">[]bcd</a>e</p>',
+            contentBefore: '<p>a<a href="http://test.test/">[]bcd</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: "<p>a[]bcde</p>",
         });
         // With fontawesome at the start of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>[]bcd</a>e</p>',
+                '<p>a<a href="http://test.test/"><span class="fa fa-music" contenteditable="false">\u200B</span>[]bcd</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a<span class="fa fa-music"></span>[]bcde</p>',
         });
         // With fontawesome at the middle of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">[]bc<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
+                '<p>a<a href="http://test.test/">[]bc<span class="fa fa-music" contenteditable="false">\u200B</span>d</a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a[]bc<span class="fa fa-music"></span>de</p>',
         });
         // With fontawesome at the end of the link.
         await testEditor({
             contentBefore:
-                '<p>a<a href="exist">[]bcd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
+                '<p>a<a href="http://test.test/">[]bcd<span class="fa fa-music" contenteditable="false">\u200B</span></a>e</p>',
             stepFunction: unlinkFromPopover,
             contentAfter: '<p>a[]bcd<span class="fa fa-music"></span>e</p>',
         });
@@ -94,33 +94,34 @@ describe("range collapsed, remove by popover unlink button", () => {
     test("should remove only the current link if collapsed range in the middle of a link", async () => {
         await testEditor({
             contentBefore:
-                '<p><a href="exist">a</a>b<a href="exist">c[]d</a>e<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>b<a href="http://test.test/">c[]d</a>e<a href="http://test.test/">f</a></p>',
             stepFunction: unlinkFromPopover,
-            contentAfter: '<p><a href="exist">a</a>bc[]de<a href="exist">f</a></p>',
+            contentAfter:
+                '<p><a href="http://test.test/">a</a>bc[]de<a href="http://test.test/">f</a></p>',
         });
         // With fontawesome at the start of the link.
         await testEditor({
             contentBefore:
-                '<p><a href="exist">a</a>b<a href="exist"><span class="fa fa-music" contenteditable="false">\u200B</span>c[]d</a>e<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>b<a href="http://test.test/"><span class="fa fa-music" contenteditable="false">\u200B</span>c[]d</a>e<a href="http://test.test/">f</a></p>',
             stepFunction: unlinkFromPopover,
             contentAfter:
-                '<p><a href="exist">a</a>b<span class="fa fa-music"></span>c[]de<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>b<span class="fa fa-music"></span>c[]de<a href="http://test.test/">f</a></p>',
         });
         // With fontawesome at the middle of the link.
         await testEditor({
             contentBefore:
-                '<p><a href="exist">a</a>b<a href="exist">c<span class="fa fa-music" contenteditable="false">\u200B</span>d[]e</a>f<a href="exist">g</a></p>',
+                '<p><a href="http://test.test/">a</a>b<a href="http://test.test/">c<span class="fa fa-music" contenteditable="false">\u200B</span>d[]e</a>f<a href="http://test.test/">g</a></p>',
             stepFunction: unlinkFromPopover,
             contentAfter:
-                '<p><a href="exist">a</a>bc<span class="fa fa-music"></span>d[]ef<a href="exist">g</a></p>',
+                '<p><a href="http://test.test/">a</a>bc<span class="fa fa-music"></span>d[]ef<a href="http://test.test/">g</a></p>',
         });
         // With fontawesome at the end of the link.
         await testEditor({
             contentBefore:
-                '<p><a href="exist">a</a>b<a href="exist">c[]d<span class="fa fa-music" contenteditable="false">\u200B</span></a>e<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>b<a href="http://test.test/">c[]d<span class="fa fa-music" contenteditable="false">\u200B</span></a>e<a href="http://test.test/">f</a></p>',
             stepFunction: unlinkFromPopover,
             contentAfter:
-                '<p><a href="exist">a</a>bc[]d<span class="fa fa-music"></span>e<a href="exist">f</a></p>',
+                '<p><a href="http://test.test/">a</a>bc[]d<span class="fa fa-music"></span>e<a href="http://test.test/">f</a></p>',
         });
     });
 });
@@ -297,7 +298,7 @@ describe("range not collapsed", () => {
     });
     test("should be able to remove link if selection has FEFF character (2)", async () => {
         const { el } = await setupEditor(
-            '<p><a href="google.com" class="btn btn-primary">[]test</a></p>'
+            '<p><a href="http://test.test/" class="btn btn-primary">[]test</a></p>'
         );
         const link = el.querySelector("a");
         const firstFeffChar = link.firstChild;

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2624,7 +2624,8 @@ describe("link", () => {
 
         test("should replace link for new content when pasting in an empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#" oe-zws-empty-inline="">[]\u200B</a></p>',
+                contentBefore:
+                    '<p><a href="http://test.test/" oe-zws-empty-inline="">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc");
                 },
@@ -2633,7 +2634,8 @@ describe("link", () => {
         });
         test("should replace link for new content when pasting in an empty link (collapsed)(2)", async () => {
             await testEditor({
-                contentBefore: '<p>xy<a href="#" oe-zws-empty-inline="">\u200B[]</a>z</p>',
+                contentBefore:
+                    '<p>xy<a href="http://test.test/" oe-zws-empty-inline="">\u200B[]</a>z</p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc");
                 },
@@ -2643,7 +2645,7 @@ describe("link", () => {
 
         test("should replace link for new content (url) when pasting in an empty link (collapsed)", async () => {
             const { el, editor } = await setupEditor(
-                `<p>xy<a href="#" oe-zws-empty-inline="">\u200B[]</a>z</p>`
+                `<p>xy<a href="http://test.test/" oe-zws-empty-inline="">\u200B[]</a>z</p>`
             );
             pasteText(editor, "http://odoo.com");
             await animationFrame();
@@ -2654,9 +2656,11 @@ describe("link", () => {
         });
 
         test("should replace link for new content (imgUrl) when pasting in an empty link (collapsed) (1)", async () => {
-            const { el, editor } = await setupEditor(`<p>xy<a href="#">[]</a>z</p>`);
+            const { el, editor } = await setupEditor(
+                `<p>xy<a href="http://test.test/">[]</a>z</p>`
+            );
             expect(getContent(el)).toBe(
-                `<p>xy\ufeff<a href="#" class="o_link_in_selection">\ufeff[]</a>\ufeffz</p>`
+                `<p>xy\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]</a>\ufeffz</p>`
             );
             pasteText(editor, imgUrl);
             await animationFrame();
@@ -2669,7 +2673,7 @@ describe("link", () => {
 
         test("should replace link for new content (url) when pasting in an empty link (collapsed) (2)", async () => {
             const { el, editor } = await setupEditor(
-                `<p>xy<a href="#" oe-zws-empty-inline="">\u200B[]</a>z</p>`
+                `<p>xy<a href="http://test.test/" oe-zws-empty-inline="">\u200B[]</a>z</p>`
             );
             pasteText(editor, imgUrl);
             await animationFrame();
@@ -2687,14 +2691,14 @@ describe("link", () => {
 
         test("should paste and transform plain text content over an empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "abc www.odoo.com xyz");
                 },
                 contentAfter: '<p>abc <a href="http://www.odoo.com">www.odoo.com</a> xyz[]</p>',
             });
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteText(editor, "odoo.com\ngoogle.com");
                 },
@@ -2706,7 +2710,7 @@ describe("link", () => {
 
         test("should paste html content over an empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,
@@ -2719,7 +2723,7 @@ describe("link", () => {
         });
         test("should paste html content over an empty link (collapsed) (2)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">[]\u200B</a></p>',
+                contentBefore: '<p><a href="http://test.test/">[]\u200B</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(
                         editor,
@@ -2795,11 +2799,11 @@ describe("link", () => {
 
         test("should paste plain text inside non empty link (collapsed)", async () => {
             await testEditor({
-                contentBefore: '<p><a href="#">a[]b</a></p>',
+                contentBefore: '<p><a href="http://test.test/">a[]b</a></p>',
                 stepFunction: async (editor) => {
                     pasteHtml(editor, "<span>123</span>");
                 },
-                contentAfter: '<p><a href="#">a123[]b</a></p>',
+                contentAfter: '<p><a href="http://test.test/">a123[]b</a></p>',
             });
         });
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -928,7 +928,7 @@ test("toolbar should close on open link popover", async () => {
 
 test.tags("desktop");
 test("toolbar should close on edit link from preview", async () => {
-    await setupEditor(`<p><a href="#">[a]</a></p>`);
+    await setupEditor(`<p><a href="http://test.test/">[a]</a></p>`);
     await expectElementCount(".o-we-toolbar", 1);
     await click(".o-we-toolbar .fa-link");
     await waitFor(".o-we-linkpopover");

--- a/addons/website/static/tests/website_html_editor.test.js
+++ b/addons/website/static/tests/website_html_editor.test.js
@@ -35,6 +35,8 @@ test("autocomplete should shown and able to edit the link", async () => {
             ],
         };
     });
+    onRpc("/contactus", () => ({}));
+    onRpc("/html_editor/link_preview_internal", () => ({}));
 
     const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
 


### PR DESCRIPTION
This PR is backport of https://github.com/odoo/odoo/pull/216832 and https://github.com/odoo/odoo/pull/218587

Steps to reproduce:

- Open website builder
- Click on a link with a relative URL (there is /contactus in footer)
- Bug: the url shown is an absolute url (https://.../contactus)
- Click "Edit Link" (one of the icons)
- Click "Apply"
- Bug: the url in the dom has changed (it saved the absolute url)

The link popover used HTMLAnchorElement.href to get the url. This getter returns an absolute url even if the href attribute is a relative url.

task-4890293

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
