### PR TITLE
[FIX] web: parse non-rgb(a) gradients in gradient picker

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -122,7 +122,7 @@
             </div>
             <div class="px-2">
                 <button t-attf-style="background-image: {{ currentGradient }};" class="w-50 border btn mb-2 o_custom_gradient_button" t-att-class="{'selected': currentGradient and !this.DEFAULT_GRADIENT_COLORS.includes(currentGradient)}" t-att-data-color="currentGradient" t-on-click="this.toggleGradientPicker" title="Define a custom gradient">Custom</button>
-                <GradientPicker t-if="state.showGradientPicker" onGradientChange.bind="applyColor" selectedGradient="currentGradient"/>
+                <GradientPicker t-if="state.showGradientPicker" onGradientChange.bind="applyColor" selectedGradient="getCurrentGradientColor()"/>
             </div>
         </t>
     </div>

--- a/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.js
+++ b/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.js
@@ -1,6 +1,11 @@
 import { Component, onWillUpdateProps, useState, useRef } from "@odoo/owl";
 import { CustomColorPicker as ColorPicker } from "@web/core/color_picker/custom_color_picker/custom_color_picker";
-import { isColorGradient, rgbaToHex, convertCSSColorToRgba } from "@web/core/utils/colors";
+import {
+    isColorGradient,
+    standardizeGradient,
+    rgbaToHex,
+    convertCSSColorToRgba,
+} from "@web/core/utils/colors";
 
 export class GradientPicker extends Component {
     static components = { ColorPicker };
@@ -45,6 +50,7 @@ export class GradientPicker extends Component {
         if (!gradient || !isColorGradient(gradient)) {
             return;
         }
+        gradient = standardizeGradient(gradient);
         const colors = [
             ...gradient.matchAll(
                 /(#[0-9a-f]{6}|rgba?\(\s*[0-9]+\s*,\s*[0-9]+\s*,\s*[0-9]+\s*[,\s*[0-9.]*]?\s*\)|[a-z]+)\s*([[0-9]+%]?)/g

--- a/addons/web/static/src/core/utils/colors.js
+++ b/addons/web/static/src/core/utils/colors.js
@@ -320,6 +320,19 @@ export function isColorGradient(value) {
     return value && value.includes("-gradient(");
 }
 
+/**
+ * @param {string} gradient
+ * @returns {string} standardized gradient
+ */
+export function standardizeGradient(gradient) {
+    if (isColorGradient(gradient)) {
+        const el = document.createElement("div");
+        el.style.setProperty("background-image", gradient);
+        gradient = el.style.getPropertyValue("background-image");
+    }
+    return gradient;
+}
+
 export const RGBA_REGEX = /[\d.]{1,5}/g;
 
 /**

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -232,3 +232,22 @@ test("custom color picker change from grey to solid color on hue click", async (
         expect(Math.round(hsl.lightness)).toBe(25);
     }
 });
+
+test("custom gradient must be defined", async () => {
+    await mountWithCleanup(ColorPicker, {
+        props: {
+            state: {
+                selectedColor: "#FF0000", //linear-gradient(0deg, rgb(0,0,0) 0%, rgb(100,100,100) 100%)",
+                defaultTab: "gradient",
+            },
+            getUsedCustomColors: () => [],
+            applyColor() {},
+            applyColorPreview() {},
+            applyColorResetPreview() {},
+            colorPrefix: "",
+        },
+    });
+    await click(".o_custom_gradient_button");
+    await animationFrame();
+    expect(".gradient-colors input[type='range']").toHaveCount(2);
+});


### PR DESCRIPTION
Gradient picker's parsing can only cope with rgb(a) format for its colors. In some cases the gradient value is expressed with `#rrggbbaa` which is not recognized and leads to errors.

This commit standardizes the gradient value before trying to parse it.

Steps to reproduce:
- Edit a website page
- Select a button
- Edit button
- Change "Fill Color"
- Go to "Gradient" tab
- Click on "Custom"

=> Preview range rectangle is empty, and errors are thrown when trying to pick a color.

task-4367641
