### PR TITLE
[IMP] mail: keep composer when closing full composer

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -366,10 +366,10 @@ const chatterPatch = {
     },
 
     onCloseFullComposerCallback(isDiscard) {
-        this.toggleComposer();
         super.onCloseFullComposerCallback();
         if (!isDiscard) {
             this.reloadParentView();
+            this.toggleComposer();
         }
     },
 

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -732,6 +732,8 @@ export class Composer extends Component {
                             }
                         },
                     });
+                } else if (isDiscard) {
+                    this.saveContentAndUpdateComposer();
                 } else {
                     this.clear();
                 }
@@ -1015,27 +1017,43 @@ export class Composer extends Component {
         if (composer.restoredFromFullComposer && !this.state.isFullComposerOpen) {
             return;
         }
+        this._saveContent();
+    }
+
+    saveContentAndUpdateComposer() {
+        this._saveContent(true);
+    }
+
+    _saveContent(updateComposer = false) {
+        const composer = this.props.composer;
         const saveContentToLocalStorage = ({
             composerHtml,
             emailAddSignature,
             replyToMessageId,
             fromFullComposer = composer.restoredFromFullComposer,
         }) => {
+            if (updateComposer) {
+                if (!isHtmlEmpty(composerHtml)) {
+                    composer.composerHtml = composerHtml;
+                    composer.emailAddSignature = emailAddSignature;
+                }
+                if (Number.isInteger(replyToMessageId)) {
+                    composer.replyToMessage = this.store["mail.message"].insert(replyToMessageId);
+                }
+            }
             if (isHtmlEmpty(composerHtml)) {
                 browser.localStorage.removeItem(composer.localId);
-            } else {
-                browser.localStorage.setItem(
-                    composer.localId,
-                    JSON.stringify({
-                        emailAddSignature,
-                        replyToMessageId,
-                        composerHtml: isMarkup(composerHtml)
-                            ? ["markup", composerHtml]
-                            : composerHtml,
-                        fromFullComposer,
-                    })
-                );
+                return;
             }
+            browser.localStorage.setItem(
+                composer.localId,
+                JSON.stringify({
+                    emailAddSignature,
+                    replyToMessageId,
+                    composerHtml: isMarkup(composerHtml) ? ["markup", composerHtml] : composerHtml,
+                    fromFullComposer,
+                })
+            );
         };
         if (this.state.isFullComposerOpen) {
             this.fullComposerBus.trigger("SAVE_CONTENT", {

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -159,15 +159,6 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             run: "click",
         },
         {
-            content: "Click on Send Message",
-            trigger: "button:contains(Send message)",
-            run: "click",
-        },
-        {
-            content: "Check incite for click 'full composer' button (to restore formatting)",
-            trigger: ".o-mail-Composer button[title='Open Full Composer'].active",
-        },
-        {
             content: "Check full composer text is kept",
             trigger: ".o-mail-Composer-input:value(keep the content)",
         },
@@ -187,17 +178,6 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         {
             content: "Close full composer",
             trigger: ".btn-close",
-            run: "click",
-        },
-        {
-            content: "Click on Send Message",
-            trigger: "button:contains(Send message)",
-            run: "click",
-        },
-        {
-            content: "Continue Message Composition with Small Composer",
-            trigger:
-                ".o_popover:contains('Continue with Full Composer?') button:contains('No (Remove formatting)')",
             run: "click",
         },
         {

--- a/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
@@ -88,9 +88,8 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_html_compo
             run: "click",
         },
         {
-            content: "Click on Send Message",
-            trigger: "button:not(.active):contains(Send message)",
-            run: "click",
+            content: "Wait for content to be restored before checking formatting",
+            trigger: ".o-mail-Composer-html.odoo-editor-editable:contains(Hello)",
         },
         {
             content: "The italicized text is in the composer",

--- a/addons/web/static/src/views/view_button/view_button_hook.js
+++ b/addons/web/static/src/views/view_button/view_button_hook.js
@@ -105,7 +105,7 @@ export function useViewButtons(ref, options = {}) {
                 }
                 await options.afterExecuteAction?.(clickParams);
                 if (closeDialog) {
-                    closeDialog();
+                    closeDialog(clickParams);
                 }
                 if (error) {
                     return Promise.reject(error);


### PR DESCRIPTION
**Current behavior before PR**:

- Closing the full composer (via X button or discard) also closed the basic
  composer in the chatter, causing users to lose their draft content.
- The `closeDialog` callback in `view_button_hook` didn't pass `clickParams`,
  preventing the composer from properly distinguishing between dismiss,
  discard, and send actions.
- Draft content was not restored to the basic composer when discarding
  the full composer.

**Desired behavior after PR is merged**:

- The basic composer remains open when closing the full composer, allowing
  users to continue editing their draft.
- `closeDialog` now passes `clickParams` to the `onClose` callback, enabling
  proper action handling.
- When discarding the full composer (X button or discard), the draft content
  is automatically saved and restored to the basic composer.
- The basic composer only closes when a message is actually sent/logged
  from the full composer.
  
The implementation simplifies the previous `ACCIDENTAL_DISCARD` mechanism by
using a unified `saveContent` method that can update the composer state when
discarding, ensuring draft content is preserved.

task-[4780706](https://odoo.com/odoo/project/1519/tasks/4780706)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
