### PR TITLE
[FIX] mail: "done" activities are not due

### DIFF
--- a/addons/crm/static/src/activity_menu_patch.js
+++ b/addons/crm/static/src/activity_menu_patch.js
@@ -1,5 +1,6 @@
 /* @odoo-module */
 
+import { Domain } from "@web/core/domain";
 import { ActivityMenu } from "@mail/core/web/activity_menu";
 import { patch } from "@web/core/utils/patch";
 
@@ -33,10 +34,16 @@ patch(ActivityMenu.prototype, {
             // Necessary because activity_ids of mail.activity.mixin has auto_join
             // So, duplicates are faking the count and "Load more" doesn't show up
             context["force_search_count"] = 1;
-            context["active_test"] = 0; // to show lost leads in the activity
-            this.action.doAction("crm.crm_lead_action_my_activities", {
-                additionalContext: context,
-                clearBreadcrumbs: true,
+            this.action.loadAction("crm.crm_lead_action_my_activities").then((action) => {
+                // to show lost leads in the activity
+                action.domain = Domain.and([
+                    action.domain || [],
+                    [["active", "in", [true, false]]],
+                ]);
+                this.action.doAction(action, {
+                    additionalContext: context,
+                    clearBreadcrumbs: true,
+                });
             });
         } else {
             return super.openActivityGroup(group, filter);

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1139,10 +1139,15 @@
             <field name="view_mode">tree,kanban,graph,pivot,calendar,form,activity</field>
             <field name="view_id" ref="crm_lead_view_list_activities"/>
             <!-- Ensure that only records with at least one activity, "done" (archived) or not, are fetched. -->
-            <field name="domain">[("activity_ids.active", "in", [True, False])]</field>
+            <field name="domain">[("active", "in", [True, False]), ("activity_ids.active", "in", [True, False])]</field>
             <field name="search_view_id" ref="crm.view_crm_case_my_activities_filter"/>
-            <field name="context">{'default_type': 'opportunity',
-                    'search_default_assigned_to_me': 1}
+            <!-- force_search_count because activity_ids has auto_join so duplicates are faking the count and "Load more". -->
+            <field name="context">
+            {
+                'default_type': 'opportunity',
+                'force_search_count': 1,
+                'search_default_assigned_to_me': 1,
+            }
             </field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -235,6 +235,7 @@ class MailActivityMixin(models.AbstractModel):
 
     def _search_my_activity_date_deadline(self, operator, operand):
         activity_ids = self.env['mail.activity']._search([
+            ('active', '=', True),  # never overdue if "done"
             ('date_deadline', operator, operand),
             ('res_model', '=', self._name),
             ('user_id', '=', self.env.user.id)

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -746,6 +746,7 @@ class TestActivityMixin(TestActivityCommon):
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_my_activity_flow_employee(self):
+        self.env.ref('test_mail.mail_act_test_todo').keep_done = True
         Activity = self.env['mail.activity']
         date_today = date.today()
         Activity.create({
@@ -764,7 +765,7 @@ class TestActivityMixin(TestActivityCommon):
         })
 
         test_record_1 = self.env['mail.test.activity'].with_context(self._test_context).create({'name': 'Test 1'})
-        Activity.create({
+        test_record_1_late_activity = Activity.create({
             'activity_type_id': self.env.ref('test_mail.mail_act_test_todo').id,
             'date_deadline': date_today,
             'res_model_id': self.env.ref('test_mail.model_mail_test_activity').id,
@@ -774,6 +775,11 @@ class TestActivityMixin(TestActivityCommon):
         with self.with_user('employee'):
             record = self.env['mail.test.activity'].search([('my_activity_date_deadline', '=', date_today)])
             self.assertEqual(test_record_1, record)
+            test_record_1_late_activity._action_done()
+            record = self.env['mail.test.activity'].with_context(active_test=False).search([
+                ('my_activity_date_deadline', '=', date_today)
+            ])
+            self.assertFalse(record, "Should not find record if the only late activity is done")
 
     @users('employee')
     def test_record_unlink(self):


### PR DESCRIPTION
The search for "my_activity_date_deadline" is used to find activities due before some set date.

When keeping done activities for reporting purposes, we should never consider "done" activities for this search.

Issue is introduced in CRM in [1]
but it could happen anywhere

task-4951716

[1]: https://github.com/odoo/odoo/commit/f9f0529c93614bb9f9deec1a5aaa1daccfe8b58c