### PR TITLE
[IMP] resource: Resource calendar rework

### DIFF
--- a/addons/resource/data/resource_demo.xml
+++ b/addons/resource/data/resource_demo.xml
@@ -23,7 +23,6 @@
                     (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'})
                 ]"
             />
-            <field name="full_time_required_hours">35</field>
         </record>
 
         <record id="resource_calendar_std_38h" model="resource.calendar">
@@ -57,7 +56,6 @@
             <field name="company_id" ref="base.main_company"/>
             <field name="hours_per_day">8</field>
             <field name="flexible_hours" eval="True"/>
-            <field name="full_time_required_hours">40</field>
         </record>
 
     </data>

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -23,7 +23,6 @@
         <field name="model">resource.calendar</field>
         <field name="arch" type="xml">
             <form string="Working Time">
-                <field name="two_weeks_calendar" invisible="1"/>
                 <header>
                 </header>
                 <sheet string="Working Time">
@@ -53,7 +52,6 @@
                     </div>
                     <group name="resource_details" col="2">
                         <group name="resource_working_hours">
-                            <field name="flexible_hours" invisible="1"/>
                             <field name="schedule_type" widget="radio"/>
                             <label for="full_time_required_hours" invisible="not company_id"/>
                             <label for="full_time_required_hours" string="Required Full Time" invisible="company_id"/>
@@ -66,14 +64,12 @@
                                 <field name="work_time_rate" nolabel="1" style="width: 6ch;"/>
                                 <span class="ms-1">%</span>
                             </div>
-                            <field name="is_fulltime" invisible="1"/>
                         </group>
                         <group>
                             <group name="resource_company" colspan="2">
-                                <field name="active" invisible="1"/>
                                 <field name="company_id" placeholder="Visible to all"/>
                                 <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset', 'mismatch_title': 'Timezone Mismatch : This timezone is different from that of your browser.\nPlease, be mindful of this when setting the working hours or the time off.'}" />
-                                <field name="tz_offset" invisible="1"/>
+                                <field name="tz_offset" invisible="1"/> <!-- Computed field needed for timezone_mismatch widget -->
                             </group>
                             <group name="flex_details" invisible="not flexible_hours" colspan="2">
                                 <label for="hours_per_day" string="Avg"/>
@@ -90,11 +86,11 @@
                             <group name="switch_calendar" invisible="flexible_hours">
                                 <label for="switch_calendar_type" string="2 Week's Calendar" class="o_form_label"/>
                                 <button name="switch_calendar_type" invisible="two_weeks_calendar" type="object"
-                                    icon="fa-square-o" class="btn p-0"
+                                    icon="fa-square-o" title="Switch to 2-weeks calendar" class="btn p-0"
                                     confirm="Are you sure you want to switch to a 2-week calendar? All work entries will be lost."
                                     confirm-label="Switch"/>
                                 <button name="switch_calendar_type" invisible="not two_weeks_calendar" type="object"
-                                    icon="fa-check-square" class="btn p-0"
+                                    icon="fa-check-square" title="Switch to 1-week calendar" class="btn p-0"
                                     confirm="Are you sure you want to switch to a 1-week calendar? All work entries will be lost."
                                     confirm-label="Switch"/>
                             </group>
@@ -120,7 +116,7 @@
                             </group>
                             <field name="attendance_ids" widget="section_one2many"/>
                         </page>
-                        <page string="Week 1 Working Hours" name="working_hours" invisible="not two_weeks_calendar">
+                        <page string="Week 1 Working Hours" name="working_hours" invisible="flexible_hours or not two_weeks_calendar">
                             <field name="two_weeks_explanation"/>
                             <group>
                                 <group>
@@ -140,7 +136,7 @@
                             </group>
                             <field name="attendance_ids_1st_week" widget="section_one2many"/>
                         </page>
-                        <page string="Week 2 Working Hours" name="working_hours" invisible="not two_weeks_calendar">
+                        <page string="Week 2 Working Hours" name="working_hours" invisible="flexible_hours or not two_weeks_calendar">
                             <field name="two_weeks_explanation"/>
                             <group>
                                 <group>
@@ -158,7 +154,7 @@
                                     </div>
                                 </group>
                             </group>
-                            <field name="attendance_ids_1st_week" widget="section_one2many"/>
+                            <field name="attendance_ids_2nd_week" widget="section_one2many"/>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -25,12 +25,6 @@
             <form string="Working Time">
                 <field name="two_weeks_calendar" invisible="1"/>
                 <header>
