### PR TITLE
[IMP] project, * : add a 4th setting in the project privacy

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -50,7 +50,7 @@ class AccountAnalyticLine(models.Model):
     def _domain_project_id(self):
         domain = Domain([('allow_timesheets', '=', True), ('is_template', '=', False)])
         if not self.env.user.has_group('hr_timesheet.group_timesheet_manager'):
-            domain &= Domain('privacy_visibility', '!=', 'followers') | Domain('message_partner_ids', 'in', [self.env.user.partner_id.id])
+            domain &= Domain('privacy_visibility', 'in', ['employees', 'portal']) | Domain('message_partner_ids', 'in', [self.env.user.partner_id.id])
         return domain
 
     def _domain_employee_id(self):
@@ -389,7 +389,7 @@ class AccountAnalyticLine(models.Model):
                 Domain('message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id])
                 | Domain('partner_id', 'child_of', [self.env.user.partner_id.commercial_partner_id.id])
             )
-            & Domain('project_id.privacy_visibility', '=', 'portal')
+            & Domain('project_id.privacy_visibility', 'in', ['invited_users', 'portal'])
         )
 
     def _timesheet_preprocess_get_accounts(self, vals):

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -37,7 +37,7 @@
             <field name="domain_force">[
                 ('project_id', '!=', False),
                 ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
-                ('project_id.privacy_visibility', '=', 'portal'),
+                ('project_id.privacy_visibility', 'in', ['invited_users', 'portal']),
                 ('project_id.collaborator_ids.partner_id', 'in', [user.partner_id.id]),
             ]</field>
             <field name="perm_read" eval="True"/>
@@ -54,7 +54,7 @@
                 ('user_id', '=', user.id),
                 ('project_id', '!=', False),
                 '|', '|',
