### PR TITLE
[IMP] account,analytic: allow partial edition of analytic

### DIFF
--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -764,3 +764,214 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon, AnalyticCommon):
             f"{self.analytic_account_1.id}": 30,
             f"{self.analytic_account_2.id}": 60,
         })
+
+    def test_analytic_dynamic_update(self):
+        plan1 = self.analytic_account_1.plan_id._column_name()
+        plan2 = self.analytic_account_3.plan_id._column_name()
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'date': '2023-01-01',
+            'invoice_date': '2023-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 100.0,
+                    'analytic_distribution': {
+                        self.analytic_account_1.id: 40,
+                        self.analytic_account_2.id: 60,
+                    },
+                }),
+            ],
+        })
+        invoice_line = invoice.invoice_line_ids
+
+        for comment, init, update, expect in [(
+            "Add a distribution on a previously empty plan",
+            {
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            }, {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 25,
+                f"{self.analytic_account_4.id}": 75,
+            }, {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 10,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 15,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 30,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 45,
+            },
+        ), (
+            "Add a distribution on a previously empty plan, both less than 100%",
+            {
+                f"{self.analytic_account_1.id}": 20,
+                f"{self.analytic_account_2.id}": 30,
+            }, {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 10,
+                f"{self.analytic_account_4.id}": 40,
+            }, {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 4,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 6,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 16,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 24,
+            },
+        ), (
+            "Add a distribution on a previously empty plan, both more than 100%",
+            {
+                f"{self.analytic_account_1.id}": 200,
+                f"{self.analytic_account_2.id}": 300,
+            }, {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 100,
+                f"{self.analytic_account_4.id}": 400,
+            }, {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 40,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 60,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 160,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 240,
+            },
+        ), (
+            "Update the percentage of one plan without changing the other",
+            {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 10,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 15,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 30,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 45,
+            }, {
+                '__update__': [plan1, plan2],
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 15,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 10,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 45,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 30,
+            }, {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 15,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 10,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 45,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 30,
+            },
+        ), (
+            "Update the percentage on both plans at the same time",
+            {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 10,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 15,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 30,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 45,
+            }, {
+                '__update__': [plan1, plan2],
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 45,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 30,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 15,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 10,
+            }, {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 45,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 30,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 15,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 10,
+            },
+        ), (
+            "Remove everything set on plan 1",
+            {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 45,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 30,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 15,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 10,
+            }, {
+                '__update__': [plan1],
+            }, {
+                f"{self.analytic_account_3.id}": 75,
+                f"{self.analytic_account_4.id}": 25,
+            },
+        ), (
+            "Nothing changes because there is nothing in __update__",
+            {
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            }, {
+                '__update__': [],
+            }, {
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            },
+        ), (
+            "remove everything because __update__ is not set",
+            {
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            }, {
+            }, False,
+        ), (
+            "Add a distribution on a previously empty plan, with more than 100%",
+            {
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            }, {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 33,
+                f"{self.analytic_account_4.id}": 167,
+            }, {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 6.6,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 33.4,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 9.9,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 50.1,
+                f"{self.analytic_account_3.id}": 16.5,
+                f"{self.analytic_account_4.id}": 83.5,
+            },
+        ), (
+            "Add a distribution on a previously empty plan, with previous values more than 100%",
+            {
+                f"{self.analytic_account_3.id}": 33,
+                f"{self.analytic_account_4.id}": 167,
+            }, {
+                '__update__': [plan1],
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            }, {
+                f"{self.analytic_account_3.id},{self.analytic_account_1.id}": 6.6,
+                f"{self.analytic_account_4.id},{self.analytic_account_1.id}": 33.4,
+                f"{self.analytic_account_3.id},{self.analytic_account_2.id}": 9.9,
+                f"{self.analytic_account_4.id},{self.analytic_account_2.id}": 50.1,
+                f"{self.analytic_account_3.id}": 16.5,
+                f"{self.analytic_account_4.id}": 83.5,
+            },
+        ), (
+            "Add a distribution on a previously empty plan, with less than 100%",
+            {
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            }, {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 20,
+                f"{self.analytic_account_4.id}": 30,
+            }, {
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 8,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 12,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 12,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 18,
+                f"{self.analytic_account_1.id}": 20,
+                f"{self.analytic_account_2.id}": 30,
+            },
+        ), (
+            "Add a distribution on a previously empty plan, with previous values less than 100%",
+            {
+                f"{self.analytic_account_3.id}": 20,
+                f"{self.analytic_account_4.id}": 30,
+            }, {
+                '__update__': [plan1],
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            }, {
+                f"{self.analytic_account_3.id},{self.analytic_account_1.id}": 8,
+                f"{self.analytic_account_4.id},{self.analytic_account_1.id}": 12,
+                f"{self.analytic_account_3.id},{self.analytic_account_2.id}": 12,
+                f"{self.analytic_account_4.id},{self.analytic_account_2.id}": 18,
+                f"{self.analytic_account_1.id}": 20,
+                f"{self.analytic_account_2.id}": 30,
+            },
+        )]:
+            with self.subTest(comment=comment):
+                invoice_line.analytic_distribution = init
+                invoice_line.flush_recordset(['analytic_distribution'])
+                invoice_line.analytic_distribution = update
+                self.assertEqual(invoice_line.analytic_distribution, expect)

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -174,7 +174,7 @@
                            widget="analytic_distribution"
                            groups="analytic.group_analytic_accounting"
                            optional="hide"
-                           options="{'product_field': 'product_id', 'account_field': 'account_id', 'force_applicability': 'optional'}"
+                           options="{'product_field': 'product_id', 'account_field': 'account_id', 'force_applicability': 'optional', 'multi_edit': true}"
                     />
                     <field name="tax_ids" widget="many2many_tags" optional="hide" readonly="1"/>
                     <field name="amount_currency" string="In Currency" groups="base.group_multi_currency" optional="hide" readonly="1" invisible="is_same_currency"/>

