### PR TITLE
[IMP] mrp: improve default layout of MO overview

### DIFF
--- a/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.js
+++ b/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.js
@@ -105,7 +105,7 @@ export class MoOverview extends Component {
             receipts: true,
             unitCosts: false,
             moCosts: true,
-            bomCosts: true,
+            bomCosts: false,
             realCosts: true,
         };
     }


### PR DESCRIPTION
To simplify the Manufacturing Order overview and avoid confusion between MO Cost 
and BOM Cost. This update hides the BOM Cost column by default when viewing MOs 
Overview in the Draft or Confirmed state. This provides a cleaner and more 
focused initial view, especially for users not dealing with complex costing 
scenarios.

Task Id: 4882136