### PR TITLE
[IMP] l10n_au: Adapt invoice format for GST registration status

### DIFF
--- a/addons/l10n_au/models/__init__.py
+++ b/addons/l10n_au/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import account_move
 from . import chart_template
+from . import res_company

--- a/addons/l10n_au/models/account_move.py
+++ b/addons/l10n_au/models/account_move.py
@@ -7,5 +7,9 @@ class AccountMove(models.Model):
 
     def _get_name_invoice_report(self):
         if self.company_id.account_fiscal_country_id.code == 'AU':
-            return 'l10n_au.report_invoice_document'
+            return (
+                'l10n_au.report_invoice_document'
+                if self.company_id.gst_registered
+                else 'account.report_invoice_document'
+            )
         return super()._get_name_invoice_report()

--- a/addons/l10n_au/models/res_company.py
+++ b/addons/l10n_au/models/res_company.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    gst_registered = fields.Boolean(string="GST registered", help="Enable if your company is registered for GST.")

--- a/addons/l10n_au/views/res_company_views.xml
+++ b/addons/l10n_au/views/res_company_views.xml
@@ -8,11 +8,20 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="attributes">
                 <attribute name="nolabel">1</attribute>
+                <attribute name="class" add="oe_inline" separator=" "/>
             </xpath>
             <field name="vat" position="before">
                 <label for="vat" attrs="{'invisible':[('country_code', '=', 'AU')]}" />
                 <label for="vat" string="ABN" attrs="{'invisible':[('country_code', '!=', 'AU')]}" />
             </field>
+            <xpath expr="//field[@name='vat']" position="after">
+                <div name="abn_gst_container"/>
+            </xpath>
+            <xpath expr="//div[@name='abn_gst_container']" position="inside">
+                <xpath expr="//field[@name='vat']" position="move"/>
+                <label for="gst_registered" string="GST registered" attrs="{'invisible':[('country_code', '!=', 'AU')]}" class="fw-bold"/>
+                <field name="gst_registered" attrs="{'invisible':[('country_code', '!=', 'AU')]}" class="oe_inline"/>
+            </xpath>
             <xpath expr="//field[@name='company_registry']" position="attributes">
                 <attribute name="nolabel">1</attribute>
             </xpath>


### PR DESCRIPTION
Australian companies that are not registered for GST must not issue tax invoices.
This commit adds a GST-registered setting on the company form to help 
businesses comply with this requirement.

- When unchecked, invoice printouts will automatically use the standard 
  **Odoo invoice layout** instead of the **"Tax Invoice"** format. This ensures, 
  that both GST-registered and non-registered companies can issue invoices 
  that align with ATO guidelines.

task-4945470

