### PR TITLE
[FIX] website_sale: use lowercase for order in email

### DIFF
--- a/addons/website_sale/tests/test_website_sale_mail.py
+++ b/addons/website_sale/tests/test_website_sale_mail.py
@@ -45,4 +45,4 @@ class TestWebsiteSaleMail(HttpCase):
                                                     order='create_date DESC', limit=1)
             self.assertTrue(new_mail)
             self.assertIn('Your', new_mail.body_html)
-            self.assertIn('Order', new_mail.body_html)
+            self.assertIn('order', new_mail.body_html)


### PR DESCRIPTION
in the email body it is 'order' not 'Order' , check the error in the runbot build error log

build_error-223173

