### PR TITLE
[FIX] l10n_om: Add missing account.return.type data

### DIFF
--- a/addons/l10n_om/__manifest__.py
+++ b/addons/l10n_om/__manifest__.py
@@ -16,12 +16,13 @@ Activates:
 """,
     'countries': ['om'],
     'depends': [
-        'account',
+        'account_reports'
     ],
     'auto_install': True,
     'data': [
         'data/res.country.state.csv',
         'data/tax_report.xml',
+        'data/account_report_data.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_om/data/account_report_data.xml
+++ b/addons/l10n_om/data/account_report_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="om_tax_return_type" model="account.return.type">
+            <field name="name">Oman Tax</field>
+            <field name="report_id" ref="l10n_om_tax_report"/>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
### Issue:
This commit adds a missing account.return.type data in the Oman localization. This is related to the new Accounting Returns [feature](https://github.com/odoo/enterprise/pull/81569).

The l10n_om module did not include an account.return.type record, which prevents the "Returns" button (linked to the action_open_returns) from appearing in the Tax Report. As a result, users in Oman are unable to access the Tax Closing form.

### Issue:
This commit adds a missing account.return.type data in the Oman localization. This is related to the new Accounting Returns feature (#81569).

The l10n_om module did not include an account.return.type record, which prevents the "Returns" button (linked to the action_open_returns) from appearing in the Tax Report. As a result, users in Oman are unable to access the Tax Closing form.

The visibility of the button is controlled by the following condition: [Code](https://github.com/odoo/enterprise/blob/f924f120cbd04002e21c78b081e1c8006b56a4b6/account_reports/models/account_report.py#L1776)

#### Affected Versions:
18.3 and later

### Steps to reproduce:

1.Install the l10n_om module
2.Switch to the Oman company
3.Go to Accounting > Reporting > Tax Report
4.The "Returns" button is not visible

### Expected behavior
The "Returns" button should be visible, allowing the user to generate the closing tax form.

### Current behavior
The button is hidden due to missing account.return.type data in the Oman localization.

OPW-4943024

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
