### PR TITLE
[FIX] point_of_sale: prevent deleting a partner linked to a PoS order

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/backend_utils.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/backend_utils.js
@@ -56,3 +56,31 @@ export function openProductForm(name) {
         },
     ];
 }
+
+export function openCustomerForm(name) {
+    return [
+        {
+            trigger: ".o_main_navbar span:contains('Orders')",
+            run: "click",
+        },
+        {
+            trigger: ".dropdown-item:contains('Customers')",
+            run: "click",
+        },
+        {
+            trigger: ".o_facet_values",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_facet .o_facet_remove",
+            run: "click",
+        },
+        {
+            trigger: `.o_kanban_record:contains("${name}")`,
+            run: "click",
+        },
+        {
+            trigger: `.o_form_renderer`,
+        },
+    ];
+}

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -10,6 +10,7 @@ from odoo.fields import Command
 from odoo.tests import Form
 from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
 from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_combo_items
+from odoo.exceptions import UserError
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -2611,3 +2612,28 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         pos_order = self.env['pos.order'].search([])
         pos_order.action_pos_order_invoice()
         self.assertEqual(pos_order.state, 'done')
+
+    def test_unlink_partner_containing_pos_order(self):
+        """
+        Restrict the user to unlink a partner by raising a User Exception if it contains a PoS Order
+        """
+        self.pos_config.open_ui()
+        self.PosOrder.create({
+            'company_id': self.env.company.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'partner_id': self.partner1.id,
+            'lines': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'qty': 1,
+                    'price_subtotal': 134.38,
+                    'price_subtotal_incl': 134.38,
+                }),
+            ],
+            'amount_tax': 0.0,
+            'amount_total': 134.38,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+        })
+        with self.assertRaises(UserError):
+            self.partner1.unlink()


### PR DESCRIPTION
Currently, a partner can be deleted even if they have associated PoS orders.
This causes inconsistent behavior, such as missing record tracebacks 
when reopening a PoS session.

**To reproduce this issue:**

1) Install point_of_sale and pos_settle_due.
2) Open a PoS session
3) Create a customer and place an order with payment. 
4) Without closing the session, go to the backend. 
5) Delete the customer from Contacts.
6) Reopen the previously opened PoS session.

**Error:-**
A `missing record` exception is triggered.

**Cause:**

- Starting from SaaS-18.1, PoS supports offline mode with limited functionality, due to this commit:
https://github.com/odoo/odoo/pull/184417/commits/711e248efd54500f91acfb1b9a30f48177c34925

- Before this commit, data was reloaded whenever a session was opened or reopened, 
ensuring proper synchronization with the backend.

- After this commit, IndexedDB is used to cache data and it is reused every time the session is reopened.

- When the user reopens a PoS session after deleting a partner, the method 
`setAllTotalDueOfPartners` is triggered during setup.

- This method makes an RPC call to `get_all_total_due` to update all partners due amounts.
Since the partner was deleted, this causes a missing record exception.

**Solution:**

- Prevent users from deleting a partner who has PoS orders and an open session. 
- Before calling `get_total_due`, verify the partner still exists in the database.

Related Enterprise PR:- https://github.com/odoo/enterprise/pull/90596

opw-4897814
