### PR TITLE
[REF] core: rename auto_join to bypass_search_access

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -24,7 +24,7 @@ class AccountBankStatementLine(models.Model):
     # == Business fields ==
     move_id = fields.Many2one(
         comodel_name='account.move',
-        auto_join=True,
+        bypass_search_access=True,
         string='Journal Entry', required=True, readonly=True, ondelete='cascade',
         index=True,
         check_company=True)

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -35,7 +35,7 @@ class AccountMoveLine(models.Model):
         required=True,
         readonly=True,
         index=True,
-        auto_join=True,
+        bypass_search_access=True,
         ondelete="cascade",
         check_company=True,
     )
@@ -96,7 +96,7 @@ class AccountMoveLine(models.Model):
         compute='_compute_account_id', store=True, readonly=False, precompute=True,
         inverse='_inverse_account_id',
         index=False,  # covered by account_move_line_account_id_date_idx defined in init()
-        auto_join=True,
+        bypass_search_access=True,
         ondelete="cascade",
         domain="[('account_type', '!=', 'off_balance')]",
         check_company=True,
@@ -168,19 +168,19 @@ class AccountMoveLine(models.Model):
         comodel_name='account.payment',
         string="Originator Payment",
         related='move_id.origin_payment_id', store=True,
-        auto_join=True,
+        bypass_search_access=True,
         index='btree_not_null',
         help="The payment that created this entry")
     statement_line_id = fields.Many2one(
         comodel_name='account.bank.statement.line',
         string="Originator Statement Line",
         related='move_id.statement_line_id', store=True,
-        auto_join=True,
+        bypass_search_access=True,
         index='btree_not_null',
         help="The statement line that created this entry")
     statement_id = fields.Many2one(
         related='statement_line_id.statement_id', store=True,
-        auto_join=True,
+        bypass_search_access=True,
         index='btree_not_null',
         copy=False,
         help="The bank statement used for bank reconciliation")
@@ -657,7 +657,7 @@ class AccountMoveLine(models.Model):
                 query_value = value.select('id') if isinstance(value, Query) else value
                 value = [row[0] for row in self.env.execute_query(query_value)]
             else:  # isinstance(value, Domain) is True
-                # sudo reason: ignore ir.rules, `account_id` is with `auto_join=True`
+                # sudo reason: ignore ir.rules, `account_id` is with `bypass_search_access=True`
                 value = self.env['account.account'].sudo()._search(value).get_result_ids()
 
         return [('account_id', operator, value)]

--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -12,7 +12,7 @@ class AccountPayment(models.Model):
         string="Payment Transaction",
         comodel_name='payment.transaction',
         readonly=True,
