### PR TITLE
[FIX] mail: message related to deleted record doesn't break discuss

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import contextlib
 import logging
 import re
 import textwrap
@@ -7,7 +8,7 @@ from binascii import Error as binascii_error
 from collections import defaultdict
 
 from odoo import _, api, fields, models, modules, tools
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, MissingError
 from odoo.osv import expression
 from odoo.tools import clean_context, format_list, groupby, SQL
 from odoo.tools.misc import OrderedSet
@@ -988,8 +989,11 @@ class Message(models.Model):
         for record in records:
             thread_data = {}
             if record._name != "discuss.channel":
-                # sudo: mail.thread - if mentionned in a non accessible thread, name is allowed
-                thread_data["name"] = record.sudo().display_name
+                try:
+                    # sudo: mail.thread - if mentionned in a non accessible thread, name is allowed
+                    thread_data["name"] = record.sudo().display_name
+                except MissingError:
+                    continue  # related non mail.thread document deleted, still show message in history
             if self.env[record._name]._original_module:
                 thread_data["module_icon"] = modules.module.get_module_icon(
                     self.env[record._name]._original_module
@@ -1004,16 +1008,17 @@ class Message(models.Model):
             # model, res_id, record_name need to be kept for mobile app as iOS app cannot be updated
             data = message._read_format(fields, load=False)[0]
             record = record_by_message.get(message)
+            record_name = False
+            default_subject = False
             if record:
-                # sudo: if mentionned in a non accessible thread, user should be able to see the name
-                record_name = record.sudo().display_name
-                default_subject = record_name
-                if hasattr(record, "_message_compute_subject"):
-                    # sudo: if mentionned in a non accessible thread, user should be able to see the subject
-                    default_subject = record.sudo()._message_compute_subject()
-            else:
-                record_name = False
-                default_subject = False
+                with contextlib.suppress(MissingError):
+                    # sudo: if mentionned in a non accessible thread, user should be able to see the name
+                    record_name = record.sudo().display_name
+                if record_name:
+                    default_subject = record_name
+                    if hasattr(record, "_message_compute_subject"):
+                        # sudo: if mentionned in a non accessible thread, user should be able to see the subject
+                        default_subject = record.sudo()._message_compute_subject()
             data["default_subject"] = default_subject
             vals = {
                 # sudo: mail.message - reading attachments on accessible message is allowed

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -42,7 +42,7 @@
                             </small>
                             <small t-if="isPersistentMessageFromAnotherThread" t-on-click.prevent="openRecord" class="ms-1 text-500">
                                 <t t-if="message.thread.model !== 'discuss.channel'">
-                                    on <a t-att-href="message.resUrl"><t t-esc="message.thread.displayName"/></a>
+                                    on <a t-if="message.thread.displayName" t-att-href="message.resUrl" t-esc="message.thread.displayName"/><em class="pe-1 text-decoration-line-through" t-else="">Deleted document</em>
                                 </t>
                                 <t t-else="">
                                     (from <a t-att-href="message.resUrl"><t t-esc="message.thread.prefix"/><t t-esc="message.thread.displayName or message.default_subject"/></a>)


### PR DESCRIPTION
Before this commit, when a message notification from inbox or history has its related record deleted, the user couldn't load inbox or history.

Steps to reproduce:
- Have mitchell admin receive notification in Odoo
- Install `mail_group`
- Wait a few seconds to receive following user_notification from mail group:
```
on My Company News
Hello,
You have messages to moderate, please go for the proceedings.
```
- Go to related record then delete it
- Go back to inbox or history

=> One of them show `An error occurred while fetching messages.`

This happens because the related record is not a `mail.thread`, but still creates some `mail.message` to send user notifications.

`mail.thread` cascade delete the messages in message list, but threadless records do not. Because the related record is deleted, these messages are attempted to be displayed in mailbox, but due to related record having no `display_name` by non-existing, the fetch data of inbox/history crashes with:
```
MissingError: Record does not exist or has been deleted
```

This commit fixes the issue by doing its best to show message even when the related record has been deleted.

opw-4546920

Before
![Screenshot 2025-05-13 at 14 35 04](https://github.com/user-attachments/assets/eb0fdf04-5a47-4fd3-8e47-be26abec54a3)

After
![Screenshot 2025-05-13 at 14 35 25](https://github.com/user-attachments/assets/c706f8d2-780e-45e5-9bda-0be16354f60f)
