### PR TITLE
[FIX] account: Refund invoices are recorded at the rate of the original invoice date

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -691,7 +691,10 @@ class AccountMoveLine(models.Model):
 
     def _get_rate_date(self):
         self.ensure_one()
-        return self.move_id.invoice_date or self.move_id.date or fields.Date.context_today(self)
+        if self.move_id.move_type in ('in_refund', 'out_refund'):
+            return self.move_id.date or self.move_id.invoice_date or fields.Date.context_today(self)
+        else:
+            return self.move_id.invoice_date or self.move_id.date or fields.Date.context_today(self)
 
     @api.depends('currency_id', 'company_currency_id')
     def _compute_same_currency(self):


### PR DESCRIPTION

1. Create out invoice at date 31/12/2024, with amount 100 CU and currency rate 31/12/2024: 2 USD/CU
Invoice date 31/12/2024, Accounting date 31/12/2024

2. Credit note reverse 01/01/2025, Invoice date 01/01/2025, Accounting date 31/12/2024. Currency rate 01/01/2025: 3 USD/CU

Due to the adjusted invoice, the accounting date will be recorded on 12/31/2024. But the exchange rate is recorded according to the invoice date 01/01/2025. This causes an unexpected exchange rate difference, causing

Refer to item 21 of [ IAS 21](https://www.ifrs.org/content/dam/ifrs/publications/pdf-standards/english/2024/issued/part-a/ias-21-the-effects-of-changes-in-foreign-exchange-rates.pdf?bypass=on)

<img width="660" height="561" alt="image" src="https://github.com/user-attachments/assets/a31333e7-5b1e-4095-acf9-a99929ae1220" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
