### PR TITLE
[FIX] website: fix edition bootstrap tests

### DIFF
--- a/addons/website/static/tests/builder/website_builder/edition_bootstrap.test.js
+++ b/addons/website/static/tests/builder/website_builder/edition_bootstrap.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { animationFrame } from "@odoo/hoot-dom";
+import { waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
 
@@ -40,7 +40,6 @@ test("Opening an offcancas should not add mutations to the history", async () =>
     );
     await contains(":iframe .toggleCanvas").click();
     const editor = getEditor();
-    await animationFrame();
-    expect(":iframe .offcanvas").toHaveClass("show");
+    await waitFor(":iframe .offcanvas.show");
     expect(editor.shared.history.addStep()).toBe(false);
 });


### PR DESCRIPTION
By attempting to fix another indeterministic error, commit [c6d38a2d] introduced an indeterministic error in the test "Opening an offcancas should not add mutations to the history".
Most of the times, the offcanvas element will have the class `.show`, but it can happen that it still has the class `.showing`. In the context of the test, we do not care which class it is, we only care that there is a class.

Bootstrap manages its transitions with a `setTimeout` with a minimum delay of 5ms before removing the transitioning class (`showing`) and applying the final class (`show`). We need to wait for those in the test.

[c6d38a2d]: https://github.com/odoo/odoo/commit/c6d38a2da7964baa016c05bd9e8adc0211261603

runbot-229958