### PR TITLE
[FIX] website: prevent edit_megamenu_big_icons_subtitles from failing

### DIFF
--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -273,6 +273,14 @@ registerWebsitePreviewTour('edit_megamenu_big_icons_subtitles', {
         trigger: ':iframe .s_mega_menu_odoo_menu .row > div:first-child .nav > :first-child',
         run: "click",
     },
+    {
+        trigger: "body",
+        run: async () => {
+            const { promise, resolve } = Promise.withResolvers();
+            setTimeout(resolve, 200);
+            return promise;
+        },
+    },
     changeOption("MegaMenuLayout", "we-toggler"),
     {
         content: "Select Big Icons Subtitles mega menu",


### PR DESCRIPTION
The test `test_31_website_edit_megamenu_big_icons_subtitles` is failing
randomly and more often with watch=True

When selecting the link, `_updateRightPanelContent` is called, which in
turns calls `_closeWidgets`. We should wait for that call to be finished
before interacting with the sidebar.
When the widgets are closed, the active class is removed from `Big Icons
Subtitles´. It is already too late because we already changed the
MegaMenuLayout option. Since nothing changes inside the DOM, we need to
wait a certain amount of time before proceeding.

runbot-163061