### PR TITLE
[FIX] html_editor: fix iframe assertion in editor tests

### DIFF
--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -153,7 +153,6 @@ export async function testEditor(config) {
             });
         };
     }
-    const isMobileTest = config.props?.mobile;
     delete config.props?.mobile;
     const { el, editor } = await setupEditor(contentBefore, config);
     // The stageSelection should have been triggered by the click on
@@ -165,20 +164,7 @@ export async function testEditor(config) {
     editor.shared.history.stageSelection();
 
     if (config.props?.iframe) {
-        const selection = editor.document.getSelection();
-        // If there is no selection, iframe count remains 1 on both mobile
-        // and desktop since the toolbar is not open.
-        // When a selection exists:
-        //   - On mobile: The toolbar remains open regardless of whether
-        //     selection is collapsed or not, so the iframe count is 2.
-        //   - On desktop: The toolbar opens only when selection is not
-        //     collapsed, resulting in 2 iframes; otherwise, it remains 1.
-        // 2 iframes because the font size input is inside its own iframe.
-        let iframeCount = 1;
-        if (selection.anchorNode) {
-            iframeCount = isMobileTest || !selection.isCollapsed ? 2 : 1;
-        }
-        expect("iframe").toHaveCount(iframeCount);
+        expect(".o-wysiwyg iframe").toHaveCount(1);
     }
 
     // Wait for selectionchange handlers to react before any actual testing.


### PR DESCRIPTION
The assertion of a second iframe (due to the font selector in the toolbar) for every test that used the `testEditor` helper was not very useful. This commit reverts the assertion to its original goal, which is just to make sure that the editable is inside an iframe when such prop is present.

Moreover, it was prone to indeterminism, as the toolbar is rendered asynchronously, and might not be ready when the assertion is made.

