### PR TITLE
[FIX] account: prevent error when removing bank accounts

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -75,6 +75,7 @@ class ResPartnerBank(models.Model):
              LEFT JOIN res_partner_bank other ON this.acc_number = other.acc_number
                                              AND this.id != other.id
                  WHERE this.id = ANY(%(ids)s)
+                 AND other.partner_id IS NOT NULL
                    AND (
                         ((this.company_id = other.company_id) OR (this.company_id IS NULL AND other.company_id IS NULL))
                         OR

--- a/addons/account/tests/test_duplicate_res_partner_bank.py
+++ b/addons/account/tests/test_duplicate_res_partner_bank.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 
+from odoo.tests import Form
 from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
 
 
@@ -34,3 +35,17 @@ class TestDuplicatePartnerBank(SavepointCaseWithUserDemo):
         self.partner_a.company_id = False
         self.partner_bank_a.company_id = False
         self.assertTrue(self.partner_bank_b.duplicate_bank_partner_ids, self.partner_a)
+
+    def test_remove_bank_account_from_partner(self):
+        bank = self.env['res.bank'].create({'name': 'SBI Bank'})
+        self.partner_bank_a.write({
+            'acc_number': '99999',
+            'bank_id': bank.id,
+        })
+
+        self.assertEqual(len(self.partner_a.bank_ids), 1)
+
+        with Form(self.partner_a) as partner_form:
+            partner_form.bank_ids.remove(0)
+
+        self.assertEqual(len(self.partner_a.bank_ids), 0)


### PR DESCRIPTION
Currently an error occurs when we try to remove bank accounts from a partner.

**Steps to reproduce:**
- Install `accountant` (with demo), Go to customers and create a new one with random name.
- Under accounting tab add a new bank account with an acc number, bank and save.
- Now remove the bank account record.

**Error:**
`AttributeError: 'NoneType' object has no attribute 'origin'`

**Cause:**
- The error occurs because of the SQL query [1] returning None values in the `id2duplicates` dict, somewhat like `{1: [None]}`, this caused the browse [2] to assign `None` to the `duplicate_bank_partner_ids`.
- While recording snapshots for diff checking in onchange system the none value will be stored like`None: {display_name:{}}` and when the line [3] tries to access `id_.origin` where `id_` is None and causes the error.

**Solution:**
- Added a condition which makes sure null values are not accounted. (The Join is added to makes sure that the correct `partner_id` is fetched.)

[1]: https://github.com/odoo/odoo/blob/04ba4e4a51843701dd42a3f0243add50b3ac0c79/addons/account/models/res_partner_bank.py#L71-L85

[2]: https://github.com/odoo/odoo/blob/04ba4e4a51843701dd42a3f0243add50b3ac0c79/addons/account/models/res_partner_bank.py#L88

[3]: https://github.com/odoo/odoo/blob/04ba4e4a51843701dd42a3f0243add50b3ac0c79/addons/web/models/models.py#L1173

sentry-6748249363
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
