### PR TITLE
[FIX] hr: remove setting to install hr_contract module

### DIFF
--- a/addons/hr/models/res_config_settings.py
+++ b/addons/hr/models/res_config_settings.py
@@ -9,7 +9,6 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.resource_calendar_id', readonly=False)
     module_hr_presence = fields.Boolean(string="Advanced Presence Control")
     module_hr_skills = fields.Boolean(string="Skills Management")
-    module_hr_contract = fields.Boolean(string="Contracts Management")
     hr_presence_control_login = fields.Boolean(related='company_id.hr_presence_control_login', readonly=False)
     hr_presence_control_email = fields.Boolean(related='company_id.hr_presence_control_email', readonly=False)
     hr_presence_control_ip = fields.Boolean(related='company_id.hr_presence_control_ip', readonly=False)

--- a/addons/hr/views/res_config_settings_views.xml
+++ b/addons/hr/views/res_config_settings_views.xml
@@ -55,9 +55,6 @@
                         <setting help="Enrich employee profiles with skills and resumes" id="enrich_employee_setting">
                             <field name="module_hr_skills"/>
                         </setting>
-                        <setting help="Manage the contracts of your employees or create contract templates" id="manage_contracts_setting">
-                            <field name="module_hr_contract"/>
-                        </setting>
                     </block>
                     <block title="Work Organization" name="work_organization_setting_container">
                         <setting company_dependent="1" help="Set default company schedule to manage your employees working time" id="default_company_schedule_setting">


### PR DESCRIPTION
Issue:
currently we are not able to install `hr_contract` from settings

Cause:
After odoo/odoo@21f18b1a6fdbf1a01c3dda83acfa66addd01a759 we have merged hr_contract with hr module, hence there is not module name 'hr_contract' to begin with

Fix:
Remove option to install `hr_contract`

opw-4947952

see odoo/upgrade#8102

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
