### PR TITLE
[FIX] pos_self_order: prevent display of all variant with combo

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
@@ -4,7 +4,7 @@ import { AttributeSelectionHelper } from "./attribute_selection_helper";
 
 export class AttributeSelection extends Component {
     static template = "pos_self_order.AttributeSelection";
-    static props = ["productTemplate", "onSelection?"];
+    static props = ["productTemplate", "onSelection?", "isCombo?"];
 
     setup() {
         this.selfOrder = useSelfOrder();
@@ -25,9 +25,17 @@ export class AttributeSelection extends Component {
     }
 
     availableAttributeValue(attribute) {
-        return this.selfOrder.config.self_ordering_mode === "kiosk"
-            ? attribute.product_template_value_ids.filter((a) => !a.is_custom)
-            : attribute.product_template_value_ids;
+        const isKiosk = this.selfOrder.config.self_ordering_mode === "kiosk";
+        const isNoVariantCreation = attribute.attribute_id.create_variant === "no_variant";
+        return attribute.product_template_value_ids.filter((a) => {
+            if (isKiosk && a.is_custom) {
+                return false;
+            }
+            if (this.props.isCombo) {
+                return isNoVariantCreation;
+            }
+            return true;
+        });
     }
 
     getCustomSelectedValue(attribute) {

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -2,26 +2,29 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.AttributeSelection">
          <t t-foreach="props.productTemplate.attribute_line_ids" t-as="attribute" t-key="attribute.id">
-             <h2 class="text-start py-3 m-0" t-out="attribute.attribute_id.name"/>
-             <div class="self_order_attribute_selection row pb-3">
-                <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">
-                    <t t-set="valueSelected" t-value="isValueSelected(attribute,value)"/>
-                    <div class="d-flex col-12 col-md-6 col-lg-4">
-                        <button
-                            t-on-click="() => this.selectAttribute(attribute, value)"
-                            role="button" class="btn btn-light px-3 px-sm-3 py-3 py-sm-3 w-100 d-flex flex-column align-items-start align-items-md-center text-start text-md-center justify-content-center gap-0 border-0 shadow-sm rounded-4"
-                            t-attf-class="{{ valueSelected ? 'o_self_box_selected text-bg-primary': '' }}">
-                            <span t-esc="value.name" class="fs-4"/>
-                            <span t-if="shouldShowPriceExtra(value)" t-esc="formatExtraPrice(value)" class="fs-5  "
-                                 t-att-class="{ 'text-reset opacity-75' : valueSelected, 'text-primary': !valueSelected  }"/>
-                        </button>
+         <t t-set="availableValues" t-value="availableAttributeValue(attribute)"/>
+            <t t-if="availableValues.length">
+                <h2 class="text-start py-3 m-0" t-out="attribute.attribute_id.name"/>
+                <div class="self_order_attribute_selection row pb-3">
+                    <t t-foreach="availableValues" t-as="value" t-key="value.id">
+                        <t t-set="valueSelected" t-value="isValueSelected(attribute,value)"/>
+                        <div class="d-flex col-12 col-md-6 col-lg-4">
+                            <button
+                                t-on-click="() => this.selectAttribute(attribute, value)"
+                                role="button" class="btn btn-light px-3 px-sm-3 py-3 py-sm-3 w-100 d-flex flex-column align-items-start align-items-md-center text-start text-md-center justify-content-center gap-0 border-0 shadow-sm rounded-4"
+                                t-attf-class="{{ valueSelected ? 'o_self_box_selected text-bg-primary': '' }}">
+                                <span t-esc="value.name" class="fs-4"/>
+                                <span t-if="shouldShowPriceExtra(value)" t-esc="formatExtraPrice(value)" class="fs-5  "
+                                    t-att-class="{ 'text-reset opacity-75' : valueSelected, 'text-primary': !valueSelected  }"/>
+                            </button>
+                        </div>
+                    </t>
+                    <t t-set="customValue" t-value="getCustomSelectedValue(attribute)"/>
+                    <div t-if="customValue">
+                        <input type="text" t-model="selectedValues.getCustomValue(attribute,customValue).custom_value" class="form-control px-3 py-3 rounded-4 bg-white shadow-sm mt-2" t-ref="customValueInput" placeholder="Enter your custom value" />
                     </div>
-                </t>
-                 <t t-set="customValue" t-value="getCustomSelectedValue(attribute)"/>
-                 <div t-if="customValue">
-                     <input type="text" t-model="selectedValues.getCustomValue(attribute,customValue).custom_value" class="form-control px-3 py-3 rounded-4 bg-white shadow-sm mt-2" t-ref="customValueInput" placeholder="Enter your custom value" />
-                 </div>
-            </div>
+                </div>
+            </t>
           </t>
     </t>
 </templates>

--- a/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.js
+++ b/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.js
@@ -1,6 +1,7 @@
 import { Component } from "@odoo/owl";
 import { ProductInfoPopup } from "../product_info_popup/product_info_popup";
 import { useService } from "@web/core/utils/hooks";
+import { formatProductName } from "../../utils";
 
 export class ProductNameWidget extends Component {
     static template = "pos_self_order.ProductNameWidget";
@@ -13,5 +14,8 @@ export class ProductNameWidget extends Component {
         this.dialog.add(ProductInfoPopup, {
             productTemplate: this.props.product,
         });
+    }
+    formatProductName(product) {
+        return formatProductName(product);
     }
 }

--- a/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.xml
+++ b/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.xml
@@ -3,7 +3,7 @@
     <t t-name="pos_self_order.ProductNameWidget">
        <div class="self_order_product_name d-inline-block">
            <t t-set="product" t-value="props.product"/>
-           <span t-esc="product.name" class="align-middle fs-4 fw-bold text-break"/>
+           <span t-esc="formatProductName(product)" class="align-middle fs-4 fw-bold text-break"/>
            <div t-if="product.public_description or product.product_tag_ids.length > 0"
                 class="product_info_icon d-inline-flex justify-content-center align-items-center border border-dark rounded-circle text-center"
                 t-on-click.stop="()=>this.displayProductInfo()">

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -10,6 +10,7 @@ import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/
 import { CancelPopup } from "@pos_self_order/app/components/cancel_popup/cancel_popup";
 import { rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
+import { formatProductName } from "../../utils";
 
 export class CartPage extends Component {
     static template = "pos_self_order.CartPage";
@@ -265,6 +266,10 @@ export class CartPage extends Component {
     }
     get displayTaxes() {
         return !this.selfOrder.isTaxesIncludedInPrice();
+    }
+
+    formatProductName(product) {
+        return formatProductName(product);
     }
 
     /*

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -33,7 +33,7 @@
                                         <div t-foreach="line.combo_line_ids" t-as="cline" t-key="cline.uuid" class="ps-3 mb-2">
                                             <t t-set="c_qty" t-value="cline.qty / line.qty"/>
                                             <span t-if="(c_qty &gt; 1)"><t t-esc="c_qty"/>x </span>
-                                            <t t-esc="cline.product_id.name"/>
+                                            <t t-esc="formatProductName(cline.product_id)"/>
                                             <div t-foreach="cline.attribute_value_ids" t-as="attrVal" t-key="attrVal.id" class="ps-3 mt-1 text-muted">
                                                 <t t-esc="attrVal.attribute_id.name" />:
                                                 <t t-esc="attrVal.name" />

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -6,6 +6,7 @@ import { ProductNameWidget } from "@pos_self_order/app/components/product_name_w
 import { ComboStepper } from "@pos_self_order/app/components/combo_stepper/combo_stepper";
 import { computeTotalComboPrice } from "../../services/card_utils";
 import { useScrollShadow } from "../../utils/scroll_shadow_hook";
+import { formatProductName } from "../../utils";
 
 export class ComboPage extends Component {
     static template = "pos_self_order.ComboPage";
@@ -113,12 +114,20 @@ export class ComboPage extends Component {
         const selection = (selectedItems[item.id] ||= { item });
         selection.item = item;
         selection.qty = 1;
-
-        if (product.attribute_line_ids.length > 0) {
+        if (this.hasAttribute(product)) {
             this.currentChoiceState.displayAttributesOfItem = item;
         } else if (!this.hasMultiItemSelection) {
             this.next();
         }
+    }
+
+    hasAttribute(product) {
+        return (
+            product.attribute_line_ids.length > 0 &&
+            product.attribute_line_ids.some(
+                (line) => line.attribute_id?.create_variant === "no_variant"
+            )
+        );
     }
 
     getSelectedItems(choiceState = undefined) {
@@ -205,13 +214,18 @@ export class ComboPage extends Component {
         const product = comboItem.product_id;
         const selection = this.state.selectedValues[product.id];
 
-        if (product.attribute_line_ids.length === 0) {
+        const attributeLines = product.attribute_line_ids.filter(
+            (line) => line.attribute_id?.create_variant === "no_variant"
+        );
+
+        if (attributeLines.length === 0) {
             return false;
         }
         if (!selection) {
             return true;
         }
-        return selection.hasMissingAttributeValues(product.attribute_line_ids);
+
+        return selection.hasMissingAttributeValues(attributeLines);
     }
 
     changeQuantity(increase) {
@@ -284,9 +298,7 @@ export class ComboPage extends Component {
         } else if (!isAttributeSelection && !hasMultiItemSelection) {
             const selectedItem = this.getSelectedItems()[0];
             if (selectedItem) {
-                // Display attributes of the selected item, if any are available
-                const hasAttributes = selectedItem.item.product_id.attribute_line_ids.length > 0;
-                if (hasAttributes) {
+                if (this.hasAttribute(selectedItem.item.product_id)) {
                     this.currentChoiceState.displayAttributesOfItem = selectedItem.item;
                     newSectionDisplayed = true;
                 }
@@ -438,6 +450,10 @@ export class ComboPage extends Component {
 
     goBack() {
         this.router.navigate("product_list");
+    }
+
+    formatProductName(product) {
+        return formatProductName(product);
     }
 
     /*

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -109,7 +109,7 @@
                         </div>
                         <!-- Attributes -->
                         <div class="">
-                            <AttributeSelection t-if="product.attribute_line_ids.length" productTemplate="product" onSelection="onAttributeSelection" />
+                            <AttributeSelection t-if="product.attribute_line_ids.length" productTemplate="product" onSelection="onAttributeSelection" isCombo="true" />
                         </div>
                     </div>
 
@@ -128,7 +128,8 @@
                                         </div>
                                         <div class="d-flex flex-column gap-1">
                                             <div class="fs-4 fw-bold text-break">
-                                                <span t-if="item_qty &gt; 1" class="fw-normal"><t t-esc="item_qty"/>x </span><t t-esc="product.name"/>
+                                                <span t-if="item_qty &gt; 1" class="fw-normal"><t t-esc="item_qty"/>x </span>
+                                                    <span t-esc="formatProductName(product)"/>
                                             </div>
                                             <div class="text-muted fw-medium" t-foreach="attributes" t-as="attrVal" t-key="attrVal.attribute_line_id.id">
                                                 <t t-esc="attrVal.attribute_line_id.attribute_id.name" />:

--- a/addons/pos_self_order/static/src/app/utils.js
+++ b/addons/pos_self_order/static/src/app/utils.js
@@ -54,3 +54,8 @@ export const attributeFlatter = (attribute) =>
         })
         .flat()
         .map((v) => parseInt(v));
+
+export const formatProductName = (product) => {
+    const attributes = product.product_template_attribute_value_ids?.map((v) => v.name).join(",");
+    return attributes ? `${product.name} (${attributes})` : product.name;
+};

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -3,6 +3,7 @@ import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
+import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
 
 registry.category("web_tour.tours").add("self_combo_selector", {
     steps: () => [
@@ -69,5 +70,25 @@ registry.category("web_tour.tours").add("self_combo_selector_category", {
         Utils.clickBtn("Order"),
         Utils.clickBtn("Ok"),
         Utils.checkIsNoBtn("Order Now"),
+    ],
+});
+
+registry.category("web_tour.tours").add("test_product_dont_display_all_variants", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
+        ProductPage.clickCategory("Uncategorised"),
+        ProductPage.clickProduct("Meal Combo"),
+        ProductPage.clickComboProduct("Coke always never"),
+        Utils.clickBtn("Red"),
+        Utils.clickBtn("Next"),
+        Utils.clickBtn("Add to cart"),
+        ProductPage.clickProduct("Meal Combo"),
+        ProductPage.clickComboProduct("Coke always only"),
+        Utils.clickBtn("Add to cart"),
+        ProductPage.clickProduct("Meal Combo"),
+        ProductPage.clickComboProduct("Coke never only"),
+        Utils.clickBtn("Red"),
+        Utils.clickBtn("Add to cart"),
     ],
 });


### PR DESCRIPTION
**Problem:**
When we have a combo product that has a variant product, if we order it from the Kiosk, all the variants for that product will be displayed. The extra price will also be added, even though it is not specified on the combo definition.

**Steps to reproduce:**
- Create a combo that has a variant product (like aluminium chair) 
- Go to the Kiosk and order said combo
- In the combo page, click on the variant, all the possible variants are displayed

**Why the fix:**
When creating a combo, we should specify which product variant we want, so that only those are displayed on the combo selection page. The way it is done right now, every variant is displayed whether we want them or not, without a way to refrain them from being displayed. After this commit, if the variants are specified on the combo, only
those are displayed in the Kiosk once we click on the combo. If we specify a product that has variants in the combo, all variants will still be displayed when clicking the product in the Kiosk, as it was before.

opw-4924019