### PR TITLE
[IMP] website_sale: add margin-bottom to product name in cart

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2773,7 +2773,7 @@
                     <div class="d-flex flex-column flex-grow-1 gap-3 min-w-0">
                         <div class="d-flex gap-3">
                             <div class="flex-grow-1 text-wrap w-100">
-                                <div class="d-flex justify-content-between">
+                                <div class="d-flex justify-content-between mb-2">
                                     <div class="d-md-flex flex-md-wrap column-gap-md-1 align-items-md-center">
                                         <t t-call="website_sale.cart_line_product_link">
                                             <h6


### PR DESCRIPTION
Before this PR, the title was to close to the content which in the scenario of a list product (cf: combo) it was unbalanced with the list's border.
| Before | After |
|--------|--------|
| <img width="783" height="429" alt="Screenshot 2025-07-18 at 15 28 01" src="https://github.com/user-attachments/assets/8d248fc0-d177-4cf5-8af7-86a725418c54" /> | <img width="783" height="429" alt="Screenshot 2025-07-18 at 15 27 43" src="https://github.com/user-attachments/assets/760880e3-b3d8-4953-8790-6c959808142a" /> | 

task-4920358

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
