### PR TITLE
[FIX] account: fix the visibility of payment method inside branch

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -621,7 +621,7 @@ class ResPartner(models.Model):
     property_outbound_payment_method_line_id = fields.Many2one(
         comodel_name='account.payment.method.line',
         company_dependent=True,
-        domain=lambda self: [('payment_type', '=', 'outbound'), ('company_id', '=', self.env.company.id)],
+        domain=lambda self: [('payment_type', '=', 'outbound'), ('company_id', 'parent_of', self.env.company.id)],
         help="Preferred payment method when buying from this vendor. This will be set by default on all"
              " outgoing payments created for this vendor",
     )
@@ -629,7 +629,7 @@ class ResPartner(models.Model):
     property_inbound_payment_method_line_id = fields.Many2one(
         comodel_name='account.payment.method.line',
         company_dependent=True,
-        domain=lambda self: [('payment_type', '=', 'inbound'), ('company_id', '=', self.env.company.id)],
+        domain=lambda self: [('payment_type', '=', 'inbound'), ('company_id', 'parent_of', self.env.company.id)],
         help="Preferred payment method when selling to this customer. This will be set by default on all"
              " incoming payments created for this customer",
     )


### PR DESCRIPTION
In this bug, the payment method is not shown in the child branch.

To reproduce:
1- Create a db with account and contact app installed
2- Create a company and a branch
3- Create a payment method in parent company and add it to contact form of a partner
4- Go to child branch. You can see the payment method is not shown in the contact form.

opw-4920219