### PR TITLE
[FIX] pos_self_order: synchronise data self order

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -722,6 +722,7 @@ export class SelfOrder extends Reactive {
                 });
                 openOrder.recomputeChanges();
             }
+            this.data.debouncedSynchronizeLocalDataInIndexedDB();
         } catch (error) {
             this.handleErrorNotification(
                 error,


### PR DESCRIPTION
If you paid for an order in self-order mode with an online payment method, then close the session and open a new one. The paid order would appear again in the self-order as not paid.

Steps to reproduce:
-------------------
* Setup a PoS with self-ordering and online payment method.
* Open mobile menu and create a new order.
* Add a product and pay for the order.
* Close the session and open a new one.
* Open mobile menu.
> Observation: The order you just paid for appears again.

Why the fix:
------------
When reading user data from server we should synchronise them with the indexedDB that still contains the old order that is not paid.

Note:
----------
I was not able to come up with a test because the indexedDB is not kept between 2 tours.

opw-4819672