### PR TITLE
[REF] *: remove string attribute from group in search view

### DIFF
--- a/addons/account/report/account_invoice_report_view.xml
+++ b/addons/account/report/account_invoice_report_view.xml
@@ -115,7 +115,7 @@
                 <field name="invoice_user_id" />
                 <field name="product_id" />
                 <field name="product_categ_id" filter_domain="[('product_categ_id', 'child_of', self)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Salesperson" name='user' context="{'group_by':'invoice_user_id'}"/>
                     <filter string="Partner" name="partner_id" context="{'group_by':'partner_id','residual_visible':True}"/>
                     <filter string="Product Category" name="category_product" context="{'group_by':'product_categ_id','residual_invisible':True}"/>

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -159,7 +159,7 @@
                     <filter string="Inactive Accounts" name="inactiveacc" domain="[('active', '=', False)]"/>
                     <separator/>
                     <field name="account_type"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Account Type" name="accounttype" domain="" context="{'group_by':'account_type'}"/>
                     </group>
                     <searchpanel class="account_root w-auto">

--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -38,7 +38,7 @@
                     <separator/>
                     <filter name="filter_date" date="date"/>
                     <field name="journal_id" domain="[('type', 'in', ('bank', 'cash', 'credit'))]" />
-                    <group string="Group By">
+                    <group>
                         <filter string="Journal" name="journal" context="{'group_by': 'journal_id'}"/>
                         <filter string="Date" name="date" context="{'group_by': 'date'}"/>
                     </group>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -362,7 +362,7 @@
                     <filter string="Report Dates" name="date_before" domain="[('date', '&lt;=', context.get('date_to'))]" invisible="1"/>
                     <separator/>
                     <filter string="Analytic Accounts" name="analytic_accounts" domain="[('analytic_distribution', 'in', context.get('analytic_ids'))]" invisible="1"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Journal Entry" name="group_by_move" domain="[]" context="{'group_by': 'move_name'}"/>
                         <filter string="Account" name="group_by_account" domain="[]" context="{'group_by': 'account_id'}"/>
                         <filter string="Partner" name="group_by_partner" domain="[]" context="{'group_by': 'partner_id'}"/>
@@ -453,7 +453,7 @@
                     <filter string="Report Dates" name="date_between" domain="[('date', '&gt;=', context.get('date_from')), ('date', '&lt;=', context.get('date_to'))]" invisible="1"/>
                     <filter string="Report Dates" name="date_before" domain="[('date', '&lt;=', context.get('date_to'))]" invisible="1"/>
                     <separator/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Currency" name="group_by_currencies" domain="[]" context="{'group_by': 'currency_id'}"/>
                         <filter string="Partner" name="group_by_partner" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Journal" name="journal" domain="[]" context="{'group_by': 'journal_id'}"/>
@@ -1596,7 +1596,7 @@
                     <filter string="Date" name="date" date="date"/>
                     <filter string="Invoice Date" name="invoice_date" date="invoice_date"/>
                     <separator/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Partner" name="partner" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Journal" name="journal" domain="[]" context="{'group_by': 'journal_id'}"/>
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
@@ -1692,7 +1692,7 @@
                         domain="[('activity_date_deadline', '=', 'today')]"/>
                     <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Salesperson" name="salesperson" context="{'group_by':'invoice_user_id'}"/>
                         <filter string="Partner" name="partner" context="{'group_by':'partner_id'}"/>
                         <filter name="status" string="Status" context="{'group_by':'state'}"/>

--- a/addons/account/views/account_reconcile_model_views.xml
+++ b/addons/account/views/account_reconcile_model_views.xml
@@ -132,7 +132,7 @@
                     <filter string="With tax" name="withtax" domain="[('line_ids.tax_ids', '!=', False)]"/>
                     <separator/>
                     <filter name="inactive" string="Archived" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Journals Availability" name="group_by_journal" context="{'group_by': 'match_journal_ids'}"/>
                         <filter string="Automation" name="group_by_auto_validate" context="{'group_by': 'trigger'}"/>
                     </group>

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -109,7 +109,7 @@
                     <separator/>
                     <filter name="active" string="Active" domain="[('active','=',True)]" help="Show active taxes"/>
                     <filter name="inactive" string="Inactive" domain="[('active','=',False)]" help="Show inactive taxes"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Company" name="company" domain="[]" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
                         <filter string="Tax Type" name="taxapp" domain="[]" context="{'group_by':'type_tax_use'}"/>
                         <filter string="Tax Scope" name="taxapp" domain="[]" context="{'group_by':'tax_scope'}"/>
@@ -235,7 +235,7 @@
                 <search string="Search Group">
                     <field name="name"/>
                     <field name="country_id"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Country" name="group_by_country" domain="[]" context="{'group_by': 'country_id'}"/>
                     </group>
                 </search>

--- a/addons/account/views/mail_message_views.xml
+++ b/addons/account/views/mail_message_views.xml
@@ -49,7 +49,7 @@
                 <filter string="Restricted" name="restricted_by_audit_trail" domain="[('account_audit_log_restricted', '=', True)]"/>
                 <separator/>
                 <filter name="date" string="Date" date="date"/>
-                <group string="Group By">
+                <group>
                     <filter string="Date" name="group_by_date" domain="[]" context="{'group_by': 'date'}"/>
                     <filter string="Updated Data" name="group_by_res_id" domain="[]" context="{'group_by': 'res_id'}"/>
                 </group>

--- a/addons/account/views/res_partner_bank_views.xml
+++ b/addons/account/views/res_partner_bank_views.xml
@@ -75,7 +75,7 @@
                         <filter string="Phishing risk: Medium" name="medium_phishing_risk" domain="[('has_iban_warning', '!=', False)]"/>
                         <separator/>
                         <filter string="Created On" name="create_date" date="create_date"/>
-                        <group string="Group By">
+                        <group>
                             <filter string="Created On" name="groupby_create_date" context="{'group_by': 'create_date'}"/>
                             <filter string="Created By" name="groupby_create_by" context="{'group_by': 'create_uid'}"/>
                         </group>

--- a/addons/analytic/views/analytic_account_views.xml
+++ b/addons/analytic/views/analytic_account_views.xml
@@ -108,7 +108,7 @@
                     <field name="partner_id"/>
                     <separator/>
                     <filter string="Archived" domain="[('active', '=', False)]" name="inactive"/>
-                    <group string="Group By...">
+                    <group>
                         <filter string="Associated Partner" name="associatedpartner" domain="[]" context="{'group_by': 'partner_id'}"/>
                     </group>
                 </search>

--- a/addons/analytic/views/analytic_line_views.xml
+++ b/addons/analytic/views/analytic_line_views.xml
@@ -28,7 +28,7 @@
                 <field name="date"/>
                 <separator/>
                 <filter name="month" string="Date" date="date"/>
-                <group string="Group By..." name="groupby">
+                <group name="groupby">
                     <separator/>
                     <filter string="Date" name="group_date" context="{'group_by': 'date'}"/>
                 </group>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -397,7 +397,7 @@
                 <filter string="Recurrent" name="recurrent" domain="[('recurrency', '=', True)]"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Responsible" name="responsible" domain="[]" context="{'group_by': 'user_id'}"/>
                 </group>
             </search>

--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -63,7 +63,7 @@
                     <filter name="filter_date" date="date"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Activity" name="group_by_activity_type" context="{'group_by': 'mail_activity_type_id'}"/>
                         <filter string="Type" name="group_by_subtype" context="{'group_by': 'subtype_id'}"/>
                         <filter string="Assigned To" name="group_by_author_id" context="{'group_by': 'author_id'}"/>

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -122,7 +122,7 @@
                     <filter name="filter_create_date" date="create_date" default_period="year"/>
                     <filter string="Expected Closing" name="filter_date_deadline" date="date_deadline"/>
                     <filter string="Date Closed" name="date_closed_filter" date="date_closed"/>
-                    <group string="Extended Filters">
+                    <group>
                         <field name="partner_id" filter_domain="[('partner_id','child_of',self)]"/>
                         <field name="stage_id" domain="['|', ('team_id', '=', False), ('team_id', '=', 'team_id')]"/>
                         <field name="campaign_id"/>
@@ -135,7 +135,7 @@
                         <field name="date_closed"/>
                     </group>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Salesperson" name="salesperson" context="{'group_by':'user_id'}" />
                         <filter string="Sales Team" name="saleschannel" context="{'group_by':'team_id'}"/>
                         <filter string="City" name="city" context="{'group_by':'city'}" />

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -681,7 +681,7 @@
                             domain="[('activity_date_deadline', '&gt;', 'today')]"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Salesperson" name="salesperson" context="{'group_by':'user_id'}"/>
                         <filter string="Sales Team" name="saleschannel" context="{'group_by':'team_id'}"/>
                         <filter name="city" string="City" context="{'group_by': 'city'}"/>
@@ -995,7 +995,7 @@
                     <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('my_activity_date_deadline', '&gt;', 'today')]"/>
                     <separator/>
-                    <group string="Group By" colspan="16">
+                    <group colspan="16">
                         <filter string="Salesperson" name="salesperson" context="{'group_by':'user_id'}"/>
                         <filter string="Sales Team" name="saleschannel" context="{'group_by':'team_id'}"/>
                         <filter name="stage" string="Stage" context="{'group_by':'stage_id'}"/>

--- a/addons/crm_iap_mine/views/crm_iap_lead_mining_request_views.xml
+++ b/addons/crm_iap_mine/views/crm_iap_lead_mining_request_views.xml
@@ -144,7 +144,7 @@
                 <separator/>
                 <filter name="type_is_lead" string="Leads" domain="[('lead_type', '=', 'lead')]"/>
                 <filter name="type_is_opportunity" string="Opportunities" domain="[('lead_type', '=', 'opportunity')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Type" name="groupby_lead_type" domain="[]" context="{'group_by':'lead_type'}"/>
                     <filter string="Sales Team" name="groupby_team_id" domain="[]" context="{'group_by':'team_id'}"/>
                     <filter string="Salesperson" name="groupby_user_id" domain="[]" context="{'group_by':'user_id'}"/>

--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -28,7 +28,7 @@
                 <field name="delivery_type"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Provider" name="provider" context="{'group_by':'delivery_type', 'residual_visible':True}"/>
                 </group>
             </search>

--- a/addons/digest/views/digest_views.xml
+++ b/addons/digest/views/digest_views.xml
@@ -84,7 +84,7 @@
                 <field name="user_ids"/>
                 <filter name="filter_activated" string="Activated" domain="[('state', '=', 'activated')]"/>
                 <filter name="filter_deactivated" string="Deactivated" domain="[('state', '=', 'deactivated')]"/>
-                <group string="Group by">
+                <group>
                     <filter string="Periodicity" name="periodicity" context="{'group_by': 'periodicity'}"/>
                 </group>
             </search>

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -338,7 +338,7 @@
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('activity_date_deadline', '&gt;', 'today')]"/>
                 <filter string="Online" name="filter_online" domain="[('address_id', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Responsible" name="responsible" context="{'group_by': 'user_id'}"/>
                     <filter string="Template" name="event_type_id" context="{'group_by': 'event_type_id'}"/>
                     <!--

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -233,7 +233,7 @@
                 <filter string="Last 30 days" name="filter_last_month_creation" domain="[('create_date','&gt;', 'today -30d')]"/>
                 <separator/>
                 <filter string="Archived" name="filter_inactive" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Partner" name="partner" domain="[]" context="{'group_by':'partner_id'}"/>
                     <filter string="Event" name="group_event" domain="[]" context="{'group_by':'event_id'}"/>
                     <filter string="Ticket Type" name ="group_event_ticket_id" domain="[]" context="{'group_by': 'event_ticket_id'}"/>

