### PR TITLE
[FIX] web_tour: add expectUloadPage to goToUrl

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -318,6 +318,7 @@ export const stepUtils = {
             content: `Navigate to ${url}`,
             trigger: "body",
             run: `goToUrl ${url}`,
+            expectUnloadPage: true,
         };
     },
 };


### PR DESCRIPTION
In this commit, we add expectUloadPage to goToUrl util. This util redirect to another page an involves a unload event so we need to add this key to this util to avoid undeterministic behaviors in tours that use it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
