### PR TITLE
[IMP] core: 'expr' operator 

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -88,7 +88,7 @@ class MailComposeMessage(models.TransientModel):
         'mail.message', 'Parent Message', ondelete='set null')
     template_id = fields.Many2one(
         'mail.template', 'Use template',
-        domain="[('model', '=', model), '|', ('user_id','=', False), ('user_id', '=', uid)]"
+        domain="[('model', '=', model), '|', ('user_id','=', False), ('user_id', 'expr', 'user')]"
     )
     attachment_ids = fields.Many2many(
         'ir.attachment', 'mail_compose_message_ir_attachments_rel',

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -212,7 +212,7 @@ class ProjectTask(models.Model):
     # See project_task_stage_personal.py for the model defininition
     personal_stage_type_ids = fields.Many2many('project.task.type', 'project_task_user_rel', column1='task_id', column2='stage_id',
         ondelete='restrict', group_expand='_read_group_personal_stage_type_ids', copy=False,
-        domain="[('user_id', '=', uid)]", string='Personal Stages', export_string_translation=False)
+        domain="[('user_id', 'expr', 'user')]", string='Personal Stages', export_string_translation=False)
     # Personal Stage computed from the user
     personal_stage_id = fields.Many2one('project.task.stage.personal', string='Personal Stage State', compute_sudo=False,
         compute='_compute_personal_stage_id',
@@ -222,7 +222,7 @@ class ProjectTask(models.Model):
     personal_stage_type_id = fields.Many2one('project.task.type', string='Personal Stage',
         related='personal_stage_id.stage_id',
         readonly=False, store=False,
-        help="The current user's personal task stage.", domain="[('user_id', '=', uid)]",
+        help="The current user's personal task stage.", domain="[('user_id', 'expr', 'user')]",
         group_expand='_read_group_personal_stage_type_ids')
     partner_id = fields.Many2one('res.partner',
         string='Customer', recursive=True, tracking=True, compute='_compute_partner_id', store=True, readonly=False, index='btree_not_null',

--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -19,7 +19,7 @@ class SpreadsheetDashboard(models.Model):
     group_ids = fields.Many2many('res.groups', default=lambda self: self.env.ref('base.group_user'))
     favorite_user_ids = fields.Many2many(
         'res.users',
-        domain=lambda self: [('id', '=', self.env.uid)],
+        domain=[('id', 'expr', 'user')],
         string='Favorite Users',
         help='Users who have favorited this dashboard'
     )

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -12,6 +12,7 @@ class ResUsers(models.Model):
     _inherit = 'res.users'
 
     website_id = fields.Many2one('website', related='partner_id.website_id', store=True, related_sudo=False, readonly=False)
+    current_website_id = fields.Many2one('website', "Current Website", compute='_compute_current_website_id')
 
     _login_key = models.Constraint(
         'unique (login, website_id)',
@@ -105,3 +106,12 @@ class ResUsers(models.Model):
     # the required method.
     def website_publish_button(self):
         return self.partner_id.website_publish_button()
+
+    @api.depends_context('website_id')
+    def _compute_current_website_id(self):
+        website = self.env['website'].get_current_website(fallback=False)
+        if website:
+            self.current_website_id = website
+            return
+        for rec in self:
+            rec.current_website_id = self.website_id or website.get_current_website(fallback=True)

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -296,7 +296,7 @@
                     <field name="channel_id"/>
                     <field name="user_id"/>
                     <field name="tag_ids"/>
-                    <filter name="filter_user_id_uid" string="My Content" domain="[('user_id', '=', uid)]"/>
+                    <filter name="filter_user_id_uid" string="My Content" domain="[('user_id', 'expr', 'user')]"/>
                     <separator/>
                     <filter name="published" string="Published" domain="[('is_published', '=', True)]"/>
                     <filter name="not_published" string="Waiting for validation" domain="[('is_published', '=', False)]"/>

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -293,8 +293,17 @@ class ResPartner(models.Model):
         'res.partner', string='Commercial Entity',
         compute='_compute_commercial_partner', store=True,
         recursive=True, index=True)
-    commercial_company_name = fields.Char('Company Name Entity', related='commercial_partner_id.name',
-                                          store=True)
+    commercial_company_name = fields.Char(
+        'Company Name Entity',
+        related='commercial_partner_id.name',
+        store=True)
+    commercial_descendant_ids = fields.Many2many(
+        'res.partner', string="Commercial Descdendants",
+        compute='_compute_commercial_descdendants',
+        recursive=True,
+        context={'active_test': False},
+        help="All contacts under the commercial entity",
+    )
     barcode = fields.Char(help="Use a barcode to identify this contact.", copy=False, company_dependent=True)
 
     # hack to allow using plain browse record in qweb views, and used in ir.qweb.field.contact
@@ -508,6 +517,15 @@ class ResPartner(models.Model):
                 partner.commercial_partner_id = partner
             else:
                 partner.commercial_partner_id = partner.parent_id.commercial_partner_id
+
+    @api.depends('commercial_partner_id.child_ids', 'child_ids')
+    def _compute_commercial_descdendants(self):
+        for company, partners in self.grouped('commercial_partner_id').items():
+            descendants = to_check = company
+            while to_check:
+                to_check = to_check.child_ids
+                descendants |= to_check
+            partners.commercial_descendant_ids = descendants
 
     def _compute_company_registry(self):
         # exists to allow overrides

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -45,7 +45,7 @@
             <field name="name">self user write access</field>
             <field name="model_id" ref="model_res_partner"/>
             <field name="groups" eval="[Command.set([ref('base.group_user')])]"/>
-            <field name="domain_force">[('id', '=', user.partner_id.id)]</field>
+            <field name="domain_force">[('id', 'expr', 'user.partner_id')]</field>
             <field name="perm_read" eval="False"/> <!-- read: already handled by commercial partner -->
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="False"/>
@@ -55,7 +55,7 @@
         <record model="ir.rule" id="res_partner_portal_public_rule">
             <field name="name">res_partner: portal/public: read access on my commercial partner</field>
             <field name="model_id" ref="base.model_res_partner"/>
-            <field name="domain_force">[('id', 'child_of', user.commercial_partner_id.id)]</field>
+            <field name="domain_force">[('id', 'expr', 'user.commercial_descendant_ids')]</field>
             <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
             <field name="perm_create" eval="False"/>
             <field name="perm_unlink" eval="False"/>
@@ -120,19 +120,20 @@
         <record id="res_partner_bank_rule" model="ir.rule">
             <field name="name">Partner bank company rule</field>
             <field name="model_id" ref="model_res_partner_bank"/>
-            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'expr', 'companies')]</field>
         </record>
 
         <record id="res_currency_rate_rule" model="ir.rule">
             <field name="name">multi-company currency rate rule</field>
             <field name="model_id" ref="model_res_currency_rate"/>
