### PR TITLE
[FIX] payment_razorpay_oauth: add constraints on credentials before publication

### DIFF
--- a/addons/payment_razorpay_oauth/models/payment_provider.py
+++ b/addons/payment_razorpay_oauth/models/payment_provider.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 
 import requests
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import RedirectWarning, ValidationError
 from odoo.http import request
 
@@ -130,6 +130,21 @@ class PaymentProvider(models.Model):
                 'next': {'type': 'ir.actions.client', 'tag': 'soft_reload'},
             },
         }
+
+    # === CONSTRAINT METHODS === #
+
+    @api.constrains('state')
+    def _check_razorpay_credentials_are_set_before_enabling(self):
+        """ Check that the Razorpay credentials are valid when the provider is enabled.
+
+        :raise ValidationError: If the Razorpay credentials are not valid.
+        """
+        for provider in self.filtered(lambda p: p.code == 'razorpay' and p.state != 'disabled'):
+            if not provider.razorpay_key_id or not provider.razorpay_key_secret:
+                raise ValidationError(_(
+                    "Razorpay credentials are missing. Click the \"Connect\" button to set up your"
+                    " account"
+                ))
 
     # === BUSINESS METHODS - OAUTH === #
 

--- a/addons/payment_razorpay_oauth/tests/__init__.py
+++ b/addons/payment_razorpay_oauth/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_payment_provider

--- a/addons/payment_razorpay_oauth/tests/test_payment_provider.py
+++ b/addons/payment_razorpay_oauth/tests/test_payment_provider.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.exceptions import ValidationError
+
+from odoo.addons.payment_razorpay.tests.common import RazorpayCommon
+
+
+@tagged('post_install', '-at_install')
+class TestPaymentProvider(RazorpayCommon):
+
+    def test_allow_enabling_if_credentials_are_set(self):
+        """ Test that enabling a Razorpay provider with credentials succeeds. """
+        self._assert_does_not_raise(ValidationError, self.provider.write({'state': 'enabled'}))
+
+    def test_prevent_enabling_if_credentials_are_not_set(self):
+        """ Test that enabling a Razorpay provider without credentials raises a ValidationError. """
+        self.provider.write({
+            'razorpay_key_id': None,
+            'razorpay_key_secret': None,
+        })
+        with self.assertRaises(ValidationError):
+            self.provider.state = 'enabled'


### PR DESCRIPTION
## Version
17.0+
No OAuth in 16.0

## Issue
Razorpay can be enabled and published without being properly configured.

## Steps to reproduce
- Go to `Payment Providers` and open `Razorpay`;
- Set the state to `Enabled` and publish without providing any credentials.

## Fix
Added constraints and revised account linking logic, similar to Stripe.
Based on 1b6a7aeb245f0007675943ed7aacf5064e46fe61 suggested by ALSH.

opw-4922315