### PR TITLE
[FIX] html_editor: apply feff to icons within paragraphRelatedElements

### DIFF
--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -7,6 +7,7 @@ import {
     isMediaElement,
     isProtected,
     isProtecting,
+    paragraphRelatedElementsSelector,
 } from "@html_editor/utils/dom_info";
 import {
     backgroundImageCssToParts,
@@ -77,7 +78,8 @@ export class MediaPlugin extends Plugin {
         clipboard_content_processors: this.clean.bind(this),
         clipboard_text_processors: (text) => text.replace(/\u200B/g, ""),
 
-        selectors_for_feff_providers: () => ICON_SELECTOR,
+        selectors_for_feff_providers: () =>
+            `:is(${paragraphRelatedElementsSelector}) :is(${ICON_SELECTOR})`,
         before_save_handlers: this.savePendingImages.bind(this),
     };
 

--- a/addons/html_editor/static/tests/font_awesome.test.js
+++ b/addons/html_editor/static/tests/font_awesome.test.js
@@ -155,6 +155,15 @@ describe("parse/render", () => {
             contentAfter: '<p>a[b]c<i class="fa fa-pastafarianism"></i></p>',
         });
     });
+
+    test("should not add U+FEFF characters around icons not within a paragraph related element or a base container", async () => {
+        await testEditor({
+            contentBefore: '<div><i class="fa fa-pastafarianism"></i><div><p>abc</p></div></div>',
+            contentBeforeEdit:
+                '<div><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i><div><p>abc</p></div></div>',
+            contentAfter: '<div><i class="fa fa-pastafarianism"></i><div><p>abc</p></div></div>',
+        });
+    });
     /** not sure this is necessary, keep for now in case it is
         test('should insert navigation helpers when before a fontawesome, in an editable', async () => {
             await testEditor({

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -43,7 +43,7 @@ describe("collapsed selection", () => {
                 editor.shared.history.addStep();
             },
             contentAfterEdit:
-                '<p><br></p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]',
+                '<p><br></p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]',
             contentAfter: '<p><br></p><i class="fa fa-pastafarianism"></i>[]',
             config: { allowInlineAtRoot: true },
         });


### PR DESCRIPTION
Description of the issue this PR addresses:

Commit [1] added "\uFEFF" around icons to improve cursor movement. But it caused unintended side-effects in non-paragraph contexts (e.g., alert snippets). This commit confines the "\uFEFF" insertion to icons that are within a paragraph related element or a base container.

[1]: https://github.com/odoo/odoo/commit/4c2e5925824b9bcb7bb4bcddf4aceb464c6551ff

task-4942953

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