-                    <button name="switch_calendar_type" invisible="two_weeks_calendar or flexible_hours" string="Switch to 2 weeks calendar" type="object"
-                        confirm="Are you sure you want to switch to a 2-week calendar? All work entries will be lost."
-                        confirm-label="Switch"/>
-                    <button name="switch_calendar_type" invisible="flexible_hours or not two_weeks_calendar" string="Switch to 1 week calendar" type="object"
-                        confirm="Are you sure you want to switch to a 1-week calendar? All work entries will be lost."
-                        confirm-label="Switch"/>
                 </header>
                 <sheet string="Working Time">
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
@@ -59,39 +53,112 @@
                     </div>
                     <group name="resource_details" col="2">
                         <group name="resource_working_hours">
-                            <field name="flexible_hours"/>
-                            <label for="full_time_required_hours" invisible="flexible_hours"/>
-                            <label for="full_time_required_hours" string="Hours per Week" invisible="not flexible_hours"/>
+                            <field name="flexible_hours" invisible="1"/>
+                            <field name="schedule_type" widget="radio"/>
+                            <label for="full_time_required_hours" invisible="not company_id"/>
+                            <label for="full_time_required_hours" string="Required Full Time" invisible="company_id"/>
                             <div>
-                                <field name="full_time_required_hours" style="width: 6ch;" widget="float_time"/>
+                                <field name="full_time_required_hours" style="width: 6ch;" widget="float_time" readonly="company_id"/>
                                 <span>hours/week</span>
                             </div>
-                            <field name="hours_per_day" widget="float_time" readonly="not flexible_hours"/>
-                            <label for="work_time_rate" string="Work Time Rate" invisible="flexible_hours"/>
-                            <div invisible="flexible_hours">
-                                <field name="work_time_rate" nolabel="1"  style="width: 5ch;"/>
+                            <label for="work_time_rate" string="Work Time Rate"/>
+                            <div>
+                                <field name="work_time_rate" nolabel="1" style="width: 6ch;"/>
                                 <span class="ms-1">%</span>
                             </div>
                             <field name="is_fulltime" invisible="1"/>
                         </group>
-                        <group name="resource_company">
-                            <field name="active" invisible="1"/>
-                            <field name="company_id" groups="base.group_multi_company" placeholder="Visible to all"/>
-                            <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset', 'mismatch_title': 'Timezone Mismatch : This timezone is different from that of your browser.\nPlease, be mindful of this when setting the working hours or the time off.'}" />
-                            <field name="tz_offset" invisible="1"/>
-                        </group>
-                    </group>
-                    <notebook>
-                        <page string="Working Hours" name="working_hours" invisible="flexible_hours">
-                            <field name="two_weeks_explanation" invisible="not two_weeks_calendar"/>
-                            <field name="attendance_ids" widget="section_one2many"/>
-                            <group class="oe_subtotal_footer">
+                        <group>
+                            <group name="resource_company" colspan="2">
+                                <field name="active" invisible="1"/>
+                                <field name="company_id" placeholder="Visible to all"/>
+                                <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset', 'mismatch_title': 'Timezone Mismatch : This timezone is different from that of your browser.\nPlease, be mindful of this when setting the working hours or the time off.'}" />
+                                <field name="tz_offset" invisible="1"/>
+                            </group>
+                            <group name="flex_details" invisible="not flexible_hours" colspan="2">
+                                <label for="hours_per_day" string="Avg"/>
+                                <div class="d-flex">
+                                    <field name="hours_per_day" nolabel="1" style="width: 6ch;" widget="float_time"/>
+                                    <span class="ms-2">hours/day</span>
+                                </div>
                                 <label for="hours_per_week" string="Total"/>
                                 <div class="d-flex">
-                                    <field name="hours_per_week" nolabel="1" widget="float_time"/>
+                                    <field name="hours_per_week" nolabel="1" style="width: 6ch;" widget="float_time"/>
                                     <span class="ms-2">hours/week</span>
                                 </div>
                             </group>
