### PR TITLE
[FIX][17.0] web: correct currency formatting in AnimatedNumber component

### DIFF
--- a/addons/web/static/src/views/view_components/animated_number.js
+++ b/addons/web/static/src/views/view_components/animated_number.js
@@ -2,6 +2,7 @@
 
 import { browser } from "@web/core/browser/browser";
 import { formatInteger } from "@web/views/fields/formatters";
+import { formatCurrency } from "@web/core/currency";
 
 import { Component, onWillUpdateProps, onWillUnmount, useState } from "@odoo/owl";
 
@@ -52,6 +53,9 @@ export class AnimatedNumber extends Component {
     }
 
     format(value) {
+        if (this.props.currency) {
+            return formatCurrency(value, this.props.currency.id, { humanReadable: true });
+        }
         return this.formatInteger(value, { humanReadable: true, decimals: 0, minDigits: 3 });
     }
 }


### PR DESCRIPTION
Previously, the AnimatedNumber component only used formatInteger for all values, even when displaying monetary values in CRM kanban views. This led to incorrect formatting when the value was a currency

Solution:
- Add formatCurrency import from @web/core/currency
- Modify the format method to check for props.currency
- If currency exists, use formatCurrency with proper currency formatting
- If no currency, keep using formatInteger as before

With this change, monetary values in AnimatedNumber (such as MRR in CRM kanban) will be displayed with the correct currency format.

Description of the issue/feature this PR addresses:

Current behavior before PR:
<img width="1911" height="888" alt="Screenshot 2025-07-18 at 9 09 06 AM" src="https://github.com/user-attachments/assets/fba5cdfc-c1a8-4ca1-ac5a-744f5ae56ffc" />


Desired behavior after PR is merged:

<img width="317" height="329" alt="Screenshot 2025-07-18 at 9 11 01 AM" src="https://github.com/user-attachments/assets/8082e091-d643-4b34-85d3-510d2e992b47" />





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
