### PR TITLE
[FIX] pos_event_sale: match registration state between PoS and website

### DIFF
--- a/addons/pos_event_sale/models/event_registration.py
+++ b/addons/pos_event_sale/models/event_registration.py
@@ -11,7 +11,7 @@ class EventRegistration(models.Model):
         for record in self.filtered("pos_order_id.id"):
             if record.pos_order_id.state in ['paid', 'done', 'invoiced']:
                 record.sale_status = 'sold'
-                record.state = 'done'
+                record.state = 'open'
             else:
                 record.sale_status = 'to_pay'
                 record.state = 'draft'


### PR DESCRIPTION
Before this commit, if we buy an event registration from PoS and pay for it, its state will be 'done', i.e. "Attended" [1]. While if we buy the registration from the website and pay for it, its state is 'open', i.e. "Registered" [2].

We want the state of the registration to be 'open' when we buy it.

After this commit, we set the state of events bought from PoS to 'open' as well, matching the case where we buy them from the website.

[1]: https://github.com/odoo/odoo/blob/c3ae4b29c51c7b0cff11aac5f4bf4aab5fad16c9/addons/pos_event_sale/models/event_registration.py#L14
[2]: https://github.com/odoo/odoo/blob/c3ae4b29c51c7b0cff11aac5f4bf4aab5fad16c9/addons/event_sale/models/event_registration.py#L40

opw-4920574