### PR TITLE
[FIX] hr_timesheet: fix employee domain in calendar view

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -340,7 +340,8 @@
                     <field name="project_id"/>
                     <field name="task_id" invisible="not task_id"/>
                     <field name="name"/>
-                    <field name="employee_id" avatar_field="avatar_128" filters="1" write_model="account.analytic.line.calendar.employee" write_field="employee_id" filter_field="checked"/>
+                    <field name="employee_id" avatar_field="avatar_128" filters="1" write_model="account.analytic.line.calendar.employee"
+                        write_field="employee_id" filter_field="checked" domain="[('company_id', 'in', allowed_company_ids + [False])]"/>
                 </calendar>
             </field>
         </record>


### PR DESCRIPTION
In the calendar view of timesheets, a domain is missing on the "Employees" filter. When clicking on "search more", an access error occurs. This PR adds the missing domain.

Task-4916289