### PR TITLE
[FIX] pos*: remove cancelled orders from Ticket Screen

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1034,6 +1034,8 @@ class PosOrder(models.Model):
     def action_pos_order_cancel(self):
         cancellable_orders = self.filtered(lambda order: order.state == 'draft')
         cancellable_orders.write({'state': 'cancel'})
+        for config in self.config_id:
+            config.notify_synchronisation(config.current_session_id.id, self.env.context.get('login_number', 0))
         return {
             'pos.order': cancellable_orders.read(self._load_pos_data_fields(self.config_id.ids[0]), load=False)
         }

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -60,7 +60,7 @@ export class PosOrder extends Base {
         if (!this.uiState) {
             this.uiState = {
                 lineToRefund: {},
-                displayed: true,
+                displayed: this.state !== "cancel",
                 booked: false,
                 screen_data: {},
                 selected_orderline_uuid: undefined,

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -469,7 +469,7 @@ export class PosStore extends Reactive {
         }
 
         if (ids.size > 0) {
-            await this.data.callRelated("pos.order", "action_pos_order_cancel", [Array.from(ids)]);
+            await this.data.call("pos.order", "action_pos_order_cancel", [Array.from(ids)]);
             return true;
         }
 

--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -1,3 +1,4 @@
+/* global posmodel */
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { negate } from "@point_of_sale/../tests/tours/utils/common";
 const { DateTime } = luxon;
@@ -137,5 +138,20 @@ export function isSynced() {
     return {
         content: "Check if the request is proceeded",
         trigger: negate(".fa-spin", ".status-buttons"),
+    };
+}
+
+export function storedOrderCount(expectedCount) {
+    return {
+        content: `Stored order count should be ${expectedCount}`,
+        trigger: "body",
+        run: () => {
+            const actualCount = posmodel.data.models["pos.order"].length;
+            if (actualCount !== expectedCount) {
+                throw new Error(
+                    `Expected stored order count to be ${expectedCount}, but got ${actualCount}`
+                );
+            }
+        },
     };
 }

--- a/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/ticket_screen_util.js
@@ -214,3 +214,10 @@ export function nthColumnContains(nRow, nCol, string) {
         },
     ];
 }
+
+export function noOrderIsThere() {
+    return {
+        content: "No orders should be visible on the Ticket Screen",
+        trigger: ".ticket-screen:not(:has(.order-row))",
+    };
+}

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -51,6 +51,30 @@ registry.category("web_tour.tours").add("OrderNumberConflictTour", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_cancel_order_from_ui", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.isShown(),
+            ProductScreen.addOrderline("Coca-Cola", "1", "3"),
+            Chrome.clickPlanButton(),
+            Chrome.isSynced(),
+            FloorScreen.isShown(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickReview(),
+            ProductScreen.clickControlButton("Cancel Order"),
+            Dialog.confirm(),
+            FloorScreen.isShown(),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.noOrderIsThere(),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.noOrderIsThere(),
+            Chrome.storedOrderCount(0),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("OrderSynchronisationTour", {
     steps: () =>
         [

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -528,6 +528,12 @@ class TestFrontend(TestFrontendCommon):
         """
         self.start_pos_tour("OrderSynchronisationTour")
 
+    def test_cancel_order_from_ui(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_cancel_order_from_ui')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.state, "cancel", "The order should be in cancel state")
+
     def test_book_and_release_table(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_book_and_release_table', login="pos_user")


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant

Steps to reproduce:
- Open the Restaurant POS and place an order.
- Send it to the preparation screen by clicking Order.
- Reopen the order and cancel it via the Action button.

Issue:
- The cancelled order still appears under the Paid section on the Ticket Screen.

Fix:
- Cancelled orders are now excluded from the Ticket Screen display.
- Remove canceled orders from local records.

Task: 4936636

