### PR TITLE
[FIX] l10n_fr_hr_work_entry_holidays: fix traceback when creating a work entry

### DIFF
--- a/addons/l10n_fr_hr_work_entry_holidays/models/hr_work_entry.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/models/hr_work_entry.py
@@ -27,6 +27,6 @@ class HrWorkEntry(models.Model):
         if not french_part_time_work_entries:
             return res
         for entry in french_part_time_work_entries:
-            if entry.id in res and res[entry.id] == 0:
+            if entry.id in res and res[entry.id] == 0 and entry.date_start and entry.date_stop:
                 res[entry.id] = (entry.date_stop - entry.date_start).seconds/3600
         return res

--- a/addons/l10n_fr_hr_work_entry_holidays/tests/test_french_work_entries.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/tests/test_french_work_entries.py
@@ -5,7 +5,7 @@ import logging
 import time
 
 from datetime import datetime
-from odoo.tests.common import TransactionCase, tagged
+from odoo.tests.common import Form, TransactionCase, tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -87,3 +87,12 @@ class TestFrenchWorkEntries(TransactionCase):
         # Make sure that the gap filling does not go past the requested date
         work_entry_create_vals = self.employee_contract._get_contract_work_entries_values(datetime(2021, 9, 6), datetime(2021, 9, 9, 23, 59, 59))
         self.assertEqual(len(work_entry_create_vals), 8, 'Should have generated 8 work entries.')
+
+    def test_create_work_entry_with_french_company(self):
+        self.employee_contract.write({'state': 'open'})
+        with Form(self.env['hr.work.entry'].with_company(self.company)) as work_entry_form:
+            work_entry_form.employee_id = self.employee
+            work_entry_form.date_start = '2020-01-01 08:00:00'
+            work_entry_form.date_stop = '2020-01-01 17:00:00'
+            work_entry = work_entry_form.save()
+        self.assertEqual(work_entry.duration, 9)


### PR DESCRIPTION
Currently, a traceback occurs when a user attempts to create a work entry in the list view.

**To reproduce this issue:**

1) Install the `l10n_fr_hr_work_entry_holidays` module. 
2) Switch to the `French` company and open the payroll. 
3) Open the work entries in list view and try to create a new record.

**Error:**
```
AttributeError: 'int' object has no attribute 'seconds'
```

**Cause:**
By default, when creating a work entry through the list view, no `start` or `end` date is provided.

This leads to the traceback originating from the following line 
when computing the duration.
https://github.com/odoo/odoo/blob/84b15dc1f866e27d5c8a5fe3e457c2f982bcb133/addons/l10n_fr_hr_work_entry_holidays/models/hr_work_entry.py#L28-L32

**Solution:**
Adding an extra check of the `start` and `end` date would resolve this issue.

opw-4943104