+            <!-- XXX expr to get all parents-->
             <field name="domain_force">['|', ('company_id', 'parent_of', company_ids), ('company_id', '=', False)]</field>
         </record>
 
         <record id="change_password_rule" model="ir.rule">
             <field name="name">change user password rule</field>
             <field name="model_id" ref="model_change_password_user"/>
-            <field name="domain_force">[('create_uid', '=', user.id)]</field>
+            <field name="domain_force">[('create_uid', 'expr', 'user')]</field>
         </record>
 
         <!-- Restrict modifications on ir.filters to owner only -->
@@ -161,7 +162,7 @@
         <record id="ir_filters_portal_public_rule" model="ir.rule">
             <field name="name">ir.filter: portal/public</field>
             <field name="model_id" ref="model_ir_filters"/>
-            <field name="domain_force">[('user_ids', 'in', user.ids)]</field>
+            <field name="domain_force">[('user_ids', 'expr', 'user')]</field>
             <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
         </record>
 
@@ -171,7 +172,7 @@
             <field name="model_id" ref="model_res_company"/>
             <field eval="False" name="global"/>
             <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
-            <field name="domain_force">[('id','in', company_ids)]</field>
+            <field name="domain_force">[('id', 'expr', 'companies')]</field>
         </record>
         <record id="res_company_rule_erp_manager" model="ir.rule">
             <field name="name">company rule erp manager</field>
