### PR TITLE
[FIX] account: fiscal position autodetect fail without vat

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -253,7 +253,7 @@ class AccountFiscalPosition(models.Model):
             return manual_fiscal_position
 
         # First search only matching VAT positions
-        vat_required = bool(partner.vat)
+        vat_required = bool(delivery.vat)
         fp = self._get_fpos_by_region(delivery.country_id.id, delivery.state_id.id, delivery.zip, vat_required)
 
         # Then if VAT required found no match, try positions that do not require it

--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -270,6 +270,15 @@ class TestFiscalPosition(common.TransactionCase):
             fp_eu_extra
         )
 
+        # Case : 7
+        # Billing (VAT/country) : None/US
+        # Delivery (VAT/country) : NL/NL
+        # Expected FP : Régime Intra-Communautaire
+        self.assertEqual(
+            self.env['account.fiscal.position']._get_fiscal_position(partner_us_no_vat, partner_nl_vat),
+            fp_eu_intra
+        )
+
     def test_fiscal_position_constraint(self):
         """
         Test fiscal position constraint by updating the record


### PR DESCRIPTION
In Fiscal position settings users may enable the "vat required" flag, allowing the fiscal position to be selected only when the partner record has vat.
However, this will make the fiscal position not automatically selected when a delivery partner has vat and the invoice partner has not.

Steps to reproduce:
- Create a Fiscal Position [TEST]:
  - Detect Automatically: True
  - VAT required: True
  - Country Group: Europe
- Create partners:
  - Partner A outside EU and no vat
  - Partner B within EU and vat
- Create an invoice with invoice partner A, delivery partner B

Issue:
Fiscal position [TEST] will not be choosen. Because the invoice partner has no vat, the system will look for fiscal positions without vat required.

This seems not correct as we use delivery partner data to search for fiscal position

opw-4813988
