### PR TITLE
[FIX] calendar: show meetings with no organizer in grouped view

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -957,10 +957,14 @@ class Meeting(models.Model):
         public_users_settings_ids = self.env['res.users.settings'].sudo().search(
             [('calendar_default_privacy', '!=', 'private')]).ids
         # display public, confidential events and events with default privacy when owner's default privacy is not private
-        return [
-            '|', '|', '|', ('privacy', '=', 'public'), ('privacy', '=', 'confidential'), ('user_id', '=', self.env.user.id),
-            '&', ('privacy', '=', False), ('user_id.res_users_settings_id', 'in', public_users_settings_ids)
-        ]
+        return ['|', '|',
+            ('privacy', 'in', ['public', 'confidential']),
+            ('user_id', '=', self.env.user.id),
+            '&',
+                ('privacy', '=', False),
+                '|',
+                    ('user_id', '=', False),
+                    ('user_id.res_users_settings_id', 'in', public_users_settings_ids)]
 
     def _is_event_over(self):
         """Check if the event is over. This method is used to check if the event

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -642,6 +642,47 @@ class TestCalendar(SavepointCaseWithUserDemo):
         self.assertEqual(new_calendar_event.start_date, calendar_event.start_date, "Start date should match the original.")
         self.assertEqual(new_calendar_event.stop_date, calendar_event.stop_date, "Stop date should match the original.")
 
+    def test_event_privacy_domain(self):
+        """Test privacy domain filtering in read_group for events with user_id=False and default privacy (False)"""
+        now = datetime.now()
+        test_user = self.user_demo
+
+        self.env['calendar.event'].create([
+            {
+                'name': 'event_a',
+                'start': now + timedelta(days=-1),
+                'stop': now + timedelta(days=-1, hours=2),
+                'user_id': False,
+                'privacy': 'public',
+            },
+            {
+                'name': 'event_b',
+                'start': now + timedelta(days=1),
+                'stop': now + timedelta(days=1, hours=1),
+                'user_id': False,
+                'privacy': False,
+            },
+            {
+                'name': 'event_c',
+                'start': now + timedelta(days=-1, hours=3),
+                'stop': now + timedelta(days=-1, hours=5),
+                'user_id': False,
+                'privacy': 'private',
+            }
+        ])
+
+        meetings = self.env['calendar.event'].with_user(test_user)
+        result = meetings.read_group(
+            domain=[['user_id', '=', False]],
+            fields=['duration:sum'],
+            groupby=['create_date:month']
+        )
+
+        # Verify privacy domain filtered out the private event only
+        total_visible_events = sum(group['create_date_count'] for group in result)
+        self.assertEqual(total_visible_events, 2,
+                        "Should see 2 events (public and no-privacy), private event filtered out")
+
 @tagged('post_install', '-at_install')
 class TestCalendarTours(HttpCaseWithUserDemo):
     def test_calendar_month_view_start_hour_displayed(self):


### PR DESCRIPTION
__Issue__
In the calendar list view, meetings with no organizer and default privacy (`privacy=False`) are excluded when grouping by Responsible and Created On.

__Steps to Reproduce__
1. Create a meeting with:
   - `privacy` set to default,
   - no `organizer`
2. Go to Calendar > List view.
3. Group by Responsible, then by Created On.

→ The meeting is missing from the view.

__Fix__
Adjust the domain to include meetings where:
- `privacy=False`, and
- either `user_id` is unset or their settings are in the public allowed list.

- opw-4841266