### PR TITLE
[FIX] mail: pip icon in public page

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -18,7 +18,9 @@
                         <t t-set-slot="content">
                             <div class="d-flex flex-column py-0">
                                 <span t-foreach="callActions.actions.slice(isMobileOS ? 3 : 4)" t-as="action" t-key="action_index" class="o-discuss-CallActionList-dropdownItem cursor-pointer rounded-1 d-flex align-items-center px-2 py-2 m-0" t-att-title="action.name" t-on-click="action.select">
-                                    <i class="fa fa-fw" t-att-class="{
+                                    <i t-att-class="{
+                                        'fa fa-fw': (action.isActive or !action.inactiveIcon ? action.icon : action.inactiveIcon).includes('fa-'), 
+                                        'oi oi-fw': (action.isActive or !action.inactiveIcon ? action.icon : action.inactiveIcon).includes('oi-'),
                                         [action.inactiveIcon]: !action.isActive,
                                         [action.icon]: action.isActive or !action.inactiveIcon,
                                     }"/>

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -118,7 +118,7 @@ callActionsRegistry
             }
         },
         isActive: (component) => component.rtc?.state.isPipMode,
-        icon: "oi oi-launch",
+        icon: "oi-launch",
         select: (component) => {
             const isPipMode = component.rtc?.state.isPipMode;
             if (isPipMode) {


### PR DESCRIPTION
Before this commit, the picture in picture icon was not displayed on the public page. Call actions always add the `fa fa-fw` class. However, this action uses odoo icons. In the public page, the `fa` class is loaded after odoo icons, thus shadowing most of the `oi` class declarations.

This commit ensures the correct lib prefix is used according to the action's icon.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
