### PR TITLE
[FIX] sale_loyalty: round lines points based on currency precision

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -534,7 +534,7 @@ class SaleOrder(models.Model):
         if reward.discount_mode == 'per_point' and not reward.clear_wallet:
             # Calculate the actual point cost if the cost is per point
             converted_discount = self.currency_id._convert(min(max_discount, discountable), reward_currency, self.company_id, fields.Date.today())
-            point_cost = converted_discount / reward.discount
+            point_cost = coupon.currency_id.round(converted_discount / reward.discount)
 
         if reward_program.is_payment_program:  # Gift card / eWallet
             reward_line_values = {

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -1818,6 +1818,42 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertEqual(order.order_line[1].tax_id, tax_15pc_excl)
         self.assertEqual(order.amount_total, 156.0, '140$ + 15% - 5$ = 156$')
 
+    def test_rounded_used_loyalty_points(self):
+        """Check that the loyalty points used in a reward are rounded according to the currency."""
+        loyalty_program = self.env['loyalty.program'].create({
+            'name': 'Test loyalty card',
+            'program_type': 'loyalty',
+            'trigger': 'auto',
+            'applies_on': 'both',
+            'rule_ids': [Command.set([])],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount_mode': 'per_point',
+                'discount': 0.03,
+                'discount_applicability': 'order',
+                'required_points': 1,
+            })],
+        })
+        order = self.empty_order
+        self.env['loyalty.card'].create([{
+            'program_id': loyalty_program.id,
+            'partner_id': order.partner_id.id,
+            'points': 3030,
+        }])
+        product_a = self._create_product(
+            name='product_a',
+            lst_price=3000.0,
+            taxes_id=[Command.set([])],
+        )
+        order.order_line = [Command.create({'product_id': product_a.id})]
+
+        coupon = loyalty_program.coupon_ids[0]
+        order._apply_program_reward(loyalty_program.reward_ids[0], coupon)
+        order.action_confirm()
+        self.assertEqual(len(order.order_line), 2, 'Promotion should add 1 line')
+        used_points = coupon.history_ids[0].used
+        self.assertEqual(used_points, coupon.currency_id.round(used_points))
+
     def test_apply_order_and_specific_discounts(self):
         """Ensure you can apply a full-order discount, and then a product-specific discount."""
         order_program, specific_program = self.env['loyalty.program'].create([


### PR DESCRIPTION
## Version
18.0+

## Issue
A slightly higher number of loyalty points might be used when python division can't be precise enough.

## Steps to reproduce
- Create a new Discount & Loyalty program:
  - Program Type: Loyalty Cards;
  - Conditional rules: None;
  - Rewards: 1:
    - Reward Type: Discount;
    - Discount: 0.03$ per point on Order.
- Create a new Loyalty Card for any partner (remember which one):
  - Change the points balance for 3030.
- Create a new Quotation for the previously selected partner as customer:
  - Add a product:
    - Use any product;
    - Quantity: 1;
    - Unit Price: 3000.0;
    - Taxes: None.
- Apply the Reward and Confirm the SO;
- Check Loyalty Card's details at the bottom of the SO.

opw-4928963