### PR TITLE
[18.0][FIX] point_of_sale: search_read with elevated access

### DIFF
--- a/addons/point_of_sale/models/ir_module_module.py
+++ b/addons/point_of_sale/models/ir_module_module.py
@@ -16,6 +16,6 @@ class IrModuleModule(models.Model):
         domain = self._load_pos_data_domain()
         fields = self._load_pos_data_fields()
         return {
-            'data': self.search_read(domain, fields, load=False),
+            'data': self.sudo().search_read(domain, fields, load=False),
             'fields': self._load_pos_data_fields(),
         }

--- a/doc/cla/individual/yotsubasuzu.md
+++ b/doc/cla/individual/yotsubasuzu.md
@@ -1,0 +1,11 @@
+Vietnam, 2025-07-17
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Nguyen Ngoc Linh nguyenlinh125891@gmail.com https://github.com/yotsubasuzu


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The method was first introduce from this PR https://github.com/odoo/odoo/pull/183540.
In [pos.session.load_data](https://github.com/odoo/odoo/blob/18.0/addons/point_of_sale/models/pos_session.py#L185), a fallback method call inside the except AccessError block may raise a TypeError.
This occurs if the user lacks read access to the ir.module.module model, which normally should be granted by the base.group_user group when the base_install_request module is auto-installed.
If the module is not installed, access rights are missing, leading to an unintended method signature mismatch.

**Current behavior before PR:**
- If `base_install_request` is not installed, `base.group_user` users may not have read access to `ir.module.module`.
- The `AccessError` is correctly caught, but the fallback method call includes an argument not expected by the method, leading to a `TypeError`.

**Desired behavior after PR is merged:**
- Elevated access `search_read` will able to read the data.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
