### PR TITLE
[FIX] website_event_sale: convert ticket prices into website currency

### DIFF
--- a/addons/website_event_sale/static/tests/tours/website_event_view_price.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_view_price.js
@@ -1,0 +1,15 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('view_ticket_price', {
+    test: true,
+    steps: () => [{
+        content: "Open the register modal",
+        trigger: 'button[data-bs-target="#modal_ticket_registration"]',
+    }, {
+        content: "Select price of FR ticket",
+        trigger: '.o_wevent_ticket_selector:contains($):contains(33.33)',
+        isCheck: true,
+    }]
+});

--- a/addons/website_event_sale/tests/__init__.py
+++ b/addons/website_event_sale/tests/__init__.py
@@ -5,3 +5,4 @@ from . import common
 from . import test_frontend_buy_tickets
 from . import test_website_event_sale_cart
 from . import test_website_event_sale_pricelist
+from . import test_website_event_sale_tickets

--- a/addons/website_event_sale/tests/test_website_event_sale_tickets.py
+++ b/addons/website_event_sale/tests/test_website_event_sale_tickets.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from odoo import Command
+from odoo.tests import tagged
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.website_event_sale.tests.common import TestWebsiteEventSaleCommon
+
+
+@tagged('post_install', '-at_install')
+class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
+
+    def test_check_conversion_website_sale_event(self):
+        # Assign the currency rate modified above to EUR relative to USD
+        eur_cur = self.env.ref('base.EUR')
+        eur_cur.rate_ids = [Command.create({
+            'name': '2025-07-25',
+            'rate': 3,
+            'currency_id': eur_cur.id,
+            'company_id': self.env.company.id,
+        })]
+        self.assertEqual(len(eur_cur.rate_ids), 1, "SafetyNet")
+
+        # Create new company with different currency (Eur)
+        c1 = self.env['res.company'].create({
+            'name': 'test_company_different_currency',
+            'currency_id': eur_cur.id,
+        })
+        c2 = self.env.company
+        # Make product of type event from company FR and company US
+        product_1, product_2 = self.env['product.product'].create([{
+            'name': 'Ticket 1',
+            'detailed_type': 'event',
+            'list_price': 100,
+            'standard_price': 30.0,
+            'company_id': c1.id,
+        }, {
+            'name': 'Ticket 2',
+            'detailed_type': 'event',
+            'list_price': 100,
+            'standard_price': 30.0,
+            'company_id': c2.id,
+        }])
+
+        # Create event with company US and include two tickets from products created above
+        event = self.env['event.event'].create({
+            'name': 'TestEvent',
+            'date_begin': datetime.now() + relativedelta(days=-1),
+            'date_end': datetime.now() + relativedelta(days=1),
+            'event_ticket_ids': [
+                Command.create({
+                    'name': 'FR ticket',
+                    'product_id': product_1.id,
+                }),
+                Command.create({
+                    'name': 'US ticket',
+                    'product_id': product_2.id,
+                }),
+            ],
+        })
+        self.start_tour("/event/TestEvent-%d/register" % event.id, "view_ticket_price", login="admin")

--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -19,20 +19,20 @@
                 <del t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
                      class="text-danger me-1"
                      t-field="ticket.price"
-                     t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                     t-options="{'widget': 'monetary', 'from_currency': ticket.currency_id, 'display_currency': website.currency_id}"/>
                 <del t-else=""
                      class="text-danger me-1"
                      t-field="ticket.price_incl"
-                     t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                     t-options="{'widget': 'monetary', 'from_currency': ticket.currency_id, 'display_currency': website.currency_id}"/>
             </t>
             <span t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
                   class="fs-6"
                   t-field="ticket.price_reduce"
-                  t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                  t-options="{'widget': 'monetary', 'from_currency': ticket.currency_id, 'display_currency': website.currency_id}"/>
             <span t-else=""
                   t-field="ticket.price_reduce_taxinc"
                   class="fs-6"
-                  t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                  t-options="{'widget': 'monetary', 'from_currency': ticket.currency_id, 'display_currency': website.currency_id}"/>
             <span itemprop="price" class="d-none" t-out="ticket.price"/>
             <span itemprop="priceCurrency" class="d-none" t-out="website.currency_id.name"/>
         </t>
@@ -46,10 +46,10 @@
         <t t-if="highest_price > 0">
             <small class="text-muted">
                 From
-                <span t-out="lowest_price" t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                <span t-out="lowest_price" t-options="{'widget': 'monetary', 'from_currency': ticket.currency_id, 'display_currency': website.currency_id}"/>
                 <t t-if="lowest_price != highest_price">
                     to
-                    <span t-out="highest_price" t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                    <span t-out="highest_price" t-options="{'widget': 'monetary', 'from_currency': ticket.currency_id, 'display_currency': website.currency_id}"/>
                 </t>
             </small>
         </t>
@@ -62,20 +62,20 @@
                     <del t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
                          class="text-danger me-1"
                          t-field="tickets.price"
-                         t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                         t-options="{'widget': 'monetary', 'from_currency': tickets.currency_id, 'display_currency': website.currency_id}"/>
                     <del t-else=""
                          class="text-danger me-1"
                          t-field="tickets.price_incl"
-                         t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                         t-options="{'widget': 'monetary', 'from_currency': tickets.currency_id, 'display_currency': website.currency_id}"/>
                 </t>
                 <span t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
                       class="badge text-bg-secondary fs-6"
                       t-field="tickets.price_reduce"
-                      t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                      t-options="{'widget': 'monetary', 'from_currency': tickets.currency_id, 'display_currency': website.currency_id}"/>
                 <span t-else=""
                       class="badge text-bg-secondary fs-6"
                       t-field="tickets.price_reduce_taxinc"
-                      t-options="{'widget': 'monetary', 'from_currency': event.company_id.sudo().currency_id, 'display_currency': website.currency_id}"/>
+                      t-options="{'widget': 'monetary', 'from_currency': tickets.currency_id, 'display_currency': website.currency_id}"/>
                 <span itemprop="price" class="d-none" t-out="tickets.price"/>
                 <span itemprop="priceCurrency" class="d-none" t-out="website.currency_id.name"/>
             </t>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Related to this task: [4720354](https://www.odoo.com/odoo/project.task/project.task/4720354)
This issue considers a multi company environment, where two companies are set to have different currencies. If an event is created, it belongs to one of these companies. Tickets from either companies can be added to the event's registration, and the end user will see the price for these tickets in the currency of the website, despite some tickets having a different  currency set.

Current behavior before PR:
The registration wizard displays the prices of tickets at face value, i.e. without any conversion. A ticket with its price being 100 euros will be displayed as 100 dollars.

Desired behavior after PR is merged:
The wizard would display the converted amount of the euros tickets in dollars. The 100 euros will be $77.92

Steps to reproduce the issue:
- Create a second company with a currency different than the current company (ex: current company uses dollars, new company uses euros)
- Make two products of type 'event', one for the dollar company and one for the euro company
- Create an event, add two tickets (related to the products)
- Click the register button on the website, see the prices of both tickets, with the modified view, the euro ticket should have its amount converted to the website's currency.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
