### PR TITLE
[FIX] l10n_it_edi: correctly assign TD01 document type from XML import

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -793,7 +793,7 @@ class AccountMove(models.Model):
     def _l10n_it_edi_document_type_mapping(self):
         """ Returns a dictionary with the required features for every TDxx FatturaPA document type """
         return {
-            'TD01': {'move_types': ['out_invoice'],
+            'TD01': {'move_types': ['in_invoice', 'out_invoice'],
                      'import_type': 'in_invoice',
                      'self_invoice': False,
                      'simplified': False,

--- a/addons/l10n_it_edi/tests/test_account_move_document_type.py
+++ b/addons/l10n_it_edi/tests/test_account_move_document_type.py
@@ -39,3 +39,13 @@ class TestItAccountMoveDocumentType(TestItEdi):
         reversal_wizard.modify_moves()
         credit_note_y = invoice_y.reversal_move_ids[0]
         self.assertEqual(credit_note_y.l10n_it_document_type, dt_credit_note)
+
+    def test_td01_assigned_on_posted_in_invoice(self):
+        """Test that TD01 is correctly assigned to an in_invoice after posting."""
+        dt_invoice = self.env.ref('l10n_it_edi.l10n_it_document_type_01')
+
+        invoice_x = self.init_invoice("in_invoice", amounts=[1000])
+        self.assertFalse(invoice_x.l10n_it_document_type)
+
+        invoice_x.action_post()
+        self.assertEqual(invoice_x.l10n_it_document_type, dt_invoice)


### PR DESCRIPTION
**Issue**
When importing an XML invoice of document type TD01, it is incorrectly assigned type TD05 after processing.

**Steps to Reproduce**
1. Install Accounting, l10n_it and l10n_it_edi
2. Go to Accounting > Vendors > Vendor Bills
3. Upload an XML invoice with TD01 as the document type
4. Upon confirming the bill, observe that the document type is incorrectly set to TD05

**Root Cause**
The document type matching logic fails to assign TD01 because the uploaded invoice has move_type = in_invoice, while TD01 was only configured to match out_invoice. https://github.com/odoo-dev/odoo/blob/7436e8cee2f605c6d5d559cb410e7a3dc8f372b9/addons/l10n_it_edi/models/account_move.py#L886-L891

**Fix**
According to Italian e-invoicing specifications, TD01 applies to both sales and purchase invoices ("Fatture di vendita" and "Fatture d’acquisto"). To reflect this, in_invoice is now added to the list of supported move_types for TD01, allowing correct detection during XML import.

opw-4931438
