### PR TITLE
[FIX] im_livechat:  restrict access to conversations of other agents

### DIFF
--- a/addons/im_livechat/models/rating_rating.py
+++ b/addons/im_livechat/models/rating_rating.py
@@ -22,7 +22,7 @@ class Rating(models.Model):
     def action_open_rated_object(self):
         action = super(Rating, self).action_open_rated_object()
         if self.res_model == 'discuss.channel':
-            if self.env[self.res_model].browse(self.res_id):
+            if self.env["discuss.channel"].browse(self.res_id).is_member or self.env.user.has_group("im_livechat.im_livechat_group_manager"):
                 ctx = self.env.context.copy()
                 ctx.update({'active_id': self.res_id})
                 return {

--- a/addons/im_livechat/static/tests/tours/im_livechat_channel_rating.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_channel_rating.js
@@ -1,0 +1,17 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("livechat_operator_cannot_access_other_operator_session", {
+    steps: () => [
+        {
+            trigger: ".o_kanban_record:contains('The channel') a",
+            run: "click",
+        },
+        {
+            trigger: ".o_kanban_record:contains('Michel')",
+            run: "click",
+        },
+        {
+            trigger: ".modal .o_error_dialog:contains('Access Error')",
+        },
+    ],
+});


### PR DESCRIPTION
**Specifications:**
- Raise an AccessError when a livechat agent attempts to open a rating that belongs to another agent, unless they are a livechat manager.

**Purpose:**
- Previously, clicking on a rating by another agent as a live chat user opened an unrelated conversation, leading to confusion.
- This fix prevents agents from accessing live chat sessions of other agents unless they are livechat manager.

task-4607634

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
