### PR TITLE
[FIX] hr: officer user can load demo data

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -870,7 +870,7 @@ class HrEmployee(models.Model):
         }
         if dep_rd:
             return action_reload
-        convert.convert_file(env=self.env, module='hr', filename='data/scenarios/hr_scenario.xml', idref=None, mode='init', kind="data")
+        convert.convert_file(env=self.sudo().env, module='hr', filename='data/scenarios/hr_scenario.xml', idref=None, mode='init', kind="data")
         if 'resume_line_ids' in self:
             convert.convert_file(env=self.env, module='hr_skills', filename='data/scenarios/hr_skills_scenario.xml', idref=None, mode='init', kind="data")
         return action_reload


### PR DESCRIPTION
Currently, an error occurs when a user with Officer access rights attempts to load sample data in the Employees app.

**Steps to reproduce:**
- Install the HR app without demo data.
- Delete the Administrator employee record.
- Create a new user and assign the access right "Office: Manage All Employees".
- Log in with the newly created user.
- Open the Employees app and click on the Load Sample Data button.

**Traceback:**
```
AccessError
Ops! Parece que você se deparou com alguns registros ultrassecretos.

Desculpe, Wendel  Xavier de Miranda (id=2) não tem 'criar' acesso a:
- Contato (res.partner)

Se você realmente precisar de acesso, talvez valha a pena tentar conquistar o administrador com uns pães de queijo.

Esse parece ser um problema de várias empresas. Talvez seja possível acessar o registro mudando para a empresa: WM SERVICOS TECNICOS E COMISSIONAMENTO LTDA.

ParseError
while parsing /home/odoo/src/odoo/saas-18.4/addons/hr/data/scenarios/hr_scenario.xml:79, somewhere inside <record id="work_contact_eg" model="res.partner" forcecreate="1"> ...

ValueError - ParseError('while parsing /home/odoo/src/odoo/saas-18.4/addons/hr/data/scenarios/hr_scenario.xml:79 ....
```

**Cause:**
The issue occurs because the user doesn’t have the required rights to create res partner records when loading sample data.

**Fix:**
This commit resolves the issue by granting the user superuser rights.

sentry-6751634609