### PR TITLE
[IMP] l10n_ar: show better the incoterm on invoice report

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -224,11 +224,7 @@
                     <t t-if="o.invoice_incoterm_id">
                         <br/>
                         <strong>Incoterm:</strong>
-                        <p t-if="o.incoterm_location">
-                            <span t-field="o.invoice_incoterm_id.code"/> <br/>
-                            <span t-field="o.incoterm_location"/>
-                        </p>
-                        <p t-else="" t-field="o.invoice_incoterm_id.name" class="m-0"/>
+                        <span t-field="o.invoice_incoterm_id.code"/><span t-if="o.incoterm_location" t-out="' - %s' % o.incoterm_location"/>
                     </t>
 
                 </div>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
It is neccesary to show incoterm on invoice report on same line as the incoterm field. 

**Steps to reproduce**:
1. Go to runbot odoo 18 enterprise instance, install l10n_ar module "Argentina - Accounting" and take position on "(AR) Responsable Inscripto" company.
2. Create a customer invoice and set incoterm and incoterm location on page "Other Info" on the invoice form view.
<img width="1226" height="792" alt="image" src="https://github.com/user-attachments/assets/c7b8b36b-4209-4bb2-9a6c-59571d553707" />
3. Print pdf without payment
<img width="1105" height="355" alt="image" src="https://github.com/user-attachments/assets/9d9ef043-375e-4e79-80e7-09acc2eacc05" />

**Current behavior before PR**:
<img width="758" height="410" alt="image" src="https://github.com/user-attachments/assets/1491ac44-831c-4611-862a-356c1ec94c4d" />

**Desired behavior after PR is merged**:
<img width="740" height="360" alt="image" src="https://github.com/user-attachments/assets/946fc60c-005c-4bf6-8cf1-b8f4c1f3384b" />

_Task Adhoc side_: 52734.
_Task Latam side_: 1354

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
