### PR TITLE
[REV] web: views don't need action manager to scroll

### DIFF
--- a/addons/web/static/src/webclient/webclient_layout.scss
+++ b/addons/web/static/src/webclient/webclient_layout.scss
@@ -36,6 +36,7 @@
           flex: 0 0 auto;
         }
         .o_content {
+          overflow: auto;
           height: 100%;
         }
 
@@ -65,7 +66,6 @@
       direction: ltr; //Define direction attribute here so when rtlcss preprocessor run, it converts it to rtl
       flex: 1 1 auto;
       position: relative; // Allow to redistribute the 100% height to its child
-      overflow: auto;
 
       > .o_view_controller {
         position: absolute; // Get the 100% height of its flex parent


### PR DESCRIPTION
Steps to reproduce
==================

- Use a mobile viewport
- Go to contact
- Open a record
- Edit the contry
- Try to scroll

=> Nothing happens

Cause of the issue
==================

Both the `.o_content` and the `.modal-body` are scrollable, so we need to scroll twice to go to the bottom.

Solution
========

We revert https://github.com/odoo/odoo/commit/7d7aedc6149a170db2c73b1f62872bd35786c5ca

opw-4851373