### PR TITLE
[FIX] mail: Correctly update PopOut on props update

### DIFF
--- a/addons/mail/static/src/core/common/mail_popout_service.js
+++ b/addons/mail/static/src/core/common/mail_popout_service.js
@@ -233,10 +233,7 @@ export const mailPopoutService = {
             };
         }
 
-        return {
-            createManager,
-            ...createManager(),
-        };
+        return Object.assign(createManager(), { createManager });
     },
 };
 


### PR DESCRIPTION
Steps:
- Install  `account_accountant`
- Open bills
- Create two bills with two different PDF
- Go to list view, open first bill
- On the pager you have now 2 records (1/2)
- Click on the attachment_preview to open PDF in a PopOut
- Click on the next button in the pager
- PopOut is not updated (still with the first PDF)

since https://github.com/odoo/odoo/pull/214726

Before to this commit, the popout service returned an object containing `createManager` (which also contains useful getters such as `.id` and `.externalWindow` used to retrieve the window and communicate with it), and it also contains all createManager's methods using the following code:

```js
    return {
        createManager,
        ...createManager(), // ❌ Converts getters to static values
    };
```

But all that getters become obsolete as a copy of the object is made at that precise moment and so, for example, `externalWindow` will remain null forever instead of being re-evaluated each time it's accessed.

Since other parts of the code (such those in charge of updating the popout when props are updated) use `externalWindow`, this no longer worked at all, as it never detected an external window.

The solution (in stable) is to use this code instead:

```js
    const service = createManager();
    service.createManager = createManager;
    return service; // ✅ Preserves getters behavior
````
This ensures `externalWindow` getter is properly re-evaluated on each access and returns the current state of the external window.

In master a fix containing breaking changes will be made to improve the service.

opw-4948511