### PR TITLE
[IMP] web: tree editor: use dsl for relative deltas

### DIFF
--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -148,6 +148,7 @@ export class Domain {
 
     /**
      * Check if the set of records represented by a domain contains a record
+     * Warning: smart dates (see parseSmartDateInput) are not handled here.
      *
      * @param {Object} record
      * @returns {boolean}

--- a/addons/web/static/src/core/domain_selector/domain_selector.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector.js
@@ -28,14 +28,12 @@ export class DomainSelector extends Component {
         className: { type: String, optional: true },
         defaultConnector: { type: [{ value: "&" }, { value: "|" }], optional: true },
         isDebugMode: { type: Boolean, optional: true },
-        allowExpressions: { type: Boolean, optional: true },
         readonly: { type: Boolean, optional: true },
         update: { type: Function, optional: true },
         debugUpdate: { type: Function, optional: true },
     };
     static defaultProps = {
         isDebugMode: false,
-        allowExpressions: true,
         readonly: true,
         update: () => {},
     };
@@ -104,15 +102,11 @@ export class DomainSelector extends Component {
     }
 
     getDefaultOperator(fieldDef) {
-        return getDomainDisplayedOperators(fieldDef, {
-            allowExpressions: this.props.allowExpressions,
-        })[0];
+        return getDomainDisplayedOperators(fieldDef)[0];
     }
 
     getOperatorEditorInfo(fieldDef) {
-        const operators = getDomainDisplayedOperators(fieldDef, {
-            allowExpressions: this.props.allowExpressions,
-        });
+        const operators = getDomainDisplayedOperators(fieldDef);
         return getOperatorEditorInfo(operators, fieldDef);
     }
 

--- a/addons/web/static/src/core/domain_selector/domain_selector.xml
+++ b/addons/web/static/src/core/domain_selector/domain_selector.xml
@@ -9,7 +9,6 @@
                     update.bind="update"
                     readonly="props.readonly"
                     isDebugMode="props.isDebugMode"
-                    allowExpressions="props.allowExpressions"
                     defaultConnector="props.defaultConnector"
                     getDefaultCondition.bind="getDefaultCondition"
                     getOperatorEditorInfo.bind="getOperatorEditorInfo"

--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -1,4 +1,4 @@
-export function getDomainDisplayedOperators(fieldDef, params = {}) {
+export function getDomainDisplayedOperators(fieldDef) {
     if (!fieldDef) {
         fieldDef = {};
     }
@@ -25,14 +25,7 @@ export function getDomainDisplayedOperators(fieldDef, params = {}) {
             return ["=", "!=", "ilike", "not ilike", "starts with", "set", "not set"];
         case "date":
         case "datetime":
-            return [
-                ...("allowExpressions" in params && !params.allowExpressions ? [] : ["in range"]),
-                "=",
-                "<",
-                ">",
-                "set",
-                "not set",
-            ];
+            return ["in range", "=", "<", ">", "set", "not set"];
         case "integer":
         case "float":
         case "monetary":

--- a/addons/web/static/src/core/expression_editor/expression_editor.js
+++ b/addons/web/static/src/core/expression_editor/expression_editor.js
@@ -33,6 +33,7 @@ export class ExpressionEditor extends Component {
             this.tree = treeFromExpression(props.expression, {
                 getFieldDef: (name) => this.getFieldDef(name, props),
                 distributeNot: !this.isDebugMode,
+                generateSmartDates: false,
             });
         } catch {
             this.tree = null;
@@ -105,6 +106,7 @@ export class ExpressionEditor extends Component {
     update(tree) {
         const expression = expressionFromTree(tree, {
             getFieldDef: (name) => this.getFieldDef(name),
+            generateSmartDates: false,
         });
         this.props.update(expression);
     }

--- a/addons/web/static/src/core/tree_editor/expression_from_tree.js
+++ b/addons/web/static/src/core/tree_editor/expression_from_tree.js
@@ -2,6 +2,6 @@ import { constructExpressionFromTree } from "./construct_expression_from_tree";
 import { eliminateVirtualOperators } from "./virtual_operators";
 
 export function expressionFromTree(tree, options = {}) {
-    const simplifiedTree = eliminateVirtualOperators(tree);
+    const simplifiedTree = eliminateVirtualOperators(tree, options);
     return constructExpressionFromTree(simplifiedTree, options);
 }

--- a/addons/web/static/src/core/tree_editor/tree_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor.js
@@ -31,10 +31,8 @@ export class TreeEditor extends Component {
         isDebugMode: { type: Boolean, optional: true },
         defaultConnector: { type: [{ value: "&" }, { value: "|" }], optional: true },
         isSubTree: { type: Boolean, optional: true },
-        allowExpressions: { type: Boolean, optional: true },
     };
     static defaultProps = {
-        allowExpressions: true,
         defaultConnector: "&",
         readonly: false,
         isSubTree: false,
@@ -179,9 +177,7 @@ export class TreeEditor extends Component {
 
     getValueEditorInfo(node) {
         const fieldDef = this.getFieldDef(node.path);
-        return getValueEditorInfo(fieldDef, node.operator, {
-            allowExpressions: this.props.allowExpressions,
-        });
+        return getValueEditorInfo(fieldDef, node.operator);
     }
 
     async _updatePath(node, path) {

--- a/addons/web/static/src/views/fields/domain/domain_field.xml
+++ b/addons/web/static/src/views/fields/domain/domain_field.xml
@@ -50,7 +50,6 @@
                             debugUpdate.bind="debugUpdate"
                             update.bind="update"
                             isDebugMode="!!env.debug"
-                            allowExpressions="allowExpressions(props)"
                             className="props.readonly ? 'o_read_mode' : 'o_edit_mode'"
                         />
                     </div>

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -1060,7 +1060,7 @@ test(`"in range" facets`, async () => {
         ["birthday", ">=", "2019-03-11"],
         ["birthday", "<=", "2019-03-11"],
         "&",
-        ["birthday", ">=", "2019-03-11"],
-        ["birthday", "<", "2019-03-12"],
+        ["birthday", ">=", "today"],
+        ["birthday", "<", "today +1d"],
     ]);
 });


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/216665, a dsl for handling dynamic dates and relative deltas in domains has been introduced. We make the domain domain selector use it so that the operator "in range" can now be used also in the domain widget without limitation.
The expression editor still uses expressions to handle dynamic dates since we don't want to have to use bad heuristics to support the dsl in py_js. For the same reason we do not support the dsl in the method contains of the Domain class (@web/core/domain.js).