### PR TITLE
[REM] html_builder: remove unnecessary height constraint on dropdown

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.js
@@ -48,13 +48,13 @@ export class BuilderSelect extends Component {
 
         this.dropdown = useDropdownState();
 
-        this.buttonRef = useRef("button");
+        const buttonRef = useRef("button");
         let currentLabel;
         const updateCurrentLabel = () => {
             if (!this.props.slots.fixedButton) {
                 const newHtml = currentLabel || _t("None");
-                if (this.buttonRef.el && this.buttonRef.el.innerHTML !== newHtml) {
-                    setElementContent(this.buttonRef.el, newHtml);
+                if (buttonRef.el && buttonRef.el.innerHTML !== newHtml) {
+                    setElementContent(buttonRef.el, newHtml);
                 }
             }
         };
@@ -70,9 +70,5 @@ export class BuilderSelect extends Component {
                 this.dropdown.close();
             },
         });
-    }
-
-    heightOfButton() {
-        return this.buttonRef.el.getBoundingClientRect().height;
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_select.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.xml
@@ -12,7 +12,7 @@
                     <t t-slot="fixedButton"/>
                 </button>
                 <t t-set-slot="content">
-                    <div t-att-class="props.dropdownContainerClass" data-prevent-closing-overlay="true" t-att-style="'max-height: calc(50dvh - ' + heightOfButton() + 'px);'">
+                    <div t-att-class="props.dropdownContainerClass" data-prevent-closing-overlay="true">
                         <t t-slot="default" />
                     </div>
                 </t>


### PR DESCRIPTION
The constraint on the height of the dropdown was introduced in cdc74d6e5c1dc2c8d84d028b7b7c0284118a9d66 to avoid going out of the viewport

The issue was fixed in a general way in
bbcbab63ea3cdd12fdd9854fcd68c804a97d72c0, so the fix specific to builder select can be removed

task-4367641
