### PR TITLE
[FIX] mrp: keep owner_id of quant when unbuilding MO

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -183,7 +183,7 @@ class MrpUnbuild(models.Model):
         # TODO: Will fail if user do more than one unbuild with lot on the same MO. Need to check what other unbuild has aready took
         qty_already_used = defaultdict(float)
         for move in produce_moves | consume_moves:
-            if move.has_tracking != 'none':
+            if move._need_precise_unbuild():
                 original_move = move in produce_moves and self.mo_id.move_raw_ids or self.mo_id.move_finished_ids
                 original_move = original_move.filtered(lambda m: m.product_id == move.product_id)
                 needed_quantity = move.product_uom_qty
@@ -195,6 +195,8 @@ class MrpUnbuild(models.Model):
                     taken_quantity = min(needed_quantity, move_line.quantity - qty_already_used[move_line])
                     if taken_quantity:
                         move_line_vals = self._prepare_move_line_vals(move, move_line, taken_quantity)
+                        if move_line.owner_id:
+                            move_line_vals['owner_id'] = move_line.owner_id.id
                         self.env['stock.move.line'].create(move_line_vals)
                         needed_quantity -= taken_quantity
                         qty_already_used[move_line] += taken_quantity

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -756,3 +756,7 @@ class StockMove(models.Model):
                         for move in self):
             res = 'assigned'
         return res
+
+    def _need_precise_unbuild(self):
+        self.ensure_one()
+        return bool(self.has_tracking != 'none' or self.origin_returned_move_id.move_line_ids.owner_id)

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -1008,3 +1008,25 @@ class TestUnbuild(TestMrpCommon):
         self.assertEqual(len(unbuild_fns_move), 1)
         self.assertEqual(unbuild_fns_move.state, "done")
         self.assertEqual(unbuild_fns_move.quantity, 12)
+
+    def test_unbuild_consigned_comp(self):
+        """ Test that after unbuild, consigned quant still have the same owner as before the MO."""
+        consigned_partner = self.env['res.partner'].create({'name': 'consigned partner'})
+        mo, _, _, p1, _ = self.generate_mo(qty_final=1, qty_base_1=7)
+        self.assertEqual(len(mo), 1, 'MO should have been created')
+        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 3)
+        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 4, owner_id=consigned_partner)
+
+        mo.action_assign()
+        mo_form = Form(mo)
+        mo_form.qty_producing = 1
+        mo = mo_form.save()
+        mo.button_mark_done()
+        self.assertEqual(mo.state, 'done', "Production order should be in done state.")
+
+        unbuild_form = Form(self.env['mrp.unbuild'])
+        unbuild_form.mo_id = mo
+        unbuild_form.save().action_unbuild()
+
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(p1, self.stock_location), 7)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(p1, self.stock_location, owner_id=consigned_partner), 4)


### PR DESCRIPTION
**Problem:**
when a MO is unbuild, if some components
where consigned, they will come back in stock as not consigned

**Steps to reproduce:**
- enable "consignemnet" setting
- create a storable product (the comp)
- set on on hand quantity of 3 without owner
- set on on hand quantity of 4 with an owner
- create another product (the final product), with a BOM of 7 of the comp product
- create a manufacturing order for the final product, confirm and produce all.
- unbuild it
- open the comp product form, click on the on hand smart button

**Current behavior:**
- there is a quantity of 7 unconsigned

**Expected behavior:**
- there should be a quantity of 3 unconsigned and a quantity of 4 consigned

**Cause of the issue:**
when the stock move line is create in action_unbuild() there is no mechanism to get back the owner of the original stock move line from the MO
https://github.com/odoo/odoo/blob/ceccb92af19a6a3fc0c7b5924d9f497b1aec1d55/addons/mrp/models/mrp_unbuild.py#L204

opw-4900386