### PR TITLE
[FIX] point_of_sale: Ensure saving init data in indexedDB

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -176,12 +176,17 @@ export class PosData extends Reactive {
     }
 
     async synchronizeServerDataInIndexedDB(serverData = {}) {
-        for (const [model, data] of Object.entries(serverData)) {
-            try {
-                await this.indexedDB.create(model, data);
-            } catch {
-                console.info(`Error while updating ${model} in indexedDB.`);
+        try {
+            const clone = JSON.parse(JSON.stringify(serverData));
+            for (const [model, data] of Object.entries(clone)) {
+                try {
+                    await this.indexedDB.create(model, data);
+                } catch {
+                    console.info(`Error while updating ${model} in indexedDB.`);
+                }
             }
+        } catch {
+            console.debug("Error while synchronizing server data in indexedDB.");
         }
     }
 


### PR DESCRIPTION
Prior to this commit, when sending an object to
`synchronizeServerDataInIndexedDB` without waiting for the method to return. If the object is modified later in the process, certain data is not saved.

We now make a copy of the object in question before the asynchronous event to ensure that all data is saved.

