### PR TITLE
[FIX] website: translate Content saved

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -487,7 +487,7 @@ export class WebsiteBuilderClientAction extends Component {
         // trigger an new instance of the builder menu
         this.state.key++;
 
-        this.notification.add("Content saved", {
+        this.notification.add(_t("Content saved"), {
             type: "success",
         });
     }


### PR DESCRIPTION
Commit [e7a68432] simplified the "Content saved" notification, but wrongly removed the translatable string.

[e7a68432]: https://github.com/odoo/odoo/commit/e7a68432fd7da666ed1214c4e2aa532a22e911fa