--- a/addons/event_booth/views/event_booth_views.xml
+++ b/addons/event_booth/views/event_booth_views.xml
@@ -149,7 +149,7 @@
                     domain="[('state', '=', 'available')]"/>
                 <filter string="Unavailable" name="filter_booth_unavailable"
                     domain="[('state', '=', 'unavailable')]"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_state" context="{'group_by': 'state'}"/>
                     <filter name="group_by_partner_id" context="{'group_by': 'partner_id'}"/>
                     <filter name="group_by_booth_category_id" context="{'group_by': 'booth_category_id'}"/>

--- a/addons/event_booth/views/event_type_booth_views.xml
+++ b/addons/event_booth/views/event_type_booth_views.xml
@@ -62,7 +62,7 @@
         <field name="arch" type="xml">
             <search string="Event Type Booths">
                 <field name="name"/>
-                <group string="Group By">
+                <group>
                     <filter string="Booth Type" name="booth_category" context="{'group_by': 'booth_category_id'}"/>
                 </group>
             </search>

--- a/addons/event_sale/report/event_sale_report_views.xml
+++ b/addons/event_sale/report/event_sale_report_views.xml
@@ -110,7 +110,7 @@
                         domain="[('event_date_end', '&lt;', 'now')]"/>
                 <filter string="Event Start Date" name="event_date_start" date="event_date_begin" default_period="year"/>
                 <filter string="Event End Date" name="event_date_end" date="event_date_end"/>
-                <group string="Group By">
+                <group>
                     <filter string="Event Type" name="group_by_event_type_id" context="{'group_by': 'event_type_id' }"/>
                     <filter string="Event" name="group_by_event_id" context="{'group_by': 'event_id' }"/>
                     <separator/>

--- a/addons/fleet/views/fleet_board_view.xml
+++ b/addons/fleet/views/fleet_board_view.xml
@@ -12,7 +12,7 @@
                 <filter string="Contract" name="contract" domain="[('cost_type', '=', 'contract')]"/>
                 <separator/>
                 <filter name="filter_date_start" date="date_start" default_period="year"/>
-                <group string="Group By">
+                <group>
                     <filter string="Vehicle" name="vehicle" context="{'group_by':'vehicle_id'}"/>
                     <filter string="Driver" name="driver" context="{'group_by':'driver_id'}"/>
                 </group>

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -148,7 +148,7 @@
                     domain="[('activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Vehicle" name="vehicle" context="{'group_by': 'vehicle_id'}"/>
                 </group>
             </search>
@@ -348,7 +348,7 @@
                 <field name="description"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Service Type" name="groupby_service_type_id" context="{'group_by': 'service_type_id'}"/>
                     <filter string="Fleet Manager" name="groupby_manager_id" context="{'group_by': 'manager_id'}"/>
                     <filter string="Model" name="groupby_model_id" context="{'group_by': 'model_id'}"/>

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -140,7 +140,7 @@
                 <field name="name" string="Model" />
                 <field name="brand_id"/>
                 <filter string="Contains Vehicle" name="contains_vehicle" domain="[('vehicle_count', '!=', 0)]"/>
-                <group string="Group By">
+                <group>
                     <filter name="groupby_brand" context="{'group_by' : 'brand_id'}" string="Manufacturers"/>
                     <filter name="groupby_category" context="{'group_by' : 'category_id'}" string="Category"/>
                     <filter name="groupby_vehicle_type" context="{'group_by' : 'vehicle_type'}" string="Vehicle Type"/>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -255,7 +255,7 @@
                     domain="[('activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Model" name="groupby_model" context="{'group_by': 'model_id'}"/>
                     <filter string="Brand" name="groupby_make" context="{'group_by': 'brand_id'}"/>
                     <filter string="Status" name="groupby_status" context="{'group_by': 'state_id'}"/>
@@ -430,7 +430,7 @@
                 <field name="driver_id"/>
                 <field name="value"/>
                 <field name="date"/>
-                <group string="Group By">
+                <group>
                     <filter name="groupby_vehicle" context="{'group_by': 'vehicle_id'}" string="Vehicle"/>
                     <filter name="groupby_date" context="{'group_by': 'date'}" string="Date"/>
                 </group>
@@ -482,7 +482,7 @@
             <search>
                 <field name="name"/>
                 <field name="category"/>
-                <group string="Group By">
+                <group>
                     <filter name="groupby_category" context="{'group_by' : 'category'}"/>
                 </group>
             </search>

--- a/addons/gamification/views/gamification_challenge_views.xml
+++ b/addons/gamification/views/gamification_challenge_views.xml
@@ -182,7 +182,7 @@
                 <filter name="hr_challenges" string="HR Challenges"
                     domain="[('challenge_category', '=', 'hr')]"/>
                 <field name="name"/>
-                <group string="Group By">
+                <group>
                     <filter string="State" name="state" domain="[]" context="{'group_by':'state'}"/>
                     <filter string="Period" name="period" domain="[]" context="{'group_by':'period'}"/>
                 </group>

--- a/addons/gamification/views/gamification_goal_definition_views.xml
+++ b/addons/gamification/views/gamification_goal_definition_views.xml
@@ -89,7 +89,7 @@
                 <field name="name"/>
                 <field name="model_id"/>
                 <field name="field_id"/>
-                <group string="Group By">
+                <group>
                     <filter string="Model" name="model" domain="[]" context="{'group_by':'model_id'}"/>
                     <filter string="Computation Mode" name="computationmode" domain="[]" context="{'group_by':'computation_mode'}"/>
                 </group>

--- a/addons/gamification/views/gamification_goal_views.xml
+++ b/addons/gamification/views/gamification_goal_views.xml
@@ -131,7 +131,7 @@
                 <field name="user_id"/>
                 <field name="definition_id"/>
                 <field name="challenge_id"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_user" string="User" domain="[]" context="{'group_by':'user_id'}"/>
                     <filter name="group_by_definition" string="Goal Definition" domain="[]" context="{'group_by':'definition_id'}"/>
                     <filter string="State" name="state" domain="[]" context="{'group_by':'state'}"/>

--- a/addons/gamification/views/gamification_karma_tracking_views.xml
+++ b/addons/gamification/views/gamification_karma_tracking_views.xml
@@ -15,7 +15,7 @@
                 <separator/>
                 <filter string="Manual" name="filter_res_users"
                     domain="[('origin_ref', 'ilike', 'res.users,')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Granted By" name="group_by_create_uid"
                         context="{'group_by': 'create_uid'}"/>
                     <filter string="Source Type" name="group_by_origin_ref_model_name"

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -21,7 +21,7 @@
                     <filter name="newly_hired" string="Newly Hired" domain="[('newly_hired', '=', True)]"/>
                     <separator/>
                     <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter name="group_manager" string="Manager" domain="[]" context="{'group_by':'parent_id'}"/>
                         <filter name="group_department" string="Department" domain="[]" context="{'group_by':'department_id'}"/>
                         <filter name="group_job" string="Job" domain="[]" context="{'group_by':'job_id'}"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -62,7 +62,7 @@
                     <filter string="Contract End Date" name="contract_date_end" date="contract_date_end"/>
                     <separator />
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter name="group_manager" string="Manager" domain="[]" context="{'group_by': 'parent_id'}"/>
                         <filter name="group_department" string="Department" domain="[]" context="{'group_by': 'department_id'}"/>
                         <filter name="group_job" string="Job Position" domain="[]" context="{'group_by': 'job_id'}"/>

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -83,7 +83,7 @@
                     <filter name="message_needaction" string="Unread Messages" domain="[('message_needaction', '=', True)]" groups="mail.group_mail_notification_type_inbox"/>
                     <separator/>
                     <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Department" name="department" domain="[]" context="{'group_by': 'department_id'}"/>
                         <filter string="Company" name="company" domain="[]" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                         <filter string="Employment Type" name="employment_type" domain="[]" context="{'group_by': 'contract_type_id'}"/>

--- a/addons/hr_attendance/views/hr_attendance_overtime_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_view.xml
@@ -20,7 +20,7 @@
                 <field name="employee_id"/>
                 <field name="duration" filter_domain="[('duration', '>=', self)]"/>
                 <filter string="Last 3 Months" invisible="1" name="last_three_months" domain="[('date','&gt;=', '-3m')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Date" name="groupby_date" context="{'group_by': 'date:week'}"/>
                     <filter string="Employee" name="employee" context="{'group_by': 'employee_id'}"/>
                 </group>

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -266,7 +266,7 @@
                     domain="[('employee_id.active', '=', False)]"/>
                 <separator invisible="1"/>
                 <filter string="Last 3 Months" invisible="1" name="last_three_months" domain="[('check_in','&gt;=', '-3m')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Employee" name="employee" context="{'group_by': 'employee_id'}"/>
                     <filter string="Departement" name="departement" context="{'group_by': 'department_id'}"/>
                     <filter string="Manager" name="manager" context="{'group_by': 'manager_id'}"/>
@@ -355,7 +355,7 @@
                     string="Archived Employees"
                     name="archivedemployees"
                     domain="[('employee_id.active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Employee" name="employee" context="{'group_by': 'employee_id'}"/>
                     <filter string="Date" name="groupby_date" context="{'group_by': 'check_in'}"/>
                 </group>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -467,7 +467,7 @@
                         domain="[('activity_date_deadline', '&gt;', 'today')]"/>
 
                     <!-- Group bys -->
-                    <group string="Group By" name="group_filters">
+                    <group name="group_filters">
                         <filter string="Employee" name="employee" domain="[]" context="{'group_by': 'employee_id'}"/>
                         <filter string="Category" name="product" domain="[]" context="{'group_by': 'product_id'}"/>
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>

--- a/addons/hr_holidays/report/hr_leave_reports.xml
+++ b/addons/hr_holidays/report/hr_leave_reports.xml
@@ -21,7 +21,7 @@
                 <filter string="My Requests" name="my_leaves" domain="[('employee_id.user_id', '=', uid)]"/>
                 <field name="department_id" operator="child_of"/>
                 <field name="holiday_status_id"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_employee" string="Employee" context="{'group_by':'employee_id'}"/>
                     <filter name="group_type" string="Type" context="{'group_by':'holiday_status_id'}"/>
                     <filter name="group_company" string="Company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -74,7 +74,7 @@
                 <filter name="approved_state" string="To Approve or Approved Allocations" invisible="1"
                     domain="[('state', 'in', ('confirm', 'validate'))]"/>
                 <separator/>
-                <group string="Group By">
+                <group>
                     <filter name="group_employee" string="Employee" context="{'group_by':'employee_id'}"/>
                     <filter name="group_type" string="Type" context="{'group_by':'holiday_status_id'}"/>
                     <filter name="group_allocation_type" string="Allocation Type" context="{'group_by':'allocation_type'}"/>

--- a/addons/hr_holidays/views/hr_leave_mandatory_day_views.xml
+++ b/addons/hr_holidays/views/hr_leave_mandatory_day_views.xml
@@ -47,7 +47,7 @@
                 <field name="company_id" groups="base.group_multi_company"/>
                 <separator />
                 <filter name="filter_date" date="start_date" default_period="year" string="Period"/>
-                <group string="Group By">
+                <group>
                     <filter name="department" string="Department" context="{'group_by': 'department_ids'}"/>
                     <filter name="job" string="Job" context="{'group_by': 'job_ids'}"/>
                     <filter name="company" string="Company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -72,7 +72,7 @@
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('activity_date_deadline', '&gt;', 'today')
                         ]"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_employee" string="Employee" context="{'group_by':'employee_id'}"/>
                     <filter name="group_type" string="Type" context="{'group_by':'holiday_status_id'}"/>
                     <filter name="group_state" string="Status" context="{'group_by': 'state'}"/>

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -302,7 +302,7 @@
                 <filter invisible="1" string="Running Applicants" name="running_applicant_activities"
                     domain="[('stage_id.hired_stage', '=', False)]"/>
                 <separator/>
