### PR TITLE
[FIX] website_payment: clear persistent cache for payment snippet

### DIFF
--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -159,7 +159,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
 
     @http.route(
         '/website_payment/snippet/supported_payment_methods',
-        type='jsonrpc', auth='public', website=True, sitemap=False, readonly=True,
+        type='http', methods=['GET'], auth='public', website=True, sitemap=False, readonly=True,
     )
     def get_supported_payment_methods(self, limit=None):
         """Retrieve the payment methods linked to payment providers published on the current
@@ -201,7 +201,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
             ('provider_ids', 'in', compatible_providers_sudo.ids),
         ])
 
-        return request.env['payment.method'].search(
+        supported_pms = request.env['payment.method'].search(
             Domain.OR([brands_domain, primary_without_brands_domain]),
             limit=limit,
         ).mapped(lambda pm: {
@@ -209,6 +209,18 @@ class PaymentPortal(payment_portal.PaymentPortal):
             # Loading the image via this url caches the image on the client browser
             'image_url': request.env['website'].image_url(pm, 'image'),
         })
+
+        if request.env.user._is_internal():
+            # Ensure the internal users can always see the most up to date list of PMs.
+            cache_control = 'no-cache'
+        else:
+            # Cache the PMs for public/portal users for 7 days, with an additional day to re-use
+            # the stale PMs while a background task updates the client cache.
+            cache_control = 'public, max-age=604800, stale-while-revalidate=86400'
+
+        return request.make_json_response(
+            supported_pms, headers=[('Cache-Control', cache_control)],
+        )
 
 
 class PortalAccount(account_payment_portal.PortalAccount):

--- a/addons/website_payment/static/src/snippets/s_supported_payment_methods/supported_payment_methods.js
+++ b/addons/website_payment/static/src/snippets/s_supported_payment_methods/supported_payment_methods.js
@@ -1,5 +1,3 @@
-import { browser } from '@web/core/browser/browser';
-import { rpc } from '@web/core/network/rpc';
 import { registry } from '@web/core/registry';
 import { Interaction } from '@web/public/interaction';
 
@@ -23,22 +21,9 @@ export class SupportedPaymentMethods extends Interaction {
      * the editor as any edit reloads the interaction.
      */
     async fetchPaymentMethods() {
-        let cache = JSON.parse(
-            browser.sessionStorage.getItem('website_payment.supported_payment_methods') || '{}',
-        );
-
-        // Re-fetch if the cached list can potentially be larger
-        if (cache.payment_methods === undefined || cache.limit < this.limit) {
-            cache.payment_methods = await this.waitFor(
-                rpc('/website_payment/snippet/supported_payment_methods', { limit: this.limit }),
-            ).catch(_ => []);
-            cache.limit = this.limit;
-            browser.sessionStorage.setItem(
-                'website_payment.supported_payment_methods', JSON.stringify(cache),
-            );
-        }
-
-        this.payment_methods = cache.payment_methods.slice(0, this.limit);
+        this.payment_methods = await this.waitFor(this.services.http.get(
+            `/website_payment/snippet/supported_payment_methods?limit=${this.limit}`
+        )).catch(_ => []);
     }
 
     start() {

--- a/addons/website_payment/static/src/website_builder/supported_payment_methods_option_plugin.js
+++ b/addons/website_payment/static/src/website_builder/supported_payment_methods_option_plugin.js
@@ -2,7 +2,6 @@ import { BuilderAction } from '@html_builder/core/builder_action';
 import { SNIPPET_SPECIFIC } from '@html_builder/utils/option_sequence';
 import { Plugin } from '@html_editor/plugin';
 import { withSequence } from '@html_editor/utils/resource';
-import { browser } from '@web/core/browser/browser';
 import { _t } from '@web/core/l10n/translation';
 import { registry } from '@web/core/registry';
 
@@ -23,14 +22,9 @@ class SupportedPaymentMethodsOptionPlugin extends Plugin {
         get_overlay_buttons: withSequence(0, { getButtons: this.getOptionButtons.bind(this) }),
     };
 
-    setup() {
-        // Invalidate the cache if the user made backend changes and reloads the page.
-        this.addDomListener(this.window, "beforeunload", this.invalidateSnippetCache.bind(this));
-    }
-
     /**
      * Add a reload button at the top in case the user made some changes to the supported payment
-     * methods.
+     * methods. This only reloads the snippet element and not the entire editor page.
      */
     getOptionButtons(editingElement) {
         if (editingElement.dataset.snippet !== 's_supported_payment_methods') {
@@ -39,16 +33,9 @@ class SupportedPaymentMethodsOptionPlugin extends Plugin {
         return [{
             class: 'fa fa-fw fa-rotate-right btn btn-outline-info',
             title: _t("Reload the payment methods"),
-            handler: () => {
-                this.invalidateSnippetCache();
-                this.dependencies.edit_interaction.restartInteractions(editingElement);
-            }
+            // Force the interaction to call the server again in case the user made backend changes.
+            handler: () => this.dependencies.edit_interaction.restartInteractions(editingElement),
         }];
-    }
-
-    invalidateSnippetCache() {
-        // Invalidate the interaction cache to force a new call to the server.
-        browser.sessionStorage.removeItem('website_payment.supported_payment_methods');
     }
 }
 

--- a/addons/website_payment/views/snippets/s_supported_payment_methods.xml
+++ b/addons/website_payment/views/snippets/s_supported_payment_methods.xml
@@ -2,7 +2,17 @@
 <odoo>
 
     <template id="s_supported_payment_methods" name="Supported Payment Methods">
-        <div class="s_supported_payment_methods o_not_editable" data-limit="6" data-height="30px"/>
+        <!-- `o_not_editable` prevents the user from selecting content inside the snippet like
+             images as they will not be saved either way.
+             `data-oe-protected` prevents the history plugin from registering DOM changes in this
+             element, otherwise a warning is logged when reverting previewed changes.
+        -->
+        <div
+            class="s_supported_payment_methods o_not_editable"
+            data-limit="6"
+            data-height="30px"
+            data-oe-protected="true"
+        />
     </template>
 
     <record id="s_supported_payment_methods_OOO_xml" model="ir.asset">


### PR DESCRIPTION
The "Supported Payment Methods" snippet introduced in [^1] was designed to cache payment methods to minimize server calls. However, this cache was stored in session storage, meaning it wasn't invalidated on page reloads. While this behavior worked well for regular customers, it was problematic for admins who needed to see backend changes reflected
immediately upon reloading the page.

This commit shifts the caching logic to rely on the HTTP caching mechanism. This change eliminates a significant amount of frontend code and centralizes the logic in the backend.

The new approach disables caching for logged-in internal users while enforcing caching for regular customers visiting the website. Since payment methods are not expected to change frequently, a 7-day cache policy is enforced. After this period, the client must revalidate with the server, ensuring any inconsistencies are resolved in a timely manner.

Additionally, a safeguard has been added to the snippet to prevent warnings in the console.

task-2889752

[^1]: https://github.com/odoo/odoo/pull/213234
