### PR TITLE
[FIX] hr_recruitment: prevent error on copy email button

### DIFF
--- a/addons/hr_recruitment/static/src/js/fields/recruitment_copy_clipboard_char_field/recruitment_copy_clipboard_char_field.xml
+++ b/addons/hr_recruitment/static/src/js/fields/recruitment_copy_clipboard_char_field/recruitment_copy_clipboard_char_field.xml
@@ -4,7 +4,7 @@
     <t t-name="hr_recruitment.RecruitmentCopyClipboardCharField">
         <div class="d-flex">
             <span t-esc="props.displayedValue"></span>
-            <GenerateContentAndCopyButton t-if="props.contentGenerationFunctionName" className="copyButtonClassName" contentGenerationFunction="contentGenerationFunction" icon="copyButtonIcon" successText="successText"/>
+            <GenerateContentAndCopyButton t-if="props.contentGenerationFunctionName" className="copyButtonClassName" disabled="props.record.isNew" contentGenerationFunction="contentGenerationFunction" icon="copyButtonIcon" successText="successText"/>
             <GenerateContentAndCopyButton t-else="" className="copyButtonClassName" content="props.record.data[props.name]" icon="copyButtonIcon" successText="successText"/>
         </div>
     </t>


### PR DESCRIPTION
Currently an error occurs when user try to copy email on a newly created record.

Steps to reproduce:
- Install `hr_recruitment`with demo data.
- Add a random Alias Domain (`Settings > Technical > Email > Alias Domains`).
- Open `hr_recruitment` and on 'Experienced Developer', open the option dropdown (meatball) and click on 'Trackers'.
- Now click on `New` and click the copy email button (without saving).

Error:
`ValueError: Expected singleton: hr.recruitment.source()`

Cause:
- Error occurs due to a recent change in this [commit](https://github.com/odoo/odoo/pull/198995/commits/f8cf1b70e28166c100558d2bf5cbc6d8d3513cc6) that introduced the new copy widget
- The error occurs because the function was called even before the record was saved. This caused the function call to be made with empty recordset that causes the singleton error at line [1].

Solution:
- Made the copy button disabled until record is saved.

[1]: https://github.com/odoo/odoo/blob/679d99b8bd233a1046e3219ddb3e23e8465f6107/addons/hr_recruitment/models/hr_recruitment_source.py#L49

sentry-6753165441
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
