### PR TITLE
[FIX] sale: product type filter in compute_invoice_policy

### DIFF
--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -945,7 +945,7 @@ class TestSalePrices(SaleCommon):
     def test_discount_and_untaxed_subtotal(self):
         """When adding a discount on a SO line, this test ensures that the untaxed amount to invoice is
         equal to the untaxed subtotal"""
-        self.product.invoice_policy = 'delivery'
+        self.product.invoice_policy = 'order'
         order = self.empty_order
 
         order.order_line = [Command.create({


### PR DESCRIPTION
steps to reproduce:
1- install l10n_ke_edi_oscu_mrp
2- run test test_discount_and_untaxed_subtotal

changing the invoice policy to 'order' in the test

refer to this PR for more details: https://github.com/odoo/enterprise/pull/90252

build_error-70728
