### PR TITLE
[FIX] mail: fix non-deterministic crash in new discuss test

### DIFF
--- a/addons/mail/static/tests/messaging/messaging.test.js
+++ b/addons/mail/static/tests/messaging/messaging.test.js
@@ -77,7 +77,18 @@ test("Show conversations with new message in chat hub (outside of discuss app)",
             name: "GroupChat",
         },
     ]);
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "<p>Test</p>",
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: groupChatId,
+    });
     await start();
+    await openDiscuss(groupChatId);
+    await contains(".o-mail-Message:contains('Test')");
+    await openFormView("res.partner", partnerId);
+    await contains(".o-mail-Message:contains('Test')", { count: 0 });
     // simulate receiving new message (chat, outside discuss app)
     await withUser(userId, () =>
         rpc("/mail/message/post", {


### PR DESCRIPTION
Before this commit, new test "Show conversations with new message in chat hub (outside of discuss app)" would non-deterministically crash with following error:

```
Failed to find 0 of ".o-mail-ChatBubble[name='Dumbledore']" (Timeout of 3 seconds). Found 1 instead.
```

This happens because the test `start()` and immediately simulate a new message from another user to show a chat bubble with badge "1". The badge is shown when this is a new message from init messaging, which doesn't necessarily mean `await start()` has messaging fully initialized. When discuss is not fully initialized, the new message post would be considered as not a new message and thus wouldn't open a chat bubble with badge.

This commit fixes the issue by using a similar pattern as many other tests to ensure discuss is fully loaded initially: have it open a conversation with at least 1 message and assert the message is visible on the UI.

Fixes https://runbot.odoo.com/runbot/build/85195954