### PR TITLE
[IMP] point_of_sale: require schedule field when using time slots

### DIFF
--- a/addons/point_of_sale/views/pos_preset_view.xml
+++ b/addons/point_of_sale/views/pos_preset_view.xml
@@ -35,7 +35,7 @@
 
                             <label for="resource_calendar_id" string="Schedule based on" class="fw-bold ms-2" />
                             <div>
-                                <field name="resource_calendar_id" readonly="not use_timing" />
+                                <field name="resource_calendar_id" readonly="not use_timing" required="use_timing"/>
                             </div>
 
                             <label for="slots_per_interval" string="Preparation capacity" class="fw-bold ms-2" />


### PR DESCRIPTION
PURPOSE:
---------------
- To stop users from getting stuck in POS when they forget to set a schedule after turning on time slot management.

BEFORE:
------------------
- Users could turn on "Manage orders by time" without selecting a schedule.
- This caused problems in POS during order finalization.

AFTER:
--------------
- Now, the system checks that a schedule is set when using time slots.
- This prevents misconfiguration and makes POS more reliable.

Task-4929896