### PR TITLE
[IMP] hr: Add Send mail button in form, list, kanban

### DIFF
--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -45,6 +45,7 @@
         'views/discuss_channel_views.xml',
         'views/res_users.xml',
         'views/hr_templates.xml',
+        'views/mail_compose_message.xml',
         'data/hr_data.xml',
     ],
     'demo': [

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1364,6 +1364,24 @@ class HrEmployee(models.Model):
 
     def get_avatar_card_data(self, fields):
         return self.read(fields)
+
+    def action_send_email(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_model': 'mail.compose.message',
+            'views': [[self.env.ref('hr.mail_compose_message_view_form').id, 'form']],
+            'target': 'new',
+            'context': {
+                'default_email_layout_xmlid': 'mail.mail_notification_light',
+                'default_model': 'hr.employee',
+                'default_res_ids': self.ids,
+                'default_partner_ids': self.work_contact_id.ids,
+                'default_composition_mode': 'mass_mail',
+                'default_auto_delete_keep_log': False,
+                'default_auto_delete': True
+            },
+        }
     # ---------------------------------------------------------
     # Messaging
     # ---------------------------------------------------------

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -11,6 +11,8 @@ class HrEmployeePublic(models.Model):
     _name = 'hr.employee.public'
     _description = 'Public Employee'
     _order = 'name'
+    _inherit = ['mail.thread.main.attachment']
+    _mail_post_access = 'read'
     _auto = False
     _log_access = True  # Include magic fields
 
@@ -214,3 +216,19 @@ class HrEmployeePublic(models.Model):
 
     def get_avatar_card_data(self, fields):
         return self.read(fields)
+
+    def action_send_email(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_model': 'mail.compose.message',
+            'views': [[self.env.ref('hr.mail_compose_message_view_form').id, 'form']],
+            'target': 'new',
+            'context': {
+                'default_email_layout_xmlid': 'mail.mail_notification_light',
+                'default_model': 'hr.employee.public',
+                'default_partner_ids': self.work_contact_id.ids,
+                'default_composition_mode': 'mass_mail',
+                'default_reply_to': self.env.user.employee_id.work_contact_id.email
+            },
+        }

--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -8,7 +8,7 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     employee_ids = fields.One2many(
-        'hr.employee', 'work_contact_id', string='Employees', groups="hr.group_hr_user",
+        'hr.employee', 'work_contact_id', string='Employees',
         help="Related employees based on their private address")
     employees_count = fields.Integer(compute='_compute_employees_count', groups="hr.group_hr_user")
     employee = fields.Boolean(help="Whether this contact is an Employee.", compute='_compute_employee', store=True, readonly=False)

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -36,7 +36,10 @@
             <field name="model">hr.employee.public</field>
             <field name="arch" type="xml">
                 <form string="Employee" create="0" write="0" js_class="hr_employee_form">
-                    <header/>
+                    <header>
+                        <button name="action_send_email" string="Send Email" type="object"
+                            groups="hr.group_hr_user"/>
+                    </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <!-- Used by other modules-->
@@ -106,6 +109,9 @@
             <field name="model">hr.employee.public</field>
             <field name="arch" type="xml">
                 <list string="Employees" sample="1" expand="context.get('expand', False)">
+                    <header>
+                        <button name="action_send_email" string="Send Email" type="object"/>
+                    </header>
                     <field name="name"/>
                     <field name="work_phone" class="o_force_ltr"/>
                     <field name="work_email"/>
@@ -126,6 +132,9 @@
                 <kanban class="o_hr_employee_kanban" sample="1">
                     <field name="show_hr_icon_display"/>
                     <field name="image_128" />
+                    <header>
+                        <button name="action_send_email" string="Send Email" type="object"/>
+                    </header>
                     <templates>
                         <t t-name="card" class="flex-row">
                             <aside class="o_kanban_aside_full">
@@ -292,6 +301,5 @@
             <field name="view_mode">form</field>
             <field name="act_window_id" ref="hr.hr_employee_public_action"/>
         </record>
-
     </data>
 </odoo>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -91,6 +91,8 @@
                                 context="{'default_create_employee': True}"/>
                         <button name="%(plan_wizard_action)d" string="Launch Plan" type="action"
                             groups="hr.group_hr_user" invisible="not active or not id" context="{'sort_by_responsible': True}"/>
+                        <button name="action_send_email" string="Send Email" type="object"
+                            groups="hr.group_hr_user"/>
                         <field name="version_id" widget="versions_timeline" invisible="not id" options="{'clickable': True}" readonly="False"/>
                     </header>
                     <sheet>
@@ -381,6 +383,8 @@
                 <list string="Employees" expand="context.get('expand', False)" multi_edit="1" duplicate="false" sample="1" js_class="hr_employee_list">
                     <header>
                         <button name="%(plan_wizard_action)d" string="Launch Plan" type="action" groups="hr.group_hr_user"/>
+                        <button name="action_send_email" string="Send Email" type="object"
+                            groups="hr.group_hr_user"/>
                     </header>
                     <field name="avatar_128" widget="image" options="{'size': [24, 24], 'img_class': 'rounded-3'}" width="30" nolabel="1"/>
                     <field name="name" readonly="1"/>
@@ -438,6 +442,10 @@
                     <field name="show_hr_icon_display"/>
                     <field name="image_128" />
                     <field name="company_id"/>
+                    <header>
+                        <button name="action_send_email" string="Send Email" type="object"
+                            groups="hr.group_hr_user"/>
+                    </header>
                     <templates>
                         <t t-name="card" class="flex-row">
                             <aside class="o_kanban_aside_full">
@@ -761,6 +769,15 @@ employees = env['hr.employee'].browse(env.context.get('selected_ids', []))
 if employees:
     action = employees.action_create_users()
             </field>
+        </record>
+
+        <record id="action_hr_employee_send_mail" model="ir.actions.server">
+            <field name="name">Send Mail</field>
+            <field name="model_id" ref="hr.model_hr_employee"/>
+            <field name="binding_model_id" ref="hr.model_hr_employee"/>
+            <field name="binding_view_types">list,kanban,form</field>
+            <field name="state">code</field>
+            <field name="code">action = records.action_send_email()</field>
         </record>
     </data>
 </odoo>

--- a/addons/hr/views/mail_compose_message.xml
+++ b/addons/hr/views/mail_compose_message.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="hr.mail_compose_message_view_form" model="ir.ui.view">
+            <field name="name">mail.compose.message.view.form.inherit.hr</field>
+            <field name="model">mail.compose.message</field>
+            <field name="inherit_id" ref="mail.email_compose_message_wizard_form"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='partner_ids'][1]" position="attributes">
+                    <attribute name="domain">
+                        [
+                            ('employee', '=', True),
+                            ('employee_ids', 'any',
+                                [('company_id', 'in', allowed_company_ids)]
+                            )
+                        ]
+                    </attribute>
+                </xpath>
+                <xpath expr="//field[@name='partner_ids'][2]" position="attributes">
+                    <attribute name="domain">
+                        [
+                            ('employee', '=', True),
+                            ('employee_ids', 'any',
+                                [('company_id', 'in', allowed_company_ids)]
+                            )
+                        ]
+                    </attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Add the action server "Send email" to allow the user to send an email to multiple employees from kanban, list and form. The selected employees are included by default and the user can add more employees if desired.

task-3927412

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
