### PR TITLE
[FIX] website_event: improve cache for events

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -304,7 +304,7 @@
     </div>
     <!-- List -->
     <div t-foreach="event_ids" t-as="event" t-attf-class=" #{opt_event_size}">
-        <a t-cache="event if not editable and event.website_published else None" t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-reset " t-att-data-publish="event.website_published and 'on' or 'off'">
+        <a t-cache="(event, event.is_participating) if not editable and event.website_published else None" t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-reset " t-att-data-publish="event.website_published and 'on' or 'off'">
             <article t-attf-class="h-100 #{opt_events_list_cards and 'card'}" itemscope="itemscope" itemtype="http://schema.org/Event">
                 <div t-attf-class="h-100 #{opt_events_list_columns and 'd-flex flex-wrap flex-column' or 'row mx-0'}">
                     <!-- Header -->

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -43,7 +43,7 @@
             </div>
         </t>
 
-        <section id="o_wevent_event_main" class="h-100" t-cache="event if not editable and event.website_published else None">
+        <section id="o_wevent_event_main" class="h-100" t-cache="(event, event.is_participating) if not editable and event.website_published else None">
             <div class="container overflow-hidden pb-5">
                 <div class="row">
                     <div class="col pe-xxl-5">


### PR DESCRIPTION
We had an inconsistent display of the Registered banner for events on the website. The banner would appear or disappear randomly, regardless of whether the user was logged in or not.

Steps to reproduce:
-------------------
- start the server
- log in as a user that does not have access to website editor
- get a ticket for an event
- go to the event list
-> event is marked register
- go to the event page in a new browser session (incognito)
-> event is still marked register

> Observation:
On refresh, Registered green banner on events
appear and disappear randomly

Why the fix:
------------
Keys that are not stored on the table of event should be added to the cache key to force a re-render when they change, or t-nocache should be used

opw-4819021

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
