### PR TITLE
[FIX] hr_attendance: Fix overtime and time off compatibility

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -125,6 +125,7 @@ class HrAttendance(models.Model):
             ('employee_id', 'in', self.employee_id.ids),
             ('date', '>=', date_min),
             ('date', '<=', date_max),
+            ('adjustment', '=', False),
         ])
 
         for ot in overtimes:


### PR DESCRIPTION
When you create an attendance entry it will create an attendance overtime entry corresponding to that day. The relation is used to count the ammount of extra hours in that day. Only one overtime is expected per day in order for it to work properly. The issue arises when you create a time off using extra hours. That will also create an overtime

This commit aims to filter the overtimes when counting the extra hours. The same was used before a refactoring that happened in a fix [bc1f2cdf3b8d448c9522311393aad728a33a2404] which aparently removed it.

opw-4806193