### PR TITLE
[FIX] html_editor: fix undeterministic test showing link popover

### DIFF
--- a/addons/html_editor/static/tests/keyboard/arrow.test.js
+++ b/addons/html_editor/static/tests/keyboard/arrow.test.js
@@ -242,11 +242,11 @@ describe("Around ZWS", () => {
 describe("Around links", () => {
     test("should move into a link (ArrowRight)", async () => {
         await testEditor({
-            contentBefore: '<p>ab[]<a href="#">cd</a>ef</p>',
+            contentBefore: '<p>ab[]<a href="http://test.test/">cd</a>ef</p>',
             contentBeforeEdit:
                 "<p>ab[]" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="http://test.test/">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
@@ -257,24 +257,24 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="http://test.test/" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "[]cd" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "ef</p>",
-            contentAfter: '<p>ab<a href="#">[]cd</a>ef</p>',
+            contentAfter: '<p>ab<a href="http://test.test/">[]cd</a>ef</p>',
         });
     });
 
     test("should move into a link (ArrowLeft)", async () => {
         await testEditor({
-            contentBefore: '<p>ab<a href="#">cd</a>[]ef</p>',
+            contentBefore: '<p>ab<a href="http://test.test/">cd</a>[]ef</p>',
             contentBeforeEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#">' +
+                '<a href="http://test.test/">' +
                 "\ufeff" + // start zwnbsp
                 "cd" + // content
                 "\ufeff" + // end zwnbsp
@@ -285,14 +285,14 @@ describe("Around links", () => {
             contentAfterEdit:
                 "<p>ab" +
                 "\ufeff" + // before zwnbsp
-                '<a href="#" class="o_link_in_selection">' +
+                '<a href="http://test.test/" class="o_link_in_selection">' +
                 "\ufeff" + // start zwnbsp
                 "cd[]" + // content
                 "\ufeff" + // end zwnbsp
                 "</a>" +
                 "\ufeff" + // after zwnbsp
                 "ef</p>",
-            contentAfter: '<p>ab<a href="#">cd[]</a>ef</p>',
+            contentAfter: '<p>ab<a href="http://test.test/">cd[]</a>ef</p>',
         });
     });
 
@@ -555,8 +555,9 @@ describe("Around invisible chars in RTL languages", () => {
     });
 
     describe("ZWNBSP", () => {
-        const content = "<p>" + "الرجال" + '<a href="#">اءيتجنب</a>' + "هؤلاء" + "</p>";
-        // Displayed as "هؤلاء<a href="#">اءيتجنب</a>الرجال" in the editor:
+        const content =
+            "<p>" + "الرجال" + '<a href="http://test.test/">اءيتجنب</a>' + "هؤلاء" + "</p>";
+        // Displayed as "هؤلاء<a href="http://test.test/">اءيتجنب</a>الرجال" in the editor:
         //                third +         link      + first
         test("should move into a link (ArrowLeft)", async () => {
             const { editor, el } = await setupEditor(content, { config: { direction: "rtl" } });
@@ -564,7 +565,7 @@ describe("Around invisible chars in RTL languages", () => {
             // childNodes[1] and childNodes[3] are the ZWNBSP text nodes
             const link = el.firstChild.childNodes[2];
             // Place cursor at the end of first child (before the FEFF char)
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]الرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]الرجال
             setSelection({ anchorNode: pFirstChild, anchorOffset: pFirstChild.length });
 
             await keyPress("ArrowLeft")(editor);
@@ -572,9 +573,9 @@ describe("Around invisible chars in RTL languages", () => {
             const selection = editor.document.getSelection();
             expect(selection.anchorNode).toBe(link.firstChild); // FEFF node
             expect(selection.anchorOffset).toBe(1);
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFالرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال\uFEFF<a href="#" class="o_link_in_selection">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
+                '<p>الرجال\uFEFF<a href="http://test.test/" class="o_link_in_selection">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
             );
         });
         test("should move into a link (ArrowRight)", async () => {
@@ -584,7 +585,7 @@ describe("Around invisible chars in RTL languages", () => {
             const pFifthChild = el.firstChild.childNodes[4]; // "هؤلاء"
             const link2ndChild = link.childNodes[1]; // اءيتجنب
             // Place cursor at the beginning of fifth child (after the FEFF char)
-            // Displayed as هؤلاء[]\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء[]\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFFالرجال
             setSelection({ anchorNode: pFifthChild, anchorOffset: 0 });
 
             await keyPress("ArrowRight")(editor);
@@ -592,9 +593,9 @@ describe("Around invisible chars in RTL languages", () => {
             const selection = editor.document.getSelection();
             expect(selection.anchorNode).toBe(link2ndChild);
             expect(selection.anchorOffset).toBe(link2ndChild.length);
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFالرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال\uFEFF<a href="#" class="o_link_in_selection">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFهؤلاء</p>'
+                '<p>الرجال\uFEFF<a href="http://test.test/" class="o_link_in_selection">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFهؤلاء</p>'
             );
         });
         test("should move out of a link (ArrowLeft)", async () => {
@@ -603,7 +604,7 @@ describe("Around invisible chars in RTL languages", () => {
             const link = el.firstChild.childNodes[2];
             const link2ndChild = link.childNodes[1]; // text content inside link: اءيتجنب
             // Place cursor at the end of link's content (before the FEFF char)
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFF[]اءيتجنب\uFEFF</a>\uFEFFالرجال
             setSelection({ anchorNode: link2ndChild, anchorOffset: link2ndChild.length });
 
             await keyPress("ArrowLeft")(editor);
@@ -611,9 +612,9 @@ describe("Around invisible chars in RTL languages", () => {
             const selection = editor.document.getSelection();
             expect(selection.anchorNode).toBe(el.firstChild.childNodes[3]); // FEFF node outside link
             expect(selection.anchorOffset).toBe(1);
-            // Displayed as هؤلاء[]\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء[]\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFFالرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]هؤلاء</p>'
+                '<p>الرجال\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]هؤلاء</p>'
             );
         });
         test("should move out of a link (ArrowRight)", async () => {
@@ -623,7 +624,7 @@ describe("Around invisible chars in RTL languages", () => {
             const link = el.firstChild.childNodes[2];
             const link2ndChild = link.childNodes[1]; // text content inside link: اءيتجنب
             // Place cursor at the beginning of link's content (after the FEFF char)
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFالرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب[]\uFEFF</a>\uFEFFالرجال
             setSelection({ anchorNode: link2ndChild, anchorOffset: 0 });
 
             await keyPress("ArrowRight")(editor);
@@ -631,9 +632,9 @@ describe("Around invisible chars in RTL languages", () => {
             const selection = editor.document.getSelection();
             expect(selection.anchorNode).toBe(pFirstChild);
             expect(selection.anchorOffset).toBe(pFirstChild.length);
-            // Displayed as هؤلاء\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]الرجال
+            // Displayed as هؤلاء\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFF[]الرجال
             expect(getContent(el)).toBe(
-                '<p>الرجال[]\uFEFF<a href="#">\uFEFFاءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
+                '<p>الرجال[]\uFEFF<a href="http://test.test/">\uFEFFاءيتجنب\uFEFF</a>\uFEFFهؤلاء</p>'
             );
         });
     });

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -12,30 +12,30 @@ import { expectElementCount } from "../_helpers/ui_expectations";
 
 test("should pad a link with ZWNBSPs and add visual indication", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/">b</a>c</p>',
-        contentBeforeEdit: '<p>a\ufeff<a href="#/">\ufeffb\ufeff</a>\ufeffc</p>',
+        contentBefore: '<p>a<a href="http://test.test/">b</a>c</p>',
+        contentBeforeEdit: '<p>a\ufeff<a href="http://test.test/">\ufeffb\ufeff</a>\ufeffc</p>',
         stepFunction: async (editor) => {
             setSelection({ anchorNode: editor.editable.querySelector("a"), anchorOffset: 1 });
             await tick();
         },
         contentAfterEdit:
-            '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeffc</p>',
-        contentAfter: '<p>a<a href="#/">[]b</a>c</p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeffc</p>',
+        contentAfter: '<p>a<a href="http://test.test/">[]b</a>c</p>',
     });
 });
 
 test("should pad a link with ZWNBSPs and add visual indication (2)", async () => {
     await testEditor({
-        contentBefore: '<p>a<a href="#/"><span class="a">b</span></a></p>',
+        contentBefore: '<p>a<a href="http://test.test/"><span class="a">b</span></a></p>',
         contentBeforeEdit:
-            '<p>a\ufeff<a href="#/">\ufeff<span class="a">b</span>\ufeff</a>\ufeff</p>',
+            '<p>a\ufeff<a href="http://test.test/">\ufeff<span class="a">b</span>\ufeff</a>\ufeff</p>',
         stepFunction: async (editor) => {
             setSelection({ anchorNode: editor.editable.querySelector("a span"), anchorOffset: 0 });
             await tick();
         },
         contentAfterEdit:
-            '<p>a\ufeff<a href="#/" class="o_link_in_selection">\ufeff<span class="a">[]b</span>\ufeff</a>\ufeff</p>',
-        contentAfter: '<p>a<a href="#/"><span class="a">[]b</span></a></p>',
+            '<p>a\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff<span class="a">[]b</span>\ufeff</a>\ufeff</p>',
+        contentAfter: '<p>a<a href="http://test.test/"><span class="a">[]b</span></a></p>',
     });
 });
 

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1134,7 +1134,7 @@ describe("links with inline image", () => {
 
 describe("readonly mode", () => {
     test("popover should not display edit buttons in readonly mode", async () => {
-        await setupEditor('<p><a class="o_link_readonly" href="#">link[]</a></p>');
+        await setupEditor('<p><a class="o_link_readonly" href="http://test.test/">link[]</a></p>');
         await waitFor(".o-we-linkpopover");
         // Copy link button should be available
         expect(".o-we-linkpopover .o_we_copy_link").toHaveCount(1);


### PR DESCRIPTION
This PR is backport of  https://github.com/odoo/odoo/pull/218587

Update test to use a real href (`http://test.test/`) to reflect new behavior showing link href in the input, avoiding popover issues with `#`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
