### PR TITLE
[FIX] website_cf_turnstile: no turnstile on extra step


### DIFF
--- a/addons/website_cf_turnstile/static/src/js/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/js/turnstile.js
@@ -156,6 +156,9 @@ publicWidget.registry.s_website_form.include({
      */
     start: function () {
         const res = this._super(...arguments);
+        if (this.$target[0].classList.contains('s_website_form_no_recaptcha')) {
+            return res;
+        }
         if (session.turnstile_site_key) {
             const button = this.el.querySelector(".s_website_form_send, .o_website_form_send");
             this.addSpinner(button);


### PR DESCRIPTION

Scenario:

- enable extra step in website ecommerce
- enable turnstile
- do the checkout process until after "extra step" step
- go check the sale order

Result: there is a big "turnstile_captcha: {1000 character hash}" that is
logged each time the customer filled the "extra step" step.

Cause:

turnstile if enabled is activated for all website_form and will add a
turnstile_captcha parameter.

For other website.form, the captcha is removed from the params when
calling:

request.env['ir.http']._verify_request_recaptcha_token('website_form')

but the custom route /website/form/shop.sale.order doesn't do that so
the captcha is logged in note.

Fix:

Recaptcha is already disabled on the extra_step with the class:
s_website_form_no_recaptcha, so it makes sense to just have the
same behavior for turnstile.

opw-4934132
