### PR TITLE
[FIX] sale_project: correctly get projects in SO stat button

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -200,11 +200,12 @@ class SaleOrder(models.Model):
             return {'type': 'ir.actions.act_window_close'}
 
         sorted_line = self.order_line.sorted('sequence')
+        projects = self.with_context(active_test=False).project_ids
         default_sale_line = next((sol for sol in sorted_line if sol.product_id.detailed_type == 'service'), None)
         action = {
             'type': 'ir.actions.act_window',
             'name': _('Projects'),
-            'domain': ['|', ('sale_order_id', '=', self.id), ('id', 'in', self.with_context(active_test=False).project_ids.ids), ('active', 'in', [True, False])],
+            'domain': ['|', ('sale_order_id', '=', self.id), ('id', 'in', projects.ids), ('active', 'in', [True, False])],
             'res_model': 'project.project',
             'views': [(False, 'kanban'), (False, 'tree'), (False, 'form')],
             'view_mode': 'kanban,tree,form',
@@ -215,8 +216,8 @@ class SaleOrder(models.Model):
                 'default_allow_billable': 1,
             }
         }
-        if len(self.with_context(active_test=False).project_ids) == 1:
-            action.update({'views': [(False, 'form')], 'res_id': self.project_ids.id})
+        if len(projects) == 1:
+            action.update({'views': [(False, 'form')], 'res_id': projects.id})
         return action
 
     def action_view_milestone(self):

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -563,6 +563,11 @@ class TestSaleProject(TestSaleProjectCommon):
         action = sale_order.action_view_project_ids()
         self.assertEqual(len(get_project_ids_from_action_domain(action)), 2, "Domain should contain 2 projects. (one archived, one not)")
 
+        project_A.unlink()
+        self.assertFalse(project_B.active)
+        action = sale_order.action_view_project_ids()
+        self.assertEqual(action['res_id'], project_B.id, "Action should still return Product B, even if it was archived.")
+
     def test_sale_order_line_view_form_editable(self):
         """ Check the behavior of the form view editable of `sale.order.line` introduced in that module
 


### PR DESCRIPTION
Before this commit, and since commit [1], the project stat button counter on the SO form view would count archived projects. It also changed the stat button related action python method to consider the archived projects, but it came with a bug when the only project existing for a SO is archived.

In this case, when clicking on the stat button (showing "1"), it would navigate to an empty form view to create a new project, because the action wrongly returned a `False` `res_id`.

Just an oversight of the `if` condition considering archived projects correctly but not the actual line inside that condition. The chance is taken to save the `projects` in a variable to avoid such oversights later, even tho it makes the diff harder to read.

Steps to reproduce:
- Create a service product, set it to "Create a task"
- Add a project on that product, say "Project 1"
- Create a SO with that product, confirm it
- You see the project stat button set to 1, clicking on it go to the
  project (good)
- Now archive the "Project 1" project
- Go back to the SO, stat button still show "1" (good) but clicking on
  it won't redirect to the project (bad), it will open a new form view
  to create a project.

Note that if there is 2 projects, and one is archived, there is no issue because you don't go into that `if` condition, and the action return a list/kanban views with the correct list of projects ids (including the archived ones)

There is no bug in 16, because archived products are not counted in the stat button, see commit [2]. Such a case can't happen there, as if only one project exists for a SO and its archived, the stat button won't be shown. The button visibility wasn't based on the `project_count` field but the `project_ids` field. The ORM when reading `project_ids` is ignoring the archived one (expected ORM behavior when going through relational fields without `active_test=False` forced).

[1]: https://github.com/odoo/odoo/commit/eef4506f32f09dcda9990556e55131bc17855dcc
[2]: https://github.com/odoo/odoo/commit/76a6a0d2ec802db2d9a7f9db61b20323d47479ce

opw-4878303
