### PR TITLE
Master presets and link edition bvr

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -69,6 +69,7 @@ export class Builder extends Component {
 
         this.lastTrigerUpdateId = 0;
         this.editorBus = new EventBus();
+        this.colorPresetToShow = null;
 
         // TODO: maybe do a different config for the translate mode and the
         // "regular" mode.
@@ -167,6 +168,7 @@ export class Builder extends Component {
             editor: this.editor,
             editorBus: this.editorBus,
             triggerDomUpdated: this.triggerDomUpdated.bind(this),
+            editColorCombination: this.editColorCombination.bind(this),
         });
         // onMounted(() => {
         //     // actionService.setActionMode("fullscreen");
@@ -264,11 +266,14 @@ export class Builder extends Component {
      * Called when clicking on a tab. Sets the active tab to the given tab.
      *
      * @param {String} tab the tab to set
+     * @param {Number | null} presetId the color preset expanding on "theme" tab
+     * open.
      */
-    onTabClick(tab) {
+    onTabClick(tab, presetId = null) {
         this.setTab(tab);
         // Deactivate the options when clicking on the "BLOCKS" or "THEME" tabs.
         if (tab === "theme" || tab === "blocks") {
+            this.colorPresetToShow = presetId;
             this.editor.shared["builderOptions"].deactivateContainers();
         }
     }
@@ -322,5 +327,9 @@ export class Builder extends Component {
         this.state.invisibleEls = [
             ...this.editor.editable.querySelectorAll(this.getInvisibleSelector(isMobile)),
         ];
+    }
+
+    editColorCombination(presetId) {
+        this.onTabClick("theme", presetId);
     }
 }

--- a/addons/html_builder/static/src/builder.variables.scss
+++ b/addons/html_builder/static/src/builder.variables.scss
@@ -792,21 +792,6 @@ $o-bg-shapes: (
     @return add-extra-shape-colors-mapping($module, $shape-name, 'footer', $mapping, $shapes);
 }
 
-@mixin o-input-number-no-arrows() {
-    // Remove arrows/spinners from input type number
-    // => Chrome, Safari, Edge, Opera
-    input::-webkit-outer-spin-button,
-    input::-webkit-inner-spin-button {
-        -webkit-appearance: none;
-        margin: 0;
-    }
-
-    // => Firefox
-    input[type=number] {
-        -moz-appearance: textfield;
-    }
-};
-
 %o-hb-input-base {
     border: $o-we-sidebar-content-field-border-width solid $o-we-sidebar-content-field-border-color;
     border-radius: $o-we-sidebar-content-field-border-radius;

--- a/addons/html_builder/static/src/builder.xml
+++ b/addons/html_builder/static/src/builder.xml
@@ -41,7 +41,7 @@
                 <CustomizeTab t-else="" currentOptionsContainers="state.currentOptionsContainers" snippetModel="snippetModel"/>
             </t>
             <t t-if="state.activeTab === 'theme'">
-                <t t-component="ThemeTab"/>
+                <t t-component="ThemeTab" colorPresetToShow="colorPresetToShow"/>
             </t>
         </div>
         <InvisibleElementsPanel t-if="state.invisibleEls.length" invisibleEls="state.invisibleEls" invisibleSelector="this.getInvisibleSelector()"/>

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -139,6 +139,7 @@ export class BuilderColorPicker extends Component {
                 noTransparency: this.props.noTransparency,
                 enabledTabs: this.props.enabledTabs,
                 className: "o-hb-colorpicker",
+                editColorCombination: this.env.editColorCombination,
             },
             {
                 onClose: onPreviewRevert,

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
@@ -17,7 +17,7 @@
     }
 
     & > div:not(:first-child) {
-        .btn {
+        .btn:not(.o-hb-edit-color-combination) {
             @include button-variant(
                 $background: $o-we-item-clickable-bg,
                 $border: transparent,
@@ -82,6 +82,15 @@
             0 0 0 1px $o-we-bg-darker,
             0 0 0 3px var(--o-color-picker-active-color);
         outline: none;
+    }
+
+    .o-hb-edit-color-combination {
+        color: $o-we-item-clickable-color;
+        border: none;
+
+        &:hover {
+            color: $o-we-fg-lighter;
+        }
     }
 
     // Gradients

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.js
@@ -1,4 +1,4 @@
-import { Component, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, useEffect, useRef, useState, onMounted } from "@odoo/owl";
 import {
     useVisibilityObserver,
     useApplyVisibility,
@@ -18,6 +18,7 @@ export class BuilderRow extends Component {
         slots: { type: Object, optional: true },
         level: { type: Number, optional: true },
         expand: { type: Boolean, optional: true },
+        initialExpandAnim: { type: Boolean, optional: true },
     };
     static defaultProps = { expand: false };
 
@@ -38,6 +39,7 @@ export class BuilderRow extends Component {
 
         this.labelRef = useRef("label");
         this.collapseContentRef = useRef("collapse-content");
+
         useEffect(
             (labelEl) => {
                 if (!this.state.tooltip && labelEl && labelEl.clientWidth < labelEl.scrollWidth) {
@@ -46,6 +48,14 @@ export class BuilderRow extends Component {
             },
             () => [this.labelRef.el]
         );
+
+        onMounted(() => {
+            if (this.props.initialExpandAnim) {
+                setTimeout(() => {
+                    this.toggleCollapseContent();
+                }, 150);
+            }
+        });
     }
 
     getLevelClass() {

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.js
@@ -37,6 +37,7 @@ export class BuilderRow extends Component {
         }
 
         this.labelRef = useRef("label");
+        this.collapseContentRef = useRef("collapse-content");
         useEffect(
             (labelEl) => {
                 if (!this.state.tooltip && labelEl && labelEl.clientWidth < labelEl.scrollWidth) {
@@ -53,5 +54,23 @@ export class BuilderRow extends Component {
 
     toggleCollapseContent() {
         this.state.expanded = !this.state.expanded;
+        const expanded = this.state.expanded;
+        const contentEl = this.collapseContentRef.el;
+
+        if (!contentEl) return;
+
+        const cleanup = () => {
+            contentEl.style.display = expanded ? "block" : "";
+            contentEl.style.overflow = "";
+            contentEl.style.height = expanded ? "auto" : "";
+            contentEl.removeEventListener("transitionend", cleanup);
+        };
+
+        contentEl.style.display = "block";
+        contentEl.style.overflow = "hidden";
+        contentEl.style.height = contentEl.scrollHeight + "px";
+        void contentEl.offsetHeight; // force reflow
+        contentEl.style.height = expanded ? contentEl.scrollHeight + "px" : "0px";
+        contentEl.addEventListener("transitionend", cleanup);
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -63,13 +63,19 @@
     .o_hb_collapse_toggler {
         position: absolute;
         padding-left: $o-hb-row-spacing;
+        align-self: baseline;
         z-index: $_z-index + 1;
-        font-size: 0.8em;
+        box-shadow: none;
+        font-size: 1em;
         color: inherit;
 
         &.active i {
             margin-left: -1px;
         }
+    }
+
+    &:has(> div > .o_cc_preview_wrapper) > .o_hb_collapse_toggler {
+        align-self: center;
     }
 
     // ==== States
@@ -132,5 +138,14 @@
             @include sublevel-line($_level-left);
             z-index: $_z-index - $_level;
         }
+    }
+
+    &:not(:has(> .o_hb_collapse_toggler.active)) + .hb-collapse-content {
+        display: none;
+        height: 0;
+    }
+
+    & + .hb-collapse-content {
+        transition: height 0.35s ease;
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.variables.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.variables.scss
@@ -1,4 +1,4 @@
 $o-hb-row-min-height: 28px !default;
 $o-hb-row-spacing: 4px !default;
-$o-hb-row-padding-left: $o-hb-row-spacing * 2 + $o-we-border-width * 2 !default;
+$o-hb-row-padding-left: $o-hb-row-spacing * 2.6 + $o-we-border-width * 2 !default;
 $o-hb-row-indent-left: $o-hb-row-spacing * 2 !default;

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.xml
@@ -51,7 +51,9 @@
                 <t t-slot="default" toggleCollapseContent="() => this.toggleCollapseContent()"/>
             </div>
         </div>
-        <div t-if="props.slots.collapse" t-att-class="{ 'd-none': !state.expanded }" t-ref="collapse-content" t-att-id="collapseContentId">
+        <div t-if="props.slots.collapse"
+             class="hb-collapse-content"
+             t-ref="collapse-content" t-att-id="collapseContentId">
             <t t-slot="collapse"/>
         </div>
     </BuilderComponent>

--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -13,23 +13,23 @@
 }
 
 .o-we-linkpopover {
-    .custom-fill-color, .custom-text-color, .custom-border-color, .input-group {
+    .custom-fill-color, .custom-text-color, .custom-border, .input-group {
         label {
             width: 70px;
-            &:not(:first-child) {
-                margin-left: 15px;
-            }
         }
     }
 }
 
 .custom-border {
-    padding-left: 70px;
+    @include o-input-number-no-arrows();
+
     input.form-control {
-        width: 40px;
+        width: 35px;
+    }
+    .input-group-text {
+        padding: 0 0.35rem;
     }
     select.form-select {
-        width: 110px;
-        margin-left: 15px;
+        width: 60px;
     }
 }

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -49,31 +49,31 @@
                         <t t-if="state.type === 'custom'">
                             <div class="d-flex mb-1 custom-text-color">
                                 <label>Text Color</label>
-                                <button class="o_we_color_preview custom-text-picker" t-att-data-color="this.customTextColorState.selectedColor" t-ref="customTextColorButton"
-                                        t-attf-style="background-color: {{this.customTextColorState.selectedColor}}" />
+                                <button class="o_we_color_preview custom-text-picker me-3" t-att-data-color="this.customTextColorState.selectedColor" t-ref="customTextColorButton"
+                                        t-attf-style="background-color: {{this.customTextColorState.selectedColor}}"/>
                                 <label>Fill Color</label>
                                 <button class="o_we_color_preview custom-fill-picker" t-att-data-color="this.customFillColorState.selectedColor" t-ref="customFillColorButton"
                                         t-attf-style="{{this.customFillColorState.selectedColor?.includes('gradient') ? 'background-image' : 'background-color'}}: {{this.customFillColorState.selectedColor}}" />
                             </div>
-                            <div class="d-flex mb-1 custom-border-color">
-                                <label>Border</label>
-                                <button class="o_we_color_preview custom-border-picker" t-att-data-color="this.customBorderColorState.selectedColor" t-ref="customBorderColorButton"
-                                        t-attf-style="background-color: {{this.customBorderColorState.selectedColor}}" />
-                            </div>
-                            <div class="d-flex mb-1 custom-border">
-                                <div class="input-group">
-                                    <input t-ref="customBoderSize" type="text" pattern="[0-9]*"
-                                           class="form-control form-control-sm custom-border-size" t-model="state.customBorderSize"
-                                           placeholder="Border Size"  t-on-keydown="onKeydownEnter"/>
+                            <div class="d-flex mb-1 custom-border align-items-center">
+                                <label class="flex-shrink-0">Border</label>
+                                <div class="input-group me-1">
+                                    <input type="number" pattern="[0-9]*"
+                                        class="form-control form-control-sm custom-border-size flex-grow-0" t-model="state.customBorderSize"
+                                        placeholder="Border Size"  t-on-keydown="onKeydownEnter"/>
                                     <span class="input-group-text">px</span>
                                 </div>
-                                <select name="link_style_border" class="form-select form-select-sm custom-border-style" t-model="state.customBorderStyle" t-on-change="onChange">
-                                    <t t-foreach="this.borderData" t-as="borderData" t-key="borderData.style">
-                                        <option t-att-value="borderData.style" t-att-selected="state.customBorderStyle === borderData.style">
-                                            <span t-esc="borderData.label"/>
-                                        </option>
-                                    </t>
-                                </select>
+                                <div class="d-flex align-items-center" t-if="state.customBorderSize > 0">
+                                    <select name="link_style_border" class="form-select form-select-sm custom-border-style me-1" t-model="state.customBorderStyle" t-on-change="onChange">
+                                        <t t-foreach="this.borderData" t-as="borderData" t-key="borderData.style">
+                                            <option t-att-value="borderData.style" t-att-selected="state.customBorderStyle === borderData.style">
+                                                <span t-esc="borderData.label"/>
+                                            </option>
+                                        </t>
+                                    </select>
+                                    <button class="o_we_color_preview custom-border-picker" t-att-data-color="this.customBorderColorState.selectedColor" t-ref="customBorderColorButton"
+                                            t-attf-style="background-color: {{this.customBorderColorState.selectedColor}}"/>
+                                </div>
                             </div>
                             <div class="input-group mb-1">
                                 <label>Size</label>

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -53,6 +53,7 @@ export class ColorPicker extends Component {
         applyColor: Function,
         applyColorPreview: Function,
         applyColorResetPreview: Function,
+        editColorCombination: { type: Function, optional: true },
         enabledTabs: { type: Array, optional: true },
         colorPrefix: { type: String },
         showRgbaField: { type: Boolean, optional: true },
@@ -125,7 +126,7 @@ export class ColorPicker extends Component {
     }
 
     onColorApply(ev) {
-        if (this.getTarget(ev).tagName !== "BUTTON") {
+        if (!this.isColorButton(this.getTarget(ev))) {
             return;
         }
         const color = this.processColorFromEvent(ev);
@@ -144,14 +145,14 @@ export class ColorPicker extends Component {
     }
 
     onColorHover(ev) {
-        if (this.getTarget(ev).tagName !== "BUTTON") {
+        if (!this.isColorButton(this.getTarget(ev))) {
             return;
         }
         this.onColorPreview(ev);
     }
 
     onColorHoverOut(ev) {
-        if (this.getTarget(ev).tagName !== "BUTTON") {
+        if (!this.isColorButton(this.getTarget(ev))) {
             return;
         }
         this.props.applyColorResetPreview();
@@ -179,14 +180,14 @@ export class ColorPicker extends Component {
     }
 
     onColorFocusout(ev) {
-        if (ev.relatedTarget?.tagName !== "BUTTON") {
+        if (!ev.relatedTarget || !this.isColorButton(ev.relatedTarget)) {
             // Do not trigger a revert if we are in the focus loop (i.e. focus
             // a button > selection is reset > focusout). Otherwise, the
             // relatedTarget should always be one of the colorpicker's buttons.
             return;
         }
         const activeEl = document.activeElement;
-        this.onColorHoverOut(ev);
+        this.props.applyColorResetPreview();
         if (document.activeElement !== activeEl) {
             // The focus was lost during revert. Reset it where it should be.
             ev.relatedTarget.focus();
@@ -239,6 +240,10 @@ export class ColorPicker extends Component {
         if (targetBtn && targetBtn.classList.contains("o_color_button")) {
             targetBtn.focus();
         }
+    }
+
+    isColorButton(targetEl) {
+        return targetEl.tagName === "BUTTON" && !targetEl.matches(".o_colorpicker_ignore");
     }
 }
 

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -45,19 +45,22 @@
                 <t t-foreach="[1, 2, 3, 4, 5]" t-as="number" t-key="number">
                     <t t-set="className" t-value="'o_cc' + number"/>
                     <t t-set="activeClass" t-value="this.props.state.selectedColorCombination === className ? 'selected' : ''"/>
-                    <button
-                            type="button"
-                            class="w-100 p-0 border-0 color-combination-button"
-                            t-att-class="[className, activeClass].join(' ')"
-                            t-att-data-color="className"
-                            t-attf-title="Preset {{number}}">
-                        <div inert="" class="p-2 d-flex justify-content-between align-items-center">
-                            <h1 class="m-0 fs-4">Title</h1>
-                            <p class="m-0 flex-grow-1">Text</p>
-                            <span class="py-1 px-1 rounded-1 fs-6 btn btn-sm lh-1 btn btn-sm me-1 d-flex flex-column justify-content-center btn-primary"><small>Button</small></span>
-                            <span class="py-1 px-1 rounded-1 fs-6 btn btn-sm lh-1 btn btn-sm d-flex flex-column justify-content-center btn-secondary"><small>Button</small></span>
-                        </div>
-                    </button>
+                    <div class="d-flex align-items-center">
+                        <button
+                                type="button"
+                                class="w-100 p-0 border-0 color-combination-button"
+                                t-att-class="[className, activeClass].join(' ')"
+                                t-att-data-color="className"
+                                t-attf-title="Preset {{number}}">
+                            <div inert="" class="p-2 d-flex justify-content-between align-items-center">
+                                <h1 class="m-0 fs-4">Title</h1>
+                                <p class="m-0 flex-grow-1">Text</p>
+                                <span class="py-1 px-1 rounded-1 fs-6 btn btn-sm lh-1 btn btn-sm me-1 d-flex flex-column justify-content-center btn-primary"><small>Button</small></span>
+                                <span class="py-1 px-1 rounded-1 fs-6 btn btn-sm lh-1 btn btn-sm d-flex flex-column justify-content-center btn-secondary"><small>Button</small></span>
+                            </div>
+                        </button>
+                        <button t-on-click="() => this.props.editColorCombination(number)" class="o-hb-edit-color-combination o_colorpicker_ignore fa fa-pencil btn pe-1" title="Edit"/>
+                    </div>
                 </t>
             </div>
         </t>

--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -371,7 +371,7 @@
             @content;
         }
     } @else {
-        @warn "'media-only()' - missing argument"
+        @warn "'media-only()' - missing argument";
     }
 }
 
@@ -390,3 +390,21 @@
         cursor: pointer;
     }
 }
+
+// ----------------------------------------------------------------------------
+// Input type number
+// ----------------------------------------------------------------------------
+// Remove arrows/spinners from input type number.
+@mixin o-input-number-no-arrows() {
+    // => Chrome, Safari, Edge, Opera
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+
+    // => Firefox
+    input[type=number] {
+        -moz-appearance: textfield;
+    }
+};

--- a/addons/web_editor/static/src/scss/web_editor.variables.scss
+++ b/addons/web_editor/static/src/scss/web_editor.variables.scss
@@ -809,18 +809,3 @@ $o-bg-shapes: (
 @function add-footer-shape-colors-mapping($module, $shape-name, $mapping, $shapes: $o-bg-shapes) {
     @return add-extra-shape-colors-mapping($module, $shape-name, 'footer', $mapping, $shapes);
 }
-
-@mixin o-input-number-no-arrows() {
-    // Remove arrows/spinners from input type number
-    // => Chrome, Safari, Edge, Opera
-    input::-webkit-outer-spin-button,
-    input::-webkit-inner-spin-button {
-        -webkit-appearance: none;
-        margin: 0;
-    }
-
-    // => Firefox
-    input[type=number] {
-        -moz-appearance: textfield;
-    }
-};

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
@@ -8,6 +8,7 @@ export class ThemeColorsOption extends BaseOptionComponent {
     setup() {
         super.setup();
         this.palettes = this.getPalettes();
+        this.colorPresetToShow = this.env.colorPresetToShow,
         this.state = useDomState(() => ({
             presets: this.getPresets(),
         }));

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -68,14 +68,14 @@
                     </div>
                 </div>
             </BuilderRow>
-            <BuilderRow label.translate="Color Presets">
+            <BuilderRow label.translate="Color Presets" expand="!!colorPresetToShow">
                 <div></div>     <!-- This is required, without it the row is not displayed at all -->
                 <t t-set-slot="collapse">
                     <t t-foreach="state.presets" t-as="preset" t-key="preset.id">
-                        <BuilderRow t-slot-scope="row">
-                            <div class="o_cc_preview_wrapper" t-on-click="row.toggleCollapseContent">
+                        <BuilderRow t-slot-scope="row" initialExpandAnim="colorPresetToShow === preset.id">
+                            <div class="o_cc_preview_wrapper w-100" t-on-click="row.toggleCollapseContent">
                                 <div inert="" t-att-class="`o_cc${preset.id}`"
-                                     class="w-100 p-2 d-flex justify-content-between align-items-center ms-3">
+                                     class="p-2 d-flex justify-content-between align-items-center ms-3">
                                     <h3 class="m-0">
                                         Title
                                     </h3>

--- a/addons/website/static/src/builder/plugins/theme/theme_tab.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab.js
@@ -1,4 +1,4 @@
-import { Component, useState } from "@odoo/owl";
+import { Component, useState, useSubEnv } from "@odoo/owl";
 import { OptionsContainer } from "@html_builder/sidebar/option_container";
 import { useOptionsSubEnv } from "@html_builder/utils/utils";
 
@@ -7,6 +7,7 @@ export class ThemeTab extends Component {
     static components = { OptionsContainer };
     static props = {
         // optionsContainers: { type: Array, optional: true },
+        colorPresetToShow: { type: Number | null, optional: true },
     };
     static defaultProps = {
         // optionsContainers: [],
@@ -14,6 +15,9 @@ export class ThemeTab extends Component {
 
     setup() {
         useOptionsSubEnv(() => [this.env.editor.document.body]);
+        useSubEnv({
+            colorPresetToShow: this.props.colorPresetToShow,
+        });
         this.state = useState({
             fontsData: {},
         });

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_row.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_row.test.js
@@ -2,8 +2,16 @@ import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpe
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, hover, queryAllTexts, queryOne, waitFor } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
-import { contains } from "@web/../tests/web_test_helpers";
+import { contains, defineStyle } from "@web/../tests/web_test_helpers";
 import { addOption, defineWebsiteModels, setupWebsiteBuilder } from "../../website_helpers";
+
+function reapplyCollapseTransition() {
+    defineStyle(/* css */ `
+        hoot-fixture:not(.allow-transitions) * .hb-collapse-content {
+            transition: height 0.35s ease !important;
+        }
+    `);
+}
 
 describe("website tests", () => {
     defineWebsiteModels();
@@ -167,6 +175,7 @@ describe("website tests", () => {
         });
 
         test("Click on toggler collapses / expands the BuilderRow", async () => {
+            reapplyCollapseTransition();
             addOption({
                 selector: ".test-options-target",
                 template: collapseOptionTemplate(),
@@ -181,10 +190,12 @@ describe("website tests", () => {
             expect(".options-container button[data-class-action='b']").toBeVisible();
             await contains(".o_hb_collapse_toggler:not(.d-none)").click();
             expect(".o_hb_collapse_toggler:not(.d-none)").not.toHaveClass("active");
+            await waitFor(".hb-collapse-content:not([style*='overflow: hidden'])", { timeout: 500 });
             expect(".options-container button[data-class-action='b']").not.toBeVisible();
         });
 
         test("Click header row's label collapses / expands the BuilderRow", async () => {
+            reapplyCollapseTransition();
             addOption({
                 selector: ".test-options-target",
                 template: collapseOptionTemplate(),
@@ -199,6 +210,7 @@ describe("website tests", () => {
             expect(".options-container button[data-class-action='b']").toBeVisible();
             await contains("[data-label='Test Collapse'] span:contains('Test Collapse')").click();
             expect(".o_hb_collapse_toggler:not(.d-none)").not.toHaveClass("active");
+            await waitFor(".hb-collapse-content:not([style*='overflow: hidden'])", { timeout: 500 });
             expect(".options-container button[data-class-action='b']").not.toBeVisible();
         });
 


### PR DESCRIPTION
**[IMP] web, html_builder, website: add button to edit color presets**

The goal of this commit is to help users understand that presets can be
edited. To achieve this, we added a pencil icon next to the color
presets in the colorpicker, which opens the Theme tab and the
corresponding color preset.

------

**[IMP] html_builder, website: add animation to row collapse transition**

Improves UX by animating row expand/collapse using height transition in
the snippet menu.

------

**[IMP] html_editor: tweak border options in link popover**

This commit updates the layout of the link popover by placing the border
options on a single line.

task-4948954