### PR TITLE
[FIX] setup: update windows iot checkout version

### DIFF
--- a/setup/win32/setup-iot.nsi
+++ b/setup/win32/setup-iot.nsi
@@ -170,7 +170,7 @@ Section $(TITLE_Odoo_IoT) SectionOdoo_IoT
 
     # Cloning odoo
     DetailPrint "Cloning Odoo"
-    nsExec::Exec '"$INSTDIR\git\cmd\git.exe" clone --filter=tree:0 -b 18.0 --single-branch --no-checkout https://github.com/odoo/odoo.git "$INSTDIR\odoo"'
+    nsExec::Exec '"$INSTDIR\git\cmd\git.exe" clone --filter=tree:0 -b saas-18.4 --single-branch --no-checkout https://github.com/odoo/odoo.git "$INSTDIR\odoo"'
 
     DetailPrint "Configuring Sparse Checkout for IoT modules"
     nsExec::Exec '"$INSTDIR\git\cmd\git.exe" -C "$INSTDIR\odoo" sparse-checkout init --no-cone'


### PR DESCRIPTION
The Virtual IoT Box installer is now using git to get the right code version depending it's linked database version.

It was checking out 18.0 by default, which is not compatible with the new Virtual IoT installer. We updated it to saas-18.4, which is ready for it.