### PR TITLE
[IMP] mail, im_livechat: introduce `member.im_status` getter

### DIFF
--- a/addons/hr_homeworking/static/src/im_status_patch.xml
+++ b/addons/hr_homeworking/static/src/im_status_patch.xml
@@ -23,11 +23,11 @@
 
     <t t-inherit="mail.ThreadIcon" t-inherit-mode="extension">
         <xpath expr="//*[@name='chat_static']" position="replace">
-            <t t-if="correspondent.persona.im_status">
-                <t t-if="correspondent.persona.im_status.split('_').length >= 2">
-                    <t t-set="location" t-value="correspondent.persona.im_status.split('_')[0]"/>
+            <t t-if="correspondent.im_status">
+                <t t-if="correspondent.im_status.split('_').length >= 2">
+                    <t t-set="location" t-value="correspondent.im_status.split('_')[0]"/>
                     <t t-if="location == 'home' || location == 'office' || location == 'other'">
-                        <t t-set="status" t-value="correspondent.persona.im_status.split('_')[1]"/>
+                        <t t-set="status" t-value="correspondent.im_status.split('_')[1]"/>
                         <t t-set="location_map" t-value="{'home': 'fa-home', 'office': 'fa-building', 'other': 'fa-map-marker'}"/>
                         <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-yellow', 'busy': 'text-danger', 'offline': 'text-body'}"/>
                         <t t-set="icon" t-value="location_map[location]"/>

--- a/addons/im_livechat/static/src/core/common/thread_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_patch.js
@@ -13,11 +13,11 @@ patch(Thread.prototype, {
         Object.assign(this.state, { isVisitorOffline: false }); // starting online avoids flickering
         useEffect(
             () => {
-                if (!this.props.thread.livechatVisitorMember?.persona?.im_status) {
+                if (!this.props.thread.livechatVisitorMember?.im_status) {
                     return;
                 }
                 clearTimeout(this.imStatusTimeoutId);
-                if (this.props.thread.livechatVisitorMember.persona.im_status.includes("offline")) {
+                if (this.props.thread.livechatVisitorMember.im_status.includes("offline")) {
                     this.imStatusTimeoutId = setTimeout(
                         () => (this.state.isVisitorOffline = true),
                         this.IM_STATUS_DELAY
@@ -27,7 +27,7 @@ patch(Thread.prototype, {
                 }
                 return () => clearTimeout(this.imStatusTimeoutId);
             },
-            () => [this.props.thread.livechatVisitorMember?.persona?.im_status]
+            () => [this.props.thread.livechatVisitorMember?.im_status]
         );
     },
     get showVisitorDisconnected() {

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -5,7 +5,7 @@
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute text-400" t-att-class="{ 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="state.showClose and !env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
-            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute'" member="thread.correspondent">
+            <ImStatus t-if="thread?.correspondent?.im_status and thread?.correspondent?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute'" member="thread.correspondent">
                 <t t-set-slot="pre_icon">
                     <i style="font-size: 18px; right: -2px; bottom: -2px; z-index: -1;" t-att-class="{
                         'bg-success rounded-pill position-absolute': thread?.correspondent?.isTyping,

--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -11,7 +11,7 @@
             <t t-elif="props.thread.channel_type?.includes('chat') and correspondent">
                 <t name="chat">
                     <t name="chat_static">
-                        <ImStatus t-if="correspondent.persona.im_status" member="correspondent" size="'md'"/>
+                        <ImStatus t-if="correspondent.im_status" member="correspondent" size="'md'"/>
                         <div t-else="" class="d-flex rounded-circle bg-inherit">
                             <i class="fa-fw" t-att-class="largeClass" t-attf-class="#{ defaultChatIcon.class }" t-att-title="defaultChatIcon.title"/>
                         </div>

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -105,6 +105,10 @@ export class ChannelMember extends Record {
         return this.partner_id?.avatarUrl || this.guest_id?.avatarUrl;
     }
 
+    get im_status() {
+        return this.partner_id?.im_status || this.guest_id?.im_status;
+    }
+
     /**
      * @returns {string}
      */

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -177,9 +177,7 @@ const threadPatch = {
             /** @this {import("models").Thread} */
             compute() {
                 return this.channel_member_ids
-                    .filter((member) =>
-                        this.store.onlineMemberStatuses.includes(member.persona.im_status)
-                    )
+                    .filter((member) => this.store.onlineMemberStatuses.includes(member.im_status))
                     .sort((m1, m2) => this.store.sortMembers(m1, m2)); // FIXME: sort are prone to infinite loop (see test "Display livechat custom name in typing status")
             },
         });
@@ -217,7 +215,7 @@ const threadPatch = {
     /** @returns {import("models").ChannelMember[]} */
     _computeOfflineMembers() {
         return this.channel_member_ids.filter(
-            (member) => !this.store.onlineMemberStatuses.includes(member.persona?.im_status)
+            (member) => !this.store.onlineMemberStatuses.includes(member.im_status)
         );
     },
     get areAllMembersLoaded() {


### PR DESCRIPTION
This commit introduces an im_status getter on channel_membe_model. This removes the need to use persona getter.

PR enterprise: https://github.com/odoo/enterprise/pull/90751