### PR TITLE
[IMP] sale: add group by UTM source to Invoice Analysis report

### DIFF
--- a/addons/sale/report/account_invoice_report.py
+++ b/addons/sale/report/account_invoice_report.py
@@ -8,6 +8,11 @@ class AccountInvoiceReport(models.Model):
     _inherit = 'account.invoice.report'
 
     team_id = fields.Many2one(comodel_name='crm.team', string="Sales Team")
+    source_id = fields.Many2one(comodel_name='utm.source', string="Source", readonly=True)
+
+    _depends = {
+        'account.move': ['source_id', 'team_id'],
+    }
 
     def _select(self) -> SQL:
-        return SQL("%s, move.team_id as team_id", super()._select())
+        return SQL("%s, move.source_id, move.team_id as team_id", super()._select())

--- a/addons/sale/report/account_invoice_report_views.xml
+++ b/addons/sale/report/account_invoice_report_views.xml
@@ -12,6 +12,9 @@
             <field name="invoice_user_id" position="after">
                 <field name="team_id"/>
             </field>
+            <filter name="status" position="after">
+                <filter string="Source" name="source_id" context="{'group_by': 'source_id'}"/>
+            </filter>
         </field>
     </record>
 


### PR DESCRIPTION
This commit:
- Adds the `source_id` field (UTM Source) to the `account.invoice.report` model for marketing campaign tracking.
- Adds a group by option for UTM Source in the Invoice Analysis report, allowing users to analyze invoice statistics by marketing    campaign source.

Task : 4950023

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
