### PR TITLE
[IMP] core: depend on python3-magic in .deb

### DIFF
--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1254,7 +1254,7 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
         -> we don't want XML nor Octet-Stream files to be set as message_main_attachment
         """
         xml_attachment, octet_attachment, pdf_attachment = (
-            [('List1', b'<xml>My xml attachment</xml>')],
+            [('List1', b'<?xml version="1.0" ?><xml>My xml attachment</xml>')],
             [('List2', b'\x00\x01My octet-stream attachment\x03\x04')],
             [('List3', b'%PDF My pdf attachment')])
 

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -240,6 +240,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
         self.assertEqual(len(res), len(messages_all))
         for format_res, message, record in zip(res, messages_all, self.messages_records):
             self.assertEqual(len(format_res['attachment_ids']), 2)
+            self.maxDiff = None
             self.assertEqual(
                 format_res['attachment_ids'],
                 [
@@ -247,7 +248,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
                         'checksum': message.attachment_ids[0].checksum,
                         'filename': 'Test file 1',
                         'id': message.attachment_ids[0].id,
-                        'mimetype': 'application/octet-stream',
+                        'mimetype': 'text/plain',
                         'name': 'Test file 1',
                         'raw_access_token': message.attachment_ids[0]._get_raw_access_token(),
                         'res_id': record.id,
@@ -256,7 +257,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
                         'checksum': message.attachment_ids[1].checksum,
                         'filename': 'Test file 0',
                         'id': message.attachment_ids[1].id,
-                        'mimetype': 'application/octet-stream',
+                        'mimetype': 'text/plain',
                         'name': 'Test file 0',
                         'raw_access_token': message.attachment_ids[1]._get_raw_access_token(),
                         'res_id': record.id,

--- a/debian/control
+++ b/debian/control
@@ -42,6 +42,7 @@ Depends:
  python3-libsass,
 # After lxml 5.2, lxml-html-clean is in a separate package
  python3-lxml-html-clean | python3-lxml,
+ python3-magic
  python3-markupsafe,
  python3-num2words,
  python3-ofxparse,

--- a/odoo/addons/test_mimetypes/tests/test_guess_mimetypes.py
+++ b/odoo/addons/test_mimetypes/tests/test_guess_mimetypes.py
@@ -1,9 +1,10 @@
-# -*- coding: utf-8 -*-
 import os.path
+import unittest
 
-from odoo.tests.common import BaseCase
+from odoo.tests import BaseCase
+from odoo.tools.mimetypes import _odoo_guess_mimetype, guess_mimetype
 from odoo.tools.misc import file_open
-from odoo.tools.mimetypes import guess_mimetype
+
 
 def contents(extension):
     with file_open(os.path.join(
@@ -14,57 +15,93 @@ def contents(extension):
         return f.read()
 
 
-class TestMimeGuessing(BaseCase):
+class MimeGuessingCases:
+    allow_inherited_tests_method = True
+    guess_mimetype: callable
+
     def test_doc(self):
         self.assertEqual(
-            guess_mimetype(contents('doc')),
-            'application/msword'
+            self.guess_mimetype(contents('doc')),
+            'application/msword',
         )
+
     def test_xls(self):
         self.assertEqual(
-            guess_mimetype(contents('xls')),
-            'application/vnd.ms-excel'
+            self.guess_mimetype(contents('xls')),
+            'application/vnd.ms-excel',
         )
+
     def test_docx(self):
         self.assertEqual(
-            guess_mimetype(contents('docx')),
-            'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+            self.guess_mimetype(contents('docx')),
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         )
+
     def test_xlsx(self):
         self.assertEqual(
-            guess_mimetype(contents('xlsx')),
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+            self.guess_mimetype(contents('xlsx')),
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         )
+
     def test_odt(self):
         self.assertEqual(
-            guess_mimetype(contents('odt')),
-            'application/vnd.oasis.opendocument.text'
+            self.guess_mimetype(contents('odt')),
+            'application/vnd.oasis.opendocument.text',
         )
+
     def test_ods(self):
         self.assertEqual(
-            guess_mimetype(contents('ods')),
-            'application/vnd.oasis.opendocument.spreadsheet'
+            self.guess_mimetype(contents('ods')),
+            'application/vnd.oasis.opendocument.spreadsheet',
         )
 
     def test_zip(self):
         self.assertEqual(
-            guess_mimetype(contents('zip')),
-            'application/zip'
+            self.guess_mimetype(contents('zip')),
+            'application/zip',
         )
 
     def test_gif(self):
         self.assertEqual(
-            guess_mimetype(contents('gif')),
-            'image/gif'
-        )
-    def test_jpeg(self):
-        self.assertEqual(
-            guess_mimetype(contents('jpg')),
-            'image/jpeg'
+            self.guess_mimetype(contents('gif')),
+            'image/gif',
         )
 
-    def test_unknown(self):
+    def test_jpeg(self):
         self.assertEqual(
-            guess_mimetype(contents('csv')),
-            'text/plain'
+            self.guess_mimetype(contents('jpg')),
+            'image/jpeg',
+        )
+
+    def test_text(self):
+        self.assertEqual(
+            self.guess_mimetype(b"Some text with no special format.\n"),
+            'text/plain',
+        )
+
+    def test_unkown(self):
+        self.assertEqual(
+            self.guess_mimetype(b"\1\2\3\1\2\3\1\2\3\1\2\3\1\2\3"),
+            'application/octet-stream',
+        )
+
+
+class TestMimeGuessingOdoo(BaseCase, MimeGuessingCases):
+    guess_mimetype = staticmethod(_odoo_guess_mimetype)
+
+    def test_csv(self):
+        self.assertEqual(
+            self.guess_mimetype(contents('csv')),
+            'text/plain',
+        )
+
+
+@unittest.skipIf(guess_mimetype is _odoo_guess_mimetype, "python-magic not installed")
+class TestMimeGuessingMagic(BaseCase, MimeGuessingCases):
+    guess_mimetype = staticmethod(guess_mimetype)
+
+    def test_csv(self):
+        self.assertEqual(
+            self.guess_mimetype(contents('csv')),
+            'text/csv',
         )

--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -178,28 +178,9 @@ def _odoo_guess_mimetype(bin_data, default='application/octet-stream'):
 
 try:
     import magic
-except ImportError:
-    magic = None
-
-if magic:
-    # There are 2 python libs named 'magic' with incompatible api.
-    # magic from pypi https://pypi.python.org/pypi/python-magic/
-    if hasattr(magic, 'from_buffer'):
-        _guesser = functools.partial(magic.from_buffer, mime=True)
-    # magic from file(1) https://packages.debian.org/squeeze/python-magic
-    elif hasattr(magic, 'open'):
-        ms = magic.open(magic.MAGIC_MIME_TYPE)
-        ms.load()
-        _guesser = ms.buffer
-
     def guess_mimetype(bin_data, default=None):
-        mimetype = _guesser(bin_data[:1024])
-        # upgrade incorrect mimetype to official one, fixed upstream
-        # https://github.com/file/file/commit/1a08bb5c235700ba623ffa6f3c95938fe295b262
-        if mimetype == 'image/svg':
-            return 'image/svg+xml'
-        return mimetype
-else:
+        return magic.from_buffer(bin_data[:1024], mime=True)
+except ImportError:
     guess_mimetype = _odoo_guess_mimetype
 
 

--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -128,7 +128,7 @@ _mime_mappings = (
     _Entry('image/png', [b'\x89PNG\r\n\x1A\n'], []),
     _Entry('image/gif', [b'GIF87a', b'GIF89a'], []),
     _Entry('image/bmp', [b'BM'], []),
-    _Entry('application/xml', [b'<'], [
+    _Entry('text/xml', [b'<'], [
         _check_svg,
     ]),
     _Entry('image/x-icon', [b'\x00\x00\x01\x00'], []),

--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -180,10 +180,10 @@ try:
     import magic
     def guess_mimetype(bin_data, default=None):
         mimetype = magic.from_buffer(bin_data[:1024], mime=True)
-        # application/x-ole-storage is the generic file format that
-        # Microsoft Office was using before 2006, use our own check to
-        # further discriminate the mimetype.
-        if mimetype == 'application/x-ole-storage':
+        if mimetype in ('application/CDFV2', 'application/x-ole-storage'):
+            # Those are the generic file format that Microsoft Office
+            # was using before 2006, use our own check to further
+            # discriminate the mimetype.
             try:
                 if msoffice_mimetype := _check_olecf(bin_data):
                     return msoffice_mimetype

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,8 @@ pypiwin32 ; sys_platform == 'win32'
 pyserial==3.5
 python-dateutil==2.8.1 ; python_version < '3.11'
 python-dateutil==2.8.2 ; python_version >= '3.11'
+python-magic==0.4.24; sys_platform != 'win32' and python_version < '3.12'  # (jammy)
+python-magic==0.4.27; sys_platform != 'win32' and python_version >= '3.12'  # (noble)
 python-ldap==3.4.0 ; sys_platform != 'win32' and python_version < '3.12' # min version = 3.2.0 (Focal with security backports)
 python-ldap==3.4.4 ; sys_platform != 'win32' and python_version >= '3.12'  # (Noble) Mostly to have a wheel package
 python-stdnum==1.17 ; python_version < '3.11'  # (jammy)

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -38,6 +38,7 @@ RUN apt-get update -qq &&  \
         python3-libsass \
         python3-lxml \
         python3-lxml-html-clean \
+        python3-magic \
         python3-ofxparse \
         python3-openpyxl \
         python3-passlib \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -31,6 +31,7 @@ RUN dnf update -d 0 -e 0 -y && \
         python3-jinja2 \
         python3-libsass \
         python3-lxml \
+        python3-magic \
         python3-markupsafe \
         python3-mock \
         python3-num2words \


### PR DESCRIPTION
The python3-magic is a undeclared POSIX-only dependency used in odoo.tools.mimetypes to determine the mimetype of a file given its content.

It uses magic(5) as backend, which is not available on Windows.

When the library is missing, it fallbacks on our own (very bad) pure-python magic implementation, which fail to distinguate .xlsx and .zip files apart may the file be larger than 1kB.

The python-magic (pypi) and python3-magic (debian 12/ubuntu 22.04) now all have the functions we need, with the same API, and return `image/svg+xml` for svg files.

Enterprise: https://github.com/odoo/enterprise/pull/90400

#213647