### PR TITLE
[FIX] point_of_sale: invoice order with rounding after closure

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -747,7 +747,13 @@ class PosOrder(models.Model):
         # Cash rounding.
         cash_rounding = self.config_id.rounding_method
         if self.config_id.cash_rounding and cash_rounding and (not self.config_id.only_round_cash_method or any(p.payment_method_id.is_cash_count for p in self.payment_ids)):
-            amount_currency = cash_rounding.compute_difference(self.currency_id, total_amount_currency)
+            if self.config_id.only_round_cash_method and any(not p.payment_method_id.is_cash_count for p in self.payment_ids):
+                # If only_round_cash_method is True, and there are non-cash payments, cash rounding must be computed
+                # based on the total amount of the order, and total payment amount.
+                total_payment_amount = self.currency_id.round(sum(p.amount for p in self.payment_ids))
+                amount_currency = sign * self.currency_id.round(self.currency_id.round(total_amount_currency) + total_payment_amount)
+            else:
+                amount_currency = cash_rounding.compute_difference(self.currency_id, total_amount_currency)
             if not self.currency_id.is_zero(amount_currency):
                 balance = company_currency.round(amount_currency * rate)
 

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2394,3 +2394,75 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.PosOrder.create_from_ui(refund_values)
         refunded_order_line = self.env['pos.order.line'].search([('product_id', '=', product.id), ('qty', '=', -2)])
         self.assertEqual(refunded_order_line.total_cost, -20)
+
+    def test_invoice_rounding_overpaid_backend(self):
+        rouding_method = self.env['account.cash.rounding'].create({
+            'name': 'Rounding up',
+            'rounding': 0.05,
+            'rounding_method': 'UP',
+            'profit_account_id': self.company_data['default_account_revenue'].id,
+            'loss_account_id': self.company_data['default_account_expense'].id,
+        })
+
+        product = self.env['product.product'].create({
+            'name': 'Product Test',
+            'available_in_pos': True,
+            'list_price': 149.99,
+            'taxes_id': False,
+        })
+
+        self.pos_config.write({
+            'rounding_method': rouding_method.id,
+            'cash_rounding': True,
+            'only_round_cash_method': True,
+        })
+
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+
+        pos_order_data = {
+            'data':
+            {
+                'amount_paid': 149.99,
+                'amount_tax': 0,
+                'amount_return': 0.01,
+                'amount_total': 149.99,
+                'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+                'fiscal_position_id': False,
+                'lines': [[0, 0, {
+                    'discount': 0,
+                    'pack_lot_ids': [],
+                    'price_unit': 149.99,
+                    'product_id': product.id,
+                    'price_subtotal': 149.99,
+                    'price_subtotal_incl': 149.99,
+                    'tax_ids': [[6, False, []]],
+                    'qty': 1,
+                }]],
+                'name': 'Order 12345-123-1234',
+                'partner_id': self.partner1.id,
+                'pos_session_id': current_session.id,
+                'sequence_number': 2,
+                'statement_ids': [[0, 0, {
+                    'amount': 100,
+                    'name': fields.Datetime.now(),
+                    'payment_method_id': self.cash_payment_method.id
+                }], [0, 0, {
+                    'amount': 50,
+                    'name': fields.Datetime.now(),
+                    'payment_method_id': self.bank_payment_method.id
+                }]],
+                'uid': '12345-123-1234',
+                'user_id': self.env.uid,
+                'to_invoice': False,
+            }
+        }
+        self.PosOrder.create_from_ui([pos_order_data])
+
+        total_cash_payment = sum(current_session.mapped('order_ids.payment_ids').filtered(lambda payment: payment.payment_method_id.type == 'cash').mapped('amount'))
+        current_session.post_closing_cash_details(total_cash_payment)
+        current_session.close_session_from_ui()
+
+        pos_order = self.env['pos.order'].search([])
+        pos_order.action_pos_order_invoice()
+        self.assertEqual(pos_order.state, 'invoiced')


### PR DESCRIPTION
Currently it's not always possible to invoice an order from another
sessio nthat is already closed when there is cash rounding.

Steps to reproduce:
-------------------
* Enable cash rounding for cash methods only, 5cents half-up
* Open pos session
* Add a produc with price 174.99 to order
* Add a customer
* Go to pay
* Select pm cash and enter 100
* Select pm bank and enter 75
* Change 0.01
* Validate
* Close session
* Open session
* Try invoicing the precedent order
> Observation: Not possible to invoice, move is not balanced

Back porting as it is exaclty the same issue: https://github.com/odoo/odoo/commit/626c3fd1bff85cc6cb222bdba80c14dd761dafd3

opw-[4829919](https://www.odoo.com/web#id=4829919&view_type=form&model=project.task)