### PR TITLE
[FIX] base: prevent creation of new profiling records

### DIFF
--- a/odoo/addons/base/views/ir_profile_views.xml
+++ b/odoo/addons/base/views/ir_profile_views.xml
@@ -17,7 +17,7 @@
         <field name="name">IR Profile List</field>
         <field name="model">ir.profile</field>
         <field name="arch" type="xml">
-            <list string="Profile Session" default_order="session desc, id desc">
+            <list string="Profile Session" default_order="session desc, id desc" create="0">
                 <header>
                     <button name="action_view_speedscope" type="object" string="View in speedscope"/>
                 </header>


### PR DESCRIPTION
Currently, the speedscope URL is generates even for unsaved records and clicking this URL resulted in an error.

**Steps to reproduce:**
- Open Profiling.
- Create new Ir Profile.
- Without saving the record, click on the speedscope URL in the 'Open' field.

**Error:**
`ValueError - invalid literal for int() with base 10: 'NewId_0x789d07a57b80'`

**Cause:**
The `speedscope_url` compute method [1] generated the URL using a temporary `NewId`. When this URL was accessed, the controller [2] attempted to process it as an integer, which resulted in the error.

**Fix:**
This fix prevents the creation of new `ir.profile` records.

[1] - https://github.com/odoo/odoo/blob/679d99b8bd233a1046e3219ddb3e23e8465f6107/odoo/addons/base/models/ir_profile.py#L109-L112
[2] - https://github.com/odoo/odoo/blob/679d99b8bd233a1046e3219ddb3e23e8465f6107/addons/web/controllers/profiling.py#L33

sentry-6753780250