### PR TITLE
[IMP] html_editor: add markdown shortcuts for separator and blockquote

### DIFF
--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -1,4 +1,7 @@
 import { Plugin, isValidTargetForDomListener } from "../plugin";
+import { closestBlock } from "@html_editor/utils/blocks";
+import { fillEmpty } from "@html_editor/utils/dom";
+import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
 
 /**
  * @typedef {Object} Shortcut
@@ -21,6 +24,10 @@ import { Plugin, isValidTargetForDomListener } from "../plugin";
 export class ShortCutPlugin extends Plugin {
     static id = "shortcut";
     static dependencies = ["userCommand", "selection"];
+
+    resources = {
+        input_handlers: this.onInput.bind(this),
+    };
 
     setup() {
         const hotkeyService = this.services.hotkey;
@@ -57,5 +64,43 @@ export class ShortCutPlugin extends Plugin {
                     (global || isValidTargetForDomListener(target)),
             })
         );
+    }
+
+    onInput(ev) {
+        if (ev.data !== " ") {
+            return;
+        }
+        const selection = this.dependencies.selection.getEditableSelection();
+        const blockEl = closestBlock(selection.anchorNode);
+        const leftDOMPath = leftLeafOnlyNotBlockPath(selection.anchorNode);
+        let spaceOffset = selection.anchorOffset;
+        let leftLeaf = leftDOMPath.next().value;
+        while (leftLeaf) {
+            // Calculate spaceOffset by adding lengths of previous text nodes
+            // to correctly find offset position for selection within inline
+            // elements. e.g. <p>ab<strong>cd []e</strong></p>
+            spaceOffset += leftLeaf.length;
+            leftLeaf = leftDOMPath.next().value;
+        }
+        const precedingText = blockEl.textContent.substring(0, spaceOffset - 1);
+        const matchedShortcut = this.getResource("shorthands").find(({ pattern }) =>
+            pattern.test(precedingText)
+        );
+        if (matchedShortcut) {
+            const command = this.dependencies.userCommand.getCommand(matchedShortcut.commandId);
+            if (command) {
+                this.dependencies.selection.setSelection({
+                    anchorNode: blockEl.firstChild,
+                    anchorOffset: 0,
+                    focusNode: selection.focusNode,
+                    focusOffset: selection.focusOffset,
+                });
+                this.dependencies.selection.extractContent(
+                    this.dependencies.selection.getEditableSelection()
+                );
+                fillEmpty(blockEl);
+                command.run(matchedShortcut.commandParams);
+            }
+        }
     }
 }

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -1,7 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { Plugin } from "../plugin";
 import { closestBlock } from "../utils/blocks";
-import { closestElement } from "../utils/dom_traversal";
+import { closestElement, firstLeaf } from "../utils/dom_traversal";
 import {
     isEmptyBlock,
     isListItemElement,
@@ -42,15 +42,23 @@ export class SeparatorPlugin extends Plugin {
     };
 
     insertSeparator() {
-        const selection = this.dependencies.selection.getEditableSelection();
-        const sep = this.document.createElement("hr");
+        const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
         const block = closestBlock(selection.startContainer);
         const element =
             closestElement(selection.startContainer, paragraphRelatedElementsSelector) ||
             (block && !isListItemElement(block) ? block : null);
 
         if (element && element !== this.editable) {
-            if (isEmptyBlock(element)) {
+            const sep = this.document.createElement("hr");
+            const firstLeafNode = firstLeaf(block);
+            /**
+             * Insert the separator before the element when it’s empty
+             * or when the caret is at the very start of the block.
+             */
+            if (
+                isEmptyBlock(element) ||
+                (selection.anchorNode === firstLeafNode && selection.anchorOffset === 0)
+            ) {
                 element.before(sep);
             } else {
                 element.after(sep);

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -32,6 +32,13 @@ export class SeparatorPlugin extends Plugin {
         }),
         force_not_editable_selector: "hr",
         contenteditable_to_remove_selector: "hr[contenteditable]",
+        shorthands: [
+            {
+                pattern: /^---$/,
+                commandId: "insertSeparator",
+            },
+        ],
+
         /** Handlers */
         selectionchange_handlers: this.handleSelectionInHr.bind(this),
         deselect_custom_selected_nodes_handlers: this.deselectHR.bind(this),

--- a/addons/html_editor/static/tests/insert/separator.test.js
+++ b/addons/html_editor/static/tests/insert/separator.test.js
@@ -19,6 +19,15 @@ describe("insert separator", () => {
         });
     });
 
+    test("should insert a separator inside editable with contenteditable set to false before the block", async () => {
+        await testEditor({
+            contentBefore: "<p>[]abc<br></p>",
+            stepFunction: insertSeparator,
+            contentAfterEdit: `<hr contenteditable="false"><p>[]abc<br></p>`,
+            contentAfter: "<hr><p>[]abc<br></p>",
+        });
+    });
+
     test("should insert a separator before current element if empty", async () => {
         await testEditor({
             contentBefore: "<p>content</p><p>[]<br></p>",

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -618,4 +618,35 @@ describe("transform", () => {
         await insertText(editor, " ");
         expect(getContent(el)).toBe(`<p># a<strong>b []cd</strong>e</p>`);
     });
+
+    test("should transform three dashes in an empty block to separator before the block", async () => {
+        const { el, editor } = await setupEditor("<p>[]<br></p>");
+        await insertText(editor, "--- ");
+        expect(getContent(el)).toBe(
+            `<hr contenteditable="false"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+        );
+    });
+
+    test("should transform three dashes at the start of text to separator before the block", async () => {
+        const { el, editor } = await setupEditor("<p>[]abc</p>");
+        await insertText(editor, "--- ");
+        expect(getContent(el)).toBe(`<hr contenteditable="false"><p>[]abc</p>`);
+    });
+
+    test("should transform space preceding by greater-than symbol to blockquote", async () => {
+        const { el, editor } = await setupEditor("<p>[]<br></p>");
+        await insertText(editor, "> ");
+        expect(getContent(el)).toBe(
+            `<blockquote o-we-hint-text="Quote" class="o-we-hint">[]<br></blockquote>`
+        );
+    });
+
+    test("should transform space preceding by a greater-than symbol at the starting of text to blockquote", async () => {
+        const { el, editor } = await setupEditor("<p>[]abc</p>");
+        await insertText(editor, "> ");
+        expect(getContent(el)).toBe(`<blockquote>[]abc</blockquote>`);
+
+        undo(editor);
+        expect(getContent(el)).toBe(`<p>> []abc</p>`);
+    });
 });


### PR DESCRIPTION
### Desired behavior after PR is merged:

- Adjust separator insertion logic based on cursor position:
```html
<div>/separator[]</div> → before
<div>/separator[]abc</div> → before
<div>ab/separator[]c</div> → after
<div>abc/separator[]</div> → after
```
- Refactor markdown shortcuts implementation by introducing `shorthands` resource containing objects with pattern and commandId keys.
- In the shortcut_plugin, bind an onInput handler to process input events and match precedingText against the defined patterns, triggering the corresponding commands when matched.
- Add support for > (blockquote) and --- (separator) markdown shortcuts.
- Separator insertion behavior:
```html
<div>--- []</div> → before
<div>--- []abc</div> → before
```

task-4908567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
