### PR TITLE
[FIX] point_of_sale: fix mobile grid layout

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
@@ -29,7 +29,6 @@
 
     &.no-image {
         -webkit-line-clamp: 7;
-        aspect-ratio: 4 / 3;
     }
 }
 

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -16,7 +16,7 @@
             </div>
             <div class="product-content d-flex flex-row px-2 justify-content-between rounded-bottom rounded-3 flex-shrink-1" t-att-class="{'h-100' : !props.imageUrl}">
                 <div class="overflow-hidden lh-sm product-name my-2"
-                    t-att-class="{'no-image d-flex justify-content-center align-items-center text-center fs-4': !props.imageUrl}"
+                    t-att-class="{'no-image d-flex justify-content-center align-items-center text-center fs-4': !props.imageUrl, 'hasImage': props.imageUrl}"
                     t-attf-id="article_product_{{props.productId}}"
                     t-esc="props.name" />
                 <h1 t-if="props.productCartQty"

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
@@ -12,6 +12,10 @@
     @include media-breakpoint-down(sm) {
         grid-template-columns: repeat(3, 1fr);
     }
+
+    :where(:not(:has(.hasImage)) .product) {
+        aspect-ratio: 4 / 3;
+    }
 }
 
 .button-no-demo {


### PR DESCRIPTION
This commit fixes an issue related to the `product card` which has an enforced `4 /3` aspect ratio.

Currently, there are two different grid layouts in `point_of_sale` depending on the breakpoint.

On Mobile, we use a `3 cols` layout with each col being the same size, which conflicts with the grid layout as it try to enforce a specific `width/height` on the element.

On other devices, we use an `auto-fill` rule, which provides way more flexibility for items to grow, but even there the aspect-ratio is not working as the item is sized as the other grid items.

To fix this issue, we remove the `aspect-ratio` property, which was not affecting the design of the item and rely on the default grid sizing behaviour, to prevent any issue.

task-4965395

| 18.0 and above | This PR |
|--------|--------|
| <img width="391" height="844" alt="image" src="https://github.com/user-attachments/assets/a191bfcf-20f6-4621-832b-a40ed42c2358" /> | <img width="391" height="844" alt="image" src="https://github.com/user-attachments/assets/7f07000e-b0e5-411e-bce6-12a5072bb854" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
