### PR TITLE
[FIX] Unnecessary zero valued valuation is created in case of backorder.

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -80,7 +80,7 @@ class StockMove(models.Model):
         self.ensure_one()
         res = OrderedSet()
         for move_line in self.move_line_ids:
-            if not move_line.picked:
+            if not move_line.picked or float_is_zero(move_line.quantity, precision_rounding=self.product_id.uom_id.rounding):
                 continue
             if move_line._should_exclude_for_valuation():
                 continue
@@ -110,7 +110,7 @@ class StockMove(models.Model):
         """
         res = self.env['stock.move.line']
         for move_line in self.move_line_ids:
-            if not move_line.picked:
+            if not move_line.picked or float_is_zero(move_line.quantity, precision_rounding=self.product_id.uom_id.rounding):
                 continue
             if move_line._should_exclude_for_valuation():
                 continue


### PR DESCRIPTION
Description of the issue/feature this PR addresses
A stock valuation layer (SVL) with zero quantity and zero value is created when receipts or deliveries are processed with the backroder from the barcode interface.

Current behavior before PR
When processing an incoming shipment through the barcode view, if part of the quantity is assigned to an inventory loss account and the remaining quantity leads to a backorder, the system generates an SVL with quantity = 0 and value = 0.

Desired behavior after PR is merged.
The system should not create a stock valuation layer in such cases.

PFA behaviour proof from the runbot:

https://github.com/user-attachments/assets/d0cf2856-ab32-4e03-ba97-bf7aa4967df2

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
