### PR TITLE
[FIX] l10n_sa_edi: Fix exemption reason code

### DIFF
--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -1083,8 +1083,8 @@ msgstr "VATEX-SA-34-1 الشحن الدولي للبضائع."
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-2
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-2
-msgid "VATEX-SA-34-1 The international transport of Passengers."
-msgstr "VATEX-SA-34-1 المواصلات الدولية للركاب."
+msgid "VATEX-SA-34-2 The international transport of Passengers."
+msgstr "VATEX-SA-34-2 المواصلات الدولية للركاب."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-3

--- a/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
+++ b/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
@@ -1123,7 +1123,7 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-34-2
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-34-2
-msgid "VATEX-SA-34-1 The international transport of Passengers."
+msgid "VATEX-SA-34-2 The international transport of Passengers."
 msgstr ""
 
 #. module: l10n_sa_edi

--- a/addons/l10n_sa_edi/models/account_tax.py
+++ b/addons/l10n_sa_edi/models/account_tax.py
@@ -9,7 +9,7 @@ EXEMPTION_REASON_CODES = [
     ('VATEX-SA-32', 'VATEX-SA-32 Export of goods.'),
     ('VATEX-SA-33', 'VATEX-SA-33 Export of Services.'),
     ('VATEX-SA-34-1', 'VATEX-SA-34-1 The international transport of Goods.'),
-    ('VATEX-SA-34-2', 'VATEX-SA-34-1 The international transport of Passengers.'),
+    ('VATEX-SA-34-2', 'VATEX-SA-34-2 The international transport of Passengers.'),
     ('VATEX-SA-34-3', 'VATEX-SA-34-3 Services directly connected and incidental to a Supply of international passenger transport.'),
     ('VATEX-SA-34-4', 'VATEX-SA-34-4 Supply of a qualifying means of transport.'),
     ('VATEX-SA-34-5', 'VATEX-SA-34-5 Any services relating to Goods or passenger transportation, as defined in article twenty five of these Regulations.'),


### PR DESCRIPTION
The code for The international transport of Passengers was wrong. It was VATEX-SA-34-1 instead of VATEX-SA-34-2.
This commit fixes the code.

task-id: 4949581


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
