### PR TITLE
[FIX] base: enable invisible view fields for l10n

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -4343,7 +4343,7 @@ class TestRenderAllViews(TransactionCaseWithUserDemo):
             count, self.env.user.name, elapsed)
 
 
-@common.tagged('post_install', '-at_install')
+@common.tagged('post_install', '-at_install', 'post_install_l10n')
 class TestInvisibleField(TransactionCaseWithUserDemo):
     def test_uncommented_invisible_field(self):
         # NEVER add new name in this list ! The new addons must add comment for all always invisible field.


### PR DESCRIPTION
This test is not run during the l10n standalone tests leading to error in nightly that are not detected before the merge.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