@@ -228,7 +229,7 @@
             <field name="name">portal user access</field>
             <field name="model_id" ref="model_res_users"/>
             <field name="groups" eval="[Command.set([ref('base.group_portal')])]"/>
-            <field name="domain_force">[('commercial_partner_id', '=', user.commercial_partner_id.id)]</field>
+            <field name="domain_force">[('commercial_partner_id', 'expr', 'user.commercial_partner_id')]</field>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="False"/>
             <field name="perm_create" eval="False"/>

--- a/odoo/addons/base/views/ir_attachment_views.xml
+++ b/odoo/addons/base/views/ir_attachment_views.xml
@@ -68,7 +68,7 @@
                     <field name="create_date"/>
                     <filter name="my_documents_filter"
                         string="My Document(s)"
-                        domain="[('create_uid','=',uid)]"
+                        domain="[('create_uid','expr','user')]"
                         help="Filter on my documents"/>
                     <filter name="url_filter" string="URL" domain="[('type', '=', 'url')]"/>
                     <filter name="binary_filter" string="Stored" domain="[('type', '=', 'binary')]"/>

--- a/odoo/addons/base/views/ir_filters_views.xml
+++ b/odoo/addons/base/views/ir_filters_views.xml
@@ -61,7 +61,7 @@
                 <search string="Filters">
                     <field name="name" string="Filter Name"/>
                     <filter string="Global" domain="[('user_ids','=',False)]" name="shared" help="Filters shared with all users"/>
-                    <filter string="My filters" domain="[('user_ids','in',[uid])]" name="my_filters" help="Filters shared with myself"/>
+                    <filter string="My filters" domain="[('user_ids', 'expr', 'user')]" name="my_filters" help="Filters shared with myself"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group>

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -59,11 +59,13 @@ import operator
 import types
 import typing
 import warnings
+from collections.abc import Mapping
 from datetime import date, datetime, time, timedelta, timezone, UTC
 
 from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.tools import SQL, OrderedSet, classproperty, partition, str2bool
 from odoo.tools.date_utils import parse_date, parse_iso_date
+from odoo.tools.safe_eval import expr_eval
 from .identifiers import NewId
 from .query import Query, TableSQL
 from .utils import COLLECTION_TYPES, parse_field_expr
@@ -1888,59 +1890,61 @@ def _operator_parent_of_domain(comodel: BaseModel, parent):
     return parent_ids
 
 
+class ExprContext(Mapping):
+    def __init__(self, model: BaseModel):
+        self.env = model.env
+
+    def __getitem__(self, key):
+        env = self.env
+        match key:
+            case 'user':
+                value = env.user
+            case 'company':
+                value = env.company
+            case 'companies':
+                value = env.companies
+            case 'partner_id':
+                value = env.user.partner_id
+            case 'groups':
+                value = env.user.all_group_ids
+            case 'context':
+                return env.context
+            case _:
+                raise KeyError(key)
+        return value.with_env(env)
+
+    def __iter__(self):
+        return iter(('user', 'company', 'companies', 'partner_id', 'groups', 'context'))
+
+    def __len__(self):
+        return 6
+
+
 @operator_optimization(['expr'], OptimizationLevel.DYNAMIC_VALUES)
 def _operator_expr_eval(condition, model):
     """Evaluate a dynamic value given by the expression.
 
-    The value can be a `str` of `list[str]`. We search for the first expression
-    that will have a non-falsy value.
-
-    - "{rec}" or "{rec}.{value}" where rec is user, company, companies,
-      partner_id, groups are recordsets on which we can map a value;
-      for example "user.name" is `in user.mapped('name')`
-    - "context.{value}" read a value from env.context
+    The value is evaluated using `expr_eval` with context containing:
+    user, company, companies, partner_id, groups, context.
     """
