### PR TITLE
[FIX] mail: message related to deleted record doesn't break discuss

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from __future__ import annotations
 
+import contextlib
 import logging
 import re
 import textwrap
@@ -8,7 +9,7 @@ from binascii import Error as binascii_error
 from collections import defaultdict
 
 from odoo import _, api, fields, models, modules, tools
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, MissingError
 from odoo.osv import expression
 from odoo.tools import clean_context, format_list, groupby, SQL
 from odoo.tools.misc import OrderedSet
@@ -1033,13 +1034,17 @@ class MailMessage(models.Model):
         for message in self:
             # model, res_id, record_name need to be kept for mobile app as iOS app cannot be updated
             record = record_by_message.get(message)
+            record_name = False
+            default_subject = False
             if record:
                 # sudo: if mentionned in a non accessible thread, user should be able to see the name
-                record_name = record.sudo().display_name
-                default_subject = record_name
-                if hasattr(record, "_message_compute_subject"):
-                    # sudo: if mentionned in a non accessible thread, user should be able to see the subject
-                    default_subject = record.sudo()._message_compute_subject()
+                with contextlib.suppress(MissingError):
+                    record_name = record.sudo().display_name
+                if record_name:
+                    default_subject = record_name
+                    if hasattr(record, "_message_compute_subject"):
+                        # sudo: if mentionned in a non accessible thread, user should be able to see the subject
+                        default_subject = record.sudo()._message_compute_subject()
             else:
                 record_name = False
                 default_subject = False

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -43,7 +43,7 @@
                             </small>
                             <small t-if="isPersistentMessageFromAnotherThread" t-on-click.prevent="openRecord" class="ms-1 text-500">
                                 <t t-if="message.thread.model !== 'discuss.channel'">
-                                    on <a t-att-href="message.resUrl"><t t-esc="message.thread.displayName"/></a>
+                                    on <a t-if="message.thread.displayName" t-att-href="message.resUrl" t-esc="message.thread.displayName"/><em class="pe-1 text-decoration-line-through" t-else="">Deleted document</em>
                                 </t>
                                 <t t-else="">
                                     (from <a t-att-href="message.resUrl"><t t-esc="message.thread.prefix"/><t t-esc="message.thread.displayName or message.default_subject"/></a>)

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 
 import odoo
 from odoo import models
+from odoo.exceptions import MissingError
 from odoo.tools import groupby
 
 
@@ -212,7 +213,10 @@ class Store:
                 if isinstance(field, dict):
                     data.update(field)
                 elif not field.predicate or field.predicate(record):
-                    data[field.rename or field.field_name] = field._get_value(record)
+                    try:
+                        data[field.rename or field.field_name] = field._get_value(record)
+                    except MissingError:
+                        break
         return records_data
 
     def _get_record_index(self, model_name, values):


### PR DESCRIPTION
Before this commit, when a message notification from inbox or history has its related record deleted, the user couldn't load inbox or history.

Steps to reproduce:
- Have mitchell admin receive notification in Odoo
- Install `mail_group`
- Wait a few seconds to receive following user_notification from mail group:
```
on My Company News
Hello,
You have messages to moderate, please go for the proceedings.
```
- Go to related record then delete it
- Go back to inbox or history

=> One of them show `An error occurred while fetching messages.`

This happens because the related record is not a `mail.thread`, but still creates some `mail.message` to send user notifications.

`mail.thread` cascade delete the messages in message list, but threadless records do not. Because the related record is deleted, these messages are attempted to be displayed in mailbox, but due to related record having no `display_name` by non-existing, the fetch data of inbox/history crashes with:
```
MissingError: Record does not exist or has been deleted
```

This commit fixes the issue by doing its best to show message even when the related record has been deleted.

opw-4546920