### PR TITLE
[IMP] mrp: MO calendar view card update

### DIFF
--- a/addons/mrp/static/src/views/calendar/common/mrp_calendar_common_renderer.js
+++ b/addons/mrp/static/src/views/calendar/common/mrp_calendar_common_renderer.js
@@ -1,0 +1,5 @@
+import { CalendarCommonRenderer } from "@web/views/calendar/calendar_common/calendar_common_renderer";
+
+export class MRPCalendarCommonRenderer extends CalendarCommonRenderer {
+    static eventTemplate = "mrp.CalendarCommonRenderer.event"
+}

--- a/addons/mrp/static/src/views/calendar/common/mrp_calendar_common_renderer.xml
+++ b/addons/mrp/static/src/views/calendar/common/mrp_calendar_common_renderer.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+  <t t-name="mrp.CalendarCommonRenderer.event" t-inherit="web.CalendarCommonRenderer.event" t-inherit-mode="primary">
+    <xpath expr="//div[hasclass('o_event_title')]" position="after">
+      <t t-if="rawRecord.product_id">
+        <span class="d-block">
+          <t t-out="rawRecord.product_id[1]"/>
+          <t t-if="rawRecord.product_qty">
+            <span> (<t t-out="rawRecord.product_qty"/> <t t-if="rawRecord.product_uom_id" t-out="rawRecord.product_uom_id[1]"/>)</span>
+          </t>
+        </span>
+      </t>
+    </xpath>
+  </t>
+
+</templates>

--- a/addons/mrp/static/src/views/calendar/mrp_calendar_renderer.js
+++ b/addons/mrp/static/src/views/calendar/mrp_calendar_renderer.js
@@ -1,0 +1,10 @@
+import { CalendarRenderer } from "@web/views/calendar/calendar_renderer";
+import { MRPCalendarCommonRenderer } from '@mrp/views/calendar/common/mrp_calendar_common_renderer';
+
+export class MRPCalendarRenderer extends CalendarRenderer {
+    static components = {
+        ...CalendarRenderer.components,
+        day: MRPCalendarCommonRenderer,
+        week: MRPCalendarCommonRenderer,
+    };
+}

--- a/addons/mrp/static/src/views/calendar/mrp_calendar_view.js
+++ b/addons/mrp/static/src/views/calendar/mrp_calendar_view.js
@@ -1,0 +1,9 @@
+import { registry } from "@web/core/registry";
+import { calendarView } from "@web/views/calendar/calendar_view";
+import { MRPCalendarRenderer } from '@mrp/views/calendar/mrp_calendar_renderer';
+
+export const MRPCalendarView = {
+    ...calendarView,
+    Renderer: MRPCalendarRenderer,
+}
+registry.category("views").add('mrp_calendar', MRPCalendarView);

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -591,11 +591,12 @@
             <field name="model">mrp.production</field>
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
-                <calendar date_start="date_start" date_stop="date_finished"
-                          string="Manufacturing Orders" event_limit="5" quick_create="0">
+                <calendar js_class="mrp_calendar" date_start="date_start" date_stop="date_finished"
+                          string="Manufacturing Orders" event_limit="5" quick_create="0" color="product_id" hide_time="True">
                     <field name="user_id" avatar_field="avatar_128"/>
                     <field name="product_id"/>
                     <field name="product_qty"/>
+                    <field name="product_uom_id" invisible="1"/>  <!-- To show the unit next to the quantity -->
                 </calendar>
             </field>
         </record>


### PR DESCRIPTION
When accessing the manufacturing orders from calendar view, the default card only shows the time and title. so it was improved to also show (in day and week format):

1- Title
2- Product being manufactured
3- Quantity to be produced

Task: 4904686

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
