### PR TITLE
Saas 18.4 UI adjustments role

### DIFF
--- a/addons/html_builder/static/src/builder.scss
+++ b/addons/html_builder/static/src/builder.scss
@@ -9,6 +9,12 @@
 .o-snippets-top-actions {
     border-bottom: $o-we-border-width solid $o-we-bg-lighter;
     height: 46px;
+
+    .o_rtl & {
+        .fa-undo, .fa-repeat {
+            transform: scaleX(-1);
+        }
+    }
 }
 
 .o-snippets-top-actions, .o-snippets-tabs {

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -24,6 +24,10 @@
     align-items: center;
     color: var(--o-hb-row-color, #{$o-we-fg-dark});
 
+    .hb-container-subtitle {
+        padding: $o-hb-row-spacing 0 $o-hb-row-spacing $o-hb-row-padding-left;
+    }
+
     .hb-row-label {
         min-width: 0;
         flex: 0 0 44%;

--- a/addons/html_builder/static/src/plugins/border_configurator_option.scss
+++ b/addons/html_builder/static/src/plugins/border_configurator_option.scss
@@ -7,7 +7,7 @@
     border-bottom: none !important;
 
     .o-overlay-item & {
-        margin: map-get($spacers , 2) 0;
+        margin: (map-get($spacers, 3) * .8) 0;
         max-width: none;
     }
 }

--- a/addons/website/static/src/builder/plugins/options/accordion_option.xml
+++ b/addons/website/static/src/builder/plugins/options/accordion_option.xml
@@ -4,10 +4,10 @@
 <t t-name="website.AccordionOption">
     <BuilderRow label.translate="Items">
         <BuilderButton
+            type="'success'"
             action="'addItem'"
             actionParam="'.accordion > .accordion-item:last-of-type'"
-            preview="false"
-            className="'o_we_bg_brand_primary'">
+            preview="false">
             Add New
         </BuilderButton>
     </BuilderRow>

--- a/addons/website_sale/static/src/website_builder/product_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/product_page_option.xml
@@ -4,7 +4,7 @@
 <t t-name="website_sale.ProductPageOption">
     <!-- Image config -->
     <BuilderRow>
-        <h6 class="text-white">Product Images</h6>
+        <div class="hb-container-subtitle h6 text-white">Product Images</div>
     </BuilderRow>
     <BuilderRow label.translate="Width">
         <BuilderButtonGroup action="'productPageImageWidth'" applyTo="'#product_detail_main'">
@@ -89,7 +89,7 @@
     </t>
     <hr/>
     <BuilderRow>
-        <h6 class="text-white">Product Details</h6>
+        <div class="hb-container-subtitle h6 text-white">Product Details</div>
     </BuilderRow>
     <BuilderRow label.translate="Purchase Style">
         <t


### PR DESCRIPTION
**[FIX] website_sale, html_builder: fix alignment of options title**

Steps to reproduce:
- Go to /shop and click on a product
- Edit the page
=> "Product Images" and "Product Details" don't have any left margin,
they are not aligned with the rest of the options.

task-4879833

**[FIX] website: set accordion Add New option to primary**

task-4879833

**[FIX] html_builder: set more space on border style select**

task-4879833

**[FIX] html_builder: reverse undo/redo icons in RTL languages**

Undo and redo icons should be reversed in RTL languages. Culturally,
like in LTR languages, the "forward" icon should go in the direction of
reading, while the "reward" icon should go in the opposite direction.

task-4879833