### PR TITLE
[FIX] website_forum, *: Fix tour by using editSelectMenu util

### DIFF
--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -2,6 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import {
     registerBackendAndFrontendTour,
 } from '@website/js/tours/tour_utils';
+import { stepUtils } from "@web_tour/tour_utils";
 
 registerBackendAndFrontendTour("question", {
     url: '/forum/1',
@@ -35,13 +36,7 @@ registerBackendAndFrontendTour("question", {
     tooltipPosition: "top",
     run: "click",
 },
-{
-    trigger: ".o_select_menu input",
-    run: async function() {
-        this.anchor.value = "Test";
-        this.anchor.dispatchEvent(new InputEvent("input"));
-    }
-},
+...stepUtils.editSelectMenuInput(".o_select_menu_input", "Test"),
 {
     content: "Select found select menu item",
     trigger: ".o_popover.o_select_menu_menu .o_select_menu_item:contains('Test')",

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('forum_question', {
     url: '/forum/help-1',
@@ -29,10 +30,7 @@ registry.category("web_tour.tours").add('forum_question', {
         trigger: '.o_select_menu_toggler',
         run: 'click',
     },
-    {
-        trigger: '.o_select_menu_toggler',
-        run: 'edit Tag',
-    },
+    ...stepUtils.editSelectMenuInput(".o_select_menu_input", "Tag"),
     {
         content: "Click to post your question.",
         trigger: 'button:contains("Post")',

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -1,5 +1,6 @@
 import { registry } from "@web/core/registry";
 import { browser } from "@web/core/browser/browser";
+import { stepUtils } from "@web_tour/tour_utils";
 
 function fillSelectMenu(inputID, search) {
     return [
@@ -8,14 +9,7 @@ function fillSelectMenu(inputID, search) {
             trigger: `.o_website_links_utm_forms div#${inputID} .o_select_menu_toggler`,
             run: "click",
         },
-        {
-            content: "Enter selectMenu search query",
-            trigger: `.o_website_links_utm_forms div#${inputID} .o_select_menu_input`,
-            run: async function() {
-                this.anchor.value = search;
-                this.anchor.dispatchEvent(new InputEvent("input"));
-            }
-        },
+        ...stepUtils.editSelectMenuInput(`.o_website_links_utm_forms div#${inputID} .o_select_menu_input`, search),
         {
             content: "Select found selectMenu item",
             trigger: `.o_popover .o_select_menu_item:contains("${search}")`,


### PR DESCRIPTION
*: website_links

This commit fixes tours that were randomly crashing due to an unexpected timing issue when editing the input of the SelectMenu component.

By using the dedicated util, the behavior should be more consistent and the tours should not crash anymore.

runbot-error-229966