### PR TITLE
[FIX] account: incorrect amount in currency shown on payment receipt PDF

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -76,7 +76,7 @@
                                     <td><span t-field="payment.date">2023-01-05</span></td>
                                     <td><span t-field="payment.name">PAY001</span></td>
                                     <td><span t-field="payment.ref" data-oe-demo="Payment Ref"/></td>
-                                    <t t-set="amountPayment" t-value="-par[0].amount"/>
+                                    <t t-set="amountPayment" t-value="-(par[0].debit_amount_currency if par[2].debit > 0 else par[0].credit_amount_currency)"/>
                                     <t t-set="amountInvoice" t-value="-par[1]"/>
                                     <t t-set="currencyPayment" t-value="payment.currency_id"/>
                                     <t t-set="currencyInvoice" t-value="inv.currency_id"/>


### PR DESCRIPTION
**Steps to reproduce**:
1. Install the `accounting` module.
2. Activate a foreign currency form `Accounting -> Configuration -> Currencies` and fetch its exchange rate.
<img width="599" height="267" alt="image" src="https://github.com/user-attachments/assets/34e7c719-20f7-4cd0-a1d6-0e94764461ba" />

3. Create an invoice using the company’s default currency (e.g., USD).
4. Register a payment using the foreign currency (e.g., VES).
5. Reconcile the payment with the invoice.
6. Print the payment receipt PDF.

**Observations**:
In the printed PDF, under the `Amount In Currency` column, the amount is incorrectly displayed.

For example, suppose `1 USD` = `100 VES`.
- An invoice of `100 USD`  is created.
- A payment of `10,000 Bs` is registered (equivalent to 100 USD).
- When the payment receipt is printed, the output appears as:

```
| Invoice Number     | Reference         | Amount In Currency | Amount      |
|--------------------|-------------------|--------------------|-------------|
| INV/2025/00001     |                   |                    |  100.00 USD |
| PBNK1/2025/00001   | INV/2025/00001    | -100.00 Bs         | -100.00 USD |
```
Here, the `Amount In Currency` for the payment line shows **100 Bs** instead of the correct **10,000 Bs**.

**Issue**:
The payment receipt uses the `_get_reconciled_invoices_partials()` method to fetch details about reconciled invoices. However, the report incorrectly uses the `amount` field (in company currency) for the `Amount In Currency` column, leading to this mismatch.

**Solution**:
The report now uses `(debit/credit)_amount_currency` instead of `amount` to correctly reflect the foreign currency values in the `Amount In Currency` column.

opw-4898706