### PR TITLE
[FIX] base: should check only the already fully upgraded views at update

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -438,6 +438,13 @@ actual arch.
                                 sibling_primary_views += child
                             else:
                                 stack.append(child)
+
+                    # During an upgrade, we can only use the views that have been
+                    # fully upgraded already.
+                    if self.pool._init:
+                        sibling_primary_views = sibling_primary_views._filter_loaded_views(set(sibling_primary_views.ids))
+
+                    # Check if we know how to apply inheritances
                     sibling_primary_views._get_combined_archs()
 
                 if view.type == 'qweb':


### PR DESCRIPTION
Issue:
Error occurs when updating `hr_timesheet` after having installed it.

The view fail because `timesheet_grid.hr_timesheet_line_form_grid` primary view remove the header `<header position="replace"/>`. The tag is not present in the combined arch because the inheritance loaded only the fully upgraded view. The header tag is added by `timesheet_grid.timesheet_form_view`.

`_check_xml` should check only the fully upgraded primary views.

see: https://github.com/odoo/odoo/pull/218645/commits/ac2028a9be5cfa493825f788364a7c71ac02efe6
