### PR TITLE
[FIX] html_builder, html_editor: apply backend domain on m2o field in editor

### DIFF
--- a/addons/html_builder/static/src/plugins/many2one_option.js
+++ b/addons/html_builder/static/src/plugins/many2one_option.js
@@ -11,6 +11,7 @@ export class Many2OneOption extends BaseOptionComponent {
         onWillStart(async () => {
             const el = this.env.getEditingElement();
             this.model = el.dataset.oeMany2oneModel;
+            this.domain = JSON.parse(el.dataset.oeMany2oneDomain|| "[]");
             const searchResult = await this.orm.searchRead(
                 "ir.model",
                 [["model", "=", this.model]],

--- a/addons/html_builder/static/src/plugins/many2one_option.xml
+++ b/addons/html_builder/static/src/plugins/many2one_option.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.Many2OneOption">
     <BuilderRow label="label">
-        <BuilderMany2One action="'many2One'" model="model" fields="['name']" allowUnselect="false"/>
+        <BuilderMany2One action="'many2One'" model="model" fields="['name']" domain="domain" allowUnselect="false"/>
     </BuilderRow>
 </t>
 

--- a/addons/html_editor/models/ir_qweb_fields.py
+++ b/addons/html_editor/models/ir_qweb_fields.py
@@ -26,6 +26,7 @@ from werkzeug import urls
 from odoo import _, api, models, fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import posix_to_ldml
+from odoo.tools.json import scriptsafe as json_safe
 from odoo.tools.misc import file_open, get_lang, babel_locale_parse
 
 REMOTE_CONNECTION_TIMEOUT = 2.5
@@ -240,6 +241,7 @@ class IrQwebFieldMany2one(models.AbstractModel):
 
     @api.model
     def attributes(self, record, field_name, options, values=None):
+        field = record._fields[field_name]
         attrs = super().attributes(record, field_name, options, values)
         if options.get('inherit_branding'):
             many2one = record[field_name]
@@ -250,6 +252,7 @@ class IrQwebFieldMany2one(models.AbstractModel):
                 attrs['data-oe-many2one-allowreset'] = 1
                 if not many2one:
                     attrs['data-oe-many2one-model'] = record._fields[field_name].comodel_name
+            attrs['data-oe-many2one-domain'] = json_safe.dumps(field._description_domain(self.env))
         return attrs
 
     @api.model


### PR DESCRIPTION
Steps to reproduce:
1. Install `website_hr_recruitment`
2. Open the Recruitment module's tree view
3. Create a new job position
4. See the Job Location field in the form view under the recruitment page
5. Observe the fetched records
6. Go to the website via the smart button
7. Edit the website and click on the remote under the job position (Job Location)
8. Observe contacts in the web editor

Issue:
All partners are fetched instead of the filtered ones.

Cause:
The backend domain of the clicked field is not applied while fetching records in the web editor.
https://github.com/odoo/odoo/blob/afa26af132566a68ad6bf67565062bd73ddd7429/addons/hr_recruitment/models/hr_job.py#L25-L36

Solution:
Apply the backend domain of the clicked field when fetching records in editor.

opw-4879929