### PR TITLE
[18.0][FIX] stock: Reset stock.move.picked if move lines are deleted

### DIFF
--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -449,16 +449,11 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         self.assertRecordValues(mo.move_raw_ids, [
             {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},
         ])
-        move = self.env['stock.move'].create({
-            'name': mo.name,
-            'product_id': compo2.id,
-            'raw_material_production_id': mo.id,
-            'location_id': self.ref('stock.stock_location_stock'),
-            'location_dest_id': self.env['stock.location'].search([('usage', '=', 'production'), ('company_id', '=', self.env.company.id)]).id,
-        })
-        move.should_consume_qty = 1
-        move.quantity = 1
-        move._action_assign()
+        mo_form = Form(mo)
+        with mo_form.move_raw_ids.new() as move_form:
+            move_form.product_id = compo2
+            move_form.product_uom_qty = 1
+        mo = mo_form.save()
         self.assertRecordValues(mo.move_raw_ids, [
             {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},
             {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -263,7 +263,7 @@ class StockMove(models.Model):
         for move in self:
             if move.state == 'done' or any(ml.picked for ml in move.move_line_ids):
                 move.picked = True
-            elif move.move_line_ids:
+            else:
                 move.picked = False
 
     def _inverse_picked(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1689,6 +1689,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             'location_dest_id': self.location_dest_id.id,
             'picking_id': self.picking_id.id,
             'company_id': self.company_id.id,
+            'picked': self.picked,
         }
         if quantity:
             # TODO could be also move in create/write


### PR DESCRIPTION
To reproduce:
- Use a picking type to 'move entire packs'
- Have a qty in stock in a package
- Create a picking to move the package and confirm
- Mark the package level as done
- Unmark the package level as done

When the package level is marked as done, the related stock move line will be marked as picked, which will in turn set the stock move as picked.

When the done checkbox is removed from the package level, the stock move line will be deleted, and said package level will be deleted, but the move did remain as picked.

OPW-4964561

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
