### PR TITLE
[FIX] point_of_sale: Remove enterprise fields from Hoot

### DIFF
--- a/addons/point_of_sale/static/tests/unit/data/pos_config.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/pos_config.data.js
@@ -112,8 +112,6 @@ export class PosConfig extends models.ServerModel {
             fallback_nomenclature_id: false,
             create_date: "2025-07-03 12:40:00",
             write_date: "2025-07-03 14:35:55",
-            module_pos_iot: false,
-            module_pos_urban_piper: false,
             epson_printer_ip: false,
         },
     ];

--- a/addons/point_of_sale/static/tests/unit/data/res_partner.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/res_partner.data.js
@@ -52,10 +52,7 @@ export class ResPartner extends MailResPartner {
             company_type: "person",
             fiscal_position_id: false,
             credit_limit: 0.0,
-            total_due: 0.0,
             use_partner_credit_limit: false,
-            pos_orders_amount_due: 0.0,
-            invoices_amount_due: 0.0,
         },
     ];
 }


### PR DESCRIPTION
Remove fields that are declared in enterprise from the Hoot tests in point of sale. This is to ensure that the tests can be run without the enterprise module being installed.