--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models, fields, api, _
-from odoo.tools import SQL, Query, unique
-from odoo.tools.float_utils import float_round, float_compare
+from collections import defaultdict
+
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import SQL, Query, unique
+from odoo.tools.float_utils import float_compare, float_round
+
 
 class AnalyticMixin(models.AbstractModel):
     _name = 'analytic.mixin'
@@ -179,5 +182,77 @@ class AnalyticMixin(models.AbstractModel):
         """ Normalize the float of the distribution """
         if 'analytic_distribution' in vals:
             vals['analytic_distribution'] = vals.get('analytic_distribution') and {
-                account_id: float_round(distribution, decimal_precision) for account_id, distribution in vals['analytic_distribution'].items()}
+                account_id: float_round(distribution, decimal_precision) if account_id != '__update__' else distribution
+                for account_id, distribution in vals['analytic_distribution'].items()
+            }
         return vals
+
+    def _modifiying_distribution_values(self, old_distribution, new_distribution):
+        fnames_to_update = set(new_distribution.pop('__update__', ()))
+        if old_distribution:
+            old_distribution.pop('__update__', None)  # might be set before in `create`
+        project_plan, other_plans = self.env['account.analytic.plan']._get_all_plans()
+        non_changing_plans = {
+            plan
+            for plan in project_plan + other_plans
+            if plan._column_name() not in fnames_to_update
+        }
+
+        non_changing_values = defaultdict(float)
+        non_changing_amount = 0
+        for old_key, old_val in old_distribution.items():
+            remaining_key = tuple(sorted(
+                account.id
+                for account in self.env['account.analytic.account'].browse(int(aid) for aid in old_key.split(','))
+                if account.plan_id.root_id in non_changing_plans
+            ))
+            if remaining_key:
+                non_changing_values[remaining_key] += old_val
+                non_changing_amount += old_val
+
+        changing_values = defaultdict(float)
+        changing_amount = 0
+        for new_key, new_val in new_distribution.items():
+            remaining_key = tuple(sorted(
+                account.id
+                for account in self.env['account.analytic.account'].browse(int(aid) for aid in new_key.split(','))
+                if account.plan_id.root_id not in non_changing_plans
+            ))
+            if remaining_key:
+                changing_values[remaining_key] += new_val
+                changing_amount += new_val
+
+        return non_changing_values, changing_values, non_changing_amount, changing_amount
+
+    def _merge_distribution(self, old_distribution: dict, new_distribution: dict) -> dict:
+        if '__update__' not in new_distribution:
+            return new_distribution  # update everything by default
+
+        non_changing_values, changing_values, non_changing_amount, changing_amount = self._modifiying_distribution_values(
+            old_distribution,
+            new_distribution,
+        )
+        if non_changing_amount > changing_amount:
+            ratio = changing_amount / non_changing_amount
+            additional_vals = {
+                ','.join(map(str, old_key)): old_val * (1 - ratio)
+                for old_key, old_val in non_changing_values.items()
+                if old_key
+            }
+            ratio = 1
+        elif changing_amount > non_changing_amount:
+            ratio = non_changing_amount / changing_amount
+            additional_vals = {
+                ','.join(map(str, new_key)): new_val * (1 - ratio)
+                for new_key, new_val in changing_values.items()
+                if new_key
+            }
+        else:
+            ratio = 1
+            additional_vals = {}
+
+        return {
+            ','.join(map(str, old_key + new_key)): ratio * old_val * new_val / non_changing_amount
+            for old_key, old_val in non_changing_values.items()
+            for new_key, new_val in changing_values.items()
+        } | additional_vals

--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -45,6 +45,7 @@ export class AnalyticDistribution extends Component {
         business_domain_compute: { type: String, optional: true },
         force_applicability: { type: String, optional: true },
         allow_save: { type: Boolean, optional: true },
+        multi_edit: { type: Boolean, optional: true },
     }
 
     setup(){
@@ -54,6 +55,7 @@ export class AnalyticDistribution extends Component {
         this.state = useState({
             showDropdown: false,
             formattedData: [],
+            update_plan: {},
         });
 
         this.widgetRef = useRef("analyticDistribution");
@@ -66,6 +68,7 @@ export class AnalyticDistribution extends Component {
         this.focusSelector = false;
 
         this.currentValue = this.props.record.data[this.props.name];
+        this.initialFormattedData = [];
 
         onWillStart(this.willStart);
         useRecordObserver(this.willUpdateRecord.bind(this));
@@ -95,6 +98,7 @@ export class AnalyticDistribution extends Component {
             fieldString: _t("Analytic Distribution Model"),
         });
         this.allPlans = [];
+        this.planIdToColumn = {};
         this.lastAccount = this.props.account_field && this.props.record.data[this.props.account_field] || false;
         this.lastProduct = this.props.product_field && this.props.record.data[this.props.product_field] || false;
     }
@@ -106,6 +110,10 @@ export class AnalyticDistribution extends Component {
             await this.fetchAllPlans(this.props);
         }
         await this.jsonToData(this.props.record.data[this.props.name]);
+        if (this.props.multi_edit) {
+            this.initialFormattedData = this.state.formattedData;
+            this.state.formattedData = [];
+        }
     }
 
     async willUpdateRecord(record) {
@@ -127,6 +135,10 @@ export class AnalyticDistribution extends Component {
             this.lastAccount = accountChanged && currentAccount || this.lastAccount;
             this.lastProduct = productChanged && currentProduct || this.lastProduct;
             await this.jsonToData(record.data[this.props.name]);
+            if (this.props.multi_edit) {
+                this.initialFormattedData = this.state.formattedData;
+                this.state.formattedData = [];
+            }
         }
         this.currentValue = record.data[this.props.name];
     }
