### PR TITLE
[FIX] account: fix general section visibility in partner invoicing tab

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -244,9 +244,9 @@
                         <group>
                             <group string="General" name="general" groups="account.group_account_invoice,account.group_account_readonly">
                                 <field name="bank_ids" context="{'default_partner_id': id}" domain="[('partner_id','=', id)]" widget="many2many_tags_banks" options="{'color_field': 'color', 'allow_out_payment_field': 'allow_out_payment', 'edit_tags': True, 'no_search_more': True}"/>
-                                <field name="property_account_receivable_id" required="True"/>
-                                <field name="property_account_payable_id" required="True"/>
-                                <field name="autopost_bills" groups="account.group_account_invoice,account.group_account_readonly"/>
+                                <field name="property_account_receivable_id" required="True" groups="account.group_account_user"/>
+                                <field name="property_account_payable_id" required="True" groups="account.group_account_user"/>
+                                <field name="autopost_bills" groups="account.group_account_user"/>
                                 <field name="ignore_abnormal_invoice_amount" groups="base.group_no_one"/>
                                 <field name="ignore_abnormal_invoice_date" groups="base.group_no_one"/>
                             </group>


### PR DESCRIPTION
In this PR:
- Keep General section with bank field visible for basic invoicing users and hide account fields (receivable/payable/autopost) when only account or account_accountant is installed.
- Show account fields only when full accountant module is installed .

Task-4953707
