### PR TITLE
[FIX] web: embedded actions in URL

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -587,7 +587,7 @@ export class ControlPanel extends Component {
                 name: action.python_method || action.action_id[0] || action.action_id,
                 resModel: action.parent_res_model,
                 context,
-                stackPosition: this.env.config.parentActionId ? "replaceCurrentAction" : "",
+                stackPosition: "replaceCurrentAction",
                 viewType: action.default_view_mode,
             },
             { isEmbeddedAction: true }

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -281,22 +281,21 @@ test("breadcrumbs are updated when clicking on embeddeds", async () => {
     ).click();
     expect(".o_control_panel .breadcrumb-item").toHaveCount(0);
     expect(".o_control_panel .o_breadcrumb .active").toHaveText("Partners Action 1");
+    expect(browser.location.href).toBe("https://www.hoot.test/odoo/action-1");
     await contains(".o_embedded_actions > button > span:contains('Embedded Action 2')").click();
     await runAllTimers();
+    expect(browser.location.href).toBe("https://www.hoot.test/odoo/action-3");
     expect(router.current.action).toBe(3, {
         message: "the current action should be the one of the embedded action previously clicked",
     });
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
-        "Partners Action 1",
-        "Favorite Ponies",
-    ]);
+    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual(["Favorite Ponies"]);
     await contains(".o_embedded_actions > button > span:contains('Embedded Action 3')").click();
     await runAllTimers();
+    expect(browser.location.href).toBe("https://www.hoot.test/odoo/action-4");
     expect(router.current.action).toBe(4, {
         message: "the current action should be the one of the embedded action previously clicked",
     });
     expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
-        "Partners Action 1",
         "Favorite Ponies from python action",
     ]);
 });


### PR DESCRIPTION
- Open the Project app. The URL is `/odoo/project`;
- Open a project. For example, the project with ID 5. The URL is `/odoo/project/5/tasks`;
- Click on an embedded action. For example, 'Planning'. The URL  is `/odoo/project/5/tasks/5/action1574`;
- Switch to another embedded action. For exemple, `Timesheet`. The URL is `/odoo/project/5/tasks/5/project-timesheets`. Note that in this case, the last action of the URL has changed.

Reload the browser (F5).

When reloading the router and the action service will use the URL to reconstruct the breadcrumb. It will decompose the URL as follows:

- `/odoo/project` : The list of projects;
- `/odoo/project/5` : The form view of the project '5', this is a known limitation; this step was not included the initial flow;
- `/odoo/project/5/tasks`: The list of tasks of the project 5;
- `/odoo/project/5/tasks/5` : The form view of the task 5. This line is an error, the task 5 should not be included in the breadcrumb.
- `/odoo/project/5/tasks/5/project-timesheets` : The `Timesheet` embedded action.

The issue occurs because the 'active_id' of the 'Timesheet' embedded action is taken as a 'resId' for the action tasks, which add an error on the breadcrumb.

This commit, changes the behaviour to allways replace the last action with the embedded action. This behaviour is already done when changing of embedded action, but not for the first one.

If we take our example again :
- `/odoo/project`;
- `/odoo/project/5/tasks`;
- Click on an embedded action: `/odoo/project/5/action1574`;
- Switch to another embedded action: `/odoo/project/5/project-timesheets`

After reloading, the breadcrumb will be:
- `/odoo/project` : The list of projects;
- `/odoo/project/5` : The form view of the project '5';
- `/odoo/project/5/project-timesheets` : The `Timesheet` embedded action.

However, this commit causes a side effect. The list of tasks will no longer appear in the breadcrumb. Users can still access it via the Top Menu.

opw-4889557
