### PR TITLE
[FIX] l10n_ar: add some translations

### DIFF
--- a/addons/l10n_ar/i18n/es_419.po
+++ b/addons/l10n_ar/i18n/es_419.po
@@ -1744,6 +1744,11 @@ msgid "Fiscal Position"
 msgstr "Posición fiscal"
 
 #. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
+msgid "Fiscal Transparency Regime for the Final Consumer (Law 27.743)"
+msgstr "Régimen de Transparencia Fiscal al Consumidor (Ley 27.743)"
+
+#. module: l10n_ar
 #: model:ir.model.fields,field_description:l10n_ar.field_res_partner__l10n_ar_formatted_vat
 #: model:ir.model.fields,field_description:l10n_ar.field_res_users__l10n_ar_formatted_vat
 msgid "Formatted VAT"
@@ -2996,6 +3001,13 @@ msgstr "IVA"
 #: model:ir.model.fields,field_description:l10n_ar.field_account_tax_group__l10n_ar_vat_afip_code
 msgid "VAT AFIP Code"
 msgstr "Código AFIP de IVA"
+
+#. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_move.py:0
+#, python-format
+msgid "VAT Content %s"
+msgstr "IVA Contenido %s"
 
 #. module: l10n_ar
 #: model:l10n_latam.document.type,name:l10n_ar.dc_a_rg1415


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_ar
- Switch to an Argentinian company (e.g. (AR) Responsable Inscripto)
- Activate "Spanish (Latin America)" language
- Create an Argentinian contact with that language
- Create an invoice for the created contact
- Confirm the invoice
- Print the invoice

**Issue:**
Some terms are not translated.

opw-4938520



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
