### PR TITLE
[IMP] html_editor,marketing_card,mrp,mrp_subcontracting,*: remove href="#"

### DIFF
--- a/addons/html_editor/static/src/components/history_dialog/history_dialog.xml
+++ b/addons/html_editor/static/src/components/history_dialog/history_dialog.xml
@@ -8,30 +8,28 @@
             <div class="d-flex flex-column h-100 overflow-hidden">
                 <ul class="nav nav-tabs d-md-none flex-shrink-0" role="tablist">
                     <li class="nav-item flex-grow-1">
-                        <a
-                            href="#"
+                        <button
                             id="tab-revisions"
-                            class="nav-link position-relative text-center fw-bold"
+                            class="nav-link position-relative text-center fw-bold w-100"
                             t-att-class="{'active': state.mobileActiveTab === 'revisions'}"
                             t-on-click.prevent="() => this.setMobileTab('revisions')"
                             role="tab"
                             aria-controls="revisions-panel"
                             t-att-aria-selected="state.mobileActiveTab === 'revisions' ? 'true' : 'false'">
                             <i class="fa fa-list me-1" role="img" aria-hidden="true"/>Revisions
-                        </a>
+                        </button>
                     </li>
                     <li class="nav-item flex-grow-1">
-                        <a
-                            href="#"
+                        <button
                             id="tab-preview"
-                            class="nav-link position-relative text-center fw-bold"
+                            class="nav-link position-relative text-center fw-bold w-100"
                             t-att-class="{'active': state.mobileActiveTab === 'content'}"
                             t-on-click.prevent="() => this.setMobileTab('content')"
                             role="tab"
                             aria-controls="content-panel"
                             t-att-aria-selected="state.mobileActiveTab === 'content' ? 'true' : 'false'">
                             <i class="fa fa-eye me-1" role="img" aria-hidden="true"/>Preview
-                        </a>
+                        </button>
                     </li>
                 </ul>
 

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -170,27 +170,27 @@
                         </span>
                         <div class="ms-1 w-100">
                             <div class="d-flex">
-                                <a href="#" target="_blank" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" style="max-width: 160px;" t-attf-title="{{state.urlTitle}}">
+                                <a target="_blank" t-attf-href="{{state.url}}" class="o_we_url_link fw-bold flex-grow-1 text-truncate" style="max-width: 160px;" t-attf-title="{{state.urlTitle}}">
                                     <t t-esc="state.urlTitle"/>
                                 </a>
                                 <div class="flex-grow-1 d-flex justify-content-end gap-2">
-                                    <a href="#" class="o_we_replace_title_btn text-dark"
+                                    <button class="o_we_replace_title_btn text-dark border-0 bg-transparent p-0"
                                         t-if="!state.isImage and state.urlTitle and state.label === '' and !state.showReplaceTitleBanner"
                                         t-on-click="onClickReplaceTitle"
                                         title="Replace URL with its title"
                                     >
                                         <i class="fa fa-magic"></i>
-                                    </a>
-                                    <a href="#" class="o_we_copy_link text-dark" t-on-click="onClickCopy" title="Copy Link">
+                                    </button>
+                                    <button class="o_we_copy_link text-dark border-0 bg-transparent p-0" t-on-click="onClickCopy" title="Copy Link">
                                         <i class="fa fa-clipboard"></i>
-                                    </a>
+                                    </button>
                                     <t t-if="props.canEdit">
-                                        <a href="#" class="o_we_edit_link text-dark" t-on-click="onClickEdit" title="Edit Link">
+                                        <button class="o_we_edit_link text-dark border-0 bg-transparent p-0" t-on-click="onClickEdit" title="Edit Link">
                                             <i class="fa fa-edit"></i>
-                                        </a>
-                                        <a href="#" t-if="props.canRemove" class="o_we_remove_link text-dark" t-on-click="onClickRemove" title="Remove Link">
+                                        </button>
+                                        <button t-if="props.canRemove" class="o_we_remove_link text-dark border-0 bg-transparent p-0" t-on-click="onClickRemove" title="Remove Link">
                                             <i class="fa fa-chain-broken"></i>