-    env = model.env
-    expr_value = condition.value
-    # TODO alternative use expr_eval (if it has name access)
-    if isinstance(expr_value, str):
-        expr_value = [expr_value]
-    elif not expr_value:
-        condition._raise(f"Invalid expression: {expr_value!r}")
-    for expr in expr_value:
-        if not isinstance(expr, str):
-            condition._raise(f"Invalid expression: {expr!r}")
-        env_name, is_mapped, path = expr.partition('.')
-        if env_name == 'user':
-            value = env.user
-        elif env_name == 'company':
-            value = env.company
-        elif env_name == 'companies':
-            value = env.companies
-        elif env_name == 'partner_id':
-            value = env.user.partner_id
-        elif env_name == 'groups':
-            value = env.user.all_group_ids
-        elif env_name == 'context':
-            value = env.context.get(path, ())
-            is_mapped = False  # the path is resolved entirely
-            if not isinstance(value, COLLECTION_TYPES):
-                value = (value,) if value else ()
-        else:
-            condition._raise(f"Invalid expression: {expr!r}")
-
-        if is_mapped:
-            # map the values using the environment to avoid reading in sudo
-            value = value.with_env(env).mapped(path)
-        if any(value):
-            break
-
+    expr = condition.value
+    if not expr or not isinstance(expr, str):
+        condition._raise(f"Invalid expression: {expr!r}")
+    try:
+        value = expr_eval(expr, context=ExprContext(model))
+    except Exception:  # noqa: BLE001
+        condition._raise(f"Invalid expression: {expr!r}")
+        assert False, 'unreachable'
+    if not value:
+        return Domain.FALSE
     from .models import BaseModel  # noqa: PLC0415
     if isinstance(value, BaseModel):
         field = condition._field(model)
         if (field.model_name if field.name == 'id' else field.comodel_name) != value._name:
             condition._raise(f"Cannot compare {field} and {value}")
         value = value.ids
+    elif not isinstance(value, COLLECTION_TYPES):
+        value = [value]
     return DomainCondition(condition.field_expr, 'in', value)
 
 

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1888,6 +1888,62 @@ def _operator_parent_of_domain(comodel: BaseModel, parent):
     return parent_ids
 
 
+@operator_optimization(['expr'], OptimizationLevel.DYNAMIC_VALUES)
+def _operator_expr_eval(condition, model):
+    """Evaluate a dynamic value given by the expression.
+
+    The value can be a `str` of `list[str]`. We search for the first expression
+    that will have a non-falsy value.
+
+    - "{rec}" or "{rec}.{value}" where rec is user, company, companies,
+      partner_id, groups are recordsets on which we can map a value;
+      for example "user.name" is `in user.mapped('name')`
+    - "context.{value}" read a value from env.context
+    """
+    env = model.env
+    expr_value = condition.value
+    # TODO alternative use expr_eval (if it has name access)
+    if isinstance(expr_value, str):
+        expr_value = [expr_value]
+    elif not expr_value:
+        condition._raise(f"Invalid expression: {expr_value!r}")
+    for expr in expr_value:
+        if not isinstance(expr, str):
+            condition._raise(f"Invalid expression: {expr!r}")
+        env_name, is_mapped, path = expr.partition('.')
+        if env_name == 'user':
+            value = env.user
+        elif env_name == 'company':
+            value = env.company
+        elif env_name == 'companies':
+            value = env.companies
+        elif env_name == 'partner_id':
+            value = env.user.partner_id
+        elif env_name == 'groups':
+            value = env.user.all_group_ids
+        elif env_name == 'context':
+            value = env.context.get(path, ())
+            is_mapped = False  # the path is resolved entirely
+            if not isinstance(value, COLLECTION_TYPES):
+                value = (value,) if value else ()
+        else:
+            condition._raise(f"Invalid expression: {expr!r}")
+
+        if is_mapped:
+            # map the values using the environment to avoid reading in sudo
+            value = value.with_env(env).mapped(path)
+        if any(value):
+            break
+
+    from .models import BaseModel  # noqa: PLC0415
+    if isinstance(value, BaseModel):
+        field = condition._field(model)
+        if (field.model_name if field.name == 'id' else field.comodel_name) != value._name:
+            condition._raise(f"Cannot compare {field} and {value}")
+        value = value.ids
+    return DomainCondition(condition.field_expr, 'in', value)
+
+
 @operator_optimization(['access'], level=OptimizationLevel.DYNAMIC_VALUES)
 def _operator_access_rule_domain(condition, model):
     operation = condition.value

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1901,10 +1901,10 @@ def _operator_parent_of_domain(comodel: BaseModel, parent):
 
 class ExprContext(Mapping):
     def __init__(self, model: BaseModel):