-                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                     ('partner_id', '=', user.partner_id.id),
                     ('message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
@@ -67,7 +67,7 @@
             <field name="domain_force">[
                 ('project_id', '!=', False),
                 '|', '|',
-                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                     ('message_partner_ids', 'in', [user.partner_id.id]),
                     ('partner_id', '=', user.partner_id.id),
             ]</field>
@@ -106,7 +106,7 @@
             <field name="domain_force">[
                 ('user_id', '=', user.id),
                 '|',
-                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                     ('message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
@@ -117,7 +117,7 @@
             <field name="model_id" ref="model_timesheets_analysis_report"/>
             <field name="domain_force">[
                 '|',
-                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                     ('project_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_approver'))]"/>

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -54,6 +54,7 @@
         'data/project_data.xml',
         'data/project_tour.xml',
         'wizard/project_task_type_delete_views.xml',
+        'wizard/project_task_share_wizard_views.xml',
         'wizard/project_project_stage_delete_views.xml',
         'wizard/project_template_create_wizard.xml',
         'views/project_menus.xml',

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -613,16 +613,6 @@ class ProjectTask(models.Model):
         for task in self:
             task.access_url = f'/my/tasks/{task.id}'
 
-    def _compute_access_warning(self):
-        super()._compute_access_warning()
-        for task in self.filtered(lambda x: x.project_id.privacy_visibility != 'portal'):
-            visibility_field = self.env['ir.model.fields'].search([('model', '=', 'project.project'), ('name', '=', 'privacy_visibility')], limit=1)
-            visibility_public = self.env['ir.model.fields.selection'].search([('field_id', '=', visibility_field.id), ('value', '=', 'portal')])
-            task.access_warning = _(
-                "The task cannot be shared with the recipient(s) because the privacy of the project is too restricted. Set the privacy of the project to '%(visibility)s' in order to make it accessible by the recipient(s).",
-                visibility=visibility_public.name,
-            )
-
     @api.depends('child_ids.allocated_hours')
     def _compute_subtask_allocated_hours(self):
         for task in self:
@@ -1173,7 +1163,7 @@ class ProjectTask(models.Model):
         if tasks.project_id:
             tasks.sudo()._set_stage_on_project_from_task()
         for task in tasks.sudo():
-            if task.project_id.privacy_visibility == 'portal':
+            if task.project_id.privacy_visibility in ['invited_users', 'portal']:
                 task._portal_ensure_token()
             for follower in task.parent_id.message_follower_ids:
                 task.message_subscribe(follower.partner_id.ids, follower.subtype_ids.ids)
@@ -1631,16 +1621,16 @@ class ProjectTask(models.Model):
         new_group = ('group_project_user', lambda pdata: pdata['type'] == 'user' and project_user_group_id in pdata['groups'], {})
         groups = [new_group] + groups
 
-        if self.project_privacy_visibility == 'portal':
+        if self.project_privacy_visibility in ['invited_users', 'portal']:
             groups.insert(0, (
                 'allowed_portal_users',
-                lambda pdata: pdata['type'] == 'portal',
+                lambda pdata: pdata['type'] in ['invited_users', 'portal'],
                 {
                     'active': True,
                     'has_button_access': True,
                 }
             ))
-        portal_privacy = self.project_id.privacy_visibility == 'portal'
+        portal_privacy = self.project_id.privacy_visibility in ['invited_users', 'portal']
         for group_name, _group_method, group_data in groups:
             if group_name in ('customer', 'user') or group_name == 'portal_customer' and not portal_privacy:
                 group_data['has_button_access'] = False

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -42,6 +42,7 @@ access_project_collaborator_manager,project.collaborator.manager,model_project_c
 access_project_collaborator_user,project.collaborator.user,model_project_collaborator,project.group_project_user,1,0,0,0
 access_project_collaborator_portal,project.collaborator.portal,model_project_collaborator,base.group_portal,1,0,0,0
 access_project_share_manager,project.share.wizard.manager,model_project_share_wizard,project.group_project_manager,1,1,1,0
+access_project_task_share_manager,project.task.share.wizard.manager,model_task_share_wizard,project.group_project_manager,1,1,1,0
 access_project_share_collaborator_manager,project.share.collaborator.wizard.manager,model_project_share_collaborator_wizard,project.group_project_manager,1,1,1,1
 access_project_personal_stage,project.personal.stage.user,model_project_task_stage_personal,base.group_user,1,1,1,1
 access_mail_activity_plan_project_manager,mail.activity.plan.project.manager,mail.model_mail_activity_plan,project.group_project_manager,1,1,1,1

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -70,7 +70,7 @@
         <field name="name">Project: employees: following required for follower-only projects</field>
         <field name="model_id" ref="model_project_project"/>
         <field name="domain_force">['|',
-                                        ('privacy_visibility', '!=', 'followers'),
+                                        ('privacy_visibility', 'in', ['employees', 'portal']),
                                         ('message_partner_ids', 'in', [user.partner_id.id])
                                     ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
@@ -93,7 +93,7 @@
                 '&amp;',
                     ('project_id', '!=', False),
                     '|',
-                        ('project_id.privacy_visibility', '!=', 'followers'),
+                        ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                         ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
                     ('message_partner_ids', 'in', [user.partner_id.id]),
@@ -158,7 +158,7 @@
                 '&amp;',
                     ('project_id', '!=', False),
                     '|',
-                        ('project_id.privacy_visibility', '!=', 'followers'),
+                        ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
                         ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
                     ('message_partner_ids', 'in', [user.partner_id.id]),
@@ -172,7 +172,7 @@
         <field name="name">Project: See private tasks</field>
         <field name="model_id" ref="project.model_project_task"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|', '|', ('project_id', '!=', False),
                       ('parent_id', '!=', False),
                  ('user_ids', 'in', user.id),
@@ -186,7 +186,7 @@
         <field name="model_id" ref="project.model_project_project"/>
         <field name="domain_force">[
             '&amp;',
-                ('privacy_visibility', '=', 'portal'),
+                ('privacy_visibility', 'in', ['invited_users', 'portal']),
                 ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
@@ -196,7 +196,7 @@
         <field name="name">Project/Collaborator: portal users: can only see his own collobaroration in shared projects</field>
         <field name="model_id" ref="project.model_project_collaborator"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '=', 'portal'),
+            ('project_id.privacy_visibility', 'in', ['invited_users', 'portal']),
             ('partner_id', '=', user.partner_id.id),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
@@ -206,7 +206,7 @@
         <field name="name">Project/Task: portal users: can only see a task if he's a collaborator of the project and a follower of the task</field>
         <field name="model_id" ref="project.model_project_task"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '=', 'portal'),
+            ('project_id.privacy_visibility', 'in', ['invited_users', 'portal']),
             ('active', '=', True),
             '|',
                 ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
@@ -227,7 +227,7 @@
         <field name="model_id" ref="project.model_project_task"/>
         <field name="active">0</field>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '=', 'portal'),
+            ('project_id.privacy_visibility', 'in', ['invited_users', 'portal']),
             ('active', '=', True),
             '|',
                 ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
@@ -254,7 +254,7 @@
         <field name="model_id" ref="model_project_update"/>
         <field name="domain_force">[
         '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|',
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
@@ -269,7 +269,7 @@
         <field name="model_id" ref="model_report_project_task_user"/>
         <field name="domain_force">[
         '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|',
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
@@ -298,7 +298,7 @@
         <field name="model_id" ref="model_project_task_burndown_chart_report"/>
         <field name="domain_force">[
         '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|',
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 ('user_ids', 'in', user.id),
@@ -324,7 +324,7 @@
         <field name="model_id" ref="model_project_milestone"/>
         <field name="domain_force">[
         '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            ('project_id.privacy_visibility', 'in', ['employees', 'portal']),
             '|',
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 ('project_id.user_id', '=', user.id),
@@ -343,7 +343,7 @@
         <field name="name">Project/milestone portal users: portal user can read with project sharing feature</field>
         <field name="model_id" ref="project.model_project_milestone"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '=', 'portal'),
+            ('project_id.privacy_visibility', 'in', ['invited_users', 'portal']),
             ('project_id.collaborator_ids.partner_id', 'in', [user.partner_id.id]),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -36,7 +36,7 @@
                     <field name="company_id" invisible="1"/>
                     <header>
                         <button name="action_open_share_project_wizard" string="Share Project" type="object" class="oe_highlight" groups="project.group_project_manager"
-                        invisible="privacy_visibility != 'portal' or is_template" context="{'default_access_mode': 'read'}" data-hotkey="r"/>
+                        invisible="privacy_visibility in ['followers', 'employees'] or is_template" context="{'default_access_mode': 'read'}" data-hotkey="r"/>
                         <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" groups="project.group_project_stages" domain="[('company_id', 'in', (company_id, False))]"/>
                     </header>
                 <sheet string="Project">
@@ -424,7 +424,7 @@
                                     </div>
                                     <div role="menuitem" class="col-6" groups="project.group_project_manager">
 
-                                        <a t-if="record.privacy_visibility.raw_value == 'portal' and !record.is_template.raw_value" class="dropdown-item" role="menuitem" name="action_open_share_project_wizard" type="object">Share Project</a>
+                                        <a t-if="['portal', 'invited_users'].includes(record.privacy_visibility.raw_value) and !record.is_template.raw_value" class="dropdown-item" role="menuitem" name="action_open_share_project_wizard" type="object">Share Project</a>
 
                                         <a class="dropdown-item" role="menuitem" name="copy" type="object">Duplicate</a>
                                         <a class="dropdown-item" role="menuitem" type="open">Settings</a>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -582,7 +582,7 @@
 
         <record id="portal_share_action" model="ir.actions.act_window">
             <field name="name">Share Task</field>
-            <field name="res_model">portal.share</field>
+            <field name="res_model">task.share.wizard</field>
             <field name="view_mode">form</field>
             <field name="context">{'dialog_size': 'medium'}</field>
             <field name="target">new</field>
@@ -664,7 +664,7 @@
                     <templates>
                         <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
                             <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>
-                            <a name="%(portal.portal_share_action)d" role="menuitem" type="action" class="dropdown-item" context="{'dialog_size': 'medium'}">Share Task</a>
+                            <a name="%(project.portal_share_action)d" role="menuitem" type="action" class="dropdown-item">Share Task</a>
                             <a class="dropdown-item" role="menuitem" type="object" name="copy">Duplicate</a>
                             <div role="separator" class="dropdown-divider"></div>
                             <field name="color" widget="kanban_color_picker"/>

--- a/addons/project/wizard/__init__.py
+++ b/addons/project/wizard/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import project_project_stage_delete
+from . import project_task_share_wizard
 from . import project_task_type_delete
 from . import project_share_wizard
 from . import project_share_collaborator_wizard

--- a/addons/project/wizard/project_task_share_wizard.py
+++ b/addons/project/wizard/project_task_share_wizard.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class TaskShareWizard(models.TransientModel):
+    _name = 'task.share.wizard'
+    _inherit = ['portal.share']
+    _description = 'Task Sharing'
+
+    task_id = fields.Many2one('project.task', default=lambda self: self.res_id)
+    project_privacy_visibility = fields.Selection(related='task_id.project_privacy_visibility')

--- a/addons/project/wizard/project_task_share_wizard_views.xml
+++ b/addons/project/wizard/project_task_share_wizard_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="portal_task_share_wizard" model="ir.ui.view">
+        <field name="name">task.share.wizard</field>
+        <field name="model">task.share.wizard</field>
+        <field name="inherit_id" ref="portal.portal_share_wizard"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//button[hasclass('btn-default')]" position="replace">
+                <button string="Discard" class="btn-default" special="cancel" data-hotkey="x" />
+            </xpath>
+            <xpath expr="//button[hasclass('btn-primary')]" position="attributes">
+                <attribute name="invisible">project_privacy_visibility in ['invited_users', 'followers']</attribute>
+            </xpath>
+            <xpath expr="//field[@name='note']" position="attributes">
+                <attribute name="invisible">project_privacy_visibility in ['invited_users', 'followers']</attribute>
+            </xpath>
+            <xpath expr="//field[@name='partner_ids']" position="attributes">
+                <attribute name="invisible">project_privacy_visibility in ['invited_users', 'followers']</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -53,7 +53,7 @@
                 <field name="display_sales_stat_buttons" invisible="1"/>
                 <field name="allow_billable" invisible="1" />
                 <field name="privacy_visibility" invisible="1" />
-                <button class="oe_stat_button" type="object" name="action_customer_preview" icon="fa-globe icon" invisible="not partner_id or not allow_billable or privacy_visibility != 'portal' or is_template">
+                <button class="oe_stat_button" type="object" name="action_customer_preview" icon="fa-globe icon" invisible="not partner_id or not allow_billable or privacy_visibility not in ['invited_users', 'portal'] or is_template">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">Preview</span>
                     </div>

--- a/addons/website_project/views/project_portal_project_task_template.xml
+++ b/addons/website_project/views/project_portal_project_task_template.xml
@@ -13,7 +13,7 @@
                         <t t-if="task">
                             <p class="lead mb-0">Your task has been sent.</p>
                             <p class="lead">Our team will get right on it.</p>
-                            <a t-if="request.session.uid and task.sudo().project_id.id and task.project_privacy_visibility != 'followers'" class="my-3 border rounded px-4 py-3 bg-100 fs-5 fw-bold shadow-sm text-decoration-none" t-attf-href="/my/task/#{task.id}" t-att-title="'Ticket #' + str(task.id)">
+                            <a t-if="request.session.uid and task.sudo().project_id.id and task.project_privacy_visibility in ['employees', 'portal']" class="my-3 border rounded px-4 py-3 bg-100 fs-5 fw-bold shadow-sm text-decoration-none" t-attf-href="/my/task/#{task.id}" t-att-title="'Ticket #' + str(task.id)">
                                 Task #<span t-field="task.id"/>
                             </a>
                             <span t-else="" class="my-3 border rounded px-4 py-3 fs-5 fw-bold shadow-sm">


### PR DESCRIPTION
This commit's purpose is to add a 4th setting in the project privacy_visibility. This setting will allow users to share a project with specific internal user and portal user without giving access to all internal users.

task - 4029633

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
