### PR TITLE
[FIX] hr_org_chart: fix error when clicking Indirect Subordinates

### DIFF
--- a/addons/hr_org_chart/__manifest__.py
+++ b/addons/hr_org_chart/__manifest__.py
@@ -30,6 +30,9 @@ This module extend the employee form with a organizational chart.
         'web.assets_backend_lazy': [
             'hr_org_chart/static/src/views/**/*',
         ],
+        'web.assets_tests': [
+            'hr_org_chart/static/tests/tours/*.js',
+        ],
         'web.assets_unit_tests': [
             'hr_org_chart/static/tests/**/*',
         ],

--- a/addons/hr_org_chart/controllers/hr_org_chart.py
+++ b/addons/hr_org_chart/controllers/hr_org_chart.py
@@ -86,7 +86,7 @@ class HrOrgChartController(http.Controller):
         if subordinates_type == 'direct':
             res = (employee.child_ids - employee).ids
         elif subordinates_type == 'indirect':
-            res = (employee.subordinate_ids - employee.child_ids).ids
+            res = (employee.subordinate_ids - employee.child_ids.employee_id).ids
         else:
             res = employee.subordinate_ids.ids
 

--- a/addons/hr_org_chart/static/tests/tours/hr_employee_test.js
+++ b/addons/hr_org_chart/static/tests/tours/hr_employee_test.js
@@ -1,0 +1,16 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("indirect_subordinates_tour", {
+    steps: () => [
+        {
+            content: "Click the number next to employee georges",
+            trigger: "div[name='child_ids'] .o_org_chart_entry button > a:contains('2')",
+            run: "click",
+        },
+        {
+            content: "Click Indirect Subordinates",
+            trigger: ".o_org_chart_popup a.o_employee_sub_redirect[data-type='indirect']",
+            run: "click",
+        },
+    ],
+});

--- a/addons/hr_org_chart/tests/__init__.py
+++ b/addons/hr_org_chart/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_employee
 from . import test_employee_deletion
+from . import test_employee_ui

--- a/addons/hr_org_chart/tests/test_employee_ui.py
+++ b/addons/hr_org_chart/tests/test_employee_ui.py
@@ -1,0 +1,26 @@
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.hr.tests.common import TestHrCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestEmployeeUi(TestHrCommon, HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.employee_georges, cls.employee_paul, cls.employee_pierre = cls.env['hr.employee'].with_user(cls.res_users_hr_officer).create([
+            {'name': 'Georges'},
+            {'name': 'Paul'},
+            {'name': 'Pierre'},
+        ])
+
+    def test_indirect_subordinates(self):
+        self.res_users_hr_officer.employee_id = self.employee_georges
+        self.employee_paul.parent_id = self.employee_georges
+        self.employee_pierre.parent_id = self.employee_paul
+
+        self.start_tour(f"/odoo/employees/{self.employee_georges.id}", 'indirect_subordinates_tour', login="admin")
+        indirect_subordinates = len(self.employee_georges.subordinate_ids - self.employee_georges.child_ids)
+        self.assertEqual(indirect_subordinates, 1,
+            "Georges should have 1 indirect subordinates: Pierre."
+        )


### PR DESCRIPTION
A traceback occurs when clicking Indirect Subordinates in the Organization Chart of an employee.

Steps to reproduce the error:
- Install ``hr`` module with demo data
- Go to Employees > Open ``Mitchell Admin``
- In the Organization Chart, click the number next to Mitchell Admin.
- Then click Indirect Subordinates.

Traceback:
```
TypeError: inconsistent models in: hr.employee(1, 6, 5) - hr.employee.public(5,)
```

In this [commit], ``subordinate_ids`` field was changed to be related to ``employee_id.subordinate_ids``.

https://github.com/odoo/odoo/blob/cc65ae3854f845e5cc87cb808c4707279bf28be0/addons/hr_org_chart/controllers/hr_org_chart.py#L89
So, ``subordinate_ids`` now returns records of the ``hr.employee`` model.
``child_ids`` is the records of ``hr.employee.public`` model.
So, This leads to a traceback at the above line,
where it expects consistent models.

[commit]: https://github.com/odoo/odoo/commit/21f18b1a6fdbf1a01c3dda83acfa66addd01a759

sentry-6752005852

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
