### PR TITLE
[FIX] _*: fix the timesheet generation for global working schedule.

### DIFF
--- a/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
+++ b/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
@@ -17,7 +17,9 @@ class ResourceCalendarLeaves(models.Model):
         calendars = leaves_with_calendar.calendar_id
         leaves_wo_calendar = self - leaves_with_calendar
         if leaves_wo_calendar:
-            calendars += self.env['resource.calendar'].search([('company_id', 'in', leaves_wo_calendar.company_id.ids)])
+            calendars += self.env['resource.calendar'].search([
+                ('company_id', 'in', leaves_wo_calendar.company_id.ids + [False]),
+            ])
         return calendars
 
     def _work_time_per_day(self, resource_calendars=False):
@@ -68,7 +70,7 @@ class ResourceCalendarLeaves(models.Model):
         )
         for company, leaves, resources, date_from_min, date_to_max in comp_leaves_read_group:
             for calendar_id in resource_calendars.ids:
-                if calendars_dict[calendar_id].company_id != company:
+                if (calendar_company := calendars_dict[calendar_id].company_id) and calendar_company != company:
                     continue  # only consider global leaves of the same company as the calendar
                 calendar_data = cal_attendance_intervals_dict.get(calendar_id)
                 if calendar_data is None:

--- a/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
@@ -528,3 +528,17 @@ class TestTimesheetGlobalTimeOff(common.TransactionCase):
 
         with self.assertRaises(UserError):
             timesheet.unlink()
+
+    def test_timesheet_generation_on_public_holiday_creation_with_global_working_schedule(self):
+        """ Test that public holidays are included in the global working schedule (company should be False)
+            when a global time off is created.
+        """
+        self.part_time_calendar.company_id = False
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Public Holiday',
+            'date_from': datetime(2021, 1, 4, 0, 0, 0),
+            'date_to': datetime(2021, 1, 4, 23, 59, 59),
+        })
+        timesheet_count = self.env['account.analytic.line'].search_count([('employee_id', '=', self.part_time_employee.id)])
+        self.assertEqual(timesheet_count, 1, "A timesheet should have been generated for the employee with a global working "
+                                              "schedule when a new public holiday is created")


### PR DESCRIPTION
_*= project_timesheet_holidays

Steps to Reproduce:
---------------------------
1. Create a global working schedule (company should be False).
2. Assign this working schedule to any employee.
3. Create a public time off (for all the working schedule).
4. You will notice that the timesheet entry is not generated for the public holiday for that employee.

Issue:
-------------------------------
- Employees who use the WS without a company are excluded from timesheet creation.

Cause :
--------------------------------
- When grouping employees by calendar global WS (with no company) were being excluded.
- And the timesheets were not generated due to the check `calendars_dict[calendar_id].company_id != company` 
  when the WS had no company

Fix:
------------------
- We will add the domain to include the global WS and and we will check if the the WS has company id 
  then only check the condition.

task-4900941