### PR TITLE
[FIX] l10n_in_pos: fix TestInPosBase class

### DIFF
--- a/addons/l10n_in_pos/tests/common.py
+++ b/addons/l10n_in_pos/tests/common.py
@@ -25,7 +25,6 @@ class TestInPosBase(TestPoSCommon):
             "zip": "123456",
             "country_id": country_in_id,
             "l10n_in_is_gst_registered": True,
-            "l10n_in_gst_efiling_feature": True,
         })
         cls.config = cls.basic_config
         cls.gst_5 = cls.env['account.chart.template'].ref('sgst_sale_5')


### PR DESCRIPTION
This problem was introduced with [1](https://github.com/odoo/odoo/pull/205481).

Enteprise: [90429](https://github.com/odoo/enterprise/pull/90429)

This breaks the `TestInPosBase` class in Single App Test build with an invalid field `l10n_in_gst_efiling_feature`.

Runbot - [229837](https://runbot.odoo.com/odoo/error/229837)

