### PR TITLE
[FIX] base,website: views don't prefetch restricted fields


### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -661,7 +661,7 @@ actual arch.
         where_clause = query.where_clause
         assert query.from_clause == SQL.identifier('ir_ui_view'), f"Unexpected from clause: {query.from_clause}"
 
-        field_names = [f.name for f in self._fields.values() if f.prefetch is True]
+        field_names = [f.name for f in self._fields.values() if f.prefetch is True and not f.groups]
         aliased_names = SQL(', ').join(
             SQL("%s AS %s", self._field_to_sql('ir_ui_view', name), SQL.identifier(name))
             for name in field_names


### PR DESCRIPTION
Scenario:

- get a user with "Editor and Designer" and no admin rights
- with this user, edit the website and change the menu bar

Result:

A traceback error is shown with this access error the logs:

 You do not have enough rights to access the field "visibility_password"
 on View (ir.ui.view). Please contact your system administrator.
 Operation: read
 Groups: allowed for groups 'Role / Administrator'

Issue:

In 9830f77d827c6efeb5f796caac604904350f5a80 the method
ir.ui.view()._get_combined_archs was changed to prefetch more fields
than before, but prefetching the "visibility_password" field was causing
an access error when checking if we had access to it.

Fix: prevent prefetching restricted fields.

Note: the added test without the fix, fails because of the security
warning error, and having the custom view still disabled.

opw-4935489
