### PR TITLE
[FIX] html_editor,website: use expandToolbar

### DIFF
--- a/addons/html_editor/static/tests/chatgpt_translate.test.js
+++ b/addons/html_editor/static/tests/chatgpt_translate.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, press, tick, waitFor } from "@odoo/hoot-dom";
+import { press, tick, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { loadLanguages } from "@web/core/l10n/translation";
@@ -69,8 +69,7 @@ test("Translate should be disabled if selection spans across non editable conten
     await setupEditor("<div>[ab]</div>");
     await animationFrame();
     await tick();
-    await click('button[name="expand_toolbar"]');
-    await animationFrame();
+    await expandToolbar();
     expect(".o-we-toolbar [name='translate']").not.toHaveAttribute("disabled");
 });
 
@@ -78,8 +77,7 @@ test("Translate should be disabled if selection spans across non editable conten
     await setupEditor("<div>a[b</div><div>c]d</div>");
     await animationFrame();
     await tick();
-    await click('button[name="expand_toolbar"]');
-    await animationFrame();
+    await expandToolbar();
     expect(".o-we-toolbar [name='translate']").not.toHaveAttribute("disabled");
 });
 
@@ -87,8 +85,7 @@ test("Translate should be disabled if selection spans across non editable conten
     await setupEditor('<div contenteditable="false">a[b</div><div>c]d</div>');
     await animationFrame();
     await tick();
-    await click('button[name="expand_toolbar"]');
-    await animationFrame();
+    await expandToolbar();
     expect(".o-we-toolbar [name='translate']").toHaveAttribute("disabled");
 });
 
@@ -96,8 +93,7 @@ test("Translate should be disabled if selection spans across non editable conten
     await setupEditor('<div class="oe_unbreakable">a[b</div><div>c]d</div>');
     await animationFrame();
     await tick();
-    await click('button[name="expand_toolbar"]');
-    await animationFrame();
+    await expandToolbar();
     expect(".o-we-toolbar [name='translate']").toHaveAttribute("disabled");
 });
 
@@ -105,8 +101,7 @@ test("Translate should be disabled if selection spans across non editable conten
     await setupEditor('<div>a[b</div><div>c]d</div><div class="oe_unbreakable">e</div>');
     await animationFrame();
     await tick();
-    await click('button[name="expand_toolbar"]');
-    await animationFrame();
+    await expandToolbar();
     expect(".o-we-toolbar [name='translate']").not.toHaveAttribute("disabled");
 });
 
@@ -114,8 +109,7 @@ test("Translate should be disabled if selection spans across non editable conten
     await setupEditor('<div>a[b</div><div>cd</div><div class="oe_unbreakable">e]</div>');
     await animationFrame();
     await tick();
-    await click('button[name="expand_toolbar"]');
-    await animationFrame();
+    await expandToolbar();
     expect(".o-we-toolbar [name='translate']").toHaveAttribute("disabled");
 });
 

--- a/addons/website/static/tests/builder/website_builder/animate_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/animate_option.test.js
@@ -1,3 +1,4 @@
+import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
 import { describe, expect, test } from "@odoo/hoot";
 import { queryFirst, waitFor } from "@odoo/hoot-dom";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
@@ -354,7 +355,7 @@ describe("animate text in toolbar", () => {
         selection.setBaseAndExtent(textNode, 1, textNode, 3);
 
         // click on animate and it create a span with the animation
-        await contains("button[name=expand_toolbar]").click();
+        await expandToolbar();
         expect("button[title='Animate Text']").not.toHaveClass("active");
         await contains("button[title='Animate Text']").click();
         expect(":iframe span").toHaveText("bc");
@@ -382,7 +383,7 @@ describe("animate text in toolbar", () => {
         selection.setBaseAndExtent(textNode, 0, textNode, 2);
 
         // animate is marked active
-        await contains("button[name=expand_toolbar]").click();
+        await expandToolbar();
         expect("button[title='Animate Text']").toHaveClass("active");
         await contains("button[title='Animate Text']").click();
         expect(":iframe span:contains('bc')").not.toHaveClass("o_anim_rotate_in");
@@ -402,7 +403,7 @@ describe("animate text in toolbar", () => {
         // reset removes the span
         await contains(":iframe span").click(); // move the selection around to make the toolbar re-appear
         selection.setBaseAndExtent(textNode, 0, textNode, 2);
-        await contains("button[name=expand_toolbar]").click();
+        await expandToolbar();
         await contains("button[title='Animate Text']").click();
         await contains("button[title=Reset]").click();
         expect(":iframe span").toHaveCount(0);
@@ -421,7 +422,7 @@ describe("animate text in toolbar", () => {
         selection.setBaseAndExtent(textNode, 0, textNode, 2);
 
         // animate is marked active
-        await contains("button[name=expand_toolbar]").click();
+        await expandToolbar();
         expect("button[title='Animate Text']").toHaveClass("active");
         await contains("button[title='Animate Text']").click();
         expect("div[data-class-action=o_animate]").toHaveCount(1);
@@ -442,7 +443,7 @@ describe("animate text in toolbar", () => {
 
         selection.setBaseAndExtent(test.childNodes[0], 0, span.childNodes[0], 1);
 
-        await contains("button[name=expand_toolbar]").click();
+        await expandToolbar();
         expect("button[title='Animate Text']").not.toHaveClass("active");
         await contains("button[title='Animate Text']").click();
         expect(":iframe span:eq(0)").toHaveText("ab");
@@ -461,7 +462,7 @@ describe("animate text in toolbar", () => {
 
         selection.setBaseAndExtent(span.childNodes[0], 1, test.childNodes[2], 1);
 
-        await contains("button[name=expand_toolbar]").click();
+        await expandToolbar();
         expect("button[title='Animate Text']").not.toHaveClass("active");
         await contains("button[title='Animate Text']").click();
         expect(":iframe span:eq(0)").toHaveText("b");
@@ -479,7 +480,7 @@ describe("animate text in toolbar", () => {
 
         selection.setBaseAndExtent(span.childNodes[0], 1, span.childNodes[0], 2);
 
-        await contains("button[name=expand_toolbar]").click();
+        await expandToolbar();
         expect("button[title='Animate Text']").not.toHaveClass("active");
         await contains("button[title='Animate Text']").click();
         expect(":iframe span[other-attribute]:eq(0)").toHaveText("b");
@@ -503,7 +504,7 @@ describe("animate text in toolbar", () => {
             1
         );
 
-        await contains("button[name=expand_toolbar]").click();
+        await expandToolbar();
         expect("button[title='Animate Text']").not.toHaveClass("active");
         await contains("button[title='Animate Text']").click();
         expect(":iframe span:eq(0)").toHaveText("b");


### PR DESCRIPTION
This commit will use the expandToolbar utility in all tests that need to
expand the toolbar.
Tests that didn't use this utils could fail indeterministically.
They fail because the expand is debounced, which means you have to wait
longer than a frame animation sometimes. So we opted to use the waitFor.
Here's the commit that introduces debounce: https://github.com/odoo/odoo/commit/982fbd75267787c26abf7c6c3c73acaeb6d5bf38#diff-bbe541897d87fdda0566776a1f38db00c056baeb2a5a992bba92ac82816c2d37R320