### PR TITLE
[FIX] point_of_sale: tranfer tour slow network

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.js
@@ -8,6 +8,7 @@ export class ActionpadWidget extends Component {
     static template = "point_of_sale.ActionpadWidget";
     static components = { SelectPartnerButton, BackButton };
     static props = {
+        order: Object,
         partner: { type: [Object, { value: null }], optional: true },
         onClickMore: { type: Function, optional: true },
         actionName: String,
@@ -24,6 +25,10 @@ export class ActionpadWidget extends Component {
     }
 
     get currentOrder() {
-        return this.pos.getOrder();
+        return this.props.order;
+    }
+
+    get partner() {
+        return this.currentOrder.getPartner();
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -6,7 +6,7 @@
             <div t-if="ui.isSmall" class="d-flex gap-2">
                 <BackButton t-if="!props.showActionButton and pos.showBackButton()" onClick="() => pos.onClickBackButton()"/>
                 <t t-if="props.onClickMore">
-                    <SelectPartnerButton partner="props.partner"/>
+                    <SelectPartnerButton partner="partner"/>
                     <button t-if="pos.config.use_presets and currentOrder"
                         class="btn btn-secondary btn-lg flex-shrink-0 border-0"
                         t-attf-class="{{`o_colorlist_item_color_${currentOrder.preset_id?.color}`}}"

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -15,6 +15,7 @@ export class ControlButtons extends Component {
         showRemainingButtons: { type: Boolean, optional: true },
         onClickMore: { type: Function, optional: true },
         close: { type: Function, optional: true },
+        order: { type: Object, optional: true },
     };
     static defaultProps = {
         showRemainingButtons: false,
@@ -26,10 +27,10 @@ export class ControlButtons extends Component {
         this.notification = useService("notification");
     }
     get partner() {
-        return this.pos.getOrder()?.getPartner();
+        return this.currentOrder?.getPartner();
     }
     get currentOrder() {
-        return this.pos.getOrder();
+        return this.props.order;
     }
     async clickFiscalPosition() {
         const currentFiscalPosition = this.currentOrder.fiscal_position_id;
@@ -135,10 +136,11 @@ export class ControlButtonsPopup extends Component {
     static components = { Dialog, ControlButtons };
     static template = xml`
         <Dialog bodyClass="'d-flex flex-column'" footer="false" title="'Actions'" t-on-click="props.close">
-            <ControlButtons showRemainingButtons="true" close="props.close"/>
+            <ControlButtons showRemainingButtons="true" close="props.close" order="props.order"/>
         </Dialog>
     `;
     static props = {
         close: Function,
+        order: { type: Object, optional: true },
     };
 }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -15,7 +15,7 @@ export class OrderSummary extends Component {
         Orderline,
         OrderDisplay,
     };
-    static props = {};
+    static props = { order: Object };
 
     setup() {
         super.setup();
@@ -30,7 +30,7 @@ export class OrderSummary extends Component {
     }
 
     get currentOrder() {
-        return this.pos.getOrder();
+        return this.props.order;
     }
 
     async editPackLotLines(line) {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -266,7 +266,9 @@ export class ProductScreen extends Component {
         this.numberBuffer.reset();
     }
     displayAllControlPopup() {
-        this.dialog.add(ControlButtonsPopup);
+        this.dialog.add(ControlButtonsPopup, {
+            order: this.currentOrder,
+        });
     }
     get selectedOrderlineQuantity() {
         return this.currentOrder.getSelectedOrderline()?.getQuantityStr();

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -4,15 +4,15 @@
         <div class="product-screen d-flex h-100">
             <div t-att-class="{'flex-grow-1 w-100 mw-100': ui.isSmall, 'd-none': ui.isSmall and pos.mobile_pane !== 'left'}"
                 class="leftpane d-flex flex-column pb-2 border-end bg-white">
-                <OrderSummary />
+                <OrderSummary order="currentOrder"/>
                 <div class="pads px-2">
                     <div class="control-buttons d-flex justify-content-between gap-2 w-100 py-2">
-                        <ControlButtons t-if="!ui.isSmall" onClickMore.bind="displayAllControlPopup"/>
+                        <ControlButtons t-if="!ui.isSmall" onClickMore.bind="displayAllControlPopup" order="currentOrder"/>
                     </div>
                     <div class="subpads d-flex flex-column gap-2">
                         <Numpad t-if="!currentOrder?.isEmpty() and pos.getOrder()?.uiState.selected_orderline_uuid" class="'d-grid'" buttons="getNumpadButtons()" onClick.bind="onNumpadClick"/>
                         <ActionpadWidget 
-                            partner="currentOrder?.getPartner()" 
+                            order="currentOrder"
                             onClickMore.bind="displayAllControlPopup"
                             actionName.translate="Payment"
                             actionToTrigger="() => pos.pay()"

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -186,7 +186,7 @@
                                     <Numpad class="'pb-2'" buttons="getNumpadButtons()"/>
                                         <ActionpadWidget
                                             t-if="this.pos.cashier._role !== 'minimal'"
-                                            partner="getSelectedOrder()?.getPartner()"
+                                            order="_selectedSyncedOrder"
                                             actionName.translate="Refund"
                                             actionToTrigger.bind="onDoRefund"
                                         />


### PR DESCRIPTION
Steps to reproduce:
- open a pos with network set to 3g
- trasfert a table
- short after the product screen is shown the curent order is unset and Direct Sale or the original table is shown.

Issue:
When the tranfert is done, it opens the floor_screen. When the floor_screen is mounted it calls resetTable that will call syncAllOrders on the current state (before the table is changed) of the order inside the unsetTable function. If the network is slow, the resolve of the syncAllOrders will restore the old table. Also it would set the order to null after in the end of the resetTable function. Since all this happens after the product_screen is mounted it will rerender it's coponents with the no order / order table.

Fix:
Remove the syncAllOrders on the unsetTable when tranfer mode. Ensure that syncAllOrders is called in prepareOrderTransfer function if the dest table is empty. syncAllOrders is already called if the destination table has order when calling mergeOrder

This commit also ensure that subcomponents always receive a valid order prop, even when re-rendered independently. Since ProductScreen creates an order if none exists, passing it down explicitly guarantees consistency and avoids relying getting the order with getOrder.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
