### PR TITLE
[FIX] *: get human-readable strings out of inline XML templates

### DIFF
--- a/addons/account/static/src/components/tests_shared_js_python/test_shared_js_python.xml
+++ b/addons/account/static/src/components/tests_shared_js_python/test_shared_js_python.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<templates>
+<t t-name="account.TestsSharedJsPython">
+    <button t-attf-class="#{state.done ? 'text-success' : ''}" t-on-click="processTests">Test</button>
+</t>
+</templates>

--- a/addons/account/static/src/components/tests_shared_js_python/tests_shared_js_python.js
+++ b/addons/account/static/src/components/tests_shared_js_python/tests_shared_js_python.js
@@ -3,12 +3,10 @@ import { registry } from "@web/core/registry";
 
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 
-import { xml, useState, Component } from "@odoo/owl";
+import { useState, Component } from "@odoo/owl";
 
 export class TestsSharedJsPython extends Component {
-    static template = xml`
-        <button t-attf-class="#{state.done ? 'text-success' : ''}" t-on-click="processTests">Test</button>
-    `;
+    static template = "account.TestsSharedJsPython";
     static props = {
         tests: { type: Array, optional: true },
     };

--- a/addons/api_doc/static/src/doc_client.js
+++ b/addons/api_doc/static/src/doc_client.js
@@ -1,4 +1,4 @@
-import { Component, useState, xml, onMounted, useSubEnv } from "@odoo/owl";
+import { Component, useState, onMounted, useSubEnv } from "@odoo/owl";
 import { ModelStore } from "@api_doc/doc_model_store";
 import { useDocUI } from "@api_doc/utils/doc_ui_store";
 import { ApiKeyModal } from "@api_doc/components/doc_modal_api_key";
@@ -7,52 +7,7 @@ import { DocSidebar } from "@api_doc/components/doc_sidebar";
 import { DocModel } from "@api_doc/components/doc_model";
 
 export class DocClient extends Component {
-    static template = xml`
-        <header class="position-fixed bg-1 flex gap-1 align-items-center justify-content-between w-100">
-            <div class="flex">
-                <h2>Odoo Runtime Doc</h2>
-            </div>
-            <div>
-                <input
-                    t-on-click="() => this.state.showSearchModal = true"
-                    placeholder="Find anything..."
-                />
-            </div>
-            <div class="flex gap-1">
-                <button class="btn" role="button" t-on-click="() => this.env.modelStore.showApiKeyModal = true">
-                    <i class="fa fa-key" aria-hidden="true"></i>
-                </button>
-                <button class="btn" role="button" t-on-click="() => this.toggleTheme()">
-                    <i class="fa fa-moon-o" aria-hidden="true"></i>
-                </button>
-            </div>
-        </header>
-        <main class="position-relative flex">
-            <DocSidebar t-if="!ui.isSmall"/>
-            <t t-if="modelStore.models.length > 0">
-                <DocModel t-if="modelStore.activeModel"/>
-            </t>
-            <div t-elif="!modelStore.error" class="h-100 w-100 flex align-items-center justify-content-center gap-1">
-                <i class="fa fa-spinner o-doc-spinner" aria-hidden="true"></i>
-                <div>Loading Models</div>
-            </div>
-
-            <div t-if="modelStore.error" class="flex align-items-center justify-content-center w-100 h-100">
-                <div class="alert error mt-1 flex flex-column">
-                    <h5 class="mb-2 flex align-items-center">
-                        <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
-                        <span>Error while loading models</span>
-                    </h5>
-                    <div t-out="modelStore.error.message"></div>
-                </div>
-            </div>
-        </main>
-        <ApiKeyModal t-if="modelStore.showApiKeyModal"/>
-        <SearchModal
-            t-if="state.showSearchModal"
-            close="() => this.state.showSearchModal = false"
-        />
-    `;
+    static template = "api_doc.DocClient";
 
     static components = {
         DocSidebar,

--- a/addons/api_doc/static/src/doc_client.xml
+++ b/addons/api_doc/static/src/doc_client.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<templates>
+<t t-name="api_doc.DocClient">
+    <header class="position-fixed bg-1 flex gap-1 align-items-center justify-content-between w-100">
+        <div class="flex">
+            <h2>Odoo Runtime Doc</h2>
+        </div>
+        <div>
+            <input
+                t-on-click="() => this.state.showSearchModal = true"
+                placeholder="Find anything..."
+            />
+        </div>
+        <div class="flex gap-1">
+            <button class="btn" role="button" t-on-click="() => this.env.modelStore.showApiKeyModal = true">
+                <i class="fa fa-key" aria-hidden="true"></i>
+            </button>
+            <button class="btn" role="button" t-on-click="() => this.toggleTheme()">
+                <i class="fa fa-moon-o" aria-hidden="true"></i>
+            </button>
+        </div>
+    </header>
+    <main class="position-relative flex">
+        <DocSidebar t-if="!ui.isSmall"/>
+        <t t-if="modelStore.models.length > 0">
+            <DocModel t-if="modelStore.activeModel"/>
+        </t>
+        <div t-elif="!modelStore.error" class="h-100 w-100 flex align-items-center justify-content-center gap-1">
+            <i class="fa fa-spinner o-doc-spinner" aria-hidden="true"></i>
+            <div>Loading Models</div>
+        </div>
+
+        <div t-if="modelStore.error" class="flex align-items-center justify-content-center w-100 h-100">
+            <div class="alert error mt-1 flex flex-column">
+                <h5 class="mb-2 flex align-items-center">
+                    <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
+                    <span>Error while loading models</span>
+                </h5>
+                <div t-out="modelStore.error.message"></div>
+            </div>
+        </div>
+    </main>
+    <ApiKeyModal t-if="modelStore.showApiKeyModal"/>
+    <SearchModal
+        t-if="state.showSearchModal"
+        close="() => this.state.showSearchModal = false"
+    />
+</t>
+</templates>

--- a/addons/html_editor/static/src/main/media/media_dialog/attachment_error.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/attachment_error.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<templates>
+<t t-name="html_editor.AttachmentError">
+    <Dialog title="title">
+        <div class="form-text">
+            <p>The image could not be deleted because it is used in the
+                following pages or views:</p>
+            <ul t-foreach="props.views" t-as="view" t-key="view.id">
+                <li>
+                    <a t-att-href="'/odoo/ir.ui.view/' + window.encodeURIComponent(view.id)">
+                        <t t-esc="view.name"/>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <t t-set-slot="footer">
+            <button class="btn btn-primary" t-on-click="() => this.props.close()">
+                Ok
+            </button>
+        </t>
+    </Dialog>
+</t>
+</templates>

--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
@@ -38,25 +38,7 @@ class RemoveButton extends Component {
 
 export class AttachmentError extends Component {
     static components = { Dialog };
-    static template = xml`
-        <Dialog title="title">
-            <div class="form-text">
-                <p>The image could not be deleted because it is used in the
-                    following pages or views:</p>
-                <ul t-foreach="props.views"  t-as="view" t-key="view.id">
-                    <li>
-                        <a t-att-href="'/odoo/ir.ui.view/' + window.encodeURIComponent(view.id)">
-                            <t t-esc="view.name"/>
-                        </a>
-                    </li>
-                </ul>
-            </div>
-            <t t-set-slot="footer">
-                <button class="btn btn-primary" t-on-click="() => this.props.close()">
-                    Ok
-                </button>
-            </t>
-        </Dialog>`;
+    static template = "html_editor.AttachmentError";
     static props = ["views", "close"];
     setup() {
         this.title = _t("Alert");

--- a/addons/html_editor/static/src/main/media/media_dialog/search_media.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/search_media.js
@@ -1,14 +1,10 @@
 import { useDebounced } from "@web/core/utils/timing";
 import { useAutofocus } from "@web/core/utils/hooks";
 
-import { Component, xml, useEffect, useState } from "@odoo/owl";
+import { Component, useEffect, useState } from "@odoo/owl";
 
 export class SearchMedia extends Component {
-    static template = xml`
-        <div class="position-relative mw-lg-25 flex-grow-1 me-auto">
-            <input type="text" class="o_we_search o_input form-control" t-att-placeholder="props.searchPlaceholder.trim()" t-model="state.input" t-ref="autofocus"/>
-            <i class="oi oi-search input-group-text position-absolute end-0 top-50 me-n3 px-2 py-1 translate-middle bg-transparent border-0" title="Search" role="img" aria-label="Search"/>
-        </div>`;
+    static template = "html_editor.SearchMedia";
     static props = ["searchPlaceholder", "search", "needle"];
     setup() {
         useAutofocus({ mobile: true });

--- a/addons/html_editor/static/src/main/media/media_dialog/search_media.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/search_media.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<templates>
+<t t-name="html_editor.SearchMedia">
+    <div class="position-relative mw-lg-25 flex-grow-1 me-auto">
+        <input type="text" class="o_we_search o_input form-control" t-att-placeholder="props.searchPlaceholder.trim()" t-model="state.input" t-ref="autofocus"/>
+        <i class="oi oi-search input-group-text position-absolute end-0 top-50 me-n3 px-2 py-1 translate-middle bg-transparent border-0" title="Search" role="img" aria-label="Search"/>
+    </div>
+</t>
+</templates>

--- a/addons/iot_drivers/static/src/app/Homepage.js
+++ b/addons/iot_drivers/static/src/app/Homepage.js
@@ -103,80 +103,82 @@ export class Homepage extends Component {
     }
 
     static template = xml`
-    <LoadingFullScreen t-if="this.state.waitRestart">
-        <t t-set-slot="body">
-           Restarting IoT Box, please wait...
-        </t>
-    </LoadingFullScreen>
+    <t t-translation="off">
+        <LoadingFullScreen t-if="this.state.waitRestart">
+            <t t-set-slot="body">
+            Restarting IoT Box, please wait...
+            </t>
+        </LoadingFullScreen>
 
-    <div t-if="!this.state.loading" class="w-100 d-flex flex-column align-items-center justify-content-center background">
-        <div class="bg-white p-4 rounded overflow-auto position-relative w-100 main-container">
-            <div class="position-absolute end-0 top-0 mt-3 me-4 d-flex gap-1">
-                <IconButton t-if="!store.base.is_access_point_up" onClick.bind="toggleAdvanced" icon="this.store.advanced ? 'fa-cog' : 'fa-cogs'" />
-                <IconButton onClick.bind="restartOdooService" icon="'fa-power-off'" />
-            </div>
-            <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
-                <h4 class="text-center m-0">IoT Box</h4>
-            </div>
-            <div t-if="!state.data.certificate_end_date and !store.base.is_access_point_up" class="alert alert-warning" role="alert">
-                <p class="m-0 fw-bold">
-                    No subscription linked to your IoT Box.
-                </p>
-                <small>
-                    Please contact your account manager to take advantage of your IoT Box's full potential.
-                </small>
-            </div>
-            <div t-if="store.advanced and state.data.certificate_end_date and !store.base.is_access_point_up" class="alert alert-info" role="alert">
-                Your IoT Box subscription is valid until <span class="fw-bold" t-esc="state.data.certificate_end_date"/>.
-            </div>
-            <div t-if="store.base.is_access_point_up" class="alert alert-info" role="alert">
-                <p class="m-0 fw-bold">No Internet Connection</p>
-                <small>
-                    Please connect your IoT Box to internet via an ethernet cable or via Wi-Fi by clicking on "Configure" below
-                </small>
-            </div>
-            <SingleData name="'Identifier'" value="state.data.identifier" icon="'fa-address-card'" />
-            <SingleData t-if="store.advanced" name="'Version'" value="state.data.version" icon="'fa-microchip'">
-                <t t-set-slot="button">
-                    <UpdateDialog />
-                </t>
-            </SingleData>
-            <SingleData t-if="store.advanced" name="'IP address'" value="state.data.ip" icon="'fa-globe'" />
-            <SingleData t-if="store.isLinux" name="'Internet Status'" value="networkStatus" icon="'fa-wifi'">
-                <t t-set-slot="button">
-                    <WifiDialog />
-                </t>
-            </SingleData>
-            <SingleData t-if="!store.base.is_access_point_up" name="'Odoo database connected'" value="state.data.server_status" icon="'fa-link'">
-				<t t-set-slot="button">
-					<ServerDialog />
-				</t>
-			</SingleData>
-            <SingleData t-if="state.data.pairing_code and !this.store.base.is_access_point_up and !state.data.pairing_code_expired" name="'Pairing Code'" value="state.data.pairing_code + ' - Enter this code in the IoT app in your Odoo database'" icon="'fa-code'"/>
-            <SingleData t-if="state.data.pairing_code_expired" name="'Pairing Code'" value="'Code has expired - restart the IoT Box to generate a new one'" icon="'fa-code'"/>
-            <SingleData  t-if="store.advanced and !store.base.is_access_point_up" name="'Six terminal'" value="state.data.six_terminal" icon="'fa-money'">
-                <t t-set-slot="button">
-                    <SixDialog />
-                </t>
-            </SingleData>
-            <SingleData t-if="!this.store.base.is_access_point_up" name="'Devices'" value="numDevices + ' devices'" icon="'fa-plug'">
-                <t t-set-slot="button">
-                    <DeviceDialog />
-                </t>
-            </SingleData>
+        <div t-if="!this.state.loading" class="w-100 d-flex flex-column align-items-center justify-content-center background">
+            <div class="bg-white p-4 rounded overflow-auto position-relative w-100 main-container">
+                <div class="position-absolute end-0 top-0 mt-3 me-4 d-flex gap-1">
+                    <IconButton t-if="!store.base.is_access_point_up" onClick.bind="toggleAdvanced" icon="this.store.advanced ? 'fa-cog' : 'fa-cogs'" />
+                    <IconButton onClick.bind="restartOdooService" icon="'fa-power-off'" />
+                </div>
+                <div class="d-flex mb-4 flex-column align-items-center justify-content-center">
+                    <h4 class="text-center m-0">IoT Box</h4>
+                </div>
+                <div t-if="!state.data.certificate_end_date and !store.base.is_access_point_up" class="alert alert-warning" role="alert">
+                    <p class="m-0 fw-bold">
+                        No subscription linked to your IoT Box.
+                    </p>
+                    <small>
+                        Please contact your account manager to take advantage of your IoT Box's full potential.
+                    </small>
+                </div>
+                <div t-if="store.advanced and state.data.certificate_end_date and !store.base.is_access_point_up" class="alert alert-info" role="alert">
+                    Your IoT Box subscription is valid until <span class="fw-bold" t-esc="state.data.certificate_end_date"/>.
+                </div>
+                <div t-if="store.base.is_access_point_up" class="alert alert-info" role="alert">
+                    <p class="m-0 fw-bold">No Internet Connection</p>
+                    <small>
+                        Please connect your IoT Box to internet via an ethernet cable or via Wi-Fi by clicking on "Configure" below
+                    </small>
+                </div>
+                <SingleData name="'Identifier'" value="state.data.identifier" icon="'fa-address-card'" />
+                <SingleData t-if="store.advanced" name="'Version'" value="state.data.version" icon="'fa-microchip'">
+                    <t t-set-slot="button">
+                        <UpdateDialog />
+                    </t>
+                </SingleData>
+                <SingleData t-if="store.advanced" name="'IP address'" value="state.data.ip" icon="'fa-globe'" />
+                <SingleData t-if="store.isLinux" name="'Internet Status'" value="networkStatus" icon="'fa-wifi'">
+                    <t t-set-slot="button">
+                        <WifiDialog />
+                    </t>
+                </SingleData>
+                <SingleData t-if="!store.base.is_access_point_up" name="'Odoo database connected'" value="state.data.server_status" icon="'fa-link'">
+                    <t t-set-slot="button">
+                        <ServerDialog />
+                    </t>
+                </SingleData>
+                <SingleData t-if="state.data.pairing_code and !this.store.base.is_access_point_up and !state.data.pairing_code_expired" name="'Pairing Code'" value="state.data.pairing_code + ' - Enter this code in the IoT app in your Odoo database'" icon="'fa-code'"/>
+                <SingleData t-if="state.data.pairing_code_expired" name="'Pairing Code'" value="'Code has expired - restart the IoT Box to generate a new one'" icon="'fa-code'"/>
+                <SingleData  t-if="store.advanced and !store.base.is_access_point_up" name="'Six terminal'" value="state.data.six_terminal" icon="'fa-money'">
+                    <t t-set-slot="button">
+                        <SixDialog />
+                    </t>
+                </SingleData>
+                <SingleData t-if="!this.store.base.is_access_point_up" name="'Devices'" value="numDevices + ' devices'" icon="'fa-plug'">
+                    <t t-set-slot="button">
+                        <DeviceDialog />
+                    </t>
+                </SingleData>
 
-            <hr class="mt-5" />
-            <FooterButtons />
-            <div class="d-flex justify-content-center gap-2 mt-2" t-if="!store.base.is_access_point_up">
-                <a href="https://www.odoo.com/fr_FR/help" target="_blank" class="link-primary">Help</a>
-                <a href="https://www.odoo.com/documentation/master/applications/general/iot.html" target="_blank" class="link-primary">Documentation</a>
+                <hr class="mt-5" />
+                <FooterButtons />
+                <div class="d-flex justify-content-center gap-2 mt-2" t-if="!store.base.is_access_point_up">
+                    <a href="https://www.odoo.com/fr_FR/help" target="_blank" class="link-primary">Help</a>
+                    <a href="https://www.odoo.com/documentation/master/applications/general/iot.html" target="_blank" class="link-primary">Documentation</a>
+                </div>
             </div>
         </div>
-    </div>
-    <div t-else="" class="w-100 d-flex align-items-center justify-content-center background">
-        <div class="spinner-border" role="status">
-            <span class="visually-hidden">Loading...</span>
+        <div t-else="" class="w-100 d-flex align-items-center justify-content-center background">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
         </div>
-    </div>
+    </t>
   `;
 }

--- a/addons/iot_drivers/static/src/app/components/FooterButtons.js
+++ b/addons/iot_drivers/static/src/app/components/FooterButtons.js
@@ -26,7 +26,7 @@ export class FooterButtons extends Component {
     }
 
     static template = xml`
-    <div class="w-100 d-flex flex-wrap align-items-cente gap-2 justify-content-center">
+    <div class="w-100 d-flex flex-wrap align-items-cente gap-2 justify-content-center" t-translation="off">
         <a t-if="store.isLinux and !store.base.is_access_point_up" class="btn btn-primary btn-sm" t-att-href="this.url + '/status'" target="_blank">
             Status Display
         </a>

--- a/addons/iot_drivers/static/src/app/components/IconButton.js
+++ b/addons/iot_drivers/static/src/app/components/IconButton.js
@@ -15,7 +15,7 @@ export class IconButton extends Component {
     }
 
     static template = xml`
-    <div class="d-flex align-items-center justify-content-center icon-button btn btn-primary" t-on-click="this.props.onClick">
+    <div class="d-flex align-items-center justify-content-center icon-button btn btn-primary" t-translation="off" t-on-click="this.props.onClick">
         <i class="fa" t-att-class="this.props.icon" aria-hidden="true"></i>
     </div>
   `;

--- a/addons/iot_drivers/static/src/app/components/LoadingFullScreen.js
+++ b/addons/iot_drivers/static/src/app/components/LoadingFullScreen.js
@@ -31,7 +31,7 @@ export class LoadingFullScreen extends Component {
     }
 
     static template = xml`
-    <div class="position-fixed top-0 start-0 bg-white vh-100 w-100 justify-content-center align-items-center d-flex flex-column gap-3 always-on-top">
+    <div class="position-fixed top-0 start-0 bg-white vh-100 w-100 justify-content-center align-items-center d-flex flex-column gap-3 always-on-top" t-translation="off">
         <div class="spinner-border" role="status">
             <span class="visually-hidden">Loading...</span>
         </div>

--- a/addons/iot_drivers/static/src/app/components/SingleData.js
+++ b/addons/iot_drivers/static/src/app/components/SingleData.js
@@ -29,7 +29,7 @@ export class SingleData extends Component {
     }
 
     static template = xml`
-    <div class="w-100 d-flex justify-content-between align-items-center bg-light rounded ps-2 pe-3 py-1 mb-2 gap-2">
+    <div class="w-100 d-flex justify-content-between align-items-center bg-light rounded ps-2 pe-3 py-1 mb-2 gap-2" t-translation="off">
         <div t-att-class="this.props.style === 'primary' ? 'odoo-bg-primary' : 'odoo-bg-secondary'" class="rounded odoo-pill" />
         <div class="flex-grow-1 overflow-hidden">
             <h6 class="m-0">

--- a/addons/iot_drivers/static/src/app/components/dialog/BootstrapDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/BootstrapDialog.js
@@ -39,6 +39,7 @@ export class BootstrapDialog extends Component {
     }
 
     static template = xml`
+    <t t-translation="off">
         <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" t-att-data-bs-target="'#'+this.props.identifier" t-esc="this.props.btnName" />
         <div t-ref="dialog" t-att-id="this.props.identifier" class="modal modal-dialog-scrollable fade" t-att-class="{'modal-lg': props.isLarge}" tabindex="-1" aria-hidden="true">
             <div class="modal-dialog">
@@ -57,5 +58,6 @@ export class BootstrapDialog extends Component {
                 </div>
             </div>
         </div>
+    </t>
     `;
 }

--- a/addons/iot_drivers/static/src/app/components/dialog/CredentialDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/CredentialDialog.js
@@ -54,6 +54,7 @@ export class CredentialDialog extends Component {
     }
 
     static template = xml`
+    <t t-translation="off">
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
                 Your IoT Box is currently processing your request. Please wait.
@@ -79,5 +80,6 @@ export class CredentialDialog extends Component {
                 <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>
+    </t>
     `;
 }

--- a/addons/iot_drivers/static/src/app/components/dialog/DeviceDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/DeviceDialog.js
@@ -49,6 +49,7 @@ export class DeviceDialog extends Component {
     }
 
     static template = xml`
+    <t t-translation="off">
         <BootstrapDialog identifier="'device-list'" btnName="'Show'" isLarge="true">
             <t t-set-slot="header">
                 Devices list
@@ -87,5 +88,6 @@ export class DeviceDialog extends Component {
                 <button type="button" class="btn btn-primary btn-sm" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>
+    </t>
     `;
 }

--- a/addons/iot_drivers/static/src/app/components/dialog/HandlerDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/HandlerDialog.js
@@ -58,6 +58,7 @@ export class HandlerDialog extends Component {
     }
 
     static template = xml`
+    <t t-translation="off">
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
                 Processing your request, please wait...
@@ -148,5 +149,6 @@ export class HandlerDialog extends Component {
                 <button type="button" class="btn btn-primary btn-sm" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>
+    </t>
     `;
 }

--- a/addons/iot_drivers/static/src/app/components/dialog/RemoteDebugDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/RemoteDebugDialog.js
@@ -92,6 +92,7 @@ export class RemoteDebugDialog extends Component {
     }
 
     static template = xml`
+    <t t-translation="off">
         <BootstrapDialog identifier="'remote-debug-configuration'" btnName="'Remote debug'">
             <t t-set-slot="header">
                 Remote Debugging
@@ -133,5 +134,6 @@ export class RemoteDebugDialog extends Component {
                 <button type="button" t-att-class="'btn btn-sm btn-' + (state.ngrok ? 'secondary' : 'primary')" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>
+    </t>
     `;
 }

--- a/addons/iot_drivers/static/src/app/components/dialog/ServerDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/ServerDialog.js
@@ -49,6 +49,7 @@ export class ServerDialog extends Component {
     }
 
     static template = xml`
+    <t t-translation="off">
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
                 Updating Odoo Server information, please wait...
@@ -84,5 +85,6 @@ export class ServerDialog extends Component {
                 <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>
+    </t>
     `;
 }

--- a/addons/iot_drivers/static/src/app/components/dialog/SixDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/SixDialog.js
@@ -51,6 +51,7 @@ export class SixDialog extends Component {
     }
 
     static template = xml`
+    <t t-translation="off">
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
                 Your IoT Box is currently processing your request. Please wait.
@@ -77,5 +78,6 @@ export class SixDialog extends Component {
                 <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>
+    </t>
     `;
 }

--- a/addons/iot_drivers/static/src/app/components/dialog/UpdateDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/UpdateDialog.js
@@ -79,6 +79,7 @@ export class UpdateDialog extends Component {
     }
 
     static template = xml`
+    <t t-translation="off">
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
                 Updating your device, please wait...
@@ -151,5 +152,6 @@ export class UpdateDialog extends Component {
                 </button>
             </t>
         </BootstrapDialog>
+    </t>
     `;
 }

--- a/addons/iot_drivers/static/src/app/components/dialog/WifiDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/WifiDialog.js
@@ -106,6 +106,7 @@ export class WifiDialog extends Component {
     }
 
     static template = xml`
+    <t t-translation="off">
         <LoadingFullScreen t-if="this.state.waitRestart">
             <t t-set-slot="body">
                 Updating Wi-Fi configuration, please wait...
@@ -172,5 +173,6 @@ export class WifiDialog extends Component {
                 <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>
+    </t>
     `;
 }

--- a/addons/iot_drivers/static/src/app/status.js
+++ b/addons/iot_drivers/static/src/app/status.js
@@ -31,141 +31,143 @@ class StatusPage extends Component {
     }
 
     static template = xml`
-    <div class="text-center pt-5">
-        <img class="odoo-logo" src="/web/static/img/logo2.png" alt="Odoo logo"/>
-    </div>
-    <div t-if="state.loading || state.data.new_database_url" class="position-fixed top-0 start-0 vh-100 w-100 justify-content-center align-items-center d-flex flex-column gap-5">
-        <div class="spinner-border">
-            <span class="visually-hidden">Loading...</span>
+    <t t-translation="off">
+        <div class="text-center pt-5">
+            <img class="odoo-logo" src="/web/static/img/logo2.png" alt="Odoo logo"/>
         </div>
-        <span t-if="state.data.new_database_url" class="fs-4">
-            Connecting to <t t-out="state.data.new_database_url"/>, please wait
-        </span>
-    </div>
-    <div t-else="" class="container-fluid">
-        <!-- QR Codes shown on status page -->
-        <div class="qr-code-box">
-            <div class="status-display-box qr-code">
-                <div>
-                    <h4 class="text-center mb-1">IoT Box Configuration</h4>
-                    <hr/>
-                    <!-- If the IoT Box is connected to internet -->
-                    <div t-if="!state.data.is_access_point_up and state.data.qr_code_url">
-                        <p>
-                            1. Connect to
-                            <!-- Only wifi connection is shown as ethernet connections look like "Wired connection 2" -->
-                            <t t-if="state.data.wifi_ssid">
-                                <b>
-                                    <t t-out="state.data.wifi_ssid"/>
-                                </b>
-                            </t>
-                            <t t-else=""> the IoT Box network</t>
-                            <br/>
-                            <br/>
-                            <div t-if="state.data.qr_code_wifi" class="qr-code">
-                                <img t-att-src="state.data.qr_code_wifi" alt="QR Code Wi-FI"/>
-                            </div>
-                        </p>
-                        <p>
-                            2. Open the IoT Box setup page
-                            <br/>
-                            <br/>
+        <div t-if="state.loading || state.data.new_database_url" class="position-fixed top-0 start-0 vh-100 w-100 justify-content-center align-items-center d-flex flex-column gap-5">
+            <div class="spinner-border">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+            <span t-if="state.data.new_database_url" class="fs-4">
+                Connecting to <t t-out="state.data.new_database_url"/>, please wait
+            </span>
+        </div>
+        <div t-else="" class="container-fluid">
+            <!-- QR Codes shown on status page -->
+            <div class="qr-code-box">
+                <div class="status-display-box qr-code">
+                    <div>
+                        <h4 class="text-center mb-1">IoT Box Configuration</h4>
+                        <hr/>
+                        <!-- If the IoT Box is connected to internet -->
+                        <div t-if="!state.data.is_access_point_up and state.data.qr_code_url">
+                            <p>
+                                1. Connect to
+                                <!-- Only wifi connection is shown as ethernet connections look like "Wired connection 2" -->
+                                <t t-if="state.data.wifi_ssid">
+                                    <b>
+                                        <t t-out="state.data.wifi_ssid"/>
+                                    </b>
+                                </t>
+                                <t t-else=""> the IoT Box network</t>
+                                <br/>
+                                <br/>
+                                <div t-if="state.data.qr_code_wifi" class="qr-code">
+                                    <img t-att-src="state.data.qr_code_wifi" alt="QR Code Wi-FI"/>
+                                </div>
+                            </p>
+                            <p>
+                                2. Open the IoT Box setup page
+                                <br/>
+                                <br/>
+                                <div class="qr-code">
+                                    <img t-att-src="state.data.qr_code_url" alt="QR Code Homepage"/>
+                                </div>
+                            </p>
+                        </div>
+                        <!-- If the IoT Box is in access point and not connected to internet yet -->
+                        <div t-elif="state.data.is_access_point_up and state.data.qr_code_wifi and state.data.qr_code_url"> 
+                            <p>Scan this QR code with your smartphone to connect to the IoT box's <b>Wi-Fi hotspot</b>:</p>
                             <div class="qr-code">
-                                <img t-att-src="state.data.qr_code_url" alt="QR Code Homepage"/>
+                                <img t-att-src="state.data.qr_code_wifi" alt="QR Code Access Point"/>
                             </div>
-                        </p>
-                    </div>
-                    <!-- If the IoT Box is in access point and not connected to internet yet -->
-                    <div t-elif="state.data.is_access_point_up and state.data.qr_code_wifi and state.data.qr_code_url"> 
-                        <p>Scan this QR code with your smartphone to connect to the IoT box's <b>Wi-Fi hotspot</b>:</p>
-                        <div class="qr-code">
-                            <img t-att-src="state.data.qr_code_wifi" alt="QR Code Access Point"/>
+                            <br/>
+                            <br/>
+                            <p>Once you are connected to the Wi-Fi hotspot, you can scan this QR code to access the IoT box <b>Wi-Fi configuration page</b>:</p>
+                            <div class="qr-code">
+                                <img t-att-src="state.data.qr_code_url" alt="QR Code Wifi Config"/>
+                            </div>
+                            <br/>
+                            <br/>
                         </div>
-                        <br/>
-                        <br/>
-                        <p>Once you are connected to the Wi-Fi hotspot, you can scan this QR code to access the IoT box <b>Wi-Fi configuration page</b>:</p>
-                        <div class="qr-code">
-                            <img t-att-src="state.data.qr_code_url" alt="QR Code Wifi Config"/>
-                        </div>
-                        <br/>
-                        <br/>
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="status-display-boxes">
-            <div t-if="(state.data.pairing_code || state.data.pairing_code_expired) and !state.data.is_access_point_up" class="status-display-box">
-                <h4 class="text-center mb-3">Pairing Code</h4>
-                <hr/>
-                <t t-if="state.data.pairing_code and !state.data.pairing_code_expired">
-                    <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
-                    <p class="text-center mb-3">
-                        Enter this code in the IoT app in your Odoo database to pair the IoT Box.
+            <div class="status-display-boxes">
+                <div t-if="(state.data.pairing_code || state.data.pairing_code_expired) and !state.data.is_access_point_up" class="status-display-box">
+                    <h4 class="text-center mb-3">Pairing Code</h4>
+                    <hr/>
+                    <t t-if="state.data.pairing_code and !state.data.pairing_code_expired">
+                        <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
+                        <p class="text-center mb-3">
+                            Enter this code in the IoT app in your Odoo database to pair the IoT Box.
+                        </p>
+                    </t>
+                    <p t-else="" class="text-center mb-3">
+                        The pairing code has expired. Please restart your IoT Box to generate a new one.
                     </p>
-                </t>
-                <p t-else="" class="text-center mb-3">
-                    The pairing code has expired. Please restart your IoT Box to generate a new one.
-                </p>
-            </div>
-            <div t-if="state.data.is_access_point_up and accessPointSsid" class="status-display-box">
-                <h4 class="text-center mb-3">No Internet Connection</h4>
-                <hr/>
-                <p class="mb-3">
-                    Please connect your IoT Box to internet via an ethernet cable or connect to Wi-FI network<br/>
-                    <a class="alert-link" t-out="accessPointSsid" /><br/>
-                    to configure a Wi-Fi connection on the IoT Box
-                </p>
-            </div>
-            <div class="status-display-box">
-                <h4 class="text-center mb-3">Status display</h4>
-                
-                <h5 class="mb-1">General</h5>
-                <table class="table table-hover table-sm">
-                    <tbody>
-                        <tr>
-                            <td class="col-3"><i class="me-1 fa fa-fw fa-id-card"/>Identifier</td>
-                            <td class="col-3" t-out="state.data.identifier"/>
-                        </tr>
-                        <tr t-if="state.data.server_status">
-                            <td class="col-3"><i class="me-1 fa fa-fw fa-database"/>Database</td>
-                            <td class="col-3" t-out="state.data.server_status"/>
-                        </tr>
-                    </tbody>
-                </table>
-                
-                <h5 class="mb-1" t-if="state.data.network_interfaces.length > 0">Internet Connection</h5>
-                <table class="table table-hover table-sm" t-if="state.data.network_interfaces.length > 0">
-                    <tbody>
-                        <tr t-foreach="state.data.network_interfaces" t-as="interface" t-key="interface.id">
-                            <td class="col-3"><i t-att-class="'me-1 fa fa-fw fa-' + (interface.is_wifi ? 'wifi' : 'sitemap')"/><t t-out="interface.is_wifi ? interface.ssid : 'Ethernet'"/></td>
-                            <td class="col-3" t-out="interface.ip"/>
-                        </tr>
-                    </tbody>
-                </table>
-                <div t-if="Object.keys(state.data.devices).length > 0">
-                    <h5 class="mb-1">Devices</h5>
+                </div>
+                <div t-if="state.data.is_access_point_up and accessPointSsid" class="status-display-box">
+                    <h4 class="text-center mb-3">No Internet Connection</h4>
+                    <hr/>
+                    <p class="mb-3">
+                        Please connect your IoT Box to internet via an ethernet cable or connect to Wi-FI network<br/>
+                        <a class="alert-link" t-out="accessPointSsid" /><br/>
+                        to configure a Wi-Fi connection on the IoT Box
+                    </p>
+                </div>
+                <div class="status-display-box">
+                    <h4 class="text-center mb-3">Status display</h4>
+                    
+                    <h5 class="mb-1">General</h5>
                     <table class="table table-hover table-sm">
                         <tbody>
-                            <tr t-foreach="Object.keys(state.data.devices)" t-as="deviceType" t-key="deviceType">
-                                <td class="device-type col-3">
-                                    <i t-att-class="'me-1 fa fa-fw fa- ' + icons[deviceType]"/>
-                                    <t t-out="deviceType.replaceAll('_', ' ') + (deviceType === 'unsupported' ? '' : 's')"/>
-                                </td>
-                                <td class="col-3">
-                                    <ul>
-                                        <li t-foreach="state.data.devices[deviceType].slice(0, 10)" t-as="device" t-key="device.identifier">
-                                            <t t-out="device.name"/>
-                                        </li>
-                                        <li t-if="state.data.devices[deviceType].length > 10">...</li>
-                                    </ul>
-                                </td>
+                            <tr>
+                                <td class="col-3"><i class="me-1 fa fa-fw fa-id-card"/>Identifier</td>
+                                <td class="col-3" t-out="state.data.identifier"/>
+                            </tr>
+                            <tr t-if="state.data.server_status">
+                                <td class="col-3"><i class="me-1 fa fa-fw fa-database"/>Database</td>
+                                <td class="col-3" t-out="state.data.server_status"/>
                             </tr>
                         </tbody>
                     </table>
+                    
+                    <h5 class="mb-1" t-if="state.data.network_interfaces.length > 0">Internet Connection</h5>
+                    <table class="table table-hover table-sm" t-if="state.data.network_interfaces.length > 0">
+                        <tbody>
+                            <tr t-foreach="state.data.network_interfaces" t-as="interface" t-key="interface.id">
+                                <td class="col-3"><i t-att-class="'me-1 fa fa-fw fa-' + (interface.is_wifi ? 'wifi' : 'sitemap')"/><t t-out="interface.is_wifi ? interface.ssid : 'Ethernet'"/></td>
+                                <td class="col-3" t-out="interface.ip"/>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <div t-if="Object.keys(state.data.devices).length > 0">
+                        <h5 class="mb-1">Devices</h5>
+                        <table class="table table-hover table-sm">
+                            <tbody>
+                                <tr t-foreach="Object.keys(state.data.devices)" t-as="deviceType" t-key="deviceType">
+                                    <td class="device-type col-3">
+                                        <i t-att-class="'me-1 fa fa-fw fa- ' + icons[deviceType]"/>
+                                        <t t-out="deviceType.replaceAll('_', ' ') + (deviceType === 'unsupported' ? '' : 's')"/>
+                                    </td>
+                                    <td class="col-3">
+                                        <ul>
+                                            <li t-foreach="state.data.devices[deviceType].slice(0, 10)" t-as="device" t-key="device.identifier">
+                                                <t t-out="device.name"/>
+                                            </li>
+                                            <li t-if="state.data.devices[deviceType].length > 10">...</li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    </t>
     `;
 }
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -1,4 +1,4 @@
-import { Component, xml } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
 import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
@@ -148,11 +148,7 @@ export class ControlButtons extends Component {
 
 export class ControlButtonsPopup extends Component {
     static components = { Dialog, ControlButtons };
-    static template = xml`
-        <Dialog bodyClass="'d-flex flex-column'" footer="false" title="'Actions'" t-on-click="props.close">
-            <ControlButtons showRemainingButtons="true" close="props.close"/>
-        </Dialog>
-    `;
+    static template = "point_of_sale.ControlButtonsPopup";
     static props = {
         close: Function,
     };

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -49,4 +49,9 @@
             </div>
         </t>
     </t>
+    <t t-name="point_of_sale.ControlButtonsPopup">
+        <Dialog bodyClass="'d-flex flex-column'" footer="false" title.translate="Actions" t-on-click="props.close">
+            <ControlButtons showRemainingButtons="true" close="props.close"/>
+        </Dialog>
+    </t>
 </templates>

--- a/addons/web/static/src/core/ui/block_ui.js
+++ b/addons/web/static/src/core/ui/block_ui.js
@@ -1,33 +1,14 @@
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
 
-import { EventBus, Component, useState, xml } from "@odoo/owl";
+import { EventBus, Component, useState } from "@odoo/owl";
 
 export class BlockUI extends Component {
     static props = {
         bus: EventBus,
     };
 
-    static template = xml`
-        <t t-if="state.blockState === BLOCK_STATES.UNBLOCKED">
-            <div/>
-        </t>
-        <t t-else="">
-            <t t-set="visiblyBlocked" t-value="state.blockState === BLOCK_STATES.VISIBLY_BLOCKED"/>
-            <div class="o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100"
-                 t-att-class="visiblyBlocked ? '' : 'o_blockUI_invisible'">
-                <t t-if="visiblyBlocked">
-                    <div class="o_spinner mb-4">
-                        <img src="/web/static/img/spin.svg" alt="Loading..."/>
-                    </div>
-                    <div class="o_message text-center px-4">
-                        <t t-esc="state.line1"/><br/>
-                        <t t-esc="state.line2"/>
-                    </div>
-                </t>
-            </div>
-        </t>
-    `;
+    static template = "web.BlockUI";
 
     setup() {
         this.messagesByDuration = [

--- a/addons/web/static/src/core/ui/block_ui.xml
+++ b/addons/web/static/src/core/ui/block_ui.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<templates>
+<t t-name="web.BlockUI">
+    <t t-if="state.blockState === BLOCK_STATES.UNBLOCKED">
+        <div/>
+    </t>
+    <t t-else="">
+        <t t-set="visiblyBlocked" t-value="state.blockState === BLOCK_STATES.VISIBLY_BLOCKED"/>
+        <div class="o_blockUI fixed-top d-flex justify-content-center align-items-center flex-column vh-100"
+                t-att-class="visiblyBlocked ? '' : 'o_blockUI_invisible'">
+            <t t-if="visiblyBlocked">
+                <div class="o_spinner mb-4">
+                    <img src="/web/static/img/spin.svg" alt="Loading..."/>
+                </div>
+                <div class="o_message text-center px-4">
+                    <t t-esc="state.line1"/><br/>
+                    <t t-esc="state.line2"/>
+                </div>
+            </t>
+        </div>
+    </t>
+</t>
+</templates>

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -36,12 +36,7 @@ import { exprToBoolean } from "@web/core/utils/strings";
 
 class BlankComponent extends Component {
     static props = ["onMounted", "withControlPanel", "*"];
-    static template = xml`
-        <ControlPanel display="{disableDropdown: true}" t-if="props.withControlPanel and !env.isSmall">
-            <t t-set-slot="layout-buttons">
-                <button class="btn btn-primary invisible"> empty </button>
-            </t>
-        </ControlPanel>`;
+    static template = "web.BlankComponent";
     static components = { ControlPanel };
 
     setup() {

--- a/addons/web/static/src/webclient/actions/blank_component.xml
+++ b/addons/web/static/src/webclient/actions/blank_component.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<templates>
+<t t-name="web.BlankComponent">
+    <ControlPanel display="{disableDropdown: true}" t-if="props.withControlPanel and !env.isSmall">
+        <t t-set-slot="layout-buttons">
+            <button class="btn btn-primary invisible"> empty </button>
+        </t>
+    </ControlPanel>
+</t>
+</templates>

--- a/addons/web_editor/static/src/components/media_dialog/file_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.js
@@ -30,25 +30,7 @@ class RemoveButton extends Component {
 
 export class AttachmentError extends Component {
     static components = { Dialog };
-    static template = xml`
-        <Dialog title="title">
-            <div class="form-text">
-                <p>The image could not be deleted because it is used in the
-                    following pages or views:</p>
-                <ul t-foreach="props.views"  t-as="view" t-key="view.id">
-                    <li>
-                        <a t-att-href="'/odoo/ir.ui.view/' + window.encodeURIComponent(view.id)">
-                            <t t-esc="view.name"/>
-                        </a>
-                    </li>
-                </ul>
-            </div>
-            <t t-set-slot="footer">
-                <button class="btn btn-primary" t-on-click="() => this.props.close()">
-                    Ok
-                </button>
-            </t>
-        </Dialog>`;
+    static template = "web_editor.AttachmentError";
     static props = ["views", "close"];
     setup() {
         this.title = _t("Alert");

--- a/addons/web_editor/static/src/components/media_dialog/file_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.xml
@@ -76,4 +76,25 @@
             t-on-click="handleScrollAttachments"/>
     </div>
 </t>
+
+<t t-name="web_editor.AttachmentError">
+    <Dialog title="title">
+        <div class="form-text">
+            <p>The image could not be deleted because it is used in the
+                following pages or views:</p>
+            <ul t-foreach="props.views"  t-as="view" t-key="view.id">
+                <li>
+                    <a t-att-href="'/odoo/ir.ui.view/' + window.encodeURIComponent(view.id)">
+                        <t t-esc="view.name"/>
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <t t-set-slot="footer">
+            <button class="btn btn-primary" t-on-click="() => this.props.close()">
+                Ok
+            </button>
+        </t>
+    </Dialog>
+</t>
 </templates>

--- a/addons/web_editor/static/src/components/media_dialog/search_media.js
+++ b/addons/web_editor/static/src/components/media_dialog/search_media.js
@@ -1,14 +1,10 @@
 import { useDebounced } from '@web/core/utils/timing';
 import { useAutofocus } from '@web/core/utils/hooks';
 
-import { Component, xml, useEffect, useState } from "@odoo/owl";
+import { Component, useEffect, useState } from "@odoo/owl";
 
 export class SearchMedia extends Component {
-    static template = xml`
-        <div class="position-relative mw-lg-25 flex-grow-1 me-auto">
-            <input type="text" class="o_we_search o_input form-control" t-att-placeholder="props.searchPlaceholder.trim()" t-model="state.input" t-ref="autofocus"/>
-            <i class="oi oi-search input-group-text position-absolute end-0 top-50 me-n3 px-2 py-1 translate-middle bg-transparent border-0" title="Search" role="img" aria-label="Search"/>
-        </div>`;
+    static template = "web_editor.SearchMedia";
     static props = ["searchPlaceholder", "search", "needle"];
     setup() {
         useAutofocus();

--- a/addons/web_editor/static/src/components/media_dialog/search_media.xml
+++ b/addons/web_editor/static/src/components/media_dialog/search_media.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<templates>
+<t t-name="web_editor.SearchMedia">
+    <div class="position-relative mw-lg-25 flex-grow-1 me-auto">
+        <input type="text" class="o_we_search o_input form-control" t-att-placeholder="props.searchPlaceholder.trim()" t-model="state.input" t-ref="autofocus"/>
+        <i class="oi oi-search input-group-text position-absolute end-0 top-50 me-n3 px-2 py-1 translate-middle bg-transparent border-0" title="Search" role="img" aria-label="Search"/>
+    </div>
+</t>
+</templates>

--- a/addons/web_tour/static/src/js/onboarding_item.xml
+++ b/addons/web_tour/static/src/js/onboarding_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<templates>
+<t t-name="web_tour.OnboardingItem">
+    <DropdownItem>
+        <div class="d-flex justify-content-between ps-3">
+            <div class="align-self-center">
+                <span class="form-check form-switch" t-on-click.stop.prevent="() => this.props.toggleItem()">
+                    <input type="checkbox" class="form-check-input" id="onboarding" t-att-checked="this.props.toursEnabled"/>
+                    <label class="form-check-label">Onboarding</label>
+                </span>
+            </div>
+        </div>
+    </DropdownItem>
+</t>
+</templates>

--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -1,4 +1,4 @@
-import { Component, markup, whenReady, validate, xml } from "@odoo/owl";
+import { Component, markup, whenReady, validate } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
@@ -18,18 +18,7 @@ import { tourRecorderState } from "@web_tour/js/tour_recorder/tour_recorder_stat
 
 class OnboardingItem extends Component {
     static components = { DropdownItem };
-    static template = xml`
-    <DropdownItem>
-        <div class="d-flex justify-content-between ps-3">
-            <div class="align-self-center">
-                <span class="form-check form-switch" t-on-click.stop.prevent="() => this.props.toggleItem()">
-                    <input type="checkbox" class="form-check-input" id="onboarding" t-att-checked="this.props.toursEnabled"/>
-                    <label class="form-check-label">Onboarding</label>
-                </span>
-            </div>
-        </div>
-    </DropdownItem>
-    `;
+    static template = "web_tour.OnboardingItem";
     static props = {
         toursEnabled: { type: Boolean },
         toggleItem: { type: Function },


### PR DESCRIPTION
Inline XML templates aren't translated. This commit redefines inline XML templates containing human-readable strings as full-fledged XML files so that they can be translated.

Enterprise: https://github.com/odoo/enterprise/pull/90639