### PR TITLE
[FIX] website_{cf_turnstile,mass_mailing}: turnstile ok with newsletter


### DIFF
--- a/addons/website_cf_turnstile/static/src/js/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/js/turnstile.js
@@ -28,7 +28,7 @@ export const turnStile = {
         };
         // `this` is bound to the turnstile widget calling the callback
         globalThis.turnstileSuccess = function () {
-            const form = this.wrapper.closest("form");
+            const form = this.wrapper.closest("form") || this.wrapper.parentElement.parentElement;
             const buttons = form.querySelectorAll(".cf_form_disabled");
             for (const button of buttons) {
                 button.classList.remove("disabled", "cf_form_disabled");

--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.js
@@ -97,13 +97,13 @@ publicWidget.registry.subscribe = publicWidget.Widget.extend({
         // When the website is in edit mode, window.top != window. We don't want turnstile to render during edit mode
         // and mess up the DOM and saving it.
         if (!isSubscriber && this._turnstile && window.top === window) {
-            const el = this._turnstile.addTurnstile('website_mass_mailing_subscribe');
-            if (el) {
-                this._turnstile.addSpinner(subscribeBtnEl);
-                el[0].classList.add('mt-3');
-                el.insertAfter(this.el);
-                this._turnstile.renderTurnstile(el);
+            const turnstileNodes = [...this._turnstile.addTurnstile("website_mass_mailing_subscribe")];
+            this._turnstile.disableSubmit(subscribeBtnEl);
+            for (const node of turnstileNodes) {
+                node.classList.add('mt-3');
+                this.el.after(node);
             }
+            this._turnstile.renderTurnstile(turnstileNodes[0]);
         }
     },
 


### PR DESCRIPTION

Scenario:

- configure turnstile in setting
- install website_mass_mailing
- drop the newsletter widget in any page

Result:

In saas-18.1, we get this traceback error and the turnstile code is not
working:

Uncaught Promise > this._turnstile.addSpinner is not a function

Cause:

- On November 2024, in saas-18.1 and over,
  37fb21911ef33885a3dae309158a359ed1a604e0 adds the addTurnstile method
  but not the addSpinner method
- On January 2025, in saas-18.2 and over,
  421c5e5c4ee6271bb1085b43505cc1c28b2cb574 moved
  addons/website_cf_turnstile/static/src/js/turnstile.js to
  addons/website_cf_turnstile/static/src/interactions/turnstile.js
- On January 2025, in saas-18.2 and over,
  22e777c046521f3f89b62caa5876680beb7f5aba rewrote the Turnstile class
  removing addTurnstile
- On February 2025, in 17.0 up to 18.0,
  7ec74bcc692fc1c0d89fbeb243eef31685996784 adds the addTurnstile and
  addSpinner method
- On April 2025, in 17.0 up to master,
  c48e74f57569a1670fee65d65625488846513d79 uses addTurnstile and
  addSpinner method and the old file link without being adapted in
  saas-18.1 and over

That last commit cause a traceback error in saas-18.1 up to master since
it was forward-ported without adaptation.

Fix: adapt the code for saas-18.1, more adaptation will be needed in
saas-18.2 and over since the turnstile code was rewritten.

Note: the code also modifies website_cf_turnstile to add the possibility
that there is no form around the turnstile elements (which is the case
for the subscribe (.js_subscribe) widget) in which case we fallbacks on
the parent element of the turnstile element.

opw-4933957
opw-4925771