-                <group string="Group By">
+                <group>
                     <filter string="Job" name="job" domain="[]" context="{'group_by': 'job_id'}"/>
                     <filter string="Stage" name="stage" domain="[]" context="{'group_by': 'stage_id'}"/>
                     <filter string="Responsible" name="responsible" domain="[]"  context="{'group_by': 'user_id'}"/>
@@ -615,14 +615,14 @@
                 <separator/>
                 <filter string="Archived" name="archived" domain="[('active', '=', False)]"/>
                 <separator/>
-                <group string="Extended Filters">
+                <group>
                     <field name="priority"/>
                     <field name="stage_id"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <field name="create_date"/>
                     <field name="date_closed"/>
                 </group>
-                <group string="Group By">
+                <group>
                     <filter string="Responsible" name='User' context="{'group_by':'user_id'}"/>
                     <filter string="Company" name="company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
                     <filter string="Jobs" name="job" context="{'group_by':'job_id'}"/>

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -399,7 +399,7 @@
                 <field name="name" string="Skill"/>
                 <field name="skill_type_id" string="Skill Type"/>
                 <separator/>
-                <group string="Group By...">
+                <group>
                         <filter string="Skill Type" name="group_skill_type_id" domain="[]" context="{'group_by':'skill_type_id'}"/>
                 </group>
             </search>

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -94,7 +94,7 @@
                         domain="[('start_date', '&gt;=', 'today -1m')]"/>
                     <filter name="filter_date_last_week" invisible="1" string="Date: Last week"
                         domain="[('start_date', '&gt;=', 'today -1w')]"/>
-                    <group string="Group By...">
+                    <group>
                         <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'livechat_channel_id'}"/>
                         <filter name="group_by_operator" string="Agent" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter name="group_by_agent_requesting_help" domain="[]" context="{'group_by': 'agent_requesting_help_history'}"/>

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -28,7 +28,7 @@
                         <filter name="rated_on_last_365_days" string="Last 365 Days" domain="[('create_date', '&gt;', 'today -365d +1d')]"/>
                     </filter>
                     <separator/>
-                    <group string="Group By...">
+                    <group>
                         <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'livechat_channel_id'}"/>
                         <filter name="group_by_agent" string="Agent" domain="[]" context="{'group_by':'livechat_agent_partner_ids'}"/>
                         <filter name="group_by_agent_requesting_help" domain="[]" context="{'group_by': 'livechat_agent_requesting_help_history'}"/>
@@ -275,7 +275,7 @@
                         <filter name="created_on_last_365_days" string="Last 365 Days" domain="[('create_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=365), datetime.time(23, 59, 59)).to_utc())]"/>
                     </filter>
                     <separator/>
-                    <group string="Group By...">
+                    <group>
                         <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'livechat_channel_id'}"/>
                         <filter name="group_by_agent" string="Agent" domain="[]" context="{'group_by':'livechat_agent_partner_ids'}"/>
                         <filter name="group_by_country" string="Country" domain="[]" context="{'group_by':'country_id'}"/>

--- a/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
@@ -67,7 +67,7 @@
                         domain="[('create_date', '&gt;=', 'today -1m')]"/>
                     <filter name="filter_date_last_week" invisible="1" string="Date: Last week"
                         domain="[('create_date', '&gt;=', 'today -1w')]"/>
-                    <group string="Group By...">
+                    <group>
                         <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'session_livechat_channel_id'}"/>
                         <filter name="group_by_agent" string="Agent" domain="[]" context="{'group_by':'partner_id'}"/>
                         <filter name="group_by_help_status" domain="[]" context="{'group_by': 'help_status'}"/>

--- a/addons/l10n_in/views/port_code_views.xml
+++ b/addons/l10n_in/views/port_code_views.xml
@@ -38,7 +38,7 @@
             <search string="India Port Code">
                 <field name="name" string="Port" filter_domain="['|',('name', 'ilike', self),('code', 'ilike', self)]"/>
                 <field name="state_id"/>
-                <group string="Group By">
+                <group>
                     <filter string="State" name="state" domain="[]" context="{'group_by': 'state_id'}"/>
                 </group>
             </search>

--- a/addons/l10n_in_hr_holidays/views/l10n_in_hr_leave_optional_holiday_views.xml
+++ b/addons/l10n_in_hr_holidays/views/l10n_in_hr_leave_optional_holiday_views.xml
@@ -20,7 +20,7 @@
                 <field name="company_id" string="Company" groups="base.group_multi_company"/>
                 <separator/>
                 <filter name="filter_date" date="date" default_period="year" string="Period"/>
-                <group expand="0" string="Group By">
+                <group>
                     <filter name="company" string="Company" context="{'group_by': 'company_id'}"
                         groups="base.group_multi_company"/>
                 </group>

--- a/addons/l10n_latam_invoice_document/views/l10n_latam_document_type_view.xml
+++ b/addons/l10n_latam_invoice_document/views/l10n_latam_document_type_view.xml
@@ -45,7 +45,7 @@
                 <field name='country_id'/>
                 <filter name="active" string="Active" domain="[('active','=',True)]" help="Show active document types"/>
                 <filter name="inactive" string="Archived" domain="[('active','=',False)]" help="Show archived document types"/>
-                <group string="Group By...">
+                <group>
                     <filter string="Internal Type" name="group_by_internal_type" context="{'group_by':'internal_type'}"/>
                     <filter string="Localization" name="group_by_localization" context="{'group_by':'country_id'}"/>
                 </group>

--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -12,7 +12,7 @@
                     <field name="campaign_id"/>
                     <field name="medium_id"/>
                     <field name="source_id"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Campaign" name="groupby_campaign_id" context="{'group_by': 'campaign_id'}"/>
                         <filter string="Medium" name="groupby_medium_id" context="{'group_by': 'medium_id'}"/>
                         <filter string="Source" name="groupby_source_id" context="{'group_by': 'source_id'}"/>
@@ -114,7 +114,7 @@
                 <search string="Clicks">
                     <field name="link_id"/>
                     <field name="country_id"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Link" name="groupby_link_id" domain="[]" context="{'group_by': 'link_id'}"/>
                         <filter string="Country" name="groupby_country_id" context="{'group_by': 'country_id'}"/>
                     </group>

--- a/addons/lunch/report/lunch_cashmove_report_views.xml
+++ b/addons/lunch/report/lunch_cashmove_report_views.xml
@@ -22,7 +22,7 @@
             <search string="lunch cashmove">
                 <field name="description"/>
                 <field name="user_id"/>
-                <group string="Group By">
+                <group>
                     <filter name='group_by_user' string="By Employee" context="{'group_by':'user_id'}"/>
                 </group>
             </search>

--- a/addons/lunch/views/lunch_orders_views.xml
+++ b/addons/lunch/views/lunch_orders_views.xml
@@ -17,7 +17,7 @@
                 <filter name="date_filter" string="Today" domain="[('date', '=', 'today')]" />
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_user" string="User" context="{'group_by': 'user_id'}"/>
                     <filter name="group_by_supplier" string="Vendor" context="{'group_by': 'supplier_id'}"/>
                     <filter name="group_by_date" string="Order Date" context="{'group_by': 'date:day'}" help="Vendor Orders by Date"/>

--- a/addons/lunch/views/lunch_product_views.xml
+++ b/addons/lunch/views/lunch_product_views.xml
@@ -21,7 +21,7 @@
                 <filter name="available_on_sun" string="Sunday" domain="[('supplier_id.sun', '=', True)]"/>
                 <separator/>
                 <filter name="inactive" string="Archived" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_supplier" string="Vendor" context="{'group_by': 'supplier_id'}"/>
                     <filter name="group_by_category" string="Category" context="{'group_by': 'category_id'}"/>
                 </group>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -258,7 +258,7 @@
                 <separator/>
                 <filter string="Done" name="filter_archived" domain="[('active', '=', False)]"/>
                 <separator />
-                <group string="Group By">
+                <group>
                     <filter string="Deadline" name="date_deadline" context="{'group_by': 'date_deadline'}"/>
                     <filter string="Document Model" name="group_by_res_model_id" context="{'group_by': 'res_model_id'}"/>
                     <filter string="Assigned To" name="group_by_user_id" context="{'group_by': 'user_id'}"/>

--- a/addons/mail/views/mail_alias_domain_views.xml
+++ b/addons/mail/views/mail_alias_domain_views.xml
@@ -62,7 +62,7 @@
                 <field name="bounce_alias"/>
                 <field name="catchall_alias"/>
                 <field name="company_ids" groups="base.group_multi_company"/>
-                <group string="Group By">
+                <group>
                     <filter string="Company" name="group_by_company_ids"
                         domain="[]" context="{'group_by': 'company_ids'}"
                         groups="base.group_multi_company"/>

--- a/addons/mail/views/mail_alias_views.xml
+++ b/addons/mail/views/mail_alias_views.xml
@@ -97,7 +97,7 @@
                     <field name="alias_parent_thread_id"/>
                     <separator/>
                     <filter string="Active" name="active" domain="[('alias_name', '!=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Creator" name="groupby_create_uid"
                                 context="{'group_by': 'create_uid'}"/>
                         <filter string="Alias Domain" name="groupby_alias_domain_id"

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -131,13 +131,13 @@
                             domain="[('message_type','=','comment')]"/>
                     <filter name="filter_type_notification" string="Notification"
                             domain="[('message_type','=','notification')]"/>
-                    <group string="Extended Filters...">
+                    <group>
                         <field name="author_id"/>
                         <field name="recipient_ids"/>
                         <field name="model"/>
                         <field name="res_id"/>
                     </group>
-                    <group string="Group By">
+                    <group>
                         <filter string="Status" name="status" domain="[]" context="{'group_by':'state'}"/>
                         <filter string="Author" name="author" context="{'group_by':'author_id'}"/>
                         <filter string="Thread" name="thread" domain="[]" context="{'group_by':'message_id'}"/>

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -133,7 +133,7 @@
                     <filter name="my_templates" string="My Templates" domain="[('user_id', '=', uid)]"/>
                     <filter name="base_templates" string="Base Templates" domain="[('template_category', '=', 'base_template')]"/>
                     <filter name="custom_templates" string="Custom Templates" domain="[('template_category', '=', 'custom_template')]"/>
-                    <group string="Group by...">
+                    <group>
                         <filter string="SMTP Server" name="smtpserver" domain="[]" context="{'group_by':'mail_server_id'}"/>
                         <filter string="Model" name="group_by_model_id" domain="[]" context="{'group_by':'model_id'}"/>
                     </group>

--- a/addons/mail/views/res_role_views.xml
+++ b/addons/mail/views/res_role_views.xml
@@ -9,7 +9,7 @@
                     <field name="name" string="Role"/>
                     <field name="user_ids"/>
                     <filter string="My Roles" name="my_role_ids" domain="[('user_ids', '=', uid)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Users" name="filter_user_ids" domain="[]" context="{'group_by': 'user_ids'}"/>
                     </group>
                 </search>

--- a/addons/mail_group/views/mail_group_message_views.xml
+++ b/addons/mail_group/views/mail_group_message_views.xml
@@ -99,7 +99,7 @@
                 <field name="author_id"/>
                 <field name="moderation_status"/>
                 <separator/>
-                <group string="Group By">
+                <group>
                     <filter string="group" name="group_by_group" context="{'group_by': 'mail_group_id'}"/>
                 </group>
             </search>

