### PR TITLE
[FIX] project: make sure priority field is correctly displayed in list

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -472,7 +472,7 @@
                                     <field name="sequence" widget="handle"/>
                                     <field name="id" optional="hide" options="{'enable_formatting': False}"/>
                                     <field name="parent_id" column_invisible="True"/>
-                                    <field name="priority" widget="priority" optional="show" width="70px"/>
+                                    <field name="priority" widget="priority" optional="hide" width="70px"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
                                     <field name="name" widget="name_with_subtask_count"/>
                                     <field name="subtask_count" column_invisible="True"/>
@@ -518,7 +518,7 @@
                                     <field name="subtask_count" column_invisible="True"/>
                                     <field name="closed_subtask_count" column_invisible="True"/>
                                     <field name="id" optional="hide" options="{'enable_formatting': False}"/>
-                                    <field name="priority" widget="priority" nolabel="1" width="70px"/>
+                                    <field name="priority" widget="priority" optional="hide" width="70px"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
                                     <field name="name" widget="name_with_subtask_count"/>
                                     <field name="project_id" optional="hide" options="{'no_open': 1}" />


### PR DESCRIPTION
Before this commit, the priority field of project.task was not correctly rendered inside the sub-list view of task dependencies (in "Blocked by" tab in task form view).

This commit makes sure the priority field of project.task is correctly in that sub-list view. Also, it also hides by default the column to let more spaces for the most relevant fields (state, name and assignees).