### PR TITLE
[FIX] website_sale: fix decrease cart quantity

### DIFF
--- a/addons/website_sale/static/src/interactions/cart_line.js
+++ b/addons/website_sale/static/src/interactions/cart_line.js
@@ -33,7 +33,8 @@ export class CartLine extends Interaction {
         const maxQuantity = parseFloat(input.dataset.max || Infinity);
         const oldQuantity = parseFloat(input.value || 0);
         const newQuantity = currentTargetEl.querySelector('i').classList.contains('oi-minus')
-            ? Math.max(oldQuantity - 1, 0) : Math.min(oldQuantity + 1, maxQuantity);
+            ? Math.min(Math.max(oldQuantity - 1, 0), maxQuantity)
+            : Math.min(oldQuantity + 1, maxQuantity);
         if (oldQuantity !== newQuantity) {
             input.value = newQuantity;
             await this._changeQuantity(input);


### PR DESCRIPTION
Prior to https://github.com/odoo/odoo/commit/d337bc1bc4fbb848d0141e88e8d3d6f0d9c56929, decreasing the quantity of a product on the cart would set the quantity to the minimum between the current quantity - 1, and the maximum available.

After, https://github.com/odoo/odoo/commit/d337bc1bc4fbb848d0141e88e8d3d6f0d9c56929, when decreasing the quantity of a product on the cart. The max quantity is not used. E.g., if there are 10 Chair floor protection in stock and it is not allowed to make out-of-stock orders. But a client was able to add 30 items in his cart at a prior time, and then decides that he needs less and decreases the quantity. Then an error message would be displayed.

> You asked for 29.0 Chair floor protection but only 10.0 are available from .

This commit reverts to the previous behavior to prevent situations where the customer has to decrease the quantity one by one, each time with an error displayed, until reaching a quantity in the range of what is available.

See also:
- https://github.com/odoo/odoo/pull/203769

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