+                            <group name="switch_calendar" invisible="flexible_hours">
+                                <label for="switch_calendar_type" string="2 Week's Calendar" class="o_form_label"/>
+                                <button name="switch_calendar_type" invisible="two_weeks_calendar" type="object"
+                                    icon="fa-square-o" class="btn p-0"
+                                    confirm="Are you sure you want to switch to a 2-week calendar? All work entries will be lost."
+                                    confirm-label="Switch"/>
+                                <button name="switch_calendar_type" invisible="not two_weeks_calendar" type="object"
+                                    icon="fa-check-square" class="btn p-0"
+                                    confirm="Are you sure you want to switch to a 1-week calendar? All work entries will be lost."
+                                    confirm-label="Switch"/>
+                            </group>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Working Hours" name="working_hours" invisible="flexible_hours or two_weeks_calendar">
+                            <group>
+                                <group>
+                                    <label for="hours_per_day" string="Avg"/>
+                                    <div class="d-flex">
+                                        <field name="hours_per_day" nolabel="1" style="width: 6ch;" widget="float_time" readonly="1"/>
+                                        <span class="ms-2">hours/day</span>
+                                    </div>
+                                </group>
+                                <group>
+                                    <label for="hours_per_week" string="Total"/>
+                                    <div class="d-flex">
+                                        <field name="hours_per_week" nolabel="1" style="width: 6ch;" widget="float_time" readonly="1"/>
+                                        <span class="ms-2">hours/week</span>
+                                    </div>
+                                </group>
+                            </group>
+                            <field name="attendance_ids" widget="section_one2many"/>
+                        </page>
+                        <page string="Week 1 Working Hours" name="working_hours" invisible="not two_weeks_calendar">
+                            <field name="two_weeks_explanation"/>
+                            <group>
+                                <group>
+                                    <label for="hours_per_day" string="Avg"/>
+                                    <div class="d-flex">
+                                        <field name="hours_per_day" nolabel="1" style="width: 6ch;" widget="float_time" readonly="1"/>
+                                        <span class="ms-2">hours/day</span>
+                                    </div>
+                                </group>
+                                <group>
+                                    <label for="hours_per_week" string="Total"/>
+                                    <div class="d-flex">
+                                        <field name="hours_per_week" nolabel="1" style="width: 6ch;" widget="float_time" readonly="1"/>
+                                        <span class="ms-2">hours/week</span>
+                                    </div>
+                                </group>
+                            </group>
+                            <field name="attendance_ids_1st_week" widget="section_one2many"/>
+                        </page>
+                        <page string="Week 2 Working Hours" name="working_hours" invisible="not two_weeks_calendar">
+                            <field name="two_weeks_explanation"/>
+                            <group>
+                                <group>
+                                    <label for="hours_per_day" string="Avg"/>
+                                    <div class="d-flex">
+                                        <field name="hours_per_day" nolabel="1" style="width: 6ch;" widget="float_time" readonly="1"/>
+                                        <span class="ms-2">hours/day</span>
+                                    </div>
+                                </group>
+                                <group>
+                                    <label for="hours_per_week" string="Total"/>
+                                    <div class="d-flex">
+                                        <field name="hours_per_week" nolabel="1" style="width: 6ch;" widget="float_time" readonly="1"/>
+                                        <span class="ms-2">hours/week</span>
+                                    </div>
+                                </group>
+                            </group>
+                            <field name="attendance_ids_1st_week" widget="section_one2many"/>
                         </page>
                     </notebook>
                 </sheet>
@@ -106,8 +173,8 @@
             <list string="Working Time">
                 <field name="name" string="Working Time"/>
                 <field name="hours_per_week" string="Schedule Total Time" optional="hide"/>
-                <field name="work_time_rate" invisible="flexible_hours"/>
-                <field name="flexible_hours" optional="hide"/>
+                <field name="work_time_rate"/>
+                <field name="schedule_type"/>
                 <field name="full_time_required_hours" widget="float_time" optional="hide"/>
                 <field name="work_resources_count" string="# Work Resources" optional="hide"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -103,13 +103,13 @@ class TestResource(TestResourceCommon):
             [],
             'Europe/Brussels',
         )
-        resource_attendance = self.env['resource.calendar.attendance'].create({
+        self.env['resource.calendar.attendance'].create({
             'name': 'test',
-            'calendar_id': self.calendar_jean.id,
+            'calendar_id': resource.id,
             'hour_from': 0,
             'hour_to': 0,
         })
-        resource_hour = resource._get_hours_per_day(resource_attendance)
+        resource_hour = resource._get_hours_per_day()
         self.assertEqual(resource_hour, 0.0)
 
     def test_resource_without_calendar(self):


### PR DESCRIPTION
This PR improves both the functionality and user experience of the resource calendar form view:

- Redesigned the form view for better clarity and usability.
- Introduced a schedule_type field to define calendar flexibility (to be extended in the future).
- Split the two-week schedule into separate pages for easier management.
- Updated the computation of full_time_required_hours to rely on the company's default calendar.
- Improved the "2-week switch" action to copy the current calendar instead of loading a generic one.
- Moved the default_attendance_ids definition into a helper for use in default values and computed fields.

Task: 4951007

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
