### PR TITLE
[FIX] l10n_my_edi: fix prepayment amount structure

### DIFF
--- a/addons/l10n_my_edi/data/my_ubl_templates.xml
+++ b/addons/l10n_my_edi/data/my_ubl_templates.xml
@@ -40,6 +40,16 @@
         </xpath>
         <!-- MyInvois does not support order references, having one will cause issues -->
         <xpath expr="//*[local-name()='OrderReference']" position="replace"/>
+        <xpath expr="//*[local-name()='PaymentTerms']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cac:PrepaidPayment>
+                    <cbc:PaidAmount
+                        t-att-currencyID="vals['prepaid_payment_vals']['currency'].name"
+                        t-out="format_float(vals['prepaid_payment_vals']['amount'], vals['prepaid_payment_vals']['currency_dp'])"/>
+                </cac:PrepaidPayment>
+            </t>
+        </xpath>
     </template>
 
     <!-- They are not using the same template at all, so we make a new one. They basically want the same data as supplier/customer party -->

--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -123,6 +123,9 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         # these are optional, and since we can't have the correct one at the time of generating, we avoid adding them.
         vals['vals'].pop('payment_means_vals_list', None)
 
+        # For Myinvois, prepaid amount is defined as a separate node.
+        vals['vals'].get('monetary_total_vals', {}).pop('prepaid_amount', None)
+
         # We add the company industrial classification to the supplier vals.
         vals['vals']['accounting_supplier_party_vals']['party_vals'].update({
             'industry_classification_code_attrs': {'name': invoice.company_id.l10n_my_edi_industrial_classification.name},
@@ -145,6 +148,14 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
                     'uuid': (original_document and original_document.l10n_my_edi_external_uuid) or 'NA',
                 },
             })
+
+        vals['vals'].update({
+            'prepaid_payment_vals': {
+                'currency': invoice.currency_id,
+                'currency_dp': self._get_currency_decimal_places(invoice.currency_id),
+                'amount': invoice.amount_total - invoice.amount_residual,
+            },
+        })
 
         return vals
 


### PR DESCRIPTION
Before:
Prepaid Amount was submitted under LegalMonetaryTotal node, which follows UBL format but not supported for MyInvois.

After:
Introduced separate PrepaidAmount node used specific to Malaysia to support MyInvois.

taskID-4947994
