### PR TITLE
[FIX] l10n_ar: translate some invoice report terms

### DIFF
--- a/addons/l10n_ar/i18n/es_419.po
+++ b/addons/l10n_ar/i18n/es_419.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-09 11:55+0000\n"
-"PO-Revision-Date: 2025-06-09 11:55+0000\n"
+"POT-Creation-Date: 2025-07-22 10:21+0000\n"
+"PO-Revision-Date: 2025-07-22 10:21+0000\n"
 "Last-Translator: María Fernanda Alvarez Ramírez <mfar@odoo.com>\n"
 "Language-Team: \n"
 "Language: es_419\n"
@@ -1739,6 +1739,11 @@ msgid "FORM 1116 RT"
 msgstr "FORMULARIO 1116 RT"
 
 #. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
+msgid "Fiscal Transparency Regime for the Final Consumer (Law 27.743)"
+msgstr "Régimen de Transparencia Fiscal para el Consumidor Final (Ley 27.743)"
+
+#. module: l10n_ar
 #: model:ir.model,name:l10n_ar.model_account_fiscal_position
 msgid "Fiscal Position"
 msgstr "Posición fiscal"
@@ -2406,6 +2411,13 @@ msgid "Only numbers allowed for \"%s\""
 msgstr "Solo se permiten números para “%s”"
 
 #. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+#, python-format
+msgid "Other National Ind. Taxes %s"
+msgstr "Otros impuestos nacionales %s"
+
+#. module: l10n_ar
 #: model:ir.model.fields,field_description:l10n_ar.field_res_partner__l10n_ar_special_purchase_document_type_ids
 #: model:ir.model.fields,field_description:l10n_ar.field_res_users__l10n_ar_special_purchase_document_type_ids
 msgid "Other Purchase Documents"
@@ -2996,6 +3008,13 @@ msgstr "IVA"
 #: model:ir.model.fields,field_description:l10n_ar.field_account_tax_group__l10n_ar_vat_afip_code
 msgid "VAT AFIP Code"
 msgstr "Código AFIP de IVA"
+
+#. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+#, python-format
+msgid "VAT Content %s"
+msgstr "IVA Contenido %s"
 
 #. module: l10n_ar
 #: model:l10n_latam.document.type,name:l10n_ar.dc_a_rg1415


### PR DESCRIPTION
Before this change, the VAT Content section in Argentinean Legal PDF was always shown as "VAT Content" although the user has Spanish as its language.

With this change will show the correct translation: "IVA Contenido" when printing the PDF report in Spanish.

### **Description of the issue/feature this PR addresses:**
Missing Spanish translation of "VAT Content" column in the Argentinean Legal PDF Report

1. Install Argentinean - Accounting module
2. Install Spanish language
3. Log into to one of the demo Argentinean Companies: (AR) Responsable Inscripto
4. Create a customer invoices of type "B"
5. Go to the partner and change the Language to Spanish
6. Return to the invoice and print the PDF
7. Check that the VAT Content section is not translated.

### **Current behavior before PR:**
<img width="572" height="407" alt="image" src="https://github.com/user-attachments/assets/e28e609e-2cd2-4ace-9509-f969692ec893" />

### **Desired behavior after PR is merged:**
The "VAT Content section should appear as "IVA Contenido" when printing the report in Spanish.


opw-4938520

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
