### PR TITLE
[FIX] bus,im_livechat,mail: do not feed old bus notifications late

### DIFF
--- a/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
+++ b/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
@@ -17,7 +17,7 @@ export class IrWebSocket extends models.ServerModel {
 
         channels = [...channels];
         channels.push("broadcast");
-        const authenticatedUserId = this.env.cookie.get("authenticated_user_sid");
+        const authenticatedUserId = this.env.cookie.get("authenticated_user_sid") ?? this.env.uid;
         const [authenticatedPartner] = authenticatedUserId
             ? ResPartner.search_read(
                   [["user_ids", "in", [authenticatedUserId]]],

--- a/addons/im_livechat/controllers/cors/thread.py
+++ b/addons/im_livechat/controllers/cors/thread.py
@@ -3,6 +3,7 @@
 from odoo.http import route
 from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.addons.im_livechat.tools.misc import force_guest_env
+from odoo.addons.mail.tools.discuss import bus_rpc
 
 
 class LivechatThreadController(ThreadController):
@@ -12,6 +13,7 @@ class LivechatThreadController(ThreadController):
         return self.mail_message_post(thread_model, thread_id, post_data, context, **kwargs)
 
     @route("/im_livechat/cors/message/update_content", methods=["POST"], type="jsonrpc", auth="public", cors="*")
+    @bus_rpc
     def livechat_message_update_content(
         self, guest_token, message_id, body, attachment_ids, attachment_tokens=None, partner_ids=None
     ):

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -7,7 +7,7 @@ from werkzeug.exceptions import NotFound
 from odoo import _, http
 from odoo.exceptions import UserError
 from odoo.http import request
-from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
+from odoo.addons.mail.tools.discuss import add_guest_to_context, bus_rpc, Store
 
 
 class ThreadController(http.Controller):
@@ -217,6 +217,7 @@ class ThreadController(http.Controller):
         return store.add(message).get_result()
 
     @http.route("/mail/message/update_content", methods=["POST"], type="jsonrpc", auth="public")
+    @bus_rpc
     @add_guest_to_context
     def mail_message_update_content(self, message_id, body, attachment_ids, attachment_tokens=None, partner_ids=None, **kwargs):
         attachments = request.env["ir.attachment"].browse(attachment_ids)

--- a/addons/mail/static/src/core/common/bus_rpc_service.js
+++ b/addons/mail/static/src/core/common/bus_rpc_service.js
@@ -1,0 +1,37 @@
+import { Deferred } from "@bus/workers/websocket_worker_utils";
+
+import { rpc } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+import { uuid } from "@web/core/utils/strings";
+
+/**
+ * Service that wraps RPC calls to coordinate with bus notifications.
+ * Ensures the client waits for both the RPC response and the corresponding
+ * bus notifications.
+ */
+export const busRpcService = {
+    dependencies: ["bus_service"],
+    /**
+     * @param {import("@web/env").OdooEnv}
+     * @param {Partial<import("services").Services>} services
+     */
+    start(env, { bus_service: busService }) {
+        const uuidToDeferred = new Map();
+        busService.subscribe("bus_rpc/end", (uuid) => uuidToDeferred.get(uuid)?.resolve());
+        return async function busRpc(url, params = {}, settings = {}) {
+            const requestId = uuid();
+            const deferred = new Deferred();
+            uuidToDeferred.set(requestId, deferred);
+            params["bus_rpc_uuid"] = requestId;
+            try {
+                const result = await rpc(url, params, settings);
+                await deferred;
+                return result;
+            } finally {
+                uuidToDeferred.delete(requestId);
+            }
+        };
+    },
+};
+
+registry.category("services").add("mail.busRpc", busRpcService);

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -529,7 +529,7 @@ export class Message extends Record {
             mentionedRoles,
         });
         const hadLink = this.hasLink; // to remove old previews if message no longer contains any link
-        const data = await rpc("/mail/message/update_content", {
+        await this.store.busRpc("/mail/message/update_content", {
             attachment_ids: attachments
                 .concat(this.attachment_ids)
                 .map((attachment) => attachment.id),
@@ -542,7 +542,6 @@ export class Message extends Record {
             role_ids: validMentions?.roles?.map((role) => role.id),
             ...this.thread.rpcParams,
         });
-        this.store.insert(data);
         if ((hadLink || this.hasLink) && this.store.hasLinkPreviewFeature) {
             rpc("/mail/link_preview", { message_id: this.id }, { silent: true });
         }

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -459,11 +459,7 @@ export class Store extends BaseStore {
 
     getMentionsFromText(
         body,
-        {
-            mentionedChannels = [],
-            mentionedPartners = [],
-            mentionedRoles = [],
-        } = {}
+        { mentionedChannels = [], mentionedPartners = [], mentionedRoles = [] } = {}
     ) {
         const validMentions = {};
         validMentions.threads = mentionedChannels.filter((thread) => {
@@ -482,6 +478,11 @@ export class Store extends BaseStore {
             .filter((special) => body.includes(`@${special.label}`))
             .map((special) => special.label);
         return validMentions;
+    }
+
+    /** @returns {import("services")["mail.busRpc"]} */
+    get busRpc() {
+        return this.env.services["mail.busRpc"];
     }
 
     /**

--- a/addons/mail/static/src/js/tooling/types/services.d.ts
+++ b/addons/mail/static/src/js/tooling/types/services.d.ts
@@ -6,6 +6,7 @@ declare module "services" {
     import { discussCorePublicWeb } from "@mail/discuss/core/public_web/discuss_core_public_web_service";
     import { discussCoreWeb } from "@mail/discuss/core/web/discuss_core_web_service";
     import { im_status } from "@mail/core/common/im_status_service";
+    import { busRpcService } from "@mail/core/common/bus_rpc_service";
     import { mailCoreCommon } from "@mail/core/common/mail_core_common_service";
     import { mailCoreWeb } from "@mail/core/web/mail_core_web_service";
     import { mailPopoutService } from "@mail/core/common/mail_popout_service";
@@ -37,6 +38,7 @@ declare module "services" {
         "mail.sound_effects": typeof soundEffects;
         "mail.store": typeof storeService;
         "mail.suggestion": typeof suggestionService;
+        "mail.busRpc": typeof busRpcService,
         im_status: typeof im_status;
     }
 }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -177,11 +177,7 @@ test("Editing message keeps the mentioned channels", async () => {
     await contains(".o-mail-Discuss-threadName", { value: "other" });
 });
 
-test.skip("Can edit message comment in chatter", async () => {
-    // Fails on runbot often because race condition between RPC returns and bus notifications,
-    // leading to late steps receiving old bus notifications and therefore assertion error.
-    // This happens with heavy CPU load, e.g. when test takes around 2.5 seconds to run rather
-    // than 400ms in ideal condition.
+test("Can edit message comment in chatter", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
     pyEnv["mail.message"].create({

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -20,6 +20,17 @@ import { createDocumentFragmentFromContent } from "@web/core/utils/html";
 const mockRpcRegistry = registry.category("mail.mock_rpc");
 export const DISCUSS_ACTION_ID = 104;
 
+export function bus_rpc(func) {
+    return async function (request) {
+        const { bus_rpc_uuid } = await parseRequestParams(request);
+        const result = await func.call(this, request);
+        if (bus_rpc_uuid) {
+            const [partner] = this.env["res.partner"].read(this.env.user.partner_id);
+            this.env["bus.bus"]._sendone(partner, "bus_rpc/end", bus_rpc_uuid);
+        }
+        return result;
+    };
+}
 /**
  * @template [T={}]
  * @typedef {import("@web/../tests/web_test_helpers").RouteCallback<T>} RouteCallback
@@ -661,7 +672,7 @@ registerRoute("/mail/message/translate", translate);
 /** @type {RouteCallback} */
 async function translate(request) {}
 
-registerRoute("/mail/message/update_content", mail_message_update_content);
+registerRoute("/mail/message/update_content", bus_rpc(mail_message_update_content));
 /** @type {RouteCallback} */
 async function mail_message_update_content(request) {
     /** @type {import("mock_models").BusBus} */

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -14,6 +14,7 @@ from . import test_discuss_reaction_controller
 from . import test_discuss_res_role
 from . import test_discuss_sub_channels
 from . import test_discuss_thread_controller
+from . import test_discuss_tools
 from . import test_message_controller
 from . import test_guest_feature
 from . import test_toggle_upload

--- a/addons/mail/tests/discuss/test_discuss_tools.py
+++ b/addons/mail/tests/discuss/test_discuss_tools.py
@@ -1,0 +1,29 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import Controller, route
+from odoo.tests import HttpCase, new_test_user, tagged
+
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tools.discuss import bus_rpc
+
+
+@tagged("post_install", "-at_install")
+class TestDiscussTools(MailCommon, HttpCase):
+    def test_bus_rpc(self):
+        class Dummycontroller(Controller):
+            @route("/bus/foo", type="jsonrpc", auth="public")
+            @bus_rpc
+            def bus_foo(self):
+                pass
+
+        self.env.registry.clear_cache("routing")
+        self.addCleanup(self.env.registry.clear_cache, "routing")
+        bob_user = new_test_user(self.env, "bob_user")
+        self.authenticate("bob_user", "bob_user")
+        self._reset_bus()
+        self.assertFalse(self.env["bus.bus"].search([]))
+        with self.assertBus(
+            [[self.env.cr.dbname, "res.partner", bob_user.partner_id.id]],
+            [{"type": "bus_rpc/end", "payload": "foo"}],
+        ):
+            self.make_jsonrpc_request("/bus/foo", {"bus_rpc_uuid": "foo"})


### PR DESCRIPTION
Before this commit, RPC returns and bus notifications resulting from
RPC calls were prone to race conditions (e.g. bus notification from
a first RPC could overwrite the latest state, received from a second
RPC).

To solve this issue, this commit introduces the `busRpc` service with
is essentially the same than `rpc` except that it waits for every
notification resulting from the rpc call to be received before
resolving.

This will fix tests such as `Can edit message comment in chatter` that
shows those symptoms (message body being overwritten by the first RPC
notifications).

fixes runbot-227618