### PR TITLE
[FIX] core: Fix float_repr/formatFloat displaying -0.0

### DIFF
--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -109,7 +109,7 @@
         <TotalGrossAmount>-200.00</TotalGrossAmount>
         <TotalGrossAmountBeforeTaxes>-200.00</TotalGrossAmountBeforeTaxes>
         <TotalTaxOutputs>-42.00</TotalTaxOutputs>
-        <TotalTaxesWithheld>-0.00</TotalTaxesWithheld>
+        <TotalTaxesWithheld>0.00</TotalTaxesWithheld>
         <InvoiceTotal>-242.00</InvoiceTotal>
         <TotalOutstandingAmount>-242.00</TotalOutstandingAmount>
         <TotalExecutableAmount>-242.00</TotalExecutableAmount>

--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -211,18 +211,21 @@ export function humanNumber(number, options = { decimals: 0, minDigits: 1 }) {
  * @returns {string}
  */
 export function formatFloat(value, options = {}) {
-    if (options.humanReadable) {
-        return humanNumber(value, options);
-    }
-    const grouping = options.grouping || l10n.grouping;
-    const thousandsSep = "thousandsSep" in options ? options.thousandsSep : l10n.thousandsSep;
-    const decimalPoint = "decimalPoint" in options ? options.decimalPoint : l10n.decimalPoint;
     let precision;
     if (options.digits && options.digits[1] !== undefined) {
         precision = options.digits[1];
     } else {
         precision = 2;
     }
+    if (floatIsZero(value, precision)) {
+        value = 0.0;
+    }
+    if (options.humanReadable) {
+        return humanNumber(value, options);
+    }
+    const grouping = options.grouping || l10n.grouping;
+    const thousandsSep = "thousandsSep" in options ? options.thousandsSep : l10n.thousandsSep;
+    const decimalPoint = "decimalPoint" in options ? options.decimalPoint : l10n.decimalPoint;
     const formatted = value.toFixed(precision).split(".");
     formatted[0] = insertThousandsSep(formatted[0], thousandsSep, grouping);
     if (options.trailingZeros === false && formatted[1]) {

--- a/addons/web/static/tests/core/utils/numbers.test.js
+++ b/addons/web/static/tests/core/utils/numbers.test.js
@@ -317,6 +317,7 @@ describe("formatFloat", () => {
         expect(formatFloat(-1e21, options)).toBe("-1e+21");
         expect(formatFloat(-1.0045e22, options)).toBe("-1e+22");
         expect(formatFloat(-1.012e43, options)).toBe("-1.01e+43");
+        expect(formatFloat(-0.0000001, options)).toBe("0.00");
 
         Object.assign(options, { decimals: 2, minDigits: 2 });
         expect(formatFloat(1020000, options)).toBe("1,020k");
@@ -329,5 +330,8 @@ describe("formatFloat", () => {
         Object.assign(options, { decimals: 3, minDigits: 1 });
         expect(formatFloat(1.0045e22, options)).toBe("1.005e+22");
         expect(formatFloat(-1.0045e22, options)).toBe("-1.004e+22");
+
+        Object.assign(options, { humanReadable: false });
+        expect(formatFloat(-0.0000001, options)).toBe("0.00");
     });
 });

--- a/odoo/addons/base/tests/test_float.py
+++ b/odoo/addons/base/tests/test_float.py
@@ -22,7 +22,7 @@ class TestFloatPrecision(TransactionCase):
         try_round(2.675,'2.68')   # in Python 2.7.2, round(2.675,2) gives 2.67
         try_round(-2.675,'-2.68') # in Python 2.7.2, round(2.675,2) gives 2.67
         try_round(0.001,'0.00')
-        try_round(-0.001,'-0.00')
+        try_round(-0.001, '0.00')
         try_round(0.0049,'0.00')   # 0.0049 is closer to 0 than to 0.01, so should round down
         try_round(0.005,'0.01')   # the rule is to round half away from zero
         try_round(-0.005,'-0.01') # the rule is to round half away from zero
@@ -81,7 +81,7 @@ class TestFloatPrecision(TransactionCase):
         try_round(2.6744, '2.674')
         try_round(-2.6744, '-2.674')
         try_round(0.0004, '0.000')
-        try_round(-0.0004, '-0.000')
+        try_round(-0.0004, '0.000')
         try_round(357.4555, '357.456')
         try_round(-357.4555, '-357.456')
         try_round(457.4554, '457.455')
@@ -95,7 +95,7 @@ class TestFloatPrecision(TransactionCase):
         try_round(2.6744, '2.674', method='HALF-DOWN')
         try_round(-2.6744, '-2.674', method='HALF-DOWN')
         try_round(0.0004, '0.000', method='HALF-DOWN')
-        try_round(-0.0004, '-0.000', method='HALF-DOWN')
+        try_round(-0.0004, '0.000', method='HALF-DOWN')
         try_round(357.4555, '357.455', method='HALF-DOWN')
         try_round(-357.4555, '-357.455', method='HALF-DOWN')
         try_round(457.4554, '457.455', method='HALF-DOWN')
@@ -109,7 +109,7 @@ class TestFloatPrecision(TransactionCase):
         try_round(2.6744, '2.674', method='HALF-EVEN')
         try_round(-2.6744, '-2.674', method='HALF-EVEN')
         try_round(0.0004, '0.000', method='HALF-EVEN')
-        try_round(-0.0004, '-0.000', method='HALF-EVEN')
+        try_round(-0.0004, '0.000', method='HALF-EVEN')
         try_round(357.4555, '357.456', method='HALF-EVEN')
         try_round(-357.4555, '-357.456', method='HALF-EVEN')
         try_round(457.4554, '457.455', method='HALF-EVEN')
@@ -228,7 +228,7 @@ class TestFloatPrecision(TransactionCase):
         try_split(2.675, ('2', '68'), float_split_str)   # in Python 2.7.2, round(2.675,2) gives 2.67
         try_split(-2.675, ('-2', '68'), float_split_str) # in Python 2.7.2, round(2.675,2) gives 2.67
         try_split(0.001, ('0', '00'), float_split_str)
-        try_split(-0.001, ('-0', '00'), float_split_str)
+        try_split(-0.001, ('0', '00'), float_split_str)
         try_split(42, ('42', '00'), float_split_str)
         try_split(0.1, ('0', '10'), float_split_str)
         try_split(13.0, ('13', ''), float_split_str, rounding=0)

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -205,6 +205,8 @@ def float_repr(value, precision_digits):
     # Can't use str() here because it seems to have an intrinsic
     # rounding to 12 significant digits, which causes a loss of
     # precision. e.g. str(123456789.1234) == str(123456789.123)!!
+    if float_is_zero(value, precision_digits=precision_digits):
+        value = 0.0
     return "%.*f" % (precision_digits, value)
 
 


### PR DESCRIPTION
float_repr(-0.00000001, 2)
formatFloat(-0.00000001, { digits: [16, 2] })

Before: "-0.00"
After: "0.00"

opw-4685953

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
