### PR TITLE
[FIX] pos_iot: update customer display using websocket

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -18,7 +18,6 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { user } from "@web/core/user";
 import { OrderTabs } from "@point_of_sale/app/components/order_tabs/order_tabs";
 import { _t } from "@web/core/l10n/translation";
-import { openProxyCustomerDisplay } from "@point_of_sale/customer_display/utils";
 import { uuidv4 } from "@point_of_sale/utils";
 import { QrCodeCustomerDisplay } from "@point_of_sale/app/customer_display/customer_display_qr_code_popup";
 import { useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
@@ -141,29 +140,24 @@ export class Navbar extends Component {
     }
 
     openCustomerDisplay() {
-        const proxyIP = this.pos.getDisplayDeviceIP();
-        if (proxyIP) {
-            openProxyCustomerDisplay(proxyIP, this.pos, this.notification);
-        } else {
-            const getDeviceUuid = () => {
-                if (!localStorage.getItem("device_uuid")) {
-                    localStorage.setItem("device_uuid", uuidv4());
-                }
-                return localStorage.getItem("device_uuid");
-            };
-            const customer_display_url = `/pos_customer_display/${
-                this.pos.config.id
-            }/${getDeviceUuid()}`;
-
-            if (this.ui.isSmall) {
-                this.dialog.add(QrCodeCustomerDisplay, {
-                    customerDisplayURL: `${this.pos.session._base_url}${customer_display_url}`,
-                });
-                return;
+        const getDeviceUuid = () => {
+            if (!localStorage.getItem("device_uuid")) {
+                localStorage.setItem("device_uuid", uuidv4());
             }
-            window.open(customer_display_url, "newWindow", "width=800,height=600,left=200,top=200");
-            this.notification.add(_t("PoS Customer Display opened in a new window"));
+            return localStorage.getItem("device_uuid");
+        };
+        const customer_display_url = `/pos_customer_display/${
+            this.pos.config.id
+        }/${getDeviceUuid()}`;
+
+        if (this.ui.isSmall) {
+            this.dialog.add(QrCodeCustomerDisplay, {
+                customerDisplayURL: `${this.pos.session._base_url}${customer_display_url}`,
+            });
+            return;
         }
+        window.open(customer_display_url, "newWindow", "width=800,height=600,left=200,top=200");
+        this.notification.add(_t("PoS Customer Display opened in a new window"));
     }
 
     get showCreateProductButton() {

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -191,10 +191,6 @@ export class ClosePosPopup extends Component {
     }
     async closeSession() {
         this.pos._resetConnectedCashier();
-        const proxyIP = this.pos.getDisplayDeviceIP();
-        if (proxyIP) {
-            this.pos.hardwareProxy.deviceControllers.customerDisplay.action({ action: "close" });
-        }
         // If there are orders in the db left unsynced, we try to sync.
         const syncSuccess = await this.pos.pushOrdersWithClosingPopup();
         if (!syncSuccess) {

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
@@ -17,24 +17,16 @@ export class CustomerDisplayPosAdapter {
     }
 
     dispatch(pos) {
-        const proxyIP = pos.getDisplayDeviceIP();
-        if (proxyIP) {
-            pos.hardwareProxy.deviceControllers.customerDisplay.action({
-                action: "set",
-                data: this.data,
+        this.channel.postMessage(JSON.parse(JSON.stringify(this.data)));
+        pos.data
+            .call("pos.config", "update_customer_display", [
+                [pos.config.id],
+                this.data,
+                localStorage.getItem("device_uuid"),
+            ])
+            .catch((error) => {
+                console.info("Failed to update customer display:", error);
             });
-        } else {
-            this.channel.postMessage(JSON.parse(JSON.stringify(this.data)));
-            pos.data
-                .call("pos.config", "update_customer_display", [
-                    [pos.config.id],
-                    this.data,
-                    localStorage.getItem("device_uuid"),
-                ])
-                .catch((error) => {
-                    console.info("Failed to update customer display:", error);
-                });
-        }
     }
 
     formatOrderData(order) {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -34,7 +34,6 @@ import { WithLazyGetterTrap } from "@point_of_sale/lazy_getter";
 import { debounce } from "@web/core/utils/timing";
 import DevicesSynchronisation from "../utils/devices_synchronisation";
 import { deserializeDateTime, formatDate } from "@web/core/l10n/dates";
-import { openProxyCustomerDisplay } from "@point_of_sale/customer_display/utils";
 import { ProductInfoPopup } from "@point_of_sale/app/components/popups/product_info_popup/product_info_popup";
 import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_slots_popup/preset_slots_popup";
 import { DebugWidget } from "../utils/debug/debug_widget";
@@ -697,7 +696,6 @@ export class PosStore extends WithLazyGetterTrap {
 
         this.markReady();
         await this.deviceSync.readDataFromServer();
-        openProxyCustomerDisplay(this.getDisplayDeviceIP(), this);
     }
 
     get productListViewMode() {

--- a/addons/point_of_sale/static/src/customer_display/utils.js
+++ b/addons/point_of_sale/static/src/customer_display/utils.js
@@ -1,24 +1,4 @@
-import { DeviceController } from "@iot_base/device_controller";
-import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-
-export function openProxyCustomerDisplay(displayDeviceIp, pos, notificationService = null) {
-    if (!displayDeviceIp) {
-        return;
-    }
-
-    pos.hardwareProxy.deviceControllers.customerDisplay ??= new DeviceController(
-        pos.iotLongpolling,
-        { iot_ip: displayDeviceIp, identifier: "display" }
-    );
-
-    notificationService?.add(_t("Connecting to the IoT Box"));
-    pos.hardwareProxy.deviceControllers.customerDisplay.action({
-        action: "open",
-        access_token: pos.config.access_token,
-        pos_id: pos.config.id,
-    });
-}
 
 export function useSingleDialog() {
     let close = null;


### PR DESCRIPTION
We fixed the customer display not opening and displaying a traceback when the Iot Box was not reachable, by calling the action via iot_http, fallbacking on websocket when needed.
We also removed the "customer display with IoT Box" logic from the PoS to the module pos_iot.

Enterprise PR: odoo/enterprise#90657