### PR TITLE
[FIX] website: fix image grid to column crash

### DIFF
--- a/addons/website/static/src/builder/plugins/image/image_grid_option.xml
+++ b/addons/website/static/src/builder/plugins/image/image_grid_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.ImageGridOption">
-    <BuilderRow t-if="state.isOptionActive" label.translate="Position">
+    <BuilderRow t-if="isActiveItem('grid_mode') and state.isOptionActive" label.translate="Position">
         <BuilderSelect action="'setGridImageMode'" >
             <BuilderSelectItem title.translate="Contain" actionValue="'contain'">Contain</BuilderSelectItem>
             <BuilderSelectItem title.translate="Cover" actionValue="'cover'">Cover</BuilderSelectItem>


### PR DESCRIPTION
Steps to reproduce:
- Drop a "Punchy Image" snippet
- Click on the image
- Select Layout > Column => The grid element cannot be found.

The option component's state is updated later than the call to `isApplied`. We need to guarantee that the `"grid_mode"` option is active before displaying the option.