### PR TITLE
[IMP] l10n_ar_withholding: Phase IV - Check amount automation

### DIFF
--- a/addons/l10n_ar_withholding/wizards/account_payment_register.py
+++ b/addons/l10n_ar_withholding/wizards/account_payment_register.py
@@ -18,16 +18,46 @@ class AccountPaymentRegister(models.TransientModel):
     l10n_ar_net_amount = fields.Monetary(compute='_compute_l10n_ar_net_amount', readonly=True, help="Net amount after withholdings")
     l10n_ar_adjustment_warning = fields.Boolean(compute="_compute_l10n_ar_adjustment_warning")
 
-    @api.depends('l10n_latam_move_check_ids.amount', 'amount', 'l10n_ar_net_amount', 'l10n_latam_new_check_ids.amount', 'payment_method_code')
-    def _compute_l10n_ar_adjustment_warning(self):
-        wizard_register = self
+    @api.depends('can_edit_wizard', 'source_amount', 'source_amount_currency', 'source_currency_id', 'company_id', 'currency_id', 'payment_date', 'installments_mode', 'l10n_latam_move_check_ids.amount', 'l10n_latam_new_check_ids.amount', 'payment_method_code')
+    def _compute_amount(self):
+        super()._compute_amount()
         for wizard in self:
             checks = wizard.l10n_latam_new_check_ids if wizard.filtered(lambda x: x._is_latam_check_payment(check_subtype='new_check')) else wizard.l10n_latam_move_check_ids
             checks_amount = sum(checks.mapped('amount'))
-            if checks_amount and wizard.l10n_ar_net_amount != checks_amount:
-                wizard.l10n_ar_adjustment_warning = True
-                wizard_register -= wizard
-        wizard_register.l10n_ar_adjustment_warning = False
+            if not wizard.currency_id.is_zero(checks_amount) and wizard.currency_id.compare_amounts(checks_amount, wizard.l10n_ar_net_amount) != 0:
+                if wizard.partner_type == 'supplier':
+                    original_amount = wizard.amount
+                    f_delta = checks_amount - wizard.l10n_ar_net_amount
+                    if f_delta < 0:
+                        # Removing withholdings can result in an overshoot of the initial amount
+                        wizard.amount = checks_amount
+                        f_delta = checks_amount - wizard.l10n_ar_net_amount
+                    d = f_delta
+                    f_previous = wizard.l10n_ar_net_amount
+                    wizard.amount += d
+                    wizard._compute_l10n_ar_net_amount()
+                    for i in range(201):
+                        f_delta = checks_amount - wizard.l10n_ar_net_amount
+                        if wizard.currency_id.is_zero(f_delta):
+                            break
+                        der = ((wizard.l10n_ar_net_amount - f_previous) / d) if abs(d) >= 0.01 else 1.0
+                        if wizard.currency_id.is_zero(der):
+                            i = 200
+                            break
+                        d = max(f_delta / der, 0.01)
+                        f_previous = wizard.l10n_ar_net_amount
+                        wizard.amount += d
+                        wizard._compute_l10n_ar_net_amount()
+                    if i == 200:
+                        # Adjustment failed, resetting
+                        wizard.amount = original_amount
+
+    @api.depends('amount', 'l10n_latam_move_check_ids', 'l10n_latam_new_check_ids', 'payment_method_code')
+    def _compute_l10n_ar_adjustment_warning(self):
+        for wizard in self:
+            checks = wizard.l10n_latam_new_check_ids if wizard.filtered(lambda x: x._is_latam_check_payment(check_subtype='new_check')) else wizard.l10n_latam_move_check_ids
+            checks_amount = sum(checks.mapped('amount'))
+            wizard.l10n_ar_adjustment_warning = not wizard.currency_id.is_zero(checks_amount) and wizard.currency_id.compare_amounts(checks_amount, wizard.l10n_ar_net_amount) != 0
 
     @api.depends('amount', 'l10n_ar_withholding_ids.amount')
     def _compute_l10n_ar_net_amount(self):


### PR DESCRIPTION
Current behavior: when using third-party checks to create vendor payments, withholding amounts are creating a difference between the checks amount and the payment amount, resulting in a warning and requiring manual adjustment of the payment amount until the amount minus withholdings matches checks amount.
Solution: adding an automated adjustment algorithm to the wizard.

task-4257629

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
