### PR TITLE
[IMP] sale_management,sale_project,sale_stock,stock,*: remove href=#

### DIFF
--- a/addons/sale_management/static/src/interactions/sale_update_line_button.js
+++ b/addons/sale_management/static/src/interactions/sale_update_line_button.js
@@ -6,7 +6,7 @@ import { rpc } from "@web/core/network/rpc";
 export class SaleUpdateLineButton extends Interaction {
     static selector = ".o_portal_sale_sidebar";
     dynamicContent = {
-        "a.js_update_line_json": {
+        "button.js_update_line_json": {
             "t-on-click.prevent.withTarget": this.onUpdateLineClick,
         },
         ".js_quantity": {

--- a/addons/sale_management/views/sale_portal_templates.xml
+++ b/addons/sale_management/views/sale_portal_templates.xml
@@ -5,16 +5,15 @@
         <div t-if="line._can_be_edited_on_portal()" class="d-inline-flex">
             <div class="input-group js_quantity_container pull-right">
                 <span class="d-print-none input-group-text d-none d-md-inline-block">
-                    <a
+                    <button
                         title="Remove one"
                         aria-label="Remove one"
-                        href="#"
-                        t-att-class="'opacity-50' if line.product_uom_qty == 0 else 'js_update_line_json'"
+                        t-att-class="'opacity-50 btn btn-link p-0' if line.product_uom_qty == 0 else 'js_update_line_json'"
                         t-att-data-line-id="line.id"
                         t-att-data-remove="True"
                     >
                         <span class="fa fa-minus"/>
-                    </a>
+                    </button>
                 </span>
                 <input
                     type="text"
@@ -23,15 +22,14 @@
                     t-att-value="int(line.product_uom_qty) or '0'"
                 />
                 <span class="d-print-none input-group-text d-none d-md-inline-block">
-                    <a
+                    <button
                         title="Add one"
                         aria-label="Add one"
-                        class="js_update_line_json"
-                        href="#"
+                        class="js_update_line_json btn btn-link p-0"
                         t-att-data-line-id="line.id"
                     >
                         <span class="fa fa-plus"/>
-                    </a>
+                    </button>
                 </span>
             </div>
             <div class="ms-1 align-self-center">

--- a/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/components/project_profitability_section.xml
@@ -12,16 +12,16 @@
                         </button>
                     </t>
                     <t t-esc="revenue_label" t-else=""/>
-                    <a
+                    <button
                         class="revenue_section btn btn-link my-n2 py-2 text-action"
-                        t-if="revenue.action" href="#"
+                        t-if="revenue.action"
                         t-on-click="() => this.props.onClick(revenue.action)"
                         t-att-class="{ 'ms-auto': env.isSmall, 'opacity-0': !env.isSmall and state.isFolded, 'opacity-100-hover': !env.isSmall }"
                         aria-label="Internal link"
                         data-tooltip="Internal link"
                     >
                         <i class="oi oi-arrow-right"/>
-                    </a>
+                    </button>
                 </div>
             </td>
             <td t-attf-class="text-end {{ revenue.invoiced + revenue.to_invoice === 0 ? 'text-500' : ''}}"><t t-esc="props.formatMonetary(revenue.invoiced + revenue.to_invoice)"/></td>
@@ -44,9 +44,9 @@
                             <tr t-foreach="sale_items" t-as="sale_item" t-key="sale_item.id">
                                 <t t-set="uom_name" t-value="sale_item.product_uom_id and sale_item.product_uom_id[1]"/>
                                 <td class="ps-4">
-                                    <a t-if="sale_item.action" href="#" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">
+                                    <button t-if="sale_item.action" class="btn btn-link fw-normal p-0 text-start" t-on-click="() => this.onSaleItemActionClick(sale_item.action)">
                                         <t t-esc="sale_item.display_name"/>
-                                    </a>
+                                    </button>
                                     <t t-else="" t-esc="sale_item.display_name"/>
                                 </td>
                                 <td class="text-end">

--- a/addons/sale_stock/static/src/xml/delay_alert.xml
+++ b/addons/sale_stock/static/src/xml/delay_alert.xml
@@ -2,7 +2,7 @@
     <div t-name="sale_stock.DelayAlertWidget" class="m-1">
         <p>The delivery
             <t t-foreach="props.late_elements" t-as="late_element" t-key="late_element.id">
-                <a t-esc="late_element.name" href="#" t-on-click="openElement" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
+                <button class="btn btn-link p-0 fw-normal" t-esc="late_element.name" t-on-click="openElement" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
             </t> will be late.
         </p>
     </div>

--- a/addons/stock/report/report_stock_reception.xml
+++ b/addons/stock/report/report_stock_reception.xml
@@ -39,7 +39,7 @@
         <field name="tag">reception_report</field>
         <field name="res_model">report.stock.report_reception</field>
     </record>
-
+    <!-- TODO: do we need to change this <a> tag to button for this template?  -->
     <template id="report_reception_body">
         <div class="o_report_reception justify-content-between">
             <div class="o_report_reception_header my-5">

--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
@@ -62,13 +62,13 @@
                         </t>
 
                         <span t-if="col and line.reference === col" t-att-class="!line.unfoldable ? 'o_stock_reports_nofoldable' : ''">
-                            <a class="o_stock_reports_web_action" href="#" t-on-click.prevent="() => this.onClickBoundLink(line)" t-esc="col"/>
+                            <button class="o_stock_reports_web_action btn btn-link p-0 fw-normal" t-on-click.prevent="() => this.onClickBoundLink(line)" t-esc="col"/>
                         </span>
                         <span t-elif="col and ((line.picking_type_code == 'incoming' and line.location_source === col) or (line.picking_type_code == 'outgoing' and line.location_destination === col))">
-                            <a class="o_stock_report_partner_action" href="#" t-on-click.prevent="() => this.onClickPartner(line)" t-esc="col"/>
+                            <button class="o_stock_report_partner_action btn btn-link p-0 fw-normal" t-on-click.prevent="() => this.onClickPartner(line)" t-esc="col"/>
                         </span>
                         <span t-elif="col and line.lot_name === col">
-                            <a class="o_stock_report_lot_action" href="#" t-on-click.prevent="() => this.onClickOpenLot(line)" t-esc="col"/>
+                            <button class="o_stock_report_lot_action btn btn-link p-0 fw-normal" t-on-click.prevent="() => this.onClickOpenLot(line)" t-esc="col"/>
                         </span>
                         <t t-elif="col" t-esc="col"/>
                     </td>

--- a/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
+++ b/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
@@ -14,7 +14,7 @@
                 <h1>
                     <t t-if="data.docs">
                         <div t-foreach="data.docs" t-as="doc" t-key="doc.id">
-                            <a href="#" t-on-click.prevent="() => this.onClickTitle(doc.id)" view-type="form" t-esc="doc.name"/>
+                            <button class="btn btn-link p-0 fs-1" t-on-click.prevent="() => this.onClickTitle(doc.id)" view-type="form" t-esc="doc.name"/>
                             <span t-esc="doc.display_state" t-attf-class="ms-1 align-text-top badge rounded-pill bg-opacity-50 {{ doc.state == 'done' ? 'bg-success' : 'bg-info' }}"/>
                         </div>
                     </t>

--- a/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.xml
+++ b/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.xml
@@ -6,12 +6,12 @@
             <tr class="bg-light">
                 <th>
                     <i t-if="props.source[0].priority == '1'" class="o_priority o_priority_star fa fa-star"/>
-                    <a href="#" t-on-click.prevent="() => this.onClickLink(props.source[0].model, props.source[0].id, 'form')" t-out="props.source[0].name"/>
+                    <button class="btn btn-link p-0" t-on-click.prevent="() => this.onClickLink(props.source[0].model, props.source[0].id, 'form')" t-out="props.source[0].name"/>
                     <span t-if="props.source.length > 1">
-                        (<a href="#" t-on-click.prevent="() => this.onClickLink(props.source[1].model, props.source[1].id, 'form')" t-out="props.source[1].name"/>)
+                        (<button class="btn btn-link p-0" t-on-click.prevent="() => this.onClickLink(props.source[1].model, props.source[1].id, 'form')" t-out="props.source[1].name"/>)
                     </span>
                     <span t-if="props.source[0].model == 'stock.picking' and props.source[0].partner_id">:
-                        <a href="#" t-on-click.prevent="() => this.onClickLink('res.partner', props.source[0].partner_id, 'form')" t-out="props.source[0].partner_name"/>
+                        <button class="btn btn-link p-0" t-on-click.prevent="() => this.onClickLink('res.partner', props.source[0].partner_id, 'form')" t-out="props.source[0].partner_name"/>
                     </span>
                 </th>
                 <th>Expected Delivery: <t t-esc="props.scheduledDate"/></th>

--- a/addons/stock/static/src/scss/stock_traceability_report.scss
+++ b/addons/stock/static/src/scss/stock_traceability_report.scss
@@ -51,12 +51,6 @@
     .o_stock_reports_nofoldable {
         margin-left: 17px;
     }
-    a.o_stock_report_lot_action  {
-        cursor: pointer;
-    }
-    a.o_stock_report_partner_action  {
-        cursor: pointer;
-    }
     .o_stock_reports_unfolded td + td {
         visibility: hidden;
     }

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -38,11 +38,10 @@
                             <td t-attf-rowspan="#{skip_row > 0 and skip_row}"/>
                             <td t-attf-rowspan="#{skip_row > 0 and skip_row}">
                                 <t t-if="line.document_in">
-                                    <a t-if="line.document_in"
-                                        href="#"
+                                    <button t-if="line.document_in"
                                         t-on-click.prevent="() => this.props.openView(line.document_in._name, 'form', line.document_in.id)"
                                         t-out="line.document_in.name"
-                                        class="fw-bold"/>
+                                        class="btn btn-link p-0 fw-bold"/>
                                     <span t-if="line.receipt_date">:
                                         <t t-out="_formatFloat(skip_row > 0 ? mergesLinesData[line_index].tot_qty : line.quantity)"/> <t t-out="line.uom_id.display_name"/> expected on <t t-out="line.receipt_date"/>
                                     </span>
@@ -70,12 +69,11 @@
                                 t-attf-class="o_priority o_priority_star me-1 fa fa-star#{line.move_out.picking_id.priority=='1' ? '' : '-o'}"
                                 t-on-click="() => this._onClickChangePriority('stock.picking', line.move_out.picking_id)"
                                 name="change_priority_link"/>
-                            <a t-if="line.document_out"
-                                href="#"
+                            <button t-if="line.document_out"
                                 t-attf-class="#{line.is_matched and 'fst-italic'}"
                                 t-on-click.prevent="() => this.props.openView(line.document_out._name, 'form', line.document_out.id)"
                                 t-out="line.document_out.name"
-                                class="fw-bold"/>
+                                class="btn btn-link p-0 fw-bold"/>
                         </td>
                         <td class="p-0 text-center border-start-0">
                             <t t-if="displayReserve(line)">

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.xml
@@ -6,14 +6,14 @@
                 <h3 name="product_name">
                     <t t-if="props.docs.product_templates">
                         <t t-foreach="props.docs.product_templates" t-as="product_template" t-key='product_template.id'>
-                            <a href="#"
+                            <button class="btn btn-link p-0 fs-3"
                             t-on-click.prevent="() => this.props.openView('product.template', 'form', product_template.id)"
                             t-out="product_template.display_name"/>
                         </t>
                     </t>
                     <t t-elif="props.docs.product_variants">
                         <t t-foreach="props.docs.product_variants" t-as="product_variant" t-key="product_variant.id">
-                            <a href="#"
+                            <button class="btn btn-link p-0 fs-3"
                             t-on-click.prevent="() => this.props.openView('product.product', 'form', product_variant.id)"
                             t-out="product_variant.display_name"/>
                         </t>
@@ -23,7 +23,7 @@
             <div class="row">
                 <div class="col-md-auto text-center" name="on_hand">
                     <div class="h3">
-                        <a href="#"
+                        <button class="btn btn-link p-0 fs-3 lh-1"
                             t-on-click.prevent="() => this._onClickInventory()"
                            t-out="_formatFloat(this.quantityOnHand)"/>
                     </div>

--- a/addons/stock/static/src/widgets/stock_rescheduling_popover.xml
+++ b/addons/stock/static/src/widgets/stock_rescheduling_popover.xml
@@ -5,7 +5,7 @@
         <h6>Planning Issue</h6>
         <p>Preceding operations
         <t t-foreach="props.late_elements" t-as="late_element" t-key="late_element.id">
-            <a t-out="late_element.name" t-on-click="openElement" href="#" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
+            <button class="btn btn-link p-0 fw-normal" t-out="late_element.name" t-on-click="openElement" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
         </t>
         planned on <t t-out="props.delay_alert_date"/>.</p>
     </div>

--- a/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
+++ b/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
@@ -4,7 +4,7 @@
         <xpath expr="//h3[@name='product_name']" position="after">
             <h6 t-if="() => env.user.has_group('stock.group_stock_manager')">
                 Value On Hand:
-                <a href="#"
+                <button class="btn btn-link p-0 lh-1 ms-1"
                    t-out="props.docs.value"
                    t-on-click.prevent="_onClickValuation"/>
             </h6>


### PR DESCRIPTION
*stock_account
We use `href=#` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href=#` and replaces it with the appropriate element or class to activate the <a> elements correctly.

Task-4380519

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
