### PR TITLE
[FIX] account: prevent error on opening Analytic Distribution

### DIFF
--- a/addons/account/models/account_analytic_distribution_model.py
+++ b/addons/account/models/account_analytic_distribution_model.py
@@ -52,7 +52,10 @@ class AccountAnalyticDistributionModel(models.Model):
     # value directly, analytic precision has a default.
     @api.depends('analytic_precision')
     def _compute_prefix_placeholder(self):
-        expense_account = self.env['account.account'].search([('account_type', '=', 'expense')], limit=1)
+        expense_account = self.env['account.account'].search([
+            *self.env['account.account']._check_company_domain(self.env.company),
+            ('account_type', '=', 'expense'),
+        ], limit=1)
         for model in self:
             account_prefixes = "60, 61, 62"
             if expense_account:


### PR DESCRIPTION
Currently, an error occurs when a new company is created without selecting a `Fiscal Localization`, and then both companies are selected while creating a new `Analytic Distribution`.

Steps to reproduce:
---
- Install `Accounting` module(without demo)
- Enable `Analytic Accounting`
- Create a New company and switch to it
- Select both companies and Open `Analytic Distribution` and click `New`

Traceback:
---
`TypeError: 'bool' object is not subscriptable`

At [1], we are searching by `account_type`, but if `Fiscal Localization` is not set for the current company, there will be no records in `account.account`. However, due to the multi-company setup, it still return accounts from the first company. In such cases, the `code` field is empty, which causes the `code` to be treated as False.

[1]: https://github.com/odoo/odoo/blob/d155edfd729ab9b53f38939fe24b6d1e7b578083/addons/account/models/account_analytic_distribution_model.py#L55-L58

sentry-6754820454

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
