### PR TITLE
[FIX] website_blog: Fix tour by using editSelectMenu util

### DIFF
--- a/addons/website_blog/static/tests/tours/blog_tags_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_tour.js
@@ -30,14 +30,7 @@ registerWebsitePreviewTour('blog_tags', {
         trigger: "[data-label='Tags'] button.o_select_menu_toggler",
         run: "click",
     },
-    {
-        content: "Enter tag name",
-        trigger: ".o_select_menu_input",
-        run: async function() {
-            this.anchor.value = "testtag";
-            this.anchor.dispatchEvent(new InputEvent("input"));
-        }
-    },
+    ...stepUtils.editSelectMenuInput(".o_select_menu_input", "testtag"),
     {
         content: "Save tag",
         trigger: ".dropdown-menu a.o_we_m2o_create",


### PR DESCRIPTION
This commit fixes a tour that was randomly crashing due to an unexpected timing issue when editing the input of the SelectMenu component.

By using the dedicated util, the behavior should be more consistent and the tour should not crash anymore.

runbot-error-229950