--- a/addons/mail_group/views/mail_group_views.xml
+++ b/addons/mail_group/views/mail_group_views.xml
@@ -174,7 +174,7 @@
                 <separator/>
                 <filter string="Archived" name="archived" domain="[('active', '=', False)]"/>
                 <filter string="Moderated" name="moderation" domain="[('moderation', '=', True)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Moderation" name="Moderation" context="{'group_by':'moderation'}"/>
                 </group>
             </search>

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -45,7 +45,7 @@
                 <separator/>
                 <filter string="Active" name="active" domain="[('archive', '=', False)]"/>
                 <filter string="Cancelled" name="inactive" domain="[('archive', '=', True)]"/>
-                <group string='Group by...'>
+                <group>
                     <filter string='Assigned to' name="assigned" domain="[]" context="{'group_by': 'user_id'}"/>
                     <filter string='Category' name="category" domain="[]" context="{'group_by' : 'category_id'}"/>
                     <filter string='Stage' name="stages" domain="[]" context="{'group_by' : 'stage_id'}"/>
@@ -537,7 +537,7 @@
                     domain="[('activity_date_deadline', '&gt;', 'today')]"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
-                <group string='Group by...'>
+                <group>
                     <filter string='Technician' name="technicians" domain="[]" context="{'group_by': 'technician_user_id'}"/>
                     <filter string='Category' name="category" domain="[]" context="{'group_by': 'category_id'}"/>
                     <filter string='Owner' name="owner" domain="[]" context="{'group_by': 'owner_user_id'}"/>
@@ -643,7 +643,7 @@
         <field name="arch" type="xml">
             <search string="Search">
                 <field name="name" string="Category Name" filter_domain="[('name','ilike',self)]"/>
-                <group  string='Group by...'>
+                <group>
                     <filter string='Responsible' name="responsible" domain="[]" context="{'group_by' : 'technician_user_id'}"/>
                 </group>
             </search>

--- a/addons/marketing_card/views/card_campaign_views.xml
+++ b/addons/marketing_card/views/card_campaign_views.xml
@@ -207,7 +207,7 @@
                 <field name="name"/>
                 <field name="tag_ids"/>
                 <separator/>
-                <group string="Group By">
+                <group>
                     <filter string="Responsible" name="by_responsible" domain="[]" context="{'group_by': 'user_id'}"/>
                     <filter string="Tags" name="by_tags" domain="[]" context="{'group_by': 'tag_ids'}"/>
                 </group>

--- a/addons/marketing_card/views/card_card_views.xml
+++ b/addons/marketing_card/views/card_card_views.xml
@@ -21,12 +21,12 @@
         <field name="model">card.card</field>
         <field name="arch" type="xml">
             <search string="Search Card">
-                <group string="Filter By">
+                <group>
                     <field name="share_status"/>
                     <filter string="Shared" name="filter_shared" domain="[('share_status', '=', 'shared')]"/>
                     <filter string="Visited" name="filter_visited" domain="[('share_status', '=', 'visited')]"/>
                 </group>
-                <group string="Group By">
+                <group>
                     <field name="campaign_id"/>
                     <filter string="Campaign" name="by_campaign" context="{'group_by': 'campaign_id'}"/>
                 </group>

--- a/addons/mass_mailing/report/mailing_trace_report_views.xml
+++ b/addons/mass_mailing/report/mailing_trace_report_views.xml
@@ -65,10 +65,10 @@
                     <field name="name" string="Mailing"/>
                     <field name="campaign" string="Campaign" groups="mass_mailing.group_mass_mailing_campaign"/>
                     <filter name="filter_scheduled_date" date="scheduled_date"/>
-                    <group string="Extended Filters...">
+                    <group>
                         <field name="scheduled_date"/>
                     </group>
-                    <group string="Group By...">
+                    <group>
                         <filter string="Mass Mailing Campaign" domain="[]" name="mass_mailing_campaign"
                             context="{'group_by':'campaign'}" groups="mass_mailing.group_mass_mailing_campaign"/>
                         <filter string="State" domain="[]" name="state"

--- a/addons/mass_mailing/views/mail_blacklist_views.xml
+++ b/addons/mass_mailing/views/mail_blacklist_views.xml
@@ -28,7 +28,7 @@
         <field name="inherit_id" ref="mail.mail_blacklist_view_search"/>
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='inactive']" position="after">
-                <group string="Group By">
+                <group>
                     <filter string="Reason"
                             name="group_by_opt_out_reason_id"
                             context="{'group_by': 'opt_out_reason_id'}"/>

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -29,7 +29,7 @@
                     name="filter_not_optout"
                     domain="[('opt_out', '=', False)]"
                     invisible="not context.get('default_list_ids')"/>
-                <group string="Group By">
+                <group>
                     <filter string="Creation Date" name="group_create_date"
                         context="{'group_by': 'create_date'}"/>
                     <filter string="Properties" name="group_properties"

--- a/addons/mass_mailing/views/mailing_filter_views.xml
+++ b/addons/mass_mailing/views/mailing_filter_views.xml
@@ -11,7 +11,7 @@
                         name="filter_saved_by_me"
                         domain="[('create_uid', '=', uid)]"
                         help="Filters saved by me"/>
-                <group string="Group By">
+                <group>
                     <filter name="groupby_recepient_model"
                             context="{'group_by' : 'mailing_model_id'}"
                             string="Recipients"/>

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -9,7 +9,7 @@
                 <field name="name"/>
                 <field name="create_date"/>
                 <filter name="inactive" string="Archived" domain="[('active','=',False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Creation Period" name="group_create_date"
                         context="{'group_by': 'create_date'}"/>
                 </group>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -19,7 +19,7 @@
                         domain="[('ab_testing_enabled', '=', True), ('ab_testing_winner_selection', '=', 'manual'), ('ab_testing_completed', '=', False)]"/>
                     <separator/>
                     <filter name="inactive" string="Archived" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Status" name="group_state" context="{'group_by': 'state'}"/>
                         <filter string="Sent By" name="sent_by" domain="[]" context="{'group_by': 'email_from'}"/>
                         <filter string="Mailing List" name="group_by_contact_list_ids" domain="[]" context="{'group_by': 'contact_list_ids'}"/>

--- a/addons/mass_mailing/views/mailing_subscription_views.xml
+++ b/addons/mass_mailing/views/mailing_subscription_views.xml
@@ -78,7 +78,7 @@
                 <filter string="Subscription Date" name="filter_create_date" date="create_date" default_period="month"/>
                 <separator/>
                 <filter string="Unsubscription Date" name="filter_opt_out_datetime" date="opt_out_datetime" default_period="month"/>
-                <group string="Group By">
+                <group>
                     <filter string="Unsubscription Date" name="group_by_opt_out_datetime" context="{'group_by': 'opt_out_datetime:week'}"/>
                     <filter string="Mailing List" name="group_by_list_id" context="{'group_by': 'list_id'}"/>
                     <filter string="Reason" name="group_by_opt_out_reason_id" context="{'group_by': 'opt_out_reason_id'}"/>

--- a/addons/mass_mailing/views/mailing_trace_views.xml
+++ b/addons/mass_mailing/views/mailing_trace_views.xml
@@ -21,7 +21,7 @@
                 <filter string="Bounced" name="filter_bounced" domain="[('trace_status', '=', 'bounce')]"/>
                 <filter string="Failed" name="filter_failed" domain="[('trace_status', '=', 'error')]"/>
                 <filter string="Test Traces" name="filter_is_test_trace" domain="[('is_test_trace', '=', 'True')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="State" name="state" domain="[]" context="{'group_by': 'trace_status'}"/>
                     <filter string="Open Date" name="group_open_date" domain="[('trace_status', 'in', ['open', 'reply'])]" context="{'group_by': 'open_datetime:day'}"/>
                     <filter string="Reply Date" name="group_reply_date" domain="[('trace_status', '=', 'reply')]" context="{'group_by': 'reply_datetime:day'}"/>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -222,7 +222,7 @@
                     <filter string="Kit" name="phantom" domain="[('type', '=', 'phantom')]"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By...">
+                    <group>
                         <filter string="Product" name="product" domain="[]" context="{'group_by': 'product_tmpl_id'}"/>
                         <filter string='BoM Type' name="group_by_type" domain="[]" context="{'group_by' : 'type'}"/>
                         <filter string='Unit' name="default_unit_of_measure" domain="[]" context="{'group_by' : 'product_uom_id'}"/>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -674,7 +674,7 @@
                     <separator/>
                     <filter string="Warnings" name="activities_exception"
                         domain="[('activity_exception_decoration', '!=', False)]"/>
-                    <group string="Group By...">
+                    <group>
                         <filter string="Product" name="product" domain="[]" context="{'group_by': 'product_id'}"/>
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
                         <filter string="Material Availability" name="groupby_reservation_state" domain="[]" context="{'group_by': 'reservation_state'}"/>

--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -24,7 +24,7 @@
                 <search string="Search">
                     <field name="product_id"/>
                     <field name="mo_id"/>
-                    <group string="Filters">
+                    <group>
                         <filter name="draft" string="Draft" domain="[('state', '=', 'draft')]"/>
                         <filter name="done" string="Done" domain="[('state', '=', 'done')]"/>
                         <filter invisible="1" string="My Activities" name="filter_activities_my"
@@ -38,7 +38,7 @@
                         <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                             domain="[('activity_date_deadline', '&gt;', 'today')]"/>
                     </group>
-                    <group string='Group by...'>
+                    <group>
                         <filter string='Product' name="productgroup" context="{'group_by': 'product_id'}"/>
                         <filter string="Manufacturing Order" name="mogroup" context="{'group_by': 'mo_id'}"/>
                     </group>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -366,7 +366,7 @@
                 <search string="Search for mrp workcenter">
                     <field name="name" string="Work Center" filter_domain="['|', ('name', 'ilike', self), ('code', 'ilike', self)]"/>
                     <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
-                    <group string="Group By...">
+                    <group>
                         <filter string="Company" name="company" domain="[]" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                     </group>
                 </search>
@@ -492,7 +492,7 @@
                 <filter name="productive" string="Fully Productive" domain="[('loss_type','=','productive')]"/>
                 <filter name="filter_date_start" string="Date" date="date_start"/>
                 <separator/>
-                <group string='Group by...'>
+                <group>
                     <filter string="User" name="user" context="{'group_by': 'create_uid'}"/>
                     <filter string='Workcenter' name="workcenter_group" context="{'group_by': 'workcenter_id'}"/>
                     <filter string="Loss Reason" name="loss_group" context="{'group_by': 'loss_id'}"/>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -16,7 +16,7 @@
                 <filter string="Late" name="late" domain="[('date_start','&lt;=',time.strftime('%Y-%m-%d'))]"/>
                 <separator/>
                 <filter string="Start Date" name="date_start_filter" date="date_start"/>
-                <group string="Group By...">
+                <group>
                     <filter string="Work center" name="workcenter" domain="[]" context="{'group_by': 'workcenter_id'}"/>
                     <filter string="Product" name="product" domain="[]" context="{'group_by': 'product_id'}"/>
                 </group>
@@ -290,7 +290,7 @@
                 <separator/>
                 <filter string="Late" name="late" domain="['&amp;', ('date_start', '&lt;', 'now'), ('state', '=', 'ready')]"
                     help="Production started late"/>
-                <group string="Group By">
+                <group>
                     <filter string="Work Center" name="work_center" domain="[]" context="{'group_by': 'workcenter_id'}"/>
                     <filter string="Manufacturing Order" name="production" domain="[]" context="{'group_by': 'production_id'}"/>
                     <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -205,7 +205,7 @@
                        ]"
                 />
                 <filter name="provider_installed" string="Installed" domain="[('module_state', '=', 'installed')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Provider" name="code" context="{'group_by': 'code'}"/>
                     <filter string="State" name="state" context="{'group_by': 'state'}"/>
                     <filter string="Company" name="company" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>

