### PR TITLE
Saas 18.4 mysterious egg tour divy 16

### DIFF
--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -7,7 +7,13 @@ import { insertSnippet, registerWebsitePreviewTour } from '@website/js/tours/tou
 const selectImageSteps = [{
     content: "select block",
     trigger: ":iframe #wrapwrap .s_text_image",
-    run: "click",
+    async run(helpers) {
+        await helpers.click();
+        const el = this.anchor;
+        const sel = el.ownerDocument.getSelection();
+        sel.collapse(el, 0);
+        el.focus();
+    },
 }, {
     content: "check link popover disappeared",
     trigger: ":iframe body:not(:has(.o_edit_menu_popover))",
@@ -29,52 +35,52 @@ registerWebsitePreviewTour('test_image_link', {
     ...selectImageSteps,
     {
         content: "enable link",
-        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-customizeblock-option:has(we-title:contains(Media)) we-button.fa-link",
+        trigger: ".o_customize_tab [data-container-title='Image'] button[data-action-id='setLink']",
         run: "click",
     }, {
         content: "enter site URL",
-        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        trigger: ".o_customize_tab [data-container-title='Image'] div[data-action-id='setUrl'] input",
         run: "edit odoo.com && click body",
     },
     ...selectImageSteps,
     {
         content: "check popover content has site URL",
-        trigger: ":iframe .o_edit_menu_popover a.o_we_url_link[href='http://odoo.com/']:contains(http://odoo.com/)",
+        trigger: ".o-we-linkpopover a.o_we_url_link[href='http://odoo.com']:contains(http://odoo.com)",
     }, {
         content: "remove URL",
-        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        trigger: ".o_customize_tab [data-container-title='Image'] div[data-action-id='setUrl'] input",
         run: "clear && click body",
     },
     ...selectImageSteps,
     {
         content: "check popover content has no URL",
-        trigger: ":iframe .o_edit_menu_popover a.o_we_url_link:not([href]):contains(No URL specified)",
+        trigger: ".o-we-linkpopover .o_we_href_input_link:value()",
     }, {
         content: "enter email URL",
-        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        trigger: ".o_customize_tab [data-container-title='Image'] div[data-action-id='setUrl'] input",
         run: "edit mailto:test@test.com && click body",
     },
     ...selectImageSteps,
     {
         content: "check popover content has mail URL",
-        trigger: ":iframe .o_edit_menu_popover:has(.fa-envelope-o) a.o_we_url_link[href='mailto:test@test.com']:contains(mailto:test@test.com)",
+        trigger: ".o-we-linkpopover:has(.fa-envelope-o) a.o_we_url_link[href='mailto:test@test.com']:contains(mailto:test@test.com)",
     }, {
         content: "enter phone URL",
-        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        trigger: ".o_customize_tab [data-container-title='Image'] div[data-action-id='setUrl'] input",
         run: "edit tel:555-2368 && click body",
     },
     ...selectImageSteps,
     {
         content: "check popover content has phone URL",
-        trigger: ":iframe .o_edit_menu_popover:has(.fa-phone) a.o_we_url_link[href='tel:555-2368']:contains(tel:555-2368)",
+        trigger: ".o-we-linkpopover:has(.fa-phone) a.o_we_url_link[href='tel:555-2368']:contains(tel:555-2368)",
     }, {
         content: "remove URL",
-        trigger: "#oe_snippets we-customizeblock-options:has(we-title:contains('Image')) we-input:contains(Your URL) input",
+        trigger: ".o_customize_tab [data-container-title='Image'] div[data-action-id='setUrl'] input",
         run: "clear && click body",
     },
     ...selectImageSteps,
     {
         content: "check popover content has no URL",
-        trigger: ":iframe .o_edit_menu_popover a.o_we_url_link:not([href]):contains(No URL specified)",
+        trigger: ".o-we-linkpopover .o_we_href_input_link:value()",
     },
 ]);

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -1,5 +1,5 @@
 import { patch } from "@web/core/utils/patch";
-import { VideoSelector } from '@web_editor/components/media_dialog/video_selector';
+import { VideoSelector } from "@html_editor/main/media/media_dialog/video_selector";
 import {
     changeOption,
     insertSnippet,
@@ -46,13 +46,17 @@ registerWebsitePreviewTour('test_replace_media', {
     },
     {
         content: "ensure image size is displayed",
-        trigger: "#oe_snippets we-title:contains('Image') .o_we_image_weight:contains('kb')",
+        trigger: ".o_customize_tab [data-container-title='Image'] .options-container-header:contains('kb')",
     },
-    changeOption("ImageTools", 'we-select[data-name="shape_img_opt"] we-toggler'),
-    changeOption("ImageTools", "we-button[data-set-img-shape]"),
+    changeOption("Image", "[data-label='Shape'] .dropdown-toggle"),
     {
-        content: "replace image",
-        trigger: "#oe_snippets we-button[data-replace-media]",
+        content: "Click on the first image shape",
+        trigger: "button[data-action-id='setImageShape']",
+        run: "click",
+    },
+    {
+        content: "Open MediaDialog from an image",
+        trigger: "button[data-action-id='replaceMedia']",
         run: "click",
     },
     {
@@ -61,16 +65,16 @@ registerWebsitePreviewTour('test_replace_media', {
         run: "click",
     },
     {
-        content: "ensure the svg doesn't have a shape",
-        trigger: ":iframe .s_picture figure img:not([data-shape])",
+        content: "ensure the svg does have a shape",
+        trigger: ":iframe .s_picture figure img[data-shape]",
     },
     {
-        content: "ensure image size is not displayed",
-        trigger: "#oe_snippets we-title:contains('Image'):not(:has(.o_we_image_weight:visible))",
+        content: "ensure image size is displayed",
+        trigger: ".o_customize_tab [data-container-title='Image'] span[title='Size']",
     },
     {
         content: "replace image",
-        trigger: "#oe_snippets we-button[data-replace-media]",
+        trigger: "button[data-action-id='replaceMedia']",
         run: "click",
     },
     {
@@ -80,12 +84,12 @@ registerWebsitePreviewTour('test_replace_media', {
     },
     {
         content: "select an icon",
-        trigger: ".o_select_media_dialog:has(.nav-link.active:contains('Icons')) .tab-content span.fa-lemon-o",
+        trigger: ".o_select_media_dialog:has(.nav-link.active:contains('Icons')) .tab-content span.fa-heart",
         run: "click",
     },
     {
         content: "ensure icon block is displayed",
-        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Icon')",
+        trigger: ".o_customize_tab [data-container-title='Icon']",
     },
     {
         content: "select footer",
@@ -94,16 +98,16 @@ registerWebsitePreviewTour('test_replace_media', {
     },
     {
         content: "select icon",
-        trigger: ":iframe .s_picture figure span.fa-lemon-o",
+        trigger: ":iframe .s_picture figure span.fa-heart",
         run: "click",
     },
     {
         content: "ensure icon block is still displayed",
-        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Icon')",
+        trigger: ".o_customize_tab [data-container-title='Icon']",
     },
     {
         content: "replace icon",
-        trigger: "#oe_snippets we-button[data-replace-media]",
+        trigger: "button[data-action-id='replaceMedia']",
         run: "click",
     },
     {
@@ -129,11 +133,11 @@ registerWebsitePreviewTour('test_replace_media', {
     },
     {
         content: "ensure video option block is displayed",
-        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Video')",
+        trigger: ".o_customize_tab [data-container-title='Video']",
     },
     {
         content: "replace image",
-        trigger: "#oe_snippets we-button[data-replace-media]",
+        trigger: ".btn-success[data-action-id='replaceMedia']",
         run: "click",
     },
     {
@@ -143,12 +147,12 @@ registerWebsitePreviewTour('test_replace_media', {
     },
     {
         content: "select an icon",
-        trigger: ".o_select_media_dialog:has(.nav-link.active:contains('Icons')) .tab-content span.fa-lemon-o",
+        trigger: ".o_select_media_dialog:has(.nav-link.active:contains('Icons')) .tab-content span.fa-heart",
         run: "click",
     },
     {
         content: "ensure icon block is displayed",
-        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Icon')",
+        trigger: ".o_customize_tab [data-container-title='Icon']",
     },
     {
         content: "select footer",
@@ -157,11 +161,11 @@ registerWebsitePreviewTour('test_replace_media', {
     },
     {
         content: "select icon",
-        trigger: ":iframe .s_picture figure span.fa-lemon-o",
+        trigger: ":iframe .s_picture figure span.fa-heart",
         run: "click",
     },
     {
         content: "ensure icon block is still displayed",
-        trigger: "#oe_snippets we-customizeblock-options we-title:contains('Icon')",
+        trigger: ".o_customize_tab [data-container-title='Icon']",
     },
 ]);

--- a/addons/test_website/tests/test_media.py
+++ b/addons/test_website/tests/test_media.py
@@ -5,11 +5,8 @@ import base64
 
 import odoo.tests
 from odoo.tools import mute_logger
-import unittest
 
 
-# TODO master-mysterious-egg fix error
-@unittest.skip("prepare mysterious-egg for merging")
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestMedia(odoo.tests.HttpCase):
 


### PR DESCRIPTION
test_01_replace_media tests was broken and disabled after the
new website builder changes.This PR adapts the tour steps accordingly
and re-enables the related test.

Additionally, In this PR[1] we prevent adding shape for SVG image.
now we support the shape on SVG image.

[1]: https://github.com/odoo/odoo/pull/128084