### PR TITLE
[IMP] web: Change 'clear' button in SelectMenu with the BottomSheet

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -112,7 +112,7 @@ export class SelectMenu extends Component {
             if (!this.dropdownState.isOpen) {
                 this.dropdownState.open();
             }
-            const searchString = ev.target.value || "";
+            const searchString = ev.target.value;
             this.state.searchValue = searchString;
             this.onInput(searchString);
         }, DEBOUNCED_DELAY);

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -39,9 +39,6 @@
                             <TagsList t-if="props.value.length" tags="multiSelectChoices"/>
                         </t>
                         <t t-call="web.SelectMenu.search" />
-                        <span t-if="!props.searchable and canDeselect" t-on-click.stop="onInputClear" class="o_select_menu_toggler_clear position-absolute top-50 end-0 me-3">
-                            <i class="fa fa-times"></i>
-                        </span>
                         <span class="o_select_menu_caret align-self-center" />
                     </div>
                 </t>
@@ -49,8 +46,7 @@
                     <button type="button" t-attf-class="o_select_menu_toggler d-flex border btn btn-light w-100 bg-light {{ props.togglerClass }}" t-att-disabled="props.disabled">
                         <span class="o_select_menu_toggler_slot text-start text-truncate">
                             <span t-if="props.placeholder and !props.value" class="text-muted" t-out="props.placeholder"/>
-                            <t t-if="!props.slots or !props.slots.default" t-esc="displayValue" />
-                            <t t-else="" t-slot="default" />
+                            <t t-slot="default" />
                         </span>
                         <span t-if="canDeselect" t-on-click.stop="onInputClear" class="o_select_menu_toggler_clear position-absolute top-50 end-0 me-3">
                             <i class="fa fa-times"></i>
@@ -59,6 +55,7 @@
                     </button>
                 </t>
                 <t t-set-slot="content">
+                    <button t-if="isBottomSheet and canDeselect" class="btn o_clear_button px-4 d-block ms-auto" t-on-click="onInputClear">Clear</button>
                     <div class="o_select_menu_searchbox position-sticky start-0 d-empty-none" t-att-data-id="selectMenuId">
                         <t t-if="displayInputInDropdown">
                             <t t-set="inputClass" t-value="'o_select_menu_input dropdown-item'"/>

--- a/addons/web/static/tests/_framework/view_test_helpers.js
+++ b/addons/web/static/tests/_framework/view_test_helpers.js
@@ -322,7 +322,7 @@ export async function hideTab() {
  */
 export async function editSelectMenu(selector, { value, index }) {
     async function selectItem(value) {
-        const elementToSelect = queryFirst(`.o_select_menu_menu :contains(${value})`);
+        const elementToSelect = queryFirst(`.o_select_menu_item:contains(${value})`);
         if (elementToSelect) {
             await click(elementToSelect);
             return;
@@ -348,7 +348,7 @@ export async function editSelectMenu(selector, { value, index }) {
         // Because this helper must work even when no input is editable (searchable=false),
         // we unselect the currently selected value with the 'X' button
         const clearButton = queryFirst(
-            `.o_select_menu[data-id='${selectMenuId}'] .o_select_menu_toggler_clear`
+            `.o_select_menu[data-id='${selectMenuId}'] .o_select_menu_toggler_clear, .o_select_menu_menu .o_clear_button`
         );
         if (clearButton) {
             await click(clearButton);

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -975,7 +975,7 @@ test("Choices are updated and filtered when props change", async () => {
     expect(".o_select_menu_toggler").toHaveValue("Hello");
 
     await open();
-    expect(".o_select_menu_menu").toHaveText("Coucou\nHello");
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Coucou", "Hello"]);
 
     // edit the input, to trigger onInput and update the props
     await editInput("aft");
@@ -985,7 +985,7 @@ test("Choices are updated and filtered when props change", async () => {
     expect(".o_select_menu_toggler").toHaveValue("Good afternoon");
 
     await open();
-    expect(".o_select_menu_menu").toHaveText("Coucou\nGood afternoon");
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Coucou", "Good afternoon"]);
 });
 
 test("SelectMenu group items only after being opened", async () => {
@@ -1226,4 +1226,32 @@ test("Fetch choices", async () => {
     await open();
     await editInput("test");
     expect(queryAllTexts(".o_select_menu_item")).toEqual(["test"]);
+});
+
+test.tags("mobile");
+test("In the BottomSheet, a 'Clear' button is present", async () => {
+    class MyParent extends Component {
+        static props = ["*"];
+        static components = { SelectMenu };
+        static template = xml`
+            <SelectMenu
+                choices="choices"
+                value="'test'"
+                onSelect.bind="this.onSelect"
+            />
+        `;
+        setup() {
+            this.state = useState({ value: "hello" });
+            this.choices = [{ label: "Test", value: "test" }];
+        }
+        onSelect(value) {
+            expect.step("Cleared");
+            expect(value).toBe(null);
+        }
+    }
+    await mountSingleApp(MyParent);
+    await contains(".o_select_menu_toggler").click();
+    expect(".o_select_menu_menu .o_clear_button").toHaveCount(1);
+    await contains(".o_select_menu_menu .o_clear_button").click();
+    expect.verifySteps(["Cleared"]);
 });


### PR DESCRIPTION
This commit makes the UI of the SelectMenu more aligned with the behavior of the Many2One dialog, by using a 'Clear' button at the top right of the list of items, instead of using a cross in the input currently.

A test has been added as well, and the editSelectMenu helper has been adapted to this change.