--- a/addons/payment/views/payment_token_views.xml
+++ b/addons/payment/views/payment_token_views.xml
@@ -55,7 +55,7 @@
                 <field name="partner_id"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Provider" name="provider_id" context="{'group_by': 'provider_id'}"/>
                     <filter string="Partner" name="partner_id" context="{'group_by': 'partner_id'}"/>
                     <filter string="Company" name="company" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -113,7 +113,7 @@
                 <field name="provider_id"/>
                 <field name="partner_id"/>
                 <field name="partner_name"/>
-                <group string="Group By">
+                <group>
                     <filter string="Provider" name="provider_id" context="{'group_by': 'provider_id'}"/>
                     <filter string="Partner" name="partner_id" context="{'group_by': 'partner_id'}"/>
                     <filter string="Status" name="state" context="{'group_by': 'state'}"/>

--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -59,7 +59,7 @@
                     <field name="partner_id"/>
                     <field name="product_id"/>
                     <field name="product_categ_id"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="User" name="User" context="{'group_by':'user_id'}"/>
                         <filter string="Point of Sale" name="pos" context="{'group_by':'config_id'}"/>
                         <filter string="Product" name="product" context="{'group_by':'product_id'}"/>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -425,7 +425,7 @@
                 <filter string="Cancelled" name="cancelled" domain="[('state', '=', 'cancel')]"/>
                 <separator/>
                 <filter string="Order Date" name="order_date" date="date_order"/>
-                <group string="Group By">
+                <group>
                     <filter string="Session" name="session" domain="[]" context="{'group_by': 'session_id'}"/>
                     <filter string="User" name="user_id" domain="[]" context="{'group_by': 'user_id'}"/>
                     <filter string="Point of Sale" name="config_id" domain="[]" context="{'group_by': 'config_id'}"/>

--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -67,7 +67,7 @@
             <search string="Payment Methods">
                 <field name="name"/>
                 <field name="receivable_account_id" groups="account.group_account_readonly" />
-                <group string="Group By">
+                <group>
                     <filter name="group_by_receivable_account" string="Account" domain="[]"  context="{'group_by':'receivable_account_id'}"/>
                     <filter name="group_by_pos_config" string="Point of Sale" domain="[]" context="{'group_by':'config_ids'}"/>
                     <filter name="group_by_method_name" string="Method Name" domain="[]" context="{'group_by':'name'}"/>

--- a/addons/point_of_sale/views/pos_payment_views.xml
+++ b/addons/point_of_sale/views/pos_payment_views.xml
@@ -49,7 +49,7 @@
                 <field name="name"/>
                 <field name="amount"/>
                 <field name="pos_order_id" />
-                <group string="Group By">
+                <group>
                     <filter name="group_by_payment_method" string="Payment Method" domain="[]"  context="{'group_by':'payment_method_id'}"/>
                     <filter name="group_by_session" string="Session" domain="[]"  context="{'group_by':'session_id'}"/>
                 </group>

--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -132,7 +132,7 @@
                 <filter name="open_sessions" string="In Progress" domain="[('state', '=', 'opened')]"/>
                 <separator/>
                 <filter string="Opening Date" name="start_date" date="start_at" />
-                <group string="Group By">
+                <group>
                     <filter string="Opened By" name="user" domain="[]" context="{'group_by' : 'user_id'}"/>
                     <filter string="Point of Sale" name="point_of_sale" domain="[]" context="{'group_by': 'config_id'}"/>
                     <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>

--- a/addons/privacy_lookup/wizard/privacy_lookup_wizard_views.xml
+++ b/addons/privacy_lookup/wizard/privacy_lookup_wizard_views.xml
@@ -71,7 +71,7 @@
                 <field name="is_active" invisible="1"/>
                 <filter string="Can be archived" name="can_be_archived" domain="[('has_active', '=', True)]"/>
                 <filter string="Archived" name="archived" domain="[('is_active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Model" name="group_by_res_model_id" domain="[]" context="{'group_by': 'res_model_id'}"/>
                 </group>
             </search>

--- a/addons/product/views/product_pricelist_item_views.xml
+++ b/addons/product/views/product_pricelist_item_views.xml
@@ -13,7 +13,7 @@
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="currency_id" groups="base.group_multi_currency"/>
                 <filter string="Active" name="visible" domain="[('pricelist_id.active', '=', True)]"/>
-                <group string="Group By">
+                <group>
                     <filter
                         string="Product"
                         name="groupby_product"

--- a/addons/product/views/product_supplierinfo_views.xml
+++ b/addons/product/views/product_supplierinfo_views.xml
@@ -55,7 +55,7 @@
                 <separator />
                 <filter string="Active" name="active" domain="['|', ('date_end', '=', False), ('date_end', '&gt;=',  'today -1d')]"/>
                 <filter string="Archived" name="archived" domain="[('date_end', '&lt;',  'today -1d')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Product" name="groupby_product" domain="[]" context="{'group_by': 'product_tmpl_id'}"/>
                     <filter string="Vendor" name="groupby_vendor" domain="[]" context="{'group_by': 'partner_id'}"/>
                 </group>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -262,7 +262,7 @@
                         domain="[('activity_exception_decoration', '!=', False)]"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Product Type" name="group_by_type" context="{'group_by':'type'}"/>
                     <filter string="Product Category" name="group_by_categ_id" context="{'group_by':'categ_id'}"/>
                     <filter string="Product Properties" name="group_by_product_properties" context="{'group_by': 'product_properties'}"/>
@@ -721,7 +721,7 @@ action = {
                         name="goods"
                         domain="[('type', '=', 'consu')]"/>
                 <!-- Group By -->
-                <group string="Group By">
+                <group>
                     <filter string="Product Type" name="type" context="{'group_by':'type'}"/>
                     <filter string="Product Category"
                             name="categ_id"

--- a/addons/project/report/project_task_burndown_chart_report_views.xml
+++ b/addons/project/report/project_task_burndown_chart_report_views.xml
@@ -24,7 +24,7 @@
                 <separator/>
                 <filter string="Open Tasks" name="open_tasks" domain="[('is_closed', '=', 'open')]"/>
                 <filter string="Closed Tasks" name="closed_tasks" domain="[('is_closed', '=', 'closed')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Date" name="date" context="{'group_by': 'date:week'}" />
                     <filter string="Stage (Burndown Chart)" name="stage" context="{'group_by': 'stage_id'}"/>
                     <filter string="Is Closed (Burn-up Chart)" name="is_closed" context="{'group_by': 'is_closed'}"/>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -197,7 +197,7 @@
                         domain="[('activity_date_deadline', '=', 'today')]"/>
                     <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Project Manager" name="Manager" context="{'group_by': 'user_id'}"/>
                         <filter string="Stage" name="groupby_stage" context="{'group_by': 'stage_id'}" groups="project.group_project_stages"/>
                         <filter string="Status" name="status" context="{'group_by': 'last_update_status'}" invisible="context.get('default_is_template')"/>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -10,7 +10,7 @@
                    <field name="mail_template_id"/>
                    <field name="rating_template_id"/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Projects" name="project_ids" context="{'group_by': 'project_ids'}"/>
                     </group>
                 </search>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -28,7 +28,7 @@
                         <filter name="create_date_last_30_days" string="Last 30 Days" domain="[('date_last_stage_update', '&gt;=', 'today -30d +1d')]"/>
                         <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('date_last_stage_update', '&gt;=', 'today -365d +1d')]"/>
                     </filter>
-                    <group string="Group By">
+                    <group>
                         <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}" groups="project.group_project_milestone"/>
                         <filter string="Priority" name="groupby_priority" context="{'group_by': 'priority'}"/>

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -257,7 +257,7 @@
                         domain="[('activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Priority" name="groupby_priority" context="{'group_by': 'priority'}"/>
                     <filter string="Tags" name="tags" help="By assigned tags" context="{'group_by':'tag_ids'}"/>
                     <filter string="Assignees" name="user_ids" context="{'group_by': 'user_ids'}"/>

--- a/addons/purchase/report/purchase_report_views.xml
+++ b/addons/purchase/report/purchase_report_views.xml
@@ -58,14 +58,14 @@
                 <filter name="filter_date_approve" date="date_approve" default_period="month"/>
                 <field name="partner_id"/>
                 <field name="product_id"/>
-                <group string="Extended Filters">
+                <group>
                     <field name="user_id"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <field name="date_order"/>
                     <field name="date_approve"/>
                     <field name="category_id" filter_domain="[('category_id', 'child_of', self)]"/>
                 </group>
-                <group string="Group By">
+                <group>
                     <filter string="Vendor" name="group_partner_id" context="{'group_by':'partner_id'}"/>
                     <filter string="Vendor Country" name="country_id" context="{'group_by':'country_id'}"/>
                     <filter string="Buyer" name="user_id" context="{'group_by':'user_id'}"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -449,7 +449,7 @@
                     <separator/>
                     <filter string="Warnings" name="activities_exception"
                         domain="[('activity_exception_decoration', '!=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Vendor" name="vendor" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Buyer" name="representative" domain="[]" context="{'group_by': 'user_id'}"/>
                         <filter string="Order Date" name="order_date" domain="[]" context="{'group_by': 'date_order'}"/>
@@ -491,7 +491,7 @@
                     <separator/>
                     <filter string="Warnings" name="activities_exception"
                         domain="[('activity_exception_decoration', '!=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Vendor" name="vendor" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter string="Buyer" name="representative" domain="[]" context="{'group_by': 'user_id'}"/>
                         <filter string="Order Date" name="order_date" domain="[]" context="{'group_by': 'date_order'}"/>
@@ -802,7 +802,7 @@
                         domain="[
                             ('date_order', '>', 'today -1y')
                         ]" invisible="1"/>
-                    <group string="Group By">
+                    <group>
                         <filter name="groupby_supplier" string="Vendor" domain="[]" context="{'group_by' : 'partner_id'}" />
                         <filter name="groupby_product" string="Product" domain="[]" context="{'group_by' : 'product_id'}" />
                         <filter string="Order Reference" name="order_reference" domain="[]" context="{'group_by' :'order_id'}"/>

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -185,7 +185,7 @@
                         domain="[('activity_date_deadline', '=', 'today')]"/>
                     <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Purchase Representative" name="representative" domain="[]" context="{'group_by': 'user_id'}"/>
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
                         <filter string="Ordering Date" name="date_start" domain="[]" context="{'group_by': 'date_start'}"/>

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -200,7 +200,7 @@
                         <filter name="rated_on_last_30_days" string="Last 30 Days" domain="[('rated_on', '&gt;', 'today -30d +1d')]"/>
                         <filter name="rated_on_last_365_days" string="Last 365 Days" domain="[('rated_on', '&gt;', 'today -365d +1d')]"/>
                     </filter>
-                    <group string="Group By">
+                    <group>
                         <filter string="Rated Operator" name="responsible" context="{'group_by':'rated_partner_id'}"/>
                         <filter string="Customer" name="customer" context="{'group_by':'partner_id'}"/>
                         <filter string="Rating" name="rating_text" context="{'group_by':'rating_text'}"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -256,7 +256,7 @@
                     domain="[('activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Customer" name="partner" domain="[]" context="{'group_by': 'partner_id'}"/>
                     <filter string="Product" name="product" domain="[]" context="{'group_by': 'product_id'}"/>
                     <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>

