### PR TITLE
[REV] point_of_sale: revert LNE orderline unit change

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -21,9 +21,7 @@
                 </div>
                 <ul class="info-list d-flex flex-column">
                     <li class="price-per-unit">
-                        <span class="qty px-1 border rounded text-bg-view fw-bolder me-1">
-                            <t t-esc="line.qty" /> <t t-if="line.unit and line.unit !== 'Units'" t-esc="line.unit" />
-                        </span>
+                        <span class="qty px-1 border rounded text-bg-view fw-bolder me-1" t-esc="line.qty"/>
                         <t t-if="!props.basic_receipt">
                             x
                             <t t-if="line.price !== 0">


### PR DESCRIPTION
This commit reverts commit ffdedf9, as the change is no longer required due to the LNE certification being implemented in a separate module. It also had a bug where the hiding of 'Units' only worked in English.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
