### PR TITLE
[FIX] website_livechat: don't user demo user in live chat test

### DIFF
--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -96,7 +96,7 @@ export const feedback = [
 export const emailTranscript = [
     {
         content: "Check email field",
-        trigger: ".o-livechat-root:shadow input:value(mark.brown23@example.com)",
+        trigger: ".o-livechat-root:shadow input:value(e.e@example.com)",
     },
     {
         content: "Send the conversation to your email address",

--- a/addons/website_livechat/tests/test_ui.py
+++ b/addons/website_livechat/tests/test_ui.py
@@ -21,7 +21,7 @@ class TestLivechatUI(HttpCaseWithUserDemo, TestLivechatCommon):
         self._check_end_of_rating_tours()
 
     def test_complete_rating_flow_ui_logged_in(self):
-        self.start_tour("/", "website_livechat_complete_flow_tour_logged_in", login="demo")
+        self.start_tour("/", "website_livechat_complete_flow_tour_logged_in", login=self.user_employee.login)
         self._check_end_of_rating_tours()
 
     def test_happy_rating_flow_ui(self):


### PR DESCRIPTION
This commit fixes a failing test in the nightly "With Demo" build. The test fails because it checks the email of the demo user, which is overridden by the demo data from another module.

This commit fixes the issue by making the test run with a different user than the demo user, so that the email remains predictable.

fixes runbot-229925
