### PR TITLE
[FIX] {sale_,}purchase_stock: switch to MTS only mto product without seller

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -85,7 +85,7 @@ class StockRule(models.Model):
                     moves._action_cancel()
                 moves.procure_method = 'make_to_stock'
                 self._notify_responsible(procurement)
-                return
+                continue
 
             partner = supplier.partner_id
             # we put `supplier_info` in values for extensibility purposes

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -29,6 +29,11 @@ class TestSalePurchaseStockFlow(TransactionCase):
                 'partner_id': cls.vendor.id,
             })],
         })
+        cls.mto_product_without_seller = cls.env['product.product'].create({
+            'name': 'SuperProduct',
+            'is_storable': True,
+            'route_ids': [Command.set((cls.mto_route + cls.buy_route).ids)],
+        })
         cls.warehouse = cls.env['stock.warehouse'].create({
             'name': 'Other Warehouse',
             'code': 'OTH',
@@ -397,27 +402,45 @@ class TestSalePurchaseStockFlow(TransactionCase):
         self.assertEqual(po.order_line.price_unit, 5)
 
     def test_reservation_on_mto_product_after_po_cancellation(self):
-        """
-        Test that a reservation can be made on an MTO product after PO cancellation.
-        Create a sale order with an MTO product, confirm it, cancel the
-        related purchase order, and then check that the reservation can be done
-        on the picking move of the SO.
+        """Test that a reservation can be made on an MTO product after its purchase order is cancelled.
+        - Create a sale order with two MTO products: one with a seller and one without.
+        - Confirm the SO: only the product with a vendor should trigger a purchase order.
+        - Cancel the generated purchase order.
+        - The MTO product should switch to MTS (Make to Stock), allowing reservation.
         """
         sale_order = self.env['sale.order'].create({
             'partner_id': self.customer.id,
-            'order_line': [Command.create({
-                'product_id': self.mto_product.id,
-                'product_uom_qty': 1,
-            })],
+            'order_line': [
+                Command.create({
+                    'product_id': self.mto_product.id,
+                    'product_uom_qty': 1,
+                }),
+                Command.create({
+                    'product_id': self.mto_product_without_seller.id,
+                    'product_uom_qty': 1,
+                }),
+            ],
         })
         sale_order.action_confirm()
         self.assertEqual(sale_order.state, 'sale')
         self.assertEqual(sale_order.picking_ids.state, 'waiting')
-        self.assertEqual(sale_order.picking_ids.move_ids.quantity, 0)
+
+        mto_move = sale_order.picking_ids.move_ids.filtered(lambda m: m.product_id == self.mto_product)
+        self.assertEqual(mto_move.quantity, 0)
+        self.assertEqual(mto_move.procure_method, 'make_to_order')
+        # As the MTO product has no seller, it should be switched to MTS
+        mto_move_without_seller = sale_order.picking_ids.move_ids - mto_move
+        self.assertEqual(mto_move_without_seller.quantity, 0)
+        self.assertEqual(mto_move_without_seller.procure_method, 'make_to_stock')
+        # Cancel the purchase order related to the MTO product
         purchase_order = sale_order._get_purchase_orders()
+        self.assertEqual(purchase_order.state, 'draft')
         purchase_order.button_cancel()
         self.assertEqual(purchase_order.state, 'cancel')
+        # The MTO product should now be in MTS
+        self.assertEqual(sale_order.picking_ids.move_ids.mapped('procure_method'), ['make_to_stock', 'make_to_stock'])
         # update the quantity on hand of the MTO product
         self.env['stock.quant']._update_available_quantity(self.mto_product, sale_order.picking_ids.move_ids.location_id, 1)
         sale_order.picking_ids.action_assign()
-        self.assertEqual(sale_order.picking_ids.move_ids.quantity, 1)
+        self.assertEqual(mto_move.quantity, 1)
+        self.assertEqual(mto_move.procure_method, 'make_to_stock')


### PR DESCRIPTION
Bug introduced in: https://github.com/odoo/odoo/commit/eb26262f17cf0c828e8fdf03a8e2f916e3619d81

Steps to reproduce the bug:
- Create two storable products:
    - P1: 
        - Routes: Make To Order (MTO) + Buy - Vendor: Azure Interior
    - P2:
        - Routes: Make To Order (MTO) + Buy
        - No vendor defined

- Create a sales order with one unit of P1 and one unit of P2
- Confirm the SO

Problem:
The stock move for P2 is created with the procurement method Make To
Stock (MTS), while P1 uses Make To Order. but the purchase order for P1
is not created, because When processing P2 the `run_buy`, a return
occurs and  function is stopped instead of continuing to process
the other moves/flow.

Solution:
Ensure that the absence of a vendor for MTO+Buy products only causes a fallback to MTS and notify responsible, without breaking the processing of other moves.

opw-4945468
