### PR TITLE
[FIX] l10n_vn: merchant city is not required in some country

### DIFF
--- a/addons/l10n_vn/i18n_extra/l10n_vn.pot
+++ b/addons/l10n_vn/i18n_extra/l10n_vn.pot
@@ -68,6 +68,34 @@ msgid ""
 msgstr ""
 
 #. module: l10n_vn
+#. odoo-python
+#: code:addons/l10n_vn/models/res_bank.py:0
+#, python-format
+msgid "Missing Merchant Account Information."
+msgstr ""
+
+#. module: l10n_vn
+#. odoo-python
+#: code:addons/l10n_vn/models/res_bank.py:0
+#, python-format
+msgid "Missing Merchant City or State."
+msgstr ""
+
+#. module: l10n_vn
+#. odoo-python
+#: code:addons/l10n_vn/models/res_bank.py:0
+#, python-format
+msgid "Missing Proxy Type."
+msgstr ""
+
+#. module: l10n_vn
+#. odoo-python
+#: code:addons/l10n_vn/models/res_bank.py:0
+#, python-format
+msgid "Missing Proxy Value."
+msgstr ""
+
+#. module: l10n_vn
 #: model:ir.model.fields.selection,name:l10n_vn.selection__res_partner_bank__proxy_type__payment_service
 msgid "Payment Service"
 msgstr ""

--- a/addons/l10n_vn/i18n_extra/vi_VN.po
+++ b/addons/l10n_vn/i18n_extra/vi_VN.po
@@ -71,6 +71,34 @@ msgstr ""
 "Hãy cấu hình nó ở trong phần thiết lập ngân hàng."
 
 #. module: l10n_vn
+#. odoo-python
+#: code:addons/l10n_vn/models/res_bank.py:0
+#, python-format
+msgid "Missing Merchant Account Information."
+msgstr "Thiếu thông tin tài khoản người bán"
+
+#. module: l10n_vn
+#. odoo-python
+#: code:addons/l10n_vn/models/res_bank.py:0
+#, python-format
+msgid "Missing Merchant City or State."
+msgstr "Thiếu thành phố hoặc tỉnh thành của người bán. "
+
+#. module: l10n_vn
+#. odoo-python
+#: code:addons/l10n_vn/models/res_bank.py:0
+#, python-format
+msgid "Missing Proxy Type."
+msgstr "Thiếu loại proxy."
+
+#. module: l10n_vn
+#. odoo-python
+#: code:addons/l10n_vn/models/res_bank.py:0
+#, python-format
+msgid "Missing Proxy Value."
+msgstr "Thiếu giá trị proxy."
+
+#. module: l10n_vn
 #: model:ir.model.fields.selection,name:l10n_vn.selection__res_partner_bank__proxy_type__payment_service
 msgid "Payment Service"
 msgstr "Dịch vụ Thanh toán"

--- a/addons/l10n_vn/models/res_bank.py
+++ b/addons/l10n_vn/models/res_bank.py
@@ -53,6 +53,13 @@ class ResPartnerBank(models.Model):
             return self._serialize(8, re.sub(r"[^a-zA-Z0-9 _\\\-.]+", "", comment))
         return super()._get_additional_data_field(comment)
 
+    def _get_qr_code_vals_list(self, qr_method, amount, currency, debtor_partner, free_communication, structured_communication):
+        res = super()._get_qr_code_vals_list(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)
+        if self.country_code == 'VN':
+            merchant_city = (self.partner_id.city and self._remove_accents(self.partner_id.city)[:15]) or (self.partner_id.state_id and self._remove_accents(self.partner_id.state_id.name)[:15]) or ''
+            res[8] = (60, merchant_city)
+        return res
+
     def _get_error_messages_for_qr(self, qr_method, debtor_partner, currency):
         if qr_method == 'emv_qr' and self.country_code == 'VN':
             if currency.name not in ['VND']:
@@ -65,7 +72,16 @@ class ResPartnerBank(models.Model):
         return super()._get_error_messages_for_qr(qr_method, debtor_partner, currency)
 
     def _check_for_qr_code_errors(self, qr_method, amount, currency, debtor_partner, free_communication, structured_communication):
-        if qr_method == 'emv_qr' and self.country_code == 'VN' and self.proxy_type not in ['merchant_id', 'payment_service', 'atm_card', 'bank_acc']:
-            return _("The proxy type %s is not supported for Vietnamese partners. It must be either Merchant ID, ATM Card Number or Bank Account", self.proxy_type)
+        if qr_method != 'emv_qr' or self.country_code != 'VN':
+            return super()._check_for_qr_code_errors(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)
 
-        return super()._check_for_qr_code_errors(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)
+        if not self._get_merchant_account_info():
+            return _("Missing Merchant Account Information.")
+        if not (self.partner_id.city or self.partner_id.state_id):
+            return _("Missing Merchant City or State.")
+        if not self.proxy_type:
+            return _("Missing Proxy Type.")
+        if not self.proxy_value:
+            return _("Missing Proxy Value.")
+        if self.proxy_type not in ['merchant_id', 'payment_service', 'atm_card', 'bank_acc']:
+            return _("The proxy type %s is not supported for Vietnamese partners. It must be either Merchant ID, ATM Card Number or Bank Account", self.proxy_type)

--- a/addons/l10n_vn/tests/test_l10n_vn_emv_qr.py
+++ b/addons/l10n_vn/tests/test_l10n_vn_emv_qr.py
@@ -56,11 +56,15 @@ class TestL10nVNEmvQrCode(AccountTestInvoicingCommon):
         with self.assertRaises(UserError, msg="The chosen QR-code type is not eligible for this invoice."):
             self.emv_qr_invoice._generate_qr_code()
 
-        # Without company partner city should fail
+        # Without company partner city or state should fail
         self.emv_qr_invoice.currency_id = self.env.ref('base.VND')
         self.company_data['company'].partner_id.city = False
         with self.assertRaises(UserError, msg="Missing Merchant City."):
             self.emv_qr_invoice._generate_qr_code()
+
+        # With state and no city should ok
+        self.company_data['company'].partner_id.state_id = self.env.ref('base.state_vn_VN-HP')
+        self.emv_qr_invoice._generate_qr_code()
 
         # Without paynow infomation should fail
         self.company_data['company'].partner_id.city = 'Vietnam'


### PR DESCRIPTION
* Problem: Using Vietnam localisation, leave city empty and just input state_id as Hà Nội or Hải Phòng, try to use vietqr code -> Raise error missing city
* Solution: Just like https://github.com/odoo/odoo/pull/218984 we should check for state too although according to VietQR document, merchant city is not required see
(https://vietqr.net/portal-service/download/documents/QR_Format_T&C_v1.0_VN_092021.pdf and search for term 'Merchant City')

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
