### PR TITLE
[FIX] l10n_sa, l10n_sa_edi: fix access error when printing ZATCA invoices

### DIFF
--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -9,7 +9,7 @@ from odoo.tools import float_repr, format_datetime
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_sa_qr_code_str = fields.Char(string='Zatka QR Code', compute='_compute_qr_code_str')
+    l10n_sa_qr_code_str = fields.Char(string='Zatka QR Code', compute='_compute_qr_code_str', compute_sudo=True)
     l10n_sa_confirmation_datetime = fields.Datetime(string='Confirmation Date',
                                                     readonly=True,
                                                     copy=False,

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -39,12 +39,12 @@ class AccountMove(models.Model):
             if move.country_code == 'SA' and move.move_type in ('out_invoice', 'out_refund') and zatca_document and move.state != 'draft':
                 qr_code_str = ''
                 if move._l10n_sa_is_simplified():
-                    x509_cert_sudo = move.journal_id.sudo().l10n_sa_production_csid_certificate_id
+                    x509_cert = move.journal_id.l10n_sa_production_csid_certificate_id
                     xml_content = self.env.ref('l10n_sa_edi.edi_sa_zatca')._l10n_sa_generate_zatca_template(move)
-                    qr_code_str = move._l10n_sa_get_qr_code(move.journal_id, xml_content, x509_cert_sudo,
+                    qr_code_str = move._l10n_sa_get_qr_code(move.journal_id, xml_content, x509_cert,
                                                             move.l10n_sa_invoice_signature, True)
                     qr_code_str = b64encode(qr_code_str).decode()
-                elif zatca_document.state == 'sent' and zatca_document.sudo().attachment_id.datas:
+                elif zatca_document.state == 'sent' and zatca_document.attachment_id.datas:
                     document_xml = zatca_document.attachment_id.with_context(bin_size=False).datas.decode()
                     root = etree.fromstring(b64decode(document_xml))
                     qr_node = root.xpath('//*[local-name()="ID"][text()="QR"]/following-sibling::*/*')[0]


### PR DESCRIPTION
**Steps to reproduce:**
1. Install Accounting and l10n_sa_edi
2. Switch to a SA company
3. Go to Accounting > Configuration > Journals > Sales > ZATCA > Re-onboard
4. Create or duplicate a customer invoice > Confirm
5. Click on blue banner "Process Now"
6. Log in as a non-admin user (e.g., Marc Demo) and Switch to a SA company
7. Go to invoice > Open Same invoice > Click to "PRINT"

**Issue:**
- A traceback is raised when trying to access the attachment linked to the ZATCA document.

**Cause:**
- Since commit https://github.com/odoo/odoo/commit/44a4cdb3944a4b722dcfbca5e2947a4372b8501d, access to  EDI document's attachment (`attachment_id`) is restricted to users 
belonging to "Role > Administrator" group (`group_system`).
- This was introduced as part of changes from  Task [#4341594](https://www.odoo.com/odoo/project/49/tasks/4341594)
 As a result, non-admin users (even with accounting rights) are unable to access the attachment causing a traceback.

**Solution:**
- Apply `compute_sudo`to field `l10n_sa_qr_code_str` to bypass the restrictive access rights.
  So even if for any case any other field causes issues in the future, compute_sudo will take care of it

**opw-4923399**
