### PR TITLE
[FIX] website: preserve default field value after visibility change

### DIFF
--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -91,7 +91,7 @@
                 type="hidden"
                 class="form-control s_website_form_input"
                 t-att-name="field.name"
-                t-att-value="field.value"
+                t-attf-value="#{field.value}"
                 t-att-id="field.id"
             />
         </t>
@@ -105,7 +105,7 @@
                 class="form-control s_website_form_input"
                 t-att-name="field.name"
                 t-att-required="field.required || field.modelRequired || None"
-                t-att-value="field.value"
+                t-attf-value="#{field.value}"
                 t-att-data-fill-with="field.fillWith"
                 t-att-placeholder="field.placeholder"
                 t-att-id="field.id"
@@ -161,7 +161,7 @@
                 t-att-name="field.name"
                 step="1"
                 t-att-required="field.required || field.modelRequired || None"
-                t-att-value="field.value"
+                t-attf-value="#{field.value}"
                 t-att-placeholder="field.placeholder"
                 t-att-id="field.id"
             />
@@ -177,7 +177,7 @@
                 t-att-name="field.name"
                 step="any"
                 t-att-required="field.required || field.modelRequired || None"
-                t-att-value="field.value"
+                t-attf-value="#{field.value}"
                 t-att-placeholder="field.placeholder"
                 t-att-id="field.id"
             />
@@ -193,7 +193,7 @@
                         class="form-control datetimepicker-input s_website_form_input"
                         t-att-name="field.name"
                         t-att-required="field.required || field.modelRequired || None"
-                        t-att-value="field.value"
+                        t-attf-value="#{field.value}"
                         t-att-placeholder="field.placeholder"
                         t-att-id="field.id"
                 />
@@ -211,7 +211,7 @@
                         class="form-control datetimepicker-input s_website_form_input"
                         t-att-name="field.name"
                         t-att-required="field.required || field.modelRequired || None"
-                        t-att-value="field.value"
+                        t-attf-value="#{field.value}"
                         t-att-placeholder="field.placeholder"
                         t-att-id="field.id"
                 />


### PR DESCRIPTION
Problem:
When changing the default value of a field, then modifying its
position and visibility, the field loses its default value.

Cause:
Setting a default value assigns the `value` attribute to the field's
input element. However, after re-rendering with `_renderField`, the
HTML `value` attribute is lost. As a result, when
`_computeWidgetState` called with `selectAttribute` as method name, it
fails to retrieve the value because there is no HTML `value` attribute
on the input.

Using `t-att-value="field.value"` will lead to `value` attribute loss
during owl rendering, this is an owl bug but this fix is to work around
it until it is globally fixed.

Solution:
use `t-attf-value="#{field.value}"` instead of
`t-att-value="field.value"`

Steps to reproduce:
- Add a form
- Select any input field
- Set a default value
- Change the field's position
- Change the field's visibility
-> The default value is lost

opw-4902544

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
