### PR TITLE
[FIX] html_editor: remove checkmark when deleting checked list item

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -855,6 +855,7 @@ export class ListPlugin extends Plugin {
         if (!closestLIendContainer.classList.contains("oe-nested")) {
             // Remove LI marker on first backspace.
             closestLIendContainer.classList.add("oe-nested");
+            closestLIendContainer.classList.remove("o_checked");
         } else {
             // Fully outdent the LI but keep its direction.
             const list = closestElement(closestLIendContainer, "ul[dir], ol[dir]");

--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -931,6 +931,14 @@ describe("Selection collapsed", () => {
                 });
             });
 
+            test("should remove the checkmark when the list item marker is deleted", async () => {
+                await testEditor({
+                    contentBefore: '<ul class="o_checklist"><li class="o_checked">[]</li></ul>',
+                    stepFunction: deleteBackward,
+                    contentAfter: '<ul class="o_checklist"><li class="oe-nested">[]</li></ul>',
+                });
+            });
+
             describe("should merge a list item with its previous list item", () => {
                 test("should merge a list item with its previous list item (1)", async () => {
                     await testEditor({
@@ -2726,7 +2734,8 @@ describe("Selection not collapsed", () => {
                         contentBefore:
                             '<ul class="o_checklist"><li class="o_checked">ab[cd</li></ul><ul><li>ef]gh</li></ul>',
                         stepFunction: deleteBackward,
-                        contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                        contentAfter:
+                            '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
                     });
                 });
                 test("should delete across an checklist list and an unordered list (2)", async () => {
@@ -2735,7 +2744,8 @@ describe("Selection not collapsed", () => {
                         contentBefore:
                             '<ul class="o_checklist"><li class="o_checked">ab]cd</li></ul><ul><li>ef[gh</li></ul>',
                         stepFunction: deleteBackward,
-                        contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                        contentAfter:
+                            '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
                     });
                 });
                 test("should delete across an checklist list and an unordered list (3)", async () => {


### PR DESCRIPTION
Problem:
After commit 02ae5a645a80e6088a596b6273e70b5476e79e88, pressing backspace on a `li` adds the `oe-nested` class. If that `li` is a checked checkbox item, only the checkbox is removed, but the checkmark remains visible.

Solution:
Always remove the `o_checked` class when converting the list item to `oe-nested`.

**After we backspace on checked item:**
Before:
<img width="975" height="324" alt="image" src="https://github.com/user-attachments/assets/374bf407-25d7-45fa-a84e-0aef72aa3690" />
After:
<img width="972" height="366" alt="image" src="https://github.com/user-attachments/assets/33575d7c-ea1c-432c-b4b6-4ce248e2fc78" />


Steps to reproduce:
- Add a checklist
- Check an item
- Press backspace to remove the checkbox -> The checkmark remains visible, even though the box is gone

opw-4953981

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
