### PR TITLE
[FIX] purchase_stock: inherit the right view for catalog

### DIFF
--- a/addons/purchase_stock/views/product_views.xml
+++ b/addons/purchase_stock/views/product_views.xml
@@ -27,7 +27,7 @@
     <record id="product_view_kanban_catalog_purchase_only" model="ir.ui.view">
         <field name="name">product.view.kanban.catalog.purchase_stock</field>
         <field name="model">product.product</field>
-        <field name="inherit_id" ref="product.product_view_kanban_catalog"/>
+        <field name="inherit_id" ref="stock.product_view_kanban_catalog"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//kanban" position="attributes">


### PR DESCRIPTION
Steps to reproduce:
- Install a fresh database with `purchase_stock`
- Update the `product` module

Issue:
An error will raise as `<t name="qty_free"/>` isn't found within the `product.product_view_kanban_catalog` view.

Since both `qty_free` and `qty_available` are defined in the override made in the stock module, the override in purchase_stock should inherit from the override made in stock instead of the base one from product.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
