### PR TITLE
[FIX] bus,mail: do not feed old bus notifications late

### DIFF
--- a/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
+++ b/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
@@ -17,7 +17,7 @@ export class IrWebSocket extends models.ServerModel {
 
         channels = [...channels];
         channels.push("broadcast");
-        const authenticatedUserId = this.env.cookie.get("authenticated_user_sid");
+        const authenticatedUserId = this.env.cookie.get("authenticated_user_sid") ?? this.env.uid;
         const [authenticatedPartner] = authenticatedUserId
             ? ResPartner.search_read(
                   [["user_ids", "in", [authenticatedUserId]]],

--- a/addons/im_livechat/controllers/cors/thread.py
+++ b/addons/im_livechat/controllers/cors/thread.py
@@ -3,7 +3,7 @@
 from odoo.http import route
 from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.addons.im_livechat.tools.misc import force_guest_env
-
+from odoo.addons.mail.tools.discuss import bus_rpc
 
 class LivechatThreadController(ThreadController):
     @route("/im_livechat/cors/message/post", methods=["POST"], type="jsonrpc", auth="public", cors="*")
@@ -12,6 +12,7 @@ class LivechatThreadController(ThreadController):
         return self.mail_message_post(thread_model, thread_id, post_data, context, **kwargs)
 
     @route("/im_livechat/cors/message/update_content", methods=["POST"], type="jsonrpc", auth="public", cors="*")
+    @bus_rpc
     def livechat_message_update_content(
         self, guest_token, message_id, body, attachment_ids, attachment_tokens=None, partner_ids=None
     ):

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -6,8 +6,7 @@ from werkzeug.exceptions import NotFound
 
 from odoo import http
 from odoo.http import request
-from odoo.tools import frozendict
-from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
+from odoo.addons.mail.tools.discuss import add_guest_to_context, bus_rpc, Store
 
 
 class ThreadController(http.Controller):
@@ -205,6 +204,7 @@ class ThreadController(http.Controller):
         return store.add(message).get_result()
 
     @http.route("/mail/message/update_content", methods=["POST"], type="jsonrpc", auth="public")
+    @bus_rpc
     @add_guest_to_context
     def mail_message_update_content(self, message_id, body, attachment_ids, attachment_tokens=None, partner_ids=None, **kwargs):
         guest = request.env["mail.guest"]._get_guest_from_context()

--- a/addons/mail/static/src/core/common/bus_rpc_service.js
+++ b/addons/mail/static/src/core/common/bus_rpc_service.js
@@ -1,0 +1,36 @@
+import { Deferred } from "@bus/workers/websocket_worker_utils";
+import { rpc } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+import { uuid } from "@web/core/utils/strings";
+
+/**
+ * Service that wraps RPC calls to coordinate with bus notifications.
+ * Ensures the client waits for both the RPC response and the corresponding
+ * bus notifications.
+ */
+export const busRpcService = {
+    dependencies: ["bus_service"],
+    /**
+     * @param {import("@web/env").OdooEnv}
+     * @param {Partial<import("services").Services>} services
+     */
+    start(env, { bus_service: busService }) {
+        const uuidToDeferred = new Map();
+        busService.subscribe("bus_rpc/end", (uuid) => uuidToDeferred.get(uuid)?.resolve());
+        return async function busRpc(url, params = {}, settings = {}) {
+            const requestId = uuid();
+            const deferred = new Deferred();
+            uuidToDeferred.set(requestId, deferred);
+            params["bus_rpc_uuid"] = requestId;
+            try {
+                const result = await rpc(url, params, settings);
+                await deferred;
+                return result;
+            } finally {
+                uuidToDeferred.delete(requestId);
+            }
+        };
+    },
+};
+
+registry.category("services").add("mail.busRpc", busRpcService);

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -531,7 +531,7 @@ export class Message extends Record {
             mentionedRoles,
         });
         const hadLink = this.hasLink; // to remove old previews if message no longer contains any link
-        const data = await rpc("/mail/message/update_content", {
+        const data = await this.store.busRpc("/mail/message/update_content", {
             attachment_ids: attachments
                 .concat(this.attachment_ids)
                 .map((attachment) => attachment.id),

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -483,6 +483,11 @@ export class Store extends BaseStore {
         return validMentions;
     }
 
+    /** @returns {import("services")["mail.busRpc"]} */
+    get busRpc() {
+        return this.env.services["mail.busRpc"];
+    }
+
     /**
      * Get the parameters to pass to the message post route.
      */

--- a/addons/mail/static/src/js/tooling/types/services.d.ts
+++ b/addons/mail/static/src/js/tooling/types/services.d.ts
@@ -6,6 +6,7 @@ declare module "services" {
     import { discussCorePublicWeb } from "@mail/discuss/core/public_web/discuss_core_public_web_service";
     import { discussCoreWeb } from "@mail/discuss/core/web/discuss_core_web_service";
     import { im_status } from "@mail/core/common/im_status_service";
+    import { busRpcService } from "@mail/core/common/bus_rpc_service";
     import { mailCoreCommon } from "@mail/core/common/mail_core_common_service";
     import { mailCoreWeb } from "@mail/core/web/mail_core_web_service";
     import { mailPopoutService } from "@mail/core/common/mail_popout_service";
@@ -37,6 +38,7 @@ declare module "services" {
         "mail.sound_effects": typeof soundEffects;
         "mail.store": typeof storeService;
         "mail.suggestion": typeof suggestionService;
+        "mail.busRpc": typeof busRpcService,
         im_status: typeof im_status;
     }
 }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -177,11 +177,7 @@ test("Editing message keeps the mentioned channels", async () => {
     await contains(".o-mail-Discuss-threadName", { value: "other" });
 });
 
-test.skip("Can edit message comment in chatter", async () => {
-    // Fails on runbot often because race condition between RPC returns and bus notifications,
-    // leading to late steps receiving old bus notifications and therefore assertion error.
-    // This happens with heavy CPU load, e.g. when test takes around 2.5 seconds to run rather
-    // than 400ms in ideal condition.
+test("Can edit message comment in chatter", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
     pyEnv["mail.message"].create({
@@ -217,7 +213,7 @@ test.skip("Can edit message comment in chatter", async () => {
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });
 });
 
-test.skip("Can edit message comment in chatter (mobile)", async () => {
+test("Can edit message comment in chatter (mobile)", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
     pyEnv["mail.message"].create({

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -14,6 +14,7 @@ from . import test_discuss_reaction_controller
 from . import test_discuss_res_role
 from . import test_discuss_sub_channels
 from . import test_discuss_thread_controller
+from . import test_discuss_tools
 from . import test_message_controller
 from . import test_guest_feature
 from . import test_toggle_upload

--- a/addons/mail/tests/discuss/test_discuss_tools.py
+++ b/addons/mail/tests/discuss/test_discuss_tools.py
@@ -1,0 +1,29 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import Controller, route
+from odoo.tests import HttpCase, new_test_user, tagged
+
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tools.discuss import bus_rpc
+
+
+@tagged("post_install", "-at_install")
+class TestDiscussTools(MailCommon, HttpCase):
+    def test_bus_rpc(self):
+        class Dummycontroller(Controller):
+            @route("/bus/foo", type="jsonrpc", auth="public")
+            @bus_rpc
+            def bus_foo(self):
+                pass
+
+        self.env.registry.clear_cache("routing")
+        self.addCleanup(self.env.registry.clear_cache, "routing")
+        bob_user = new_test_user(self.env, "bob_user")
+        self.authenticate("bob_user", "bob_user")
+        self._reset_bus()
+        self.assertFalse(self.env["bus.bus"].search([]))
+        with self.assertBus(
+            [[self.env.cr.dbname, "res.partner", bob_user.partner_id.id]],
+            [{"type": "bus_rpc/end", "payload": "foo"}],
+        ):
+            self.make_jsonrpc_request("/bus/foo", {"bus_rpc_uuid": "foo"})


### PR DESCRIPTION
Before this commit, discuss RPCs like update_content were prone to race-condition that can lead to UI showing outdated content of a message that was just edited.

This happens because some store data are exclusively feed from return data of RPC whereas some store data are feed from bus notifications. Ordering of data are essentially sound among RPC returns and bus notifications, but not between the 2 groups. Therefore RPC return or bus notifications can come before or after the other one, and the ordering may be wrong and result in wrong store data.

In practice bus notifications usually before return of RPCs. Most of discuss code is robust against this ordering, even though there's likely many potential of race conditions that may happen and are genuine bugs. When bus notifications come after returned RPCs, however, problems are more apparent. This may happen when the bus notification queue is slow, but also in tests this is likely to happen because RPCs are simulated with single micro-tick whereas handling of bus notification is usually more than 1 micro-tick.

The test "Can edit message comment in chatter" is showing this problem: it's a relatively long test that interacts a lot with message edition, which has the message content being obtained from both bus notifications and RPC returns. When the CPU load is high, test takes much more time to run, e.g. 400ms becomes 2500ms. This CPU load affects barely RPC returns but bus notifications are heavily throttled and therefore causes bus notifications to come much later than expected. Test edits message twice with different content and then once without any change. The high CPU load can make test fail after 3rd edit step because the content of message is the 1st edited content instead of the last. The last edition is coming later in the bus notification, but due to timing constraints of 3 seconds assertion can lead to timeout of test because the message is not showing the most recent edited content.

Roughly:
1. message is "original message"
2. message is edited to "edited message"
3. message shows "edited message (edited)"
4. message is edited to "edited again"
5. message shows "edited again (edited)"
6. message editing is started => message content in composer is "edited message" instead of "edited again", so crash after 3 seconds

Step 6 fails because message content between 5 and 6 is changed to "edited message" from the bus notification. All previous steps had the message edited relatively quickly (500ms each) by returned RPC. The bus notifications are throttled to about 3 seconds, thus the "edited message" bus notification arrived very late when starting edition in step 5. The composer content is wrong and the contains wait for at least 3 seconds, but due to heavy throttle of bus notifications from CPU load, the test fails.

This commit fixes the issue by introducing a `busRpc()` function on bus_service and have message edition flow use this busRpc() rather than `rpc()`. This `busRpc()` function is a special flavour of `rpc()` that awaits until the RPC and related notifications have been received. `busRPC()` works by forging a UUID bus_rpc_uuid that the RPC sends back at end of RPC. The `busRPC()` function waits until this notification is received.s

This commit ensures ordering of store data received from server is good, because RPC properly awaits bus notification. Store data of RPC return makes sense after these bus notifications, but ideally it should also be sent to bus notification and business code should ignore returned data from RPC, so that ordering of store data is always good even with interleaving if discuss actions.

This also solves the race condition in the test "Can edit message comment in chatter", because each assertion of message content ensures we are in the window of data feed by related bus notifications. When a message is being edited the composer is not affected by new message content from store data of bus notifications, but the save of the message edition should necessarily have to await related bus notifications, ensuring no previous bus notifications can be feed after this store data state.

Fixes runbot 227618

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
