### PR TITLE
[FIX] website: prevent deletion of order_by input

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2773,7 +2773,7 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
     <xpath expr="//div[@role='search']" position="replace">
         <form t-attf-class="o_searchbar_form o_wait_lazy_js s_searchbar_input #{_form_classes}" t-att-action="action" method="get" t-attf-data-snippet="s_searchbar_input">
             <t>$0</t>
-            <input name="order" type="hidden" class="o_search_order_by" t-att-value="order_by if order_by else 'name asc'"/>
+            <input name="order" type="hidden" class="o_search_order_by oe_unremovable" t-att-value="order_by if order_by else 'name asc'"/>
             <t t-out="0"/>
         </form>
     </xpath>


### PR DESCRIPTION
Problem:
In Website, the `order_by` hidden input stores the selected sort
order for search. This input can currently be deleted via
`oDeleteBackward`, which may break the form behavior.

Solution:
Make `order_by` input unremovable to ensure form integrity.

Steps to reproduce:
- Add a "Title" text block
- Insert a search element before the text
- Delete all the text
- Use backspace to delete the header block
- Save
- > A traceback occurs because the `order_by` input was deleted

opw-4863089

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
