### PR TITLE
[FIX] point_of_sale: fix attribute exclusion

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
@@ -216,6 +216,12 @@ export class ProductConfiguratorPopup extends Component {
         );
     }
 
+    isValidCombination() {
+        return !this.selectedValues.some((value) =>
+            this.pos.doHaveConflictWith(value, this.selectedValues)
+        );
+    }
+
     get title() {
         const info = this.props.productTemplate.getProductPriceInfo(this.product, this.pos.company);
         const name = this.props.productTemplate.display_name;

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -10,7 +10,6 @@
                             type="radio"
                             t-att-checked="value.id === props.selected.id"
                             t-on-change="() => props.setSelected(value)"
-                            t-att-disabled="pos.doHaveConflictWith(value, props.allSelectedValues)" 
                             t-att-name="value.attribute_id.id"
                             t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}"
                             class="form-check-input radio-check"
@@ -71,7 +70,7 @@
 
             <select class="configurator_select form-select form-select-md" t-on-change="(e) => this.onChange(e)">
                 <t t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
-                    <option t-att-value="value.id" t-att-disabled="pos.doHaveConflictWith(value, props.allSelectedValues)"  t-att-class="{'ptav-not-available': value.excluded}">
+                    <option t-att-value="value.id" t-att-class="{'ptav-not-available': value.excluded}">
                         <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == props.selected.id)"/>
                         <t t-esc="value.name"/>
                         <t t-if="value.price_extra">
@@ -103,7 +102,6 @@
                                 t-att-checked="value.id === props.selected.id"
                                 t-on-change="() => props.setSelected(value)"
                                 t-att-name="value.attribute_id.id"
-                                t-att-disabled="pos.doHaveConflictWith(value, props.allSelectedValues)" 
                                 t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}"
                                 class="m-2 opacity-0" 
                             />
@@ -181,7 +179,7 @@
                 <div class="d-flex flex-row gap-2 w-100">
                     <button
                             class="btn btn-primary btn-lg lh-lg w-50 o-default-button"
-                            t-att-class="{'disabled': isArchivedCombination()}"
+                            t-att-class="{'disabled': isArchivedCombination() or !this.isValidCombination()}"
                             t-on-click="confirm">
                             Add
                         </button>

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -165,3 +165,25 @@ registry.category("web_tour.tours").add("test_combo_variant_mix", {
             ),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_cross_exclusion_attribute_values", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Test Product 1"),
+            ProductConfigurator.pickRadio("attribute_1_value_1"),
+            ProductConfigurator.pickRadio("attribute_2_value_1"),
+            ProductConfigurator.isAddDisabled(),
+            ProductConfigurator.pickRadio("attribute_2_value_2"),
+            ProductConfigurator.pickRadio("attribute_1_value_2"),
+            ProductConfigurator.isAddDisabled(),
+            ProductConfigurator.pickRadio("attribute_1_value_1"),
+            ProductConfigurator.pickRadio("attribute_2_value_2"),
+            ProductConfigurator.isAddEnabled(),
+            ProductConfigurator.pickRadio("attribute_1_value_2"),
+            ProductConfigurator.pickRadio("attribute_2_value_1"),
+            ProductConfigurator.isAddEnabled(),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
@@ -66,3 +66,21 @@ export function isUnavailable(option) {
         },
     ];
 }
