### PR TITLE
[IMP] rpc: /web/version and /json/version

### DIFF
--- a/addons/rpc/controllers/__init__.py
+++ b/addons/rpc/controllers/__init__.py
@@ -1,4 +1,5 @@
-from odoo.http import request
+import odoo.release
+from odoo.http import request, route
 
 from . import json2
 
@@ -13,4 +14,9 @@ from .xmlrpc import XMLRPC  # noqa: E402
 
 
 class RPC(XMLRPC, JSONRPC):
-    pass
+    @route(['/web/version', '/json/version'], type='http', auth='none', readonly=True)
+    def version(self):
+        return request.make_json_response({
+            'version_info': odoo.release.version_info,
+            'version': odoo.release.version,
+        })

--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -158,6 +158,12 @@ class TestHttpMisc(TestHttpBase):
             self.url_open('/test_http/concurrency_error').raise_for_status()
         self.assertIn("A dummy concurrency error occurred", log_catcher.output[0])
 
+    def test_misc9_webversion(self):
+        res = self.nodb_url_open('/web/version')
+        res.raise_for_status()
+        self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')
+        self.assertEqual(set(res.json()), {'version', 'version_info'})
+
 
 @tagged('post_install', '-at_install')
 class TestHttpCors(TestHttpBase):


### PR DESCRIPTION
A simple route that returns the current version of the server, as json.

* [x] test