### PR TITLE
[FIX] pos_self_order: display background image on cart page

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.CartPage">
-        <div class="o_self_cart_page d-flex flex-column vh-100 overflow-hidden o_self_background o_self_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
+        <div class="o_self_cart_page d-flex flex-column vh-100 overflow-hidden o_self_background o_self_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImageUrl};background-size: cover; background-position: center;">
             <div class="d-flex flex-column flex-grow-1 overflow-y-auto pb-0 pb-sm-3 pt-3 py-lg-4" t-ref="scrollContainer">
                 <div class="d-flex justify-content-end px-3">
                     <button t-if="showCancelButton" t-on-click="() => this.cancelOrder()" class="btn btm-xs btn-secondary" type="button">


### PR DESCRIPTION
Before this commit, the custom background image was not displayed on the cart page because an outdated method was used. This commit resolves the issue by applying the correct method.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
