### PR TITLE
[FIX] html_editor: remove use of closest for data-skip-hisory-hack

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -687,10 +687,7 @@ export class HistoryPlugin extends Plugin {
                         // it does not accidentally get observed during those
                         // operations.
                         // TODO Find a better solution.
-                        if (
-                            added?.dataset?.skipHistoryHack ||
-                            added?.closest?.("data-skip-history-hack")
-                        ) {
+                        if (added?.dataset?.skipHistoryHack) {
                             return;
                         }
                         const mutation = {
@@ -716,10 +713,7 @@ export class HistoryPlugin extends Plugin {
                     });
                     record.removedNodes.forEach((removed) => {
                         // TODO Find a better solution.
-                        if (
-                            removed?.dataset?.skipHistoryHack ||
-                            removed?.closest?.("data-skip-history-hack")
-                        ) {
+                        if (removed?.dataset?.skipHistoryHack) {
                             return;
                         }
                         this.currentStep.mutations.push({


### PR DESCRIPTION
`data-skip-history-hack` was introduced during initial website refactor, the selector to detect the nodes under that attribute was incorrect.

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
