### PR TITLE
[FIX] stock: fix the wrong language in return label report

### DIFF
--- a/addons/stock/report/report_return_slip.xml
+++ b/addons/stock/report/report_return_slip.xml
@@ -2,8 +2,7 @@
 <odoo>
     <template id="stock.report_return_slip">
         <t t-call="web.html_container">
-            <t t-foreach="docs" t-as="o">
-                <t t-call="web.external_layout">
+            <t t-call="web.external_layout">
                 <div class="page">
                     <div class="oe_structure"/>
                     <div class="row mt8">
@@ -32,7 +31,12 @@
                     <div class="oe_structure"/>
                 </div>
             </t>
-            </t>
+        </t>
+    </template>
+
+    <template id="stock.report_return_slip_wrapper">
+        <t t-foreach="docs" t-as="o">
+            <t t-call="stock.report_return_slip" t-lang="o._get_report_lang()"/>
         </t>
     </template>
 
@@ -40,7 +44,7 @@
         <field name="name">Return slip</field>
         <field name="model">stock.picking</field>
         <field name="report_type">qweb-pdf</field>
-        <field name="report_name">stock.report_return_slip</field>
+        <field name="report_name">stock.report_return_slip_wrapper</field>
         <field name="report_file">return_slip</field>
         <field name="binding_model_id" ref="model_stock_picking"/>
         <field name="binding_type">report</field>


### PR DESCRIPTION
In this bug, the language of return label is not set properly.
The return label should be in customer language.

To reproduce:
1- Create a quote for a client with a specific lang, e.g. fr and and confirm the order
2- In Delivary, return the order
3- Print Return slip
4- As you can see the return label is in wrong language

In this fix, we put the template inside a wrapper template.
It makes it be translated correctly.

opw-4945685
