### PR TITLE
[FIX] purchase: fix TestPurchase class

### DIFF
--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -986,7 +986,6 @@ class TestPurchase(AccountTestInvoicingCommon):
     def test_purchase_order_uom(self):
         fuzzy_drink = self.env['product.product'].create({
             'name': 'Fuzzy Drink',
-            'is_storable': True,
             'uom_id': self.env.ref('uom.product_uom_unit').id,
             'seller_ids': [Command.create({
                 'partner_id': self.partner_a.id,


### PR DESCRIPTION
This issue comes from [218483](https://github.com/odoo/odoo/pull/218483)

The field `is_storable` is invalid in single app build and breaks the `TestPurchase` class.

Runbot - [230096](https://runbot.odoo.com/odoo/runbot.build.error/230096)