### PR TITLE
[IMP] im_livechat,*: leave warning only when livechat is active

### DIFF
--- a/addons/im_livechat/static/src/core/common/close_confirmation.xml
+++ b/addons/im_livechat/static/src/core/common/close_confirmation.xml
@@ -7,8 +7,8 @@
                 <div class="position-absolute top-0 end-0 p-1 o-xsmaller">
                     <button class="o-livechat-CloseConfirmation-close btn-close" t-on-click.stop="() => this.props.onCloseConfirmationDialog()"/>
                 </div>
-                <span class="pt-2 pb-3">Leaving will end the livechat. Proceed leaving?</span>
-                <button class="o-livechat-CloseConfirmation-leave btn btn-danger p-2 gap-1" t-on-keydown.stop.prevent="onKeydown" t-on-click.stop="() => this.props.onClickLeaveConversation()" t-ref="confirm"><i class="fa fa-fw fa-sign-out"/>Yes, leave conversation</button>
+                <span class="pt-2 pb-3">Leaving will end the livechat. Do you want to continue?</span>
+                <button class="o-livechat-CloseConfirmation-leave btn btn-danger p-2 gap-1" t-on-keydown.stop.prevent="onKeydown" t-on-click.stop="() => this.props.onClickLeaveConversation()" t-ref="confirm"><i class="fa fa-fw fa-sign-out"/>Yes, end chat</button>
             </div>
         </div>
     </t>

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -61,14 +61,19 @@ patch(Thread.prototype, {
         return this.channel_type === "livechat" || super.isChatChannel;
     },
 
-    get composerDisabled() {
+    get hasLivechatEnded() {
         return this.channel_type === "livechat" && this.livechat_end_dt;
     },
 
+    get composerDisabled() {
+        return this.hasLivechatEnded;
+    },
+
     get composerDisabledText() {
-        return this.channel_type === "livechat" && this.livechat_end_dt
-            ? _t("This livechat conversation has ended")
-            : "";
+        return this.hasLivechatEnded ? _t("This livechat conversation has ended") : "";
+    },
+    get leaveConfirmationLabel() {
+        return this.channel_type === "livechat" ? _t("End Chat") : super.leaveConfirmationLabel;
     },
     /**
      * @override

--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -78,8 +78,15 @@ patch(Thread.prototype, {
         }
     },
     async leaveChannel({ force = false } = {}) {
-        if (this.channel_type === "livechat" && this.channel_member_ids.length <= 2 && !force) {
-            await this.askLeaveConfirmation(_t("Leaving will end the livechat. Proceed leaving?"));
+        if (
+            this.channel_type === "livechat" &&
+            this.channel_member_ids.length <= 2 &&
+            !force &&
+            !this.hasLivechatEnded
+        ) {
+            await this.askLeaveConfirmation(
+                _t("Leaving will end the livechat. Do you want to continue?")
+            );
         }
         super.leaveChannel(...arguments);
     },

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -162,13 +162,14 @@ patch(Thread.prototype, {
         );
     },
 
+    get hasLivechatEnded() {
+        return (super.hasLivechatEnded && !this.chatbot) || this.chatbot?.completed;
+    },
+
     get composerDisabledText() {
         const text = super.composerDisabledText;
-        if (text || !this.chatbot) {
+        if (text) {
             return text;
-        }
-        if (this.chatbot.completed) {
-            return _t("This livechat conversation has ended");
         }
         if (
             this.chatbot.currentStep?.step_type === "question_selection" &&

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -372,7 +372,7 @@ test("Clicking on leave button leaves the channel", async () => {
     await contains(".o-mail-DiscussSidebarChannel", { text: "Visitor 11" });
     await click("[title='Chat Actions']");
     await click(".o-dropdown-item:contains('Leave Channel')");
-    await click("button:contains(Leave Conversation)");
+    await click("button:contains(End Chat)");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Visitor 11" });
 });
 
@@ -452,7 +452,7 @@ test("unknown livechat can be displayed and interacted with", async () => {
     await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Jane" });
     await click("[title='Chat Actions']");
     await click(".o-dropdown-item:contains('Leave Channel')");
-    await click("button:contains('Leave Conversation')");
+    await click("button:contains('End Chat')");
     await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -109,12 +109,15 @@ patch(Thread.prototype, {
             );
         }
     },
+    get leaveConfirmationLabel() {
+        return _t("Leave Conversation");
+    },
     /** @param {string} body */
     async askLeaveConfirmation(body) {
         await new Promise((resolve) => {
             this.store.env.services.dialog.add(ConfirmationDialog, {
                 body: body,
-                confirmLabel: _t("Leave Conversation"),
+                confirmLabel: this.leaveConfirmationLabel,
                 confirm: resolve,
                 cancel: () => {},
             });

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
@@ -59,7 +59,7 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow button:contains('Yes, leave conversation')",
+            trigger: ".o-livechat-root:shadow button:contains('Yes, end chat')",
             run: "click",
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
@@ -32,7 +32,7 @@ registry.category("web_tour.tours").add("website_livechat_no_session_with_hide_r
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow button:contains('Yes, leave conversation')",
+            trigger: ".o-livechat-root:shadow button:contains('Yes, end chat')",
             run: "click",
         },
         {
@@ -54,7 +54,7 @@ registry.category("web_tour.tours").add("website_livechat_no_session_with_hide_r
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow button:contains('Yes, leave conversation')",
+            trigger: ".o-livechat-root:shadow button:contains('Yes, end chat')",
             run: "click",
         },
         {


### PR DESCRIPTION
*: website_livechat

Before this PR, when leaving a livechat, the user was getting a warning even when the livechat was already ended.

Now, the user is able to directly leave the livechat without getting this warning when the livechat is already ended.

task-4926337


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
