### PR TITLE
[IMP] html_editor, *: review image selector + content saved popup

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.xml
@@ -29,7 +29,7 @@
         </div>
         <input type="file" class="d-none o_file_input" t-on-change="onChangeFileInput" t-ref="file-input" t-att-accept="props.accept" t-att-multiple="props.multiSelect and 'multiple'"/>
         <div class="col-auto btn-group">
-            <button type="button" class="btn btn-primary o_upload_media_button" t-on-click="onClickUpload">
+            <button type="button" class="btn btn-secondary o_upload_media_button" t-on-click="onClickUpload">
                 <t t-esc="props.uploadText"/>
             </button>
         </div>

--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.xml
@@ -33,7 +33,7 @@
                 <p class="o_empty_folder_subtitle">Wow, it feels a bit empty in here. Upload from the button in the top right corner!</p>
             </div>
             <div t-else="" class="o_we_search_prompt">
-                <h2>Discover a world of awesomeness in our copyright-free image haven. No legal drama, just nice images!</h2>
+                <h2>Search the web for royalty-free images</h2>
             </div>
         </t>
         <t t-else="">

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -100,7 +100,7 @@ html, body {
     height: 100%;
 }
 
-pre {    
+pre {
     padding: map-get($spacers, 2) map-get($spacers, 3);
     border: $border-width solid $border-color;
     border-radius: $border-radius;
@@ -482,7 +482,7 @@ a.o_underline {
     &::before {
         transform: scale(-1, 1);
         content: "";
-        @include o-position-absolute($top: 0, $left: 50px);
+        @include o-position-absolute($top: 12px, $left: 40px);
         width: 100px;
         height: 150px;
         opacity: .5;

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -483,8 +483,7 @@ export class WebsiteBuilderClientAction extends Component {
         // trigger an new instance of the builder menu
         this.state.key++;
 
-        this.notification.add(_t("Your modifications were saved to apply this option."), {
-            title: _t("Content saved."),
+        this.notification.add("Content saved", {
             type: "success",
         });
     }

--- a/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
+++ b/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
@@ -40,7 +40,7 @@ registerWebsitePreviewTour("dropdowns_and_header_hide_on_scroll", {
     ...changeOptionInPopover("Header", "Scroll Effect", ".dropdown-item:contains('Fixed')"),
     {
         content: "Wait for the modification has been applied",
-        trigger: ".o_notification .o_notification_title:contains('Content saved')",
+        trigger: ".o_notification .o_notification_content:contains('Content saved')",
         timeout: 30000,
     },
     {


### PR DESCRIPTION
[IMP] html_editor, *: review image selector UI + content saved popup

*: web_editor, website

This commit sets the `Upload an image` button to secondary so that the
`Search an image` input and copywriting pops out in the interface.

It also simplifies the "Content saved" popup.

task-4879833