### PR TITLE
[PERF] models: Do not cache HTML fields on record creation

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4229,7 +4229,7 @@ class BaseModel(metaclass=MetaModel):
                     self.env.cache.set(record, field, field.convert_to_cache(None, record))
             for fname, value in vals.items():
                 field = self._fields[fname]
-                if field.type in ('one2many', 'many2many'):
+                if field.type in ('one2many', 'many2many', 'html'):
                     cachetoclear.append((record, field))
                 else:
                     cache_value = field.convert_to_cache(value, record)


### PR DESCRIPTION
Description
-----------
When creating records with `vals` for HTML fields, there are two 'sanitization' operations happening:

1) Once in `convert_to_column`, when converting the `vals` for *database* insertion
2) Once post-insert in `convert_to_cache`, when converting the `vals` for insertion in the *cache* for the newly created records.

This redundancy has a negative performance impact when creating many records where new HTML fields are set, e.g., mass-mailing, as potentially large HTML documents are parsed and validated, often with external libraries.

To address this issue, this commit removes the insertion into *cache* of the HTML values for the newly created records. This removes the overhead of the second sanitization, speeding up the creation, and also helps with overall memory pressure, as we're not inserting large HTML fields into cache. The latter is particularly noticeable for long-running batch creation processes that do *not* commit intermediate results.

The downside of this patch is the potential *cache-miss* (and therefore the subsequent *query*) if the HTML field of the newly created records is read. This is unlikely in business code because intrinsically, an HTML field is often just a data 'blob' that has no logical usage. In the rare case where it needs to be read after creation, since the value in the database is already sanitized, re-sanitization is not necessary for insertion in the cache. Given these considerations, the trade-off seems reasonable to make.

Benchmark
---------
In a scenario for a marketing campaign with 1000 recipients, using a *mid-sized* email template and emulating a typical campaign, the results were:

| Method                        | Before   | After     | Speed up |
|-------------------------------|----------|-----------|----------|
| `_process_mass_mailing_queue` | 2.84 min | 1.55 min  | 1.8x     |
| `create`                      | 2.11 min | 50.23 sec | 2.5x     |

This represents roughly a *2x* performance improvement in processing an email campaign.

* more detailed benchmarks are available in the task's description

Reference
---------
task-4962646

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
