### PR TITLE
[IMP]: mrp: BOM selection based on explicit picking type

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -401,15 +401,16 @@ class MrpProduction(models.Model):
 
     @api.depends('product_id', 'never_product_template_attribute_value_ids')
     def _compute_bom_id(self):
-        mo_by_company_id = defaultdict(lambda: self.env['mrp.production'])
+        mo_by_company_and_pick_type = defaultdict(lambda: self.env['mrp.production'])
         for mo in self:
             if not mo.product_id and not mo.bom_id:
                 mo.bom_id = False
                 continue
-            mo_by_company_id[mo.company_id.id] |= mo
+            mo_by_company_and_pick_type[mo.company_id.id, mo.picking_type_id.id] |= mo
 
-        for company_id, productions in mo_by_company_id.items():
-            picking_type_id = self._context.get('default_picking_type_id')
+        for (company_id, picking_type_id), productions in mo_by_company_and_pick_type.items():
+            if not picking_type_id:
+                picking_type_id = self._context.get('default_picking_type_id')
             picking_type = picking_type_id and self.env['stock.picking.type'].browse(picking_type_id)
             boms_by_product = self.env['mrp.bom'].with_context(active_test=True)._bom_find(productions.product_id, picking_type=picking_type, company_id=company_id, bom_type='normal')
             for production in productions:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Explicitly passed picking type in MO creation was not taken into account to perform BOM finding. The MRP barcode app for example is used by scanning a picking type, which is then passed as a param for the MO creation. This picking type however did not result in the right BOM being selected if you have different BOMs assigned to different picking types. Considering you do not have any other option for selecting a BOM in the barcode app, I believe it makes sense to take the `picking_type_id` into account when picking a BOM during MO creation.

Current behavior before PR:

`picking_type_id` passed directly is not taken into account to select the most suitable BOM.

Desired behavior after PR is merged:


`picking_type_id` passed directly is taken into account to select the most suitable BOM.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
