### PR TITLE
[FIX] crm: properly show lost records with filter

### DIFF
--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -54,7 +54,7 @@
                     <filter string="Opportunities" name="opportunity" domain="[('lead_type', '=', 'opportunity')]" help="Show only opportunity" groups="crm.group_use_lead"/>
                     <separator/>
                     <filter string="Won" name="won" domain="[('stage_id.is_won', '=', True)]"/>
-                    <filter string="Lost" name="lost" domain="[('won_status', '=', 'lost')]"/>
+                    <filter string="Lost" name="lost" domain="[('won_status', '=', 'lost')]" context="{'active_test': False}"/>
                     <separator/>
                     <filter string="Trailing 12 months" name="completion_date" domain="[
                         ('date', '>=', (datetime.datetime.combine(context_today() + relativedelta(days=-365), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),


### PR DESCRIPTION
#### Issue:

The `Lost` filter does not reveal any records, as any records moved to the lost status are archived.

#### Solution:

Override default context that hides archived records when using the filter.

opw-4937003
