### PR TITLE
[FIX] mail: always use authorName

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -35,7 +35,7 @@
             <i class="fa fa-mail-reply me-1 opacity-75"/>You:
         </t>
         <t t-elif="!message.author?.eq(thread.correspondent?.persona)">
-            <t t-esc="message.author?.name ?? message.email_from"/>:
+            <t t-esc="message.authorName"/>:
         </t>
     </t>
 

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -33,7 +33,7 @@
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">
-                    Replying to <b t-esc="props.messageToReplyTo.message.author?.name ?? props.messageToReplyTo.message.email_from"/>
+                    Replying to <b t-esc="props.messageToReplyTo.message.authorName"/>
                 </span>
                 <span t-if="props.messageToReplyTo.message.thread.notEq(props.composer.thread)">
                     on: <b><t t-esc="props.messageToReplyTo.message.thread.displayName"/></b>

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -259,10 +259,7 @@ export class Message extends Component {
     }
 
     get authorName() {
-        if (this.message.author) {
-            return this.message.getPersonaName(this.message.author);
-        }
-        return this.message.email_from;
+        return this.message.authorName;
     }
 
     get authorAvatarUrl() {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Message">
         <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-muted opacity-50 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1"/>
-            <span class="o-mail-NotificationMessage-author d-inline" t-if="authorName and !message.body.includes(escape(authorName))" t-esc="authorName"/> <t t-out="message.body"/>
+            <span class="o-mail-NotificationMessage-author d-inline" t-if="message.authorName and !message.body.includes(escape(message.authorName))" t-esc="message.authorName"/> <t t-out="message.body"/>
         </div>
         <ActionSwiper t-else="" onRightSwipe="hasTouch() and props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
             <div class="o-mail-Message position-relative rounded-0"
@@ -38,8 +38,8 @@
                     </div>
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
                         <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note, 'pe-2': props.asCard and isMobileOS }" name="header">
-                            <span t-if="authorName and shouldDisplayAuthorName" class="o-mail-Message-author smaller" t-att-class="getAuthorAttClass()">
-                                <strong class="me-1" t-esc="authorName"/>
+                            <span t-if="message.authorName and shouldDisplayAuthorName" class="o-mail-Message-author smaller" t-att-class="getAuthorAttClass()">
+                                <strong class="me-1" t-esc="message.authorName"/>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
                             <small t-if="!message.is_transient" class="o-mail-Message-date o-xsmaller" t-att-title="message.datetimeShort">

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -9,9 +9,9 @@
             }">
                 <span class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
                     <t t-if="!props.message.parentMessage.isEmpty">
-                        <img class="o-mail-MessageInReply-avatar me-2 o-rounded-bubble o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
+                        <img class="o-mail-MessageInReply-avatar me-2 o-rounded-bubble o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.authorName" alt="Avatar"/>
                         <span class="o-mail-MessageInReply-content overflow-hidden smaller">
-                            <b class="o-mail-MessageInReply-author"><t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
+                            <b class="o-mail-MessageInReply-author"><t t-out="props.message.parentMessage.authorName"/></b>:
                             <span class="o-mail-MessageInReply-message ms-1 text-break">
                                 <t t-if="!props.message.parentMessage.isBodyEmpty">
                                     <t t-out="props.message.parentMessage.body"/>

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -373,6 +373,16 @@ export class Message extends Record {
         );
     }
 
+    /**
+     * This is the preferred way to display the name of the author of a message.
+     */
+    get authorName() {
+        if (this.author) {
+            return this.getPersonaName(this.author);
+        }
+        return this.email_from;
+    }
+
     get inlineBody() {
         if (this.isEmpty) {
             return _t("This message has been removed");
@@ -469,6 +479,8 @@ export class Message extends Record {
     }
 
     /**
+     * Provide fallback to displayName in the absence of a thread
+     *
      * @param {import("models").Persona} persona
      * @returns {string}
      */

--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -46,11 +46,11 @@ export class OutOfFocusService {
             icon = author.avatarUrl;
             if (message.thread?.channel_type === "channel") {
                 notificationTitle = _t("%(author name)s from %(channel name)s", {
-                    "author name": author.name,
+                    "author name": message.authorName,
                     "channel name": message.thread.displayName,
                 });
             } else {
-                notificationTitle = author.name;
+                notificationTitle = message.authorName;
             }
         }
         const notificationContent = htmlToTextContentInline(message.body).substring(

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -361,6 +361,7 @@ export class Thread extends Record {
      * thread.
      *
      * @param {import("models").Persona} persona
+     * @returns {string}
      */
     getPersonaName(persona) {
         return persona.displayName;
@@ -377,6 +378,7 @@ export class Thread extends Record {
     get supportsCustomChannelName() {
         return this.isChatChannel && this.channel_type !== "group";
     }
+
     get displayName() {
         return this.display_name;
     }


### PR DESCRIPTION
Before this commit, using author.name directly could lead to not showing anything to livechat visitors. This is because the information is not send to the visitor.
By using the authorName getter, we leverable the override in livechat and correctly use the livechat_username.

task-4965911