### PR TITLE
[PERF] sale_service: Fix OOM when installing `sale_amazon`

### DIFF
--- a/addons/sale_service/models/sale_order_line.py
+++ b/addons/sale_service/models/sale_order_line.py
@@ -33,6 +33,8 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id.type')
     def _compute_is_service(self):
+        self.fetch(['is_service', 'product_id'])
+        self.product_id.fetch(['type'])
         for so_line in self:
             so_line.is_service = so_line.product_id.type == 'service'
 


### PR DESCRIPTION
Description
-----------
On databases that had `sale_amazon` installed in the past, were used for sales for a certain period, then had the module uninstalled, and later attempted to re-install it, a memory error will occur.

The peak memory usage stems from `sale.order.line._compute_is_service`. The reason the compute is triggered is because of the "re-creation" of the master data products `default_product` & `shipping_product`, which writes `type`, which the compute depends on. So the compute will be triggered for all `sale.order.line` records that had those products.

This commit avoids the excessive memory usage by explicitly fetching the fields that are needed for the compute, which avoids fetching large fields like the different products' HTML descriptions.

Benchmark
---------
On a database with 400k+ `sale.order.line` with an amazon related product, installing `sale_amazon` peak memory usage was:

|        | Peak Mem. |
|--------|-----------|
| Before | 3.8 GiB   |
| After  | 580 MiB   |

Reference
---------
opw-4915892

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
