### PR TITLE
[FIX] html_editor: put gradient button background in background-image

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -121,7 +121,12 @@ export class LinkPopover extends Component {
         });
         this.customTextResetPreviewColor = this.customTextColorState.selectedColor;
         this.customFillColorState = useState({
-            selectedColor: computedStyle.backgroundColor || DEFAULT_CUSTOM_FILL_COLOR,
+            selectedColor:
+                (computedStyle.backgroundImage === "none"
+                    ? undefined
+                    : computedStyle.backgroundImage) ||
+                computedStyle.backgroundColor ||
+                DEFAULT_CUSTOM_FILL_COLOR,
             defaultTab: "solid",
         });
         this.customFillResetPreviewColor = this.customFillColorState.selectedColor;
@@ -137,6 +142,10 @@ export class LinkPopover extends Component {
                     refName,
                     {
                         state: this[colorStateRef],
+                        enabledTabs:
+                            colorStateRef === "customFillColorState"
+                                ? ["solid", "custom", "gradient"]
+                                : ["solid", "custom"],
                         getUsedCustomColors: () => [],
                         colorPrefix: "",
                         applyColor: (colorValue) => {
@@ -524,7 +533,10 @@ export class LinkPopover extends Component {
             return false;
         }
         let customStyles = `color: ${this.customTextColorState.selectedColor}; `;
-        customStyles += `background-color: ${this.customFillColorState.selectedColor}; `;
+        const backgroundProperty = this.customFillColorState.selectedColor?.includes("gradient")
+            ? "background-image"
+            : "background-color";
+        customStyles += `${backgroundProperty}: ${this.customFillColorState.selectedColor}; `;
         customStyles += `border-width: ${this.state.customBorderSize}px; `;
         customStyles += `border-color: ${this.customBorderColorState.selectedColor}; `;
         customStyles += `border-style: ${this.state.customBorderStyle}; `;

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -53,7 +53,7 @@
                                         t-attf-style="background-color: {{this.customTextColorState.selectedColor}}" />
                                 <label>Fill Color</label>
                                 <button class="o_we_color_preview custom-fill-picker" t-att-data-color="this.customFillColorState.selectedColor" t-ref="customFillColorButton"
-                                        t-attf-style="background-color: {{this.customFillColorState.selectedColor}}" />
+                                        t-attf-style="{{this.customFillColorState.selectedColor?.includes('gradient') ? 'background-image' : 'background-color'}}: {{this.customFillColorState.selectedColor}}" />
                             </div>
                             <div class="d-flex mb-1 custom-border-color">
                                 <label>Border</label>

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -798,6 +798,61 @@ describe("Link formatting in the popover", () => {
             '<p><a href="http://test.com/" class="btn btn-secondary">link2[]</a></p>'
         );
     });
+    const styleForceColor = `p > a.btn { color: black !important; border-color: gray !important }`;
+    test("custom link format fill with solid color should be stored as background-color", async () => {
+        const { el } = await setupEditor(
+            '<p><a href="http://test.com/" class="btn btn-secondary">link2[]</a></p>',
+            {
+                config: {
+                    allowCustomStyle: true,
+                },
+                styleContent: styleForceColor,
+            }
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+
+        expect(queryOne('select[name="link_type"]').selectedIndex).toBe(2);
+
+        await click('select[name="link_type"');
+        await select("custom");
+        await animationFrame();
+        await click(".o_we_color_preview.custom-fill-picker");
+        await animationFrame();
+        await click('[data-color="#FF9C00"]');
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="http://test.com/" class="btn btn-custom" style="color: rgb(0, 0, 0); background-color: #FF9C00; border-width: 1px; border-color: rgb(128, 128, 128); border-style: solid; ">link2</a></p>'
+        );
+    });
+    test("custom link format fill with gradient should be stored as background-image", async () => {
+        const { el } = await setupEditor(
+            '<p><a href="http://test.com/" class="btn btn-secondary">link2[]</a></p>',
+            {
+                config: {
+                    allowCustomStyle: true,
+                },
+                styleContent: styleForceColor,
+            }
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+
+        expect(queryOne('select[name="link_type"]').selectedIndex).toBe(2);
+
+        await click('select[name="link_type"');
+        await select("custom");
+        await animationFrame();
+        await click(".o_we_color_preview.custom-fill-picker");
+        await animationFrame();
+        await click(".gradient-tab");
+        await animationFrame();
+        await click(".o_gradient_color_button");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="http://test.com/" class="btn btn-custom" style="color: rgb(0, 0, 0); background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%); border-width: 1px; border-color: rgb(128, 128, 128); border-style: solid; ">link2</a></p>'
+        );
+    });
     test("clicking the discard button should revert the link format", async () => {
         const { el } = await setupEditor('<p><a href="http://test.com/">link1[]</a></p>');
         await waitFor(".o-we-linkpopover");


### PR DESCRIPTION
The link popover of `html_editor` makes it possible to select a gradient color as button background color.
Unfortunately, it stores it in the `background-color` property where it is not interpreted by the browser.

This commit makes the gradient colors stored in the expected `background-image` property instead.

task-4367641
