### PR TITLE
[FIX] html_builder: use saved unit in number input value conversion

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -71,14 +71,14 @@ export class BuilderNumberInput extends Component {
     formatRawValue(rawValue) {
         return this.convertSpaceSplitValues(rawValue, (value) => {
             const unit = this.props.unit;
-            const saveUnit = this.props.saveUnit;
-            // Remove the unit
-            value = value.match(/[\d.e+-]+/g)[0];
-            if (saveUnit) {
+            const { savedValue, savedUnit } = value.match(
+                /(?<savedValue>[\d.e+-]+)(?<savedUnit>\w*)/
+            ).groups;
+            if (savedUnit) {
                 // Convert value from saveUnit to unit
                 value = convertNumericToUnit(
-                    value,
-                    saveUnit,
+                    savedValue,
+                    savedUnit || this.props.saveUnit,
                     unit,
                     getHtmlStyle(this.env.getEditingElement().ownerDocument)
                 );

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
@@ -578,6 +578,35 @@ describe("unit & saveUnit", () => {
         expect.verifySteps(["customAction 51"]);
         expect(":iframe .test-options-target").toHaveInnerHTML("51");
     });
+    test("should handle savedUnit", async () => {
+        addActionOption({
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerText;
+                }
+                apply({ editingElement, value }) {
+                    expect.step(`customAction ${value}`);
+                    editingElement.innerText = value;
+                }
+            },
+        });
+        addOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" unit="'s'" saveUnit="'ms'"/>`,
+        });
+        await setupWebsiteBuilder(`
+                    <div class="test-options-target">5s</div>
+                `);
+        await contains(":iframe .test-options-target").click();
+        expect(".options-container").toBeDisplayed();
+        await click(".options-container input");
+        const input = queryFirst(".options-container input");
+        expect(input).toHaveValue("5");
+        await fill("7");
+        expect.verifySteps(["customAction 57000ms"]);
+        expect(":iframe .test-options-target").toHaveInnerHTML("57000ms");
+    });
 });
 describe("sanitized values", () => {
     test("don't allow multi values by default", async () => {


### PR DESCRIPTION
When a value is converted to the used display unit, the builder number input only relies on the configured `saveUnit`. This is wrong when the existing value is not stored using that unit.

This commit uses the actual saved unit when converting saved values to the display unit.

Steps to reproduce:
- Go to Theme/Buttons
- Select "Outline" as "Primary Style"

=> "Border Width" indicates 16px while it is actually 1px, because it is interpreted as 1rem.

task-4367641
