### PR TITLE
[FIX] account: fixes _install_demo in no demo build

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -255,7 +255,7 @@ class AccountChartTemplate(models.AbstractModel):
         if not isinstance(companies, models.BaseModel):
             companies = self.env['res.company'].browse(companies)
         for company in companies:
-            self.sudo()._load_data(self._get_demo_data(company), ignore_duplicates=True)
+            self.sudo()._load_data(self._get_demo_data(company))
             self._post_load_demo_data(company)
 
     def _pre_reload_data(self, company, template_data, data, force_create=True):


### PR DESCRIPTION
This issue was introduced with [211765](https://github.com/odoo/odoo/pull/211765), which is a FW port of [200420](https://github.com/odoo/odoo/pull/200420).

In saas-18.2 no demo build, tests that are using `_install_demo` are failing because `ignore_duplicates=True` is preventing to load demo data correctly.

As this change is not forward-ported in saas-18.3+ and was meant to fix demo data while upgrading from 16 to 17, it's probably better to revert it back for saas-18.2.

Runbot - [224203](https://runbot.odoo.com/odoo/error/224203)
