### PR TITLE
[FIX] payment_{authorize, asiapay}: avoid error when provider has no currency

### DIFF
--- a/addons/payment_asiapay/models/payment_transaction.py
+++ b/addons/payment_asiapay/models/payment_transaction.py
@@ -144,8 +144,9 @@ class PaymentTransaction(models.Model):
 
         amount = notification_data.get('Amt')
         # AsiaPay supports only one currency per account.
-        currency_code = self.provider_id.available_currency_ids[0].name
-        self._validate_amount_and_currency(amount, currency_code)
+        currency = self.provider_id.available_currency_ids
+        if currency:  # The currency has not been removed from the provider.
+            self._validate_amount_and_currency(amount, currency.name)
 
     def _process_notification_data(self, notification_data):
         """ Override of `payment' to process the transaction based on AsiaPay data.

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -213,8 +213,9 @@ class PaymentTransaction(models.Model):
         )
         amount = tx_details.get('transaction', {}).get('authAmount')
         # Authorize supports only one currency per account.
-        currency_code = self.provider_id.available_currency_ids[0].name
-        self._validate_amount_and_currency(amount, currency_code)
+        currency = self.provider_id.available_currency_ids
+        if currency:  # The currency has not been removed from the provider.
+            self._validate_amount_and_currency(amount, currency.name)
 
     def _process_notification_data(self, notification_data):
         """ Override of payment to process the transaction based on Authorize data.


### PR DESCRIPTION
The system crashes when an `authorize.net` payment provider has no currency
configured and user try to make payment.

**Steps to reproduce:-**
- Install `Sales` module.
- Install the `Authorize.net` as a `payment provider`.
- Set the mode as `Test mode` > set credentials > click on `Generate Client Key`.
- `Configuration page > remove the currency and save`.
- Now, go to any sale order > click on the gear icon > click `generate payment link` > and try to pay on that link using a card.

**Error:-** `IndexError: tuple index out of range`

**Solution:-**
- In this commit, we checked that if currency is present then we will call
  `_validate_amount_and_currency` otherwise we skip it.

**sentry-6757453610**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
