### PR TITLE
[IMP] mail: current user check for RPC contexts

### DIFF
--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -300,6 +300,8 @@ class Store:
         def is_current_user(self, env):
             """Return whether the current target is the current user or guest of the given env.
             If there is no target at all, this is always True."""
+            if self.channel is None and self.subchannel is None:
+                return True
             user = self.get_user(env)
             guest = self.get_guest(env)
             return self.subchannel is None and (


### PR DESCRIPTION
This PR adds an explicit `return True` at the top of the `is_current_user`method when `self.channel` and `self.subchannel` are both `None`. This change addresses scenarios where the user check occurs in an RPC context (which is always for current user), rather than sending on the bus.
The behavior is already in the existing documentation: `If there is no target at all, this is always True.` 
This explicit quick return ensures correct behavior, particularly for non logged in portal partners who might encounter these RPC contexts.