### PR TITLE
[FIX] event: fix event reminder email language

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -238,7 +238,7 @@
 </table>
             </field>
             <field name="report_template_ids" eval="[(4, ref('event.action_report_event_registration_badge'))]"/>
-            <field name="lang">{{ object.event_id.lang or object.partner_id.lang }}</field>
+            <field name="lang">{{ object.event_id.lang or object.partner_id.lang or object.visitor_id.lang_id.code }}</field>
             <field name="auto_delete" eval="True"/>
         </record>
 
@@ -497,7 +497,7 @@
 </table>
             </field>
             <field name="report_template_ids" eval="[(4, ref('event.action_report_event_registration_full_page_ticket'))]"/>
-            <field name="lang">{{ object.event_id.lang or object.partner_id.lang }}</field>
+            <field name="lang">{{ object.event_id.lang or object.partner_id.lang or object.visitor_id.lang_id.code }}</field>
         </record>
 
         <record id="event_reminder" model="mail.template">
@@ -732,7 +732,7 @@
 </td></tr>
 </table>
             </field>
-            <field name="lang">{{ object.event_id.lang or object.partner_id.lang }}</field>
+            <field name="lang">{{ object.event_id.lang or object.partner_id.lang or object.visitor_id.lang_id.code }}</field>
         </record>
 
     </data>


### PR DESCRIPTION
How to reproduce this bug:
1- Create a db with only one language installed e.g. fr_FR and event app installed
2- Create an event and publish it on the website
3- Register for the event using public user
4- The confirmation email is in fr_FR but the reminders are in English

This is caused because partner_id.lang is empty as a public user. The correct way to fetch the visitor lang is by
`visitor_id.lang.id`.

opw-4794184