### PR TITLE
[FIX] html_editor: apply o_cc class for color combinations

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -473,7 +473,7 @@ export class ColorPlugin extends Plugin {
         if (color.startsWith("o_cc")) {
             parts = backgroundImageCssToParts(element.style["background-image"]);
             element.classList.remove(...COLOR_COMBINATION_CLASSES);
-            element.classList.add(color);
+            element.classList.add("o_cc", color);
             setBackgroundImageAndOverride(element, element.style["background-image"]);
             this.fixColorCombination(element);
             return;
@@ -481,7 +481,7 @@ export class ColorPlugin extends Plugin {
 
         if (mode === "backgroundColor") {
             if (!color) {
-                element.classList.remove(...COLOR_COMBINATION_CLASSES);
+                element.classList.remove("o_cc", ...COLOR_COMBINATION_CLASSES);
             }
             delete parts.gradient;
             const newBackgroundImage = backgroundImagePartsToCss(parts);

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -536,7 +536,7 @@ describe("colorElement", () => {
                     "backgroundColor"
                 );
             },
-            contentAfter: '<div class="o_cc1">a</div>',
+            contentAfter: '<div class="o_cc o_cc1">a</div>',
         });
     });
     describe("when a color was defined", () => {
@@ -550,7 +550,7 @@ describe("colorElement", () => {
                         "backgroundColor"
                     );
                 },
-                contentAfter: '<div style="background-color: #ff0000;" class="o_cc1">a</div>',
+                contentAfter: '<div style="background-color: #ff0000;" class="o_cc o_cc1">a</div>',
             });
         });
         test("should apply o_cc1 class to the element when a color bg-900 was defined", async () => {
@@ -563,7 +563,7 @@ describe("colorElement", () => {
                         "backgroundColor"
                     );
                 },
-                contentAfter: '<div class="bg-900 o_cc1">a</div>',
+                contentAfter: '<div class="bg-900 o_cc o_cc1">a</div>',
             });
         });
         test("should apply o_cc1 class to the element when a color gradient was defined", async () => {
@@ -576,14 +576,14 @@ describe("colorElement", () => {
                         "backgroundColor"
                     );
                 },
-                contentAfter: `<div style="background-image: ${greenToBlueGradient};" class="o_cc1">a</div>`,
+                contentAfter: `<div style="background-image: ${greenToBlueGradient};" class="o_cc o_cc1">a</div>`,
             });
         });
     });
 
     test("should keep o_cc1 when adding a color", async () => {
         await testEditor({
-            contentBefore: `<div class="o_cc1">a</div>`,
+            contentBefore: `<div class="o_cc o_cc1">a</div>`,
             stepFunction: (editor) => {
                 editor.shared.color.colorElement(
                     editor.editable.firstChild,
@@ -591,7 +591,8 @@ describe("colorElement", () => {
                     "backgroundColor"
                 );
             },
-            contentAfter: '<div class="o_cc1" style="background-color: rgb(255, 0, 0);">a</div>',
+            contentAfter:
+                '<div class="o_cc o_cc1" style="background-color: rgb(255, 0, 0);">a</div>',
         });
     });
 
@@ -628,7 +629,7 @@ describe("colorElement", () => {
                     "backgroundColor"
                 );
             },
-            contentAfter: `<div class="o_cc2" style="background-image: ${greenToBlueGradient};">a</div>`,
+            contentAfter: `<div class="o_cc o_cc2" style="background-image: ${greenToBlueGradient};">a</div>`,
         });
     });
 
@@ -646,7 +647,7 @@ describe("colorElement", () => {
         });
         test("should remove o_cc1 when setting an empty color", async () => {
             await testEditor({
-                contentBefore: `<div class="o_cc1" style="background-image: ${redToBlueGradient};">a</div>`,
+                contentBefore: `<div class="o_cc o_cc1" style="background-image: ${redToBlueGradient};">a</div>`,
                 stepFunction: (editor) => {
                     editor.shared.color.colorElement(
                         editor.editable.firstChild,
@@ -667,7 +668,7 @@ describe("colorElement", () => {
                         "backgroundColor"
                     );
                 },
-                contentAfter: `<div class="o_cc1" style="background-image: ${redToBlueGradient};">a</div>`,
+                contentAfter: `<div class="o_cc o_cc1" style="background-image: ${redToBlueGradient};">a</div>`,
             });
         });
         test("should keep the background image when applying o_cc1 gradient", async () => {
@@ -680,7 +681,7 @@ describe("colorElement", () => {
                         "backgroundColor"
                     );
                 },
-                contentAfter: `<div style='background-image: url("https://example.com/image.png"), ${redToBlueGradient};' class="o_cc1">a</div>`,
+                contentAfter: `<div style='background-image: url("https://example.com/image.png"), ${redToBlueGradient};' class="o_cc o_cc1">a</div>`,
             });
         });
         test("change o_cc1 (with gradient) with o_cc2 (without gradient)", async () => {
@@ -693,7 +694,7 @@ describe("colorElement", () => {
                         "backgroundColor"
                     );
                 },
-                contentAfter: `<div class="o_cc2">a</div>`,
+                contentAfter: `<div class="o_cc o_cc2">a</div>`,
             });
         });
 
