### PR TITLE
[FIX] base_import_module: raise error for glob pattern in manifest

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -24,6 +24,8 @@ from odoo.tools import file_open, file_path, file_open_temporary_directory, ormc
 from odoo.tools.misc import OrderedSet, topological_sort
 from odoo.tools.translate import JAVASCRIPT_TRANSLATION_COMMENT, CodeTranslations, TranslationImporter, get_base_langs
 
+from odoo.addons.base.models.ir_asset import is_wildcard_glob
+
 _logger = logging.getLogger(__name__)
 
 APPS_URL = "https://apps.odoo.com"
@@ -257,6 +259,10 @@ class IrModuleModule(models.Model):
         for bundle, commands in terp.get('assets', {}).items():
             for command in commands:
                 directive, target, path = IrAsset._process_command(command)
+                if is_wildcard_glob(path):
+                    raise UserError(_(
+                        "The assets path in the manifest of imported module '%(module_name)s' "
+                        "cannot contain glob wildcards (e.g., *, **).", module_name=module))
                 path = path if path.startswith('/') else '/' + path # Ensures a '/' at the start
                 assets_vals.append({
                     'name': f'{module}.{bundle}.{path}',

--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -150,6 +150,22 @@ class TestImportModule(odoo.tests.TransactionCase):
         ):
             self.import_zipfile(files)
 
+    def test_import_zip_wildcard_assets(self):
+        """Assert the expected behavior when import a ZIP module with assets using glob wildcard"""
+        files = [
+            ('foo/__manifest__.py', self.manifest_content(assets={
+                'web.assets_backend': [
+                    'test_module/static/src/js/*'
+                ]
+            })),
+            ('foo/static/js/foo.js', b"console.log('foo')"),
+        ]
+        with (
+            mute_logger("odoo.addons.base_import_module.models.ir_module"),
+            self.assertRaises(UserError, msg="modules with assets path containing glob wildcards shouldn't be successcully imported"),
+        ):
+            self.import_zipfile(files)
+
     def test_import_zip_invalid_data(self):
         """Assert no data remains in the db if module import fails"""
         files = [


### PR DESCRIPTION
Imported modules' manifest files don't accept wildcard (*) in the assets path.
A check is needed to avoid blocking web UI.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