-                                        </a>
+                                        </button>
                                     </t>
                                 </div>
                             </div>
@@ -203,7 +203,7 @@
                         </div>
                     </div>
                     <div t-if="state.imgSrc" class="o_extra_info_card" style="align-self: center; max-width: 235px">
-                            <a href="#" target="_blank" t-attf-href="{{state.url}}" title="Open in a new tab">
+                            <a target="_blank" t-attf-href="{{state.url}}" title="Open in a new tab">
                                 <img t-att-src="state.imgSrc" class="img-fluid mb-1" style="max-width: 230; max-height: 100%;"/>
                             </a>
                     </div>

--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.scss
@@ -12,7 +12,7 @@ $embedded-toc-bg--active: #1ba1e4;
     & .o_embedded_toc_content {
         background-color: $o-view-background-color;
 
-        a[class*="o_embedded_toc_link_depth_"] {
+        button[class*="o_embedded_toc_link_depth_"] {
             font-family: $font-family-base !important;
             border-radius: 5px;
             min-height: $line-height-base * $font-size-base;
@@ -25,13 +25,13 @@ $embedded-toc-bg--active: #1ba1e4;
 
         }
 
-        a.o_embedded_toc_link_depth_0 {
+        button.o_embedded_toc_link_depth_0 {
             // initial 5px padding to give some space to first level
             padding-left: 5px;
         }
 
         @for $depth from 1 through 5 {
-            a.o_embedded_toc_link_depth_#{$depth} {
+            button.o_embedded_toc_link_depth_#{$depth} {
                 padding-left: calc(5px + Min(30px, 10%) * #{$depth});
             }
         }

--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.xml
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content.xml
@@ -10,10 +10,10 @@
         </div>
         <div t-if="!state.folded" class="o_embedded_toc_content">
             <t t-foreach="this.state.toc.headings" t-as="heading" t-key="heading_index">
-                <a href="#" contenteditable="false"
+                <button contenteditable="false"
                     t-out="heading.name"
                     t-on-click.prevent="() => this.onTocLinkClick(heading)"
-                    t-attf-class="o_no_link_popover py-1 pe-1 d-block text-reset o_embedded_toc_link #{'o_embedded_toc_link_depth_' + heading.depth}"/>
+                    t-attf-class="o_no_link_popover py-1 pe-1 d-block text-reset w-100 btn btn-link text-start fw-normal o_embedded_toc_link #{'o_embedded_toc_link_depth_' + heading.depth}"/>
             </t>
         </div>
     </div>

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -985,7 +985,7 @@ test("link preview in Link Popover", async () => {
     setSelectionInHtmlField(".test_target a");
     await animationFrame();
     // Click on the edit link icon
-    await contains("a.o_we_edit_link").click();
+    await contains("button.o_we_edit_link").click();
     expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("This website", {
         message: "The label input field should match the link's content",
     });
@@ -996,11 +996,11 @@ test("link preview in Link Popover", async () => {
     });
     // Click on Discard button to undo changes.
     await contains(".o-we-linkpopover .o_we_discard_link").click();
-    await waitFor("a.o_we_edit_link");
+    await waitFor("button.o_we_edit_link");
     expect(".test_target a").toHaveText("This website");
 
     // Click on the edit link icon
-    await contains("a.o_we_edit_link").click();
+    await contains("button.o_we_edit_link").click();
     expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("This website", {
         message: "The label input field should match the link's content",
     });
@@ -1015,7 +1015,7 @@ test("link preview in Link Popover", async () => {
     });
 
     // Click on the edit link icon
-    await contains("a.o_we_edit_link").click();
+    await contains("button.o_we_edit_link").click();
     expect(".o-we-linkpopover input.o_we_label_link").toHaveValue("New label", {
         message: "The label input field should match the link's content",
     });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1337,8 +1337,8 @@ describe("link preview", () => {
         await click(".o-we-command-name:first");
         await contains(".o-we-linkpopover input.o_we_href_input_link").fill("http://odoo.com/");
         await animationFrame();
-        expect("button.o_we_replace_title_btn").toHaveCount(1);
-        expect("a.o_we_replace_title_btn").toHaveCount(0);
+        expect("button.o_we_replace_title_btn.btn-primary").toHaveCount(1);
+        expect("button.o_we_replace_title_btn.text-dark").toHaveCount(0);
         const pNode = document.querySelector("p");
         setSelection({
             anchorNode: pNode,
@@ -1352,8 +1352,8 @@ describe("link preview", () => {
         });
         await waitFor(".o_we_replace_title_btn");
         await expectElementCount(".o-we-linkpopover", 1);
-        expect("a.o_we_replace_title_btn").toHaveCount(1);
-        expect("button.o_we_replace_title_btn").toHaveCount(0);
+        expect("button.o_we_replace_title_btn.text-dark").toHaveCount(1);
+        expect("button.o_we_replace_title_btn.btn-primary").toHaveCount(0);
     });
 });
 

--- a/addons/marketing_card/static/src/scss/card_campaign.scss
+++ b/addons/marketing_card/static/src/scss/card_campaign.scss
@@ -1,5 +1,5 @@
 .o_kanban_view .o_marketing_card_campaign_kanban {
-    a:hover > .badge {
+    button:hover > .badge {
         background-color: $o-brand-primary;
         color: white;
     }

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -160,18 +160,18 @@
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" class="mt-2"/>
                         <footer class="pt-0">
                             <div>
-                                <a type="object" name="action_view_cards_shared" href="#" class="me-1">
+                                <button type="object" name="action_view_cards_shared" class="me-1 p-0">
                                     <span class="badge rounded-pill">
                                         <i class="fa fa-fw fa-share" aria-label="Shares" role="img" title="Shares"/>
                                         <field name="card_share_count"/>
                                     </span>
-                                </a>
-                                <a type="object" name="action_view_cards_clicked" href="#" class="me-1">
+                                </button>
+                                <button type="object" name="action_view_cards_clicked" class="me-1 p-0">
                                     <span class="badge rounded-pill">
                                         <i class="fa fa-fw fa-mouse-pointer" aria-label="Clicks" role="img" title="Clicks"/>
                                         <field name="target_url_click_count"/>
                                     </span>
-                                </a>
+                                </button>
                             </div>
                             <field name="user_id" class="ms-auto" widget="many2one_avatar_user"/>
                         </footer>

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
@@ -11,7 +11,7 @@
                         <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
                     </span>
                 </t>
-                <a href="#" t-on-click.prevent="() => this.goToAction(data.link_id, data.link_model)" t-esc="data.name"/>
+                <button class="btn btn-link fw-normal p-0" t-on-click.prevent="() => this.goToAction(data.link_id, data.link_model)" t-esc="data.name"/>
                 <t t-if="data.phantom_bom">
                     <div class="fa fa-dropbox" title="This is a BoM of type Kit!" role="img" aria-label="This is a BoM of type Kit!"/>
                 </t>
@@ -37,7 +37,7 @@
             <t t-if="data.hasOwnProperty('availability_state')">
                 <span t-attf-class="{{availabilityColorClass}}" t-esc="data.availability_display"/>
                 <t t-if="['bom', 'component'].includes(data.type)">
-                    <a href="#" role="button" t-on-click.prevent="goToForecast" title="Forecast Report" t-attf-class="fa fa-fw fa-area-chart o_mrp_bom_forecast ms-1 {{availabilityColorClass}}"/>
+                    <button t-on-click.prevent="goToForecast" title="Forecast Report" t-attf-class="border-0 bg-transparent p-0 fa fa-fw fa-area-chart o_mrp_bom_forecast ms-1 {{availabilityColorClass}}"/>
                 </t>
             </t>
         </td>
@@ -47,14 +47,14 @@
         <td t-if="forecastMode">
             <div t-if="data.route_name">
                 <span t-attf-class="{{ data.route_alert ? 'text-danger' : '' }}"><t t-esc="data.route_name"/>: </span>
-                <a href="#" t-on-click.prevent="() => this.goToRoute(data.route_type)" t-esc="data.route_detail"/>
+                <button class="btn btn-link fw-normal p-0" t-on-click.prevent="() => this.goToRoute(data.route_type)" t-esc="data.route_detail"/>
             </div>
         </td>
         <td t-else=""/>
         <td t-attf-class="text-end {{ data.type == 'component' ? 'opacity-50' : '' }}" t-esc="formatMonetary(data.bom_cost)"/>
         <td t-if="showAttachments" class="text-center">
             <span t-if="data.has_attachments">
-                <a href="#" role="button" t-on-click.prevent="goToAttachment" class="fa fa-fw o_button_icon fa-files-o"/>
+                <button t-on-click.prevent="goToAttachment" class="btn btn-link p-0 fa fa-fw o_button_icon fa-files-o"/>
             </span>
         </td>
     </tr>

--- a/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
+++ b/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
@@ -6,7 +6,7 @@
             <div t-if="!!data.components || !!data.lines || !!data.operations" class="container-fluid">
                 <div class="d-flex mb-5">
                     <div class="me-auto">
-                        <h2><a href="#" t-on-click.prevent="goToProduct" t-esc="data.name"/></h2>
+                        <h2><button class="btn btn-link p-0 fs-2" t-on-click.prevent="goToProduct" t-esc="data.name"/></h2>
                         <hr t-if="data.bom_code"/>
                         <h6 t-if="data.bom_code">Reference: <t t-esc="data.bom_code"/></h6>
                     </div>

--- a/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.xml
+++ b/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.xml
@@ -7,8 +7,8 @@
                 <span t-if="props.hasFoldButton" class="btn btn-light p-0" t-attf-aria-label="{{ foldButtonTitle }}" t-attf-title="{{ foldButtonTitle }}" style="margin-right: 1px">
                     <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
                 </span>
-                <a t-if="data.id and data.model === 'mrp.workorder'" href="#" t-on-click.prevent="openWorkorder" t-out="data.name"/>
-                <a t-elif="data.id and data.model" href="#" t-on-click.prevent="openForm" t-out="data.name"/>
+                <button t-if="data.id and data.model === 'mrp.workorder'" class="btn btn-link p-0 fw-normal" t-on-click.prevent="openWorkorder" t-out="data.name"/>
+                <button t-elif="data.id and data.model" class="btn btn-link p-0 fw-normal" t-on-click.prevent="openForm" t-out="data.name"/>
                 <t t-else="" t-out="data.name"/>
                 <button t-if="data.model === 'to_order'" class="ms-2 py-0 btn btn-secondary" t-on-click="openReplenish">Replenish</button>
             </div>
@@ -32,7 +32,7 @@
         <td class="text-end" t-if="props.showOptions.receipts">
             <t t-if="data.receipt">
                 <span t-attf-class="{{ getColorClass(data.receipt.decorator) }}" t-out="data.receipt.display"/>
-                <a href="#" role="button" t-on-click.prevent="openForecast" title="Forecast Report" t-attf-class="fa fa-fw fa-area-chart ms-1 {{getColorClass(data.receipt.decorator)}}"/>
+                <button t-on-click.prevent="openForecast" title="Forecast Report" t-attf-class="border-0 bg-transparent p-0 fa fa-fw fa-area-chart ms-1 {{getColorClass(data.receipt.decorator)}}"/>
             </t>
         </td>
         <td class="text-end" t-if="props.showOptions.unitCosts" t-out="formatMonetary(data.unit_cost)"/>

--- a/addons/mrp_subcontracting/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
+++ b/addons/mrp_subcontracting/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mrp_subcontracting.BomOverviewSpecialLine" t-inherit="mrp.BomOverviewSpecialLine" t-inherit-mode="extension">
         <xpath expr="//td[@name='td_mrp_bom']" position="inside">
-            <t t-if="props.type == 'subcontracting'">Subcontracting: <a href="#" t-on-click.prevent="goToSubcontractor" t-esc="subcontracting.name"/></t>
+            <t t-if="props.type == 'subcontracting'">Subcontracting: <button class="btn btn-link p-0 fw-normal" t-on-click.prevent="goToSubcontractor" t-esc="subcontracting.name"/></t>
         </xpath>
 
         <xpath expr="//td[@name='quantity']" position="inside">

--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -9,16 +9,15 @@
                     t-on-mouseleave="() => this.onOptionMouseLeave()"
                     t-on-click="(ev) => this.searchWorldwide(ev)"
                 >
-                    <a
+                    <button
                         t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_{{option_index}}"
                         role="option"
-                        href="#"
                         class="dropdown-item ui-menu-item-wrapper text-truncate text-info"
                         t-att-class="{ 'ui-state-active': isActiveSourceOption([source_index, option_index]) }"
                         t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
                     >
                         Search Worldwide 🌎
-                    </a>
+                    </button>
                 </li>
             </t>
         </xpath>

--- a/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
+++ b/addons/point_of_sale/static/src/backend/pos_kanban_view/pos_kanban_view.xml
@@ -13,7 +13,7 @@
                 <div class="flex-grow-1 text-center" t-att-class="{ 'disable-buttons': !posState.has_chart_template || loadScenario.status === 'loading' }">
                     <p class="h1 text-primary mt-4" t-if="!posState.has_pos_config">Choose your store</p>
                     <p t-if="!posState.has_chart_template" class="h2 m-3">
-                        Please <a href="#" class="btn-link o_form_uri" role="button" t-on-click="() => action.doAction('account.action_account_config')">install a chart of accounts</a> to activate the buttons.
+                        Please <button class="btn btn-link o_form_uri p-0 fs-2" t-on-click="() => action.doAction('account.action_account_config')">install a chart of accounts</button> to activate the buttons.
                     </p>
                     <br />
                     <div t-attf-class="d-flex {{posState.is_restaurant_installed ? 'flex-column' : 'flex-column-reverse'}}">

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -145,7 +145,7 @@
                         </setting>
                         <div groups="base.group_system">
                             <p>
-                                More settings: <a href="#" name="%(action_pos_configuration)d" type="action" class="btn-link o_form_uri" role="button">Configurations > Settings</a>
+                                More settings: <button name="%(action_pos_configuration)d" type="action" class="btn-link o_form_uri p-0">Configurations > Settings</button>
                             </p>
                         </div>
                     </div>

--- a/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.xml
+++ b/addons/website/static/src/builder/plugins/navbar_link_popover/navbar_link_popover.xml
@@ -8,7 +8,7 @@
         <xpath expr="//a[hasclass('o_we_url_link')]" position="attributes">
             <attribute name="class" add="me-3" separator=" "/>
         </xpath>
-        <xpath expr="//a[@title='Remove Link']" position="replace">
+        <xpath expr="//button[@title='Remove Link']" position="replace">
             <button type="button"
                     class="js_edit_menu btn btn-sm btn-primary"
                     style="padding: 0px 6px;"

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -185,7 +185,7 @@ registerWebsitePreviewTour(
         ...openLinkPopup(":iframe .s_mega_menu_odoo_menu .nav-link:contains('Laptops')", "Laptops"),
         {
             content: "Click on 'Edit Link'",
-            trigger: ".o-we-linkpopover a.o_we_edit_link",
+            trigger: ".o-we-linkpopover button.o_we_edit_link",
             run: "click",
         },
         {

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -203,7 +203,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click on Edit Link",
-            trigger: ".o-we-linkpopover a.o_we_edit_link",
+            trigger: ".o-we-linkpopover button.o_we_edit_link",
             run: "click",
         },
         {


### PR DESCRIPTION
*partner_autocomplet,point_of_sale
We use `href="#"` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href="#"` and replaces it with the appropriate element or class to activate the <a> elements correctly.

Task-4380519

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
