### PR TITLE
[ADD] l10n_in: Add configuration settings to enable Cashfree Payout

### DIFF
--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -59,6 +59,7 @@ class ResConfigSettings(models.TransientModel):
     l10n_in_fetch_vendor_edi_feature = fields.Boolean(string="Fetch Vendor E-Invoiced Document")
     l10n_in_enet_vendor_batch_payment_feature = fields.Boolean(string="ENet Vendor Batch Payment")
 
+    module_l10n_in_cashfree_payout = fields.Boolean("Cashfree Payouts")
     module_l10n_in_reports = fields.Boolean("GST E-Filing & Matching")
     module_l10n_in_edi = fields.Boolean("Indian Electronic Invoicing")
     module_l10n_in_ewaybill = fields.Boolean("Indian Electronic Waybill")
@@ -86,6 +87,8 @@ class ResConfigSettings(models.TransientModel):
                 self._update_l10n_in_feature("l10n_in_edi_feature")
             if self.module_l10n_in_ewaybill:
                 self._update_l10n_in_feature("l10n_in_ewaybill_feature")
+            if self.module_l10n_in_cashfree_payout:
+                self._update_l10n_in_feature("l10n_in_cashfree_payout_feature")
 
     def _update_l10n_in_feature(self, column):
         """ This way, after installing the module, the field will already be set for the active company. """

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -113,6 +113,10 @@
                          invisible="country_code != 'IN'">
                     <field name="l10n_in_enet_vendor_batch_payment_feature" widget="upgrade_boolean"/>
                 </setting>
+                <setting name="cashfree_payout" invisible="country_code != 'IN'"
+                    help="Use Cashfree to process vendor payments and monitor their status within your Odoo accounting workflows." company_dependent="1">
+                    <field name="module_l10n_in_cashfree_payout" widget="upgrade_boolean"/>
+                </setting>
             </block>
             <block id="default_accounts" position="inside">
                 <setting string="India TDS Control:" invisible="not l10n_in_tds_feature">


### PR DESCRIPTION
Added setting in the Config settings to enable Cashfree Payout.

Related Enterprise PR: https://github.com/odoo/enterprise/pull/90426
taskid:4723786