### PR TITLE
[FIX] point_of_sale: fix session stuck on closing

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1143,7 +1143,7 @@ class PosSession(models.Model):
         payment_method = payment.payment_method_id
         if not payment_method.journal_id:
             return self.env['account.move.line']
-        outstanding_account = payment_method.outstanding_account_id
+        outstanding_account = payment_method.outstanding_account_id or self.company_id.transfer_account_id
         accounting_partner = self.env["res.partner"]._find_accounting_partner(payment.partner_id)
         destination_account = accounting_partner.property_account_receivable_id
 


### PR DESCRIPTION
When using a bank payment method that needs to identify the customer, if you made a pos order with negative amount, the session would get stuck when trying to close it.

Steps to reproduce:
-------------------
* Create a bank payment method and check the option "Identify Customer"
* Open a POS session
* Make a pos order with a negative amount
* Pay the order with the bank payment method
* Close the session
> Observation: There is an error and you cannot close the session.

Why the fix:
------------
If the payment method has no oustanding account set, it will violate an sql constraint when trying to close the session.
sql constraint: account_move_line_check_accountable_required_fields

opw-4939806