### PR TITLE
[ADD] website_practice: added module to verify asset loaded

### DIFF
--- a/addons/website_practice/__manifest__.py
+++ b/addons/website_practice/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "Website Practice",
+    "version": "1.0",
+    "depends": ["website"],
+    "category": "Website",
+    "data": [
+        "views/snippets/s_dynamic_snippet.xml",
+    ],
+    "assets": {
+        "web.assets_frontend": [
+            "website_practice/static/src/js/practice_task.js",
+        ],
+    },
+    "application": True,
+    "sequence": 1,
+    "installable": True,
+}

--- a/addons/website_practice/static/src/js/practice_task.js
+++ b/addons/website_practice/static/src/js/practice_task.js
@@ -1,0 +1,20 @@
+/** @odoo-module **/
+
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+
+export class PracticeTask extends Interaction {
+    static selector = ".SHSApractice";
+
+    async start() {
+        window.Popover.getOrCreateInstance(this.el, {
+            placement: "bottom",
+            trigger: "click",
+            html: true,
+            content: () => `<div class="text-success fw-bold">Assets loaded successfully!</div>`,
+        });
+    }
+}
+
+registry.category("public.interactions").add("website_practice.task2", PracticeTask);

--- a/addons/website_practice/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website_practice/views/snippets/s_dynamic_snippet.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="website_practice.s_dynamic_snippet_template_addon" inherit_id="website.s_dynamic_snippet_template">
+        <xpath expr="//div[@t-if='main_page_url']" position="before">
+            <button type="button" class="btn btn-primary SHSApractice">
+                Show Popup
+            </button>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Created a module and added the popover instance if the assets for that are loaded successfully.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
