### PR TITLE
[IMP] stock: enhance address labeling in delivery slip report

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -10,6 +10,7 @@
                     <div name="div_outgoing_address">
                         <div name="outgoing_delivery_address"
                             t-if="o.should_print_delivery_address()">
+                            <strong>Delivery Address</strong>
                             <div t-out="o.move_ids[0].partner_id or o.partner_id"
                                 t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
                         </div>
@@ -30,7 +31,7 @@
                                 <t t-set="show_partner" t-value="True" />
                             </div>
                             <div name="customer_address" t-if="o.picking_type_id.code=='outgoing' and partner and partner != partner.commercial_partner_id">
-                                <strong>Customer Address</strong>
+                                <strong>Customer</strong>
                                 <t t-set="show_partner" t-value="True" />
                             </div>
                             <div t-if="show_partner" name="partner_header">


### PR DESCRIPTION
To resolve ambiguities and improve operational efficiency:
1. The delivery address is explicitly labeled 'Delivery Address'. Ensuring no doubt about the final destination.
2. The label for the customer's primary information has been updated from 'Customer Address' to simply Customer, which prevents operators from mistaking it for the delivery point.

Task Id: 4929649