### PR TITLE
[FIX] sale_project: prevent no record error when modifying milestone

### DIFF
--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -25,6 +25,7 @@
                     icon="fa-check-square-o"
                     invisible="not is_product_milestone or not project_ids or state == 'draft'"
                     groups="project.group_project_milestone"
+                    context="{'active_id': project_id}"
                 >
                     <field name="milestone_count" widget="statinfo" string="Milestones"/>
                 </button>


### PR DESCRIPTION
**Issue:**

A MissingError is raised when trying to modify a milestone from a sale order

**Steps to reproduce:**

1. In Sales, create a quotation based on a product milestone (this creates a project + task)
2. Confirm the quotation
3. Click the Milestone button on the sale.order
4. Modify any field in the milestone list view

The error “Record does not exist or has been deleted” is raised

**cause:**

https://github.com/odoo/odoo/blob/61116191c6b933ca9b40863774d506f219a410a1/addons/project/models/project_milestone.py#L18-L19

The active_id being passed down is the sale order id not the project id

**opw-4944212**