### PR TITLE
[FIX] {test_,}website: avoid restricted page in search result


### DIFF
--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -19,14 +19,21 @@ class TestAutoComplete(TransactionCase):
         cls.website = cls.env['website'].browse(1)
         cls.WebsiteController = Website()
 
-    def _autocomplete(self, term, expected_count, expected_fuzzy_term):
+    def _autocomplete(self, term, expected_count, expected_fuzzy_term, search_type="test", options=None):
         """ Calls the autocomplete for a given term and performs general checks """
         with MockRequest(self.env, website=self.website):
             suggestions = self.WebsiteController.autocomplete(
-                search_type="test", term=term, max_nb_chars=50, options={},
+                search_type=search_type, term=term, max_nb_chars=50, options=options or {},
             )
         self.assertEqual(expected_count, suggestions['results_count'], "Wrong number of suggestions")
         self.assertEqual(expected_fuzzy_term, suggestions.get('fuzzy_search', 'Not found'), "Wrong fuzzy match")
+
+    def _autocomplete_page(self, term, expected_count, expected_fuzzy_term):
+        self._autocomplete(term, expected_count, expected_fuzzy_term, search_type="pages", options={
+            'displayDescription': False, 'displayDetail': False,
+            'displayExtraDetail': False, 'displayExtraLink': False,
+            'displayImage': False, 'allowFuzzy': True
+        })
 
     def test_01_many_records(self):
         # REF1000~REF3999
@@ -96,3 +103,37 @@ class TestAutoComplete(TransactionCase):
                     'displayImage': False, 'allowFuzzy': True
                 }
             )
+
+        test_page = self.env.ref('test_website.test_page')
+        test_page.name = 'testTotallyUnique'
+
+        # Editor and Designer see pages in result
+        self._autocomplete_page('testTotallyUnique', 1, False)
+
+        test_page.visibility = 'connected'
+        self._autocomplete_page('testTotallyUnique', 1, False)
+        test_page.visibility = False
+
+        test_page.groups_id = self.env.ref('base.group_public')
+        self._autocomplete_page('testTotallyUnique', 1, False)
+        test_page.groups_id = False
+
+        # Public user don't see restricted page
+        self.website.env = self.env = self.env(user=self.website.user_id)
+        self._autocomplete_page('testTotallyUnique', 0, "Not found")
+
+        test_page.website_indexed = True
+        self._autocomplete_page('testTotallyUnique', 1, False)
+
+        test_page.groups_id = self.env.ref('base.group_system')
+        self._autocomplete_page('testTotallyUnique', 0, "Not found")
+
+        test_page.groups_id = self.env.ref('base.group_public')
+        self._autocomplete_page('testTotallyUnique', 1, False)
+        test_page.groups_id = False
+
+        test_page.visibility = 'password'
+        self._autocomplete_page('testTotallyUnique', 0, "Not found")
+
+        test_page.visibility = 'connected'
+        self._autocomplete_page('testTotallyUnique', 0, "Not found")


### PR DESCRIPTION
Searching for pages on a website requires sudo. Because of this the ACL
and visibility criteria checks are not applied on the delivered results,
making pages with restricted visibility returned in the results.

Scenario:

- add a search widget on the website
- restrict a page to a given group
- search terms of that page with a user without that group

Result: the page is shown in the search results.

Fix:

handle visibility criteria the same way as we do it in the
ir.ui.view()._handle_visibility method, and prevent showing unaccessible
pages in the autocomplete results.

Also adds access rule checks to ensure custom ACLs are taken into
account.

This commit also fixes:
- the lack of filtering when using an empty search term
- filtering out the non indexed pages

opw-3964793
opw-4930197