### PR TITLE
[IMP] website_blog: Blog Improvements

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -46,6 +46,7 @@ export class Builder extends Component {
         closeEditor: { type: Function, optional: true },
         reloadEditor: { type: Function, optional: true },
         onEditorLoad: { type: Function, optional: true },
+        newInstalledModule: { type: String, optional: true },
         installSnippetModule: { type: Function, optional: true },
         snippetsName: { type: String },
         toggleMobile: { type: Function },

--- a/addons/html_builder/static/src/builder.xml
+++ b/addons/html_builder/static/src/builder.xml
@@ -41,7 +41,7 @@
         </div>
         <div class="o-tab-content overflow-y-auto overflow-x-hidden flex-grow-1">
             <t t-if="this.state.activeTab === 'blocks'">
-                <BlockTab snippetsName="this.props.snippetsName" />
+                <BlockTab snippetsName="this.props.snippetsName" newInstalledModule="this.props.newInstalledModule"/>
             </t>
             <t t-if="this.state.activeTab === 'customize'">
                 <CustomizeTab currentOptionsContainers="this.state.currentOptionsContainers"/>

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -28,6 +28,7 @@ export class BlockTab extends Component {
     static components = { Snippet, CustomInnerSnippet };
     static props = {
         snippetsName: String,
+        newInstalledModule: { type: String, optional: true }
     };
 
     setup() {
@@ -41,6 +42,9 @@ export class BlockTab extends Component {
 
         onMounted(() => {
             this.makeSnippetDraggable();
+            if (this.props.newInstalledModule) {
+                this.handlePostModuleInstall(this.props.newInstalledModule)
+            }
         });
 
         onWillDestroy(() => {
@@ -548,6 +552,27 @@ export class BlockTab extends Component {
             }
             delete snippetEl.dataset.snippet;
             delete snippetEl.dataset.name;
+        }
+    }
+
+    /**
+     * Opens the corresponding snippet group dialog after the installation of a
+     * newly installed snippet module.
+     *
+     * @param {string} newInstalledModule - The JSON object containing title of 
+     * the snippet group to open.
+     */
+    async handlePostModuleInstall(newInstalledModule) {
+        const { snippetTitle } = JSON.parse(
+            decodeURIComponent(newInstalledModule)
+        );
+        if (snippetTitle) {
+            const snippet = this.snippetModel.snippetGroups.find(
+                (snippetEl) => snippetEl.title === snippetTitle
+            );
+            if (snippet) {
+                await this.onSnippetGroupClick(snippet);
+            }
         }
     }
 }

--- a/addons/website/static/src/client_actions/website_preview/new_content_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/new_content_systray_item.js
@@ -1,5 +1,5 @@
 import { useState } from "@web/owl2/utils";
-import { Component, xml } from "@odoo/owl";
+import { Component, onMounted, xml } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
@@ -24,6 +24,7 @@ export class NewContentSystrayItem extends Component {
     static components = { Dropdown, DropdownItem };
     static props = {
         onNewPage: Function,
+        newInstalledModule: { type: String, optional: true }
     };
 
     setup() {
@@ -106,6 +107,12 @@ export class NewContentSystrayItem extends Component {
 
         useHotkey("escape", () => this.dropdown.close(), {
             isAvailable: () => this.dropdown.isOpen,
+        });
+
+        onMounted(() => {
+            if (this.props.newInstalledModule) {
+                this.handlePostModuleInstall(this.props.newInstalledModule);
+            }
         });
     }
 
@@ -212,7 +219,8 @@ export class NewContentSystrayItem extends Component {
             .filter((el) => ("isDisplayed" in el ? el.isDisplayed : user.isSystem));
     }
 
-    async installModule(id, redirectUrl) {
+    async installModule(id, element) {
+        const { redirectUrl, moduleXmlId } = element;
         await this.orm.silent.call("ir.module.module", "button_immediate_install", [id]);
         if (redirectUrl) {
             this.website.prepareOutLoader();
@@ -230,7 +238,11 @@ export class NewContentSystrayItem extends Component {
             // the feature with patches from the installed module.
             this.website.prepareOutLoader();
             const encodedPath = encodeURIComponent(url.toString());
-            redirect(`/odoo/action-website.website_preview?website_id=${id}&path=${encodedPath}`);
+            const data = { moduleXmlId: moduleXmlId };
+            const encodedData = encodeURIComponent(JSON.stringify(data));
+            redirect(
+                `/odoo/action-website.website_preview?website_id=${id}&path=${encodedPath}&module_installed=${encodedData}`
+            );
         }
     }
 
@@ -255,7 +267,7 @@ export class NewContentSystrayItem extends Component {
                 });
                 this.website.showLoader({ title: _t("Building your %s", name) });
                 try {
-                    await this.installModule(id, element.redirectUrl);
+                    await this.installModule(id, element);
                 } catch (error) {
                     this.website.hideLoader();
                     // Update the NewContentElement with failure icon and text.
@@ -301,5 +313,26 @@ export class NewContentSystrayItem extends Component {
                 },
             },
         });
+    }
+
+    /**
+     * Opens the corresponding snippet new content dialog after the installation
+     * of a newly installed snippet module.
+     *
+     * @param {string} newInstalledModule - The JSON containing XML ID of the 
+     * installed module.
+     */
+    async handlePostModuleInstall(newInstalledModule) {
+        const { moduleXmlId } = JSON.parse(
+            decodeURIComponent(newInstalledModule)
+        );
+        if (moduleXmlId) {
+            const newContentElement = this.state.newContentElements.find(
+                (el) => el.moduleXmlId === moduleXmlId
+            );
+            if (newContentElement?.createNewContent) {
+                return newContentElement.createNewContent();
+            }
+        }
     }
 }

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -216,6 +216,7 @@ export class WebsiteBuilderClientAction extends Component {
             isMobile: this.websiteContext.isMobile,
             initialTab: this.reloadContext?.initialTab,
             onlyCustomizeTab: this.translation,
+            newInstalledModule: this.newInstalledModule,
             config: {
                 reloadContext: this.reloadContext,
                 builderSidebar: {
@@ -569,13 +570,15 @@ export class WebsiteBuilderClientAction extends Component {
         this.ui.unblock();
     }
 
-    reloadWebClient() {
+    reloadWebClient(snippetTitle) {
         const currentPath = encodeURIComponent(window.location.pathname);
         const websiteId = this.websiteService.currentWebsite.id;
+        const data = { snippetTitle: snippetTitle };
+        const encodedData = encodeURIComponent(JSON.stringify(data));
         redirect(
             `/odoo/action-website.website_preview?website_id=${encodeURIComponent(
                 websiteId
-            )}&path=${currentPath}&enable_editor=1`
+            )}&path=${currentPath}&enable_editor=1&module_installed=${encodedData}`
         );
     }
 
@@ -587,7 +590,7 @@ export class WebsiteBuilderClientAction extends Component {
             await this.orm.call("ir.module.module", "button_immediate_install", [
                 [parseInt(snippet.moduleId)],
             ]);
-            this.reloadWebClient();
+            this.reloadWebClient(snippet.title);
         } catch (e) {
             if (e instanceof RPCError) {
                 const message = _t("Could not install module %s", snippet.moduleDisplayName);

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -65,6 +65,7 @@ export class WebsiteBuilderClientAction extends Component {
         this.websiteService.websiteRootInstance = undefined;
         this.iframeFallbackUrl = "/website/iframefallback";
         this.iframefallback = useRef("iframefallback");
+        this.newInstalledModule = router.current.module_installed;
 
         this.websiteContent = useRef("iframe");
         this.builderSidebarRef = useRef("builder_sidebar");
@@ -237,6 +238,7 @@ export class WebsiteBuilderClientAction extends Component {
             onNewPage: this.onNewPage.bind(this),
             onEditPage: this.onEditPage.bind(this),
             iframeLoaded: this.iframeLoaded,
+            newInstalledModule: this.newInstalledModule,
         };
     }
 

--- a/addons/website/static/src/client_actions/website_preview/website_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/website_systray_item.js
@@ -13,6 +13,7 @@ export class WebsiteSystrayItem extends Component {
         onNewPage: { type: Function },
         onEditPage: { type: Function },
         iframeLoaded: { type: Object },
+        newInstalledModule: { type: String, optional: true}
     };
     static components = {
         MobilePreviewSystrayItem,

--- a/addons/website/static/src/client_actions/website_preview/website_systray_item.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_systray_item.xml
@@ -7,7 +7,7 @@
         <PublishSystrayItem t-if="this.canPublish"/>
         <MobilePreviewSystrayItem t-if="this.isRestrictedEditor" />
         <EditInBackendSystrayItem t-if="this.hasEditableRecordInBackend"/>
-        <NewContentSystrayItem t-if="this.isRestrictedEditor" onNewPage="this.props.onNewPage"/>
+        <NewContentSystrayItem t-if="this.isRestrictedEditor" onNewPage="this.props.onNewPage" newInstalledModule="this.props.newInstalledModule"/>
         <EditWebsiteSystrayItem t-if="this.isRestrictedEditor and this.canEdit" t-props="this.editWebsiteSystrayItemProps"/>
     </div>
 </t>

--- a/addons/website_blog/models/__init__.py
+++ b/addons/website_blog/models/__init__.py
@@ -4,3 +4,4 @@
 from . import website
 from . import website_blog
 from . import website_snippet_filter
+from . import res_partner

--- a/addons/website_blog/models/res_partner.py
+++ b/addons/website_blog/models/res_partner.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    blog_post_ids = fields.One2many('blog.post', 'author_id', string="Blog Posts")

--- a/addons/website_blog/static/src/snippets/s_blog_posts/blog_posts.js
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/blog_posts.js
@@ -9,9 +9,27 @@ export class BlogPosts extends DynamicSnippet {
      */
     getSearchDomain() {
         const searchDomain = super.getSearchDomain(...arguments);
-        const filterByBlogId = parseInt(this.el.dataset.filterByBlogId);
-        if (filterByBlogId >= 0) {
-            searchDomain.push(["blog_id", "=", filterByBlogId]);
+
+        const getParsedIds = (key) => {
+            if (!this.el.dataset[key]) {
+                return [];
+            }
+            const parsed = JSON.parse(this.el.dataset[key]);
+            return parsed.map((t) => t.id);
+        };
+
+        const filterByTagIds = getParsedIds("filterByTagIds");
+        const filterByBlogIds = getParsedIds("filterByBlogIds");
+        const filterByAuthorIds = getParsedIds("filterByAuthorIds");
+
+        if (filterByBlogIds.length) {
+            searchDomain.push(["blog_id", "in", filterByBlogIds]);
+        }
+        if (filterByTagIds.length) {
+            searchDomain.push(["tag_ids", "in", filterByTagIds]);
+        }
+        if (filterByAuthorIds.length) {
+            searchDomain.push(["author_id", "in", filterByAuthorIds]);
         }
         return searchDomain;
     }

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.js
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.js
@@ -1,5 +1,3 @@
-import { useState } from "@web/owl2/utils";
-import { onWillStart } from "@odoo/owl";
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { useDomState } from "@html_builder/core/utils";
 import { useDynamicSnippetOption } from "@website/builder/plugins/options/dynamic_snippet_hook";
@@ -12,15 +10,9 @@ export class DynamicSnippetBlogPostsOption extends BaseOptionComponent {
 
     setup() {
         super.setup();
-        const { fetchBlogs, getModelNameFilter } = this.dependencies.dynamicSnippetBlogPostsOption;
+        const { getModelNameFilter } = this.dependencies.dynamicSnippetBlogPostsOption;
         this.modelNameFilter = getModelNameFilter();
         this.dynamicOptionParams = useDynamicSnippetOption(this.modelNameFilter);
-        this.blogState = useState({
-            blogs: [],
-        });
-        onWillStart(async () => {
-            this.blogState.blogs.push(...(await fetchBlogs()));
-        });
         this.templateKeyState = useDomState((el) => ({
             templateKey: el.dataset.templateKey,
         }));

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.xml
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option.xml
@@ -9,13 +9,31 @@
 
 <t t-name="website_blog.DynamicSnippetBlogPostsOption" t-inherit="website.DynamicSnippetOption">
     <xpath expr="//BuilderRow[*[@id=&quot;'filter_opt'&quot;]]" position="after">
-        <BuilderRow label.translate="Blog" t-if="!isSingleMode">
-            <BuilderSelect dataAttributeAction="'filterByBlogId'" preview="false">
-                <BuilderSelectItem dataAttributeActionValue="'-1'">All blogs</BuilderSelectItem>
-                <t t-foreach="this.blogState.blogs" t-as="blog" t-key="blog.id">
-                    <BuilderSelectItem dataAttributeActionValue="`${blog.id}`" t-out="blog.name"/>
-                </t>
-            </BuilderSelect>
+        <BuilderRow label.translate="Blogs" preview="false">
+            <BuilderMany2Many model="'blog.blog'"
+                dataAttributeAction="'filterByBlogIds'"
+                domain="[
+                    '|',
+                    ['website_id', '=', false],
+                    ['website_id', '=', this.services.website.currentWebsite.id],
+                ]"
+            />
+        </BuilderRow>
+        <BuilderRow label.translate="Tags" preview="false">
+            <BuilderMany2Many model="'blog.tag'"
+                dataAttributeAction="'filterByTagIds'"
+            />
+        </BuilderRow>
+        <BuilderRow label.translate="Authors" preview="false">
+            <BuilderMany2Many model="'res.partner'"
+                dataAttributeAction="'filterByAuthorIds'"
+                domain="[
+                    ['blog_post_ids', '!=', false],
+                    '|',
+                    ['website_id', '=', false],
+                    ['website_id', '=', this.services.website.currentWebsite.id],
+                ]"
+        />
         </BuilderRow>
     </xpath>
     <xpath expr="//BuilderRow[*[@id=&quot;'template_opt'&quot;]]" position="after">

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option_plugin.js
@@ -1,51 +1,30 @@
-import { setDatasetIfUndefined } from "@website/builder/plugins/options/dynamic_snippet_option_plugin";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 
 /**
  * @typedef { Object } DynamicSnippetBlogPostsOptionShared
- * @property { DynamicSnippetBlogPostsOptionPlugin['fetchBlogs'] } fetchBlogs
  * @property { DynamicSnippetBlogPostsOptionPlugin['getModelNameFilter'] } getModelNameFilter
  */
 
 export class DynamicSnippetBlogPostsOptionPlugin extends Plugin {
     static id = "dynamicSnippetBlogPostsOption";
     static dependencies = ["dynamicSnippetOption"];
-    static shared = ["fetchBlogs", "getModelNameFilter"];
+    static shared = ["getModelNameFilter"];
     modelNameFilter = "blog.post";
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
     };
-    setup() {
-        this.blogs = undefined;
-    }
     getModelNameFilter() {
         return this.modelNameFilter;
     }
     async onSnippetDropped({ snippetEl }) {
         if (snippetEl.matches(".s_dynamic_snippet_blog_posts")) {
-            setDatasetIfUndefined(snippetEl, "filterByBlogId", -1);
             await this.dependencies.dynamicSnippetOption.setOptionsDefaultValues(
                 snippetEl,
                 this.modelNameFilter
             );
         }
-    }
-    async fetchBlogs() {
-        if (!this.blogs) {
-            this.blogs = this._fetchBlogs();
-        }
-        return this.blogs;
-    }
-    async _fetchBlogs() {
-        // TODO put in an utility function
-        const websiteDomain = [
-            "|",
-            ["website_id", "=", false],
-            ["website_id", "=", this.services.website.currentWebsite.id],
-        ];
-        return this.services.orm.searchRead("blog.blog", websiteDomain, ["id", "name"]);
     }
 }
 

--- a/addons/website_blog/static/tests/interactions/snippets/blog_posts.test.js
+++ b/addons/website_blog/static/tests/interactions/snippets/blog_posts.test.js
@@ -29,7 +29,7 @@ test("dynamic snippet blog posts loads items and displays them through template"
             "website_blog.dynamic_filter_template_blog_post_big_picture"
         );
         expect(json.params.limit).toBe(16);
-        expect(json.params.search_domain).toEqual([["blog_id", "=", 1]]);
+        expect(json.params.search_domain).toEqual([["blog_id", "in", [1]]]);
         return [
             `
             <div class="s_test_item" data-test-param="test">
@@ -48,7 +48,7 @@ test("dynamic snippet blog posts loads items and displays them through template"
           <section data-snippet="s_blog_posts" class="s_blog_posts s_dynamic_snippet_blog_posts s_blog_post_big_picture s_blog_posts_effect_marley s_blog_posts_post_picture_size_default s_dynamic pt32 pb32 o_colored_level"
                   data-custom-template-data="{&quot;blog_posts_post_author_active&quot;:true, &quot;blog_posts_post_teaser_active&quot;:true, &quot;blog_posts_post_date_active&quot;:true}"
                   data-name="Blog Posts"
-                  data-filter-by-blog-id="1"
+                  data-filter-by-blog-ids="[{&quot;id&quot;:1,&quot;display_name&quot;:&quot;Travel&quot;,&quot;name&quot;:&quot;Travel&quot;}]"
                   data-filter-id="1"
                   data-template-key="website_blog.dynamic_filter_template_blog_post_big_picture"
                   data-number-of-records="16"

--- a/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet_visibility.js
+++ b/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet_visibility.js
@@ -44,7 +44,7 @@ registerWebsitePreviewTour(
     () => [
         ...insertSnippet(blogPostsSnippet),
         ...clickOnSnippet({ ...blogPostsSnippet, id: "s_blog_posts" }),
-        ...changeOptionInPopover("Blog Posts", "Blog", "aaa Blog Test"),
+        ...changeOptionInPopover("Blog Posts", "Blogs", "aaa Blog Test"),
         {
             content: "Check that the blog filter is applied",
             trigger: `:iframe .s_dynamic_snippet_blog_posts:not([data-filter-by-blog-id="-1"])`,

--- a/addons/website_blog/static/tests/website_builder/snippet_filter.test.js
+++ b/addons/website_blog/static/tests/website_builder/snippet_filter.test.js
@@ -1,0 +1,92 @@
+import { expect, test } from "@odoo/hoot";
+import { SelectMany2X } from "@html_builder/core/building_blocks/select_many2x";
+import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilderWithSnippet,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("dynamic Snippet Blog Filter", async () => {
+    // We just need to fulfill these two RPCs, they are not useful in test.
+    onRpc(
+        "/website/snippet/options_filters",
+        async (args) =>
+            new Promise((resolve) => {
+                resolve([]);
+            })
+    );
+    onRpc(
+        "/website/snippet/filter_templates",
+        async (args) =>
+            new Promise((resolve) => {
+                resolve([]);
+            })
+    );
+
+    // Provide blogs, tags and authors for the filters
+    patchWithCleanup(SelectMany2X.prototype, {
+        search() {
+            switch (this.props.model) {
+                case "blog.blog":
+                    this.state.searchResults = [
+                        {
+                            id: 1,
+                            display_name: "Test Blog 1",
+                            name: "Test Blog 1",
+                        },
+                    ];
+                    break;
+                case "blog.tag":
+                    this.state.searchResults = [
+                        {
+                            id: 1,
+                            display_name: "Adventure",
+                            name: "Adventure",
+                        },
+                    ];
+                    break;
+                case "res.partner":
+                    this.state.searchResults = [
+                        {
+                            id: 1,
+                            display_name: "Author 1",
+                            name: "Author 1",
+                        },
+                    ];
+                    break;
+            }
+        },
+    });
+
+    await setupWebsiteBuilderWithSnippet(["s_blog_posts"]);
+    await contains(":iframe .s_blog_posts").click();
+
+    // Check for blog filter
+    expect(":iframe .s_blog_posts").not.toHaveAttribute("data-filter-by-blog-ids");
+    await contains("[data-label=Blogs] button.dropdown").click();
+    await contains(".dropdown-item:contains(Test Blog 1)").click();
+    expect(":iframe .s_blog_posts").toHaveAttribute(
+        "data-filter-by-blog-ids",
+        '[{"id":1,"display_name":"Test Blog 1","name":"Test Blog 1"}]'
+    );
+
+    // Check for tag filter
+    expect(":iframe .s_blog_posts").not.toHaveAttribute("data-filter-by-tag-ids");
+    await contains("[data-label=Tags] button.dropdown").click();
+    await contains(".dropdown-item:contains(Adventure)").click();
+    expect(":iframe .s_blog_posts").toHaveAttribute(
+        "data-filter-by-tag-ids",
+        '[{"id":1,"display_name":"Adventure","name":"Adventure"}]'
+    );
+
+    // Check for author filter
+    expect(":iframe .s_blog_posts").not.toHaveAttribute("data-filter-by-author-ids");
+    await contains("div[data-label=Authors] .dropdown").click();
+    await contains(".dropdown-item:contains(Author 1)").click();
+    expect(":iframe .s_blog_posts").toHaveAttribute(
+        "data-filter-by-author-ids",
+        '[{"id":1,"display_name":"Author 1","name":"Author 1"}]'
+    );
+});

--- a/addons/website_blog/views/blog_post_add.xml
+++ b/addons/website_blog/views/blog_post_add.xml
@@ -8,8 +8,8 @@
         <form js_class="website_new_content_form">
             <group>
                 <field name="website_url" invisible="1"/>  <!-- We need this for `computePath` used in `onAddContent` to redirect to the blog after creation. -->
-                <field name="blog_id" string="Select Blog"/>
                 <field name="name" placeholder="Blog Post Title"/>
+                <field name="blog_id" string="Select Blog"/>
             </group>
         </form>
     </field>


### PR DESCRIPTION
**Before this commit:**

- When opening the `New Blog Post` dialog, the focus defaulted to the `Select Blog `dropdown, requiring users to manually move to the Title field.
- The Blog Article snippet only allowed filtering by Blog, restricting editorial control.
- Installing a module from the `New` content modal did not preserve intent, users had to manually reopen the modal after installation to proceed.
- Similarly, when a snippet module was installed from the snippet selection dialog, the dialog had to be reopened manually after page reload from module installation.

**After this commit:**

- The `New Blog Post` dialog autofocuses the `Title` input, enabling faster and more intuitive content creation.
- The Blog Article snippet now supports filtering by Tags and Author, offering better content targeting and personalization.
- The `New` content modal stores the installed module’s XML ID in the website context. After reload, it auto-triggers the same modal to continue the creation flow seamlessly.
- When a snippet module is installed via the snippet dialog, the relevant snippet group is automatically reopened after reload, improving flow continuity.

**Impact:**

- Faster content creation: Users can immediately begin typing blog titles without manually changing focus.
- Enhanced editorial control: Users can now precisely filter blog content using multiple dimensions.
- Reduced friction: The system remembers and resumes user actions after installing new content or snippets.

Task - 4680670

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
