### PR TITLE
[FIX] stock: allow updating On Hand quantity to zero if a quant exists

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -10,7 +10,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools import float_is_zero, check_barcode_encoding
-from odoo.tools.float_utils import float_round
+from odoo.tools.float_utils import float_round, float_compare
 from odoo.tools.mail import html2plaintext, is_html_empty
 from odoo.tools.misc import groupby
 
@@ -234,11 +234,17 @@ class ProductProduct(models.Model):
             return
         for product in self:
             if (
-                product.type == "consu" and product.is_storable and product.qty_available > 0
+                product.type == "consu" and product.is_storable and float_compare(product.qty_available, 0.0, precision_rounding=product.uom_id.rounding) >= 0
             ):
                 warehouse = self.env['stock.warehouse'].search(
                     [('company_id', '=', self.env.company.id)], limit=1
                 )
+                if float_is_zero(product.qty_available, precision_rounding=product.uom_id.rounding):
+                    if not self.env['stock.quant'].search_count([
+                        ('product_id', '=', product.id),
+                        ('location_id', '=', warehouse.lot_stock_id.id),
+                    ], limit=1):
+                        continue
                 self.env['stock.quant'].with_context(inventory_mode=True).create({
                     'product_id': product.id,
                     'location_id': warehouse.lot_stock_id.id,

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1600,3 +1600,25 @@ class StockQuantRemovalStrategy(TransactionCase):
             ('package_id', '=', package.id),
             ('location_id', '=', self.stock_location.id),
         ]))
+
+    def test_update_available_qty_to_zero(self):
+        """
+        Test that a quant is created when a non-zero qty is set on product.qty_available.
+        Then verify that setting product.qty_available to 0.0 only updates the quant
+        to zero if a quant already exists (i.e., there was a previous quantity set).
+        """
+        self.assertEqual(self.product.qty_available, 0.0)
+        self.product.qty_available = 0.0
+        quant = self.env['stock.quant'].search([
+            ('product_id', '=', self.product.id),
+        ])
+        self.assertFalse(quant)
+        self.product.qty_available = 10.0
+        quant = self.env['stock.quant'].search([
+            ('product_id', '=', self.product.id),
+            ('on_hand', '=', True)
+        ])
+        self.assertEqual(quant.quantity, 10.0)
+        self.product.qty_available = 0.0
+
+        self.assertEqual(quant.quantity, 0.0)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”
    - Set its “Quantity On Hand” to 10 and save
    - save

- Try to update the quantity back to 0 and save again

Problem:
The quantity is not updated, it stays at 10. This happens because
the inverse method `_inverse_qty_available` does not allow setting the
quantity to zero unless the value is strictly greater than 0.

As a result, users cannot reset stock on hand to zero from the product
form once a quantity has been set.

The method was checking `product.qty_available > 0` to decide
whether to create or update a quant, which excluded zero values.
So attempts to reset the stock to zero were skipped, even when a
quant existed.

Solution:
Change the condition to allow qty = 0 only if a quant already exists
for the product in the stock location. This ensures:
- No quant is created when setting quantity to 0 for the first time.
- A quant is correctly updated to 0 when there is an existing quant.


opw-4962904