### PR TITLE
[IMP] pos: extract order picking creation for override in pos_urban_piper

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1194,6 +1194,13 @@ class PosOrder(models.Model):
     def _should_create_picking_real_time(self):
         return not self.session_id.update_stock_at_closing or (self.company_id.anglo_saxon_accounting and self.to_invoice)
 
+    def _create_pos_order_picking(self, destination_id, picking_type):
+        """Create stock picking(s) for the POS order."""
+        self.ensure_one()
+        return self.env['stock.picking']._create_picking_from_pos_order_lines(
+            destination_id, self.lines, picking_type, self.partner_id
+        )
+
     def _create_order_picking(self):
         self.ensure_one()
         if self.shipping_date:
@@ -1208,7 +1215,7 @@ class PosOrder(models.Model):
                 else:
                     destination_id = picking_type.default_location_dest_id.id
 
-                pickings = self.env['stock.picking']._create_picking_from_pos_order_lines(destination_id, self.lines, picking_type, self.partner_id)
+                pickings = self._create_pos_order_picking(destination_id, picking_type)
                 pickings.write({'pos_session_id': self.session_id.id, 'pos_order_id': self.id, 'origin': self.name})
 
     def add_payment(self, data):

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -28,7 +28,7 @@ class StockPicking(models.Model):
 
 
     @api.model
-    def _create_picking_from_pos_order_lines(self, location_dest_id, lines, picking_type, partner=False):
+    def _create_picking_from_pos_order_lines(self, location_dest_id, lines, picking_type, partner=False, src_id=False):
         """We'll create some picking based on order_lines"""
 
         pickings = self.env['stock.picking']
@@ -39,7 +39,7 @@ class StockPicking(models.Model):
         negative_lines = stockable_lines - positive_lines
 
         if positive_lines:
-            location_id = picking_type.default_location_src_id.id
+            location_id = src_id.id if src_id else picking_type.default_location_src_id.id
             positive_picking = self.env['stock.picking'].create(
                 self._prepare_picking_vals(partner, picking_type, location_id, location_dest_id)
             )
@@ -59,7 +59,7 @@ class StockPicking(models.Model):
                 return_location_id = return_picking_type.default_location_dest_id.id
             else:
                 return_picking_type = picking_type
-                return_location_id = picking_type.default_location_src_id.id
+                return_location_id = src_id.id if src_id else picking_type.default_location_src_id.id
 
             negative_picking = self.env['stock.picking'].create(
                 self._prepare_picking_vals(partner, return_picking_type, location_dest_id, return_location_id)


### PR DESCRIPTION
Following this commit:
- ` _create_pos_order_picking` method is been created for creating order picking. The reason behind making it separate is to override it in `pos_urban_piper` module. For inventory tracking in online order, we need to select a dedicated `stock.location` that is been selected in `pos.config`.

task-4896303
