### PR TITLE
[FIX] pos_restaurant: correctly sync edited lines

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -733,6 +733,11 @@ export class PosOrderline extends Base {
     isSelected() {
         return this.order_id?.uiState?.selected_orderline_uuid === this.uuid;
     }
+
+    setDirty() {
+        super.setDirty();
+        this.order_id?.setDirty();
+    }
 }
 
 registry.category("pos_available_models").add(PosOrderline.pythonModel, PosOrderline);

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -171,6 +171,10 @@ export class Base extends WithLazyGetterTrap {
         }
     }
 
+    isDirty() {
+        return this.models.commands[this.model.modelName].update.has(this.id);
+    }
+
     setupState(vals) {
         this.uiState = vals;
     }

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -468,6 +468,9 @@ patch(PosStore.prototype, {
         if (order && !order.isBooked) {
             this.removeOrder(order);
         } else if (order) {
+            if (order.isDirty()) {
+                this.addPendingOrder([order.id]);
+            }
             if (!this.isOrderTransferMode) {
                 this.syncAllOrders();
             } else if (order && this.previousScreen !== "ReceiptScreen") {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -683,3 +683,145 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt_layout",
             },
         ].flat(),
 });
+
+function assertCurrentOrderDirty(dirty = true) {
+    return {
+        trigger: "body",
+        run() {
+            if (posmodel.getOrder().isDirty() !== dirty) {
+                throw new Error("Order should be " + (dirty ? "dirty" : "not dirty"));
+            }
+        },
+    };
+}
+
+registry.category("web_tour.tours").add("test_sync_lines_qty_update", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickLine("Coca-Cola"),
+            Chrome.waitRequest(), // Wait for sync request (the order is created)
+            assertCurrentOrderDirty(false),
+            Numpad.click("3"),
+            Order.hasLine({ productName: "Coca-Cola", quantity: 3 }),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+            FloorScreen.clickTable("5"),
+            ProductScreen.isShown(),
+            assertCurrentOrderDirty(false),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_sync_set_partner", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(), // Wait for sync request
+            assertCurrentOrderDirty(false),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Deco Addict"),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_sync_set_note", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(), // Wait for sync request
+            assertCurrentOrderDirty(false),
+            ProductScreen.isShown(),
+            ProductScreen.addInternalNote("Hello world"),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_sync_set_line_note", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(), // Wait for sync request
+            assertCurrentOrderDirty(false),
+            ProductScreen.isShown(),
+            ProductScreen.clickLine("Coca-Cola"),
+            ProductScreen.addInternalNote("Demo note"),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_sync_set_pricelist", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(), // Wait for sync request
+            assertCurrentOrderDirty(false),
+            ProductScreen.isShown(),
+            ProductScreen.clickLine("Coca-Cola"),
+            ProductScreen.clickPriceList("Restaurant Pricelist"),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_delete_line_release_table", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickLine("Coca-Cola"),
+            ProductScreen.selectedOrderlineHasDirect("Coca-Cola"),
+            ...["⌫", "⌫"].map(Numpad.click),
+            ProductScreen.releaseTable(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(),
+            negateStep(...Order.hasLine({ productName: "Coca-Cola" })),
+        ].flat(),
+});

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -58,3 +58,13 @@ export function setTab(name) {
         Dialog.confirm(),
     ];
 }
+
+export function releaseTable() {
+    return [
+        {
+            content: "release table",
+            trigger: ".product-screen .leftpane .unbook-table",
+            run: "click",
+        },
+    ];
+}

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -570,3 +570,39 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.write({'iface_tipproduct': True, 'tip_product_id': self.tip.id})
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_tip_after_payment')
+
+    def test_sync_lines_qty_update(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_lines_qty_update')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.lines[0].qty, 3)
+
+    def test_sync_set_partner(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_set_partner')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.partner_id.name, "Deco Addict")
+
+    def test_sync_set_note(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_set_note')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.internal_note, "Hello world")
+
+    def test_sync_set_line_note(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_set_line_note')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.lines[0].note, "Demo note")
+
+    def test_sync_set_pricelist(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_set_pricelist')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.pricelist_id.name, "Restaurant Pricelist")
+
+    def test_delete_line_release_table(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_delete_line_release_table')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(len(order.lines), 0)


### PR DESCRIPTION
Previously, changes made to an order did not trigger synchronization when navigating back to the floor screen.
These changes include:
•	Adding a note or customer note to a line or order
•	Setting a customer
•	Modifying quantity, price, or discount via the numpad
•	Setting a pricelist

This commit ensures the order is marked as dirty, which triggers the sync when returning to the floor screen.

task.4946929

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
