### PR TITLE
[FIX] point_of_sale, pos_sale: Ensure fp matches with sale order

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -367,6 +367,18 @@ export function clickFiscalPosition(name, checkIsNeeded = false) {
 
     return [...step, { ...back(), isActive: ["mobile"] }];
 }
+export function checkFiscalPosition(name) {
+    return [
+        clickReview(),
+        ...clickControlButtonMore(),
+        {
+            content: `check fiscal position '${name}' is selected`,
+            trigger: `.o_fiscal_position_button:contains("${name}")`,
+            run: () => {},
+        },
+        Dialog.cancel(),
+    ];
+}
 export function closeWithCashAmount(val) {
     return [
         {

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -8,7 +8,10 @@ import { ask, makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dial
 import { enhancedButtons } from "@point_of_sale/app/generic_components/numpad/numpad";
 import { patch } from "@web/core/utils/patch";
 import { PosStore } from "@point_of_sale/app/store/pos_store";
-import { compute_price_force_price_include } from "@point_of_sale/app/models/utils/tax_utils";
+import {
+    compute_price_force_price_include,
+    getTaxesAfterFiscalPosition,
+} from "@point_of_sale/app/models/utils/tax_utils";
 
 patch(PosStore.prototype, {
     async onClickSaleOrder(clickedOrderId) {
@@ -49,19 +52,19 @@ patch(PosStore.prototype, {
                 this.notification.add(_t("A new order has been created."));
             }
         }
-        const orderFiscalPos =
-            sale_order.fiscal_position_id &&
-            this.models["account.fiscal.position"].find(
-                (position) => position.id === sale_order.fiscal_position_id
-            );
-        if (orderFiscalPos) {
-            this.get_order().update({
-                fiscal_position_id: orderFiscalPos,
-            });
-        }
+
         if (sale_order.partner_id) {
             this.get_order().set_partner(sale_order.partner_id);
         }
+
+        // Fiscal position should be set after the partner is set
+        // to ensure that the fiscal position is correctly computed
+        // based on sale order.
+        const orderFiscalPos = sale_order.fiscal_position_id;
+        this.get_order().update({
+            fiscal_position_id: orderFiscalPos,
+        });
+
         selectedOption == "settle"
             ? await this.settleSO(sale_order, orderFiscalPos)
             : await this.downPaymentSO(sale_order, selectedOption == "dpPercentage");
@@ -100,15 +103,13 @@ patch(PosStore.prototype, {
                 line.product_id = this.config.down_payment_product_id;
             }
 
+            const taxes = getTaxesAfterFiscalPosition(line.tax_id, orderFiscalPos, this.models);
             const newLineValues = {
                 product_id: line.product_id,
                 qty: line.product_uom_qty,
                 price_unit: line.price_unit,
                 price_type: "automatic",
-                tax_ids:
-                    orderFiscalPos || !line.tax_id
-                        ? undefined
-                        : line.tax_id.map((t) => ["link", t]),
+                tax_ids: taxes.map((tax) => ["link", tax]),
                 sale_order_origin_id: sale_order,
                 sale_order_line_id: line,
                 customer_note: line.customer_note,
@@ -250,9 +251,10 @@ patch(PosStore.prototype, {
             });
 
             // We need to remove the amount of the fixed tax as they will have a separate line
-            const fixed_tax_total_amount = fixed_taxes.reduce((total, tax) => {
-                return total + tax.amount;
-            }, 0);
+            const fixed_tax_total_amount = fixed_taxes.reduce(
+                (total, tax) => total + tax.amount,
+                0
+            );
             const total_price = group.reduce(
                 (total, line) =>
                     (total += line.price_total - line.product_uom_qty * fixed_tax_total_amount),

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -469,3 +469,27 @@ registry.category("web_tour.tours").add("test_quantity_updated_settle", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_sale_order_fp_different_from_partner_one", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.settleSaleOrderByPrice("20.00"),
+            ProductScreen.checkTaxAmount("10.00"),
+            ProductScreen.checkFiscalPosition("Partner FP"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptIsThere(),
+            ReceiptScreen.clickNextOrder(),
+            PosSale.settleSaleOrderByPrice("10.00"),
+            ProductScreen.checkTaxAmount("0.00"),
+            ProductScreen.checkFiscalPosition("Sale Order FP"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptIsThere(),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -15,6 +15,22 @@ export function selectNthOrder(n) {
     ];
 }
 
+export function settleSaleOrderByPrice(price) {
+    return [
+        ...ProductScreen.clickControlButton("Quotation/Order"),
+        {
+            content: `select sale order with price ${price}`,
+            trigger: `.modal:not(.o_inactive_modal) table.o_list_table tbody tr.o_data_row td:contains('${price}')`,
+            run: "click",
+        },
+        {
+            content: `Choose to settle the order`,
+            trigger: `.modal:not(.o_inactive_modal) .selection-item:contains('Settle the order')`,
+            run: "click",
+        },
+    ];
+}
+
 export function settleNthOrder(n, options = {}) {
     const { loadSN } = options;
     const step = [
@@ -62,12 +78,10 @@ export function checkOrdersListEmpty() {
 }
 
 export function selectedOrderLinesHasLots(productName, lots) {
-    const getSerialStep = (index, serialNumber) => {
-        return {
-            content: `check lot${index} is linked`,
-            trigger: `.info-list li:contains(${serialNumber})`,
-        };
-    };
+    const getSerialStep = (index, serialNumber) => ({
+        content: `check lot${index} is linked`,
+        trigger: `.info-list li:contains(${serialNumber})`,
+    });
     const lotSteps = lots.reduce((acc, serial, i) => acc.concat(getSerialStep(i, serial)), []);
     return [...ProductScreen.selectedOrderlineHas(productName), ...lotSteps];
 }

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1457,3 +1457,86 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_quantity_updated_settle', login="accountman")
+
+    def test_sale_order_fp_different_from_partner_one(self):
+        """
+        Tests that the fiscal position of the sale order is not the same as the partner's fiscal position.
+        The PoS should always use the fiscal position of the sale order when settling it.
+        """
+        tax = self.env['account.tax'].create({
+            'name': 'Base Tax',
+            'amount': 15,
+        })
+        tax_override_1 = self.env['account.tax'].create({
+            'name': 'Tax Override 1',
+            'amount': 100,
+            'amount_type': 'percent',
+        })
+        tax_override_2 = self.env['account.tax'].create({
+            'name': 'Tax Override 2',
+            'amount': 0,
+            'amount_type': 'percent',
+        })
+        fp_1 = self.env['account.fiscal.position'].create({
+            'name': "Partner FP",
+            'tax_ids': [(0, 0, {
+                'tax_src_id': tax.id,
+                'tax_dest_id': tax_override_1.id
+            })]
+        })
+        fp_2 = self.env['account.fiscal.position'].create({
+            'name': "Sale Order FP",
+            'tax_ids': [(0, 0, {
+                'tax_src_id': tax.id,
+                'tax_dest_id': tax_override_2.id
+            })]
+        })
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+            'taxes_id': [tax.id],
+        })
+        partner_test = self.env['res.partner'].create({
+            'name': 'Test Partner',
+            'property_account_position_id': fp_1.id,
+        })
+        sale_a = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 1,
+                'price_unit': product_a.lst_price,
+            })]
+        })
+        sale_b = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'fiscal_position_id': fp_2.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'product_uom_qty': 1,
+                'price_unit': product_a.lst_price,
+            })]
+        })
+        # Disable fiscal position in POS, it should works anyway.
+        self.main_pos_config.write({
+            'tax_regime_selection': False,
+            'default_fiscal_position_id': False,
+            'fiscal_position_ids': [odoo.Command.clear()],
+        })
+        self.assertEqual(sale_a.fiscal_position_id, fp_1, "Sale order should have the fiscal position of the partner")
+        self.assertEqual(sale_a.amount_total, 20, "Sale order amount should be 20 with the tax override 1")
+        self.assertEqual(sale_a.amount_untaxed, 10, "Sale order untaxed amount should be 10 with the tax override 1")
+        self.assertEqual(sale_b.fiscal_position_id, fp_2, "Sale order should have the fiscal position set on the sale order")
+        self.assertEqual(sale_b.amount_total, 10, "Sale order amount should be 10 with the tax override 2")
+        self.assertEqual(sale_b.amount_untaxed, 10, "Sale order untaxed amount should be 10 with the tax override 2")
+        self.start_pos_tour("test_sale_order_fp_different_from_partner_one", login="accountman")
+
+        pos_order_a = self.env['pos.order'].search([('fiscal_position_id', '=', fp_1.id)], limit=1, order='id desc')
+        pos_order_b = self.env['pos.order'].search([('fiscal_position_id', '=', fp_2.id)], limit=1, order='id desc')
+        self.assertEqual(pos_order_a.amount_total, 20, "PoS order amount should be 20 with the tax override 1")
+        self.assertEqual(pos_order_a.amount_tax, 10, "PoS order untaxed amount should be 10 with the tax override 1")
+        self.assertEqual(pos_order_a.lines[0].tax_ids, tax_override_1, "PoS order should have the tax override 1")
+        self.assertEqual(pos_order_b.amount_total, 10, "PoS order amount should be 10 with the tax override 2")
+        self.assertEqual(pos_order_b.amount_tax, 0, "PoS order untaxed amount should be 10 with the tax override 2")
+        self.assertEqual(pos_order_b.lines[0].tax_ids, tax_override_2, "PoS order should have the tax override 2")


### PR DESCRIPTION
When a sales order is imported into the PoS, the tax position does not match if the sales order has a different tax position than the one assigned to the partner.

This commit ensures that the tax position will always be the one assigned to the sales order and not that of the partner.

taskId: 4963118

