### PR TITLE
[IMP] base_address_extended: change country should empty city

### DIFF
--- a/addons/base_address_extended/models/res_partner.py
+++ b/addons/base_address_extended/models/res_partner.py
@@ -54,3 +54,9 @@ class ResPartner(models.Model):
             self.city = False
             self.zip = False
             self.state_id = False
+
+    @api.onchange('country_id')
+    def _onchange_country_id(self):
+        super()._onchange_country_id()
+        if self.country_id and self.country_id != self.city_id.country_id:
+            self.city_id = False


### PR DESCRIPTION
* Problem: When changing country_id into another country that also enforce city, the city stay the same which is a bad ux/ui

* This commit improve by overide the onchange method in base module to aslo make city_id become empty when changing country

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
