### PR TITLE
[PERF] project.task: remove 'id' from search form

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -16,7 +16,7 @@
             <field name="model">project.task</field>
             <field name="arch" type="xml">
                <search string="Tasks">
-                    <field name="name" string="Task" filter_domain="['|', ('name', 'ilike', self), ('id', 'ilike', self)]"/>
+                    <field name="name" string="Task" filter_domain="[('name', 'ilike', self)]"/>
                     <field name="tag_ids"/>
                     <field name="user_ids" filter_domain="[('user_ids.name', 'ilike', self), ('user_ids.active', 'in', [True, False])]"/>
                     <field name="milestone_id" groups="project.group_project_milestone"/>


### PR DESCRIPTION
### Issue
Slowness when searching for tasks in a database containing ~430K `project.task` records.

### Analysis
When searching for tasks by name, the `id` field is passed to the filter domain. 
This results in a suboptimal query plan, as the `id` field is cast as `text` in an `OR` leaf:
` [...] AND ((unaccent((name)::text) ~~* '%test%'::text) OR ((id)::text ~~* '%test%'::text)) [...]`
Furthermore, since refactoring the web routes, the necessity of searching for an `id` in the search form has greatly diminished.

### Benchmarks
Benchmarking the generated query using `\timing` in `psql`:
| Number of records | Before | After |
| -- | -- | -- |
| 430K | 2.3s | 3ms |

During high-usage periods, the query took up to ~10.8 seconds.

#### References
opw-4845258

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
