### PR TITLE
[FIX] website_{cf_turnstile,mass_mailing}: turnstile ok with newsletter


### DIFF
--- a/addons/website_cf_turnstile/static/src/interactions/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/interactions/turnstile.js
@@ -26,7 +26,7 @@ export class TurnStile {
         };
         // `this` is bound to the turnstile widget calling the callback
         globalThis.turnstileSuccess = function () {
-            const form = this.wrapper.closest("form");
+            const form = this.wrapper.closest("form") || this.wrapper.parentElement.parentElement;
             const buttons = form.querySelectorAll(".cf_form_disabled");
             for (const button of buttons) {
                 button.classList.remove("disabled", "cf_form_disabled");

--- a/addons/website_mass_mailing/static/src/interactions/subscribe.js
+++ b/addons/website_mass_mailing/static/src/interactions/subscribe.js
@@ -16,8 +16,10 @@ export class Subscribe extends Interaction {
         this._recaptcha = new ReCaptcha();
         this.notification = this.services['notification'];
         if (session.turnstile_site_key) {
-            const { turnStile } = odoo.loader.modules.get('@website_cf_turnstile/js/turnstile');
-            this._turnstile = turnStile;
+            const { TurnStile } = odoo.loader.modules.get(
+                "@website_cf_turnstile/interactions/turnstile"
+            );
+            this._turnstile = new TurnStile("website_mass_mailing_subscribe");
         }
     }
 
@@ -73,13 +75,12 @@ export class Subscribe extends Interaction {
         // When the website is in edit mode, window.top != window. We don't want turnstile to render during edit mode
         // and mess up the DOM and saving it.
         if (!isSubscriber && this._turnstile && window.top === window) {
-            const el = this._turnstile.addTurnstile('website_mass_mailing_subscribe');
-            if (el) {
-                this._turnstile.addSpinner(subscribeBtnEl);
-                el[0].classList.add('mt-3');
-                el.insertAfter(this.el);
-                this._turnstile.renderTurnstile(el);
-            }
+            const turnstileEl = this._turnstile.turnstileEl;
+            this._turnstile.constructor.disableSubmit(subscribeBtnEl);
+            turnstileEl.classList.add('mt-3');
+            this.el.appendChild(turnstileEl);
+            this._turnstile.insertScripts(this.el);
+            this._turnstile.render();
         }
     }
 


### PR DESCRIPTION
Forward-port of: 10550b3c7ad607576dc48eeba4d601184a2f90d4

Scenario:

- configure turnstile in setting
- install website_mass_mailing
- drop the newsletter widget in any page

Result:

In saas-18.3 and over, we get this traceback error and the turnstile
code is not working:

 TypeError: Cannot destructure property 'turnStile' of
 'odoo.loader.modules.get(...)' as it is undefined.

Cause:

- On January 2025, in saas-18.2 and over,
  421c5e5c4ee6271bb1085b43505cc1c28b2cb574 and
  22e777c046521f3f89b62caa5876680beb7f5aba rewrote turnstile
- On April 2025, in 17.0 up to master,
  c48e74f57569a1670fee65d65625488846513d79 uses addTurnstile and
  addSpinner method and the old file
- On April 2025, in saas-18.2 and only saas-18.2,
  10550b3c7ad607576dc48eeba4d601184a2f90d4 fixes turnstile for the
  interaction rewrite

So turnstile still cause an error  with the newsletter widget in
saas-18.3 up to master.

Fix: forward-port the saas-18.2 10550b3c7ad607576dc48eeba4d601184a2f90d4
fix in following versions.

opw-4925771
opw-4933957