### PR TITLE
[REM] website: test case for a form key ending with `\`

### DIFF
--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1144,7 +1144,6 @@ registerWebsitePreviewTour("website_form_special_characters", {
         run: "click",
     },
     ...addCustomField("char", "text", `Test1"'`, false),
-    ...addCustomField("char", "text", 'Test2`\\', false),
     ...clickOnSave(),
     ...essentialFieldsForDefaultFormFillInSteps,
     {
@@ -1155,10 +1154,6 @@ registerWebsitePreviewTour("website_form_special_characters", {
         content: "Complete the first added field",
         trigger: `:iframe input[name="${CSS.escape("Test1&quot;'")}"]`,
         run: "edit test1",
-    }, {
-        content: "Complete the second added field",
-        trigger: `:iframe input[name="${CSS.escape("Test2`\\")}"]`,
-        run: "edit test2",
     }, {
         content: "Click on 'Submit'",
         trigger: ":iframe a.s_website_form_send",

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -62,7 +62,6 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
         self.start_tour('/', 'website_form_special_characters', login='admin')
         mail = self.env['mail.mail'].search([], order='id desc', limit=1)
         self.assertIn('Test1&#34;&#39;', mail.body_html, 'The single quotes and double quotes characters should be visible on the received mail')
-        self.assertIn('Test2`\\', mail.body_html, 'The backtick and backslash characters should be visible on the received mail')
 
     def test_website_form_nested_forms(self):
         self.start_tour('/my/account', 'website_form_nested_forms', login='admin')


### PR DESCRIPTION
In that case Werkzeug 3.0.4 and later will drop the entire name (following pallets/werkzeug#2939, cf pallets/werkzeug#3032), we'll end up with a field named `None` on the python side, and then dispatching will blow up because `None` is not a valid kwarg.

The exact semantics of that case are unclear (see also curl/curl#7789), my reading is that [RFC 7578][1] specifies percent-encoding and thus that should be used when encoding and decoding, and `\` should be irrelevant because it's neither `%` nor `"` so it's not a metacharacter for multipart/form-data headers.

However the [whatwg living standard][2] rejects full blown percent-encoding, and instead uses percent-encoding on just a highly restricted set of inputs (which includes neither `\` nor `%`).

And while it seems like we should be able to ignore RFC 6266 (the content-disposition header) who's to say that there are no real-world deployments which follow its strictures?

Meh.

Backport from  #219478 as I apparently missed this bit when updating #219300

[1]: https://datatracker.ietf.org/doc/html/rfc7578#section-2
[2]: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data

