### PR TITLE
[FIX] stock: allow printing picking operations when an attachment is configured

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -4,8 +4,11 @@
 
         <template id="report_picking">
             <t t-call="web.report_layout">
-                <div class="article o_report_layout_standard">
-                    <t t-foreach="docs" t-as="o">
+                <t t-foreach="docs" t-as="o">
+                    <div class="article o_report_layout_standard"
+                        t-att-data-oe-model="o and o._name"
+                        t-att-data-oe-id="o and o.id"
+                        t-att-data-oe-lang="o and o.env.context.get('lang')">
                         <t t-set="address" t-value="None"/>
                         <div class="page o_report_stockpicking_operations">
                             <div class="row justify-content-between">
@@ -240,8 +243,8 @@
                             <p t-field="o.note"/>
                             <div class="oe_structure"></div>
                         </div>
-                    </t>
-                </div>
+                    </div>
+                </t>
             </t>
         </template>
         <template id="report_picking_type_label">


### PR DESCRIPTION
**Issue**:
An error occurs when printing a picking operation if the "Save as Attachment Prefix" field is set.

**Steps to reproduce**:
- Go to Settings > Technical > Reporting > Reports > Advanced Properties
- Set the "Save as Attachment Prefix" field (e.g., enter `"Picking Operations"`)
- Save and open the Sales application
- Create a new quotation and click the Delivery smart button
- Click the Print button and observe the error

**Cause**:
The error stems from the following condition in the report engine: `set(res_ids_wo_stream) != set(html_ids)` [Source](https://github.com/odoo/odoo/blob/aa4aced07c9120684ef6969cd8a13724468d1382/odoo/addons/base/models/ir_actions_report.py#L857)

In this case, `html_ids` becomes `[None]` because the rendered HTML lacks the `data-oe-model` and `data-oe-id` attributes on the `<article>` tag. These attributes are extracted by the [_prepare_html](https://github.com/odoo/odoo/blob/aa4aced07c9120684ef6969cd8a13724468d1382/odoo/addons/base/models/ir_actions_report.py#L410C9-L427C1) method.

This issue was introduced in [this commit](https://github.com/odoo/odoo/commit/381615636185b88585e5ca112e43b6a7d81e1895), which removed the use of the `web.external_layout` template in `report_stockpicking_operations.xml`. Previously, that template was responsible for adding the required `data-oe-*` attributes.

As a result, `_prepare_html` only finds the [first `<article>` tag](https://github.com/odoo/odoo/blob/381615636185b88585e5ca112e43b6a7d81e1895/addons/stock/report/report_stockpicking_operations.xml#L7), which now lacks the necessary attributes—causing `html_ids` to be `[None]`.

**Solution**:
Explicitly add the `data-oe-model`, `data-oe-id`, and `data-oe-lang` attributes to the `<div class="article">` inside the report template.

opw-4930592
