### PR TITLE
[FIX] mail: fix live chat pivot tour error

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_report_pivot_redirect_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_report_pivot_redirect_tour.js
@@ -3,21 +3,8 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("im_livechat_report_pivot_redirect_tour", {
     steps: () => [
         {
-            content: "open command palette",
-            trigger: "body:has(.o_action_manager)",
-            run: "click && press ctrl+k",
-        },
-        {
-            trigger: ".o_command_palette_search input",
-            run: "fill /Reporting",
-        },
-        {
-            trigger: ".o_command:contains(Agents)",
-            run: "click",
-        },
-        {
-            content: "click on a cell that has a single related record",
-            trigger: ".o_pivot table tbody tr:eq(2) td:eq(0)",
+            content: "Click on a cell with a single related record",
+            trigger: `.o_pivot table tbody tr:has(th:contains(operator_1)) td:eq(0)`,
             run: "click",
         },
         { trigger: ".o-mail-Discuss" },
@@ -27,8 +14,8 @@ registry.category("web_tour.tours").add("im_livechat_report_pivot_redirect_tour"
             run: "click",
         },
         {
-            content: "click on a cell that has more than one related record",
-            trigger: ".o_pivot table tbody tr:eq(0) td:eq(0)",
+            content: "Click on a cell with multiple related records",
+            trigger: `.o_pivot table tbody tr:has(th:contains(operator_2)) td:eq(0)`,
             run: "click",
         },
         { trigger: ".o_list_view" },

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -73,26 +73,29 @@ class TestImLivechatReport(TestImLivechatCommon):
     def test_redirect_to_form_from_pivot(self):
         operator_1 = new_test_user(self.env, login="operator_1", groups="im_livechat.im_livechat_group_manager")
         operator_2 = new_test_user(self.env, login="operator_2")
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {"name": "Support", "user_ids": [operator_1.id, operator_2.id]}
+        )
         [partner_1, partner_2] = self.env["res.partner"].create([{"name": "test 1"}, {"name": "test 2"}])
         [channel_1, channel_2, channel_3] = self.env["discuss.channel"].create(
             [{
                 "name": "test 1",
                 "channel_type": "livechat",
-                "livechat_channel_id": 1,
+                "livechat_channel_id": livechat_channel.id,
                 "livechat_operator_id": operator_1.partner_id.id,
                 "channel_member_ids": [Command.create({"partner_id": partner_1.id})],
             },
             {
                 "name": "test 2",
                 "channel_type": "livechat",
-                "livechat_channel_id": 1,
-                "livechat_operator_id": operator_1.partner_id.id,
+                "livechat_channel_id": livechat_channel.id,
+                "livechat_operator_id": operator_2.partner_id.id,
                 "channel_member_ids": [Command.create({"partner_id": partner_2.id})],
             },
             {
                 "name": "test 3",
                 "channel_type": "livechat",
-                "livechat_channel_id": 1,
+                "livechat_channel_id": livechat_channel.id,
                 "livechat_operator_id": operator_2.partner_id.id,
                 "channel_member_ids": [Command.create({"partner_id": partner_2.id})],
             }]
@@ -100,4 +103,9 @@ class TestImLivechatReport(TestImLivechatCommon):
         self._create_message(channel_1, operator_1.partner_id, "2025-06-26 10:05:00")
         self._create_message(channel_2, operator_1.partner_id, "2025-06-26 10:15:00")
         self._create_message(channel_3, operator_2.partner_id, "2025-06-26 10:25:00")
-        self.start_tour("/odoo", "im_livechat_report_pivot_redirect_tour", login="operator_1")
+        report_action = self.env.ref("im_livechat.im_livechat_report_channel_action")
+        self.start_tour(
+            f"/odoo/action-{report_action.id}?view_type=pivot",
+            "im_livechat_report_pivot_redirect_tour",
+            login="operator_1",
+        )


### PR DESCRIPTION
This commit fixes the `im_livechat_report_pivot_redirect_tour` that fails in 18.3. In later version, the pivot is directly accessed with the tour URL. In this version, the pivot is accessed from the command palette. Command palette steps makes the tour more complex than it should, remove them. The opportunity is taken to clean the test as well:
- Do not hardcode live chat channel id in the test setup.
- Better selectors to see what line we are clicking on at a glance (selector now includes record name).

fixes runbot-229637

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
