### PR TITLE
[IMP] project,purchase,purchase_stock,sale: remove href="#"

### DIFF
--- a/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.xml
+++ b/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.xml
@@ -10,9 +10,9 @@
         </xpath>
 
         <xpath expr="//t[@t-foreach='controls']" position="after">
-            <a t-if="ShowX2MRecords" role="button" class="ml16 o_toggle_closed_task_button" href="#" t-on-click="() => this.toggleHideClosed()">
+            <button t-if="ShowX2MRecords" class="ml16 o_toggle_closed_task_button btn btn-link" t-on-click="() => this.toggleHideClosed()">
                 <t t-esc="toggleListHideLabel"/>
-            </a>
+            </button>
         </xpath>
     </t>
 </templates>

--- a/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
@@ -17,11 +17,11 @@
                             <tr class="revenue_section">
                                 <t t-set="revenue_label" t-value="props.labels[revenue.id] or revenue.id"/>
                                 <td>
-                                    <a class="revenue_section" t-if="revenue.action" href="#"
+                                    <button class="revenue_section btn btn-link fw-normal p-0" t-if="revenue.action"
                                         t-on-click="() => this.props.onClick(revenue.action)"
                                     >
                                         <t t-esc="revenue_label"/>
-                                    </a>
+                                    </button>
                                     <t t-esc="revenue_label" t-else=""/>
                                 </td>
                                 <td t-attf-class="text-end {{ revenue.invoiced + revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced + revenue.to_invoice)"/></td>
@@ -54,11 +54,11 @@
                         <tr t-foreach="costs.data" t-as="cost" t-key="cost.id" t-if="cost.billed !== 0 || cost.to_bill !== 0">
                             <t t-set="cost_label" t-value="props.labels[cost.id] or cost.id"/>
                             <td>
-                                <a t-if="cost.action" href="#"
+                                <button t-if="cost.action" class="btn btn-link fw-normal p-0"
                                     t-on-click="() => this.props.onClick(cost.action)"
                                 >
                                     <t t-esc="cost_label"/>
-                                </a>
+                                </button>
                                 <t t-esc="cost_label" t-else=""/>
                             </td>
                             <td t-attf-class="text-end {{ cost.billed + cost.to_bill === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(cost.billed + cost.to_bill)"/></td>

--- a/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.xml
+++ b/addons/project/static/src/views/project_project_calendar/common/project_common_calendar_popover.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="project.ProjectCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='isEventDeletable']" position="before">
-            <a href="#" class="btn btn-secondary" t-on-click="onClickViewTasks">View Tasks</a>
+            <button class="btn btn-secondary" t-on-click="onClickViewTasks">View Tasks</button>
         </xpath>
     </t>
 </templates>

--- a/addons/project/static/tests/project_notebook_task_list.test.js
+++ b/addons/project/static/tests/project_notebook_task_list.test.js
@@ -123,14 +123,14 @@ test("test Project Task Calendar Popover with task_stage_with_state_selection wi
         message: "The depend on tasks list should display all blocking tasks by default, thus we are looking for 2 in total"
     });
 
