### PR TITLE
[FIX] account_edi_ubl_cii: rectify test xml file for tax prediction

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_example.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_example.xml
@@ -119,8 +119,8 @@
     <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="EUR">657.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>Locations et leasing opérationnel - Véhicule HG6542</cbc:Description>
-      <cbc:Name>Locations et leasing opérationnel</cbc:Name>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
         <cbc:Percent>16.0</cbc:Percent>


### PR DESCRIPTION
Previously, the test XML file included a product that did not exist in the test environment. As a result, on import the aml could not retrieve the product.

Due to this, the _predict_taxes method in _onchange_name_predictive was invoked, which ended up assigning the correct tax. This caused the test to pass without actually verifying the behavior of the _predict_specific_tax.

With this **PR** test xml has now been updated to properly focus on and validate the _predict_specific_tax method behavior.

**task**-4943015

Enterprise PR - https://github.com/odoo/enterprise/pull/91224