### PR TITLE
[FIX] point_of_sale: allow proper closing of multiple sessions

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -96,7 +96,7 @@ class PosSession(models.Model):
     def write(self, vals):
         if vals.get('state') == 'closed':
             for record in self:
-                record.config_id._notify(('CLOSING_SESSION', {'login_number': self.env.context.get('login_number', False), 'session_id': self.id}))
+                record.config_id._notify(('CLOSING_SESSION', {'login_number': self.env.context.get('login_number', False), 'session_id': record.id}))
         return super().write(vals)
 
     @api.model


### PR DESCRIPTION
This commit ensures that multiple sessions can be closed without errors by using each record’s ID within the recordset.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
