### PR TITLE
[IMP] 59416: allow attenance kiosk mode multi company

### DIFF
--- a/addons/hr_attendance/static/src/components/manual_selection/manual_selection.js
+++ b/addons/hr_attendance/static/src/components/manual_selection/manual_selection.js
@@ -46,6 +46,12 @@ export class KioskManualSelection extends Component {
         })
     }
 
+    getAllowedCompaniesParams() {
+        const url = new URL(window.location.href)
+        const companyIds =  url.searchParams.get("allowed_company_ids");
+        return companyIds ? companyIds : false;
+    }
+
     calculateLimit() {
         // This function calculates the maximum number of employee cards that can fit on the screen based on his size,
         // font size, and the number of cards per row.
@@ -89,12 +95,17 @@ export class KioskManualSelection extends Component {
 
     async _fetchEmployeeData() {
         const domain = Domain.and([this.state.departmentDomain, this.state.searchDomain]).toList();
-        const results = await rpc("/hr_attendance/employees_infos", {
+        const companyIds = this.getAllowedCompaniesParams();
+        const params = {
             token: this.props.token,
             limit: this.state.limit,
             offset: this.state.offset,
             domain: domain,
-        });
+        };
+        if (companyIds) {
+            params["allowed_company_ids"] = companyIds;
+        }
+        const results = await rpc("/hr_attendance/employees_infos", params);
         this.state.employeesData.records = results.records;
         this.state.employeesData.count = results.length;
     }

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
@@ -68,6 +68,12 @@ class kioskAttendanceApp extends Component{
         });
     }
 
+    getAllowedCompaniesParams() {
+        const url = new URL(window.location.href)
+        const companyIds =  url.searchParams.get("allowed_company_ids");
+        return companyIds ? companyIds : false;
+    }
+
     async setBadgeID() {
         let barcode = this.state.barcode;
         if (barcode) {
@@ -108,11 +114,15 @@ class kioskAttendanceApp extends Component{
     }
 
     async kioskConfirm(employeeId){
-        const employee = await rpc('attendance_employee_data',
-            {
-                'token': this.props.token,
-                'employee_id': employeeId
-            })
+        const companyIds = this.getAllowedCompaniesParams();
+        const params = {
+            'token': this.props.token,
+            'employee_id': employeeId
+        };
+        if (companyIds) {
+            params["allowed_company_ids"] = companyIds;
+        }
+        const employee = await rpc('attendance_employee_data', params)
         if (employee && employee.employee_name){
             if (employee.use_pin){
                 this.employeeData = employee


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Manual check-in / check-out on attendance kiosk mode is not allowed

Desired behavior after PR is merged:
- Give possibility to user to make check-in / check-out on attendance kiosk mode
- Display employees for allowed company on manual selection mode in the kiosk 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
