### PR TITLE
[FIX] website: input visiblity dependency

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -1074,7 +1074,7 @@ export class MultiCheckboxDisplayAction extends BuilderAction {
 }
 export class SetLabelTextAction extends BuilderAction {
     static id = "setLabelText";
-    apply({ editingElement: fieldEl, value }) {
+    apply({ isPreviewing, editingElement: fieldEl, value }) {
         const labelEl = fieldEl.querySelector(".s_website_form_label_content");
         labelEl.textContent = value;
         if (isFieldCustom(fieldEl)) {
@@ -1084,7 +1084,9 @@ export class SetLabelTextAction extends BuilderAction {
                 multiple.dataset.name = value;
             }
             const inputEls = fieldEl.querySelectorAll(".s_website_form_input");
-            const previousInputName = fieldEl.name;
+            if (!isPreviewing) {
+                this.previousInputName = inputEls[0].name;
+            }
             inputEls.forEach((el) => (el.name = value));
 
             // Synchronize the fields whose visibility depends on this field
@@ -1092,7 +1094,7 @@ export class SetLabelTextAction extends BuilderAction {
                 .closest("form")
                 .querySelectorAll(
                     `.s_website_form_field[data-visibility-dependency="${CSS.escape(
-                        previousInputName
+                        isPreviewing ? this.previousInputName : value
                     )}"]`
                 );
             for (const dependentEl of dependentEls) {


### PR DESCRIPTION
This commit resolve the traceback arise after the refactoring
of snippet options.

Steps to reproduce this traceback:
1. Drop Form snippet and add text field A
2. add text field B, change visibility condition to depend on A
3. change label text of B to A
4. save snippet
5. instance crashes and cant's do anything in instance after that.

This commit aims to:
- Correct `previousInputName` to be taken from the first input
  element’s `name` instead of the container element.
- Ensure dependent fields update their `data-visibility-dependency`
  correctly based on the old input name.
- Detect and remove circular visibility dependencies when renaming
  fields to conflicting names.
- Prevent instance crashes caused by corrupted visibility dependency
  data during label renames.
