### PR TITLE
[FIX] website_sale: make sortby field not-editable

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -898,7 +898,8 @@
                 <small class="d-none d-md-inline opacity-75"><t t-out="_sort_label"/>:</small>
                 <span class="d-none d-md-inline">
                     <t t-if="isSortingBy" t-out="isSortingBy[0][1]"/>
-                    <span t-else="" t-field="website.shop_default_sort"/>
+                    <!-- Prevent editing the content in website builder -->
+                    <span t-else="" t-out="dict(website_sale_sortable)[website.shop_default_sort]"/>
                 </span>
                 <i t-if="_icon_classes" t-attf-class="fa fa-sort {{_icon_classes}}" role="img"/>
             </a>


### PR DESCRIPTION
Step to reproduce:
- install website_sale
- open website -> shop page
- open editor, by clicking on `Edit` from right corner observation:
- you are now able to edit sort by element
- on saving, traceback is received.

Issue:
After odoo/odoo@9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2 , we know make every t-field [editable](https://github.com/odoo/odoo/blob/saas-18.4/addons/html_builder/static/src/core/setup_editor_plugin.js#L23-L36), from `SetupEditorPlugin.setup()` when editing a website. 
This makes `shop_default_sort` field editable, (which is a sequence field) and tries to update its name/value from `ir.qweb.field.selection()` ,raising  traceback on save()

Fix:
Use t-out instead of t-field, to prevent it from being editable

opw-4937025

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
