### PR TITLE
[FIX] website_forum: prevent error when adding multiple new tags

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -52,12 +52,9 @@ class WebsiteForumTagsWrapper extends Component {
     }
 
     onCreateOption(string) {
-        const choice = {
-            label: string.trim(),
-            value: `_${string.trim()}`,
-        };
-        this.state.choices.push(choice);
-        this.onSelect([...this.state.value, choice.value]);
+        const choices = string.split(",").map((c) => ({ label: c.trim(), value: `_${c.trim()}` }));
+        this.state.choices.push(...choices);
+        this.onSelect([...this.state.value, ...choices.map((c) => c.value)]);
     }
 
     onSelect(values) {

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -36,6 +36,38 @@ registry.category("web_tour.tours").add('forum_question', {
         run: 'edit Tag',
     },
     {
+        content: "Create a new tag.",
+        trigger: ".o-dropdown-item:contains(Create option)",
+        run: "click",
+    },
+    {
+        content: "Check that the 'Tag' tag is added.",
+        trigger: ".o_tag_badge_text:contains('Tag')",
+    },
+    {
+        content: "Insert tags related to your question.",
+        trigger: ".o_select_menu_toggler",
+        run: "click",
+    },
+    {
+        content: "Insert multiple comma-separated tags",
+        trigger: ".o_popover input.o_select_menu_sticky",
+        run: "edit tag, test tag",
+    },
+    {
+        content: "Create multiple new tags.",
+        trigger: ".o-dropdown-item:contains(Create option)",
+        run: "click",
+    },
+    {
+        content: "Check that the 'tag' tag is added.",
+        trigger: ".o_tag_badge_text:contains('tag')",
+    },
+    {
+        content: "Check that the 'test tag' tag is added.",
+        trigger: ".o_tag_badge_text:contains('test tag')",
+    },
+    {
         trigger: "#wrap:not(:has(.o_popover input.o_select_menu_sticky:not(:contains(''))))",
     },
     {

--- a/addons/website_forum/tests/test_forum_tours.py
+++ b/addons/website_forum/tests/test_forum_tours.py
@@ -23,3 +23,5 @@ class TestUi(HttpCaseGamification):
         demo = self.user_demo
         demo.karma = forum.karma_post + 1
         self.start_tour("/", 'forum_question', login="demo")
+        tags = self.env['forum.tag'].search([('name', 'in', ['Tag', 'tag', 'test tag'])])
+        self.assertEqual(len(tags), 3)


### PR DESCRIPTION
Currently, an error occurs when a user tries to add multiple comma-separated new tags to a forum post.

**Steps to reproduce:**

- Install the `website_forum` module.
- Go to: `Website > Configuration > Forums`, create a new forum, then click `Go to Website`.
- Click on `Start by creating a post`, enter content, and set the `Tags` to `_test, retour affectif rapide`.
- Click on `Post Your Question`.

**Error:**
`ValueError: invalid literal for int() with base 10: 'retour affectif rapide'`

**Root Cause:**

After PR #169472, at [1], the code prepends an underscore (_) only to the entire input string instead of each tag. When multiple tags are entered, the backend receives a mixed list of values (e.g., ['__test', 'retour affectif rapide']), leading to an error during `int()` conversion at [2].

**Fix:**
This commit updates the `onCreateOption` logic to prepend an underscore to each tag in the comma-separated input,  similar to [3].

Also updated the test case at [4], to click `Create option` to save the tags.

[1]:
https://github.com/odoo/odoo/blob/afa26af132566a68ad6bf67565062bd73ddd7429/addons/website_forum/static/src/js/website_forum.js#L54-L61

[2]:
https://github.com/odoo/odoo/blob/afa26af132566a68ad6bf67565062bd73ddd7429/addons/website_forum/models/forum_forum.py#L304

[3]:
https://github.com/odoo/odoo/blob/ac93a25b216e6194895a64fe12c0d01f6833f743/addons/website_forum/static/src/js/website_forum.js#L69-L80

[4]:
https://github.com/odoo/odoo/blob/d155edfd729ab9b53f38939fe24b6d1e7b578083/addons/website_forum/static/tests/tours/website_forum_question.js#L34-L37

sentry-6761920887