### PR TITLE
[ADD] tools: urls.py

### DIFF
--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -5,10 +5,10 @@ import re
 import requests
 from lxml import etree
 from stdnum import get_cc_module, ean
-from urllib.parse import urljoin
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools.urls import urljoin
 from odoo.addons.account.models.company import PEPPOL_LIST
 
 try:

--- a/addons/auth_signup/models/res_partner.py
+++ b/addons/auth_signup/models/res_partner.py
@@ -81,7 +81,7 @@ class ResPartner(models.Model):
 
             signup_url = "/web/%s?%s" % (route, werkzeug.urls.url_encode(query))
             if not self.env.context.get('relative_url'):
-                signup_url = werkzeug.urls.url_join(base_url, signup_url)
+                signup_url = tools.urls.urljoin(base_url, signup_url)
             res[partner.id] = signup_url
         return res
 

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -6,13 +6,14 @@ import pytz
 from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
-from werkzeug.urls import url_encode, url_join
+from werkzeug.urls import url_encode
 
 from odoo import api, fields, models, tools, _
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 from odoo.exceptions import AccessError
 from odoo.fields import Domain
 from odoo.tools.float_utils import float_round
+from odoo.tools.urls import urljoin as url_join
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/digest/tests/test_digest.py
+++ b/addons/digest/tests/test_digest.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from lxml import html
 from unittest.mock import patch
-from werkzeug.urls import url_encode, url_join
+from werkzeug.urls import url_encode
 
 from odoo import SUPERUSER_ID
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
@@ -16,7 +16,7 @@ from odoo.addons.digest.tests.common import TestDigestCommon
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests import tagged
 from odoo.tests.common import users
-from odoo.tools import mute_logger
+from odoo.tools import mute_logger, urls
 
 
 class TestDigest(TestDigestCommon):
@@ -386,5 +386,5 @@ class TestUnsubscribe(MailCommon, HttpCaseWithUserDemo):
         else:
             unsubscribe_route = "unsubscribe"
 
-        url = url_join(self.base_url, f'digest/{self.test_digest.id}/{unsubscribe_route}?{url_encode(url_params)}')
+        url = urls.urljoin(self.base_url, f'digest/{self.test_digest.id}/{unsubscribe_route}?{url_encode(url_params)}')
         return self.url_open(url, timeout=10, allow_redirects=True, method=method)

--- a/addons/google_gmail/models/google_gmail_mixin.py
+++ b/addons/google_gmail/models/google_gmail_mixin.py
@@ -6,10 +6,11 @@ import logging
 import time
 import requests
 
-from werkzeug.urls import url_encode, url_join
+from werkzeug.urls import url_encode
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import AccessError, UserError
+from odoo.tools.urls import urljoin as url_join
 
 GMAIL_TOKEN_REQUEST_TIMEOUT = 5
 

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -1,10 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import uuid
+
 from odoo import fields, models, api
 from odoo.fields import Domain
-
-import uuid
-from werkzeug.urls import url_join
+from odoo.tools.urls import urljoin as url_join
 
 
 class ResCompany(models.Model):

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -155,7 +155,7 @@ class IrHttp(models.AbstractModel):
 
         if canonical_domain:
             # canonical URLs should not have qs
-            return werkzeug.urls.url_join(canonical_domain, path)
+            return tools.urls.urljoin(canonical_domain, path)
 
         return path + sep + qs
 

--- a/addons/http_routing/tests/common.py
+++ b/addons/http_routing/tests/common.py
@@ -1,13 +1,13 @@
 import contextlib
 from unittest.mock import MagicMock, Mock, patch
 
-import werkzeug.urls
 from werkzeug.exceptions import NotFound
 from werkzeug.test import EnvironBuilder
 
 import odoo.http
 from odoo.tests import HOST, HttpCase
 from odoo.tools import DotDict, config, frozendict
+from odoo.tools.urls import urljoin as url_join
 
 
 @contextlib.contextmanager
@@ -68,7 +68,7 @@ def MockRequest(
         render=lambda *a, **kw: '<MockResponse>',
     )
     if url_root is not None:
-        request.httprequest.url = werkzeug.urls.url_join(url_root, path)
+        request.httprequest.url = url_join(url_root, path)
     if website:
         request.website_routing = website.id
     if country_code or city_name:

--- a/addons/iap/models/iap_account.py
+++ b/addons/iap/models/iap_account.py
@@ -10,6 +10,7 @@ from odoo.addons.iap.tools import iap_tools
 from odoo.exceptions import AccessError, UserError
 from odoo.modules import module
 from odoo.tools import get_lang
+from odoo.tools.urls import urljoin as url_join
 
 _logger = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ class IapAccount(models.Model):
         ):
             route = '/iap/1/update-warning-email-alerts'
             endpoint = iap_tools.iap_get_endpoint(self.env)
