### PR TITLE
[FIX] web, html_builder, *: fix colorpicker theme colors display

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -135,6 +135,7 @@ export class BuilderColorPicker extends Component {
                 getUsedCustomColors:
                     this.props.getUsedCustomColors || this.getUsedCustomColors.bind(this),
                 colorPrefix: "color-prefix-",
+                themeColorPrefix: "hb-cp-",
                 showRgbaField: true,
                 noTransparency: this.props.noTransparency,
                 enabledTabs: this.props.enabledTabs,

--- a/addons/html_builder/static/src/core/color_plugin.js
+++ b/addons/html_builder/static/src/core/color_plugin.js
@@ -5,4 +5,10 @@ export class ColorPlugin extends EditorColorPlugin {
     getUsedCustomColors(mode) {
         return getAllUsedColors(this.editable);
     }
+
+    getPropsForColorSelector(type) {
+        const props = {...super.getPropsForColorSelector(type)};
+        props.themeColorPrefix = "hb-cp-";
+        return props;
+    }
 }

--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -21,8 +21,12 @@ export class ColorSelector extends Component {
         applyColorResetPreview: Function,
         getUsedCustomColors: Function,
         colorPrefix: { type: String },
+        themeColorPrefix: { type: String, optional: true },
         onClose: Function,
     };
+    static defaultProps = {
+        themeColorPrefix: "",
+    }
 
     setup() {
         this.state = useState({});
@@ -55,6 +59,7 @@ export class ColorSelector extends Component {
                 applyColorResetPreview: this.props.applyColorResetPreview,
                 getUsedCustomColors: this.props.getUsedCustomColors,
                 colorPrefix: this.props.colorPrefix,
+                themeColorPrefix: this.props.themeColorPrefix,
             },
             {
                 onClose: () => {

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -50,15 +50,15 @@
                             <div class="d-flex mb-1 custom-text-color">
                                 <label>Text Color</label>
                                 <button class="o_we_color_preview custom-text-picker" t-att-data-color="this.customTextColorState.selectedColor" t-ref="customTextColorButton"
-                                        t-attf-style="background-color: {{this.customTextColorState.selectedColor}}" />
+                                        t-attf-style="background-color: {{this.props.formatColor(this.customTextColorState.selectedColor)}}" />
                                 <label>Fill Color</label>
                                 <button class="o_we_color_preview custom-fill-picker" t-att-data-color="this.customFillColorState.selectedColor" t-ref="customFillColorButton"
-                                        t-attf-style="{{this.customFillColorState.selectedColor?.includes('gradient') ? 'background-image' : 'background-color'}}: {{this.customFillColorState.selectedColor}}" />
+                                        t-attf-style="{{this.customFillColorState.selectedColor?.includes('gradient') ? 'background-image' : 'background-color'}}: {{this.props.formatColor(this.customFillColorState.selectedColor)}}" />
                             </div>
                             <div class="d-flex mb-1 custom-border-color">
                                 <label>Border</label>
                                 <button class="o_we_color_preview custom-border-picker" t-att-data-color="this.customBorderColorState.selectedColor" t-ref="customBorderColorButton"
-                                        t-attf-style="background-color: {{this.customBorderColorState.selectedColor}}" />
+                                        t-attf-style="background-color: {{this.props.formatColor(this.customBorderColorState.selectedColor)}}" />
                             </div>
                             <div class="d-flex mb-1 custom-border">
                                 <div class="input-group">

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -55,6 +55,7 @@ export class ColorPicker extends Component {
         applyColorResetPreview: Function,
         enabledTabs: { type: Array, optional: true },
         colorPrefix: { type: String },
+        themeColorPrefix: { type: String, optional: true },
         showRgbaField: { type: Boolean, optional: true },
         noTransparency: { type: Boolean, optional: true },
         close: { type: Function, optional: true },
@@ -64,6 +65,7 @@ export class ColorPicker extends Component {
         close: () => {},
         enabledTabs: ["solid", "gradient", "custom"],
         showRgbaField: false,
+        themeColorPrefix: "",
     };
 
     setup() {

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -71,11 +71,11 @@
                 t-on-focusin="onColorFocusin"
                 t-on-focusout="onColorFocusout">
                 <div class="o_colorpicker_section">
-                    <button data-color="o-color-1" t-attf-style="background-color: var(--o-color-1)" class="btn p-0 o_color_button"/>
-                    <button data-color="o-color-3" t-attf-style="background-color: var(--o-color-3)" class="btn p-0 o_color_button"/>
-                    <button data-color="o-color-2" t-attf-style="background-color: var(--o-color-2)" class="btn p-0 o_color_button"/>
-                    <button data-color="o-color-4" t-attf-style="grid-column: 5; background-color: var(--o-color-4)" class="btn p-0 o_color_button"/>
-                    <button data-color="o-color-5" t-attf-style="background-color: var(--o-color-5)" class="btn p-0 o_color_button"/>
+                    <button data-color="o-color-1" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-1)" class="btn p-0 o_color_button"/>
+                    <button data-color="o-color-3" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-3)" class="btn p-0 o_color_button"/>
+                    <button data-color="o-color-2" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-2)" class="btn p-0 o_color_button"/>
+                    <button data-color="o-color-4" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-4); grid-column: 5;" class="btn p-0 o_color_button"/>
+                    <button data-color="o-color-5" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-5)" class="btn p-0 o_color_button"/>
                 </div>
 
                 <div class="o_color_section">

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -1,6 +1,6 @@
 import { test, expect } from "@odoo/hoot";
 import { press, click, animationFrame, queryOne } from "@odoo/hoot-dom";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { defineStyle, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { ColorPicker, DEFAULT_COLORS } from "@web/core/color_picker/color_picker";
 import { CustomColorPicker } from "@web/core/color_picker/custom_color_picker/custom_color_picker";
 import { convertRgbToHsl } from "@web/core/utils/colors";
@@ -142,6 +142,82 @@ test("keyboard navigation", async () => {
     expect(
         ".o_font_color_selector .o_color_section .o_color_button[data-color]:last-of-type"
     ).toBeFocused();
+});
+
+test("colorpicker inside the builder are linked to the builder theme colors", async () => {
+    await mountWithCleanup(ColorPicker, {
+        props: {
+            state: {
+                selectedColor: "",
+                defaultTab: "",
+            },
+            getUsedCustomColors: () => [],
+            applyColor() {},
+            applyColorPreview() {},
+            applyColorResetPreview() {},
+            colorPrefix: "",
+            themeColorPrefix: "xyz-",
+        },
+    });
+    const getButtonColor = (sel) => getComputedStyle(queryOne(sel)).backgroundColor;
+
+    defineStyle(`
+        :root {
+            --o-color-1: rgb(113, 75, 103);
+            --o-color-2: rgb(45, 49, 66);
+            --xyz-o-color-1: rgb(113, 75, 103);
+            --xyz-o-color-2: rgb(45, 49, 66);
+        }
+    `);
+    expect(getButtonColor("button[data-color='o-color-1']")).toBe("rgb(113, 75, 103)");
+    expect(getButtonColor("button[data-color='o-color-2']")).toBe("rgb(45, 49, 66)");
+
+    defineStyle(`
+        :root {
+            --xyz-o-color-1: rgb(0, 0, 255);
+            --xyz-o-color-2: rgb(0, 255, 0);
+        }
+    `);
+    expect(getButtonColor("button[data-color='o-color-1']")).toBe("rgb(0, 0, 255)");
+    expect(getButtonColor("button[data-color='o-color-2']")).toBe("rgb(0, 255, 0)");
+});
+
+test("colorpicker outside the builder are not linked to the builder theme colors", async () => {
+    await mountWithCleanup(ColorPicker, {
+        props: {
+            state: {
+                selectedColor: "",
+                defaultTab: "",
+            },
+            getUsedCustomColors: () => [],
+            applyColor() {},
+            applyColorPreview() {},
+            applyColorResetPreview() {},
+            colorPrefix: "",
+            themeColorPrefix: "",
+        },
+    });
+    const getButtonColor = (sel) => getComputedStyle(queryOne(sel)).backgroundColor;
+
+    defineStyle(`
+        :root {
+            --o-color-1: rgb(113, 75, 103);
+            --o-color-2: rgb(45, 49, 66);
+            --xyz-o-color-1: rgb(113, 75, 103);
+            --xyz-o-color-2: rgb(45, 49, 66);
+        }
+    `);
+    expect(getButtonColor("button[data-color='o-color-1']")).toBe("rgb(113, 75, 103)");
+    expect(getButtonColor("button[data-color='o-color-2']")).toBe("rgb(45, 49, 66)");
+
+    defineStyle(`
+        :root {
+            --xyz-o-color-1: rgb(0, 0, 255);
+            --xyz-o-color-2: rgb(0, 255, 0);
+        }
+    `);
+    expect(getButtonColor("button[data-color='o-color-1']")).toBe("rgb(113, 75, 103)");
+    expect(getButtonColor("button[data-color='o-color-2']")).toBe("rgb(45, 49, 66)");
 });
 
 test("custom color picker sets default color as selected", async () => {


### PR DESCRIPTION
Before this commit, updating the theme colors in the "Theme" tab would not correctly update the interface of the colorpicker, but the colors would be applied properly.

This commit adds a props to the colorpickers in order to use the correct theme colors (Odoo or Website Theme) depending on which should be used.

task-4367641