+
+export function isAddDisabled() {
+    return [
+        {
+            content: "Add button is disabled",
+            trigger: ".modal .btn-primary.disabled",
+        },
+    ];
+}
+
+export function isAddEnabled() {
+    return [
+        {
+            content: "Add button is enabled",
+            trigger: ".modal .btn-primary:not(.disabled)",
+        },
+    ];
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2629,6 +2629,71 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_combo_variant_mix', login="pos_user")
 
+    def test_cross_exclusion_attribute_values(self):
+        """ If you create a product with two attributes and 2 values for each attribute, and you exclude one value of the first attribute with one value of the second attribute
+        and vice versa, you should still be able to select the other values of the attributes. """
+        self.attribute_1 = self.env['product.attribute'].create({
+            'name': 'attribute_1',
+            'create_variant': 'no_variant',
+        })
+
+        self.attribute_2 = self.env['product.attribute'].create({
+            'name': 'attribute_2',
+            'create_variant': 'no_variant',
+        })
+
+        self.attribute_1_value_1 = self.env['product.attribute.value'].create({
+            'name': 'attribute_1_value_1',
+            'attribute_id': self.attribute_1.id,
+        })
+        self.attribute_1_value_2 = self.env['product.attribute.value'].create({
+            'name': 'attribute_1_value_2',
+            'attribute_id': self.attribute_1.id,
+        })
+        self.attribute_2_value_1 = self.env['product.attribute.value'].create({
+            'name': 'attribute_2_value_1',
+            'attribute_id': self.attribute_2.id,
+        })
+        self.attribute_2_value_2 = self.env['product.attribute.value'].create({
+            'name': 'attribute_2_value_2',
+            'attribute_id': self.attribute_2.id,
+        })
+
+        self.test_product_1 = self.env['product.template'].create({
+            'name': 'Test Product 1',
+            'available_in_pos': True,
+            'list_price': 10.0,
+            'attribute_line_ids': [
+                (0, 0, {
+                    'attribute_id': self.attribute_1.id,
+                    'value_ids': [(6, 0, [self.attribute_1_value_1.id, self.attribute_1_value_2.id])],
+                }),
+                (0, 0, {
+                    'attribute_id': self.attribute_2.id,
+                    'value_ids': [(6, 0, [self.attribute_2_value_1.id, self.attribute_2_value_2.id])],
+                }),
+            ],
+        })
+
+        # Test the exclusion of attribute values
+        ptav_1_1 = self.test_product_1.attribute_line_ids.filtered(lambda l: l.attribute_id.id == self.attribute_1.id).product_template_value_ids.filtered(lambda v: v.product_attribute_value_id.id == self.attribute_1_value_1.id)
+        ptav_1_2 = self.test_product_1.attribute_line_ids.filtered(lambda l: l.attribute_id.id == self.attribute_1.id).product_template_value_ids.filtered(lambda v: v.product_attribute_value_id.id == self.attribute_1_value_2.id)
+        ptav_2_2 = self.test_product_1.attribute_line_ids.filtered(lambda l: l.attribute_id.id == self.attribute_2.id).product_template_value_ids.filtered(lambda v: v.product_attribute_value_id.id == self.attribute_2_value_2.id)
+        ptav_2_1 = self.test_product_1.attribute_line_ids.filtered(lambda l: l.attribute_id.id == self.attribute_2.id).product_template_value_ids.filtered(lambda v: v.product_attribute_value_id.id == self.attribute_2_value_1.id)
+        self.env['product.template.attribute.exclusion'].create({
+            'product_tmpl_id': self.test_product_1.id,
+            'product_template_attribute_value_id': ptav_1_1.id,
+            'value_ids': [Command.set([ptav_2_1.id])],
+        })
+
+        self.env['product.template.attribute.exclusion'].create({
+            'product_tmpl_id': self.test_product_1.id,
+            'product_template_attribute_value_id': ptav_1_2.id,
+            'value_ids': [Command.set([ptav_2_2.id])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_cross_exclusion_attribute_values')
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
If you setup the attribute exclusion on a product template with 2 attribute, so that only 2 valid combinations are possible, you would not be able to select the second attribute value in the product configurator popup.

Steps to reproduce:
-------------------
* Create 2 attributes with 2 values each A1V1 A1V2 and A2V1 A2V2
* Create a product template with these attributes and set the attribute exclusion so that only 2 valid combinations are possible.
* Open PoS and try to add the product to the cart.
* The configurator popup will appear.
> Observation: You will not be able to change the selection because the
  other combinations are not correct.

Why the fix:
------------
Instead of blocking the selection of wrong combinations, we disable the add button when the current selection is not valid. This allows the user to change the selection of the attributes without being blocked by the exclusion rules.

opw-4825451