-            url = werkzeug.urls.url_join(endpoint, route)
+            url = url_join(endpoint, route)
             for account in self:
                 data = {
                     'account_token': account.account_token,
@@ -87,7 +88,7 @@ class IapAccount(models.Model):
             return
         route = '/iap/1/get-accounts-information'
         endpoint = iap_tools.iap_get_endpoint(self.env)
-        url = werkzeug.urls.url_join(endpoint, route)
+        url = url_join(endpoint, route)
         params = {
             'iap_accounts': [{
                 'token': account.account_token,
@@ -198,7 +199,7 @@ class IapAccount(models.Model):
         if not base_url:
             endpoint = iap_tools.iap_get_endpoint(self.env)
             route = '/iap/1/credit'
-            base_url = werkzeug.urls.url_join(endpoint, route)
+            base_url = url_join(endpoint, route)
         if not account_token:
             account_token = self.get(service_name).account_token
         d = {
@@ -241,7 +242,7 @@ class IapAccount(models.Model):
         if account:
             route = '/iap/1/balance'
             endpoint = iap_tools.iap_get_endpoint(self.env)
-            url = werkzeug.urls.url_join(endpoint, route)
+            url = url_join(endpoint, route)
             params = {
                 'dbuuid': self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
                 'account_token': account.account_token,

--- a/addons/l10n_id/models/res_bank.py
+++ b/addons/l10n_id/models/res_bank.py
@@ -2,10 +2,10 @@
 import datetime
 import requests
 import pytz
-from urllib.parse import urljoin
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools.urls import urljoin
 
 QRIS_TIMEOUT = 35  # They say that the time to get a response vary between 6 to 30s
 

--- a/addons/l10n_my_edi/models/account_edi_proxy_user.py
+++ b/addons/l10n_my_edi/models/account_edi_proxy_user.py
@@ -2,11 +2,11 @@
 
 import logging
 
-from werkzeug.urls import url_join
 
 from odoo import _, fields, models
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 from odoo.exceptions import UserError
+from odoo.tools.urls import urljoin as url_join
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/l10n_ro_edi/controllers/main.py
+++ b/addons/l10n_ro_edi/controllers/main.py
@@ -1,11 +1,12 @@
 import binascii
 import requests
 
-from werkzeug.urls import url_encode, url_join
+from werkzeug.urls import url_encode
 
 from odoo import _, http
 from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
+from odoo.tools.urls import urljoin as url_join
 
 
 URL_ANAF_AUTHORIZE = 'https://logincert.anaf.ro/anaf-oauth2/v1/authorize'

--- a/addons/l10n_ro_edi/models/res_company.py
+++ b/addons/l10n_ro_edi/models/res_company.py
@@ -4,11 +4,11 @@ import requests
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-from werkzeug.urls import url_join
 
 from odoo import fields, models, api, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.http import request
+from odoo.tools.urls import urljoin as url_join
 from odoo.tools.safe_eval import json
 
 

--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -1,7 +1,6 @@
 import json
 from base64 import b64decode, b64encode
 from datetime import datetime
-from urllib.parse import urljoin
 
 import requests
 from lxml import etree
@@ -11,6 +10,7 @@ from requests.exceptions import HTTPError, RequestException
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 from odoo.tools.misc import file_open
+from odoo.tools.urls import urljoin
 
 ZATCA_API_URLS = {
     "sandbox": "https://gw-fatoora.zatca.gov.sa/e-invoicing/developer-portal/",

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -58,7 +58,7 @@ class LinkTracker(models.Model):
             if url.scheme:
                 tracker.absolute_url = tracker.url
             else:
-                tracker.absolute_url = urls.url_join(tracker.get_base_url(), url)
+                tracker.absolute_url = tools.urls.urljoin(tracker.get_base_url(), url.to_url())
 
     @api.depends('link_click_ids.link_id')
     def _compute_count(self):
@@ -74,7 +74,7 @@ class LinkTracker(models.Model):
     @api.depends('code')
     def _compute_short_url(self):
         for tracker in self:
-            tracker.short_url = urls.url_join(tracker.short_url_host or '', tracker.code or '')
+            tracker.short_url = tools.urls.urljoin(tracker.short_url_host or '', tracker.code or '')
 
     def _compute_short_url_host(self):
         for tracker in self:

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -10,11 +10,11 @@ import traceback
 from lxml import html
 from functools import reduce
 from markupsafe import Markup, escape
-from werkzeug import urls
 
 from odoo import _, api, fields, models, tools
 from odoo.addons.base.models.ir_qweb import QWebException
 from odoo.exceptions import UserError, AccessError
+from odoo.tools import urls
 from odoo.tools.mail import is_html_empty, prepend_html_content, html_normalize
 from odoo.tools.rendering_tools import convert_inline_template_to_qweb, parse_inline_template, render_inline_template, template_env_globals
 
@@ -144,7 +144,7 @@ class MailRenderMixin(models.AbstractModel):
             # if not base_url
             if not _sub_relative2absolute.base_url:
                 _sub_relative2absolute.base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
-            return match.group(1) + urls.url_join(_sub_relative2absolute.base_url, match.group(2))
+            return match.group(1) + urls.urljoin(_sub_relative2absolute.base_url, match.group(2))
 
         _sub_relative2absolute.base_url = base_url
         html = re.sub(r"""(<(?:img|v:fill|v:image)(?=\s)[^>]*\ssrc=")(/[^/][^"]+)""", _sub_relative2absolute, html)

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -673,7 +673,7 @@ class MailGroup(models.Model):
             })
         )
         base_url = self.get_base_url()
-        confirm_action_url = urls.url_join(base_url, confirm_action_url)
+        confirm_action_url = tools.urls.urljoin(base_url, confirm_action_url)
         return confirm_action_url
 
     def _generate_action_token(self, email, action):
@@ -707,9 +707,9 @@ class MailGroup(models.Model):
             'email': email_to,
             'token': self._generate_email_access_token(email_to),
         })
-        return urls.url_join(
+        return tools.urls.urljoin(
             self.get_base_url(),
-            f'group/{self.id}/unsubscribe_oneclick?{params}'
+            f'group/{self.id}/unsubscribe_oneclick?{params}',
         )
 
     def _find_member(self, email, partner_id=None):

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -3,7 +3,6 @@
 
 import base64
 import urllib.parse
-import werkzeug
 
 from datetime import timedelta
 from markupsafe import Markup, escape
@@ -471,7 +470,7 @@ class MassMailController(http.Controller):
         else:  # when manually trying a /view on a mailing, not through email link
             html_markupsafe = html_markupsafe.replace(
                 '/unsubscribe_from_list',
-                werkzeug.urls.url_join(
+                tools.urls.urljoin(
                     mailing_sudo.get_base_url(),
                     f'/mailing/{mailing_sudo.id}/unsubscribe',
                 )

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -16,7 +16,7 @@ class MailMail(models.Model):
 
     def _get_tracking_url(self):
         token = self._generate_mail_recipient_token(self.id)
-        return werkzeug.urls.url_join(
+        return tools.urls.urljoin(
             self.get_base_url(),
             f'mail/track/{self.id}/{token}/blank.gif'
         )

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -14,7 +14,6 @@ import werkzeug.urls
 from ast import literal_eval
 from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
-from werkzeug.urls import url_join
 from PIL import Image, UnidentifiedImageError
 
 from odoo import api, fields, models, modules, tools, _
@@ -1034,7 +1033,7 @@ class MailingMailing(models.Model):
         return [rid for rid in res_ids if rid not in done_res_ids]
 
     def _get_unsubscribe_oneclick_url(self, email_to, res_id):
-        url = werkzeug.urls.url_join(
+        url = tools.urls.urljoin(
             self.get_base_url(), 'mailing/%(mailing_id)s/unsubscribe_oneclick?%(params)s' % {
                 'mailing_id': self.id,
                 'params': werkzeug.urls.url_encode({
@@ -1042,12 +1041,12 @@ class MailingMailing(models.Model):
                     'email': email_to,
                     'hash_token': self._generate_mailing_recipient_token(res_id, email_to),
                 }),
-            }
+            },
         )
         return url
 
     def _get_unsubscribe_url(self, email_to, res_id):
-        url = werkzeug.urls.url_join(
+        url = tools.urls.urljoin(
             self.get_base_url(), 'mailing/%(mailing_id)s/confirm_unsubscribe?%(params)s' % {
                 'mailing_id': self.id,
                 'params': werkzeug.urls.url_encode({
@@ -1055,12 +1054,12 @@ class MailingMailing(models.Model):
                     'email': email_to,
                     'hash_token': self._generate_mailing_recipient_token(res_id, email_to),
                 }),
-            }
+            },
         )
         return url
 
     def _get_view_url(self, email_to, res_id):
-        url = werkzeug.urls.url_join(
+        url = tools.urls.urljoin(
             self.get_base_url(), 'mailing/%(mailing_id)s/view?%(params)s' % {
                 'mailing_id': self.id,
                 'params': werkzeug.urls.url_encode({
@@ -1068,7 +1067,7 @@ class MailingMailing(models.Model):
                     'email': email_to,
                     'hash_token': self._generate_mailing_recipient_token(res_id, email_to),
                 }),
-            }
+            },
         )
         return url
 
@@ -1295,7 +1294,7 @@ class MailingMailing(models.Model):
                        mailing_name=self.subject
                        ),
             'top_button_label': _('More Info'),
-            'top_button_url': url_join(web_base_url, f'/odoo/mailing.mailing/{self.id}'),
+            'top_button_url': tools.urls.urljoin(web_base_url, f'/odoo/mailing.mailing/{self.id}'),
             'kpi_data': [
                 kpi,
                 {

--- a/addons/mass_mailing/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing/tests/test_mailing_controllers.py
@@ -6,7 +6,6 @@ from markupsafe import Markup
 from requests import Session, PreparedRequest, Response
 
 import datetime
-import werkzeug
 
 from odoo import tools
 from odoo.addons.mail.tests.common import mail_new_test_user
@@ -140,7 +139,7 @@ class TestMailingControllers(TestMailingControllersCommon):
         ]:
             with self.subTest(test_user_id=test_user_id, test_token=test_token):
                 res = self.url_open(
-                    werkzeug.urls.url_join(
+                    tools.urls.urljoin(
                         test_mailing.get_base_url(),
                         f'mailing/report/unsubscribe?user_id={test_user_id}&token={test_token}',
                     )
@@ -153,7 +152,7 @@ class TestMailingControllers(TestMailingControllersCommon):
             'group_ids': [(3, self.env.ref('mass_mailing.group_mass_mailing_user').id)],
         })
         res = self.url_open(
-            werkzeug.urls.url_join(
+            tools.urls.urljoin(
                 test_mailing.get_base_url(),
                 f'mailing/report/unsubscribe?user_id={self.user_marketing.id}&token={hash_token}',
             )
@@ -166,7 +165,7 @@ class TestMailingControllers(TestMailingControllersCommon):
             'group_ids': [(4, self.env.ref('mass_mailing.group_mass_mailing_user').id)],
         })
         res = self.url_open(
-            werkzeug.urls.url_join(
+            tools.urls.urljoin(
                 test_mailing.get_base_url(),
                 f'mailing/report/unsubscribe?user_id={self.user_marketing.id}&token={hash_token}',
             )
@@ -277,7 +276,7 @@ class TestMailingControllers(TestMailingControllersCommon):
 
         # no group -> no direct access to /unsubscribe
         res = self.url_open(
-            werkzeug.urls.url_join(
+            tools.urls.urljoin(
                 test_mailing.get_base_url(),
                 f'mailing/{test_mailing.id}/unsubscribe',
             )
@@ -600,7 +599,7 @@ class TestMailingControllers(TestMailingControllersCommon):
         ]:
             with self.subTest(test_mid=test_mid, test_email=test_email, test_doc_id=test_doc_id, test_token=test_token):
                 res = self.url_open(
-                    werkzeug.urls.url_join(
+                    tools.urls.urljoin(
                         test_mailing.get_base_url(),
                         f'mailing/{test_mid}/view?email={test_email}&document_id={test_doc_id}&hash_token={test_token}',
                     )
@@ -609,7 +608,7 @@ class TestMailingControllers(TestMailingControllersCommon):
 
         # TEST: valid call using credentials
         res = self.url_open(
-            werkzeug.urls.url_join(
+            tools.urls.urljoin(
                 test_mailing.get_base_url(),
                 f'mailing/{test_mailing.id}/view?email={email_normalized}&document_id={doc_id}&hash_token={hash_token}',
             )
@@ -621,7 +620,7 @@ class TestMailingControllers(TestMailingControllersCommon):
             'group_ids': [(4, self.env.ref('mass_mailing.group_mass_mailing_user').id)],
         })
         res = self.url_open(
-            werkzeug.urls.url_join(
+            tools.urls.urljoin(
                 test_mailing.get_base_url(),
                 f'mailing/{test_mailing.id}/view',
             )
@@ -653,7 +652,7 @@ class TestMailingTracking(TestMailingControllersCommon):
         self.assertFalse(mailing_trace.open_datetime)
         self.assertEqual(mailing_trace.trace_status, 'sent')
 
-        short_link_url = werkzeug.urls.url_join(
+        short_link_url = tools.urls.urljoin(
             mail.get_base_url(),
             f'r/{link_tracker_code.code}/m/{mailing_trace.id}'
         )
@@ -691,7 +690,7 @@ class TestMailingTracking(TestMailingControllersCommon):
         self.assertEqual(mailing_trace.open_datetime, self._reference_now)
         self.assertEqual(mailing_trace.trace_status, 'open')
 
-        track_url = werkzeug.urls.url_join(
+        track_url = tools.urls.urljoin(
             mailing.get_base_url(),
             f'mail/track/{mail_id_int}/fake_token/blank.gif'
         )

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -3,12 +3,12 @@
 
 import logging
 
-from urllib.parse import urljoin
-
 from odoo import api, fields, models, _
-from odoo.addons.link_tracker.models.link_tracker import LINK_TRACKER_MIN_CODE_LENGTH
 from odoo.exceptions import UserError
 from odoo.fields import Domain
+from odoo.tools.urls import urljoin
+
+from odoo.addons.link_tracker.models.link_tracker import LINK_TRACKER_MIN_CODE_LENGTH
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/mass_mailing_sms/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_controllers.py
@@ -1,8 +1,7 @@
-import werkzeug.urls
-
 from odoo.tests.common import users
-from odoo.addons.mass_mailing_sms.tests.common import MassSMSCommon
 from odoo.tests import tagged
+from odoo.tools.urls import urljoin as url_join
+from odoo.addons.mass_mailing_sms.tests.common import MassSMSCommon
 
 
 @tagged('mailing_portal', 'post_install', '-at_install')
@@ -32,7 +31,7 @@ class TestMailingListSms(MassSMSCommon):
         self.assertTrue(trace, 'Trace not found for the partner')
         self.assertEqual(trace.sms_number, '+911234657890')
 
-        unsubscribe_url = werkzeug.urls.url_join(mailing.get_base_url(), f'/sms/{mailing.id}/unsubscribe/{trace.sms_code}')
+        unsubscribe_url = url_join(mailing.get_base_url(), f'/sms/{mailing.id}/unsubscribe/{trace.sms_code}')
         response = self.url_open(url=unsubscribe_url, data={'sms_number': trace.sms_number}, method='GET')
 
         self.assertEqual(response.status_code, 200)

--- a/addons/mass_mailing_sms/wizard/mailing_sms_test.py
+++ b/addons/mass_mailing_sms/wizard/mailing_sms_test.py
@@ -3,9 +3,10 @@
 
 from markupsafe import Markup
 from uuid import uuid4
-from werkzeug.urls import url_join
 
 from odoo import fields, models, _
+from odoo.tools.urls import urljoin as url_join
+
 from odoo.addons.sms.tools.sms_api import SmsApi
 
 

--- a/addons/mass_mailing_sms/wizard/sms_composer.py
+++ b/addons/mass_mailing_sms/wizard/sms_composer.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug.urls
-
-from odoo import _, api, Command, fields, models
+from odoo import _, api, Command, fields, models, tools
 
 
 class SmsComposer(models.TransientModel):
@@ -19,7 +17,7 @@ class SmsComposer(models.TransientModel):
     # ------------------------------------------------------------
 
     def _get_unsubscribe_url(self, mailing_id, trace_code):
-        return werkzeug.urls.url_join(
+        return tools.urls.urljoin(
             self.get_base_url(),
             '/sms/%s/%s' % (mailing_id, trace_code)
         )

--- a/addons/microsoft_outlook/models/microsoft_outlook_mixin.py
+++ b/addons/microsoft_outlook/models/microsoft_outlook_mixin.py
@@ -6,11 +6,12 @@ import logging
 import time
 import requests
 
-from werkzeug.urls import url_encode, url_join
+from werkzeug.urls import url_encode
 
 from odoo import _, api, fields, models
 from odoo.exceptions import AccessError, UserError
-from odoo.tools.misc import hmac
+from odoo.tools import hmac
+from odoo.tools.urls import urljoin as url_join
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/payment/tests/http_common.py
+++ b/addons/payment/tests/http_common.py
@@ -3,9 +3,9 @@
 from contextlib import contextmanager
 
 from lxml import etree, objectify
-from werkzeug import urls
 
 from odoo.tests import HttpCase, JsonRpcException
+from odoo.tools import urls
 
 from odoo.addons.payment.tests.common import PaymentCommon
 
@@ -21,7 +21,7 @@ class PaymentHttpCommon(PaymentCommon, HttpCase):
     ###########
 
     def _build_url(self, route):
-        return urls.url_join(self.base_url(), route)
+        return urls.urljoin(self.base_url(), route)
 
     def _make_http_get_request(self, url, params=None):
         """ Make an HTTP GET request to the provided URL.

--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -6,13 +6,12 @@ import hashlib
 import hmac
 import pprint
 
-from werkzeug import urls
 from werkzeug.exceptions import Forbidden
 
 from odoo import _, http
 from odoo.exceptions import ValidationError
 from odoo.http import request
-from odoo.tools import py_to_js_locale
+from odoo.tools import py_to_js_locale, urls
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
@@ -112,12 +111,12 @@ class AdyenController(http.Controller):
             'channel': 'web',  # Required to support 3DS
             'origin': provider_sudo.get_base_url(),  # Required to support 3DS
             'browserInfo': browser_info,  # Required to support 3DS
-            'returnUrl': urls.url_join(
+            'returnUrl': urls.urljoin(
                 provider_sudo.get_base_url(),
                 # Include the reference in the return url to be able to match it after redirection.
                 # The key 'merchantReference' is chosen on purpose to be the same as that returned
                 # by the /payments endpoint of Adyen.
-                f'/payment/adyen/return?merchantReference={reference}'
+                f'/payment/adyen/return?merchantReference={reference}',
             ),
             **adyen_utils.include_partner_addresses(tx_sudo),
         }

--- a/addons/payment_aps/models/payment_transaction.py
+++ b/addons/payment_aps/models/payment_transaction.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import _, api, models
+from odoo.tools import urls
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
@@ -62,7 +61,7 @@ class PaymentTransaction(models.Model):
             'currency': self.currency_id.name,
             'language': self.partner_lang[:2],
             'customer_email': self.partner_id.email_normalized,
-            'return_url': urls.url_join(base_url, APSController._return_url),
+            'return_url': urls.urljoin(base_url, APSController._return_url),
         }
         if payment_option:  # Not included if the payment method is 'card'.
             rendering_values['payment_option'] = payment_option

--- a/addons/payment_asiapay/models/payment_transaction.py
+++ b/addons/payment_asiapay/models/payment_transaction.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
+from odoo.tools import urls
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
@@ -88,7 +87,7 @@ class PaymentTransaction(models.Model):
             'reference': self.reference,
             'currency_code': const.CURRENCY_MAPPING[self.provider_id.available_currency_ids[0].name],
             'mps_mode': 'SCP',
-            'return_url': urls.url_join(base_url, AsiaPayController._return_url),
+            'return_url': urls.urljoin(base_url, AsiaPayController._return_url),
             'payment_type': 'N',
             'language': get_language_code(lang),
             'payment_method': const.PAYMENT_METHODS_MAPPING.get(self.payment_method_id.code, 'ALL'),

--- a/addons/payment_buckaroo/models/payment_transaction.py
+++ b/addons/payment_buckaroo/models/payment_transaction.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import _, api, models
+from odoo.tools import urls
 
 from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_buckaroo import const
@@ -27,7 +26,7 @@ class PaymentTransaction(models.Model):
         if self.provider_code != 'buckaroo':
             return super()._get_specific_rendering_values(processing_values)
 
-        return_url = urls.url_join(self.provider_id.get_base_url(), BuckarooController._return_url)
+        return_url = urls.urljoin(self.provider_id.get_base_url(), BuckarooController._return_url)
         rendering_values = {
             'api_url': self.provider_id._buckaroo_get_api_url(),
             'Brq_websitekey': self.provider_id.buckaroo_website_key,

--- a/addons/payment_dpo/models/payment_transaction.py
+++ b/addons/payment_dpo/models/payment_transaction.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
+from odoo.tools import urls
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
@@ -44,7 +43,7 @@ class PaymentTransaction(models.Model):
         """
         self.ensure_one()
 
-        return_url = urls.url_join(self.provider_id.get_base_url(), DPOController._return_url)
+        return_url = urls.urljoin(self.provider_id.get_base_url(), DPOController._return_url)
         first_name, last_name = payment_utils.split_partner_name(self.partner_name)
         create_date = self.create_date.strftime('%Y/%m/%d %H:%M')
         payload = (

--- a/addons/payment_flutterwave/models/payment_provider.py
+++ b/addons/payment_flutterwave/models/payment_provider.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug.urls import url_join
-
 from odoo import _, api, fields, models
+from odoo.tools.urls import urljoin as url_join
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.const import REPORT_REASONS_MAPPING

--- a/addons/payment_flutterwave/models/payment_transaction.py
+++ b/addons/payment_flutterwave/models/payment_transaction.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
+from odoo.tools import urls
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
@@ -52,7 +51,7 @@ class PaymentTransaction(models.Model):
             'tx_ref': self.reference,
             'amount': self.amount,
             'currency': self.currency_id.name,
-            'redirect_url': urls.url_join(base_url, FlutterwaveController._return_url),
+            'redirect_url': urls.urljoin(base_url, FlutterwaveController._return_url),
             'customer': {
                 'email': self.partner_email,
                 'name': self.partner_name,
@@ -60,7 +59,7 @@ class PaymentTransaction(models.Model):
             },
             'customizations': {
                 'title': self.company_id.name,
-                'logo': urls.url_join(base_url, f'web/image/res.company/{self.company_id.id}/logo'),
+                'logo': urls.urljoin(base_url, f'web/image/res.company/{self.company_id.id}/logo'),
             },
             'payment_options': const.PAYMENT_METHODS_MAPPING.get(
                 self.payment_method_code, self.payment_method_code
@@ -92,7 +91,7 @@ class PaymentTransaction(models.Model):
             'first_name': first_name,
             'last_name': last_name,
             'ip': payment_utils.get_customer_ip_address(),
-            'redirect_url': urls.url_join(base_url, FlutterwaveController._auth_return_url),
+            'redirect_url': urls.urljoin(base_url, FlutterwaveController._auth_return_url),
         }
 
         try:

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import fields, models
+from odoo.tools import urls
 
 from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_mercado_pago import const
@@ -49,7 +48,7 @@ class PaymentProvider(models.Model):
         """Override of `payment` to build the request URL."""
         if self.code != 'mercado_pago':
             return super()._build_request_url(endpoint, **kwargs)
-        return urls.url_join('https://api.mercadopago.com', endpoint)
+        return urls.urljoin('https://api.mercadopago.com', endpoint)
 
     def _build_request_headers(self, *args, **kwargs):
         """Override of `payment` to build the request headers."""

--- a/addons/payment_mercado_pago/models/payment_transaction.py
+++ b/addons/payment_mercado_pago/models/payment_transaction.py
@@ -2,11 +2,12 @@
 
 from urllib.parse import quote as url_quote
 
-from werkzeug import urls
+from werkzeug.urls import url_decode, url_parse
 
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
 from odoo.tools import float_round
+from odoo.tools.urls import urljoin
 
 from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_mercado_pago import const
@@ -44,8 +45,8 @@ class PaymentTransaction(models.Model):
         ]
 
         # Extract the payment link URL and params and embed them in the redirect form.
-        parsed_url = urls.url_parse(api_url)
-        url_params = urls.url_decode(parsed_url.query)
+        parsed_url = url_parse(api_url)
+        url_params = url_decode(parsed_url.query)
         rendering_values = {
             'api_url': api_url,
             'url_params': url_params,  # Encore the params as inputs to preserve them.
@@ -59,9 +60,9 @@ class PaymentTransaction(models.Model):
         :rtype: dict
         """
         base_url = self.provider_id.get_base_url()
-        return_url = urls.url_join(base_url, MercadoPagoController._return_url)
+        return_url = urljoin(base_url, MercadoPagoController._return_url)
         sanitized_reference = url_quote(self.reference)
-        webhook_url = urls.url_join(
+        webhook_url = urljoin(
             base_url, f'{MercadoPagoController._webhook_url}/{sanitized_reference}'
         )  # Append the reference to identify the transaction from the webhook payment data.
 

--- a/addons/payment_mollie/models/payment_provider.py
+++ b/addons/payment_mollie/models/payment_provider.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import _, fields, models, service
+from odoo.tools import urls
 
 from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_mollie import const
@@ -50,7 +49,7 @@ class PaymentProvider(models.Model):
         """Override of `payment` to build the request URL."""
         if self.code != 'mollie':
             return super()._build_request_url(endpoint, **kwargs)
-        return urls.url_join('https://api.mollie.com/v2/', endpoint.strip('/'))
+        return urls.urljoin('https://api.mollie.com/v2/', endpoint.strip('/'))
 
     def _build_request_headers(self, *args, **kwargs):
         """Override of `payment` to build the request headers."""

--- a/addons/payment_mollie/models/payment_transaction.py
+++ b/addons/payment_mollie/models/payment_transaction.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
+from odoo.tools import urls
 
 from odoo.addons.payment.const import CURRENCY_MINOR_UNITS
 from odoo.addons.payment.logging import get_payment_logger
@@ -56,8 +55,8 @@ class PaymentTransaction(models.Model):
         """
         user_lang = self.env.context.get('lang')
         base_url = self.provider_id.get_base_url()
-        redirect_url = urls.url_join(base_url, MollieController._return_url)
-        webhook_url = urls.url_join(base_url, MollieController._webhook_url)
+        redirect_url = urls.urljoin(base_url, MollieController._return_url)
+        webhook_url = urls.urljoin(base_url, MollieController._webhook_url)
         decimal_places = CURRENCY_MINOR_UNITS.get(
             self.currency_id.name, self.currency_id.decimal_places
         )

--- a/addons/payment_paymob/models/payment_transaction.py
+++ b/addons/payment_paymob/models/payment_transaction.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
+from odoo.tools import urls
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
@@ -89,8 +88,8 @@ class PaymentTransaction(models.Model):
         ]
 
         base_url = self.get_base_url()
-        redirect_url = urls.url_join(base_url, PaymobController._return_url)
-        webhook_url = urls.url_join(base_url, PaymobController._webhook_url)
+        redirect_url = urls.urljoin(base_url, PaymobController._return_url)
+        webhook_url = urls.urljoin(base_url, PaymobController._webhook_url)
 
         return {
             'special_reference': self.reference,

--- a/addons/payment_paypal/models/payment_provider.py
+++ b/addons/payment_paypal/models/payment_provider.py
@@ -3,10 +3,9 @@
 import json
 from datetime import timedelta
 
-from werkzeug import urls
-
 from odoo import _, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import urls
 
 from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_paypal import const
@@ -79,7 +78,7 @@ class PaymentProvider(models.Model):
                 "PayPal: " + _("You must have an HTTPS connection to generate a webhook.")
             )
         data = {
-            'url': urls.url_join(base_url, PaypalController._webhook_url),
+            'url': urls.urljoin(base_url, PaypalController._webhook_url),
             'event_types': [{'name': event_type} for event_type in const.HANDLED_WEBHOOK_EVENTS]
         }
         webhook_data = self._send_api_request('POST', '/v1/notifications/webhooks', json=data)

--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -5,10 +5,11 @@ import time
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
-from werkzeug.urls import url_encode, url_join
+from werkzeug.urls import url_encode
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools.urls import urljoin as url_join
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger

--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -2,10 +2,11 @@
 
 import json
 
-from werkzeug.urls import url_encode, url_join, url_parse
+from werkzeug.urls import url_encode, url_parse
 
 from odoo import _, api, fields, models
 from odoo.exceptions import RedirectWarning, UserError, ValidationError
+from odoo.tools.urls import urljoin as url_join
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -1,9 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug.urls import url_encode, url_join
+from werkzeug.urls import url_encode
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools.urls import urljoin as url_join
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -3,10 +3,11 @@
 import unittest
 from unittest.mock import patch
 
-from werkzeug.urls import url_encode, url_join
+from werkzeug.urls import url_encode
 
 from odoo.tests import tagged
 from odoo.tools import mute_logger
+from odoo.tools.urls import urljoin as url_join
 
 from odoo.addons.payment.tests.http_common import PaymentHttpCommon
 from odoo.addons.payment_stripe import const

--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
+from odoo.tools import urls
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
@@ -95,7 +94,7 @@ class PaymentTransaction(models.Model):
         base_url = self.provider_id.get_base_url()
         return_route = WorldlineController._return_url
         return_url_params = urls.url_encode({'provider_id': str(self.provider_id.id)})
-        return_url = f'{urls.url_join(base_url, return_route)}?{return_url_params}'
+        return_url = f'{urls.urljoin(base_url, return_route)}?{return_url_params}'
         first_name, last_name = payment_utils.split_partner_name(self.partner_name)
         payload = {
             'hostedCheckoutSpecificInput': {

--- a/addons/payment_xendit/models/payment_transaction.py
+++ b/addons/payment_xendit/models/payment_transaction.py
@@ -5,6 +5,7 @@ from werkzeug import urls
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
 from odoo.tools import float_round
+from odoo.tools.urls import urljoin
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.logging import get_payment_logger
@@ -68,7 +69,7 @@ class PaymentTransaction(models.Model):
         :rtype: dict
         """
         base_url = self.provider_id.get_base_url()
-        redirect_url = urls.url_join(base_url, XenditController._return_url)
+        redirect_url = urljoin(base_url, XenditController._return_url)
         access_token = payment_utils.generate_access_token(self.reference, self.amount)
         success_url_params = urls.url_encode({
             'tx_ref': self.reference,

--- a/addons/portal/tests/test_addresses.py
+++ b/addons/portal/tests/test_addresses.py
@@ -1,11 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo.http import Request
 from odoo.tests import HttpCase, tagged
 from odoo.tests.common import JsonRpcException
-from odoo.tools import mute_logger
+from odoo.tools import mute_logger, urls
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -30,8 +28,8 @@ class TestPortalAddresses(BaseCommon, HttpCase):
             'phone': '+323333333333333',
         }
         base_url = cls.base_url()
-        cls.submit_url = urls.url_join(base_url, '/my/address/submit')
-        cls.archive_url = urls.url_join(base_url, '/my/address/archive')
+        cls.submit_url = urls.urljoin(base_url, '/my/address/submit')
+        cls.archive_url = urls.urljoin(base_url, '/my/address/archive')
 
         # Company tree-like hierarchy
         #       Company

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -3,10 +3,9 @@
 import logging
 from uuid import uuid4
 
-from werkzeug.urls import url_join
-
 from odoo import api, fields, models, tools, _
 from odoo.addons.sms.tools.sms_api import SmsApi
+from odoo.tools.urls import urljoin as url_join
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -10,6 +10,7 @@ from odoo import api, exceptions, fields, models, _
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.tools import is_html_empty
+from odoo.tools.urls import urljoin as url_join
 
 
 class SurveySurvey(models.Model):
@@ -333,11 +334,11 @@ class SurveySurvey(models.Model):
     def _compute_session_link(self):
         for survey in self:
             if survey.session_code:
-                survey.session_link = werkzeug.urls.url_join(
+                survey.session_link = url_join(
                     survey.get_base_url(),
                     '/s/%s' % survey.session_code)
             else:
-                survey.session_link = werkzeug.urls.url_join(
+                survey.session_link = url_join(
                     survey.get_base_url(),
                     survey.get_start_url())
 

--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -5,7 +5,7 @@ import logging
 import re
 import werkzeug
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError
 from odoo.tools.mail import email_split_and_format, email_normalize
 
@@ -103,7 +103,7 @@ class SurveyInvite(models.TransientModel):
     @api.depends('survey_id.access_token')
     def _compute_survey_start_url(self):
         for invite in self:
-            invite.survey_start_url = werkzeug.urls.url_join(invite.survey_id.get_base_url(), invite.survey_id.get_start_url()) if invite.survey_id else False
+            invite.survey_start_url = tools.urls.urljoin(invite.survey_id.get_base_url(), invite.survey_id.get_start_url()) if invite.survey_id else False
 
     # Overrides of mail.composer.mixin
     @api.depends('survey_id')  # fake trigger otherwise not computed in new mode

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -21,7 +21,7 @@ from xml.etree import ElementTree as ET
 
 import odoo
 
-from odoo import http, models, fields, _
+from odoo import http, models, fields, tools, _
 from odoo.exceptions import AccessError, UserError
 from odoo.fields import Domain
 from odoo.http import request, SessionExpiredException
@@ -156,7 +156,10 @@ class Website(Home):
             domain_to = get_base_domain(website.domain)
             if domain_from != domain_to:
                 # redirect to correct domain for a correct routing map
-                url_to = werkzeug.urls.url_join(website.domain, '/website/force/%s?isredir=1&path=%s' % (website.id, path))
+                url_to = tools.urls.urljoin(
+                    website.domain,
+                    '/website/force/%s?isredir=1&path=%s' % (website.id, path),
+                )
                 return request.redirect(url_to)
         website._force()
         return request.redirect(path)

--- a/addons/website/models/ir_actions_server.py
+++ b/addons/website/models/ir_actions_server.py
@@ -1,8 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from werkzeug import urls
 
 from odoo import api, fields, models
 from odoo.http import request
+from odoo.tools import urls
 from odoo.tools.json import scriptsafe as json_scriptsafe
 
 
@@ -30,7 +30,7 @@ class IrActionsServer(models.Model):
         link = website_path or xml_id or (self.id and '%d' % self.id) or ''
         if base_url and link:
             path = '%s/%s' % ('/website/action', link)
-            return urls.url_join(base_url, path)
+            return urls.urljoin(base_url, path)
         return ''
 
     @api.depends('state', 'website_published', 'website_path', 'xml_id')

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -3,14 +3,13 @@
 import logging
 import re
 
-from werkzeug.urls import url_join
-
 from odoo import api, fields, models, _
 from odoo.fields import Domain
 from odoo.addons.website.tools import text_from_html
 from odoo.http import request
 from odoo.exceptions import AccessError
 from odoo.tools import escape_psql
+from odoo.tools.urls import urljoin as url_join
 from odoo.tools.json import scriptsafe as json_safe
 
 logger = logging.getLogger(__name__)

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1261,7 +1261,7 @@ class Website(models.Model):
 
     def _get_plausible_share_url(self):
         embed_url = f'/share/{self.plausible_site}?auth={self.plausible_shared_key}&embed=true&theme=system'
-        return self.plausible_shared_key and urls.url_join(self._get_plausible_server(), embed_url) or ''
+        return self.plausible_shared_key and tools.urls.urljoin(self._get_plausible_server(), embed_url) or ''
 
     def get_unique_key(self, string, template_module=False):
         """ Given a string, return an unique key including module prefix.
@@ -1700,7 +1700,7 @@ class Website(models.Model):
         cdn_filters = (self.cdn_filters or '').splitlines()
         for flt in cdn_filters:
             if flt and re.match(flt, uri):
-                return urls.url_join(cdn_url, uri)
+                return tools.urls.urljoin(cdn_url, uri)
         return uri
 
     @api.model

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -8,7 +8,7 @@ import werkzeug.urls
 from markupsafe import Markup
 from pytz import utc, timezone
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
 from odoo.tools.misc import get_lang, format_date
@@ -96,7 +96,7 @@ class EventEvent(models.Model):
     def _compute_event_share_url(self):
         """Fall back on the website_url to share the event."""
         for event in self:
-            event.event_share_url = event.event_url or werkzeug.urls.url_join(event.get_base_url(), event.website_url)
+            event.event_share_url = event.event_url or tools.urls.urljoin(event.get_base_url(), event.website_url)
  
     @api.depends('registration_ids')
     @api.depends_context('uid')
@@ -174,7 +174,7 @@ class EventEvent(models.Model):
     @api.depends('website_url')
     def _compute_event_register_url(self):
         for event in self:
-            event.event_register_url = werkzeug.urls.url_join(event.get_base_url(), f"{event.website_url}/register")
+            event.event_register_url = tools.urls.urljoin(event.get_base_url(), f"{event.website_url}/register")
 
     @api.depends('event_type_id')
     def _compute_website_menu(self):

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -707,7 +707,7 @@ class EventTrack(models.Model):
     def _get_track_calendar_description(self):
         self.ensure_one()
         return Markup("<a href='%(event_track_url)s'>%(name)s</a>\n%(short_description)s\n\n%(reminder_times_warning)s") % {
-            'event_track_url': werkzeug.urls.url_join(self.get_base_url(), self.website_url),
+            'event_track_url': tools.urls.urljoin(self.get_base_url(), self.website_url),
             'name': self.name,
             'short_description': shorten(html_to_inner_content(self.description), 1900),
             'reminder_times_warning': self._get_track_calendar_reminder_times_warning(),

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug.urls import url_join
-
 from odoo import api, fields, models, _
 from odoo.tools import mute_logger
+from odoo.tools.urls import urljoin as url_join
 from odoo.tools.translate import html_translate
 
 

--- a/addons/website_hr_recruitment/models/hr_recruitment_source.py
+++ b/addons/website_hr_recruitment/models/hr_recruitment_source.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug import urls
-
 from odoo import api, fields, models
+from odoo.tools import urls
 
 
 class HrRecruitmentSource(models.Model):
@@ -14,7 +13,7 @@ class HrRecruitmentSource(models.Model):
     @api.depends('source_id', 'source_id.name', 'job_id', 'job_id.company_id')
     def _compute_url(self):
         for source in self:
-            source.url = urls.url_join(source.job_id.get_base_url(), "%s?%s" % (
+            source.url = urls.urljoin(source.job_id.get_base_url(), "%s?%s" % (
                 source.job_id.website_url,
                 urls.url_encode({
                     'utm_campaign': self.env.ref('hr_recruitment.utm_campaign_job').name,

--- a/addons/website_links/models/link_tracker.py
+++ b/addons/website_links/models/link_tracker.py
@@ -2,8 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-
-from werkzeug import urls
+from odoo.tools import urls
 
 
 class LinkTracker(models.Model):
@@ -21,4 +20,4 @@ class LinkTracker(models.Model):
         current_website = self.env['website'].get_current_website()
         base_url = current_website.get_base_url() if current_website == self.env.company.website_id else self.env.company.get_base_url()
         for tracker in self:
-            tracker.short_url_host = urls.url_join(base_url, '/r/')
+            tracker.short_url_host = urls.urljoin(base_url, '/r/')

--- a/addons/website_sale/controllers/gmc.py
+++ b/addons/website_sale/controllers/gmc.py
@@ -1,10 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from urllib.parse import urljoin
 from werkzeug.exceptions import NotFound
 
 from odoo.fields import Domain
 from odoo.http import Controller, request, route
+from odoo.tools.urls import urljoin as url_join
 
 
 class GoogleMerchantCenter(Controller):
@@ -59,7 +59,7 @@ class GoogleMerchantCenter(Controller):
         ]))
         gmc_data = {
             'title': website_homepage.website_meta_title or website.name,
-            'link': urljoin(website.get_base_url(), request.env['ir.http']._url_lang(homepage_url)),
+            'link': url_join(website.get_base_url(), request.env['ir.http']._url_lang(homepage_url)),
             'description': website_homepage.website_meta_description,
             'items': products._prepare_gmc_items(),
         }

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -1,11 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.http import request
 from odoo.tools import float_is_zero, float_round
+from odoo.tools.urls import urljoin as url_join
 
 from odoo.addons.website_sale import const, utils
 
@@ -234,7 +235,7 @@ class ProductProduct(models.Model):
 
         def format_product_link(url_):
             url_ = urlparse(url_)._replace(query=f'pricelist={request.pricelist.id}').geturl()
-            return urljoin(base_url, self.env['ir.http']._url_lang(url_))
+            return url_join(base_url, self.env['ir.http']._url_lang(url_))
 
         delivery_methods_sudo = self.env['delivery.carrier'].sudo().search(
             [('is_published', '=', True), ('website_id', 'in', (request.website.id, False))],
@@ -278,10 +279,10 @@ class ProductProduct(models.Model):
         self.ensure_one()
         return {
             # Don't send any image link if there isn't. Google does not allow placeholder
-            'image_link': urljoin(base_url, self._get_image_1920_url()) if self.image_1920 else '',
+            'image_link': url_join(base_url, self._get_image_1920_url()) if self.image_1920 else '',
             # Supports up to 10 extra images
             'additional_image_link': [
-                urljoin(base_url, url) for url in self._get_extra_image_1920_urls()[:10]
+                url_join(base_url, url) for url in self._get_extra_image_1920_urls()[:10]
             ],
         }
 

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -1,8 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from urllib.parse import urljoin
-
 from odoo import _, api, fields, models
+from odoo.tools.urls import urljoin as url_join
 
 
 class ResConfigSettings(models.TransientModel):
@@ -127,7 +126,7 @@ class ResConfigSettings(models.TransientModel):
         for config in self:
             # Uses `config.get_base_url()` which fallbacks to `web․base․url` if `website_domain` is
             # not set.
-            config.gmc_xml_url = urljoin(config.get_base_url(), '/gmc.xml')
+            config.gmc_xml_url = url_join(config.get_base_url(), '/gmc.xml')
 
     def _inverse_account_on_checkout(self):
         for record in self:

--- a/addons/website_sale/tests/test_express_checkout_flows.py
+++ b/addons/website_sale/tests/test_express_checkout_flows.py
@@ -2,10 +2,9 @@
 
 from unittest.mock import Mock, patch
 
-from werkzeug import urls
-
 from odoo.http import root
 from odoo.tests import HttpCase, tagged
+from odoo.tools import urls
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.website_sale.controllers.delivery import Delivery as WebsiteSaleDeliveryController
@@ -130,7 +129,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         root.session_store.save(session)
 
         self.make_jsonrpc_request(
-            urls.url_join(
+            urls.urljoin(
                 self.base_url(), WebsiteSale._express_checkout_route
             ), params={
                 'billing_address': dict(self.express_checkout_billing_values)
@@ -155,7 +154,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         root.session_store.save(session)
 
         self.make_jsonrpc_request(
-            urls.url_join(
+            urls.urljoin(
                 self.base_url(), WebsiteSale._express_checkout_route
             ), params={
                 'billing_address': {
@@ -203,7 +202,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         root.session_store.save(session)
 
         self.make_jsonrpc_request(
-            urls.url_join(
+            urls.urljoin(
                 self.base_url(), WebsiteSale._express_checkout_route
             ), params={
                 'billing_address': dict(self.express_checkout_billing_values)
@@ -224,7 +223,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         root.session_store.save(session)
 
         self.make_jsonrpc_request(
-            urls.url_join(
+            urls.urljoin(
                 self.base_url(), WebsiteSale._express_checkout_route
             ), params={
                 'billing_address': dict(self.express_checkout_billing_values)
@@ -251,7 +250,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             return_value=self.rate_shipment_result
         ):
             self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_delivery_route,
                 ),
@@ -282,7 +281,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             return_value=self.rate_shipment_result
         ):
             self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_delivery_route,
                 ),
@@ -294,7 +293,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             )
             new_partner = self.sale_order.partner_shipping_id
             self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_delivery_route,
                 ),
@@ -323,7 +322,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             return_value=self.rate_shipment_result
         ):
             self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_delivery_route,
                 ),
@@ -349,7 +348,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             return_value=self.rate_shipment_result
         ):
             self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_delivery_route,
                 ),
@@ -382,7 +381,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             return_value=self.rate_shipment_result
         ):
             self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_delivery_route,
                 ),
@@ -394,7 +393,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             )
             new_partner = self.sale_order.partner_shipping_id
             self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_delivery_route,
                 ),
@@ -441,7 +440,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             return_value=self.rate_shipment_result
         ):
             shipping_options = self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_delivery_route,
                 ),
@@ -454,7 +453,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             self.assertEqual(self.sale_order.partner_id.id, self.user_demo.partner_id.id)
 
             self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_route,
                 ),
@@ -482,7 +481,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             # Won't create a new partner because the partial information are the same as an
             # exisiting partner linked to the SO
             shipping_options = self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_delivery_route,
                 ),
@@ -497,7 +496,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
             # Will create a new partner because the complete shipping information differs from
             # the partner actually selected
             self.make_jsonrpc_request(
-                urls.url_join(
+                urls.urljoin(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_route
                 ),

--- a/odoo/addons/test_http/tests/test_registry.py
+++ b/odoo/addons/test_http/tests/test_registry.py
@@ -1,7 +1,7 @@
 import logging
 from contextlib import closing
 from unittest.mock import patch
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import urlsplit
 
 import requests
 
@@ -10,6 +10,7 @@ from odoo.modules.registry import Registry
 from odoo.sql_db import close_db, db_connect
 from odoo.tests import HOST, BaseCase, Like, get_db_name, tagged
 from odoo.tools import mute_logger, reset_cached_properties, SQL
+from odoo.tools.urls import urljoin
 
 
 """

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -2,6 +2,7 @@
 # ruff: noqa: F401
 
 from . import constants
+from . import urls
 from .parse_version import parse_version
 from .cache import ormcache, ormcache_context
 from .config import config

--- a/odoo/tools/urls.py
+++ b/odoo/tools/urls.py
@@ -1,0 +1,75 @@
+import re
+import urllib.parse
+from urllib.parse import _WHATWG_C0_CONTROL_OR_SPACE
+
+__all__ = ['urljoin']
+
+
+def _contains_dot_segments(path: str) -> str:
+    # most servers decode url before doing dot segment resolutions
+    decoded_path = urllib.parse.unquote(path, errors='strict')
+    return any(seg in ('.', '..') for seg in decoded_path.split('/'))
+
+
+def urljoin(base: str, extra: str) -> str:
+    """Join a trusted base URL with a relative URL safely.
+
+    Unlike standard URL joins that follow RFC 3986 (e.g., `urllib.parse.urljoin`),
+    this function enforces strict behavior that better aligns with developer
+    expectations and guards against path traversals, unplanned redirects, and
+    accidental host/scheme overrides.
+
+    - Behaves similarly to `base + '/' + extra`
+    - Keeps scheme and netloc from `base`, and raises an error if `extra` has them
+    - Ignores any scheme/host in `extra`
+    - Forbids `.` and `..` path traversal
+    - merges path/query/fragment
+
+    :param base: Trusted base URL or path.
+    :type base: str
+    :param extra: Relative URL (`path`, `?query`, `#frag`). No scheme & host allowed unless it matches `base`
+    :type extra: str
+    :returns: joined URL.
+    :rtype: str
+    :raises AssertionError: If inputs are not strings.
+    :raises ValueError: `extra` contains dot-segments or is absolute URLs.
+
+    Examples::
+
+        >>> urljoin('https://api.example.com/v1/?bar=fiz', '/users/42?bar=bob')
+        'https://api.example.com/v1/users/42?bar=bob'
+
+        >>> urljoin('https://example.com/foo', 'http://8.8.8.8/foo')
+        Traceback (most recent call last):
+            ...
+        ValueError: Extra URL must use same scheme and host as base, and begin with base path
+
+        >>> urljoin('https://api.example.com/data/', '/?lang=fr')
+        'https://api.example.com/data/?lang=fr'
+    """
+    assert isinstance(base, str), "Base URL must be a string"
+    assert isinstance(extra, str), "Extra URL must be a string"
+
+    b_scheme, b_netloc, path, _, _ = urllib.parse.urlsplit(base)
+    e_scheme, e_netloc, e_path, e_query, e_fragment = urllib.parse.urlsplit(extra)
+
+    if e_scheme or e_netloc:
+        # allow absolute extra URL if it matches base
+        if (e_scheme != b_scheme) or (e_netloc != b_netloc) or not e_path.startswith(path):
+            raise ValueError("Extra URL must use same scheme and host as base, and begin with base path")
+
+        e_path = e_path[len(path):]
+
+    if e_path:
+        # prevent urljoin("/", "\\example.com/") to resolve as absolute to "//example.com/" in a browser redirect
+        # https://github.com/mozilla-firefox/firefox/blob/5e81b64f4ed88b610eb332e103744d68ee8b6c0d/netwerk/base/nsStandardURL.cpp#L2386-L2388
+        e_path = e_path.lstrip('/\\' + _WHATWG_C0_CONTROL_OR_SPACE)
+        path = f'{path}/{e_path}'
+
+    # normalize: foo//bar -> foo/bar
+    path = re.sub(r'/+', '/', path)
+
+    if _contains_dot_segments(path):
+        raise ValueError("Dot segments are not allowed")
+
+    return urllib.parse.urlunsplit((b_scheme, b_netloc, path, e_query, e_fragment))


### PR DESCRIPTION
This commit adds a default odoo url joining helper function that basically does the same as base.rstrip('/') + '/' + url.lstrip('/'), but with schema, hostname, path traversal and better fragments/query handling.

Most url parsing libraries like urllib and werkzeug (at least try to) follow RFC 3986 which explains in detail how to do relative resolutions. But developers usually expect simple concatenation behaviour like "api.example.com/v1/" + endpoint, but by passing a user-controlled data to urljoin, they end up giving room for people to tinker with things nobody ever expected were possible, which can lead to some nasty stuff. So the motivation here is to give a function that is somewhat better aligned with what devs expect it to do.

enterprise: https://github.com/odoo/enterprise/pull/90504

task-3792184