### PR TITLE
[FIX] website: shop crash on Enter with size option

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -748,6 +748,7 @@ export class WysiwygAdapterComponent extends Wysiwyg {
      */
     _websiteRootEvent(type, eventData = {}) {
         const websiteRootInstance = this.websiteService.websiteRootInstance;
+        if(websiteRootInstance == undefined) return;
         // If the websiteRootInstance is gone but an event still tries to reach it
         // prevent a traceback by denying the event.
         // TODO we should investigate if this is normal the websiteRootInstance


### PR DESCRIPTION
Before this commit:
Pressing the Enter key while selecting a product size option on the
/shop page crashed.

After this commit:
This fix ensures the Enter key is properly handled and prevents
unexpected crashes during product option selection.

task-4795501