### PR TITLE
[IMP] sql_db: replace now to reflect the time offset

### DIFF
--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -11,6 +11,7 @@ import traceback
 from xml.etree import ElementTree as ET
 import zipfile
 
+from datetime import datetime
 from psycopg2 import sql
 from pytz import country_timezones
 from functools import wraps
@@ -96,6 +97,30 @@ def _initialize_db(id, db_name, demo, lang, user_password, login='admin', countr
     except Exception as e:
         _logger.exception('CREATE DATABASE failed:')
 
+
+def _check_faketime_mode(db_name):
+    if os.getenv('ODOO_FAKETIME_TEST_MODE') and db_name != 'postgres':
+        try:
+            db = odoo.sql_db.db_connect(db_name)
+            with db.cursor() as cursor:
+                cursor.execute("SELECT (pg_catalog.now() AT TIME ZONE 'UTC');")
+                server_now = cursor.fetchone()[0]
+                time_offset = (datetime.now() - server_now).total_seconds()
+
+                cursor.execute("""
+                    CREATE OR REPLACE FUNCTION public.now()
+                        RETURNS timestamp with time zone AS $$
+                            SELECT pg_catalog.now() +  %s * interval '1 second';
+                        $$ LANGUAGE sql;
+                """, (int(time_offset), ))
+                cursor.execute("SELECT (now() AT TIME ZONE 'UTC');")
+                new_now = cursor.fetchone()[0]
+                _logger.info("Faketime mode, new cursor now is %s", new_now)
+                cursor.commit()
+        except psycopg2.Error as e:
+            _logger.warning("Unable to set fakedtimed NOW() : %s", e)
+
+
 def _create_empty_database(name):
     db = odoo.sql_db.db_connect('postgres')
     with closing(db.cursor()) as cr:
@@ -103,6 +128,7 @@ def _create_empty_database(name):
         cr.execute("SELECT datname FROM pg_database WHERE datname = %s",
                    (name,), log_exceptions=False)
         if cr.fetchall():
+            _check_faketime_mode(name)
             raise DatabaseExists("database %r already exists!" % (name,))
         else:
             # database-altering operations cannot be executed inside a transaction
@@ -132,6 +158,8 @@ def _create_empty_database(name):
                 cr.execute("ALTER FUNCTION unaccent(text) IMMUTABLE")
     except psycopg2.Error as e:
         _logger.warning("Unable to create PostgreSQL extensions : %s", e)
+    _check_faketime_mode(name)
+
 
 @check_db_management_enabled
 def exp_create_database(db_name, demo, lang, user_password='admin', login='admin', country_code=None, phone=None):

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -276,6 +276,9 @@ class Cursor(BaseCursor):
 
         self.cache = {}
         self._now = None
+        if self.dbname != 'postgres' and os.getenv('ODOO_FAKETIME_TEST_MODE'):
+            self.execute("SET search_path = public, pg_catalog;")
+            self.commit()  # ensure that the search_path remains after a rollback
 
     def __build_dict(self, row):
         return {d.name: row[i] for i, d in enumerate(self._obj.description)}


### PR DESCRIPTION
[IMP] sql_db: replace now to reflect the time offset

When using the faketime lib to test Odoo, only the Odoo processes are
affected, so it does not reproduce the reality.

With this commit, when an environment variable `ODOO_FAKETIME_MODE` is
set, the cursor `now` function is altered the same way faketime alters
the Odoo processes.

See https://github.com/wolfcw/libfaketime
