### PR TITLE
[FIX] hw_drivers: prevent conf file race condition

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -578,18 +578,20 @@ def update_conf(values, section='iot.box'):
     :param values: The dictionary of key-value pairs to update the config with.
     :param section: The section to update the key-value pairs in (Default: iot.box).
     """
-    _logger.debug("Updating odoo.conf with values: %s", values)
-    conf = get_conf()
-    get_conf.cache_clear()  # Clear the cache to get the updated config
+    with writable():
+        _logger.debug("Updating odoo.conf with values: %s", values)
+        conf = get_conf()
+        get_conf.cache_clear()  # Clear the cache to get the updated config
 
-    if not conf.has_section(section):
-        _logger.debug("Creating new section '%s' in odoo.conf", section)
-        conf.add_section(section)
+        if not conf.has_section(section):
+            _logger.debug("Creating new section '%s' in odoo.conf", section)
+            conf.add_section(section)
 
-    for key, value in values.items():
-        conf.set(section, key, value) if value else conf.remove_option(section, key)
+        for key, value in values.items():
+            conf.set(section, key, value) if value else conf.remove_option(section, key)
 
-    write_file("odoo.conf", conf)
+        with open(path_file("odoo.conf"), "w", encoding='utf-8') as f:
+            conf.write(f)
 
 
 @cache


### PR DESCRIPTION
In the following scenario, changes to the odoo.conf file could be lost:
1. A long-running process enters a `writable()` block (e.g. git checkout)
2. While it is still running, another process wants to update the conf file but gets blocked waiting for `writable()`. However it has already loaded the entire `odoo.conf` file into memory ready to write it back.
3. The first long running process now makes a change to the `odoo.conf` file. In the case of the checkout process, it is changing the `server_wide_modules` key.
4. The first process finishes and releases the `writable()` lock.
5. The second process now writes to the conf file, however it is using the now-stale version it held in memory from step 2.
6. The original changes to the conf file are lost.

The fundamental issue is that the `update_conf` function is loading the conf file into memory too early. To fix this, we aquire the `writable()` lock first, and then we can load the conf file knowing that it won't change until we are done.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
