### PR TITLE
[IMP] html_editor: display keyboard shortcuts in powerbox

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -108,32 +108,9 @@ export class FontPlugin extends Plugin {
         user_commands: [
             {
                 id: "setTagHeading",
+                icon: "fa-header",
                 run: ({ level } = {}) =>
                     this.dependencies.dom.setBlock({ tagName: `H${level ?? 1}` }),
-                isAvailable: this.blockFormatIsAvailable.bind(this),
-            },
-            {
-                id: "setTagHeading1",
-                title: _t("Heading 1"),
-                description: _t("Big section heading"),
-                icon: "fa-header",
-                run: () => this.dependencies.dom.setBlock({ tagName: "H1" }),
-                isAvailable: this.blockFormatIsAvailable.bind(this),
-            },
-            {
-                id: "setTagHeading2",
-                title: _t("Heading 2"),
-                description: _t("Medium section heading"),
-                icon: "fa-header",
-                run: () => this.dependencies.dom.setBlock({ tagName: "H2" }),
-                isAvailable: this.blockFormatIsAvailable.bind(this),
-            },
-            {
-                id: "setTagHeading3",
-                title: _t("Heading 3"),
-                description: _t("Small section heading"),
-                icon: "fa-header",
-                run: () => this.dependencies.dom.setBlock({ tagName: "H3" }),
                 isAvailable: this.blockFormatIsAvailable.bind(this),
             },
             {
@@ -222,18 +199,27 @@ export class FontPlugin extends Plugin {
         powerbox_categories: withSequence(5, { id: "format", name: _t("Format") }),
         powerbox_items: [
             {
+                title: _t("Heading 1"),
+                description: _t("Big section heading"),
                 categoryId: "format",
-                commandId: "setTagHeading1",
+                commandId: "setTagHeading",
+                commandParams: { level: 1 },
                 keywords: [_t("title")],
             },
             {
+                title: _t("Heading 2"),
+                description: _t("Medium section heading"),
                 categoryId: "format",
-                commandId: "setTagHeading2",
+                commandId: "setTagHeading",
+                commandParams: { level: 2 },
                 keywords: [_t("title")],
             },
             {
+                title: _t("Heading 3"),
+                description: _t("Small section heading"),
                 categoryId: "format",
-                commandId: "setTagHeading3",
+                commandId: "setTagHeading",
+                commandParams: { level: 3 },
                 keywords: [_t("title")],
             },
             {
@@ -251,41 +237,41 @@ export class FontPlugin extends Plugin {
         ],
         shorthands: [
             {
-                pattern: /^#$/,
+                literals: ["#"],
                 commandId: "setTagHeading",
                 commandParams: { level: 1 },
             },
             {
-                pattern: /^##$/,
+                literals: ["##"],
                 commandId: "setTagHeading",
                 commandParams: { level: 2 },
             },
             {
-                pattern: /^###$/,
+                literals: ["###"],
                 commandId: "setTagHeading",
                 commandParams: { level: 3 },
             },
             {
-                pattern: /^####$/,
+                literals: ["####"],
                 commandId: "setTagHeading",
                 commandParams: { level: 4 },
             },
             {
-                pattern: /^#####$/,
+                literals: ["#####"],
                 commandId: "setTagHeading",
                 commandParams: { level: 5 },
             },
             {
-                pattern: /^######$/,
+                literals: ["######"],
                 commandId: "setTagHeading",
                 commandParams: { level: 6 },
             },
             {
-                pattern: /^>$/,
+                literals: [">"],
                 commandId: "setTagQuote",
             },
             {
-                pattern: /^```$/,
+                literals: ["```"],
                 commandId: "setTagPre",
             },
         ],

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -120,25 +120,25 @@ export class ListPlugin extends Plugin {
         ],
         shorthands: [
             {
-                pattern: /^1[.)]$/,
+                literals: ["1.", "1)"],
                 commandId: "toggleListOL",
             },
             {
-                pattern: /^a[.)]$/,
+                literals: ["a.", "a)"],
                 commandId: "toggleListOL",
                 commandParams: { listStyle: "lower-alpha" },
             },
             {
-                pattern: /^A[.)]$/,
+                literals: ["A.", "A)"],
                 commandId: "toggleListOL",
                 commandParams: { listStyle: "upper-alpha" },
             },
             {
-                pattern: /^[-*]$/,
+                literals: ["*", "-"],
                 commandId: "toggleListUL",
             },
             {
-                pattern: /^\[\]$/,
+                literals: ["[]"],
                 commandId: "toggleListCL",
             },
         ],

--- a/addons/html_editor/static/src/main/powerbox/powerbox.scss
+++ b/addons/html_editor/static/src/main/powerbox/powerbox.scss
@@ -23,7 +23,7 @@
     font-size: 13px;
 }
 
-.o-we-command-description {
+.o-we-command-description, .o-we-command-shorthand {
     font-size: 12px;
     color: $o-main-color-muted;
 }

--- a/addons/html_editor/static/src/main/powerbox/powerbox.xml
+++ b/addons/html_editor/static/src/main/powerbox/powerbox.xml
@@ -14,8 +14,11 @@
                     <div class="border rounded">
                         <i class="o-we-command-img d-flex align-items-center justify-content-center fa" t-att-class="command.icon"/>
                     </div>
-                    <div class="ms-3">
-                        <div class="o-we-command-name" t-esc="command.title"/>
+                    <div class="ms-3 flex-fill">
+                        <div class="d-flex justify-content-between">
+                            <div class="o-we-command-name" t-esc="command.title"/>
+                            <div t-if="command.shorthandLiteral" class="o-we-command-shorthand" t-esc="command.shorthandLiteral"/>
+                        </div>
                         <div class="o-we-command-description" t-esc="command.description"/>
                     </div>
                 </div>

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -35,7 +35,7 @@ export class SeparatorPlugin extends Plugin {
         contenteditable_to_remove_selector: "hr[contenteditable]",
         shorthands: [
             {
-                pattern: /^---$/,
+                literals: ["---"],
                 commandId: "insertSeparator",
             },
         ],


### PR DESCRIPTION
Right now html_editor supports some useful keyboard shortcuts such as `#` for Heading 1 and `[]` for checklist. However, these shortcuts are not visible to users within the interface. This PR adds the display of shortcut labels in the corresponding commands within the powerbox.

task-4908593


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
