### PR TITLE
[FIX] html_editor: fix non-deterministic toolbar test

### DIFF
--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -72,20 +72,17 @@ test("shape_circle and shape_rounded are mutually exclusive", async () => {
     }
 
     await click(buttons["shape_rounded"]);
-    await animationFrame();
-    expect(buttons["shape_rounded"]).toHaveClass("active");
+    await waitFor(buttons["shape_rounded"] + ".active");
     expect(img).toHaveClass("rounded");
 
     await click(buttons["shape_circle"]);
-    await animationFrame();
-    expect(buttons["shape_circle"]).toHaveClass("active");
+    await waitFor(buttons["shape_circle"] + ".active");
     expect(img).toHaveClass("rounded-circle");
     expect(buttons["shape_rounded"]).not.toHaveClass("active");
     expect(img).not.toHaveClass("rounded");
 
     await click(buttons["shape_rounded"]);
-    await animationFrame();
-    expect(buttons["shape_rounded"]).toHaveClass("active");
+    await waitFor(buttons["shape_rounded"] + ".active");
     expect(img).toHaveClass("rounded");
     expect(buttons["shape_circle"]).not.toHaveClass("active");
     expect(img).not.toHaveClass("rounded-circle");

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -834,11 +834,9 @@ test("toolbar correctly show namespace button group and stop showing when namesp
     const { el } = await setupEditor("<div>[<section><p>abc</p></section><div>d]ef</div></div>", {
         config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
     });
-    await waitFor(".o-we-toolbar");
-    expect(".btn-group[name='test_group']").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar .btn-group[name='test_group']", 1);
     setContent(el, "<div><section><p>[abc]</p></section><div>def</div></div>");
-    await animationFrame();
-    expect(".btn-group[name='test_group']").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar .btn-group[name='test_group']", 0);
 });
 
 test("toolbar does not evaluate isActive when namespace does not match", async () => {


### PR DESCRIPTION
Due to the debounce added in [1], the toolbar now sometimes update in more than a single animation frame.

runbot-229914

[1]: https://github.com/odoo/odoo/pull/217555/commits/982fbd75267787c26abf7c6c3c73acaeb6d5bf38#diff-bbe541897d87fdda0566776a1f38db00c056baeb2a5a992bba92ac82816c2d37R320