@@ -708,7 +709,7 @@ describe("colorElement", () => {
                             "backgroundColor"
                         );
                     },
-                    contentAfter: `<div style="background-color: rgb(255, 0, 0); background-image: none;" class="o_cc1">a</div>`,
+                    contentAfter: `<div style="background-color: rgb(255, 0, 0); background-image: none;" class="o_cc o_cc1">a</div>`,
                 });
             });
             test("should not write o_cc1 gradient when bg-900 is already present", async () => {
@@ -721,7 +722,7 @@ describe("colorElement", () => {
                             "backgroundColor"
                         );
                     },
-                    contentAfter: `<div class="bg-900 o_cc1" style="background-image: none;">a</div>`,
+                    contentAfter: `<div class="bg-900 o_cc o_cc1" style="background-image: none;">a</div>`,
                 });
             });
             test("should not write o_cc1 gradient when a gradient is already present", async () => {
@@ -734,14 +735,14 @@ describe("colorElement", () => {
                             "backgroundColor"
                         );
                     },
-                    contentAfter: `<div style="background-image: ${greenToBlueGradient};" class="o_cc1">a</div>`,
+                    contentAfter: `<div style="background-image: ${greenToBlueGradient};" class="o_cc o_cc1">a</div>`,
                 });
             });
         });
         describe("set a color when a o_cc1 is already defined", () => {
             test("should not have an o_cc1 gradient when applying the color rgb(255, 0, 0)", async () => {
                 await testEditor({
-                    contentBefore: `<div class="o_cc1">a</div>`,
+                    contentBefore: `<div class="o_cc o_cc1">a</div>`,
                     stepFunction: (editor) => {
                         editor.shared.color.colorElement(
                             editor.editable.firstChild,
@@ -750,12 +751,12 @@ describe("colorElement", () => {
                         );
                     },
                     contentAfter:
-                        '<div class="o_cc1" style="background-image: none; background-color: rgb(255, 0, 0);">a</div>',
+                        '<div class="o_cc o_cc1" style="background-image: none; background-color: rgb(255, 0, 0);">a</div>',
                 });
             });
             test("should not have an o_cc1 gradient when applying the color bg-900", async () => {
                 await testEditor({
-                    contentBefore: `<div class="o_cc1">a</div>`,
+                    contentBefore: `<div class="o_cc o_cc1">a</div>`,
                     stepFunction: (editor) => {
                         editor.shared.color.colorElement(
                             editor.editable.firstChild,
@@ -764,12 +765,12 @@ describe("colorElement", () => {
                         );
                     },
                     contentAfter:
-                        '<div class="o_cc1 bg-900" style="background-image: none;">a</div>',
+                        '<div class="o_cc o_cc1 bg-900" style="background-image: none;">a</div>',
                 });
             });
             test("should not have an o_cc1 gradient when applying a gradient color", async () => {
                 await testEditor({
-                    contentBefore: `<div class="o_cc1">a</div>`,
+                    contentBefore: `<div class="o_cc o_cc1">a</div>`,
                     stepFunction: (editor) => {
                         editor.shared.color.colorElement(
                             editor.editable.firstChild,
@@ -777,7 +778,7 @@ describe("colorElement", () => {
                             "backgroundColor"
                         );
                     },
-                    contentAfter: `<div class="o_cc1" style="background-image: ${greenToBlueGradient};">a</div>`,
+                    contentAfter: `<div class="o_cc o_cc1" style="background-image: ${greenToBlueGradient};">a</div>`,
                 });
             });
         });

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
@@ -38,7 +38,22 @@ test("should apply o_cc color", async () => {
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await click(".o-overlay-item [data-color='o_cc3']");
     await animationFrame();
-    expect(":iframe .test-options-target").toHaveClass("test-options-target o_cc3");
+    expect(":iframe .test-options-target").toHaveClass("test-options-target o_cc o_cc3");
+});
+
+test("should remove o_cc color on reset", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker styleAction="'background-color'"/>`,
+    });
+    await setupWebsiteBuilder(`<div class="test-options-target o_cc o_cc3">b</div>`);
+    await contains(":iframe .test-options-target").click();
+    expect(".options-container").toBeDisplayed();
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    await click(".o-overlay-item .fa-trash");
+    await animationFrame();
+    expect(":iframe .test-options-target").toHaveClass("test-options-target");
+    expect(":iframe .test-options-target").not.toHaveClass("o_cc o_cc3");
 });
 
 test("should apply color to the editing element", async () => {


### PR DESCRIPTION
In the `html_builder`-based website builder, when a theme preset is selected, the `o_cc1~5` class is applied, but the `o_cc` (without number) class is not added.

This commit adds the `o_cc` class when applying a theme preset, and removes it when the color is removed.

task-4367641
