### PR TITLE
[FIX] l10n_in_edi: raise UserError on edi authentication failure

### DIFF
--- a/addons/l10n_in_edi/models/res_config_settings.py
+++ b/addons/l10n_in_edi/models/res_config_settings.py
@@ -29,8 +29,10 @@ class ResConfigSettings(models.TransientModel):
 
     def l10n_in_edi_test(self):
         self.l10n_in_check_gst_number()
-        self.env["account.edi.format"]._l10n_in_edi_authenticate(self.company_id)
-        if not self.company_id.sudo()._l10n_in_edi_token_is_valid():
+        response = self.env['account.edi.format']._l10n_in_edi_authenticate(self.company_id)
+        if response.get('error'):
+            raise UserError("\n".join(["[%s] %s" % (e.get('code'), (e.get('message'))) for e in response['error']]))
+        elif not self.company_id.sudo()._l10n_in_edi_token_is_valid():
             raise UserError(_("Incorrect username or password, or the GST number on company does not match."))
         return {
               'type': 'ir.actions.client',


### PR DESCRIPTION
Previously, the `UserError` raised on authentication failure did not include the error message returned by the IAP server.

In this commit:
---
- Added logic to extract and include detailed error messages with code from the IAP response in the `UserError` during authentication for e-invoicing.
    
Related Tickets:
---
opw-4908388
opw-4942744
opw-4946339
opw-4946193
opw-4933833
