### PR TITLE
[FIX] sale_project_stock: fix TestSaleProjectStockProfitability class

### DIFF
--- a/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
+++ b/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
@@ -2,11 +2,12 @@
 
 from odoo import Command, fields
 from odoo.addons.sale_project.tests.test_project_profitability import TestProjectProfitabilityCommon
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
 from odoo.tests.common import tagged
 
 
 @tagged("post_install", "-at_install")
-class TestSaleProjectStockProfitability(TestProjectProfitabilityCommon):
+class TestSaleProjectStockProfitability(TestProjectProfitabilityCommon, ValuationReconciliationTestCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
This problem was introduced with [203936](https://github.com/odoo/odoo/pull/203936/commits/a6bde40096da2e16d58b9dcc300c607b40633038)

The test `test_report_invoice_items_anglo_saxon_automatic_valuation` throws an error because a stock input account cannot be found for the product avco product. This breaks the class `TestSaleProjectStockProfitability`in the 17.0 No demo build.

Runbot - [229892](https://runbot.odoo.com/odoo/runbot.build.error/229892)