### PR TITLE
[FIX] account, sale: fix subtitles in email notification when partner name is empty

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6190,7 +6190,7 @@ class AccountMove(models.Model):
             force_email_company=force_email_company, force_email_lang=force_email_lang
         )
         record = render_context['record']
-        subtitles = [f"{record.name} - {record.partner_id.name}" if record.partner_id else record.name]
+        subtitles = [f"{record.name} - {record.partner_id.name}" if record.partner_id.name else record.name]
         if self.is_invoice(include_receipts=True):
             # Only show the amount in emails for non-miscellaneous moves. It might confuse recipients otherwise.
             if self.invoice_date_due and self.payment_state not in ('in_payment', 'paid'):

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -1107,3 +1107,14 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         }
         results = wizard._get_sending_settings()
         self.assertDictEqual(results, expected_results)
+
+    def test_invoice_email_subtitle(self):
+        """ Test email notification subtitle for Invoice with and without partner name. """
+        partner = self.env['res.partner'].create({'type': 'invoice', 'parent_id': self.partner_a.id})
+        invoice = self.init_invoice("out_invoice", amounts=[1000], partner=partner, post=True)
+        context = invoice._notify_by_email_prepare_rendering_context(message=self.env['mail.message'])
+        self.assertEqual(context.get('subtitles')[0], invoice.name)
+
+        invoice.partner_id.name = "Test Partner"
+        context = invoice._notify_by_email_prepare_rendering_context(message=self.env['mail.message'])
+        self.assertEqual(context.get('subtitles')[0], f"{invoice.name} - Test Partner")

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1771,7 +1771,7 @@ class SaleOrder(models.Model):
         )
         lang_code = render_context.get('lang')
         record = render_context['record']
-        subtitles = [f"{record.name} - {record.partner_id.name}" if record.partner_id else record.name]
+        subtitles = [f"{record.name} - {record.partner_id.name}" if record.partner_id.name else record.name]
         if self.amount_total:
             # Do not show the price in subtitles if zero (e.g. e-commerce orders are created empty)
             subtitles.append(

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -799,6 +799,17 @@ class TestSaleOrder(SaleCommon):
             msg="price_total should be equal to expected_total",
         )
 
+    def test_sale_order_email_subtitle(self):
+        """Test email notification subtitle for Sale Order with and without partner name."""
+        partner = self.env['res.partner'].create({'type': 'invoice', 'parent_id': self.partner.id})
+        self.sale_order.partner_id = partner
+        context = self.sale_order._notify_by_email_prepare_rendering_context(message=self.env['mail.message'])
+        self.assertEqual(context['subtitles'][0], self.sale_order.name)
+
+        self.sale_order.partner_id.name = "Test Partner"
+        context = self.sale_order._notify_by_email_prepare_rendering_context(message=self.env['mail.message'])
+        self.assertEqual(context['subtitles'][0], f"{self.sale_order.name} - Test Partner")
+
 
 @tagged('post_install', '-at_install')
 class TestSaleOrderInvoicing(AccountTestInvoicingCommon, SaleCommon):


### PR DESCRIPTION
**Steps to reproduce:**
1. Install *Accounting* and *Contacts*.
2. Create a company contact with a name & address.
3. Add a child contact:
  Type = “Invoice address” 
**Leave the Contact Name blank**
4. Configure an outgoing mail server.
5. Create & confirm a customer invoice for created invoice‑address contact.
6. Click Send, send the invoice email, and check subtitle — it displays `False`.

**Issue:**
- When the invoice is emailed to a contact without a name, the email subtitle shows False,
for example:
`INV/2025/00006 - False`

   **Note: Same issue for Sales**

**Cause:**
- The rendering logic only checked that `partner_id` existed, not whether `partner_id.name` was non‑empty
- Since name was not mandatory for address-type Invoice Address, this resulted in `False` appearing in the email subtitle.

**Solution:**
- Add an check for the validity of partner_id.name when generating the email subtitle.

**opw-4939158**