### PR TITLE
[FIX] html_editor: click selection correction for links

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -278,6 +278,10 @@ export class SelectionPlugin extends Plugin {
     onTripleClick(ev) {
         const selectionData = this.getSelectionData();
         if (selectionData.documentSelectionIsInEditable) {
+            if (this.delegateTo("triple_click_overrides", ev)) {
+                // If the override is handled, we don't do anything.
+                return;
+            }
             const { documentSelection } = selectionData;
             const block = closestBlock(documentSelection.anchorNode);
             const [anchorNode, anchorOffset] = getDeepestPosition(block, 0);

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -215,8 +215,8 @@ export class SelectionPlugin extends Plugin {
             }
         });
         this.addDomListener(this.editable, "mousedown", (ev) => {
-            if (ev.detail === 2) {
-                this.correctDoubleClick = true;
+            if (ev.detail && ev.detail % 3 === 2) {
+                this.onDoubleClick(ev);
             }
             if (ev.detail && ev.detail % 3 === 0) {
                 this.onTripleClick(ev);
@@ -275,6 +275,16 @@ export class SelectionPlugin extends Plugin {
         this.activeSelection = this.makeActiveSelection();
     }
 
+    onDoubleClick(ev) {
+        const selectionData = this.getSelectionData();
+        if (selectionData.documentSelectionIsInEditable) {
+            if (this.delegateTo("double_click_overrides", ev)) {
+                // If the override is handled, we don't do anything.
+                return;
+            }
+        }
+    }
+
     onTripleClick(ev) {
         const selectionData = this.getSelectionData();
         if (selectionData.documentSelectionIsInEditable) {
@@ -299,31 +309,6 @@ export class SelectionPlugin extends Plugin {
         this.previousActiveSelection = this.activeSelection;
         // getSelectionData sets this.activeSelection to the current selection
         const selectionData = this.getSelectionData();
-        if (selectionData.documentSelectionIsInEditable && this.correctDoubleClick) {
-            this.correctDoubleClick = false;
-            const { anchorNode, anchorOffset, focusNode } = this.activeSelection;
-            const anchorElement = closestElement(anchorNode);
-            // Allow editing the text of a link after "double click" on the last word of said link.
-            // This is done by correcting the selection focus inside of the link
-            if (
-                anchorElement.tagName === "A" &&
-                anchorNode !== focusNode &&
-                focusNode.previousSibling === anchorElement
-            ) {
-                const anchorElementLength = anchorElement.childNodes.length;
-
-                // Due to the ZWS added around links we can always expect
-                // the last childNode to be a ZWS in its own textNode.
-                // therefore we can safely set the selection focus before last node.
-                const newSelection = {
-                    anchorNode: anchorNode,
-                    anchorOffset: anchorOffset,
-                    focusNode: anchorElement,
-                    focusOffset: anchorElementLength - 1,
-                };
-                return this.setSelection(newSelection);
-            }
-        }
         if (this.fixSelectionOnEditableRoot(selectionData)) {
             return;
         }

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -14,6 +14,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { isBlock, closestBlock } from "@html_editor/utils/blocks";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { FONT_SIZE_CLASSES } from "@html_editor/utils/formatting";
+import { isBrowserFirefox } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {import("@html_editor/core/selection_plugin").EditorSelection} EditorSelection
@@ -265,6 +266,7 @@ export class LinkPlugin extends Plugin {
         split_element_block_overrides: this.handleSplitBlock.bind(this),
         insert_line_break_element_overrides: this.handleInsertLineBreak.bind(this),
         delete_image_overrides: this.deleteImageLink.bind(this),
+        triple_click_overrides: this.tripleClickButtonOverrides.bind(this),
     };
 
     setup() {
@@ -1210,5 +1212,22 @@ export class LinkPlugin extends Plugin {
 
     isLinkImmutable(linkEl) {
         return this.getResource("immutable_link_selectors").some((s) => linkEl.matches(s));
+    }
+
+    tripleClickButtonOverrides(ev) {
+        const selection = this.dependencies.selection.getEditableSelection();
+        const buttonElement = isBrowserFirefox()
+            ? findInSelection(selection, "a.btn")
+            : closestElement(selection.anchorNode, "a.btn");
+        if (buttonElement) {
+            this.dependencies.selection.setSelection({
+                anchorNode: buttonElement,
+                anchorOffset: 0,
+                focusNode: buttonElement,
+                focusOffset: nodeSize(buttonElement),
+            });
+            ev.preventDefault();
+            return true;
+        }
     }
 }

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -266,6 +266,7 @@ export class LinkPlugin extends Plugin {
         split_element_block_overrides: this.handleSplitBlock.bind(this),
         insert_line_break_element_overrides: this.handleInsertLineBreak.bind(this),
         delete_image_overrides: this.deleteImageLink.bind(this),
+        double_click_overrides: this.doubleClickLinkOverrides.bind(this),
         triple_click_overrides: this.tripleClickButtonOverrides.bind(this),
     };
 
@@ -1212,6 +1213,55 @@ export class LinkPlugin extends Plugin {
 
     isLinkImmutable(linkEl) {
         return this.getResource("immutable_link_selectors").some((s) => linkEl.matches(s));
+    }
+
+    doubleClickLinkOverrides(ev) {
+        const clickedLink = closestElement(ev.target, "a");
+        // If we double click on a link, limit the selection inside the link
+        if (clickedLink) {
+            // mimic the double click behavior of browsers
+            this.dependencies.selection.modifySelection("extend", "backward", "word");
+            this.document.getSelection().collapseToStart();
+            this.dependencies.selection.modifySelection("extend", "forward", "word");
+
+            const { anchorNode, focusNode, anchorOffset, focusOffset } =
+                this.dependencies.selection.getEditableSelection();
+
+            // We reset the word selection of double click to be inside the current clicked link
+            // when it spreads over different links. Because it's a word selection, we need to keep
+            // the correct offsets when resetting.
+            if (clickedLink.contains(anchorNode) && !clickedLink.contains(focusNode)) {
+                this.dependencies.selection.setSelection({
+                    anchorNode,
+                    anchorOffset,
+                    focusNode: clickedLink,
+                    focusOffset: nodeSize(clickedLink) - 1, // -1 to avoid the FEFF char
+                });
+            } else if (!clickedLink.contains(anchorNode) && clickedLink.contains(focusNode)) {
+                this.dependencies.selection.setSelection({
+                    anchorNode: clickedLink,
+                    anchorOffset: 1, // 1 to avoid the FEFF char
+                    focusNode,
+                    focusOffset,
+                });
+            } else if (!clickedLink.contains(anchorNode) && !clickedLink.contains(focusNode)) {
+                this.dependencies.selection.setSelection({
+                    anchorNode: clickedLink,
+                    anchorOffset: 1, // 1 to avoid the FEFF char
+                    focusNode: clickedLink,
+                    focusOffset: nodeSize(clickedLink) - 1, // -1 to avoid the FEFF char
+                });
+            } else {
+                this.dependencies.selection.setSelection({
+                    anchorNode,
+                    anchorOffset,
+                    focusNode,
+                    focusOffset,
+                });
+            }
+
+            return true;
+        }
     }
 
     tripleClickButtonOverrides(ev) {

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { click, queryOne, queryAll, select, waitFor, waitForNone } from "@odoo/hoot-dom";
+import {
+    click,
+    queryOne,
+    queryAll,
+    select,
+    waitFor,
+    waitForNone,
+    manuallyDispatchProgrammaticEvent,
+} from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "../_helpers/editor";
 import { cleanLinkArtifacts, unformat } from "../_helpers/format";
@@ -234,6 +242,26 @@ describe("button edit", () => {
         await insertText(editor, "X");
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             '<p>this is a <a href="http://test.test/">X[]</a></p>'
+        );
+    });
+
+    test("triple click select should select the full button text", async () => {
+        const { el, editor } = await setupEditor(
+            '<p>this is a <a href="http://test.test/" class="btn btn-fill-primary">test b[]tn</a></p>'
+        );
+        const button = el.querySelector("a");
+        // simulate triple click selection
+        manuallyDispatchProgrammaticEvent(button, "mousedown", { detail: 3 });
+        await animationFrame();
+        expect(getContent(el)).toBe(
+            '<p>this is a \ufeff<a href="http://test.test/" class="btn btn-fill-primary">[\ufefftest btn\ufeff]</a>\ufeff</p>'
+        );
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.test/" class="btn btn-fill-primary">[test btn]</a></p>'
+        );
+        await insertText(editor, "X");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.test/" class="btn btn-fill-primary">X[]</a></p>'
         );
     });
 });

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -160,15 +160,15 @@ registerWebsitePreviewTour('edit_link_popover', {
     },
     {
         content: "Ensure that the link toolbar is opened",
-        trigger: ".o-we-toolbar",
+        trigger: ".o-we-toolbar button[name='link']",
     },
     {
         content: "Click on the link from toolbar",
-        trigger: ".o-we-toolbar button[name='link']",
+        trigger: ".o-we-toolbar",
         run: "click",
     },
     // 6. Test link popover link opens a new window in edit mode
-    ...openLinkPopup(":iframe footer a[href='/']", "Footer Home", 0, false),
+    ...openLinkPopup(":iframe footer a[href='/']", "Footer Home", 1, true),
     {
         content: "Ensure that a click on the link popover link opens a new window in edit mode",
         trigger: ".o-we-linkpopover a.o_we_url_link[target='_blank']",


### PR DESCRIPTION
Commit 1:
Reproduction:
1. triple click in a button and input something
2. the whole button is replaced

Before this commit:
On triple click we select the whole block by default

After this commit:
For buttons, when we triple click, we select the content of the button node

Commit 2:
[FIX] html_editor: limit word selecting of double click inside link

Before this commit: when two links or buttons are next to each other without a
space, double clicking the last word of the first link will spread the selection
over the second link's first word. This is the default of browser's behavior.

Reproduction:
1. create 2 links with different urls, one with label `test one`, second with
`test two`
2. double click the `one` of the first link, the selection will spread to the
second link. so `one` and `test` are both selected

After this commit:
We seperate the double click selection correction to the link plugin. Because
now we have the selection properly set inside the link without including the
feff characters, the previous fix of the selection isn't needed anymore.

task-4897848



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
