### PR TITLE
[FIX] l10n_sa_edi: put the payable amount in the invoice QR code

### DIFF
--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -103,7 +103,7 @@ class AccountMove(models.Model):
             prehash_content = etree.tostring(root)
             invoice_hash = edi_format._l10n_sa_generate_invoice_xml_hash(prehash_content, 'digest')
 
-            amount_total = float(xpath_ns('//cbc:TaxInclusiveAmount'))
+            amount_total = float(xpath_ns('//cbc:PayableAmount'))
             amount_tax = float(xpath_ns('//cac:TaxTotal/cbc:TaxAmount'))
             x509_certificate = load_der_x509_certificate(b64decode(x509_cert), default_backend())
             seller_name_enc = self._l10n_sa_get_qr_code_encoding(1, journal_id.company_id.display_name.encode())


### PR DESCRIPTION
#### Step to reproduce:
- In a company in Saudi Arabia
- Create a sale order to a customer (B2C)
- Create an invoice as a downpayment and confirm it
- Process the ZATCA invoice if needed (blue banner at the top)
- Create an invoice as a regular payment and confirm it
- Process the ZATCA invoice if needed (blue banner at the top)

#### Current behavior:
- ZATCA return a 200 code for the downpayment invoice.
- ZATCA return a 202 code with a Warning for the regular payment invoice. The warning states that the invoice was accepted however it needs the Tag 4 of the QR code to be Amount due payment (BT-115)

#### Expected behavior
- ZATCA return a 200 code on both invoices.

opw-4848578

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
