### PR TITLE
[FIX] l10n_gr_edi: missing company XML views

### DIFF
--- a/addons/l10n_gr_edi/__manifest__.py
+++ b/addons/l10n_gr_edi/__manifest__.py
@@ -21,6 +21,7 @@
         'views/account_tax_views.xml',
         'views/product_template_views.xml',
         'views/report_invoice.xml',
+        'views/res_company_views.xml',
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
     ],


### PR DESCRIPTION
On the previous GR EDI improvements PR, the import for the company XML views was forgotten to be put back after a refactor. This causes issues, as removing views is problematic on stable version.

task-4781479