-    expect("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
-    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
+    expect("div[name='child_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
+    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
 
-    await click("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button");
+    await click("div[name='child_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button");
     await animationFrame();
 
-    expect("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Show closed tasks");
-    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
+    expect("div[name='child_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Show closed tasks");
+    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
 
     expect('div[name="child_ids"] .o_data_row').toHaveCount(3, {
         message: "The subtasks list should only display the open subtasks of the task, in this case 3"
@@ -139,11 +139,11 @@ test("test Project Task Calendar Popover with task_stage_with_state_selection wi
         message: "The depend on tasks list should still display all blocking tasks, in this case 2"
     });
 
-    await click("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button");
+    await click("div[name='depend_on_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button");
     await animationFrame();
 
-    expect("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Show closed tasks");
-    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("1 closed tasks");
+    expect("div[name='child_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("Show closed tasks");
+    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add button.o_toggle_closed_task_button").toHaveText("1 closed tasks");
 
     expect('div[name="child_ids"] .o_data_row').toHaveCount(3, {
         message: "The subtasks list should only display the open subtasks of the task, in this case 3"

--- a/addons/project/static/tests/project_project_calendar.test.js
+++ b/addons/project/static/tests/project_project_calendar.test.js
@@ -38,7 +38,7 @@ test("check 'Edit' and 'View Tasks' buttons are in Project Calendar Popover", as
     expect(queryAllTexts(".o_popover .card-footer .btn")).toEqual(["Edit", "View Tasks", ""]);
     expect(".o_popover .card-footer .btn i.fa-trash").toHaveCount(1);
 
-    await click(".o_popover .card-footer a:contains(View Tasks)");
+    await click(".o_popover .card-footer button:contains(View Tasks)");
     await click(".o_popover .card-footer a:contains(Edit)");
     expect.verifySteps(["view tasks"]);
 });

--- a/addons/purchase/static/src/views/purchase_dashboard.xml
+++ b/addons/purchase/static/src/views/purchase_dashboard.xml
@@ -10,7 +10,7 @@
                         </div>
                         <div class="g-col-12 g-col-lg-11 grid gap-1" style="--columns: 61">
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Draft RFQs" filter_name="draft_rfqs">
-                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                    t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}
                                        {{ purchaseData['global']['draft']['all'] == 0
                                           ? 'bg-secondary-subtle text-secondary-emphasis'
@@ -21,10 +21,10 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['draft']['priority']"/>
                                         </span>
                                     </div>New
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Sent RFQs" filter_name="waiting_rfqs">
-                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap"
+                                <button class="btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap"
                                    t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['sent']['all']"/>
@@ -32,10 +32,10 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['sent']['priority']"/>
                                         </span>
                                     </div>RFQ Sent
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Late RFQs" filter_name="late">
-                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                    t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}
                                        {{ purchaseData['global']['late']['all'] == 0
                                           ? 'bg-secondary-subtle text-secondary-emphasis'
@@ -46,11 +46,11 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['late']['priority']"/>
                                         </span>
                                     </div>Late RFQ
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-1"/>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Not Acknowledged POs" filter_name="not_acknowledged">
-                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                    t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}
                                        {{ purchaseData['global']['not_acknowledged']['all'] == 0
                                           ? 'bg-secondary-subtle text-secondary-emphasis'
@@ -61,10 +61,10 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['not_acknowledged']['priority']"/>
                                         </span>
                                     </div>Not Acknowledged
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Late Receipt POs" filter_name="late_receipt">
-                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                    t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}
                                        {{ purchaseData['global']['late_receipt']['all'] == 0
                                           ? 'bg-secondary-subtle text-secondary-emphasis'
@@ -76,7 +76,7 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['global']['late_receipt']['priority']"/>
                                         </span>
                                     </div>Late Receipt
-                                </a>
+                                </button>
                             </div>
                         </div>
                     </div>
@@ -86,7 +86,7 @@
                         </div>
                         <div class="g-col-12 g-col-lg-11 grid gap-1 pt-0 pt-lg-1" style="--columns: 61">
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Draft RFQs" filter_name="draft_rfqs,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['draft']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
                                     <div>
                                         <span t-out="purchaseData['my']['draft']['all']"/>
@@ -94,20 +94,20 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['draft']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Waiting RFQs" filter_name="waiting_rfqs,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap">
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap">
                                     <div>
                                         <span t-out="purchaseData['my']['sent']['all']"/>
                                         <span class="ps-4" t-if="purchaseData['my']['sent']['priority']">
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['sent']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Late RFQs" filter_name="late,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['late']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-warning-subtle text-warning-emphasis' }}">
                                     <div>
                                         <span t-out="purchaseData['my']['late']['all']"/>
@@ -115,11 +115,11 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['late']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-1"/>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Not Acknowledged POs" filter_name="not_acknowledged,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['not_acknowledged']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
                                     <div>
                                         <span t-out="purchaseData['my']['not_acknowledged']['all']"/>
@@ -127,10 +127,10 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['not_acknowledged']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Late Receipt POs" filter_name="late_receipt,my_purchases">
-                                <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                <button class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['late_receipt']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-danger-subtle text-danger-emphasis' }}">
                                     <div>
                                         <span t-out="purchaseData['my']['late_receipt']['all']"/>
@@ -138,7 +138,7 @@
                                             <span class="o_priority_star fa fa-star "/> <span t-out="purchaseData['my']['late_receipt']['priority']"/>
                                         </span>
                                     </div>
-                                </a>
+                                </button>
                             </div>
                         </div>
                     </div>

--- a/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
+++ b/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
@@ -8,8 +8,8 @@
                 <td>Requests for quotation :
                     <t t-foreach="currentProduct.draft_purchase_orders" t-as="purchase_order" t-key="purchase_order_index">
                         <t t-if="purchase_order_index > 0"> | </t>
-                        <a t-attf-href="#" t-out="purchase_order.name"
-                            class="fw-bold"
+                        <button t-out="purchase_order.name"
+                            class="fw-bold btn btn-link p-0"
                             t-on-click.prevent="() => this.props.openView('purchase.order', 'form', purchase_order.id)"/>
                     </t>
                 </td>

--- a/addons/sale/static/src/xml/sales_team_progress_bar_template.xml
+++ b/addons/sale/static/src/xml/sales_team_progress_bar_template.xml
@@ -8,9 +8,9 @@
         </t>
         <t t-else="">
             <!-- TODO is this class needed here ? -->
-            <a t-on-click.prevent="defineInvoicingTarget" href="#" class="sale_progressbar_form_link">
+            <button t-on-click.prevent="defineInvoicingTarget" class="btn btn-link fw-normal p-0 sale_progressbar_form_link">
                 Click to define an invoicing target
-            </a>
+            </button>
         </t>
     </t>
 

--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -13,7 +13,7 @@ registry.category("web_tour.tours").add('sale_signature', {
     },
     {
         content: "click sign",
-        trigger: 'a:contains("Sign")',
+        trigger: 'button:contains("Sign")',
         run: "click",
     },
     {

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -172,19 +172,17 @@
 
                         <div class="d-flex flex-column gap-4 mt-3">
                             <div class="d-flex flex-column gap-2" id="sale_order_sidebar_button">
-                                <a
+                                <button
                                     t-if="sale_order._has_to_be_signed() and not payment_amount"
-                                    role="button"
                                     class="btn btn-primary"
                                     data-bs-toggle="modal"
                                     data-bs-target="#modalaccept"
-                                    href="#"
                                 > <!-- If paying by link, signing is skipped. -->
                                     <i class="fa fa-check"/>
                                     <t t-if="sale_order._has_to_be_paid()"> Sign &amp; Pay</t>
                                     <t t-else=""> Accept &amp; Sign</t>
-                                </a>
-                                <a
+                                </button>
+                                <button
                                     t-elif="sale_order._has_to_be_paid()
                                             or (
                                                 payment_amount
@@ -192,10 +190,8 @@
                                                 and sale_order.state != 'cancel'
                                             )"
                                     id="o_sale_portal_paynow"
-                                    role="button"
                                     data-bs-toggle="modal"
                                     data-bs-target="#modalaccept"
-                                    href="#"
                                     t-att-class="'btn btn-primary' if not sale_order.transaction_ids else 'btn btn-light'"
                                 >
                                     <i class="fa fa-check"/>
@@ -203,7 +199,7 @@
                                              and sale_order._has_to_be_paid()
                                              and not payment_amount"> Accept &amp; Pay</t>
                                     <t t-else=""> Pay Now</t>
-                                </a>
+                                </button>
                                 <div
                                     id="print_invoice_sidebar_button"
                                     class="o_download_pdf d-flex gap-2 flex-lg-column flex-xl-row flex-wrap"
@@ -379,19 +375,19 @@
 
                         <t t-if="sale_order._has_to_be_signed()">
                             <div class="col-sm-auto mt8">
-                                <a role="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalaccept" href="#"><i class="fa fa-check"/><t t-if="sale_order._has_to_be_paid()"> Sign &amp; Pay</t><t t-else=""> Accept &amp; Sign</t></a>
+                                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalaccept"><i class="fa fa-check"/><t t-if="sale_order._has_to_be_paid()"> Sign &amp; Pay</t><t t-else=""> Accept &amp; Sign</t></button>
                             </div>
                             <div class="col-sm-auto mt8">
                                 <a role="button" class="btn btn-light" href="#discussion"><i class="fa fa-comment"/> Feedback</a>
                             </div>
                             <div class="col-sm-auto mt8">
-                                <a role="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modaldecline" href="#"> <i class="fa fa-times"/> Reject</a>
+                                <button class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#modaldecline"> <i class="fa fa-times"/> Reject</button>
                             </div>
                         </t>
                         <div t-elif="sale_order._has_to_be_paid()" class="col-sm-auto mt8">
-                            <a role="button" data-bs-toggle="modal" data-bs-target="#modalaccept" href="#" t-att-class="'%s' % ('btn btn-light' if sale_order.transaction_ids else 'btn btn-primary')">
+                            <button data-bs-toggle="modal" data-bs-target="#modalaccept" t-att-class="'%s' % ('btn btn-light' if sale_order.transaction_ids else 'btn btn-primary')">
                                 <i class="fa fa-check"/> <t t-if="not sale_order.signature">Accept &amp; Pay</t><t t-else="">Pay Now</t>
-                            </a>
+                            </button>
                         </div>
                     </div>
 

--- a/addons/sale/views/utm_campaign_views.xml
+++ b/addons/sale/views/utm_campaign_views.xml
@@ -7,22 +7,22 @@
         <field name="inherit_id" ref="utm.utm_campaign_view_kanban"/>
         <field name="arch" type="xml">
             <xpath expr="//footer/div" position="inside">
-                <a t-if="record.invoiced_amount" href="#" title="Revenues" role="button"
+                <button t-if="record.invoiced_amount" title="Revenues"
                     groups="sales_team.group_sale_salesman" type="object" name="action_redirect_to_invoiced"
-                    class="btn-outline-primary rounded-pill me-1 order-1">
+                    class="rounded-pill me-1 order-1 p-0">
                     <span class="badge">
                         <field name="currency_id" invisible="True"/>
                         <field name="invoiced_amount" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                     </span>
-                </a>
-                <a t-if="record.quotation_count" href="#" title="Quotations" role="button"
+                </button>
+                <button t-if="record.quotation_count" title="Quotations"
                     groups="sales_team.group_sale_salesman" type="object" name="action_redirect_to_quotations"
-                    class="btn-outline-primary rounded-pill me-1 order-2">
+                    class="btn-outline-primary rounded-pill me-1 order-2 p-0">
                     <span class="badge">
                         <i class="fa fa-fw fa-money me-1" aria-label="Quotations" role="img"/>
                         <field name="quotation_count"/>
                     </span>
-                </a>
+                </button>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
We use `href="#"` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href="#"` and replaces it with the appropriate element or class to activate the <a> elements correctly.

Task-438051

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
