### PR TITLE
[FIX] orm: ir_rule should be evaluated with fixed active_test

### DIFF
--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -502,14 +502,7 @@ class Many2one(_Relational):
                     return SQL("(%s) IS NOT TRUE", sql)
 
         # execute search and generate condition with a SQL query
-        if (
-            comodel.env.context.get('active_test', True)
-            and comodel._active_name
-            and not any(condition.field_expr == comodel._active_name for condition in value.iter_conditions())
-        ):
-            # active_test=False only of the first leaf
-            value &= Domain(comodel._active_name, 'in', [True, False])
-        domain_query = comodel._search(value)
+        domain_query = comodel._search(value, active_test=False)
         return self.condition_to_sql(fname, operator, domain_query, model, alias, query)
 
     def join(self, model: BaseModel, alias: str, query: Query) -> tuple[BaseModel, str]:

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5290,12 +5290,13 @@ class BaseModel(metaclass=MetaModel):
 
         # security access domain
         if check_access:
+            self_sudo = self.sudo().with_context(active_test=False)
             sec_domain = self.env['ir.rule']._compute_domain(self._name, 'read')
-            sec_domain = sec_domain.optimize_full(self.sudo())
+            sec_domain = sec_domain.optimize_full(self_sudo)
             if sec_domain.is_false():
                 return self.browse()._as_query()
             if not sec_domain.is_true():
-                query.add_where(sec_domain._to_sql(self.sudo(), self._table, query))
+                query.add_where(sec_domain._to_sql(self_sudo, self._table, query))
 
         # add order and limits
         if order:


### PR DESCRIPTION

Records rules should be evaluated with a fixed active_test context value
to avoid depending on the context for security.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
