### PR TITLE
[FIX] payment: users should only have access to their own tokens

### DIFF
--- a/addons/payment/models/payment_token.py
+++ b/addons/payment/models/payment_token.py
@@ -128,11 +128,11 @@ class PaymentToken(models.Model):
                 [('provider_id', 'in', providers_ids), ('partner_id', '=', partner_id)]
             )
         else:
-            # Get all the tokens of the partner and of their commercial partner, regardless of
+            # Get all the tokens of the partner, regardless of
             # whether the providers are available.
             partner = self.env['res.partner'].browse(partner_id)
             return self.env['payment.token'].search(
-                [('partner_id', 'in', [partner.id, partner.commercial_partner_id.id])]
+                [('partner_id', '=', partner.id)]
             )
 
     def _build_display_name(self, *args, max_length=34, should_pad=True, **kwargs):


### PR DESCRIPTION
Since commit https://github.com/odoo/odoo/commit/a650b2f, the access control for payment tokens has been tightened to ensure that users can only access their own tokens.

However, it appears that the `/my/payment_method` route was unintentionally overlooked in that update. This route still allows users to view the tokens of their commercial partner, which introduces an inconsistency between the intended access control and the actual behavior.

This discrepancy may cause confusion for users, as they can see both their own and their commercial partner’s tokens in the Payment Methods page (`/my/payment_method`), but are unable to use the commercial partner’s tokens during the payment process (`/payment/pay` or `/shop/payment`) — resulting in a poor user experience.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
