### PR TITLE
[FIX] website: prevent deleting fields used in website forms

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -2,7 +2,10 @@
 
 from ast import literal_eval
 
-from odoo import models, fields, api, SUPERUSER_ID
+from lxml import etree
+
+from odoo import SUPERUSER_ID, _, api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.http import request
 from odoo.osv import expression
 
@@ -146,6 +149,26 @@ class website_form_model_fields(models.Model):
         # blacklisted by default)
         self._cr.execute('ALTER TABLE ir_model_fields '
                          ' ALTER COLUMN website_form_blacklisted SET DEFAULT true')
+
+    @api.ondelete(at_uninstall=False)
+    def _check_if_used_in_website_form(self):
+        """Prevent field deletion if used in a website form."""
+        for field in self:
+            for model_name, field_name in self.env['website']._get_html_fields():
+                domain = [(field_name, 'ilike', f'data-model_name="{field.model}"')]
+                records = self.env[model_name].with_context(active_test=False).search(domain)
+                for record in records:
+                    arch_parsed = etree.fromstring(record[field_name])
+                    xpath_selector = f'//form[@data-model_name="{field.model}"]//*[@name="{field.name}"]'
+                    if arch_parsed.xpath(xpath_selector):
+                        raise ValidationError(_(
+                            "The field '%(field)s' cannot be deleted because it is referenced in a website view.\n"
+                            "Model: %(model)s\n"
+                            "View: %(view)s",
+                            field=field.name,
+                            model=field.model,
+                            view=record.display_name,
+                        ))
 
     @api.model
     def formbuilder_whitelist(self, model, fields):

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -1,12 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from unittest.mock import patch
-
+from odoo.exceptions import ValidationError
 from odoo.http import request
+from odoo.tests.common import TransactionCase, tagged
+
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 from odoo.addons.website.controllers.form import WebsiteForm
 from odoo.addons.website.tools import MockRequest
-from odoo.tests.common import tagged, TransactionCase
 
 
 @tagged('post_install', '-at_install')
@@ -66,8 +66,19 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
     def test_website_form_nested_forms(self):
         self.start_tour('/my/account', 'website_form_nested_forms', login='admin')
 
+
 @tagged('post_install', '-at_install')
 class TestWebsiteForm(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.partner_model = self.env['ir.model'].search([('model', '=', 'res.partner')])
+        self.test_field = self.env['ir.model.fields'].create({
+            'name': 'x_test_field',
+            'model_id': self.partner_model.id,
+            'ttype': 'char',
+            'field_description': 'test',
+        })
 
     def test_website_form_html_escaping(self):
         website = self.env['website'].browse(1)
@@ -105,3 +116,24 @@ class TestWebsiteForm(TransactionCase):
                 )
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.data.startswith(b'{"id":'))
+
+    def test_cannot_delete_field_used_in_website_form(self):
+        """
+        Test that deleting a field used in a website form raises a ValidationError.
+        """
+        self.env['ir.ui.view'].create({
+            'name': 'Test Form for Deletion Constraint',
+            'type': 'qweb',
+            'arch_db': f'''
+                <template id="test_form_template_for_deletion">
+                    <form action="/website/form/" data-model_name="res.partner">
+                        <label for="my_input">Test Input</label>
+                        <input type="text" name="{self.test_field.name}" id="my_input"/>
+                        <button type="submit">Submit</button>
+                    </form>
+                </template>
+            ''',
+        })
+        with self.assertRaises(ValidationError):
+            self.test_field.unlink()
+        self.assertTrue(self.test_field.exists())


### PR DESCRIPTION
The system crashes when a user tries to edit a website form field and that field has already been deleted from the model.

**Steps to produce:-**
- Install the `website` module.
- Create a `new custom field` on a model(for example, a field on the `mail.mail` model).
- Website > edit > `add Form` widget to a page, and configure it to use the `mail.mail` model.
- Add the newly created custom field to the form and save the page.
- Now, `delete` the custom field which is created previously.
- Return to the website page > edit > mark the deleted field as required, and attempt to save the changes.

**Error:-**
`ValueError: Unable to whitelist field(s) [''] for model 'mail.mail'.`

**Root cause:-**
- At [1], we can see that in the current version, it `only logs an error` using the logger, but in later versions, it `raises a ValueError` instead.

**Solution:-**
- This fix prevents a field from being deleted if it is actively used in any website form.
- It adds a validation check that blocks the deletion and raises an error, forcing the user to remove the field from the form first.

[1]: https://github.com/odoo/odoo/blob/d4f424d731fa93ccd232d0def0a7612997345ef7/addons/website/models/website_form.py#L123-L126

**sentry-5689731444**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
