### PR TITLE
[FIX] account: prevent sending auto email with payment register

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -804,7 +804,7 @@ class AccountPaymentRegister(models.TransientModel):
         payments = self.env['account.payment']
         for vals in to_process:
             payments |= vals['payment']
-        payments.action_post()
+        payments.with_context(skip_invoice_send=True).action_post()
 
     def _reconcile_payments(self, to_process, edit_mode=False):
         """ Reconcile the payments.

--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -129,7 +129,7 @@ class PaymentTransaction(models.Model):
             # even if only a partial payment was made.
             self._invoice_sale_orders()
         super()._reconcile_after_done()
-        if auto_invoice:
+        if auto_invoice and not self.env.context.get('skip_invoice_send'):
             # Must be called after the super() call to make sure the invoice are correctly posted.
             self._send_invoice()
 


### PR DESCRIPTION
**Before this commit:**
When creating an invoice payment with the "automatic invoice" option enabled in Sales settings and using a saved payment token, an email is sent to the customer before the transaction move is posted and the invoice payment status is updated to "In Payment." This results in the email incorrectly asking the customer to remit payment, even though the payment is already being processed.

**Steps to Reproduce:**
1. Enable "Automatic Invoicing" from Sales settings.
2. Enable and publish any payment provider (e.g., Demo) in test mode.
3. Create an invoice and generate a payment link. Open the link in a new incognito tab and pay using any dummy card number (ensure the "Save my payment details" checkbox is checked). This saves the payment token for the partner.
4. Create a new invoice with the same partner, then register payment. Select the payment method and the previously saved token, then confirm.
5. Observe that the payment status is "In Payment," but the email sent to the customer incorrectly asks them to remit payment.

**Fix:**
This change prevents payment notification emails from being sent automatically when the payment is manually created from the payment register wizard.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4850293)
opw-4850293