@@ -141,7 +153,8 @@ export class AnalyticDistribution extends Component {
      */
     accountTotalsByPlan() {
         const accountTotals = {};
-        this.state.formattedData.map((line) => {
+        const formattedData = this.props.multi_edit ? this.initialFormattedData : this.state.formattedData;
+        formattedData.map((line) => {
             line.analyticAccounts.map((column) => {
                 if (column.accountId) {
                     let {
@@ -220,13 +233,14 @@ export class AnalyticDistribution extends Component {
     }
 
     async jsonToData(jsonFieldValue) {
-        const analyticAccountIds = jsonFieldValue ? Object.keys(jsonFieldValue).map((key) => key.split(',')).flat().map((id) => parseInt(id)) : [];
+        const analyticAccountIds = jsonFieldValue ? Object.keys(jsonFieldValue).filter((key) => key != '__update__' ).map((key) => key.split(',')).flat().map((id) => parseInt(id)) : [];
         const analyticAccountDict = analyticAccountIds.length ? await this.fetchAnalyticAccounts([["id", "in", analyticAccountIds]]) : [];
 
         let distribution = [];
         let accountNotFound = false;
 
         for (const [accountIds, percentage] of Object.entries(jsonFieldValue)) {
+            if (accountIds == '__update__') continue;
             const defaultVals = this.plansToArray(); // empty if the popup was not opened
             const ids = accountIds.split(',');
 
@@ -272,7 +286,7 @@ export class AnalyticDistribution extends Component {
         const values = {};
         // Analytic Account fields
         line.analyticAccounts.map((account) => {
-            const fieldName = `x_plan${account.planId}_id`;
+            const fieldName = this.planIdToColumn[account.planId];
             recordFields[fieldName] = {
                 string: account.planName,
                 relation: "account.analytic.account",
@@ -354,6 +368,12 @@ export class AnalyticDistribution extends Component {
     async fetchAllPlans(props) {
         const argsPlan = this.fetchPlansArgs(props);
         this.allPlans = await this.orm.call("account.analytic.plan", "get_relevant_plans", [], argsPlan);
+        this.planIdToColumn = Object.fromEntries(this.allPlans.map((plan) => [plan.id, plan.column_name]));
+        if (!this.props.multi_edit) {
+            this.allPlans.forEach(plan => {
+                this.state.update_plan[plan.column_name] = true;
+            });
+        }
     }
 
     async fetchAnalyticAccounts(domain) {
@@ -374,7 +394,7 @@ export class AnalyticDistribution extends Component {
     async lineChanged(record, changes, line) {
         // record analytic account changes to the state
         for (const account of line.analyticAccounts) {
-            const selected = record.data[`x_plan${account.planId}_id`];
+            const selected = record.data[this.planIdToColumn[account.planId]];
             account.accountId = selected[0];
             account.accountDisplayName = selected[1];
             account.accountColor = account.planColor;
@@ -446,6 +466,9 @@ export class AnalyticDistribution extends Component {
 
     dataToJson() {
         const result = {};
+        if (this.props.multi_edit) {
+            result.__update__ = Object.entries(this.state.update_plan).filter((e) => e[1]).map((e) => e[0]);
+        }
         this.state.formattedData = this.state.formattedData.filter((line) => this.accountCount(line));
         this.state.formattedData.map((line) => {
             const key = line.analyticAccounts.reduce((p, n) => p.concat(n.accountId ? n.accountId : []), []);
@@ -456,6 +479,12 @@ export class AnalyticDistribution extends Component {
 
     async save() {
         await this.props.record.update({ [this.props.name]: this.dataToJson() });
+        if (this.props.multi_edit) {
+            await this.jsonToData(this.props.record.data[this.props.name]);
+            this.initialFormattedData = this.state.formattedData;
+            this.state.formattedData = [];
+            this.state.update_plan = {};
+        }
     }
 
     onSaveNew() {
@@ -486,6 +515,9 @@ export class AnalyticDistribution extends Component {
         if (!this.allPlans.length) {
             await this.fetchAllPlans(this.props);
             await this.jsonToData(this.props.record.data[this.props.name]);
+            if (this.props.multi_edit) {
+                this.state.formattedData = [];
+            }
         }
         if (!this.state.formattedData.length) {
             await this.addLine();
@@ -647,6 +679,11 @@ export const analyticDistribution = {
             type: "boolean",
         },
         {
+            label: _t("Multi edit"),
+            name: "multi_edit",
+            type: "boolean",
+        },
+        {
             label: _t("Force applicability"),
             name: "force_applicability",
             type: "boolean",
@@ -683,6 +720,7 @@ export const analyticDistribution = {
         business_domain_compute: attrs.business_domain_compute,
         force_applicability: options.force_applicability,
         allow_save: !options.disable_save,
+        multi_edit: options.multi_edit,
     }),
 };
 

--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
@@ -32,7 +32,13 @@
                     <thead>
                         <tr class="border-bottom">
                             <th t-foreach="allPlans" t-as="plan" t-key="plan.id">
-                                <span t-out="plan.name"/> (<span t-att-class="totals[plan.id].class" t-out="totals[plan.id].formattedValue"/>)
+                                <t t-if="props.multi_edit">
+                                    <a t-if="state.update_plan[plan.column_name]" t-on-click="() => state.update_plan[plan.column_name] = false" href="#">Don't update</a>
+                                    <a t-else="" t-on-click="() => state.update_plan[plan.column_name] = true" href="#">Update</a>
+                                    <br/>
+                                </t>
+                                <span t-out="plan.name"/>
+                                <t t-if="state.update_plan[plan.column_name]">(<span t-att-class="totals[plan.id].class" t-out="totals[plan.id].formattedValue"/>)</t>
                             </th>
                             <th t-out="'Percentage'" class="numeric_column_width"/>
                             <th t-if="valueColumnEnabled" class="numeric_column_width" t-out="props.record.fields[props.amount_field].string"/>
@@ -42,9 +48,19 @@
                     <tbody>
                         <tr t-foreach="state.formattedData" t-as="line" t-key="line.id" t-att-id="line_index" t-att-name="'line_' + line_index">
                             <Record t-props="recordProps(line)" t-slot-scope="data">
-                                <td t-foreach="Object.keys(data.record.fields).filter((f) => f.startsWith('x_plan'))" t-as="field" t-key="field">
-                                    <Field id="field" name="field" record="data.record" domain="data.record.fields[field].domain" canOpen="false" canCreate="false" canCreateEdit="false" canQuickCreate="false"/>
-                                </td>
+                                <t t-foreach="Object.keys(data.record.fields).filter((f) => f.startsWith('x_plan') || f == 'account_id')" t-as="field" t-key="field">
+                                    <td t-att-style="state.update_plan[field] ? '' : '--table-bg-state: var(--table-hover-bg);'">
+                                        <Field t-if="state.update_plan[field]"
+                                               id="field"
+                                               name="field"
+                                               record="data.record"
+                                               domain="data.record.fields[field].domain"
+                                               canOpen="false"
+                                               canCreate="false"
+                                               canCreateEdit="false"
+                                               canQuickCreate="false"/>
+                                    </td>
+                                </t>
                                 <td class="numeric_column_width">
                                     <Field id="'percentage'" name="'percentage'" record="data.record"/>
                                 </td>

--- a/addons/analytic/static/tests/analytic_distribution_tests.js
+++ b/addons/analytic/static/tests/analytic_distribution_tests.js
@@ -64,14 +64,15 @@ QUnit.module("Analytic", (hooks) => {
                         color: { string: "Color", type: "integer" },
                         all_account_count: { type: "integer" },
                         parent_id: { type: "many2one", relation: "plan" },
+                        column_name: { type: "char" },
                     },
                     records: [
-                        { id: 1, name: "Internal", applicability: "optional", all_account_count: 2 },
-                        { id: 2, name: "Departments", applicability: "mandatory", all_account_count: 3 },
-                        { id: 3, name: "Projects", applicability: "optional" },
-                        { id: 4, name: "Hidden", applicability: "unavailable", all_account_count: 1 },
-                        { id: 5, name: "Country", applicability: "optional", all_account_count: 3 },
-                        { id: 6, name: "City", applicability: "optional", all_account_count: 2, parent_id: 5 },
+                        { id: 1, name: "Internal", applicability: "optional", all_account_count: 2, column_name: 'x_plan1_id' },
+                        { id: 2, name: "Departments", applicability: "mandatory", all_account_count: 3, column_name: 'x_plan2_id' },
+                        { id: 3, name: "Projects", applicability: "optional", column_name: 'account_id' },
+                        { id: 4, name: "Hidden", applicability: "unavailable", all_account_count: 1, column_name: 'x_plan4_id' },
+                        { id: 5, name: "Country", applicability: "optional", all_account_count: 3, column_name: 'x_plan5_id' },
+                        { id: 6, name: "City", applicability: "optional", all_account_count: 2, parent_id: 5, column_name: 'x_plan5_id' },
                     ],
                 },
                 aml: {
@@ -99,7 +100,7 @@ QUnit.module("Analytic", (hooks) => {
                 },
                 move: {
                     fields: {
-                        line_ids: { string: "Move Lines", type: "one2many", relation: "aml", relation_field: "move_line_id" },
+                        line_ids: { string: "Move Lines", type: "one2many", relation: "aml", relation_field: "move_id" },
                     },
                     records: [
                         { id: 1, display_name: "INV0001", line_ids: [1, 2]},
@@ -161,7 +162,7 @@ QUnit.module("Analytic", (hooks) => {
         let field = target.querySelector('.o_field_analytic_distribution');
         await click(field, ".o_input_dropdown");
         assert.containsN(target, ".analytic_distribution_popup", 1, "popup should be visible");
-        
+
         let popup = target.querySelector('.analytic_distribution_popup');
         let planTable = popup.querySelectorAll('table')[0];
 
@@ -178,7 +179,7 @@ QUnit.module("Analytic", (hooks) => {
         await click(planTable, "tr:first-of-type .o_field_percentage input");
         let input = document.activeElement;
         await editInput(input, null, "19.7001");
-        
+
         // mandatory plan is red
         assert.containsOnce(planTable, 'th:contains("Departments") .text-danger:contains("50%")', "Mandatory plan has invalid status");
 
@@ -264,7 +265,7 @@ QUnit.module("Analytic", (hooks) => {
         await addRow(planTable)
         await selectDropdownItem(planTable.querySelector("tr[name='line_2']"), "x_plan5_id", "Search More...");
         assert.containsN(target, ".modal-dialog .o_list_renderer", 1, "select create list dialog is visible");
-        
+
         await click(target, ".modal-dialog .modal-title");
         await click(target, ".modal-dialog .o_data_row:nth-of-type(4) .o_data_cell:first-of-type");
         assert.containsNone(target, ".modal-dialog .o_list_renderer", "select create list dialog is closed");

--- a/addons/analytic/static/tests/analytic_views.test.js
+++ b/addons/analytic/static/tests/analytic_views.test.js
@@ -6,20 +6,20 @@ defineAnalyticModels()
 const searchViewArch = `
     <search>
         <filter name="account_id" context="{'group_by': 'account_id'}"/>
-        <filter name="x_plan122_id" context="{'group_by': 'x_plan122_id'}"/>
-        <filter name="x_plan122_id_1" context="{'group_by': 'x_plan122_id_1'}"/>
-        <filter name="x_plan122_id_2" context="{'group_by': 'x_plan122_id_2'}"/>
+        <filter name="x_plan1_id" context="{'group_by': 'x_plan1_id'}"/>
+        <filter name="x_plan1_id_1" context="{'group_by': 'x_plan1_id_1'}"/>
+        <filter name="x_plan1_id_2" context="{'group_by': 'x_plan1_id_2'}"/>
     </search>
 `
 
 beforeEach(async () => {
     const { env } = await makeMockServer();
     const root = env['account.analytic.plan'].create({ name: "State" });
-    const eu = env['account.analytic.plan'].create({ name: "Europe", parent_id: root });
-    const be = env['account.analytic.plan'].create({ name: "Belgium", parent_id: eu });
-    const fr = env['account.analytic.plan'].create({ name: "France", parent_id: eu });
-    const am = env['account.analytic.plan'].create({ name: "America", parent_id: root });
-    const us = env['account.analytic.plan'].create({ name: "USA", parent_id: am });
+    const eu = env['account.analytic.plan'].create({ name: "Europe", parent_id: root, root_id: root });
+    const be = env['account.analytic.plan'].create({ name: "Belgium", parent_id: eu, root_id: root });
+    const fr = env['account.analytic.plan'].create({ name: "France", parent_id: eu, root_id: root });
+    const am = env['account.analytic.plan'].create({ name: "America", parent_id: root, root_id: root });
+    const us = env['account.analytic.plan'].create({ name: "USA", parent_id: am, root_id: root });
     const accounts = env['account.analytic.account'].create([
         { plan_id: be, name: "Brussels" },
         { plan_id: be, name: "Antwerpen" },
@@ -29,12 +29,12 @@ beforeEach(async () => {
         { plan_id: us, name: "Los Angeles" },
     ])
     env["account.analytic.line"].create([
-        { x_plan122_id: accounts[0], x_plan122_id_1: eu, x_plan122_id_2: be, amount: 1 },
-        { x_plan122_id: accounts[1], x_plan122_id_1: eu, x_plan122_id_2: be, amount: 10 },
-        { x_plan122_id: accounts[2], x_plan122_id_1: eu, x_plan122_id_2: fr, amount: 100 },
-        { x_plan122_id: accounts[3], x_plan122_id_1: eu, x_plan122_id_2: fr, amount: 1000 },
-        { x_plan122_id: accounts[4], x_plan122_id_1: am, x_plan122_id_2: us, amount: 10000 },
-        { x_plan122_id: accounts[5], x_plan122_id_1: am, x_plan122_id_2: us, amount: 100000 },
+        { x_plan1_id: accounts[0], x_plan1_id_1: eu, x_plan1_id_2: be, analytic_distribution: {[accounts[0]]: 100}, amount: 1 },
+        { x_plan1_id: accounts[1], x_plan1_id_1: eu, x_plan1_id_2: be, analytic_distribution: {[accounts[1]]: 100}, amount: 10 },
+        { x_plan1_id: accounts[2], x_plan1_id_1: eu, x_plan1_id_2: fr, analytic_distribution: {[accounts[2]]: 100}, amount: 100 },
+        { x_plan1_id: accounts[3], x_plan1_id_1: eu, x_plan1_id_2: fr, analytic_distribution: {[accounts[3]]: 100}, amount: 1000 },
+        { x_plan1_id: accounts[4], x_plan1_id_1: am, x_plan1_id_2: us, analytic_distribution: {[accounts[4]]: 100}, amount: 10000 },
+        { x_plan1_id: accounts[5], x_plan1_id_1: am, x_plan1_id_2: us, analytic_distribution: {[accounts[5]]: 100}, amount: 100000 },
     ]);
 });
 

--- a/addons/analytic/static/tests/analytic_widget.test.js
+++ b/addons/analytic/static/tests/analytic_widget.test.js
@@ -1,0 +1,119 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
+import { contains, makeMockServer, mountView, onRpc } from "@web/../tests/web_test_helpers";
+import { defineAnalyticModels } from "./analytic_test_helpers";
+
+defineAnalyticModels()
+beforeEach(async () => {
+    const { env } = await makeMockServer();
+    const plan = env['account.analytic.plan'].create({ name: "State", root_id: 1 });
+    const accounts = env['account.analytic.account'].create([
+        { plan_id: plan, name: "Brussels" },
+        { plan_id: plan, name: "Antwerpen" },
+        { plan_id: plan, name: "Paris" },
+        { plan_id: plan, name: "Marseille" },
+        { plan_id: plan, name: "New York" },
+        { plan_id: plan, name: "Los Angeles" },
+    ])
+    env["account.analytic.line"].create([
+        { x_plan1_id: accounts[0], analytic_distribution: {[accounts[0]]: 100}, amount: 1 },
+        { x_plan1_id: accounts[1], analytic_distribution: {[accounts[1]]: 100}, amount: 10 },
+        { x_plan1_id: accounts[2], analytic_distribution: {[accounts[2]]: 100}, amount: 100 },
+        { x_plan1_id: accounts[3], analytic_distribution: {[accounts[3]]: 100}, amount: 1000 },
+        { x_plan1_id: accounts[4], analytic_distribution: {[accounts[4]]: 100}, amount: 10000 },
+        { x_plan1_id: accounts[5], analytic_distribution: {[accounts[5]]: 100}, amount: 100000 },
+    ]);
+});
+
+test.tags("desktop");
+test("Analytic single-edit no dynamic", async () => {
+    onRpc("account.analytic.line", "write", (params) => {
+        // don't have "to update" information if not in multi edit
+        expect(params.args[1].analytic_distribution.__update__).toBe(undefined);
+    });
+    await mountView({
+        type: "list",
+        resModel: "account.analytic.line",
+        arch: `
+            <list multi_edit="1" default_order="id DESC">
+                <field name="account_id"/>
+                <field name="x_plan1_id"/>
+                <field name="analytic_distribution" widget="analytic_distribution" options="{'multi_edit': False}"/>
+            </list>`,
+    });
+
+    // select the first 2 lines to be able to edit
+    await contains(".o_list_table tbody tr:nth-child(1) .o_list_record_selector input").click();
+    await contains(".o_list_table tbody tr:nth-child(2) .o_list_record_selector input").click();
+
+    await contains(".o_list_table tbody tr:first .o_field_analytic_distribution").click();
+    await animationFrame();
+    expect(".analytic_distribution_popup").toHaveCount(1);
+    // all the fields should be displayed
+    expect(".analytic_distribution_popup tbody tr:first .o_field_many2one").toHaveCount(1);
+    // we shouldn't display the button-links to hide/display the fields
+    expect(".analytic_distribution_popup .o_list_table thead th:first a").toHaveCount(0);
+    await contains(".o_list_renderer").click();
+})
+
+
+test.tags("desktop");
+test("Analytic dynamic multi-edit", async () => {
+    let to_update;
+    onRpc("account.analytic.line", "write", (params) => {
+        expect(params.args[1].analytic_distribution.__update__).toEqual(to_update);
+    });
+    await mountView({
+        type: "list",
+        resModel: "account.analytic.line",
+        arch: `
+            <list multi_edit="1" default_order="id DESC">
+                <field name="account_id"/>
+                <field name="x_plan1_id"/>
+                <field name="analytic_distribution" widget="analytic_distribution" options="{'multi_edit': True}"/>
+            </list>`,
+    });
+
+    expect(".o_list_table tbody tr:nth-child(1) .o_field_analytic_distribution .o_tag_badge_text").toHaveText("Los Angeles");
+    expect(".o_list_table tbody tr:nth-child(2) .o_field_analytic_distribution .o_tag_badge_text").toHaveText("New York");
+
+    // select the first 2 lines to be able to edit
+    await contains(".o_list_table tbody tr:nth-child(1) .o_list_record_selector input").click();
+    await contains(".o_list_table tbody tr:nth-child(2) .o_list_record_selector input").click();
+
+    // everything is empty when opening the widget
+    await contains(".o_list_table tbody tr:first .o_field_analytic_distribution").click();
+    await animationFrame();
+    expect(".analytic_distribution_popup").toHaveCount(1);
+    expect(".analytic_distribution_popup tbody tr:first .o_field_many2one").toHaveCount(0);
+    await contains(".o_list_renderer").click();  // close the widget
+    await contains(".modal-footer .btn-secondary").click();  // cancel confirmation
+
+    // update the right columns when ticked
+    to_update = ["x_plan1_id"];
+    await contains(".o_list_table tbody tr:first .o_field_analytic_distribution").click();
+    await animationFrame();
+    await contains(".analytic_distribution_popup .o_list_table thead th:first a").click();
+    expect(".analytic_distribution_popup tbody tr:first .o_field_many2one").toHaveCount(1);
+    await contains(".analytic_distribution_popup tbody tr:first .o_field_many2one").click();
+    await contains(".analytic_distribution_popup tbody tr:first .o_field_many2one input").edit("Brussels", {confirm: false});
+    await runAllTimers();
+    await contains(".analytic_distribution_popup tbody tr:first .o_field_many2one .o_input_dropdown a").click();
+    await contains(".o_list_renderer").click();  // close the widget
+    // we don't change the value until it's saved
+    expect(".o_list_table tbody tr:nth-child(1) .o_field_analytic_distribution .o_tag_badge_text").toHaveText("Los Angeles");
+    expect(".o_list_table tbody tr:nth-child(2) .o_field_analytic_distribution .o_tag_badge_text").toHaveText("New York");
+    await contains(".modal-footer .btn-primary").click();  // validate confirmation
+    await runAllTimers();
+    expect(".o_list_table tbody tr:nth-child(1) .o_field_analytic_distribution .o_tag_badge_text").toHaveText("Brussels");
+    expect(".o_list_table tbody tr:nth-child(2) .o_field_analytic_distribution .o_tag_badge_text").toHaveText("Brussels");
+
+    // everything should be back to like the first time we opened it
+    to_update = [];
+    await contains(".o_list_table tbody tr:first .o_field_analytic_distribution").click();
+    await animationFrame();
+    expect(".analytic_distribution_popup").toHaveCount(1);
+    expect(".analytic_distribution_popup tbody tr:first .o_field_many2one").toHaveCount(0);
+    await contains(".o_list_renderer").click();  // close the widget
+    await contains(".modal-footer .btn-primary").click();  // validate confirmation
+})

--- a/addons/analytic/static/tests/mock_server/mock_models/account_analytic_line.js
+++ b/addons/analytic/static/tests/mock_server/mock_models/account_analytic_line.js
@@ -5,7 +5,8 @@ export class AccountAnalyticLine extends models.ServerModel {
 
     amount = fields.Float()
     account_id = fields.Many2one({ relation: "account.analytic.account" })
-    x_plan122_id = fields.Many2one({ string: "State", relation: "account.analytic.account" })
-    x_plan122_id_1 = fields.Many2one({ string: "Continent", relation: "account.analytic.plan" })
-    x_plan122_id_2 = fields.Many2one({ string: "Country ", relation: "account.analytic.plan" })
+    x_plan1_id = fields.Many2one({ string: "State", relation: "account.analytic.account" })
+    x_plan1_id_1 = fields.Many2one({ string: "Continent", relation: "account.analytic.plan" })
+    x_plan1_id_2 = fields.Many2one({ string: "Country ", relation: "account.analytic.plan" })
+    analytic_distribution = fields.Json();
 }

--- a/addons/analytic/static/tests/mock_server/mock_models/account_analytic_plan.js
+++ b/addons/analytic/static/tests/mock_server/mock_models/account_analytic_plan.js
@@ -5,4 +5,17 @@ export class AccountAnalyticPlan extends models.ServerModel {
 
     name = fields.Char()
     parent_id = fields.Many2one({ relation: "account.analytic.plan" })
+
+    get_relevant_plans() {
+        return this.filter((plan) => !plan.parent_id).map((plan) => {
+            return {
+                "id": plan.id,
+                "name": plan.name,
+                "color": plan.color,
+                "applicability": plan.default_applicability || "optional",
+                "all_account_count": 1,
+                "column_name": `x_plan${plan.id}_id`,
+            }
+        })
+    }
 }

--- a/addons/analytic/tests/__init__.py
+++ b/addons/analytic/tests/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from . import test_analytic_account
+from . import test_analytic_dynamic_update
 from . import test_plan_operations
 from . import test_analytic_mixin

--- a/addons/analytic/tests/test_analytic_dynamic_update.py
+++ b/addons/analytic/tests/test_analytic_dynamic_update.py
@@ -1,0 +1,240 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from odoo.tests import tagged
+from odoo.addons.analytic.tests.common import AnalyticCommon
+
+
+@tagged('post_install', '-at_install')
+class TestAnalyticDynamicUpdate(AnalyticCommon):
+    def test_configurations(self):
+        @contextmanager
+        def capture_create():
+            container = {'created': self.env['account.analytic.line']}
+            super_create = self.env.registry['account.analytic.line'].create
+
+            def patch_create(self, vals_list):
+                records = super_create(self, vals_list)
+                container['created'] += records
+                return records
+
+            with patch.object(self.env.registry['account.analytic.line'], 'create', patch_create):
+                yield container
+
+        plan2 = self.analytic_account_3.plan_id._column_name()
+        plan1 = self.analytic_account_1.plan_id._column_name()
+        for comment, init, update, expect in [(
+            "Add a distribution on a previously empty plan",
+            [
+                {plan1: self.analytic_account_1.id, plan2: False, 'amount': 40},
+                {plan1: self.analytic_account_2.id, plan2: False, 'amount': 60},
+            ], {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 25,
+                f"{self.analytic_account_4.id}": 75,
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 10.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 15.0},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 30.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 45.0},
+            ],
+        ), (
+            "Add a distribution on a previously empty plan, both less than 100%",
+            [
+                {plan1: self.analytic_account_1.id, plan2: False, 'amount': 20},
+                {plan1: self.analytic_account_2.id, plan2: False, 'amount': 30},
+            ], {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 10,
+                f"{self.analytic_account_4.id}": 40,
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 2.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 3.0},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 8.0},
+                {plan1: self.analytic_account_1.id, plan2: False, 'amount': 10.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 12.0},
+                {plan1: self.analytic_account_2.id, plan2: False, 'amount': 15.0},
+            ],
+        ), (
+            "Add a distribution on a previously empty plan, both more than 100%",
+            [
+                {plan1: self.analytic_account_1.id, plan2: False, 'amount': 200},
+                {plan1: self.analytic_account_2.id, plan2: False, 'amount': 300},
+            ], {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 100,
+                f"{self.analytic_account_4.id}": 400,
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 40.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 60.0},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 160.0},
+                {plan1: False, plan2: self.analytic_account_3.id, 'amount': 160.0},
+                {plan1: False, plan2: self.analytic_account_4.id, 'amount': 640.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 240.0},
+                {plan1: False, plan2: self.analytic_account_3.id, 'amount': 240.0},
+                {plan1: False, plan2: self.analytic_account_4.id, 'amount': 960.0},
+            ],
+        ), (
+            "Update the percentage of one plan without changing the other",
+            [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 10},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 15},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 30},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 45},
+            ], {
+                '__update__': [plan1, plan2],
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 15,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 10,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 45,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 30,
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 1.5},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 2.25},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 4.5},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 6.75},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 1.0},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 4.5},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 3.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 1.5},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 6.75},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 4.5},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 3.0},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 13.5},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 9.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 4.5},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 20.25},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 13.5},
+            ],
+        ), (
+            "Update the percentage on both plans at the same time",
+            [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 10},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 15},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 30},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 45},
+            ], {
+                '__update__': [plan1, plan2],
+                f"{self.analytic_account_1.id},{self.analytic_account_3.id}": 45,
+                f"{self.analytic_account_2.id},{self.analytic_account_3.id}": 30,
+                f"{self.analytic_account_1.id},{self.analytic_account_4.id}": 15,
+                f"{self.analytic_account_2.id},{self.analytic_account_4.id}": 10,
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 4.5},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 6.75},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 13.5},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 20.25},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 3.0},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 1.5},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 1.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 4.5},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 2.25},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 1.5},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 9.0},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 4.5},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 3.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 13.5},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 6.75},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 4.5},
+            ],
+        ), (
+            "Remove everything set on plan 1",
+            [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 45},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 30},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 15},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 10},
+            ], {
+                '__update__': [plan1],
+            }, [
+                {plan1: False, plan2: self.analytic_account_3.id, 'amount': 45.0},
+                {plan1: False, plan2: self.analytic_account_3.id, 'amount': 30.0},
+                {plan1: False, plan2: self.analytic_account_4.id, 'amount': 15.0},
+                {plan1: False, plan2: self.analytic_account_4.id, 'amount': 10.0},
+            ],
+        ), (
+            "Nothing changes because there is nothing in __update__",
+            [
+                {plan1: self.analytic_account_1.id, plan2: False, 'amount': 40},
+                {plan1: self.analytic_account_2.id, plan2: False, 'amount': 60},
+            ], {
+                '__update__': [],
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: False, 'amount': 40.0},
+                {plan1: self.analytic_account_2.id, plan2: False, 'amount': 60.0},
+            ],
+        ), (
+            "Add a distribution on a previously empty plan, with more than 100%",
+            [
+                {plan1: self.analytic_account_1.id, plan2: False, 'amount': 40},
+                {plan1: self.analytic_account_2.id, plan2: False, 'amount': 60},
+            ], {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 33,
+                f"{self.analytic_account_4.id}": 167,
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 6.6},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 9.9},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 33.4},
+                {plan1: False, plan2: self.analytic_account_3.id, 'amount': 6.6},
+                {plan1: False, plan2: self.analytic_account_4.id, 'amount': 33.4},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 50.1},
+                {plan1: False, plan2: self.analytic_account_3.id, 'amount': 9.9},
+                {plan1: False, plan2: self.analytic_account_4.id, 'amount': 50.1},
+            ],
+        ), (
+            "Add a distribution on a previously empty plan, with previous values more than 100%",
+            [
+                {plan1: False, plan2: self.analytic_account_3.id, 'amount': 33},
+                {plan1: False, plan2: self.analytic_account_4.id, 'amount': 167},
+            ], {
+                '__update__': [plan1],
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 13.2},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 66.8},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 19.8},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 100.2},
+            ],
+        ), (
+            "Add a distribution on a previously empty plan, with less than 100%",
+            [
+                {plan1: self.analytic_account_1.id, plan2: False, 'amount': 40},
+                {plan1: self.analytic_account_2.id, plan2: False, 'amount': 60},
+            ], {
+                '__update__': [plan2],
+                f"{self.analytic_account_3.id}": 20,
+                f"{self.analytic_account_4.id}": 30,
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 8.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 12.0},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 12.0},
+                {plan1: self.analytic_account_1.id, plan2: False, 'amount': 20.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 18.0},
+                {plan1: self.analytic_account_2.id, plan2: False, 'amount': 30.0},
+            ],
+        ), (
+            "Add a distribution on a previously empty plan, with previous values less than 100%",
+            [
+                {plan1: False, plan2: self.analytic_account_3.id, 'amount': 20},
+                {plan1: False, plan2: self.analytic_account_4.id, 'amount': 30},
+            ], {
+                '__update__': [plan1],
+                f"{self.analytic_account_1.id}": 40,
+                f"{self.analytic_account_2.id}": 60,
+            }, [
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_3.id, 'amount': 8.0},
+                {plan1: self.analytic_account_1.id, plan2: self.analytic_account_4.id, 'amount': 12.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_3.id, 'amount': 12.0},
+                {plan1: self.analytic_account_2.id, plan2: self.analytic_account_4.id, 'amount': 18.0},
+            ],
+        )]:
+            with self.subTest(comment=comment):
+                lines = self.env['account.analytic.line'].create([
+                    {'name': 'test'} | vals
+                    for vals in init
+                ])
+                with capture_create() as container:
+                    lines.analytic_distribution = update
+                lines.invalidate_recordset(['analytic_distribution'])
+                self.assertRecordValues(lines + container['created'], expect)

