### PR TITLE
[FIX] point_of_sale: fix combo synchronization

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -736,6 +736,12 @@ export class PosOrderline extends Base {
     isSelected() {
         return this.order_id?.uiState?.selected_orderline_uuid === this.uuid;
     }
+    setDirty(skip = false) {
+        if (this.isPartOfCombo && !skip) {
+            this.getAllLinesInCombo().forEach((line) => line.setDirty(true));
+        }
+        super.setDirty(skip);
+    }
 }
 
 registry.category("pos_available_models").add(PosOrderline.pythonModel, PosOrderline);

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -163,7 +163,7 @@ export class Base {
         }
     }
 
-    setDirty() {
+    setDirty(skip = false) {
         if (typeof this.id === "number") {
             this.models.commands[this.model.modelName].update.add(this.id);
         }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -757,3 +757,28 @@ registry.category("web_tour.tours").add("test_book_and_release_table", {
             waitForLoading(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_combo_synchronisation", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            Dialog.confirm(),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("A"),
+            Chrome.clickPlanButton(),
+            FloorScreen.hasTable("5"),
+            FloorScreen.clickTable("5"),
+            {
+                content: "Check if there still has combo lines",
+                trigger: ".orderline-combo",
+            },
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -536,3 +536,12 @@ class TestFrontend(TestFrontendCommon):
         self.start_pos_tour('test_book_and_release_table', login="pos_user")
         order = self.env['pos.order'].search([], limit=1, order='id desc')
         self.assertEqual(order.state, "cancel", "The order should be in cancel state after releasing the table")
+
+    def test_combo_synchronisation(self):
+        """This test checks that when a combo line is set as dirty, the parent combo line is also set as dirty.
+           if this is not the case, the combo lines would lose their link to the parent combo line and appear as
+           normal line"""
+        setup_product_combo_items(self)
+        self.pos_config.is_order_printer = False
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_combo_synchronisation')


### PR DESCRIPTION
When one of the combo line is marked as "Dirty", it would be synched but it would remove it's link to the combo parent.

Steps to reproduce:
-------------------
* Create a combo product
* Open a PoS restaurant
* Open a table, and add the combo product
* Leave the table to synchronize the order with the backend
* Go back on the table and select a partner
* This will mark the combo line as "dirty"
* Leave the table again to synchronize the order with the backend
* Go back on the table
> Observation: The combo now appears as a normal product, not linked to
the combo parent.

Why the fix:
------------
When marking a line as "dirty", we now make sure to also mark it's combo parent as "dirty" so that it will be synchronized correctly. And keep the link to the combo parent.

opw-4950262