### PR TITLE
[FIX] crm: Moved active_test_false from JS to view

### DIFF
--- a/addons/crm/static/src/activity_menu_patch.js
+++ b/addons/crm/static/src/activity_menu_patch.js
@@ -33,7 +33,6 @@ patch(ActivityMenu.prototype, {
             // Necessary because activity_ids of mail.activity.mixin has auto_join
             // So, duplicates are faking the count and "Load more" doesn't show up
             context["force_search_count"] = 1;
-            context["active_test"] = 0; // to show lost leads in the activity
             this.action.doAction("crm.crm_lead_action_my_activities", {
                 additionalContext: context,
                 clearBreadcrumbs: true,

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1076,7 +1076,7 @@
             <field name="view_mode">list,kanban,graph,pivot,calendar,form,activity</field>
             <field name="view_id" ref="crm_lead_view_list_activities"/>
             <!-- Ensure that only records with at least one activity, "done" (archived) or not, are fetched. -->
-            <field name="domain">[("activity_ids.active", "in", [True, False])]</field>
+            <field name="domain">[("activity_ids.active", "in", [True, False]), ("active", "in", [True, False])]</field>
             <field name="search_view_id" ref="crm.view_crm_case_my_activities_filter"/>
             <field name="context">{'default_type': 'opportunity',
                     'search_default_assigned_to_me': 1}


### PR DESCRIPTION
The JS for CRM leads had a line adding 'active_test: 0' to the context of the action in order to enable the viewing of lost leads. This resulted in disabling all tests of the  field, eventually leading to incorrectly using deadlines from archived activities. This PR removes that behaviour and adds a domain entry to the corresponding view, enabling the action to display lost leads without affecting other queries. This does mean that showing lost leads is the default behaviour of the particular view, but I feel that's more of an improvement than detriment, since leads without activities should't factor in anyway.

Related tickets:
https://www.odoo.com/odoo/my-support-tasks/4923645
https://www.odoo.com/odoo/project/49/tasks/4946120

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
