### PR TITLE
[FIX] website, *: properly compute can_publish for pages and partners

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -296,7 +296,8 @@ class Http(models.AbstractModel):
         if page and (request.env.user.has_group('website.group_website_designer') or page.is_visible):
             _, ext = os.path.splitext(req_page)
             response = request.render(page.view_id.id, {
-                'main_object': page,
+                # See REVIEW_CAN_PUBLISH_UNSUDO
+                'main_object': page.with_context(can_publish_unsudo_main_object=True),
             }, mimetype=_guess_mimetype(ext))
             return response
         return False

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -234,6 +234,10 @@ class WebsitePublishedMixin(models.AbstractModel):
                 # Some main_record might be in sudo because their content needs
                 # to be rendered by a template even if they were not supposed
                 # to be accessible
+                # TODO in master, instead of this we should ensure main_object
+                # (which calls can_publish) is ensured to not be in sudo for all
+                # renderings, and sudo() only the required operations if needed.
+                # See REVIEW_CAN_PUBLISH_UNSUDO
                 plain_record = record.sudo(flag=False) if self._context.get('can_publish_unsudo_main_object', False) else record
                 plain_record.check_access_rights('write')
                 plain_record.check_access_rule('write')

--- a/addons/website/models/res_partner.py
+++ b/addons/website/models/res_partner.py
@@ -41,7 +41,3 @@ class Partner(models.Model):
     def _compute_display_name(self):
         self2 = self.with_context(display_website=False)
         super(Partner, self2)._compute_display_name()
-
-    def _compute_can_publish(self):
-        self2 = self.with_context(can_publish_unsudo_main_object=False)
-        super(Partner, self2)._compute_can_publish()

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -93,11 +93,11 @@ class Page(models.Model):
 
     @api.depends_context('uid')
     def _compute_can_publish(self):
+        # Note: this `if`'s purpose it to optimize the way this is computed for
+        # multiple records.
         if self.env.user.has_group('website.group_website_designer'):
             for record in self:
                 record.can_publish = True
-        # FIXME this makes it so no-rights internal users *see* the publish
-        # button for website pages (although they cannot use it)
         else:
             super()._compute_can_publish()
 

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -72,6 +72,15 @@
             'data-can-publish': 'can_publish' in main_object.fields_get() and main_object.can_publish,
             'data-editable-in-backend': editable_in_backend,
         })"/>
+        <!--
+        TODO Review in master (this is a stable fix for new databases).
+        See REVIEW_CAN_PUBLISH_UNSUDO.
+        -->
+        <t t-if="html_data and html_data.get('data-can-publish') == True">
+            <t t-set="nothing" t-value="html_data.update({
+                'data-can-publish': 'can_publish' in main_object.fields_get() and main_object.sudo(flag=False).can_publish,
+            })"/>
+        </t>
         <!-- TODO investigate: data-oe-company-name seems like dead code -->
         <t t-if="editable or translatable" t-set="nothing" t-value="html_data.update({
             'data-editable': '1' if editable else None,

--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -338,7 +338,8 @@ class WebsiteCrmPartnerAssign(WebsitePartnerPage):
                 if slug(partner) != current_slug:
                     return request.redirect('/partners/%s' % slug(partner))
                 values = {
-                    'main_object': partner,
+                    # See REVIEW_CAN_PUBLISH_UNSUDO
+                    'main_object': partner.with_context(can_publish_unsudo_main_object=True),
                     'partner': partner,
                     'current_grade': current_grade,
                     'current_country': current_country

--- a/addons/website_crm_partner_assign/static/tests/tours/publish.js
+++ b/addons/website_crm_partner_assign/static/tests/tours/publish.js
@@ -44,6 +44,16 @@ wTourUtils.registerWebsitePreviewTour('test_cannot_publish_partner', {
     content: 'Go to partner',
     trigger: 'iframe a:contains("Agrolait")',
 }, {
+    content: 'Wait for the "edit in backend" button to appear before checking the publish button',
+    trigger: '.o_menu_systray .o_website_edit_in_backend > a',
+    run: () => {
+        // Seems enough to just wait for that button presence before checking
+        // the following step but a bit of delay seems a bit more robust. At
+        // least if the rendering flow changes or the tour system changes, this
+        // should be enough to have a race condition in this test.
+        setTimeout(() => document.body.classList.add('ready-for-check'), 100);
+    },
+}, {
     content: 'Check there is no Publish/Unpublish',
-    trigger: '.o_menu_systray:not(:has(.o_menu_systray_item.o_publish_container))',
+    trigger: '.ready-for-check .o_menu_systray:has(.o_website_edit_in_backend > a):not(:has(.o_menu_systray_item.o_publish_container))',
 }]);

--- a/addons/website_customer/controllers/main.py
+++ b/addons/website_customer/controllers/main.py
@@ -151,5 +151,7 @@ class WebsiteCustomer(http.Controller):
                     return request.redirect('/customers/%s' % slug(partner))
                 values = {}
                 values['main_object'] = values['partner'] = partner
+                # See REVIEW_CAN_PUBLISH_UNSUDO
+                values['main_object'] = values['main_object'].with_context(can_publish_unsudo_main_object=True)
                 return request.render("website_customer.details", values)
         raise request.not_found()

--- a/addons/website_membership/controllers/main.py
+++ b/addons/website_membership/controllers/main.py
@@ -172,5 +172,7 @@ class WebsiteMembership(http.Controller):
                     return request.redirect('/members/%s' % slug(partner))
                 values = {}
                 values['main_object'] = values['partner'] = partner
+                # See REVIEW_CAN_PUBLISH_UNSUDO
+                values['main_object'] = values['main_object'].with_context(can_publish_unsudo_main_object=True)
                 return request.render("website_membership.partner", values)
         raise request.not_found()

--- a/addons/website_partner/controllers/main.py
+++ b/addons/website_partner/controllers/main.py
@@ -19,7 +19,8 @@ class WebsitePartnerPage(http.Controller):
                 if slug(partner_sudo) != current_slug:
                     return request.redirect('/partners/%s' % slug(partner_sudo))
                 values = {
-                    'main_object': partner_sudo,
+                    # See REVIEW_CAN_PUBLISH_UNSUDO
+                    'main_object': partner_sudo.with_context(can_publish_unsudo_main_object=True),
                     'partner': partner_sudo,
                     'edit_page': False
                 }


### PR DESCRIPTION
*: website_crm_partner_assign, website_customer, website_membership,
   website_partner

Commit [1] (alongside commits [2] and [3]) introduced a new context key `can_publish_unsudo_main_object` with the goal of properly computing `can_publish` without sudo... but it missed using it properly. The related test was passing... because it was also not properly written.

This commit fixes the issue by using the context key at the proper places. However, this limits the fix to pages and partners at the moment as the bug is not critical in stable versions.

It however fixes a test while run in no-demo (which becomes the norm in later versions). With that in mind, this also changes the view (by *adding* things to be as stable as possible) to go around the use of the context key and make new databases properly compute `can_publish` for all records type. Old databases will keep the old behavior for some models, which leads to displaying the "Publish" button but not be able to use it (access right warning).

[1]: https://github.com/odoo/odoo/commit/d47d824fc484e1592fc4af8d0d378d5a4a579550
[2]: https://github.com/odoo/odoo/commit/1a83b2508b9383e2b7df192f8641751f71f852da
[3]: https://github.com/odoo/odoo/commit/436a167dedb2ed008bcb88e8a4eccafc8d20812c

Related to runbot-161791
