### PR TITLE
[FIX] html_builder: restore support for decimal values in box-shadow

### DIFF
--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -443,7 +443,7 @@ export function setBuilderCSSVariables(htmlStyle) {
 
 export function parseBoxShadow(value) {
     const regex =
-        /(?<color>(rgb(a)?\([^)]*\))|(var\([^)]+\)))\s+(?<offsetX>-?\d+px)\s+(?<offsetY>-?\d+px)\s+(?<blur>-?\d+px)\s+(?<spread>-?\d+px)(?:\s+(?<mode>\w+))?/;
+        /(?<color>(rgb(a)?\([^)]*\))|(var\([^)]+\)))\s+(?<offsetX>-?\d+\.?\d*px)\s+(?<offsetY>-?\d+\.?\d*px)\s+(?<blur>-?\d+\.?\d*px)\s+(?<spread>-?\d+\.?\d*px)(?:\s+(?<mode>\w+))?/;
     return value.match(regex).groups;
 }
 

--- a/addons/html_builder/static/tests/shadow_option.test.js
+++ b/addons/html_builder/static/tests/shadow_option.test.js
@@ -33,19 +33,20 @@ test("edit box-shadow with ShadowOption", async () => {
     );
 
     await contains('[data-action-param="offsetX"] input').fill(10);
-    await contains('[data-action-param="offsetY"] input').fill(2, { clean: true });
+    await contains('[data-action-param="offsetY"] input').fill(2);
     expect(":iframe .test-options-target").toHaveOuterHTML(
         '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 16px 0px !important;">b</div>'
     );
 
-    await contains('[data-action-param="blur"] input').fill(3);
+    await contains('[data-action-param="blur"] input').clear();
+    await contains('[data-action-param="blur"] input').fill(10.5);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 163px 0px !important;">b</div>'
+        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0px !important;">b</div>'
     );
 
-    await contains('[data-action-param="spread"] input').fill(4);
+    await contains('[data-action-param="spread"] input').fill(".4");
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 163px 4px !important;">b</div>'
+        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px !important;">b</div>'
     );
 
     await contains('.options-container button[title="Inset"]').click();
@@ -56,9 +57,14 @@ test("edit box-shadow with ShadowOption", async () => {
         "Blur",
         "Spread",
     ]);
-    expect(queryAllValues('[data-action-id="setShadow"] input')).toEqual(["10", "82", "163", "4"]);
+    expect(queryAllValues('[data-action-id="setShadow"] input')).toEqual([
+        "10",
+        "82",
+        "10.5",
+        "0.4",
+    ]);
     expect(":iframe .test-options-target").toHaveOuterHTML(
-        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 163px 4px inset !important;">b</div>'
+        '<div class="test-options-target o-paragraph shadow" style="box-shadow: rgba(0, 0, 0, 0.15) 10px 82px 10.5px 0.4px inset !important;">b</div>'
     );
 
     await contains(".options-container button:contains(None)").click();


### PR DESCRIPTION
**Problem**
Before this commit, if the user entered a decimal value in any of the shadow settings, a traceback popped up. This was due to a regex not supporting decimal values.

**How to reproduce**
1. In edit mode
2. Click on header
3. Enter a decimal value (e.g. "1.1") in any of the shadow settings (e.g. "blur")
4. Press enter
5. Problem: traceback when clicking on the header, even after saving and reloading

**Solution**
This commit fixes the regex in `parseBoxShadow` such that it correctly matches decimal values.

task-4367641