### PR TITLE
[IMP] l10n_au: Adapt invoice format for GST registration status

### DIFF
--- a/addons/l10n_au/models/__init__.py
+++ b/addons/l10n_au/models/__init__.py
@@ -5,3 +5,4 @@ from . import account_move
 from . import res_partner_bank
 from . import account_payment
 from . import res_partner
+from . import res_company

--- a/addons/l10n_au/models/account_move.py
+++ b/addons/l10n_au/models/account_move.py
@@ -6,7 +6,7 @@ class AccountMove(models.Model):
     _inherit = 'account.move'
 
     def _get_name_invoice_report(self):
-        if self.company_id.account_fiscal_country_id.code == 'AU':
+        if self.company_id.account_fiscal_country_id.code == 'AU' and self.company_id.l10n_au_is_gst_registered:
             return 'l10n_au.report_invoice_document'
         return super()._get_name_invoice_report()
 

--- a/addons/l10n_au/models/res_company.py
+++ b/addons/l10n_au/models/res_company.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    l10n_au_is_gst_registered = fields.Boolean(string="Australia GST registered", help="Enable if your company is registered for GST.")

--- a/addons/l10n_au/views/res_company_views.xml
+++ b/addons/l10n_au/views/res_company_views.xml
@@ -11,6 +11,7 @@
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
                 <field name="vat" string="ABN" invisible="country_code != 'AU'"/>
+                <field name="l10n_au_is_gst_registered" string="GST registered" invisible="country_code != 'AU'"/>
             </xpath>
             <xpath expr="//field[@name='company_registry']" position="attributes">
                 <attribute name="invisible" add="country_code == 'AU'" separator=" or "/> 


### PR DESCRIPTION
Australian companies that are not registered for GST must not issue tax invoices.
This commit adds a GST-registered setting on the company form to help 
businesses comply with this requirement.

- When unchecked, invoice printouts will automatically use the standard 
  **Odoo invoice layout** instead of the **"Tax Invoice"** format. This ensures, 
  that both GST-registered and non-registered companies can issue invoices 
  that align with ATO guidelines.

upgrade pr- odoo/upgrade#8119
task-4945470

