### PR TITLE
[FIX] html_editor: add step when closing link tool after changes

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -576,11 +576,6 @@ export class LinkPlugin extends Plugin {
                 this.linkInDocument = null;
                 this.currentOverlay.close();
             },
-            onClose: () => {
-                this.linkInDocument = null;
-                this.currentOverlay.close();
-                this.dependencies.selection.focusEditable();
-            },
             onEdit: () => {
                 this.restoreSavePoint = this.dependencies.history.makeSavePoint();
             },

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -19,7 +19,6 @@ export class LinkPopover extends Component {
         onDiscard: Function,
         onRemove: Function,
         onCopy: Function,
-        onClose: Function,
         onEdit: Function,
         getInternalMetaData: Function,
         getExternalMetaData: Function,
@@ -265,7 +264,7 @@ export class LinkPopover extends Component {
         if (ev.key === "Escape") {
             ev.preventDefault();
             ev.stopImmediatePropagation();
-            this.props.onClose();
+            this.onClickApply();
         }
     }
 


### PR DESCRIPTION
Closing the link tools with escape did not add a step in th history, and did not clean the change in the document.

To be consistent with the click outside of th popover, pressing escape commit the changes to history.

Steps to reproduce:
- Select text
- Click on "Add a link"
- Type `#` (it create a link in the document)
- Press escape to close the suggested links
- Press escape to close the link tools
- Bug: The link is still there, but no steps were added in the history:
  - undo or redo immediately: the modifications to the link are lost
  - edit then undo: the modifications to the link are undone as well

task-4954131