--- a/addons/resource/views/resource_calendar_leaves_views.xml
+++ b/addons/resource/views/resource_calendar_leaves_views.xml
@@ -10,7 +10,7 @@
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="calendar_id"/>
                 <filter name="filter_date" date="date_from" default_period="year" string="Period"/>
-                <group string="Group By">
+                <group>
                     <filter string="Resource" name="resource" domain="[]" context="{'group_by':'resource_id'}"/>
                     <filter string="Company" name="company" domain="[]" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
                     <filter string="Date" name="leave_month" domain="[]" context="{'group_by':'date_from'}" help="Starting Date of Time Off"/>

--- a/addons/resource/views/resource_resource_views.xml
+++ b/addons/resource/views/resource_resource_views.xml
@@ -16,7 +16,7 @@
                <filter string="Material" name="material" domain="[('resource_type','=', 'material')]"/>
                <separator />
                <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
-               <group string="Group By">
+               <group>
                     <filter string="User" name="user" domain="[]" context="{'group_by':'user_id'}"/>
                     <filter string="Type" name="type" domain="[]" context="{'group_by':'resource_type'}"/>
                     <filter string="Company" name="company" domain="[]" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>

--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -96,11 +96,11 @@
                 <field name="partner_id"/>
                 <field name="country_id"/>
                 <field name="industry_id"/>
-                <group string="Extended Filters">
+                <group>
                     <field name="categ_id" filter_domain="[('categ_id', 'child_of', self)]"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                 </group>
-                <group string="Group By">
+                <group>
                     <filter string="Salesperson" name="User" context="{'group_by':'user_id'}"/>
                     <filter string="Sales Team" name="sales_channel" context="{'group_by':'team_id'}"/>
                     <filter string="Customer" name="Customer" context="{'group_by':'partner_id'}"/>

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -103,7 +103,7 @@
                 <field name="order_partner_id" operator="child_of"/>
                 <field name="product_id"/>
                 <field name="salesman_id"/>
-                <group string="Group By">
+                <group>
                     <filter string="Product" name="product" context="{'group_by':'product_id'}"/>
                     <filter string="Order" name="order" context="{'group_by':'order_id'}"/>
                     <filter string="Salesperson" name="salesperson" context="{'group_by':'salesman_id'}"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -923,7 +923,7 @@
                     domain="[('activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                <group string="Group By">
+                <group>
                     <filter name="salesperson" string="Salesperson" context="{'group_by': 'user_id'}"/>
                     <filter name="customer" string="Customer" context="{'group_by': 'partner_id'}"/>
                     <filter name="order_month" string="Order Date" context="{'group_by': 'date_order'}"/>

--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -7,7 +7,7 @@
             <search string="Search Quotation Template">
                 <field name="name"/>
                 <filter string="Archived" name="inactive" domain="[('active','=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Company" name="company_id" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                 </group>
             </search>

--- a/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
+++ b/addons/sale_pdf_quote_builder/views/quotation_document_views.xml
@@ -136,7 +136,7 @@
             <search string="Quotation Document">
                 <field name="name"/>
                 <separator/>
-                <group string="Group By">
+                <group>
                     <filter
                         string="Document type"
                         name="doc_type"

--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -10,7 +10,7 @@
                 <field name="crm_team_id"/>
                 <separator/>
                 <filter name="archived" string="Archived" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Sales Team" name="groupby_crm_team_id" context="{'group_by': 'crm_team_id'}"/>
                 </group>
             </search>

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -10,7 +10,7 @@
                 <field name="name"/>
                 <field name="user_id"/>
                 <field name="member_ids"/>
-                <group string="Group By...">
+                <group>
                     <filter string="Company" name="company" domain="[]" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                     <filter string="Team Leader" name="team_leader" domain="[]" context="{'group_by': 'user_id'}"/>
                 </group>

--- a/addons/stock/views/product_strategy_views.xml
+++ b/addons/stock/views/product_strategy_views.xml
@@ -82,7 +82,7 @@
                 <field name="category_id"/>
                 <field name="location_in_id"/>
                 <field name="location_out_id"/>
-                <group string='Filters'>
+                <group>
                     <filter name="filter_to_rules_on_product"
                             string="Rules on Products"
                             domain="[('product_id', '!=', False)]"/>
@@ -90,7 +90,7 @@
                             string="Rules on Categories"
                             domain="[('category_id' ,'!=', False)]"/>
                 </group>
-                <group string="Group By">
+                <group>
                         <filter string="Location: When arrives to" name="location_in" context="{'group_by':'location_in_id'}"/>
                         <filter string="Location: Store to" name="location_out" context="{'group_by':'location_out_id'}"/>
                     </group>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -89,7 +89,7 @@
                 <field name="warehouse_id" string="Warehouse"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Warehouse" name="warehouse" domain="[]" context="{'group_by': 'warehouse_id'}"/>
                     <filter string="Location Type" name="usage" domain="[]" context="{'group_by': 'usage'}"/>
                 </group>

--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -109,7 +109,7 @@
                 <filter string="At Customer" name="at_customer" domain="[('quant_ids.location_id.usage','=','customer'), ('quant_ids.quantity', '>', 0)]"/>
                 <filter string="On Hand" name="on_hand" domain="[('product_qty', '>', 0)]"/>
                 <filter string="Creation Date" name="creation_date" date="create_date"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_product" string="Product" domain="[]" context="{'group_by': 'product_id'}"/>
                     <filter name="group_by_location" string="Location" domain="[]" context="{'group_by': 'location_id'}" groups="stock.group_stock_multi_locations"/>
                     <filter name="group_by_creation_date" string="Creation date" domain="[]" context="{'group_by': 'create_date'}"/>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -152,7 +152,7 @@
                 <separator/>
                 <filter string="Inventory Adjustments" name="inventory" domain="[('is_inventory', '=', True)]"/>
                 <separator/>
-                <group string="Group By" name="groupby">
+                <group name="groupby">
                     <filter string="Product" name="groupby_product_id" domain="[]" context="{'group_by': 'product_id'}"/>
                     <filter string="Status" name="by_state" domain="[]"  context="{'group_by': 'state'}"/>
                     <filter string="Date" name="by_date" domain="[]" context="{'group_by': 'date'}"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -345,7 +345,7 @@
                     <filter string="Inventory" name="inventory" domain="[('is_inventory', '=', True)]"/>
                     <separator/>
                     <filter string="Date" name="today" date="date" help="Scheduled or processing date"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Product" name="by_product" domain="[]"  context="{'group_by': 'product_id'}"/>
                         <filter string="Operation Type" name="groupby_picking_type_id" domain="[]"  context="{'group_by': 'picking_type_id'}"/>
                         <filter string="Picking" name="groupby_picking_id" domain="[]"  context="{'group_by': 'picking_id'}"/>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -79,7 +79,7 @@
                 <filter string="To Reorder" name="filter_to_reorder" domain="[('qty_to_order', '&gt;', 0.0)]"/>
                 <separator/>
                 <filter string="Not Snoozed" name="filter_not_snoozed" domain="['|', ('snoozed_until', '=', False), ('snoozed_until', '&lt;=', 'today')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Warehouse" name="groupby_warehouse" domain="[]"  context="{'group_by': 'warehouse_id'}" groups="stock.group_stock_multi_warehouses"/>
                     <filter string="Location" name="groupby_location" domain="[]" context="{'group_by': 'location_id'}" groups="stock.group_stock_multi_locations"/>
                     <filter string="Product" name="groupby_product" domain="[]" context="{'group_by': 'product_id'}"/>
@@ -107,7 +107,7 @@
                 <field name="warehouse_id" groups="stock.group_stock_multi_warehouses"/>
                 <field name="location_id" groups="stock.group_stock_multi_locations"/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Warehouse" name="warehouse" domain="[]"  context="{'group_by': 'warehouse_id'}" groups="stock.group_stock_multi_warehouses"/>
                     <filter string="Location" name="location" domain="[]" context="{'group_by': 'location_id'}" groups="stock.group_stock_multi_locations"/>
                     <filter string="Product" name="product" domain="[]" context="{'group_by': 'product_id'}"/>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -47,7 +47,7 @@
                 <field name="warehouse_id"/>
                 <filter name="favorites" string="Favorites" domain="[('is_favorite', '=', True)]"/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Type of Operation" name="groupby_code" domain="[]" context="{'group_by': 'code'}"/>
                     <filter string="Warehouse" name="groupby_warehouse_id" domain="[]" context="{'group_by': 'warehouse_id'}"/>
                 </group>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -385,7 +385,7 @@
                     <separator/>
                     <filter string="Warnings" name="activities_exception"
                         domain="[('activity_exception_decoration', '!=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
                         <filter string="Scheduled Date" name="expected_date" domain="[]" context="{'group_by': 'scheduled_date'}"/>
                         <filter string="Source Document" name="origin" domain="[]" context="{'group_by': 'origin'}"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -30,7 +30,7 @@
                 <field name="lot_id" groups="stock.group_production_lot"/>
                 <field name="owner_id" groups="stock.group_tracking_owner"/>
                 <field name="lot_properties"/>
-                <group string='Filters'>
+                <group>
                     <filter name='internal_loc' string="Internal Locations" domain="[('location_id.usage','=', 'internal')]"/>
                     <filter name='transit_loc' string="Transit Locations" domain="[('location_id.usage' ,'=', 'transit')]"/>
                     <separator/>
@@ -48,7 +48,7 @@
                     <separator/>
                     <filter name="my_count" string="My Counts" domain="[('user_id', '=', uid)]"/>
                 </group>
-                <group string='Group by...'>
+                <group>
                     <filter string='Product' name="productgroup" context="{'group_by': 'product_id'}"/>
                     <filter string='Product Category' name="productcategorygroup" context="{'group_by': 'product_categ_id'}"/>
                     <filter string='Location' name="locationgroup" domain="[]" context="{'group_by': 'location_id'}"/>
@@ -254,7 +254,7 @@ No Stock On Hand. This analysis gives you an overview of the current stock level
                 <field name="location_id"/>
                 <field name="package_type_id"/>
                 <filter string="In internal locations" name="internal" domain="['|', ('location_id.usage', '=', 'internal'), ('location_id', '=', False)]" groups="stock.group_stock_multi_locations"/>
-                <group string='Group by...'>
+                <group>
                    <filter string='Location' name="location" domain="[]" context="{'group_by' : 'location_id'}" groups="stock.group_stock_multi_locations"/>
                    <filter string='Package Type' name="package_type" domain="[]" context="{'group_by' : 'package_type_id'}"/>
                </group>

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -32,7 +32,7 @@
                 <search string="Search Procurement">
                     <field name="name"/>
                     <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
-                    <group string='Group by...'>
+                    <group>
                         <filter string='Route' name="groupby_route" context="{'group_by': 'route_id'}"/>
                         <filter string='Destination Location' name="groupby_location_dest" context="{'group_by': 'location_dest_id'}"/>
                         <filter string='Warehouse' name="groupby_warehouse" context="{'group_by': 'warehouse_id'}" groups="stock.group_stock_multi_warehouses"/>

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -11,7 +11,7 @@
                     <field name="location_id"/>
                     <field name="scrap_location_id"/>
                     <field name="create_date"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Product" name="product" domain="[]" context="{'group_by':'product_id'}"/>
                         <filter string="Location" name="location" domain="[]" context="{'group_by':'location_id'}"/>
                         <filter string="Scrap Location" name="scrap_location" domain="[]" context="{'group_by':'scrap_location_id'}"/>

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -154,7 +154,7 @@
                 <filter string="Has Remaining Qty" name="has_remaining_qty" domain="[('remaining_qty', '>', 0)]"/>
                 <separator/>
                 <filter string="Date" name="date" date="create_date" />
