### PR TITLE
[IMP] web: register ServerActionWithWarningsError dialog

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -33,6 +33,7 @@ export const odooExceptionTitleMap = new Map(
         "odoo.exceptions.AccessDenied": _t("Access Denied"),
         "odoo.exceptions.MissingError": _t("Missing Record"),
         "odoo.addons.web.controllers.action.MissingActionError": _t("Missing Action"),
+        "odoo.addons.base.models.ir_actions.ServerActionWithWarningsError": _t("Invalid Operation"),
         "odoo.exceptions.UserError": _t("Invalid Operation"),
         "odoo.exceptions.ValidationError": _t("Validation Error"),
         "odoo.exceptions.AccessError": _t("Access Error"),
@@ -224,6 +225,7 @@ registry
     .add("odoo.exceptions.AccessError", WarningDialog)
     .add("odoo.exceptions.MissingError", WarningDialog)
     .add("odoo.addons.web.controllers.action.MissingActionError", WarningDialog)
+    .add("odoo.addons.base.models.ir_actions.ServerActionWithWarningsError", WarningDialog)
     .add("odoo.exceptions.UserError", WarningDialog)
     .add("odoo.exceptions.ValidationError", WarningDialog)
     .add("odoo.exceptions.RedirectWarning", RedirectWarningDialog)


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

https://github.com/odoo/odoo/commit/ef4c1350df10c186efec79b1414306e325707549 introduced a new exception `ServerActionWithWarningsError`: https://github.com/odoo/odoo/blob/851c46923332aa13c56fbce3a5ed3c5d37a70c92/odoo/addons/base/models/ir_actions.py#L486-L488
This was not registered as an error_dialog. This led to the frontend displaying the entire traceback instead of an error dialog similar to `UserError` when a `ServerActionWithWarningsError` is raised. This commit fixes it by correctly registering the error in `error_dialog` registry category so a more user friendly dialog is displayed with the error contents.

Thanks @brboi for helping with the fix

### Current behavior before PR:

A traceback error is thrown when a `ServerActionWithWarningsError` is raised. Example:
<img width="1896" height="904" alt="image" src="https://github.com/user-attachments/assets/0bfee329-e6c5-4652-a2ac-d41b763e2bdb" />


Video reproducing it: https://drive.google.com/file/d/1C_aE0d_9bP27f388dB1NJLeWHBpsM7AW/view?usp=drive_link (credits: gavb-odoo)

### Desired behavior after PR is merged:

An error dialog similar to UserError which is easier to understand is displayed

<img width="1906" height="799" alt="image" src="https://github.com/user-attachments/assets/d57c5cab-14f2-4f39-9f0c-b8099e8b0089" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

opw-4885670
