### PR TITLE
[FIX] html_editor: restore the sizing option for regular buttons

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -501,17 +501,15 @@ export class LinkPopover extends Component {
             .join(" ");
 
         let stylePrefix = "";
-        if (this.state.type === "custom") {
-            if (this.state.buttonSize) {
-                classes += ` btn-${this.state.buttonSize}`;
+        if (!!this.state.type && this.state.buttonSize) {
+            classes += ` btn-${this.state.buttonSize}`;
+        }
+        if (this.state.type === "custom" && this.state.buttonShape) {
+            const buttonShape = this.state.buttonShape.split(" ");
+            if (["outline", "fill"].includes(buttonShape[0])) {
+                stylePrefix = `${buttonShape[0]}-`;
             }
-            if (this.state.buttonShape) {
-                const buttonShape = this.state.buttonShape.split(" ");
-                if (["outline", "fill"].includes(buttonShape[0])) {
-                    stylePrefix = `${buttonShape[0]}-`;
-                }
-                classes += ` ${buttonShape.slice(stylePrefix ? 1 : 0).join(" ")}`;
-            }
+            classes += ` ${buttonShape.slice(stylePrefix ? 1 : 0).join(" ")}`;
         }
         if (this.state.type) {
             classes += ` btn btn-${stylePrefix}${this.state.type}`;

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -46,6 +46,18 @@
                             </select>
                         </div>
 
+                        <t t-if="state.type === 'primary' || state.type === 'secondary'">
+                            <div class="input-group mb-1">
+                                <label>Size</label>
+                                <select name="link_style_size" class="form-select form-select-sm link-style" t-model="state.buttonSize" t-on-change="onChange">
+                                    <t t-foreach="this.buttonSizesData" t-as="buttonSizesData" t-key="buttonSizesData.size">
+                                        <option t-att-value="buttonSizesData.size" t-att-selected="state.buttonSize === buttonSizesData.size">
+                                            <span t-esc="buttonSizesData.label"/>
+                                        </option>
+                                    </t>
+                                </select>
+                            </div>
+                        </t>
                         <t t-if="state.type === 'custom'">
                             <div class="d-flex mb-1 custom-text-color">
                                 <label>Text Color</label>


### PR DESCRIPTION
With the new builder, the option to choose the size of a button was removed for the buttons "primary" and "secondary", while it was an option available previously for them. The user had to set the button type  to "custom" to change its size, which is not convenient.

The commit reintroduces the size option for the regular buttons.

task-4367641