-                <group string='Group by...'>
+                <group>
                     <filter string='Product' name="group_by_product_id" context="{'group_by': 'product_id'}"/>
                     <filter string='Lot/Serial Number' name="group_by_lot_id" context="{'group_by': 'lot_id'}"/>
                     <filter string='Product Category' name="group_by_categ_id" context="{'group_by': 'categ_id'}"/>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -197,7 +197,7 @@
                         domain="[('activity_date_deadline', '=', 'today')]"/>
                     <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                         domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Status" name="status" context="{'group_by': 'state'}"/>
                         <filter string="Date" name="group_by_month" context="{'group_by': 'date'}"/>
                     </group>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -234,7 +234,7 @@
                     domain="[('activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Responsible" name="user" domain="[]" context="{'group_by': 'user_id'}"/>
                     <filter string="State" name="state" domain="[]" context="{'group_by': 'state'}"/>
                 </group>

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -307,7 +307,7 @@
                 <field name="title"/>
                 <field name="survey_id" string="Survey"/>
                 <field name="question_type" string="Type"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_type" string="Type" domain="[]" context="{'group_by':'question_type'}"/>
                     <filter name="group_by_survey" string="Survey" domain="[]" context="{'group_by':'survey_id'}"/>
                 </group>
@@ -377,7 +377,7 @@
         <field name="arch" type="xml">
             <search string="Search Label">
                 <field name="question_id"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_question" string="Question" domain="[]" context="{'group_by':'question_id'}"/>
                 </group>
             </search>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -383,7 +383,7 @@
                     domain="[('activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Upcoming Activities" name="activities_upcoming_all"
                     domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Responsible" name="group_by_responsible"
                         context="{'group_by': 'user_id'}"/>
                     <filter name="group_by_restrict_user_ids"

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -21,7 +21,7 @@
                 <separator/>
                 <filter string="Tests Only" name="test" domain="[('test_entry','=', True)]"/>
                 <filter string="Exclude Tests" name="not_test" domain="[('test_entry','=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_survey" string="Survey" domain="[]" context="{'group_by': 'survey_id'}"/>
                     <filter string="Email" name="group_by_email" domain="[]" context="{'group_by': 'email'}"/>
                     <filter string="Partner" name="group_by_partner" domain="[]" context="{'group_by': 'partner_id'}"/>
@@ -218,7 +218,7 @@
             <search string="Search User input lines">
                 <field name="user_input_id"/>
                 <field name="survey_id"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_survey" string="Survey" domain="[]"  context="{'group_by':'survey_id'}"/>
                     <filter name="group_by_lang" string="Language" domain="[]" context="{'group_by':'lang_id'}"/>
                     <filter name="group_by_user_input" string="User Input" domain="[]"  context="{'group_by':'user_input_id'}"/>

--- a/addons/transifex/views/code_translation_views.xml
+++ b/addons/transifex/views/code_translation_views.xml
@@ -28,7 +28,7 @@
                 <field name="value"/>
                 <separator/>
                 <filter string="Not Translated" name="not_translated" domain="[('value', '=', '')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Module" name="group_by_module" context="{'group_by': 'module'}"/>
                 </group>
             </search>

--- a/addons/uom/views/uom_uom_views.xml
+++ b/addons/uom/views/uom_uom_views.xml
@@ -42,7 +42,7 @@
                 <field name="name"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                 </group>
             </search>
         </field>

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -13,7 +13,7 @@
                     help="Campaigns that are assigned to me"/>
                 <separator/>
                 <filter string="Archived" name="filter_inactive" domain="[('active', '=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Stage" name="group_stage_id"
                         context="{'group_by': 'stage_id'}"/>
                     <filter string="Responsible" name="group_user_id"

--- a/addons/website/views/website_controller_pages_views.xml
+++ b/addons/website/views/website_controller_pages_views.xml
@@ -93,7 +93,7 @@
     <field name="arch" type="xml">
         <search>
             <field name="model" filter_domain="[('model','=', self)]" string="Model"/>
-            <group string="Group By" colspan="4">
+            <group colspan="4">
                 <filter string="Model" name="page_model" domain="[]" context="{'group_by':'model'}"/>
                 <filter string="Website" name="page_website_id" domain="[]" context="{'group_by':'website_id'}"/>
             </group>

--- a/addons/website/views/website_rewrite.xml
+++ b/addons/website/views/website_rewrite.xml
@@ -79,7 +79,7 @@
                     <filter string="308 Redirect / Rewrite" name="308" domain="[('redirect_type', '=', '308')]"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Redirection Type" name="group_by_type" domain="[]" context="{'group_by': 'redirect_type'}"/>
                         <filter string="Created by" name="group_by_author" domain="[]" context="{'group_by': 'create_uid'}"/>
                     </group>

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -156,7 +156,7 @@
                     <field name="name"/>
                     <field name="url"/>
                     <field name="website_id" groups="website.group_multi_website"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Name" name="group_by_name" domain="[]" context="{'group_by':'name'}"/>
                         <filter string="Url" name="group_by_url" domain="[]" context="{'group_by':'url'}"/>
                         <filter string="Website"  name="group_by_website_id" domain="[]" context="{'group_by':'website_id'}"/>

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -35,7 +35,7 @@
                 <field name="visit_datetime"/>
                 <filter string="Pages" name="type_page" domain="[('page_id', '!=', False)]"/>
                 <filter string="Urls &amp; Pages" name="type_url" domain="[('url', '!=', False)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Visitor" name="group_by_visitor" domain="[]" context="{'group_by': 'visitor_id'}"/>
                     <filter string="Page" name="group_by_page" domain="[]" context="{'group_by': 'page_id'}"/>
                     <filter string="Url" name="group_by_url" domain="[]" context="{'group_by': 'url'}"/>
@@ -239,7 +239,7 @@
                 <!-- connected in the last 5 minutes -->
                 <filter string="Connected" name="filter_is_connected" domain="[('last_connection_datetime', '&gt;', '-5M')]"/>
                 <separator/>
-                <group string="Group By">
+                <group>
                     <filter string="Country" name="group_by_country" context="{'group_by': 'country_id'}"/>
                     <filter string="Timezone" name="group_by_timezone" context="{'group_by': 'timezone'}"/>
                     <filter string="Language" name="group_by_lang" context="{'group_by': 'lang_id'}"/>

--- a/addons/website_blog/views/website_pages_views.xml
+++ b/addons/website_blog/views/website_pages_views.xml
@@ -85,7 +85,7 @@
             <field name="name" string="Content" filter_domain="['|', ('name','ilike',self), ('content','ilike',self)]"/>
             <field name="write_uid"/>
             <field name="blog_id"/>
-            <group string="Group By">
+            <group>
                 <filter string="Blog" name="group_by_blog" domain="[]" context="{'group_by': 'blog_id'}"/>
                 <filter string="Author" name="group_by_author" domain="[]" context="{'group_by': 'create_uid'}"/>
                 <filter string="Last Contributor" name="last_contributor" domain="[]" context="{'group_by': 'write_uid'}"/>

--- a/addons/website_crm_partner_assign/report/crm_partner_report_view.xml
+++ b/addons/website_crm_partner_assign/report/crm_partner_report_view.xml
@@ -12,7 +12,7 @@
                     <field name="activation"/>
                     <filter name="filter_date_partnership" date="date_partnership"/>
                     <filter name="filter_date_review" date="date_review"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Salesperson" name="user"
                             context="{'group_by':'user_id'}" />
                         <filter string="Partner" name="partner"

--- a/addons/website_event_booth_exhibitor/views/event_booth_category_views.xml
+++ b/addons/website_event_booth_exhibitor/views/event_booth_category_views.xml
@@ -40,7 +40,7 @@
                 <field name="use_sponsor"/>
                 <field name="sponsor_type_id"/>
                 <field name="exhibitor_type"/>
-                <group string="Group By">
+                <group>
                     <filter name="group_by_sponsor_type" string="Sponsor type" context="{'group_by': 'sponsor_type_id'}"/>
                     <filter name="group_by_exhibitor_type" string="Exhibitor type" context="{'group_by':'exhibitor_type'}"/>
                 </group>

--- a/addons/website_event_exhibitor/views/event_sponsor_views.xml
+++ b/addons/website_event_exhibitor/views/event_sponsor_views.xml
@@ -58,7 +58,7 @@
                 <separator/>
                 <filter string="Exhibitors" name="filter_is_exhibitor" domain="[('exhibitor_type', 'in', ['exhibitor', 'online'])]"/>
                 <filter string="Online" name="filter_is_exhibitor" domain="[('exhibitor_type', '=', 'online')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Event" name="group_by_event_id" domain="[]" context="{'group_by': 'event_id'}"/>
                     <filter string="Level" name="group_by_sponsor_type_id" domain="[]" context="{'group_by': 'sponsor_type_id'}"/>
                 </group>

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -116,7 +116,7 @@
                     domain="[('activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('activity_date_deadline', '&gt;', 'today')]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Responsible" name="responsible" context="{'group_by': 'user_id'}"/>
                     <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
                     <filter string="Date" name="date" context="{'group_by': 'date'}"/>

--- a/addons/website_event_track/views/event_track_visitor_views.xml
+++ b/addons/website_event_track/views/event_track_visitor_views.xml
@@ -10,7 +10,7 @@
                 <field name="visitor_id"/>
                 <field name="partner_id"/>
                 <field name="is_wishlisted"/>
-                <group string="Group By">
+                <group>
                     <filter string="Track" name="groupby_track_id" context="{'group_by': 'track_id'}"/>
                     <filter string="Visitor" name="groupby_visitor_id" context="{'group_by': 'visitor_id'}"/>
                     <filter string="Customer" name="groupby_partner_id" context="{'group_by': 'partner_id'}"/>

--- a/addons/website_event_track_quiz/views/event_quiz_question_views.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_question_views.xml
@@ -7,7 +7,7 @@
             <search string="Quiz Questions">
                 <field name="name"/>
                 <field name="quiz_id"/>
-                <group string="Group By">
+                <group>
                     <filter string="Quiz" name="groupby_quiz_id" context="{'group_by': 'quiz_id'}"/>
                 </group>
             </search>

--- a/addons/website_event_track_quiz/views/event_quiz_views.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_views.xml
@@ -8,7 +8,7 @@
                 <field name="name"/>
                 <field name="event_track_id"/>
                 <field name="event_id"/>
-                <group string="Group By">
+                <group>
                     <filter string="Track" name="groupby_event_track_id" context="{'group_by': 'event_track_id'}"/>
                     <filter string="Event" name="groupby_event_id" context="{'group_by': 'event_id'}"/>
                 </group>

--- a/addons/website_forum/views/forum_post_views.xml
+++ b/addons/website_forum/views/forum_post_views.xml
@@ -82,7 +82,7 @@
             <filter name="filter_write_date" date="write_date"/>
             <separator/>
             <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
-            <group string="Group By">
+            <group>
                 <filter string="Forum" name="forum" domain="[]" context="{'group_by': 'forum_id'}"/>
                 <filter string="Author" name="author" domain="[]" context="{'group_by': 'create_uid'}"/>
                 <filter string="Post" name="post" domain="[]" context="{'group_by': 'parent_id'}"/>

--- a/addons/website_sale/report/sale_report_views.xml
+++ b/addons/website_sale/report/sale_report_views.xml
@@ -14,7 +14,7 @@
                 <filter string="Confirmed Orders" name="confirmed" domain="[('state', '=', 'sale')]"/>
                 <separator/>
                 <filter name="filter_date" date="date" default_period="month"/>
