### PR TITLE
[FIX] l10n_uy_website_sale: fix wrong domain issue

### DIFF
--- a/addons/l10n_uy_website_sale/controllers/main.py
+++ b/addons/l10n_uy_website_sale/controllers/main.py
@@ -26,7 +26,7 @@ class L10nUYWebsiteSale(WebsiteSale):
             rendering_values.update({
                 'identification': partner_sudo.l10n_latam_identification_type_id or request.env.ref('l10n_uy.it_ci').id,
                 'identification_types': LatamIdentificationType.search([
-                    '|', ('country_id', '=', False), ('country_id.code', '=', 'PE')
+                    '|', ('country_id', '=', False), ('country_id.code', '=', 'UY')
                 ]) if can_edit_vat else LatamIdentificationType,
                 'vat_label': request.env._("Identification Number"),
             })


### PR DESCRIPTION
Steps:
- Install Uruguay Ecommerce.
- Set Uruguay company on website.
- Go to address page on the checkout.

Issue:
- Uruguay related ID types are missing.

Cause:
- Because of bad adaption of Fw-port to 18.0 wrong county_code was set on PR https://github.com/odoo/odoo/pull/218920.

Fix:
- Update county_code to UY instead PE.