-        auto_join=True,  # No access rule bypass since access to payments means access to txs too
+        bypass_search_access=True,  # No access rule bypass since access to payments means access to txs too
     )
     payment_token_id = fields.Many2one(
         string="Saved Payment Token", comodel_name='payment.token', domain="""[

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -64,11 +64,11 @@ class AccountAnalyticAccount(models.Model):
         default=lambda self: self.env.company,
     )
 
-    # use auto_join to speed up name_search call
     partner_id = fields.Many2one(
         'res.partner',
         string='Customer',
-        auto_join=True,
+        # use bypass_access to speed up name_search call
+        bypass_search_access=True,
         tracking=True,
         check_company=True,
         index='btree_not_null',

--- a/addons/gamification/models/gamification_goal.py
+++ b/addons/gamification/models/gamification_goal.py
@@ -22,7 +22,7 @@ class GamificationGoal(models.Model):
     _order = 'start_date desc, end_date desc, definition_id, id'
 
     definition_id = fields.Many2one('gamification.goal.definition', string="Goal Definition", required=True, ondelete="cascade")
-    user_id = fields.Many2one('res.users', string="User", required=True, auto_join=True, index=True, ondelete="cascade")
+    user_id = fields.Many2one('res.users', string="User", required=True, bypass_search_access=True, index=True, ondelete="cascade")
     user_partner_id = fields.Many2one('res.partner', related='user_id.partner_id')
     line_id = fields.Many2one('gamification.challenge.line', string="Challenge Line", ondelete="cascade")
     challenge_id = fields.Many2one(

--- a/addons/l10n_latam_base/models/res_partner.py
+++ b/addons/l10n_latam_base/models/res_partner.py
@@ -7,7 +7,7 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     l10n_latam_identification_type_id = fields.Many2one('l10n_latam.identification.type',
-        string="Identification Type", index='btree_not_null', auto_join=True,
+        string="Identification Type", index='btree_not_null', bypass_search_access=True,
         default=lambda self: self.env.ref('l10n_latam_base.it_vat', raise_if_not_found=False),
         inverse="_inverse_vat",  # To trigger the vat checking
         help="The type of identification")

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -57,7 +57,7 @@ class AccountMove(models.Model):
 
     l10n_latam_available_document_type_ids = fields.Many2many('l10n_latam.document.type', compute='_compute_l10n_latam_available_document_types')
     l10n_latam_document_type_id = fields.Many2one(
-        'l10n_latam.document.type', string='Document Type', readonly=False, auto_join=True, index='btree_not_null', compute='_compute_l10n_latam_document_type', store=True)
+        'l10n_latam.document.type', string='Document Type', readonly=False, bypass_search_access=True, index='btree_not_null', compute='_compute_l10n_latam_document_type', store=True)
     l10n_latam_document_number = fields.Char(
         compute='_compute_l10n_latam_document_number', inverse='_inverse_l10n_latam_document_number',
         string='Document Number', readonly=False)

--- a/addons/l10n_latam_invoice_document/models/account_move_line.py
+++ b/addons/l10n_latam_invoice_document/models/account_move_line.py
@@ -15,4 +15,4 @@ class AccountMoveLine(models.Model):
         return super()._auto_init()
 
     l10n_latam_document_type_id = fields.Many2one(
-        related='move_id.l10n_latam_document_type_id', auto_join=True, store=True, index='btree_not_null')
+        related='move_id.l10n_latam_document_type_id', bypass_search_access=True, store=True, index='btree_not_null')

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -62,7 +62,7 @@ class DiscussChannel(models.Model):
         compute='_compute_channel_partner_ids', inverse='_inverse_channel_partner_ids',
         search='_search_channel_partner_ids')
     channel_member_ids = fields.One2many('discuss.channel.member', 'channel_id', string='Members')
-    parent_channel_id = fields.Many2one("discuss.channel", help="Parent channel", ondelete="cascade", index=True, auto_join=True, readonly=True)
+    parent_channel_id = fields.Many2one("discuss.channel", help="Parent channel", ondelete="cascade", index=True, bypass_search_access=True, readonly=True)
     sub_channel_ids = fields.One2many("discuss.channel", "parent_channel_id", string="Sub Channels", readonly=True)
     from_message_id = fields.Many2one("mail.message", help="The message the channel was created from.", readonly=True)
     pinned_message_ids = fields.One2many('mail.message', 'res_id', domain=[('model', '=', 'discuss.channel'), ('pinned_at', '!=', False)], string='Pinned Messages')

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -31,7 +31,7 @@ class DiscussChannelMember(models.Model):
     guest_id = fields.Many2one("mail.guest", "Guest", ondelete="cascade", index=True)
     is_self = fields.Boolean(compute="_compute_is_self", search="_search_is_self")
     # channel
-    channel_id = fields.Many2one("discuss.channel", "Channel", ondelete="cascade", required=True, auto_join=True)
+    channel_id = fields.Many2one("discuss.channel", "Channel", ondelete="cascade", required=True, bypass_search_access=True)
     # state
     custom_channel_name = fields.Char('Custom channel name')
     fetched_message_id = fields.Many2one('mail.message', string='Last Fetched', index="btree_not_null")

--- a/addons/mail/models/discuss/discuss_voice_metadata.py
+++ b/addons/mail/models/discuss/discuss_voice_metadata.py
@@ -8,5 +8,5 @@ class DiscussVoiceMetadata(models.Model):
     _description = "Metadata for voice attachments"
 
     attachment_id = fields.Many2one(
-        "ir.attachment", ondelete="cascade", auto_join=True, copy=False, index=True
+        "ir.attachment", ondelete="cascade", bypass_search_access=True, copy=False, index=True
     )

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -48,7 +48,7 @@ class MailActivityMixin(models.AbstractModel):
 
     activity_ids = fields.One2many(
         'mail.activity', 'res_id', 'Activities',
-        auto_join=True,
+        bypass_search_access=True,
         groups="base.group_user",)
     activity_state = fields.Selection([
         ('overdue', 'Overdue'),

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -41,7 +41,7 @@ class MailMail(models.Model):
         return super().default_get(fields)
 
     # content
-    mail_message_id = fields.Many2one('mail.message', 'Message', required=True, ondelete='cascade', index=True, auto_join=True)
+    mail_message_id = fields.Many2one('mail.message', 'Message', required=True, ondelete='cascade', index=True, bypass_search_access=True)
     mail_message_id_int = fields.Integer(compute='_compute_mail_message_id_int', compute_sudo=True)
     message_type = fields.Selection(related='mail_message_id.message_type', inherited=True, default='email_outgoing')
     body_html = fields.Text('Text Contents', help="Rich-text/HTML message")

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -159,7 +159,7 @@ class MailMessage(models.Model):
     # notifications
     notification_ids = fields.One2many(
         'mail.notification', 'mail_message_id', 'Notifications',
-        auto_join=True, copy=False, depends=['notified_partner_ids'])
+        bypass_search_access=True, copy=False, depends=['notified_partner_ids'])
     # user interface
     starred_partner_ids = fields.Many2many(
         'res.partner', 'mail_message_res_partner_starred_rel', string='Favorited By')

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -141,7 +141,7 @@ class MailThread(models.AbstractModel):
     )
     message_ids = fields.One2many(
         'mail.message', 'res_id', string='Messages',
-        domain=lambda self: [('message_type', '!=', 'user_notification')], auto_join=True)
+        domain=lambda self: [('message_type', '!=', 'user_notification')], bypass_search_access=True)
     has_message = fields.Boolean(compute="_compute_has_message", search="_search_has_message", store=False)
     message_needaction = fields.Boolean(
         'Action Needed',

--- a/addons/portal/models/mail_thread.py
+++ b/addons/portal/models/mail_thread.py
@@ -14,7 +14,7 @@ class MailThread(models.AbstractModel):
 
     website_message_ids = fields.One2many('mail.message', 'res_id', string='Website Messages',
         domain=lambda self: [('model', '=', self._name), ('message_type', 'in', ('comment', 'email', 'email_outgoing', 'auto_comment'))],
-        auto_join=True,
+        bypass_search_access=True,
         help="Website communication history")
 
     def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -38,7 +38,7 @@ class ProductProduct(models.Model):
         help="If unchecked, it will allow you to hide the product without removing it.")
     product_tmpl_id = fields.Many2one(
         'product.template', 'Product Template',
-        auto_join=True, index=True, ondelete="cascade", required=True)
+        bypass_search_access=True, index=True, ondelete="cascade", required=True)
     barcode = fields.Char(
         'Barcode', copy=False, index='btree_not_null',
         help="International Article Number used for product identification.")

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -94,7 +94,7 @@ class ProjectProject(models.Model):
     description = fields.Html(help="Description to provide more information and context about this project")
     active = fields.Boolean(default=True, copy=False, export_string_translation=False)
     sequence = fields.Integer(default=10, export_string_translation=False)
-    partner_id = fields.Many2one('res.partner', string='Customer', auto_join=True, tracking=True, domain="['|', ('company_id', '=?', company_id), ('company_id', '=', False)]", index='btree_not_null')
+    partner_id = fields.Many2one('res.partner', string='Customer', bypass_search_access=True, tracking=True, domain="['|', ('company_id', '=?', company_id), ('company_id', '=', False)]", index='btree_not_null')
     company_id = fields.Many2one('res.company', string='Company', compute="_compute_company_id", inverse="_inverse_company_id", store=True, readonly=False)
     currency_id = fields.Many2one('res.currency', compute="_compute_currency_id", string="Currency", readonly=True, export_string_translation=False)
     analytic_account_balance = fields.Monetary(related="account_id.balance")

--- a/addons/rating/models/mail_thread.py
+++ b/addons/rating/models/mail_thread.py
@@ -10,7 +10,7 @@ class MailThread(models.AbstractModel):
     _inherit = 'mail.thread'
 
     rating_ids = fields.One2many('rating.rating', 'res_id', string='Ratings', groups='base.group_user',
-                                 domain=lambda self: [('res_model', '=', self._name)], auto_join=True)
+                                 domain=lambda self: [('res_model', '=', self._name)], bypass_search_access=True)
 
     # MAIL OVERRIDES
     # --------------------------------------------------

--- a/addons/rating/models/rating_parent_mixin.py
+++ b/addons/rating/models/rating_parent_mixin.py
@@ -16,7 +16,7 @@ class RatingParentMixin(models.AbstractModel):
 
     rating_ids = fields.One2many(
         'rating.rating', 'parent_res_id', string='Ratings',
-        auto_join=True, groups='base.group_user',
+        bypass_search_access=True, groups='base.group_user',
         domain=lambda self: [('parent_res_model', '=', self._name)])
     rating_percentage_satisfaction = fields.Integer(
         "Rating Satisfaction",

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -13,7 +13,7 @@ class ResourceMixin(models.AbstractModel):
 
     resource_id = fields.Many2one(
         'resource.resource', 'Resource',
-        auto_join=True, index=True, ondelete='restrict', required=True)
+        bypass_search_access=True, index=True, ondelete='restrict', required=True)
     company_id = fields.Many2one(
         'res.company', 'Company',
         default=lambda self: self.env.company,

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -222,7 +222,7 @@ class SaleOrder(models.Model):
         comodel_name='sale.order.line',
         inverse_name='order_id',
         string="Order Lines",
-        copy=True, auto_join=True)
+        copy=True, bypass_search_access=True)
 
     amount_untaxed = fields.Monetary(string="Untaxed Amount", store=True, compute='_compute_amounts', tracking=5)
     amount_tax = fields.Monetary(string="Taxes", store=True, compute='_compute_amounts')

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -367,7 +367,7 @@ class ProductProduct(models.Model):
         if not location_ids:
             return (Domain.FALSE,) * 3
         locations = self.env['stock.location'].browse(location_ids)
-        # TDE FIXME: should move the support of child_of + auto_join directly in expression
+        # TDE FIXME: should move the support of child_of + bypass_search_access directly in expression
         # this optimizes [('location_id', 'child_of', locations.ids)]
         # by avoiding the ORM to search for children locations and injecting a
         # lot of location ids into the main query

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -77,7 +77,7 @@ class StockMove(models.Model):
     location_id = fields.Many2one(
         'stock.location', 'Source Location',
         help='The operation takes and suggests products from this location.',
-        auto_join=True, index=True, required=True,
+        bypass_search_access=True, index=True, required=True,
         compute='_compute_location_id', store=True, precompute=True, readonly=False,
         check_company=True)
     location_dest_id = fields.Many2one(
@@ -89,7 +89,7 @@ class StockMove(models.Model):
         readonly=False, store=True,
         help="The operation brings the products to the intermediate location."
         "But this operation is part of a chain of operations targeting the final location.",
-        auto_join=True, index=True, check_company=True)
+        bypass_search_access=True, index=True, check_company=True)
     location_usage = fields.Selection(string="Source Location Type", related='location_id.usage')
     location_dest_usage = fields.Selection(string="Destination Location Type", related='location_dest_id.usage')
     partner_id = fields.Many2one(

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -18,7 +18,7 @@ class StockMoveLine(models.Model):
     _order = "result_package_id desc, id"
 
     picking_id = fields.Many2one(
-        'stock.picking', 'Transfer', auto_join=True,
+        'stock.picking', 'Transfer', bypass_search_access=True,
         check_company=True,
         index=True,
         help='The stock operation where the packing has been made')

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -59,7 +59,7 @@ class StockQuant(models.Model):
     location_id = fields.Many2one(
         'stock.location', 'Location',
         domain=lambda self: self._domain_location_id(),
-        auto_join=True, ondelete='restrict', required=True, index=True)
+        bypass_search_access=True, ondelete='restrict', required=True, index=True)
     warehouse_id = fields.Many2one('stock.warehouse', related='location_id.warehouse_id')
     storage_category_id = fields.Many2one(related='location_id.storage_category_id')
     cyclic_inventory_frequency = fields.Integer(related='location_id.cyclic_inventory_frequency')

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -20,7 +20,7 @@ class StockValuationLayer(models.Model):
     _rec_name = 'product_id'
 
     company_id = fields.Many2one('res.company', 'Company', readonly=True, required=True)
-    product_id = fields.Many2one('product.product', 'Product', readonly=True, required=True, check_company=True, auto_join=True, index=True)
+    product_id = fields.Many2one('product.product', 'Product', readonly=True, required=True, check_company=True, bypass_search_access=True, index=True)
     categ_id = fields.Many2one('product.category', related='product_id.categ_id')
     product_tmpl_id = fields.Many2one('product.template', related='product_id.product_tmpl_id')
     quantity = fields.Float('Quantity', readonly=True, digits='Product Unit')

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -28,7 +28,7 @@ class EventSponsor(models.Model):
     event_id = fields.Many2one('event.event', 'Event', required=True, index=True)
     sponsor_type_id = fields.Many2one(
         'event.sponsor.type', 'Sponsorship Level',
-        default=lambda self: self._default_sponsor_type_id(), required=True, auto_join=True)
+        default=lambda self: self._default_sponsor_type_id(), required=True, bypass_search_access=True)
     url = fields.Char('Sponsor Website', compute='_compute_url', readonly=False, store=True)
     sequence = fields.Integer('Sequence')
     active = fields.Boolean(default=True)
@@ -44,7 +44,7 @@ class EventSponsor(models.Model):
         readonly=False, store=True)
     show_on_ticket = fields.Boolean("Show on ticket", default=True)
     # contact information
-    partner_id = fields.Many2one('res.partner', 'Partner', required=True, auto_join=True)
+    partner_id = fields.Many2one('res.partner', 'Partner', required=True, bypass_search_access=True)
     partner_name = fields.Char('Name', related='partner_id.name')
     partner_email = fields.Char('Email', related='partner_id.email')
     partner_phone = fields.Char('Phone', related='partner_id.phone')

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -283,7 +283,7 @@ class ResPartner(models.Model):
         compute='_compute_company_type', inverse='_write_company_type')
     company_id: ResCompany = fields.Many2one('res.company', 'Company', index=True)
     color = fields.Integer(string='Color Index', default=0)
-    user_ids: ResUsers = fields.One2many('res.users', 'partner_id', string='Users', auto_join=True)
+    user_ids: ResUsers = fields.One2many('res.users', 'partner_id', string='Users', bypass_search_access=True)
     main_user_id: ResUsers = fields.Many2one(
         "res.users",
         string="Main User",

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -211,7 +211,7 @@ class ResUsers(models.Model):
             groups += default_group.implied_ids
         return groups
 
-    partner_id = fields.Many2one('res.partner', required=True, ondelete='restrict', auto_join=True, index=True,
+    partner_id = fields.Many2one('res.partner', required=True, ondelete='restrict', bypass_search_access=True, index=True,
         string='Related Partner', help='Partner-related data of the user')
     login = fields.Char(required=True, help="Used to log into the system")
     password = fields.Char(

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -281,7 +281,7 @@ class TestPartner(TransactionCaseWithUserDemo):
         self.assertEqual(partners[0][1], 'B Raoul chirurgiens-dentistes.fr', 'Incorrect partner returned, should be the first active')
 
     def test_name_search_with_user(self):
-        """ Check name_search on partner, especially with domain based on auto_join
+        """ Check name_search on partner, especially with domain based on bypass_search_access
         user_ids field. Check specific SQL of name_search correctly handle joined tables. """
         test_partner = self.env['res.partner'].create({'name': 'Vlad the Impaler'})
         test_user = self.env['res.users'].create({'name': 'Vlad the Impaler', 'login': 'vlad', 'email': 'vlad.the.impaler@example.com'})

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -1197,7 +1197,7 @@ class TestOrmAttachmentHost(models.Model):
     _description = 'Attachment Host'
 
     attachment_ids = fields.One2many(
-        'test_orm.attachment', 'res_id', auto_join=True,
+        'test_orm.attachment', 'res_id', bypass_search_access=True,
         domain=lambda self: [('res_model', '=', self._name)],
     )
 

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -230,10 +230,10 @@ class TestDomain(TransactionExpressionCase):
         res_search = self._search(Child, [('link_sibling_id', 'not any', [('quantity', '>', 5)])])
         self.assertEqual(res_search, parent_1.child_ids[1] + parent_2.child_ids)
 
-        # Check any/not any traversing auto_join Many2one
-        self.assertFalse(Child._fields['link_sibling_id'].auto_join)
-        self.patch(Child._fields['link_sibling_id'], 'auto_join', True)
-        self.assertTrue(Child._fields['link_sibling_id'].auto_join)
+        # Check any/not any traversing bypass_search_access Many2one
+        self.assertFalse(Child._fields['link_sibling_id'].bypass_search_access)
+        self.patch(Child._fields['link_sibling_id'], 'bypass_search_access', True)
+        self.assertTrue(Child._fields['link_sibling_id'].bypass_search_access)
 
         res_search = self._search(Child, [('link_sibling_id', 'any', [('quantity', '>', 5)])])
         self.assertEqual(res_search, parent_1.child_ids[0])
@@ -300,10 +300,10 @@ class TestDomain(TransactionExpressionCase):
         res_search = self._search(Parent, [('child_ids', 'not any', [('quantity', '=', 1)])])
         self.assertEqual(res_search, parent_2 + parent_3)
 
-        # Check any/not any traversing auto_join Many2one
-        self.assertFalse(Parent._fields['child_ids'].auto_join)
-        self.patch(Parent._fields['child_ids'], 'auto_join', True)
-        self.assertTrue(Parent._fields['child_ids'].auto_join)
+        # Check any/not any traversing bypass_search_access Many2one
+        self.assertFalse(Parent._fields['child_ids'].bypass_search_access)
+        self.patch(Parent._fields['child_ids'], 'bypass_search_access', True)
+        self.assertTrue(Parent._fields['child_ids'].bypass_search_access)
 
         res_search = self._search(Parent, [('child_ids', 'any', [('quantity', '=', 1)])])
         self.assertEqual(res_search, parent_1)
@@ -312,7 +312,7 @@ class TestDomain(TransactionExpressionCase):
         self.assertEqual(res_search, parent_2 + parent_3)
 
     def test_anys_many2many(self):
-        # auto_join + without
+        # bypass_search_access + without
         Child = self.env['test_orm.any.child']
 
         child_1, child_2, child_3 = Child.create([

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -4123,11 +4123,11 @@ class TestMany2oneReference(TransactionExpressionCase):
         foo = m.browse(1 if not ids[0] else (ids[0] + 1))
         self.assertTrue(foo.unlink())
 
-    def test_search_inverse_one2many_autojoin(self):
+    def test_search_inverse_one2many_bypass_search_access(self):
         record = self.env['test_orm.inverse_m2o_ref'].create({})
 
-        # the one2many field 'model_ids' should be auto_join=True
-        self.patch(type(record).model_ids, 'auto_join', True)
+        # the one2many field 'model_ids' should be bypass_search_access=True
+        self.patch(type(record).model_ids, 'bypass_search_access', True)
 
         # create a reference to record
         reference = self.env['test_orm.model_many2one_reference'].create({'res_id': record.id})

--- a/odoo/addons/test_orm/tests/test_search.py
+++ b/odoo/addons/test_orm/tests/test_search.py
@@ -82,8 +82,8 @@ class TestSubqueries(TransactionCase):
                     ('partner.phone', 'like', '01234'),
             ])
 
-    def test_or_autojoined_many2one_with_subfield(self):
-        self.patch(self.env['test_orm.multi']._fields['partner'], 'auto_join', True)
+    def test_or_bypass_access_many2one_with_subfield(self):
+        self.patch(self.env['test_orm.multi']._fields['partner'], 'bypass_search_access', True)
         with self.assertQueries(["""
             SELECT "test_orm_multi"."id"
             FROM "test_orm_multi"
@@ -101,8 +101,8 @@ class TestSubqueries(TransactionCase):
                     ('partner.phone', 'like', '01234'),
             ])
 
-    def test_not_or_autojoined_many2one_with_subfield(self):
-        self.patch(self.env['test_orm.multi']._fields['partner'], 'auto_join', True)
+    def test_not_or_bypass_access_many2one_with_subfield(self):
+        self.patch(self.env['test_orm.multi']._fields['partner'], 'bypass_search_access', True)
         with self.assertQueries(["""
             SELECT "test_orm_multi"."id"
             FROM "test_orm_multi"
@@ -1594,8 +1594,8 @@ class TestFlushSearch(TransactionCase):
             self.belgium.name = "Belgique"
             self.model.search([('country_id.name', 'like', 'foo')], order='id')
 
-    def test_flush_auto_join_field_in_domain(self):
-        self.patch(self.env.registry['test_orm.city'].country_id, 'auto_join', True)
+    def test_flush_bypass_access_field_in_domain(self):
+        self.patch(self.env.registry['test_orm.city'].country_id, 'bypass_search_access', True)
 
         with self.assertQueries(['''
             UPDATE "test_orm_city"

--- a/odoo/addons/test_read_group/tests/test_private_read_group.py
+++ b/odoo/addons/test_read_group/tests/test_private_read_group.py
@@ -779,8 +779,8 @@ class TestPrivateReadGroup(common.TransactionCase):
             )],
         )
 
-    def test_auto_join(self):
-        """ Test what happens when grouping with a domain using a one2many field with auto_join. """
+    def test_field_bypass_search_access(self):
+        """ Test what happens when grouping with a domain using a one2many field with bypass_search_access. """
         model = self.env['test_read_group.order']
         records = model.create([{
             'line_ids': [Command.create({'value': 1}), Command.create({'value': 2})],
@@ -801,8 +801,8 @@ class TestPrivateReadGroup(common.TransactionCase):
         result2 = model._read_group(domain2, aggregates=['__count'])
         self.assertEqual(result1, [(2,)])
 
-        # same requests, with auto_join
-        self.patch(type(model).line_ids, 'auto_join', True)
+        # same requests, with bypass_search_access
+        self.patch(type(model).line_ids, 'bypass_search_access', True)
 
         self.assertEqual(len(model.search(domain1)), 2)
         self.assertEqual(len(model.search(domain2)), 2)

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -92,7 +92,7 @@ This should be supported in the framework at all levels.
 - `any` works for relational fields and `id` to check if a record matches
   the condition
   - if value is SQL or Query, see `any!`
-  - if auto_join is set on the field, see `any!`
+  - if bypass_search_access is set on the field, see `any!`
   - if value is a Domain for a many2one (or `id`),
     _search with active_test=False
   - if value is a Domain for a x2many,
@@ -926,7 +926,7 @@ class DomainCondition(Domain):
 
         if level == OptimizationLevel.FULL:
             # resolve inherited fields
-            # inherits implies both Field.delegate=True and Field.auto_join=True
+            # inherits implies both Field.delegate=True and Field.bypass_search_access=True
             # so no additional permissions will be added by the 'any' operator below
             if field.inherited:
                 parent_fname = field.related.split('.')[0]

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -36,7 +36,7 @@ class _Relational(Field[BaseModel]):
     comodel_name: str
     domain: DomainType = []         # domain for searching values
     context: ContextType = {}       # context for searching values
-    auto_join: bool = False         # whether joins are generated upon search
+    bypass_search_access: bool = False  # whether access rights are bypassed on the comodel
     check_company: bool = False
 
     def __get__(self, records: BaseModel, owner=None):
@@ -211,8 +211,8 @@ class Many2one(_Relational):
     :param str ondelete: what to do when the referred record is deleted;
         possible values are: ``'set null'``, ``'restrict'``, ``'cascade'``
 
-    :param bool auto_join: whether JOINs are generated upon search through that
-        field (default: ``False``)
+    :param bool bypass_search_access: whether access rights are bypassed on the
+        comodel (default: ``False``)
 
     :param bool delegate: set it to ``True`` to make fields of the target model
         accessible from the current model (corresponds to ``_inherits``)
@@ -239,8 +239,8 @@ class Many2one(_Relational):
         # determine self.delegate
         if name in model_class._inherits.values():
             self.delegate = True
-            # self.delegate implies self.auto_join
-            self.auto_join = True
+            # self.delegate implies self.bypass_search_access
+            self.bypass_search_access = True
         elif self.delegate:
             comodel_name = self.comodel_name or 'comodel_name'
             raise TypeError((
@@ -486,7 +486,7 @@ class Many2one(_Relational):
 
         # value is a Domain
 
-        if self.auto_join or operator in ('any!', 'not any!'):
+        if self.bypass_search_access or operator in ('any!', 'not any!'):
             comodel, coalias = self.join(model, alias, query)
 
             sql = value._to_sql(comodel, coalias, query)
@@ -794,7 +794,7 @@ class _RelationalMulti(_Relational):
         if isinstance(value, Domain):
             domain = value & field_domain
             comodel = comodel.with_context(**self.context)
-            bypass_access = self.auto_join or operator in ('any!', 'not any!')
+            bypass_access = self.bypass_search_access or operator in ('any!', 'not any!')
             query = comodel._search(domain, bypass_access=bypass_access)
             assert isinstance(query, Query)
             return query
@@ -828,8 +828,8 @@ class One2many(_RelationalMulti):
     :param dict context: an optional context to use on the client side when
         handling that field
 
-    :param bool auto_join: whether JOINs are generated upon search through that
-        field (default: ``False``)
+    :param bool bypass_search_access: whether access rights are bypassed on the
+        comodel (default: ``False``)
 
     The attributes ``comodel_name`` and ``inverse_name`` are mandatory except in
     the case of related fields or field extensions.
@@ -1222,8 +1222,8 @@ class Many2many(_RelationalMulti):
     def __init__(self, comodel_name: str | Sentinel = SENTINEL, relation: str | Sentinel = SENTINEL,
                  column1: str | Sentinel = SENTINEL, column2: str | Sentinel = SENTINEL,
                  string: str | Sentinel = SENTINEL, **kwargs):
-        if 'auto_join' in kwargs:
-            raise NotImplementedError("auto_join is not supported on Many2many fields")
+        if 'bypass_search_access' in kwargs:
+            raise NotImplementedError("bypass_search_access is not supported on Many2many fields")
         super().__init__(
             comodel_name=comodel_name,
             relation=relation,
@@ -1644,7 +1644,7 @@ class Many2many(_RelationalMulti):
             ])
 
     def _condition_to_sql_relational(self, model: BaseModel, alias: str, exists: bool, coquery: Query, query: Query) -> SQL:
-        assert not self.auto_join, f"auto_join not implemented for many2many fields ({self})"
+        assert not self.bypass_search_access, f"bypass_search_access not implemented for many2many fields ({self})"
         if coquery.is_empty():
             return SQL("FALSE") if exists else SQL("TRUE")
         rel_table, rel_id1, rel_id2 = self.relation, self.column1, self.column2


### PR DESCRIPTION
`auto_join` was introduced over a decade ago to force the ORM to generate a LEFT JOIN which also bypasses applying security checks on the comodel. It was introduced to improve performance: no security checks and a LEFT JOIN contribute to a faster query.

The main feature is actually bypassing checking access. Thus, we rename the attribute to reflect this. The generation of SQL still uses LEFT JOIN when access checks are bypassed as it often results in faster queries.

odoo/enterprise#90508

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
