### PR TITLE
[FIX] website_event_sale: fix strikethrough price display in cart

### DIFF
--- a/addons/website_event_sale/models/__init__.py
+++ b/addons/website_event_sale/models/__init__.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-
 from . import product
 from . import product_pricelist
 from . import sale_order
+from . import sale_order_line

--- a/addons/website_event_sale/models/sale_order.py
+++ b/addons/website_event_sale/models/sale_order.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, models
+from odoo import _, models
 from odoo.exceptions import UserError
 
 
@@ -125,17 +125,3 @@ class SaleOrder(models.Model):
         return super()._filter_can_send_abandoned_cart_mail().filtered(
             lambda so: all(ticket.sale_available for ticket in so.order_line.event_ticket_id),
         )
-
-
-class SaleOrderLine(models.Model):
-    _inherit = "sale.order.line"
-
-    @api.depends('product_id.display_name', 'event_ticket_id.display_name')
-    def _compute_name_short(self):
-        """ If the sale order line concerns a ticket, we don't want the product name, but the ticket name instead.
-        """
-        super(SaleOrderLine, self)._compute_name_short()
-
-        for record in self:
-            if record.event_ticket_id:
-                record.name_short = record.event_ticket_id.display_name

--- a/addons/website_event_sale/models/sale_order_line.py
+++ b/addons/website_event_sale/models/sale_order_line.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.depends('product_id.display_name', 'event_ticket_id.display_name')
+    def _compute_name_short(self):
+        """ Override of `website_sale` to replace the product name with the ticket name. """
+        super()._compute_name_short()
+
+        for line in self:
+            if line.event_ticket_id:
+                line.name_short = line.event_ticket_id.display_name
+
+    def _should_show_strikethrough_price(self):
+        """ Override of `website_sale` to hide the strikethrough price for events. """
+        return super()._should_show_strikethrough_price() and not self.event_id

--- a/addons/website_event_sale/views/website_sale_templates.xml
+++ b/addons/website_event_sale/views/website_sale_templates.xml
@@ -20,12 +20,6 @@
     </template>
 
     <!-- If the sale order line concerns an event, we want to show an additional line with the event name even on small screens -->
-    <template id="cart_lines_inherit_website_event_sale" inherit_id="website_sale.cart_lines_price" name="Event Shopping Cart Lines">
-        <xpath expr="//del" position="attributes">
-            <attribute name="t-attf-class" separator=" " add="#{line.event_id and 'd-none' or ''}"/>
-        </xpath>
-    </template>
-
     <template id="cart_summary_inherit_website_event_sale" inherit_id="website_sale.cart_summary_content">
         <xpath expr="//td[@name='website_sale_cart_summary_product_name']/span" position="after">
             <span t-if="line.event_slot_id" class="text-muted" t-out="line.event_slot_id.display_name"/>

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -90,3 +90,14 @@ class SaleOrderLine(models.Model):
             raise UserError(self.env._(
                 "The given product does not have a price therefore it cannot be added to cart.",
             ))
+
+    def _should_show_strikethrough_price(self):
+        """ Compute whether the strikethrough price should be shown.
+
+        The strikethrough price should be shown if there is a discount on a sellable line for
+        which a price unit is non-zero.
+
+        :return: Whether the strikethrough price should be shown.
+        :rtype: bool
+        """
+        return self.discount and self._is_sellable() and self._get_displayed_unit_price()

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2894,13 +2894,12 @@
             class="d-flex flex-column flex-md-row align-items-end align-items-md-start justify-content-md-end mb-0 small fw-bold"
             name="website_sale_cart_line_price"
         >
-            <t t-if="line.discount and line._is_sellable() and line._get_displayed_unit_price()">
-                <del
-                    class="me-md-2 text-muted text-nowrap opacity-50"
-                    t-out="line._get_displayed_unit_price() * line.product_uom_qty"
-                    t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
-                />
-            </t>
+            <del
+                t-if="line._should_show_strikethrough_price()"
+                class="me-md-2 text-muted text-nowrap opacity-50"
+                t-out="line._get_displayed_unit_price() * line.product_uom_qty"
+                t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+            />
             <t t-set="product_price" t-value="line._get_cart_display_price()"/>
             <t t-call="website_sale.cart_product_price"/>
         </h6>

--- a/addons/website_sale_loyalty/models/sale_order_line.py
+++ b/addons/website_sale_loyalty/models/sale_order_line.py
@@ -26,3 +26,7 @@ class SaleOrderLine(models.Model):
             for order, rewards in disabled_rewards_per_order.items():
                 order.disabled_auto_rewards += rewards
         return super().unlink()
+
+    def _should_show_strikethrough_price(self):
+        """ Override of `website_sale` to hide the strikethrough price for rewards. """
+        return super()._should_show_strikethrough_price() and not self.is_reward_line

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -153,12 +153,6 @@
         </xpath>
     </template>
 
-    <template id="website_sale_coupon_cart_hide_qty" inherit_id="website_sale.cart_lines_price">
-        <xpath expr="//del" position="attributes">
-            <attribute name="t-if">not line.is_reward_line</attribute>
-        </xpath>
-    </template>
-
     <template id="layout" inherit_id="website.layout">
         <xpath expr="//*[@id='wrapwrap']" position="inside">
             <t t-set="coupon_error" t-value="request.params.get('coupon_error')"/>


### PR DESCRIPTION
Since d2fd106, in the eCommerce cart, the strikethrough price loses its classes when `website_event_sale` is installed.

See also: 
- https://github.com/odoo/upgrade/pull/8094