### PR TITLE
[IMP] account: tax details rounded total view

### DIFF
--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -223,7 +223,13 @@ export function formatFloat(value, options = {}) {
     } else {
         precision = 2;
     }
-    const formatted = value.toFixed(precision).split(".");
+
+    // Round the value to precision before converting to string with `toFixed`.
+    // Even though `toFixed` can also round the value, it sometimes produces incorrect results like:
+    // * `-0.00` -> from `(-0.0001).toFixed(2)` (incorrect sign; should be `0.00`)
+    // * `0.01`  -> from `(0.015).toFixed(2)`   (incorrect rounding; should be `0.02`)
+    const roundedValue = roundDecimals(value, precision);
+    const formatted = roundedValue.toFixed(precision).split(".");
     formatted[0] = insertThousandsSep(formatted[0], thousandsSep, grouping);
     if (options.trailingZeros === false && formatted[1]) {
         formatted[1] = formatted[1].replace(/0+$/, "");


### PR DESCRIPTION
The tax totals view component rounds the value we got from python (in the javascript `formatFloat` function). However, it has a few weird quirks because of how the function we're currently using (`toFixed`):

- When rounding value like `-0.00000001` to 2 decimal precision, it resulted in `-0.00`, while a more sensical result would be `0.00`.

- Some value are rounded incorrectly: for ex: `0.015` -> `0.01`. (it should be `0.02`)

Solution- we use the appropriate rounding function separately before converting the value to string with `toFixed`. This way, `-0.001` will become just `0.00`, and `0.015` is rounded correctly to `0.02`.

task-4685953
