### PR TITLE
[IMP] {website_}event{_sale},test_event_full: adding a limit on orderable tickets

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -34,6 +34,9 @@ class EventEvent(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _order = 'date_begin, id'
 
+    # Maximum number of tickets that can be ordered at one time on a same line
+    EVENT_MAX_TICKETS = 30
+
     @api.model
     def default_get(self, fields):
         result = super().default_get(fields)

--- a/addons/event/views/event_ticket_views.xml
+++ b/addons/event/views/event_ticket_views.xml
@@ -80,6 +80,7 @@
                 <field name="seats_max" sum="Total" width="120px" string="Maximum per slot" column_invisible="not context.get('is_event_multi_slots')"/>
                 <field name="seats_taken" sum="Total" width="120px" string="Registration" column_invisible="context.get('is_event_multi_slots')"/>
                 <field name="seats_taken" sum="Total" width="120px" string="Total Registration" column_invisible="not context.get('is_event_multi_slots')"/>
+                <field name="limit_max_per_order" optional="hidden"/>
                 <field name="color" widget="color" optional="hidden"/>
             </list>
         </field>

--- a/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
@@ -1,4 +1,3 @@
-import { queryOne } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 
@@ -7,56 +6,52 @@ var registerSteps = [{
     trigger: 'button.btn-primary:contains("Register")',
     run: "click",
 }, {
-    content: "Select 2 units of 'Ticket1' ticket type",
-    trigger: '#o_wevent_tickets_collapse .row.o_wevent_ticket_selector[name="Ticket1"] select',
-    run: "select 2",
+    content: "Add 2 units of 'Ticket1' ticket type by clicking the '+' button",
+    trigger: 'button[data-increment-type*="plus"]',
+    run: "dblclick",
 }, {
-    content: "Select 1 unit of 'Ticket2' ticket type",
-    trigger: '#o_wevent_tickets_collapse .row.o_wevent_ticket_selector[name="Ticket2"] select',
-    run: "select 1",
+    content: "Edit 1 unit of 'Ticket2' ticket type",
+    trigger: '.modal input:eq(2)',
+    run: "edit 1",
 }, {
     content: "Click on 'Register' button",
     trigger: '#o_wevent_tickets .btn-primary:contains("Register"):not(:disabled)',
     run: 'click',
 }, {
-    content: "Fill attendees details",
-    trigger: 'form[id="attendee_registration"] .btn[type=submit]',
-    run: function () {
-            document.querySelector("input[name*='1-name']").value = "Raoulette Poiluchette";
-            document.querySelector("input[name*='1-phone']").value = "0456112233";
-            document.querySelector("input[name*='1-email']").value = "raoulette@example.com";
-            document.querySelector("div[name*='Question1'] select[name*='1-simple_choice']").value =
-                queryOne("select[name*='1-simple_choice'] option:contains('Q1-Answer2')").value;
-            document.querySelector("div[name*='Question2'] select[name*='1-simple_choice']").value =
-                queryOne("select[name*='1-simple_choice'] option:contains('Q2-Answer1')").value;
-            document.querySelector("input[name*='2-name']").value = "Michel Tractopelle";
-            document.querySelector("input[name*='2-phone']").value = "0456332211";
-            document.querySelector("input[name*='2-email']").value = "michel@example.com";
-            document.querySelector("div[name*='Question1'] select[name*='2-simple_choice']").value =
-                queryOne("select[name*='2-simple_choice'] option:contains('Q1-Answer1')").value;
-            document.querySelector("div[name*='Question2'] select[name*='2-simple_choice']").value =
-                queryOne("select[name*='2-simple_choice'] option:contains('Q2-Answer2')").value;
-            document.querySelector("input[name*='3-name']").value = "Hubert Boitaclous";
-            document.querySelector("input[name*='3-phone']").value = "0456995511";
-            document.querySelector("input[name*='3-email']").value = "hubert@example.com";
-            document.querySelector("div[name*='Question1'] select[name*='3-simple_choice']").value =
-                queryOne("select[name*='3-simple_choice'] option:contains('Q1-Answer2')").value;
-            document.querySelector("div[name*='Question2'] select[name*='3-simple_choice']").value =
-                queryOne("select[name*='3-simple_choice'] option:contains('Q2-Answer2')").value;
-            document.querySelector("textarea[name*='question_answer']").textContent =
-                "Random answer from random guy";
-    },
-},
-{
-    trigger: "input[name*='1-name'], input[name*='2-name'], input[name*='3-name']",
-},
-{
+    content: "Choose the 'Q1-Answer2' answer of the 'Question1' for the first ticket",
+    trigger: 'select[name*="1-simple_choice"]',
+    run: "selectByIndex 2",
+}, {
+    content: "Choose the 'Q2-Answer1' answer of the 'Question2' for the first ticket",
+    trigger: 'select[name*="1-simple_choice"]:last',
+    run: "selectByIndex 1",
+}, {
+    content: "Choose the 'Q1-Answer1' answer of the 'Question1' for the second ticket",
+    trigger: 'select[name*="2-simple_choice"]',
+    run: "selectByIndex 1",
+}, {
+    content: "Choose the 'Q2-Answer2' answer of the 'Question2' for the second ticket",
+    trigger: 'select[name*="2-simple_choice"]:last',
+    run: "selectByIndex 2",
+}, {
+    content: "Choose the 'Q1-Answer2' answer of the 'Question1' for the third ticket",
+    trigger: 'select[name*="3-simple_choice"]',
+    run: "selectByIndex 2",
+}, {
+    content: "Choose the 'Q2-Answer2' answer of the 'Question2' for the third ticket",
+    trigger: 'select[name*="3-simple_choice"]:last',
+    run: "selectByIndex 2",
+}, {
+    content: "Fill the text content of the 'Question3' for the third ticket",
+    trigger: 'textarea[name*="text_box"]',
+    run: "edit Random answer from random guy",
+}, {
     content: "Validate attendees details",
-    trigger: 'button[type=submit]',
+    trigger: 'button[type=submit]:last',
     run: 'click',
     expectUnloadPage: true,
 },
-wsTourUtils.fillAdressForm({
+...wsTourUtils.fillAdressForm({
     name: "Raoulette Poiluchette",
     phone: "0456112233",
     email: "raoulette@example.com",
@@ -64,6 +59,12 @@ wsTourUtils.fillAdressForm({
     city: "CheeseCity",
     zip: "8888",
 }),
+{
+    content: "Confirm address",
+    trigger: 'a[name="website_sale_main_button"]',
+    run: "click",
+    expectUnloadPage: true,
+},
 ...wsTourUtils.payWithDemo(),
 ];
 

--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -83,9 +83,9 @@ const registerSteps = [
         run: "click",
     },
     {
-        content: "Select 2 units of 'Standard' ticket type",
-        trigger: ".modal .o_wevent_ticket_selector select",
-        run: "select 2",
+        content: "Edit 2 units of 'Standard' ticket type",
+        trigger: ".modal .o_wevent_ticket_selector input",
+        run: "edit 2",
     },
     {
         content: "Click on 'Register' button",

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -465,20 +465,19 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
             with self.assertQueryCount(default=39):
                 self._test_url_open('/event')
 
-    # @warmup
-    # def test_register_public(self):
-    #     with freeze_time(self.reference_now + timedelta(hours=3)):  # be sure sales has started
-    #         self.assertTrue(self.test_event.event_registrations_started)
-    #         self.authenticate(None, None)
-    #         with self.assertQueryCount(default=99999):  # tef only: 1110
-    #             self.browser_js(
-    #                 '/event/%i/register' % self.test_event.id,
-    #                 'odoo.__DEBUG__.services["web_tour.tour"].run("wevent_performance_register")',
-    #                 'odoo.__DEBUG__.services["web_tour.tour"].tours.wevent_performance_register.ready',
-    #                 login=None,
-    #                 timeout=200,
-    #             )
+    @warmup
+    def test_register_public(self):
+        with freeze_time(self.reference_now + timedelta(hours=3)):  # be sure sales has started
+            self.assertTrue(self.test_event.event_registrations_started)
+            self.authenticate(None, None)
+            with self.assertQueryCount(default=1197):  # tef: 1197
+                self.start_tour(
+                    '/event/%i/register' % self.test_event.id,
+                    'wevent_performance_register',
+                    login=None,
+                    timeout=200,
+                )
 
-    #     # minimal checkup, to be improved in future tests independently from performance
-    #     self.assertEqual(len(self.test_event.registration_ids), 3)
-    #     self.assertEqual(len(self.test_event.registration_ids.visitor_id), 1)
+        # minimal checkup, to be improved in future tests independently from performance
+        self.assertEqual(len(self.test_event.registration_ids), 3)
+        self.assertEqual(len(self.test_event.registration_ids.visitor_id), 1)

--- a/addons/website_event/static/src/interactions/website_event_ticket_details.js
+++ b/addons/website_event/static/src/interactions/website_event_ticket_details.js
@@ -12,21 +12,68 @@ export class TicketDetails extends Interaction {
         _envBus: {
             "t-on-websiteEvent.enableSubmit": () => this.buttonDisabled = false,
         },
-        ".form-select": {
-            "t-on-change": () => {}, // use updateContent() to enable/disable submit button
+        "button[data-increment-type='minus']": {
+            "t-on-click": (ev) => this.onClick(ev, -1),
+        },
+        "button[data-increment-type='plus']": {
+            "t-on-click": (ev) => this.onClick(ev, 1),
+        },
+        ".o_wevent_input_nb_tickets": {
+            "t-on-input": this.onInput, // use updateContent() to enable/disable submit button
         },
         ".a-submit": {
             "t-on-click.prevent.stop": this.onSubmitClick,
-            "t-att-disabled": () => this.noTicketsOrdered || this.buttonDisabled ? "disabled" : false,
+            "t-att-disabled": () => this.moreTicketsOrderedThanExpected || this.noTicketsOrdered || this.buttonDisabled ? "disabled" : false,
         },
     };
 
     get noTicketsOrdered() {
         return Boolean(
-            !Array.from(this.el.querySelectorAll("select").values()).find(
-                (select) => select.value > 0
+            !Array.from(this.el.querySelectorAll(".o_wevent_input_nb_tickets")).find(
+                (input) => Number.isNaN(parseInt(input.value)) ? false : parseInt(input.value) > 0
             )
         );
+    }
+
+    get moreTicketsOrderedThanExpected() {
+        return Boolean(
+            Array.from(this.el.querySelectorAll(".o_wevent_input_nb_tickets")).find(
+                (input) => Number.isNaN(parseInt(input.value)) ? true : input.max < parseInt(input.value)
+            )
+        );
+    }
+
+    /**
+     * @param {InputEvent} ev
+     */
+    async onInput(ev) {
+        const inputComponent = ev.target;
+        const maximumBound = inputComponent.max;
+        inputComponent.value = Math.min(inputComponent.value.replace(/[^0-9]/g, ''), maximumBound);
+        
+        const spinner_buttons = this.el.querySelectorAll(`button[data-input-name=${inputComponent.name}]`);
+        spinner_buttons[0].disabled = parseInt(inputComponent.value) <= 0;
+        spinner_buttons[1].disabled = parseInt(inputComponent.value) >= maximumBound;
+
+        // Display/hide maximum ticket quantity if reached
+        this.el.querySelector(`p[name=${inputComponent.name}]`).hidden = parseInt(inputComponent.value) < maximumBound;
+    }
+
+    /**
+     * @param {MouseEvent} ev
+     */
+    onClick(ev, incrementValue) {
+        const inputComponent = this.el.querySelector(`input[name=${ev.currentTarget.dataset.inputName}]`);
+        const maximumBound = inputComponent.max;
+        const inputValue = parseInt(inputComponent.value);
+        if (0 <= inputValue && inputValue <= maximumBound) {
+            inputComponent.value = Math.max(0, Math.min(inputValue + incrementValue, maximumBound));
+        } else {
+            inputComponent.value = inputValue < 0 ? 0 : maximumBound;
+        }
+
+        // Triggers an input event to update the “Register” button accessibility
+        inputComponent.dispatchEvent(new Event("input"))
     }
 
     /**

--- a/addons/website_event/static/tests/tours/tickets_questions.js
+++ b/addons/website_event/static/tests/tours/tickets_questions.js
@@ -18,9 +18,44 @@ registry.category("web_tour.tours").add("test_tickets_questions", {
             trigger: 'button:disabled:contains("Register")',
         },
         {
-            content: "Select 2 'Free' tickets to buy",
-            trigger: 'div.o_wevent_ticket_selector:contains("Free") select.form-select',
-            run: "select 2",
+            content: "Check '-' spinner button is disabled when no ticket selected",
+            trigger: 'button[data-increment-type="minus"]:disabled',
+        },
+        {
+            content: "Try adding 53 'Free' tickets",
+            trigger: 'div.o_wevent_ticket_selector:contains("Free") input.form-control',
+            run: "edit 53",
+        },
+        {
+            content: "Check '+' spinner button is disabled when no ticket selected",
+            trigger: 'button[data-increment-type="plus"]:disabled',
+        },
+        {
+            // The input number should automatically be changed to the limit per order (22 < 28)
+            trigger: 'div.o_wevent_ticket_selector:contains("Free"):contains("22") input.form-control',
+        },
+        {
+            content: "Edit 2 'Free' tickets to buy",
+            trigger: 'div.o_wevent_ticket_selector:contains("Free") input.form-control',
+            run: "edit 2",
+        },
+        {
+            content: "Try adding 150 'Other' tickets",
+            trigger: 'div.o_wevent_ticket_selector:contains("Other") input.form-control',
+            run: "edit 150",
+        },
+        {
+            // The input number should automatically be changed to the event limit (28 < 150)
+            trigger: 'div.o_wevent_ticket_selector:contains("Other"):contains("28") input.form-control',
+        },
+        {
+            content: "Remove 'Other' tickets",
+            trigger: 'div.o_wevent_ticket_selector:contains("Other") input.form-control',
+            run: "edit 0",
+        },
+        {
+            content: "Check '-' spinner button is disabled when no ticket selected",
+            trigger: 'div.o_wevent_ticket_selector:contains("Other") button[data-increment-type="minus"]:disabled',
         },
         {
             content: "Click on Register (to fill tickets data) button",

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -89,11 +89,14 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             'date_end': fields.Datetime.now() + relativedelta(days=15),
             'event_ticket_ids': [(0, 0, {
                 'name': 'Free',
-                'start_sale_datetime': fields.Datetime.now() - relativedelta(days=15)
+                'start_sale_datetime': fields.Datetime.now() - relativedelta(days=15),
+                'limit_max_per_order': 22,
             }), (0, 0, {
                 'name': 'Other',
                 'start_sale_datetime': fields.Datetime.now() - relativedelta(days=15)
             })],
+            'seats_limited': True,
+            'seats_max': 28,
             'website_published': True,
             'question_ids': [(0, 0, {
                 'title': 'Name',

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -330,7 +330,12 @@
                     </div>
                     <t t-set="counter" t-value="0"/>
                     <t t-set="input_type_by_question_type" t-value="{'name': 'text', 'email': 'email', 'phone': 'tel', 'company_name': 'text'}"/>
-                    <t t-if="availability_check" t-foreach="tickets" t-as="ticket">
+                    <t t-if="not limit_check">
+                        <div class="modal-body border-bottom">
+                            <strong> You cannot order more than available seats</strong>
+                        </div>
+                    </t>
+                    <t t-if="availability_check and limit_check" t-foreach="tickets" t-as="ticket">
                         <t t-foreach="range(1, ticket['quantity'] + 1)" t-as="att_counter" name="attendee_loop">
                             <t t-set="counter" t-value="counter + 1"/>
                             <input t-if="event_slot_id" type="hidden" t-attf-name="#{counter}-event_slot_id" t-att-value="event_slot_id"/>
@@ -349,7 +354,7 @@
                             </div>
                         </t>
                     </t>
-                    <div t-if="availability_check and event.general_question_ids" class="modal-body border-top o_wevent_registration_question_global">
+                    <div t-if="availability_check and limit_check and event.general_question_ids" class="modal-body border-top o_wevent_registration_question_global">
                         <div class="row">
                             <t t-foreach="event.general_question_ids" t-as="question">
                                 <div class="mt-2" t-att-class="question.question_type=='text_box' and 'col-lg-12' or 'col-lg-6'">
@@ -360,14 +365,14 @@
                             </t>
                         </div>
                     </div>
-                    <t t-elif="not availability_check">
+                    <t t-elif="not availability_check and limit_check">
                         <div class="modal-body border-bottom">
                             <strong> You ordered more tickets than available seats</strong>
                         </div>
                     </t>
                     <div class="modal-footer border-top">
                         <button type="button" class="btn btn-secondary js_goto_event" data-bs-dismiss="modal">Cancel</button>
-                        <button type="submit" class="btn btn-primary" t-if="availability_check">Confirm Registration</button>
+                        <button type="submit" class="btn btn-primary" t-if="availability_check and limit_check">Confirm Registration</button>
                     </div>
                 </div>
             </form>
@@ -514,7 +519,7 @@
                             <div t-foreach="tickets" t-as="ticket"
                                 t-attf-class="d-flex justify-content-between o_wevent_ticket_selector mb-2 pb-2 {{not ticket_last and 'border-bottom' or ''}}"
                                 t-att-name="ticket.name">
-                                <div itemscope="itemscope" itemtype="http://schema.org/Offer">
+                                <div class="col-6 pe-3" itemscope="itemscope" itemtype="http://schema.org/Offer">
                                     <h5 itemprop="name" t-field="ticket.name" class="h6 my-0"/>
                                     <t t-if="ticket.description">
                                         <small t-field="ticket.description" class="text-muted py-2"/>
@@ -533,26 +538,44 @@
                                         <span t-if="website_visitor_timezone != event.date_tz">(<t t-out="event.date_tz"/>)</span>
                                     </small>
                                 </div>
-                                <div class="d-flex flex-column flex-md-row align-items-center justify-content-between gap-2">
-                                    <div class="o_wevent_registration_multi_select flex-md-grow-1 text-end"/>
+                                <div class="d-flex flex-column col-6 flex-md-row align-items-end align-items-md-start text-end gap-2">
+                                    <div t-attf-class="o_wevent_registration_multi_select flex-md-grow-1 text-end"/> <!-- t-attf-class added for some dynamic classes inherited -->
                                     <div class="ms-auto">
+                                        <t t-set="limit_per_order" t-value="ticket._get_current_limit_per_order(event_slot if event_slot else False)[ticket.id]"/>
                                         <t t-set="seats_available_slot_ticket" t-value="seats_available_slot_tickets and seats_available_slot_tickets.get(ticket.id, 0) or 0"/>
                                         <t t-set="seats_available_slot" t-value="event_slot and event_slot.seats_available or 0"/>
-                                        <t t-set="seats_max_slot_ticket" t-value="((not event.seats_limited and not ticket.seats_limited) or seats_available_slot_ticket &gt; 9) and 10 or seats_available_slot_ticket + 1"/>
-                                        <t t-set="seats_max_slot" t-value="(not event.seats_limited or seats_available_slot &gt; 9) and 10 or seats_available_slot + 1"/>
-                                        <t t-set="seats_max_ticket" t-value="(not ticket.seats_limited or ticket.seats_available &gt; 9) and 10 or ticket.seats_available + 1"/>
-                                        <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
+                                        <t t-set="seats_max_slot_ticket" t-value="(not event.seats_limited and not ticket.seats_limited and limit_per_order) or min(limit_per_order or seats_available_slot_ticket, seats_available_slot_ticket)"/>
+                                        <t t-set="seats_max_slot" t-value="(not event.seats_limited and limit_per_order) or min(limit_per_order or seats_available_slot, seats_available_slot)"/>
+                                        <t t-set="seats_max_ticket" t-value="(not ticket.seats_limited and limit_per_order) or min(limit_per_order or ticket.seats_available, ticket.seats_available)"/>
+                                        <t t-set="seats_max_event" t-value="(not event.seats_limited and limit_per_order) or min(limit_per_order or event.seats_available, event.seats_available)"/>
                                         <t t-set="seats_max_event_or_slot" t-value="seats_max_slot if event_slot else seats_max_event"/>
                                         <t t-set="seats_max" t-value="seats_available_slot_tickets and seats_max_slot_ticket or min(seats_max_ticket, seats_max_event_or_slot)"/>
-                                        <select t-if="(not ticket.is_expired and ticket.sale_available) or seats_available_slot_ticket"
-                                            t-attf-name="nb_register-#{ticket.id}"
-                                            class="w-auto form-select">
-                                            <t t-foreach="range(0, seats_max)" t-as="nb">
-                                                <option t-out="nb" t-att-selected="len(ticket) == 0 and nb == 0 and 'selected'"/>
-                                            </t>
-                                        </select>
-                                        <div t-else="" class="text-danger">
-                                            <span t-if="not ticket.sale_available and not ticket.is_expired and ticket.is_launched" >Sold Out</span>
+                                        <t t-set="max_input_value" t-value="event.EVENT_MAX_TICKETS if seats_max > event.EVENT_MAX_TICKETS else (0 if 0 > seats_max else seats_max)"/>
+                                        <div t-if="(not ticket.is_expired and ticket.sale_available and max_input_value) or seats_available_slot_ticket">
+                                            <div class="rounded input-group d-inline-flex border" style="width: 120px;">
+                                                <button
+                                                    class="btn d-md-inline-block border-0 pe-2" data-increment-type="minus" type="button"
+                                                    t-att-disabled="True" t-attf-data-input-name="nb_register-#{ticket.id}">
+                                                    <i class="oi oi-minus text-600"/>
+                                                </button>
+                                                <input
+                                                    class="o_wevent_input_nb_tickets form-control text-center border-0 p-0"
+                                                    inputmode="numeric" pattern="[0-9]*" size="2" type="text" value="0"
+                                                    t-attf-max="#{max_input_value}" t-attf-name="nb_register-#{ticket.id}"/>
+                                                <button
+                                                    class="btn d-md-inline-block border-0 ps-2" data-increment-type="plus" type="button"
+                                                    t-attf-data-input-name="nb_register-#{ticket.id}">
+                                                    <i class="oi oi-plus text-600"/>
+                                                </button>
+                                            </div>
+                                            <div>
+                                                <p class="text-muted text-center mb-0" t-attf-name="nb_register-#{ticket.id}" t-att-hidden="max_input_value >= 1">
+                                                    (Max. <t t-out="max_input_value"/>)
+                                                </p>
+                                            </div>
+                                        </div>
+                                        <div t-else="" class="text-danger mt-1">
+                                            <span t-if="(not ticket.sale_available and not ticket.is_expired and ticket.is_launched) or not max_input_value">Sold Out</span>
                                             <span t-if="ticket.is_expired">Expired</span>
                                         </div>
                                     </div>
@@ -574,7 +597,7 @@
                     </t>
                     <div t-else="" class="o_wevent_registration_single">
                         <div class="modal-body row px-3 py-2 mx-0">
-                            <div class="col-12 col-md-8 p-0" itemscope="itemscope" itemtype="http://schema.org/Offer">
+                            <div class="col-12 col-md-6 p-0 pe-3" itemscope="itemscope" itemtype="http://schema.org/Offer">
                                 <h5 itemprop="name" class="my-0 pe-3 o_wevent_single_ticket_name">
                                     <span t-if="tickets" t-field="tickets.name"/>
                                     <span t-else="">Registration</span>
@@ -591,23 +614,42 @@
                                     <span t-if="website_visitor_timezone != event.date_tz">(<t t-out="event.date_tz"/>)</span>
                                 </small>
                             </div>
-                            <div class="col-md-4 d-flex align-items-center justify-content-between p-0">
+                            <div class="col-md-6 d-flex justify-content-between p-0">
                                 <t t-if="event.event_registrations_open">
                                     <link itemprop="availability" content="http://schema.org/InStock"/>
                                     <div class="o_wevent_registration_single_select w-auto ms-auto">
+                                        <t t-set="limit_per_order" t-value="tickets._get_current_limit_per_order(event_slot if event_slot else False)[tickets.id] if tickets else event.EVENT_MAX_TICKETS"/>
                                         <t t-set="seats_available_slot_ticket" t-value="seats_available_slot_tickets and tickets and seats_available_slot_tickets.get(tickets.id, 0) or 0"/>
-                                        <t t-set="seats_max_slot_ticket" t-value="((not event.seats_limited and not tickets.seats_limited) or seats_available_slot_ticket &gt; 9) and 10 or seats_available_slot_ticket + 1"/>
+                                        <t t-set="seats_max_slot_ticket" t-value="(not event.seats_limited and ((not tickets.seats_limited and limit_per_order) if tickets else event.EVENT_MAX_TICKETS)) or min(limit_per_order or seats_available_slot_ticket, seats_available_slot_ticket)"/>
                                         <t t-set="seats_available_slot" t-value="event_slot and event_slot.seats_available or 0"/>
-                                        <t t-set="seats_max_slot" t-value="(not event.seats_limited or seats_available_slot &gt; 9) and 10 or seats_available_slot + 1"/>
-                                        <t t-set="seats_max_ticket" t-value="(not tickets or not tickets.seats_limited or tickets.seats_available &gt; 9) and 10 or tickets.seats_available + 1"/>
-                                        <t t-set="seats_max_event" t-value="(not event.seats_limited or event.seats_available &gt; 9) and 10 or event.seats_available + 1"/>
+                                        <t t-set="seats_max_slot" t-value="(not event.seats_limited and limit_per_order) or min(limit_per_order or seats_available_slot, seats_available_slot)"/>
+                                        <t t-set="seats_max_ticket" t-value="((not tickets or not tickets.seats_limited) and limit_per_order) or min(limit_per_order or tickets.seats_available, tickets.seats_available)"/>
+                                        <t t-set="seats_max_event" t-value="(not event.seats_limited and limit_per_order) or min(limit_per_order or event.seats_available, event.seats_available)"/>
                                         <t t-set="seats_max_event_or_slot" t-value="seats_max_slot if event_slot else seats_max_event"/>
                                         <t t-set="seats_max" t-value="(seats_available_slot_tickets and seats_max_slot_ticket or min(seats_max_ticket, seats_max_event_or_slot)) if tickets else seats_max_event_or_slot"/>
-                                        <select t-att-name="'nb_register-%s' % (tickets.id if tickets else 0)" class="d-inline w-auto form-select">
-                                            <t t-foreach="range(0, seats_max)" t-as="nb">
-                                                <option t-out="nb" t-att-selected="nb == 1 and 'selected'"/>
-                                            </t>
-                                        </select>
+                                        <t t-set="max_input_value" t-value="event.EVENT_MAX_TICKETS if seats_max > event.EVENT_MAX_TICKETS else (0 if 0 > seats_max else seats_max)"/>
+                                        <div class="rounded input-group d-inline-flex border" style="width: 120px;">
+                                            <t t-set="register_id" t-value="tickets.id if tickets else 0"/>
+                                            <button
+                                                class="btn d-md-inline-block border-0 pe-2" data-increment-type="minus" type="button"
+                                                t-attf-data-input-name="nb_register-#{register_id}">
+                                                <i class="oi oi-minus text-600"/>
+                                            </button>
+                                            <input
+                                                class="o_wevent_input_nb_tickets form-control quantity text-center border-0 p-0"
+                                                inputmode="numeric" pattern="[0-9]*" size="2" type="text" value="1"
+                                                t-attf-max="#{max_input_value}" t-attf-name="nb_register-#{register_id}"/>
+                                            <button
+                                                class="btn d-md-inline-block border-0 ps-2" data-increment-type="plus" type="button"
+                                                t-att-disabled="seats_max == 1" t-attf-data-input-name="nb_register-#{register_id}">
+                                                <i class="oi oi-plus text-600"/>
+                                            </button>
+                                        </div>
+                                        <div>
+                                            <p class="text-muted text-center mb-0" t-attf-name="nb_register-#{register_id}" t-att-hidden="max_input_value > 1">
+                                                (Max. <t t-out="max_input_value"/>)
+                                            </p>
+                                        </div>
                                     </div>
                                 </t>
                                 <t t-else="">

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -19,20 +19,37 @@ registry.category("web_tour.tours").add("event_buy_tickets", {
             trigger: '#wrap:not(:has(a[href*="/event"]:contains("Conference for Architects")))',
         },
         {
-            content: "Select 1 unit of `Standard` ticket type",
-            trigger: ".modal select:eq(0)",
-            run: "select 1",
+            content: "Try reaching maximum `Standard` ticket orderable",
+            trigger: ".modal input:eq(1)",
+            run: "edit 1234",
         },
         {
-            trigger: ".modal select:eq(0):has(option:contains(1):selected)",
+            // The input number should be changed to EVENT_MAX_TICKETS without particular conditions (EVENT_MAX_TICKETS < 1234)
+            trigger: "div.o_wevent_ticket_selector:contains('Max.') input.form-control",
         },
         {
-            content: "Select 2 units of `VIP` ticket type",
-            trigger: ".modal select:eq(1)",
-            run: "select 2",
+            content: "Reset to 0",
+            trigger: ".modal input:eq(1)",
+            run: "edit 0"
         },
         {
-            trigger: ".modal select:eq(1):has(option:contains(2):selected)",
+            content: "Add 1 unit of `Standard` ticket type thanks to the spinner",
+            trigger: "button[data-increment-type*='plus']",
+            run: "click",
+        },
+        {
+            content: "Try reaching maximum `VIP` ticket orderable",
+            trigger: ".modal input:eq(2)",
+            run: "edit 2002",
+        },
+        {
+            // The input number should be changed to min(limit per order, seats available) (11 < 12 < 2002)
+            trigger: "div.o_wevent_ticket_selector:contains('VIP'):contains('11') input.form-control",
+        },
+        {
+            content: "Edit 2 units of `VIP` ticket type",
+            trigger: ".modal input:eq(2)",
+            run: "edit 2",
         },
         {
             content: "Click on `Order Now` button",

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -22,12 +22,9 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
         trigger: '#wrap:not(:has(a[href*="/event"]:contains("Last ticket test")))',
     },
     {
-        content: "Select 2 units of `VIP` ticket type",
-        trigger: ".modal select:eq(0)",
-        run: "select 2",
-    },
-    {
-        trigger: ".modal select:eq(0):has(option:contains(2):selected)",
+        content: "Edit 2 units of `VIP` ticket type",
+        trigger: ".modal input:eq(1)",
+        run: "edit 2",
     },
     {
         content: "Click on `Register` button",

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -36,6 +36,8 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'product_id': cls.env.ref('event_product.product_product_event').id,
             'end_sale_datetime': (Datetime.today() + timedelta(90)).strftime('%Y-%m-%d'),
             'price': 1500.0,
+            'seats_max': 12,
+            'limit_max_per_order': 11,
         })
 
         cls.event_3 = cls.env['event.event'].create({

--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -10,8 +10,12 @@
             </t>
         </div>
     </xpath>
+    <!-- Add style display for price if the ticket is available -->
+    <xpath expr="//div[contains(@t-attf-class, 'o_wevent_registration_multi_select')]" position="attributes">
+        <attribute name="t-attf-class" separator=" " add="{{'' if not ticket.sale_available and not ticket.is_expired and ticket.is_launched else ('mt-1' if ticket.price_reduce == 0 else 'mt-2')}}"/>
+    </xpath>
     <!-- Add price information on tickets (multi tickets, aka in collapse) -->
-    <xpath expr="//div[hasclass('o_wevent_registration_multi_select')]" position="inside">
+    <xpath expr="//div[contains(@t-attf-class, 'o_wevent_registration_multi_select')]" position="inside">
         <t t-if="ticket.price">
             <t t-if="(ticket.price - ticket.price_reduce) &gt; 0">
                 <del t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
@@ -54,7 +58,7 @@
     </xpath>
     <!-- Add price information on tickets (mono ticket, aka not in collapse) -->
     <xpath expr="//div[hasclass('o_wevent_registration_single_select')]" position="before">
-        <div class="flex-md-grow-1 me-2 text-end">
+        <div class="flex-md-grow-1 mt-1 me-2 text-end">
             <t t-if="tickets.price">
                 <t t-if="(tickets.price - tickets.price_reduce) &gt;0">
                     <del t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
@@ -93,7 +97,7 @@
         </t>
         <t t-else="">
             <t t-set="has_paying_ticket" t-value="any(ticket.get('price', 0) > 0 for ticket in tickets)"/>
-            <button t-if="availability_check" type="submit" class="btn btn-primary">
+            <button t-if="availability_check and limit_check" type="submit" class="btn btn-primary">
                 <span t-if="has_paying_ticket">Go to Payment</span>
                 <span t-else="">Confirm Registration</span>
             </button>

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -175,15 +175,11 @@ export function pay({ expectUnloadPage = false, waitFinalizeYourPayment = false 
 
 export function payWithDemo() {
     return [{
-        content: 'eCommerce: select Test payment provider',
-        trigger: 'input[name="o_payment_radio"][data-payment-method-code="demo"]',
-        run: "click",
-    }, {
         content: 'eCommerce: add card number',
         trigger: 'input[name="customer_input"]',
         run: "edit 4242424242424242",
     },
-    ...pay(),
+    ...pay({expectUnloadPage: true}),
     {
         content: 'eCommerce: check that the payment is successful',
         trigger: '[name="order_confirmation"]:contains("Your payment has been processed.")',


### PR DESCRIPTION
**Currently**

When purchasing tickets online, a selectbox limits the value between 0 and 9 per
ticket type.

**Implementation**

We have added a new field since the event was created, allowing this old hardcoded
maximum limit to be modified. For performance and security reasons, this limit
cannot exceed 99. The value 0 also indicates this maximum limit. The selectbox has
been replaced with a spinner (inputbox with -/+ buttons). It improves the user
experience by replicating certain behaviors of the native inputbox of
`input type=number` but using the -/+ buttons instead of the old native arrows.

**Tests**

Some Website Event tours have been modified as a result of the change from the
selectbox to the inputbox. The tours have also been completed to verify the new
limits according to the configured constraints.

task-4822074