### PR TITLE
[FIX] html_builder: avoid overriding all adopted stylesheets

### DIFF
--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -438,7 +438,9 @@ export function setBuilderCSSVariables(htmlStyle) {
         styles.push(`--hb-cp-${style}: ${value};`);
     }
     builderStylesheet.replaceSync(`html { ${styles.join(" ")} }`);
-    window.top.document.adoptedStyleSheets = [builderStylesheet];
+    if (!window.top.document.adoptedStyleSheets.find((style) => style === builderStylesheet)) {
+        window.top.document.adoptedStyleSheets.push(builderStylesheet);
+    }
 }
 
 export function parseBoxShadow(value) {


### PR DESCRIPTION
Commit [1] used the `adoptedStyleSheets` property, but overrides it every time `setBuilderCSSVariables` is called. This means the document can never have more than one adopted stylesheet, and it will override stylesheets adopted either on other parts of the code (Odoo codebase, custom code) or from outside (browser extensions). By pushing it once and updating the same stylesheet on subsequent calls, we avoid potential clashes.

[1]: https://github.com/odoo/odoo/commit/4cf0b7c51dadd05433c4d77222b65aafad39269b