### PR TITLE
[FIX] hr_recruitment: fix traceback when saving a template

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -1058,7 +1058,11 @@ class HrApplicant(models.Model):
             'res_model': 'applicant.get.refuse.reason',
             'view_mode': 'form',
             'target': 'new',
-            'context': {'default_applicant_ids': self.ids, 'active_test': False},
+            'context': {
+                'default_applicant_ids': self.ids,
+                'active_test': False,
+                'hide_mail_template_management_options': True,
+            },
             'views': [[False, 'form']]
         }
 


### PR DESCRIPTION
Steps to reproduce:
- open any applicant in recruitment app
- click on refuse button
- enable send email toggle key
- edit the message
- try to save the template

Issue:
- traceback pop ups and not able to save the template

Reason:
- The method 'open_template_creation_wizard' is missing, causing the error when trying to save the template. This method was not implemented.

Solution:
- Remove the 'save the template' feature for this version by adding the context. It require two fields which are not present in the current model, thus avoiding the error.

task-4948736

