### PR TITLE
[FIX] web_editor: fix error when saving button changed to link

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -440,6 +440,9 @@ export class LinkTools extends Link {
         this._setSelectOption($target, true);
         this._updateOptionsUI();
         this._adaptPreview();
+        // Reactivate the snippet to update the Button snippet editor's visibility
+        // if the element type has changed (e.g., from button to link or vice versa).
+        this.props.wysiwyg.snippetsMenu.activateSnippet($(this.linkEl));
     }
     /**
      * Sets the border width on the link.


### PR DESCRIPTION
Problem:
Saving the button snippet after changing its type to a link throws an error because `snippet_key` is `undefined`.

Cause:
The button snippet editor should be disabled if the button is changed to a link. However, `updateOptionsUIVisibility` is only triggered on click events. In this case, the element type changes through the editor itself, not by clicking, so the UI isn't updated accordingly.

Solution:
Trigger a `click` event on the link element programmatically to call `updateOptionsUIVisibility` and hide the button snippet editor when the element is no longer a button.

Steps to reproduce:
- Drop a button snippet
- Click inside the button to edit
- Notice the Button snippet editor appears
- Change the type to "Link" instead of "Primary"
- The Button snippet editor is still visible
- Click the floppy disk icon (save) in the snippet editor -> A traceback occurs

opw-4936796

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