-        self.env = model.env
+        self.model = model
 
     def __getitem__(self, key):
-        env = self.env
+        env = self.model.env
         match key:
             case 'user':
                 value = env.user
@@ -1920,15 +1920,17 @@ class ExprContext(Mapping):
                 value = env.website
             case 'context':
                 return env.context
+            case 'active':
+                return Domain(self.model._active_name, '=', True) if self.model._active_name else Domain.TRUE
             case _:
                 raise KeyError(key)
         return value.with_env(env)
 
     def __iter__(self):
-        return iter(('user', 'company', 'companies', 'partner_id', 'groups', 'website', 'context'))
+        return iter(('user', 'company', 'companies', 'partner_id', 'groups', 'website', 'context', 'active'))
 
     def __len__(self):
-        return 7
+        return 8
 
 
 @operator_optimization(['expr'], OptimizationLevel.DYNAMIC_VALUES)
@@ -1954,6 +1956,8 @@ def _operator_expr_eval(condition, model):
         if (field.model_name if field.name == 'id' else field.comodel_name) != value._name:
             condition._raise(f"Cannot compare {field} and {value}")
         value = value.ids
+    elif isinstance(value, Domain):
+        return DomainCondition(condition.field_expr, 'any', value)
     elif not isinstance(value, COLLECTION_TYPES):
         value = [value]
     return DomainCondition(condition.field_expr, 'in', value)

--- a/odoo/tools/safe_eval/expression.py
+++ b/odoo/tools/safe_eval/expression.py
@@ -6,6 +6,7 @@ access are needed.
 """
 import ast
 import operator
+from collections.abc import Mapping
 from types import NoneType
 from typing import Any
 
@@ -81,7 +82,7 @@ class _ExprEval(ast.NodeVisitor):
     """Evaluate supported expressions for `expr_eval`."""
     __slots__ = ("context",)
 
-    def __init__(self, context: dict[str, Any]):
+    def __init__(self, context: Mapping[str, Any]):
         self.context = context
 
     def visit_Expression(self, node):
@@ -190,7 +191,7 @@ class _ExprEval(ast.NodeVisitor):
         raise SyntaxError(f"Unsupported syntax: {type(node).__name__}")
 
 
-def expr_eval(expr: str, context: dict[str, Any] | None = None) -> Any:
+def expr_eval(expr: str, context: Mapping[str, Any] | None = None) -> Any:
     """Evaluate a restricted Python-like expression.
 
     Supported syntax includes literals, variables from ``context``,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Dynamic values implemented as a new operator.

Current behavior before PR:
```
('user_id', '=', uid)
('company_id', 'in', user.env.companies)
```

Desired behavior after PR is merged:
```
('user_id', 'expr', 'user')
('company_id', 'expr', 'companies')
```

task-4076815

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
