### PR TITLE
[FIX] spreadsheet_dashboard: fix faulty css

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
@@ -39,8 +39,7 @@
 
 .o_spreadsheet_dashboard_action {
     background-color: white;
-    height: 100dvh !important;
-    width: 100dvw !important;
+
     .o_renderer {
         height: 100%;
 


### PR DESCRIPTION
Some css rules required for the edition mode of dashboards was mistakenly added on the wrong (readonly) view.

Task: 4962437

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
