### PR TITLE
[FIX] mrp: do not copy "Apply on Variants" in BoM operation copy

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -168,7 +168,7 @@ class MrpRoutingWorkcenter(models.Model):
         if 'bom_id' in self.env.context:
             bom_id = self.env.context.get('bom_id')
             for operation in self:
-                operation.copy({'bom_id': bom_id})
+                operation.copy({'bom_id': bom_id, 'bom_product_template_attribute_value_ids': False})
             return {
                 'view_mode': 'form',
                 'res_model': 'mrp.bom',

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5275,6 +5275,23 @@ class TestMrpOrder(TestMrpCommon):
         # Check that the serial numbers follow the sequence
         self.assertEqual(mo2.lot_producing_ids.mapped('name'), ['customMRPSerial0000001', 'customMRPSerial0000002', 'customMRPSerial0000003'])
 
+    def test_copy_operation_excludes_variant(self):
+        """Test to ensure that copying an operation clears the product variant field (bom_product_template_attribute_value_ids)
+        and does not copy it from the original."""
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product_7_template.id,
+            'operation_ids': [Command.create({
+                'name': 'Weld Machine',
+                'workcenter_id': self.workcenter_1.id,
+                'bom_product_template_attribute_value_ids': [Command.link(self.product_7_attr1_v1.id)],
+            })]
+        })
+        operation = bom.operation_ids
+        operation.with_context(bom_id=bom.id).copy_to_bom()
+        self.assertEqual(len(bom.operation_ids), 2)
+        copied_operation = bom.operation_ids[1]
+        self.assertFalse(copied_operation.bom_product_template_attribute_value_ids, "'Apply on Variants' should not be copied to the new operation.")
+
 
 @tagged('-at_install', 'post_install')
 class TestTourMrpOrder(HttpCase):


### PR DESCRIPTION
Issue:
--------------------------------
When copying an existing operation to another BoM, if the source operation has "Apply on Variants" set, the same value is also copied to the new operation. This will be confusing for the user.

Steps to reproduce:
--------------------------------
- Create a Bill of Materials (BoM) for a product.
- In the Operations tab, click "Copy Existing Operation".
- Select an operation that already has "Apply on Variants" set.
- The newly copied operation will also have the same variant applied.

Technical Issue:
--------------------------------
While copying an operation to a new BoM, the `bom_product_template_attribute_value_ids` field ("Apply on Variants") was also being copied.

With this commit:
--------------------------------
If the target product does not have matching variants, the operation becomes unusable during manufacturing and can confuse the user. So explicitly clear the `bom_product_template_attribute_value_ids` field during the copy process to prevent transferring variant constraints from the original operation, making the copied operation always compatible for users.

Task ID: [4915245](https://www.odoo.com/odoo/project/966/tasks/4915245)