### PR TITLE
[FIX] purchase_stock: cap on-time delivery rate at 100%

### DIFF
--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -40,7 +40,7 @@ class ResPartner(models.Model):
         for line in order_lines:
             on_time, ordered = partner_dict.get(line.partner_id, (0, 0))
             ordered += line.product_uom_qty
-            on_time += lines_quantity[line.id]
+            on_time += min(lines_quantity[line.id], line.product_uom_qty)
             partner_dict[line.partner_id] = (on_time, ordered)
         seen_partner = self.env['res.partner']
         for partner, numbers in partner_dict.items():


### PR DESCRIPTION
If a purchase order is fulfilled with a quantity exceeding the demand, the on-time delivery rate can surpass 100%, which is nonsensical. Thus, we cap it at 100%. An excessive delivery is as good as an exact delivery.

Steps to reproduce:
1. Make a PO for a quantity of n and confirm it.
2. Validate the picking for it with a quantity of 2n.
3. Make another PO for the same vendor and observe an on-time delivery rate of 200%.

Task ID: [4938835](https://www.odoo.com/odoo/my-tasks/4938835)
