### PR TITLE
[FIX] analytic: allow to add 0% distribution on analytic lines

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -337,9 +337,6 @@ export class AnalyticDistribution extends Component {
 
     async percentageChanged(dist_tag, ev) {
         dist_tag.percentage = this.parse(ev.target.value);
-        if (dist_tag.percentage == 0) {
-            this.deleteTag(dist_tag.id, dist_tag.group_id);
-        }
         this.autoFill();
     }
 
@@ -449,7 +446,7 @@ export class AnalyticDistribution extends Component {
     }
 
     tagIsReady({analytic_account_id, percentage}) {
-        return !!analytic_account_id && !!percentage;
+        return !!analytic_account_id;
     }
 
     sumByGroup(id) {

--- a/addons/analytic/static/tests/analytic_distribution_tests.js
+++ b/addons/analytic/static/tests/analytic_distribution_tests.js
@@ -308,24 +308,22 @@ QUnit.module("Analytic", (hooks) => {
             assert.equal(el.value, expectedPercentages[i], `6: Percentage Element ${i} should be ${expectedPercentages[i]}`);
         }
 
-        // change tag 4 to 0%, tag is removed and balance goes to last tag (tag 5)
-        let accountEls = [...popup.querySelectorAll("table#plan_5 .o_analytic_account_name input")];
+        // change tag 4 to 0%, the balance resets it to its previous value
         await editInput(percentageEls[3], null, "0");
         percentageEls = [...popup.querySelectorAll("table#plan_5 .o_analytic_percentage input")];
-        expectedPercentages = ['10%', '50%', '10%', '10%', '20%'];
+        expectedPercentages = ['10%', '50%', '10%', '20%', '10%', '0%'];
         for (const [i, el] of percentageEls.entries()) {
             assert.equal(el.value, expectedPercentages[i], `7: Percentage Element ${i} should be ${expectedPercentages[i]}`);
         }
-        assert.strictEqual(document.activeElement, accountEls[4], "Focus should be on the fifth tag (one was removed)");
 
-        // delete tag 3, balance goes to last empty tag (tag 4)
+        // delete tag 3, balance goes to last empty tag (tag 5)
         let trashIcons = [...document.querySelectorAll("table#plan_5 .fa-trash-o")];
-        assert.equal(trashIcons.length, 4, "1 tag should not have a trash icon");
+        assert.equal(trashIcons.length, 5);
         await click(trashIcons[2]);
         percentageEls = [...popup.querySelectorAll("table#plan_5 .o_analytic_percentage input")];
-        expectedPercentages = ['10%', '50%', '10%', '30%'];
+        expectedPercentages = ['10%', '50%', '20%', '10%', '10%'];
         for (const [i, el] of percentageEls.entries()) {
-            assert.equal(el.value, expectedPercentages[i], `7: Percentage Element ${i} should be ${expectedPercentages[i]}`);
+            assert.equal(el.value, expectedPercentages[i], `8: Percentage Element ${i} should be ${expectedPercentages[i]}`);
         }
         assert.equal(popup.querySelector("table#plan_5 tr:last-of-type .o_analytic_account_name input").value, "",
             "Last tag's account is empty");
@@ -334,7 +332,7 @@ QUnit.module("Analytic", (hooks) => {
         triggerHotkey("Escape");
         await nextTick();
         await click(target.querySelector(".modal-dialog .btn-primary"));
-        assert.containsN(target, ".badge", 10, "should contain 2 rows of 5 tags each");
+        assert.containsN(target, ".badge", 12, "should contain 2 rows of 6 tags each");
 
     });
 });


### PR DESCRIPTION
### Steps to reproduce:
- Go to Accounting > Configuration > Analytic Distribution Models
- Add a 100% distribution in "Analytic"
- Try adding a 0% distribution in the same category => it is not added / gets deleted

### Cause:
The method `tagIsReady` returns False if precentage is 0. So the tag is considered as not ready to be added and deleted.

### Solution:
Remove the condition on `precentage`, if it's value is not valid it will get override by `remainderByGroup`.

opw-4921280