-                <group string="Group By">
+                <group>
                     <filter string="Website" name="groupby_website" context="{'group_by':'website_id'}" groups="website.group_multi_website"/>
                     <filter string="Product" name="groupby_product" context="{'group_by':'product_id'}"/>
                     <filter string="Product Category" name="groupby_product_category" context="{'group_by':'categ_id'}"/>

--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -83,7 +83,7 @@
                 <separator/>
                 <filter string="Recovery Email to Send" name="recovery_email" domain="[('cart_recovery_email_sent', '=', False)]" />
                 <filter string="Recovery Email Sent" name="recovery_email_set" domain="[('cart_recovery_email_sent', '=', True)]" />
-                <group string="Group By">
+                <group>
                     <filter string="Order Date" name="order_date" context="{'group_by':'date_order'}"/>
                 </group>
                 <!-- Dashboard filter - used by context -->

--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -16,7 +16,7 @@
                     <filter string="Joined" name="filter_joined" domain="[('member_status', '=', 'joined')]"/>
                     <filter string="Ongoing" name="filter_ongoing" domain="[('member_status', '=', 'ongoing')]"/>
                     <filter string="Completed" name="filter_completed" domain="[('member_status', '=', 'completed')]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Course" name="groupby_channel_id" context="{'group_by': 'channel_id'}"/>
                         <filter string="Status" name="groupby_member_status" context="{'group_by': 'member_status'}"/>
                     </group>

--- a/addons/website_slides/views/slide_slide_partner_views.xml
+++ b/addons/website_slides/views/slide_slide_partner_views.xml
@@ -10,7 +10,7 @@
                 <field name="channel_id"/>
                  <separator/>
                 <filter string="Completed" name="filter_completed" domain="[('completed', '=', True)]"/>
-                <group string="Group By">
+                <group>
                     <filter string="Content" name="groupby_slide_id" context="{'group_by': 'slide_id'}"/>
                 </group>
             </search>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -304,7 +304,7 @@
                     <filter name="not_published" string="Waiting for validation" domain="[('is_published', '=', False)]"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Course" name="groupby_channel" domain="[]" context="{'group_by': 'channel_id'}"/>
                         <filter string="Category" name="groupby_category" domain="[]" context="{'group_by': 'category_id'}"/>
                         <filter string="Type" name="groupby_type" domain="[]" context="{'group_by': 'slide_category'}"/>

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -297,8 +297,6 @@
             <rng:ref name="access_rights"/>
             <rng:optional><rng:attribute name="colspan"/></rng:optional>
             <rng:optional><rng:attribute name="rowspan"/></rng:optional>
-            <rng:optional><rng:attribute name="expand"/></rng:optional>
-            <rng:optional><rng:attribute name="string"/></rng:optional>
             <rng:optional><rng:attribute name="fill"/></rng:optional>
             <rng:optional><rng:attribute name="height"/></rng:optional>
             <rng:optional><rng:attribute name="width"/></rng:optional>

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -132,7 +132,7 @@
                         filter_domain="['|', '|', '|', '|', ('name','ilike',self), ('model','ilike',self), ('type','ilike',self), ('report_name','ilike',self), ('report_type','ilike',self)]"
                         string="Report"/>
                     <field name="model" filter_domain="[('model','=', self)]" string="Model"/>
-                    <group string="Group By" colspan="4">
+                    <group colspan="4">
                         <filter string="Report Type" name="report_type" domain="[]" context="{'group_by':'report_type'}"/>
                         <filter string="Report Model" name="report_model" domain="[]" context="{'group_by':'model'}"/>
                     </group>
@@ -581,7 +581,7 @@ env['res.partner'].create({'name': partner_name})
                     <field name="model_id"/>
                     <field name="state"/>
                     <filter string="Top-level actions" name="toplevel_actions" domain="[('parent_id', '=', False)]"/>
-                    <group string="Group By" colspan="4" col="4">
+                    <group colspan="4" col="4">
                         <filter string="Action Type" name="action_type" domain="[]" context="{'group_by':'state'}"/>
                         <filter string="Model" name="model" domain="[]" context="{'group_by':'model_id'}"/>
                         <filter string="Usage" name="usage" domain="[]" context="{'group_by':'usage'}"/>

--- a/odoo/addons/base/views/ir_attachment_views.xml
+++ b/odoo/addons/base/views/ir_attachment_views.xml
@@ -75,7 +75,7 @@
                     <separator/>
                     <field name="create_uid" string="Created by"/>
                     <field name="type"/>
-                    <group string="Group By">
+                    <group>
                         <filter name="owner" string="Owner" domain="[]" context="{'group_by':'create_uid'}"/>
                         <filter string="Type" name="type" domain="[]" context="{'group_by':'type'}" groups="base.group_no_one"/>
                         <filter string="Company" name="company" domain="[]" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>

--- a/odoo/addons/base/views/ir_cron_views.xml
+++ b/odoo/addons/base/views/ir_cron_views.xml
@@ -74,7 +74,7 @@
                     <filter string="All" name="all" domain="['|', ('active', '=', False), ('active', '=', True)]" />
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="User" name="user" domain="[]" context="{'group_by': 'user_id'}"/>
                         <filter string="Execution" name="execution" domain="[]" context="{'group_by': 'nextcall'}" />
                         <filter string="Model" name="groupby_model_id" domain="[]" context="{'group_by': 'model_id'}"/>

--- a/odoo/addons/base/views/ir_default_views.xml
+++ b/odoo/addons/base/views/ir_default_views.xml
@@ -45,7 +45,7 @@
                 <field name="field_id"/>
                 <field name="user_id"/>
                 <field name="company_id" groups="base.group_multi_company"/>
-                <group string="Group By">
+                <group>
                     <filter string="User" name="groupby_user" domain="[]" context="{'group_by':'user_id'}"/>
                     <filter string="Company" name="groupby_company" domain="[]" context="{'group_by':'company_id'}"/>
                 </group>

--- a/odoo/addons/base/views/ir_filters_views.xml
+++ b/odoo/addons/base/views/ir_filters_views.xml
@@ -64,7 +64,7 @@
                     <filter string="My filters" domain="[('user_ids','in',[uid])]" name="my_filters" help="Filters shared with myself"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="User" name="user" domain="[]" context="{'group_by':'user_ids'}"/>
                         <filter string="Model" name="model" domain="[]" context="{'group_by':'model_id'}"/>
                     </group>

--- a/odoo/addons/base/views/ir_logging_views.xml
+++ b/odoo/addons/base/views/ir_logging_views.xml
@@ -48,7 +48,7 @@
                     <field name="name" />
                     <field name="level" />
                     <field name="message" />
-                    <group string="Group By">
+                    <group>
                         <filter string="Database" name="database" domain="[]" context="{'group_by': 'dbname'}" />
                         <filter string="Level" name="group_by_level" domain="[]" context="{'group_by': 'level'}" />
                         <filter string="Type" name="group_by_type" domain="[]" context="{'group_by': 'type'}" />

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -398,7 +398,7 @@
                     <field name="required"/>
                     <field name="readonly"/>
                     <field name="relation"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Model" name="group_by_object" domain="[]" context="{'group_by':'model_id'}"/>
                         <filter string="Field Type" name="group_by_ttype" domain="[]" context="{'group_by':'ttype'}"/>
                     </group>
@@ -510,7 +510,7 @@
                     <field name="model"/>
                     <field name="res_id"/>
                     <field name="noupdate"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Module" name="group_by_module" domain="[]" context="{'group_by':'module'}"/>
                         <filter string="Model" name="group_by_object" domain="[]" context="{'group_by':'model'}"/>
                     </group>
@@ -564,7 +564,7 @@
                     <field name="model"/>
                     <field name="name"/>
                     <field name="message"/>
-                    <group string="Group By">
+                    <group>
                         <filter name="module" string="Module" context="{'group_by' : 'module'}"/>
                         <filter name="model" string="Model" context="{'group_by': 'model'}"/>
                         <filter name="type" string="Constraint type" context="{'group_by' : 'type'}"/>
@@ -690,7 +690,7 @@
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <field name="model_id"/>
                     <field name="group_id"/>
-                    <group string="Group By" colspan="11" col="11" groups="base.group_no_one">
+                    <group colspan="11" col="11" groups="base.group_no_one">
                         <filter string="Group" name="group" domain="[]" context="{'group_by': 'group_id'}"/>
                         <filter string="Model" name="group_by_object" domain="[]" context="{'group_by': 'model_id'}"/>
                     </group>

--- a/odoo/addons/base/views/ir_module_views.xml
+++ b/odoo/addons/base/views/ir_module_views.xml
@@ -31,7 +31,7 @@
                     <filter name="installed" string="Installed" domain="[('state', 'in', ['installed', 'to upgrade', 'to remove'])]"/>
                     <filter name="not_installed" string="Not Installed" domain="[('state', 'in', ['uninstalled', 'uninstallable', 'to install'])]"/>
                     <field name="category_id"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Author" name="author" domain="[]" context="{'group_by':'author'}"/>
                         <filter string="Category" name="category" domain="[]" context="{'group_by':'category_id'}"/>
                         <filter string="Status" name="state" domain="[]" context="{'group_by':'state'}"/>

--- a/odoo/addons/base/views/ir_rule_views.xml
+++ b/odoo/addons/base/views/ir_rule_views.xml
@@ -86,7 +86,7 @@
                     <filter string="Delete" name="delete_access_right" domain="[('perm_unlink', '=', True)]"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Model" name="group_by_object" domain="[]" context="{'group_by': 'model_id'}"/>
                         <separator/>
                         <filter string="Group" name="group_by_group" domain="[]" context="{'group_by': 'groups'}"/>

--- a/odoo/addons/base/views/ir_ui_view_views.xml
+++ b/odoo/addons/base/views/ir_ui_view_views.xml
@@ -89,7 +89,7 @@
                     <separator/>
                     <filter string="Active" name="active" domain="[('active', '=',True)]"/>
                     <filter string="Inactive" name="inactive" domain="[('active', '=',False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Model" name="object" domain="[]" context="{'group_by':'model'}"/>
                         <filter string="Type" name="type" domain="[]" context="{'group_by':'type'}"/>
                         <filter string="Inherit" name="inherit" domain="[]" context="{'group_by':'inherit_id'}"/>

--- a/odoo/addons/base/views/res_country_views.xml
+++ b/odoo/addons/base/views/res_country_views.xml
@@ -163,7 +163,7 @@
                 <search string="Country">
                     <field name="name"/>
                     <field name="country_id"/>
-                    <group string="Group By">
+                    <group>
                         <filter name="groupby_country" string="Country" context="{'group_by': 'country_id'}"/>
                     </group>
                 </search>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -329,7 +329,7 @@
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <field name="properties"/>
                     <separator/>
-                    <group name="group_by" string="Group By">
+                    <group name="group_by">
                         <filter name="salesperson" string="Salesperson" domain="[]" context="{'group_by' : 'user_id'}" />
                         <filter name="group_company" string="Company" context="{'group_by': 'parent_id'}"/>
                         <filter name="group_country" string="Country" context="{'group_by': 'country_id'}"/>
@@ -532,7 +532,7 @@
                     <field name="display_name" string="Category" />
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-                    <group string="Group By">
+                    <group>
                         <filter string="Category" name="group_parent_id" context="{'group_by': 'parent_id'}"/>
                         <filter string="Color" name="group_color" context="{'group_by': 'color'}"/>
                     </group>


### PR DESCRIPTION
Remove all the occurrences of string attribute
from group in the search view.

Also removed expand, string attribute from 
group rng in seperate commit.

Enterprise PR: https://github.com/odoo/enterprise/pull/90733

Related PR: https://github.com/odoo/odoo/pull/215362 (Remove expand attribute)

task-4915069

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
