### PR TITLE
[FIX] website, html_editor: add `o_translate_inline` on created links

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -340,11 +340,14 @@ export class LinkPlugin extends Plugin {
      */
     createLink(url, label = "") {
         const link = this.document.createElement("a");
-        link.setAttribute("href", url);
+        if (url !== undefined) {
+            link.setAttribute("href", url);
+        }
         for (const [param, value] of Object.entries(this.config.defaultLinkAttributes || {})) {
             link.setAttribute(param, `${value}`);
         }
         link.innerText = label;
+        this.dispatchTo("create_link_handlers", link);
         return link;
     }
 
@@ -442,10 +445,7 @@ export class LinkPlugin extends Plugin {
         this.linkInDocument = linkElement;
         if (!linkElement) {
             // create a new link element
-            linkElement = this.document.createElement("a");
-            if (!selection.isCollapsed) {
-                linkElement.append(selection.textContent());
-            }
+            linkElement = this.createLink(undefined, selection.textContent());
         }
 
         const selectionTextContent = selection?.textContent();

--- a/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
@@ -1,0 +1,11 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+export class TranslateLinkInlinePlugin extends Plugin {
+    static id = "translateLinkInline";
+    resources = {
+        create_link_handlers: (linkEl) => linkEl.classList.add("o_translate_inline"),
+    };
+}
+
+registry.category("website-plugins").add(TranslateLinkInlinePlugin.id, TranslateLinkInlinePlugin);

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -13,6 +13,7 @@ import { registry } from "@web/core/registry";
 import { HighlightPlugin } from "./plugins/highlight/highlight_plugin";
 import { PopupVisibilityPlugin } from "./plugins/popup_visibility_plugin";
 import { SaveTranslationPlugin } from "./plugins/save_translation_plugin";
+import { TranslateLinkInlinePlugin } from "./plugins/translate_link_inline_plugin";
 import { TranslationPlugin } from "./plugins/translation_plugin";
 import { WebsiteVisibilityPlugin } from "./plugins/website_visibility_plugin";
 import { EditInteractionPlugin } from "./plugins/edit_interaction_plugin";
@@ -25,6 +26,7 @@ const TRANSLATION_PLUGINS = [
     VisibilityPlugin,
     PopupVisibilityPlugin,
     SaveTranslationPlugin,
+    TranslateLinkInlinePlugin,
     TranslationPlugin,
     WebsiteVisibilityPlugin,
     HighlightPlugin,


### PR DESCRIPTION
After the initial website builder refactor, new links in text on the website do not contain the class `o_translate_inline`. NOTE: before the refactor it was added only for new links inside paragraph (the bugs described here were present in blocks which are not paragraph)

Steps to reproduce:
- Open website builder
- Select some text and add a link from the toolbar
- Again, with some text after in the same text block
- Save
- Change the website language
- Open website builder in translate mode
- Bugs:
  - You cannot change the links
  - You cannot make it so that the links are in another order
- Edit the text to make the translation different
- In the edited block, select some text and create a new link
- Save
- Bug: The edits are lost (the block with the new link is reset)

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
