### PR TITLE
[FIX] point_of_sale: compute price for variant with list_price = 0

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -144,7 +144,8 @@ export class ProductProduct extends Base {
             );
         }
 
-        let price = (list_price || this.lst_price) + (price_extra || 0);
+        let price =
+            (typeof list_price === "number" ? list_price : this.lst_price) + (price_extra || 0);
         const rule = this.getPricelistRule(pricelist, quantity);
         if (!rule) {
             return price;

--- a/addons/point_of_sale/static/tests/tours/product_variants_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_variants_tour.js
@@ -113,3 +113,14 @@ registry.category("web_tour.tours").add("test_integration_dynamic_always_never_v
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_integration_always_variant_price_list_price_zero", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            check_variant_price("A always product", ["S"], "0.00"),
+            check_variant_price("A always product", ["M"], "5.00"),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_pos_product_variants.py
+++ b/addons/point_of_sale/tests/test_pos_product_variants.py
@@ -303,3 +303,25 @@ class TestPoSProductVariants(ProductVariantsCommon, TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_dynamic_always_never_variant_price', login="pos_user")
+
+    def test_integration_always_variant_price_list_price_zero(self):
+        """Tests the price of products with always variant when added to cart"""
+        self.size_attribute_m.default_extra_price = 5
+
+        product_template = self.env['product.template'].create({
+            'name': 'A always product',
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'is_storable': True,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+            'list_price': 0,
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.size_attribute.id,
+            'value_ids': [Command.set([self.size_attribute_s.id, self.size_attribute_m.id])],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_integration_always_variant_price_list_price_zero', login="pos_user")


### PR DESCRIPTION
When variants have `list_price = 0` it counts the extra price twice as it is considered false in the condition but if set to 0 it should be taken into account.

Initial commit: https://github.com/odoo/odoo/commit/8c8449f51d5e327ccd2e4bb7c3c4868d51c6d619

opw-4963530