--- a/addons/analytic/views/analytic_line_views.xml
+++ b/addons/analytic/views/analytic_line_views.xml
@@ -10,6 +10,11 @@
                 <field name="date" optional="show"/>
                 <field name="name"/>
                 <field name="account_id"/>
+                <field name="analytic_distribution"
+                       widget="analytic_distribution"
+                       optional="hide"
+                       options="{'multi_edit': true}"
+                />
                 <field name="currency_id" column_invisible="True"/>
                 <field name="unit_amount" sum="Quantity" optional="hide"/>
                 <field name="product_uom_id" optional="hide"/>

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -399,6 +399,11 @@ class AccountAnalyticLine(models.Model):
                 })
         return result
 
+    def _split_amount_fname(self):
+        # split the quantity instead of the amount, since the amount is postprocessed
+        # based on the quantity
+        return 'unit_amount' if self.project_id else super()._split_amount_fname()
+
     def _is_timesheet_encode_uom_day(self):
         company_uom = self.env.company.timesheet_encode_uom_id
         return company_uom == self.env.ref('uom.product_uom_day')

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -117,6 +117,8 @@ class TestTimesheet(TestCommonTimesheet):
 
     def setUp(self):
         super(TestTimesheet, self).setUp()
+        # Make sure to clean the plan fields
+        self.env.registry.setup_models(self.env.cr)
 
         # Crappy hack to disable the rule from timesheet grid, if it exists
         # The registry doesn't contain the field timesheet_manager_id.
