### PR TITLE
[FIX] html_editor: discard link creation when click away from full-line link

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -154,6 +154,7 @@ export class LinkPlugin extends Plugin {
         "overlay",
         "color",
         "feff",
+        "linkSelection",
     ];
     // @phoenix @todo: do we want to have createLink and insertLink methods in link plugin?
     static shared = ["createLink", "insertLink", "getPathAsUrlCommand"];
@@ -404,6 +405,7 @@ export class LinkPlugin extends Plugin {
             },
             onClose: () => {
                 this.overlay.close();
+                this.removeCurrentLinkIfEmtpy();
             },
             getInternalMetaData: this.getInternalMetaData,
             getExternalMetaData: this.getExternalMetaData,
@@ -510,6 +512,10 @@ export class LinkPlugin extends Plugin {
                 this.overlay.close();
                 this.linkElement = linkEl;
                 this.LinkPopoverState.editing = false;
+            }
+
+            if (this.linkElement && this.linkElement.classList.contains("o_link_in_selection")) {
+                this.dependencies.linkSelection.padLinkWithZwnbsp(this.linkElement);
             }
 
             // if the link includes an inline image, we close the previous opened popover to reposition it

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -24,7 +24,7 @@ import { expectElementCount } from "../_helpers/ui_expectations";
 const base64Img =
     "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
 
-describe("should open a popover", () => {
+describe("should open or close a popover", () => {
     test("should open a popover when the selection is inside a link and close outside of a link", async () => {
         const { el } = await setupEditor("<p>this is a <a>link</a></p>");
         await expectElementCount(".o-we-linkpopover", 0);
@@ -34,6 +34,19 @@ describe("should open a popover", () => {
         // selection outside a link
         setContent(el, "<p>this []is a <a>link</a></p>");
         await expectElementCount(".o-we-linkpopover", 0);
+    });
+    test("should pad new created links and close a popover, remove empty link when press esc", async () => {
+        const { el } = await setupEditor("<p>[Hello]</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+        await waitFor(".o-we-linkpopover", { timeout: 1500 });
+        expect(getContent(el)).toBe(
+            '<p>\ufeff<a class="o_link_in_selection">\ufeffHello\ufeff</a>\ufeff</p>'
+        );
+        await press("escape");
+        await animationFrame();
+        await expectElementCount(".o-we-linkpopover", 0);
+        expect(cleanLinkArtifacts(getContent(el))).toBe("<p>Hello</p>");
     });
     test("link popover should have input field for href when the link doesn't have href", async () => {
         await setupEditor("<p>this is a <a>li[]nk</a></p>");
@@ -791,7 +804,8 @@ describe("link preview", () => {
     });
     test("test external metadata cached correctly", async () => {
         const title = "Open Source ERP and CRM | Odoo";
-        const description = "From ERP to CRM, eCommerce and CMS. Download Odoo or use it in the cloud. Grow Your Business.";
+        const description =
+            "From ERP to CRM, eCommerce and CMS. Download Odoo or use it in the cloud. Grow Your Business.";
         onRpc("/html_editor/link_preview_external", () => {
             expect.step("/html_editor/link_preview_external");
             return {


### PR DESCRIPTION
reproduction 18.0 and 18.1:
1. Go to the To-do app and type some text.
2. Select the typed text and click the Link button in the toolbar.
3. A link editing popover appears, without adding an href, click anywhere outside the popover.
4. The popover does not close when clicking outside. And pressing Escape and clicking again in the editor, the popover reopens

**Before this commit:**
When creating a link from the toolbar, the link element is not padded with `feff` . This results in the selection remaining inside the link when clicking away and keeps the popover open. Pressing Escape only closes the popover but does not clean up the created link element.

**After this commit:**
We pad the newly created link element with `feff` when it is eligible for visual link isolation but not already padded. This ensures the padding is limited to newly created links. Additionally, when pressing Escape, we now clean up empty link elements after closing the popover.

task-4948641



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
