### PR TITLE
[FIX] web: Fix SelectMenu style when menu is opened from button

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -193,7 +193,8 @@ export class SelectMenu extends Component {
     get menuClass() {
         return mergeClasses(
             {
-                "o_select_menu_menu my-0": true,
+                "my-0": this.displayInputInToggler,
+                o_select_menu_menu: true,
                 o_select_menu_multi_select: this.props.multiSelect,
             },
             this.props.menuClass


### PR DESCRIPTION
This commit fixes an issue where SelectMenu's menu margin is set to 0, which makes the display inconsistent with other Dropdowns when being used with a button in the toggler. The need for the menu to be sticky to the toggler only makes sense if it is being used with an input.