@@ -853,3 +855,21 @@ class TestTimesheet(TestCommonTimesheet):
             field_name: analytic_account.id
         })
         self.assertEqual(line[field_name].id, analytic_account.id, f"The value of {field_name} shouldn't get overwritten by the project's account")
+
+    def test_split_analytic_dynamic_update(self):
+        self.empl_employee.hourly_cost = 10.0
+        another_account = self.project.account_id.copy()
+
+        line = self.env['account.analytic.line'].create({
+            'name': 'Timesheet',
+            'unit_amount': 1,
+            'project_id': self.project_customer.id,
+            'account_id': self.project.account_id.id,
+            'employee_id': self.empl_employee.id,
+        })
+        self.assertEqual(line.amount, -10)
+        line.analytic_distribution = {
+            f"{self.project.account_id.id}": 50,
+            f"{another_account.id}": 50,
+        }
+        self.assertEqual(line.amount, -5)  # the line is split in 2

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -618,9 +618,11 @@ function isValidFieldValue(record, fieldDef) {
         case "binary":
         case "char":
         case "html":
-        case "json":
         case "text": {
             return typeof value === "string";
+        }
+        case "json": {
+            return typeof value === "string" || typeof value === "object";
         }
         case "boolean": {
             return typeof value === "boolean";


### PR DESCRIPTION
In Journal Items list view, mass edition of the Analytic Distribution on several records is disappointing and reported almost unusable. It is impossible to mass edit only one plan on multiple lines using a distribution. This commit is adding the possibility to do so from the list view of analytic items but also from the journal items.

task-4937143
