### PR TITLE
[IMP] web,sale: reduce memory footprint of invisible x2m

### DIFF
--- a/addons/event_booth_sale/static/src/js/sale_product_field.js
+++ b/addons/event_booth_sale/static/src/js/sale_product_field.js
@@ -42,10 +42,8 @@ patch(SaleOrderLineProductField.prototype, {
                 actionContext.default_event_booth_category_id = recordData.event_booth_category_id.id;
             }
             if (recordData.event_booth_pending_ids) {
-                actionContext.default_event_booth_ids = recordData.event_booth_pending_ids.records.map(
-                    record => {
-                        return [4, record.resId];
-                    }
+                actionContext.default_event_booth_ids = recordData.event_booth_pending_ids.currentIds.map(
+                    (resId) => [4, resId]
                 );
             }
         }

--- a/addons/mail/static/src/chatter/web/mail_composer_form.js
+++ b/addons/mail/static/src/chatter/web/mail_composer_form.js
@@ -79,9 +79,7 @@ export class MailComposerFormRenderer extends formView.Renderer {
         };
 
         onCloseWizardModal(async () => {
-            const selectedPartnerIds = this.props.record.data.partner_ids.records.map(
-                (partner) => partner.resId
-            );
+            const selectedPartnerIds = this.props.record.data.partner_ids.currentIds;
             const selectedPartners = await this.orm.searchRead(
                 "res.partner",
                 [["id", "in", selectedPartnerIds]],

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -355,9 +355,7 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
      * @return {Number[]} The sale order line's PTAV ids.
      */
     _getVariantPtavIds(saleOrderLine) {
-        return saleOrderLine.product_template_attribute_value_ids.records.map(
-            record => record.resId
-        );
+        return saleOrderLine.product_template_attribute_value_ids.currentIds;
     }
 
     /**
@@ -367,9 +365,7 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
      * @return {Number[]} The sale order line's `no_variant` PTAV ids.
      */
     _getNoVariantPtavIds(saleOrderLine) {
-        return saleOrderLine.product_no_variant_attribute_value_ids.records.map(
-            record => record.resId
-        );
+        return saleOrderLine.product_no_variant_attribute_value_ids.currentIds;
     }
 
     /**

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -25,7 +25,7 @@ export class QtyAtDatePopover extends Component {
                 active_model: 'product.product',
                 active_id: this.props.record.data.product_id.id,
                 warehouse_id: this.props.record.data.warehouse_id && this.props.record.data.warehouse_id.id,
-                move_to_match_ids: this.props.record.data.move_ids.records.map(record => record.resId),
+                move_to_match_ids: this.props.record.data.move_ids.currentIds,
                 sale_line_to_match_id: this.props.record.resId,
             },
         });

--- a/addons/survey/static/src/question_page/question_page_list_renderer.js
+++ b/addons/survey/static/src/question_page/question_page_list_renderer.js
@@ -131,7 +131,7 @@ export class QuestionPageListRenderer extends ListRenderer {
      */
     async onDeleteRecord(record) {
         const triggeredRecords = this.props.list.records.filter(
-            (rec) => rec.data.triggering_question_ids.records.map(a => a.resId).includes(record.resId)
+            (rec) => rec.data.triggering_question_ids.currentIds.includes(record.resId)
         );
         if (triggeredRecords.length) {
             const res = await super.onDeleteRecord(record);

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -606,15 +606,16 @@ export class Record extends DataPoint {
      */
     _createStaticListDatapoint(data, fieldName, { orderBys } = {}) {
         const { related, limit, defaultOrderBy } = this.activeFields[fieldName];
+        const relatedActiveFields = (related && related.activeFields) || {};
         const config = {
             resModel: this.fields[fieldName].relation,
-            activeFields: (related && related.activeFields) || {},
+            activeFields: relatedActiveFields,
             fields: (related && related.fields) || {},
             relationField: this.fields[fieldName].relation_field || false,
             offset: 0,
             resIds: data.map((r) => r.id),
             orderBy: orderBys?.[fieldName] || defaultOrderBy || [],
-            limit: limit || Number.MAX_SAFE_INTEGER,
+            limit: limit || (Object.keys(relatedActiveFields).length ? Number.MAX_SAFE_INTEGER : 1),
             context: {}, // will be set afterwards, see "_updateContext" in "_setEvalContext"
         };
         const options = {


### PR DESCRIPTION
Form, list and kanban view archs contain (always) invisible fields that are necessary to evaluate modifiers, but that we don't want to display. For x2many fields, they are represented by a StaticList like all x2manys. However, as they are invisible="1", they don't have inner sub views. As a consequence, there's no limit on the number of records to fetch (like for many2many_tags, for instance).

In the StaticList, we create a Record datapoint for each record in the relation, for the current page. If there's no limit, we thus create a Record datapoint for every record in the relation.

It may happen that "technical" x2many relations contain a lot (really) of records, which, considering the above explanations, involves the creation of a lot of Record datapoints, which is both time and memory consumming. We already faced the issue with the `valid_intrastat_code_ids` field, which contained 10k+ records, on a client database.

For invisible x2manys, those Record datapoints are actually useless. Indeed, we do no fetch any data, as we only need the ids. We only need the StaticList to generate the evaluation context of the records, and for an x2many field, it's the list of ids.

So to circumvent the issue, this commit introduces a fake limit of 1 on all x2many fields that have no fields to fetch. This means that the `records` array will contain at most 1 record. This is obviously a breaking change for custom code that looked into `list.records` to, e.g. get the number of records or the list of ids. Those cases must be adapted to read `currentIds` instead, which is the list of all ids in the relation, no matter the limit (and the `count` key for the number of records). This commit adapts a usecase in sale.

task-4921236

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
