### PR TITLE
[FIX] point_of_sale: fix test case on demo data loading crash

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -869,23 +869,17 @@ registry.category("web_tour.tours").add("test_delete_line", {
         ].flat(),
 });
 
-function clickLoadSampleButton() {
-    return [
-        {
-            trigger:
-                '.o_view_nocontent .o_nocontent_help button.btn-primary:contains("Load Sample")',
-            content: "Click on Load Sample button",
-            run: "click",
-        },
-    ].flat();
-}
-
 registry.category("web_tour.tours").add("test_load_pos_demo_data_by_pos_user", {
     steps: () =>
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            clickLoadSampleButton(),
+            {
+                trigger:
+                    '.o_view_nocontent .o_nocontent_help button.btn-primary:contains("Load Sample")',
+                content: "Click on Load Sample button",
+                run: "click",
+            },
             {
                 trigger:
                     '.modal-content:has(.modal-title:contains("Access Denied")) .modal-footer .btn.btn-primary:contains("Ok")',
@@ -900,7 +894,13 @@ registry.category("web_tour.tours").add("test_load_pos_demo_data_by_pos_admin", 
     steps: () =>
         [
             Chrome.startPoS(),
-            clickLoadSampleButton(),
+            {
+                trigger:
+                    '.o_view_nocontent .o_nocontent_help button.btn-primary:contains("Load Sample")',
+                content: "Click on Load Sample button",
+                run: "click",
+                expectUnloadPage: true,
+            },
             ProductScreen.isShown(),
             ProductScreen.clickDisplayedProduct("Small Shelf"),
             Chrome.endTour(),


### PR DESCRIPTION
The crash occurs due to the test case introduced in PR #219103 because the demo data was not fully loaded before proceeding with the next operations.

Since demo data is not loaded by default on saas-18.3, which attempts to load a larger number of product records.

This commit uses `expectUnloadPage=true` to ensure the page waits until the demo data is completely loaded completely loaded in the tour.

Runbot-229922