### PR TITLE
[FIX] web_editor: allow non-admin editor user to save  Unsplash image

### DIFF
--- a/addons/test_website_modules/tests/test_controllers.py
+++ b/addons/test_website_modules/tests/test_controllers.py
@@ -43,8 +43,10 @@ class TestWebEditorController(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             self.assertEqual(200, response.status_code, "Expect response")
             if expect_fail:
                 return json_safe.loads(response.content)
-            url = json_safe.loads(response.content).get('result')
-            self.assertTrue(url.endswith(name), "Expect name in URL")
+            content = json_safe.loads(response.content)
+            self.assertFalse(content.get('error'), "An error should not happen")
+            url = content.get('result')
+            self.assertTrue(url.partition('?unique=')[0].endswith(name), "Expect name in URL")
             response = self.url_open(url)
             self.assertEqual(200, response.status_code, "Expect response")
             self.assertTrue('image/svg+xml' in response.headers.get('Content-Type'), "Expect SVG mimetype")
@@ -86,6 +88,11 @@ class TestWebEditorController(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             ]
         })
         modify('demo', 'page-demo.gif')
+
+        # Website designer can modify url attachment (for e.g. unsplash)
+        attachment.url = '/page-logo-unique.gif'
+        modify('demo', 'page-logo-unique.gif')
+        attachment.url = False  # Reset previous value
 
         # Portal user cannot modify page
         with mute_logger('odoo.http'):

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -590,10 +590,11 @@ class Web_Editor(http.Controller):
             # empty record set.
             request.env[fields['res_model']].browse(fields['res_id']).check_access_rights('write')
 
-            # Sudo and SUPERUSER_ID because restricted editor will not be able
-            # to copy the record and the mimetype will be forced to plain text.
-            attachment = attachment.with_user(SUPERUSER_ID).sudo().copy(fields)
-            attachment = attachment.with_user(request.env.user.id).sudo(False)
+            # Sudo because restricted editor will not be able to copy the record
+            attachment = attachment.sudo().copy(fields).sudo(False)
+            # Override mimetype with SUPERUSER if it was forced to plain text
+            if attachment.mimetype == 'text/plain' != fields['mimetype']:
+                attachment.with_user(SUPERUSER_ID).mimetype = fields['mimetype']
 
         if alt_data:
             for size, per_type in alt_data.items():


### PR DESCRIPTION
Scenario:

- Setup Unsplash and install website
- Set a user as "Website: Editor and Designer"
- Login as that user and go to any website page with a qweb view
- Go to edit mode and drop Text-Image in a view
- Replace the image with an unsplash image and then save

Result: the save fails without any message shown, and there is a
security access WARNING in the logs.

Note: a similar scenario can be done for a restricted editor that is
editing a HTML field it has write access to.

Issue: to save a model with res_id 0, we need to either be admin
(base.group_system) or the record creator. Since
9c9c58a5a10101532cbf046d21d4a63c2b7d2838 to bypass the mimetype
neutering of happening, we create the attachment as SUPERUSER.

Then when we modify the attachment url (for unsplash images), we have no
access right to the attachment since we are not the creator.

Fix: create the attachment with the current user, and only use
SUPERUSER to set the mimetype if it was neutered (ie. the user doesn't
have write access right to ir.ui.view, which in normal use case should
only happen for "Restricted Editor"). This way the image is created by
the user that uploaded it and not SUPERUSER.

opw-4850611
opw-5387258
opw-5489219