### PR TITLE
[IMP] web: store to ram the decrypt key to persist key

### DIFF
--- a/addons/web/static/src/core/network/rpc.js
+++ b/addons/web/static/src/core/network/rpc.js
@@ -21,7 +21,10 @@ export class RPCError extends Error {
 
 export class ConnectionLostError extends Error {
     constructor(url, ...args) {
-        super(`Connection to "${url}" couldn't be established or was interrupted`, ...args);
+        const message = url
+            ? `Connection to "${url}" couldn't be established or was interrupted`
+            : "Connection couldn't be established or was interrupted";
+        super(message, ...args);
         this.url = url;
     }
 }

--- a/addons/web/static/src/webclient/errors/offlineFailToFetchErrorHandler.js
+++ b/addons/web/static/src/webclient/errors/offlineFailToFetchErrorHandler.js
@@ -1,0 +1,22 @@
+import { ConnectionLostError } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+
+const errorHandlerRegistry = registry.category("error_handlers");
+
+/**
+ * @param {OdooEnv} env
+ * @param {UncaughError} error
+ * @param {Error} originalError
+ * @returns {boolean}
+ */
+export function offlineFailToFetchErrorHandler(env, error, originalError) {
+    if (["Failed to fetch", "Load failed"].includes(originalError.message)) {
+        Promise.resolve().then(() => {
+            throw new ConnectionLostError();
+        });
+        return true;
+    }
+}
+errorHandlerRegistry.add("offlineFailToFetchErrorHandler", offlineFailToFetchErrorHandler, {
+    sequence: 96,
+});

--- a/addons/web/static/src/webclient/user_menu/user_menu_items.js
+++ b/addons/web/static/src/webclient/user_menu/user_menu_items.js
@@ -127,6 +127,7 @@ function logOutItem(env) {
         description: _t("Log out"),
         href: `${browser.location.origin}${route}`,
         callback: () => {
+            browser.navigator.serviceWorker?.controller?.postMessage("user_logout");
             browser.location.href = route;
         },
         sequence: 70,


### PR DESCRIPTION
The goal of this commit is to ensure that both the 'persistent cache decryption key' and the '/odoo page' are stored in the service worker's cache. For obvious security reasons, these will not be stored in a persistent cache, but rather in the service worker's RAM. This enables the cache to be cleared when the service worker is stops.

In combination with the new persistence cache, this commit will allow the users to navigate to previously visited records and views if they lose their connection momentarily.

Please note that during this temporary loss of connection, users will not be able to edit anything or view records or views that have not been visited before.

task-4479842

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
