### PR TITLE
[FIX] html_editor: ensure checkbox state is saved on blur in tasks

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -898,6 +898,15 @@ export class ListPlugin extends Plugin {
 
         if (isChecklistItem && this.isPointerInsideCheckbox(node, offsetX, offsetY)) {
             toggleClass(node, "o_checked");
+            const { documentSelectionIsInEditable } =
+                this.dependencies.selection.getSelectionData();
+            // When the editable is not focused, clicking on checkbox
+            // wont make it focused So changes will be lost
+            // as no blur event will occur when clicking outside.
+            if (!documentSelectionIsInEditable) {
+                this.editable.focus();
+                this.dependencies.selection.setSelection({ anchorNode: node, anchorOffset: 0 });
+            }
             ev.preventDefault();
             this.dependencies.history.addStep();
         }

--- a/addons/html_editor/static/tests/list/checklist.test.js
+++ b/addons/html_editor/static/tests/list/checklist.test.js
@@ -34,7 +34,7 @@ test("should check a simple item", async () => {
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">1</li>
+                <li class="o_checked">[]1</li>
             </ul>`),
     });
 });
@@ -51,7 +51,7 @@ test("should uncheck a simple item", async () => {
         },
         contentAfter: unformat(`
                 <ul class="o_checklist">
-                    <li>1</li>
+                    <li>[]1</li>
                 </ul>`),
     });
 });
@@ -68,7 +68,7 @@ test("should check an empty item", async () => {
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked"><br></li>
+                <li class="o_checked">[]<br></li>
             </ul>`),
     });
 });
@@ -85,7 +85,7 @@ test("should uncheck an empty item", async () => {
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked"><br></li>
+                <li class="o_checked">[]<br></li>
             </ul>`),
     });
 });
@@ -115,7 +115,7 @@ test("should check a nested item and the previous checklist item used as title",
                 <li class="oe-nested">
                     <ul class="o_checklist">
                         <li class="o_checked">2.1</li>
-                        <li class="o_checked">2.2</li>
+                        <li class="o_checked">[]2.2</li>
                     </ul>
                 </li>
             </ul>`),
@@ -147,7 +147,7 @@ test("should uncheck a nested item and the previous checklist item used as title
                 <li class="oe-nested">
                     <ul class="o_checklist">
                         <li class="o_checked">2.1</li>
-                        <li>2.2</li>
+                        <li>[]2.2</li>
                     </ul>
                 </li>
             </ul>`),
@@ -187,7 +187,7 @@ test("should check a nested item and the wrapper wrapper title", async () => {
                         <li class="oe-nested">
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
-                                <li class="o_checked">3.2.2</li>
+                                <li class="o_checked">[]3.2.2</li>
                             </ul>
                         </li>
                     </ul>
@@ -229,7 +229,7 @@ test("should uncheck a nested item and the wrapper wrapper title", async () => {
                         <li class="oe-nested">
                             <ul class="o_checklist">
                                 <li class="o_checked">3.1.1</li>
-                                <li>3.1.2</li>
+                                <li>[]3.1.2</li>
                             </ul>
                         </li>
                     </ul>
@@ -272,7 +272,7 @@ test("should check all nested checklist item", async () => {
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">3</li>
+                <li class="o_checked">[]3</li>
                 <li class="oe-nested">
                     <ul class="o_checklist">
                         <li>3.1</li>
@@ -325,7 +325,7 @@ test("should uncheck all nested checklist item", async () => {
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li>3</li>
+                <li>[]3</li>
                 <li class="oe-nested">
                     <ul class="o_checklist">
                         <li class="o_checked">3.1</li>
@@ -373,7 +373,7 @@ test("should check all nested checklist item and update wrapper title", async ()
                 <li>3</li>
                 <li class="oe-nested">
                     <ul class="o_checklist">
-                        <li class="o_checked">3.1</li>
+                        <li class="o_checked">[]3.1</li>
                         <li class="oe-nested">
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
@@ -415,7 +415,7 @@ test("should uncheck all nested checklist items and update wrapper title", async
                 <li class="o_checked">3</li>
                 <li class="oe-nested">
                     <ul class="o_checklist">
-                        <li>3.1</li>
+                        <li>[]3.1</li>
                         <li class="oe-nested">
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>


### PR DESCRIPTION
Problem:
In the Project app, when a task's description contains checkboxes and you check an item, then navigate back using breadcrumbs, the change is not saved.

Cause:
Breadcrumb navigation triggers a `blur` event to save the content. However, if the editable is not focused and you click on a checkbox, it doesn’t focus the editable. As a result, clicking away does not trigger `blur`, and the change is lost.

Solution:
Since `<li>` elements are not focusable, we programmatically focus the editable when toggling a checkbox. If it was already focused, we preserve the current selection.

Steps to reproduce:
- Add checkboxes to a task description
- Save
- Mark one checkbox as checked (editable remains unfocused)
- Navigate back using breadcrumbs
- Open the same task again -> The checkbox state is not saved

opw-4922375

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
