### PR TITLE
[FIX] purchase: prevent product description overlapping table header in PDF

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -52,7 +52,7 @@
             </div>
 
             <table class="o_has_total_table table o_main_table table-borderless">
-                <thead>
+                <thead style="display: table-row-group">
                     <tr>
                         <th name="th_description" class="text-start"><strong>Description</strong></th>
                         <th name="th_quantity" class="text-end"><strong>Qty</strong></th>


### PR DESCRIPTION
**Steps to reproduce**:
1. Install the `purchase` module.
2. Go to a product's `Purchase` tab and add a long purchase description (approx. 40–45 lines).
3. Create a Purchase Order using this product.
4. Print the PDF of the Purchase Order (via gear icon).

**Observation**:
The long product description overlaps with the table header when the table spans multiple pages in the generated PDF.

**Issue**:
wkhtmltopdf does not handle multi-page table headers properly by default. causing header/content overlap when the table breaks across pages.

**Solution**:
Apply a known wkhtmltopdf workaround by explicitly setting:
  `<thead style='display: table-row-group;'>`
This ensures headers will not repeat same as sale order. ref(https://github.com/odoo/odoo/pull/53909)

Before:
<img width="1003" height="426" alt="image" src="https://github.com/user-attachments/assets/38b7b4de-ea81-445f-8cd2-ae164fcb7531" />

After:
<img width="1000" height="414" alt="image" src="https://github.com/user-attachments/assets/ef09ef94-2a26-468a-b6e7-03d93b4515b8" />

opw-4908457