### PR TITLE
[IMP] account: disable documents sync during test

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -236,8 +236,9 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
             composer.action_send_and_print(allow_fallback_pdf=True)
             self.env.cr.flush()  # force tracking message
 
-        self.assertEqual(len(self._new_msgs), 1, 'Should produce 1 message (for posting template)')
-        print_msg = self._new_msgs[0]
+        new_account_msgs = self._new_msgs.filtered(lambda msg: (msg.model or '').startswith('account'))
+        self.assertEqual(len(new_account_msgs), 1, 'Should produce 1 message (for posting template)')
+        print_msg = new_account_msgs[0]
         self.assertNotified(
             print_msg,
             [{
@@ -319,8 +320,9 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
             composer.action_send_and_print()
             self.env.cr.flush()  # force tracking message
 
-        self.assertEqual(len(self._new_msgs), 1, 'Should produce 1 message (for posting template)')
-        print_msg = self._new_msgs[0]
+        new_account_msgs = self._new_msgs.filtered(lambda msg: (msg.model or '').startswith('account'))
+        self.assertEqual(len(new_account_msgs), 1, 'Should produce 1 message (for posting template)')
+        print_msg = new_account_msgs[0]
         self.assertNotified(
             print_msg,
             [{

--- a/addons/account/tests/test_ir_actions_report.py
+++ b/addons/account/tests/test_ir_actions_report.py
@@ -7,7 +7,7 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.exceptions import RedirectWarning
 from odoo.tools import pdf
 from odoo.tests import tagged
-from odoo.tools import file_open
+from odoo.tools import file_open, mute_logger
 from odoo.tools.pdf import PdfFileReader, PdfFileWriter
 
 
@@ -44,6 +44,8 @@ class TestIrActionsReport(AccountTestInvoicingCommon):
         test_record_report = self.env['ir.actions.report'].with_context(force_report_rendering=True)._render_qweb_pdf('account.action_account_original_vendor_bill', res_ids=in_invoice_1.id)
         self.assertTrue(test_record_report, "The PDF should have been generated")
 
+    # Document synchronization being enabled, avoid a warning when computing the number of page of the corrupted pdf.
+    @mute_logger('odoo.addons.documents.models.documents_document')
     def test_download_with_encrypted_pdf(self):
         """
         Same as test_download_one_corrupted_pdf

--- a/addons/l10n_de/tests/test_audit_trail.py
+++ b/addons/l10n_de/tests/test_audit_trail.py
@@ -16,15 +16,19 @@ class TestAuditTrailDE(AccountTestInvoicingHttpCommon):
         super().setUpClass()
         cls.document_installed = 'documents_account' in cls.env['ir.module.module']._installed()
         if cls.document_installed:
-            cls.env.user.company_id.documents_account_settings = True
             folder_test = cls.env['documents.document'].create({
                 'name': 'folder_test',
                 'type': 'folder',
             })
-            cls.env['documents.account.folder.setting'].create({
-                'folder_id': folder_test.id,
-                'journal_id': cls.company_data['default_journal_sale'].id,
-            })
+            existing_setting = cls.env['documents.account.folder.setting'].sudo().search(
+                [('journal_id', '=', cls.company_data['default_journal_sale'].id)])
+            if existing_setting:
+                existing_setting.folder_id = folder_test
+            else:
+                cls.env['documents.account.folder.setting'].sudo().create({
+                    'folder_id': folder_test.id,
+                    'journal_id': cls.company_data['default_journal_sale'].id,
+                })
 
     def _send_and_print(self, invoice):
         return self.env['account.move.send'].with_context(


### PR DESCRIPTION
To avoid a lot of test to fail or emit warning following the enabling of the account document synchronization by default, we disable the document account synchronization during the test.

Examples of problems happening without disabling the document synchronization:
- the main problem comes from ir.actions.report._pre_render_qweb_pdf which renders pdf as html when in test mode, causing warning in other part of the code (ex.: documents._get_is_multipage) as they expect a pdf (as the mimetype is pdf) and not html. We try to reverse that behavior but other test checks the html content (of the fake "pdf").
- some tests expect a given number of message sent but the creation of the synchronized document send an additional message.

[IMP] ln10n_de: remove accounting sync option

Adapt the test following the change in documents_account that removes documents_account_settings flags that enabled user to enable/disable the accounting synchronization with document (always enabled now when document_account is installed).

Task-4873102