### PR TITLE
[IMP] account: modify invisible for iso and clarify text

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -78,8 +78,9 @@ class AccountPayment(models.Model):
         "Payment Providers: Each payment provider has its own Payment Method. Request a transaction on/to a card thanks to a payment token saved by the partner when buying or subscribing online.\n"
         "Check: Pay bills by check and print it from Odoo.\n"
         "Batch Deposit: Collect several customer checks at once generating and submitting a batch deposit to your bank. Module account_batch_payment is necessary.\n"
-        "SEPA Credit Transfer: Pay in the SEPA zone by submitting a SEPA Credit Transfer file to your bank. Module account_sepa is necessary.\n"
-        "SEPA Direct Debit: Get paid in the SEPA zone thanks to a mandate your partner will have granted to you. Module account_sepa is necessary.\n")
+        "SEPA Credit Transfer: Pay in the SEPA zone by submitting a SEPA Credit Transfer file to your bank. Module account_iso20022 is necessary.\n"
+        "SEPA Direct Debit: Get paid in the SEPA zone thanks to a mandate your partner will have granted to you. Module account_iso20022 is necessary.\n"
+        "U.S. ISO20022: Pay in the US by submitting an ISO20022 file to your bank. Module account_iso20022 is necessary.\n")
     available_payment_method_line_ids = fields.Many2many('account.payment.method.line',
         compute='_compute_payment_method_line_fields')
     payment_method_id = fields.Many2one(

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -233,9 +233,8 @@
                                 documentation="/applications/finance/accounting/payables/pay/check.html">
                                 <field name="module_account_check_printing"/>
                             </setting>
-                            <setting id="sepa_payments" title="If you check this box, you will be able to register your payment using SEPA." company_dependent="1" help="Pay your bills in one-click using Euro SEPA Service"
-                                documentation="/applications/finance/accounting/payables/pay/sepa.html"
-                                invisible="'SEPA' not in company_country_group_codes">
+                            <setting id="sepa_payments" title="If you check this box, you will be able to register your payment using SEPA / ISO20022." company_dependent="1" help="Pay your bills in one-click using Euro SEPA Service / ISO20022"
+                                documentation="/applications/finance/accounting/payables/pay/sepa.html">
                                 <field name="module_account_iso20022" widget="upgrade_boolean"/>
                             </setting>
                         </block>


### PR DESCRIPTION
Import settings for ISO transfers are hidden in settings behind the SEPA country group, however with US banks starting to implement ISO 20022 across the board we needed a new condition to support it. As such the invisible condition has been tweaked to add the country and the text has been clarified to show that it is no longer just for SEPA transfers but others as well.

In addition, this PR has updated the tooltip for payment_method_line_id on account.payment to refer to the new method type and updated the module name as account_sepa no longer exists.

task-4939347
