### PR TITLE
[FIX] hr_holidays: prevent traceback when removing employee from allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -252,13 +252,13 @@ class HolidaysAllocation(models.Model):
                         default_holiday_status_id = self._default_holiday_status_id()
                     allocation.holiday_status_id = default_holiday_status_id
 
-    @api.depends('holiday_status_id', 'number_of_hours_display', 'number_of_days_display', 'type_request_unit')
+    @api.depends('holiday_status_id', 'number_of_hours_display', 'number_of_days_display', 'type_request_unit', 'employee_id')
     def _compute_number_of_days(self):
         for allocation in self:
             allocation_unit = allocation.type_request_unit
             if allocation_unit != 'hour':
                 allocation.number_of_days = allocation.number_of_days_display
-            else:
+            elif allocation_unit == 'hour' and allocation.employee_id:
                 allocation.number_of_days = allocation.number_of_hours_display / allocation.employee_id._get_hours_per_day(allocation.date_from)
 
     @api.depends('holiday_status_id', 'allocation_type')

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -426,3 +426,17 @@ class TestAllocations(TestHrHolidaysCommon):
 
         self.assertEqual(leave_request.employee_id, self.employee)
         self.assertEqual(leave_request.state, 'validate')
+
+    def test_leave_allocation_by_removing_employee(self):
+        """
+        Test that creating a leave allocation and then removing the employee will
+        not raise an error
+        """
+        self.leave_type.request_unit = "hour"
+        with self.assertRaises(AssertionError):  # AssertionError raised by Form as employee is required
+            with Form(self.env['hr.leave.allocation']) as allocation_form:
+                allocation_form.allocation_type = "regular"
+                allocation_form.holiday_status_id = self.leave_type
+                allocation_form.number_of_hours_display = 10
+                allocation_form.employee_id = self.env["hr.employee"]
+            allocation_form.save()


### PR DESCRIPTION
A traceback occurs when a user removes the Employee field 
while creating a time off allocation record.

**To reproduce the issue:**

1) Install the `Time Off` module.
2) Create a new time off allocation record.
3) Navigate to the `Related Time Off Type` record.
4) Change the `Take Time Off in` option to Hours.
5) Return to the allocation and remove the Employee field.

**Error:**
```
ZeroDivisionError: float division by zero
```

**Cause:**

- When the Employee field is cleared, the `_compute_number_of_days` method is triggered.
- Since the allocation_unit is set to Hours, this method attempts to calculate `number_of_days` 
using `_get_hours_per_day`.
https://github.com/odoo/odoo/blob/96d4bd7911ba122610fd42c009da0a8e565e50ec/addons/hr_holidays/models/hr_leave_allocation.py#L256-L262
- However, when `employee_id` is missing, `_get_hours_per_day` returns 0, 
resulting in a division by zero.
https://github.com/odoo/odoo/blob/96d4bd7911ba122610fd42c009da0a8e565e50ec/addons/hr_holidays/models/hr_employee.py#L140-L143

**Solution:**

Since the employee_id is a required field in allocation, 
Adding an extra check for employee_id will resolve this issue.

opw-4937893
