### PR TITLE
[FIX] sale: do not magically delete orders

### DIFF
--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -105,14 +105,3 @@ class ResPartner(models.Model):
                 fields.Date.context_today(self),
             )
             partner.commercial_partner_id.credit_to_invoice += credit_company_currency
-
-    def unlink(self):
-        # Unlink draft/cancelled SO so that the partner can be removed from database
-        self.env['sale.order'].sudo().search([
-            ('state', 'in', ['draft', 'cancel']),
-            '|', '|',
-            ('partner_id', 'in', self.ids),
-            ('partner_invoice_id', 'in', self.ids),
-            ('partner_shipping_id', 'in', self.ids),
-        ]).unlink()
-        return super().unlink()


### PR DESCRIPTION
On partner deletion, draft & cancelled orders were automatically deleted as well (to ease the deletion of 'unused' partners).

Nevertheless, since both the main customer and the shipping and invoicing addresses were considered, the deletion of a partner might lead to the unexpected deletion of an order where the deleted partner was only the invoicing or shipping address.
The user might not even be aware of it if they didn't enable the shipping/invoicing addresses setting.

We believe it's better to drop this magical deletion and let the user be aware that there are orders related to the customer, so that they can handle it the way they want to, without the program deciding for them.

opw-4866778

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
