### PR TITLE
[FIX] html_editor: add html_editor to the list of frontend modules

### DIFF
--- a/addons/html_editor/models/__init__.py
+++ b/addons/html_editor/models/__init__.py
@@ -1,1 +1,2 @@
 from . import ir_attachment
+from . import ir_http

--- a/addons/html_editor/models/ir_http.py
+++ b/addons/html_editor/models/ir_http.py
@@ -1,0 +1,9 @@
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = "ir.http"
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        return ["html_editor", *super()._get_translation_frontend_modules_name()]


### PR DESCRIPTION
On the frontend (i.e., a public page accessible to unauthenticated users), only translations of "frontend modules" are fetched.

This commit adds html_editor to the list of frontend modules so that its translations are properly loaded on public pages.