### PR TITLE
[FIX] purchase: allow unlocking PO regardless of "Lock Confirmed Orders"

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -548,8 +548,6 @@ class PurchaseOrder(models.Model):
         self.locked = True
 
     def button_unlock(self):
-        if self.lock_confirmed_po == 'lock':
-            raise UserError(_("Unlocking the order is not allowed as 'Lock Confirmed Orders' is enabled."))
         self.locked = False
 
     def _prepare_supplier_info(self, partner, line, price, currency):

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -1030,3 +1030,29 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertEqual(po.order_line.price_unit, 6)
         po.order_line.product_qty = 2
         self.assertEqual(po.order_line.price_unit, 5)
+
+    def test_purchase_order_lock(self):
+        """
+        Test that the purchase order can be locked and unlocked without the lock_confirmed_po setting.
+        """
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product_a.id,
+            })],
+        })
+        po.button_confirm()
+        self.assertFalse(po.locked)
+        # Lock the purchase order
+        po.button_lock()
+        self.assertTrue(po.locked)
+        # Unlocking should not raise an error regardless of the 'Lock Confirmed Orders' setting.
+        self.assertNotEqual(po.lock_confirmed_po, 'lock')
+        po.button_unlock()
+        self.assertFalse(po.locked)
+
+        po.button_lock()
+        self.assertTrue(po.locked)
+        po.lock_confirmed_po = 'lock'
+        po.button_unlock()
+        self.assertFalse(po.locked)


### PR DESCRIPTION
Steps to reproduce the bug:

- Do not enable the “Lock Confirmed Orders” setting.
- Create a Purchase Order:
  - Add any product.
- Confirm the PO.

Problem:

The `Lock` button is not visible. Starting from version 18.3, users must enable the setting, and all POs are locked automatically:
  [Commit reference](https://github.com/odoo/odoo/commit/63bfd81dfdec9ef2d928aed439bb7b97841e76d7)

However, a user can edit the view or use Studio to manually display the Lock button and lock the PO. But when attempting to unlock it, an error is triggered:

> “Unlocking the order is not allowed as 'Lock Confirmed Orders'
is enabled.”

**opw-4948226**
