### PR TITLE
[FIX] mail: fix discuss test from runbot error 230138

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.Discuss">
     <t t-set="partitionedActions" t-value="threadActions.partition"/>
-    <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center': ui.isSmall }" t-ref="root">
+    <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center': ui.isSmall }" t-att-data-active="store.discuss.isActive" t-ref="root">
         <DiscussSidebar t-if="!ui.isSmall and props.hasSidebar"/>
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto o-scrollbar-thin" t-ref="content">
             <div class="o-mail-Discuss-header px-2 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">

--- a/addons/mail/static/tests/messaging/messaging.test.js
+++ b/addons/mail/static/tests/messaging/messaging.test.js
@@ -88,6 +88,7 @@ test("Show conversations with new message in chat hub (outside of discuss app)",
     );
     await contains(".o-mail-ChatBubble[name='GroupChat']");
     await openDiscuss();
+    await contains(".o-mail-Discuss[data-active]");
     // simulate receiving new message (chat, inside discuss app)
     await withUser(userId, () =>
         rpc("/mail/message/post", {
@@ -96,7 +97,8 @@ test("Show conversations with new message in chat hub (outside of discuss app)",
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-DiscussSidebar-item:contains('Dumbledore') .badge", { text: "1" });
+    await click(".o-mail-DiscussSidebar-item:contains('Dumbledore'):has(.badge:contains(1))");
+    await contains(".o-mail-Message:contains('Tricky')");
     // check no new chat window/bubble while in discuss app
     await openFormView("res.partner", partnerId);
     await contains(".o-mail-ChatBubble[name='GroupChat']");


### PR DESCRIPTION
Before this commit, discuss test "Show conversations with new message in chat hub (outside of discuss app)" failed non-deterministically on runbot with the following error:

```
Failed to find 0 of ".o-mail-ChatBubble[name='Dumbledore']" (Timeout of 3 seconds). Found 1 instead.
```

The test checks that new conversations spawn in chat hub on new message when outside of discuss app. At some point, it opens discuss app and then simulate a user posting a new message. When leaving the discuss app we should not expect a chat bubble. The error above says that there's actually a chat bubble when there shouldn't be.

The `await openDiscuss()` gives the impression that this waits enough time for discuss being open, but this only awaits the action service doAction() method, which doesn't necessarily mean the client action UI is fully loaded and store has exact flag `discuss.isActive`, which is essential for a new message posted being considered inside the discuss app.

This commit fixes the issue by ensuring discuss app is loaded after `openDiscuss()` with `[data-active]`: this data attribute matches the flag `discuss.isActive` which is set reactively from rendering of `discuss_client_action`.

Also the handling of chat window / bubble to open is handled with bus notification "discuss.channel/new_message". This is no the same bus notification that changes the counter (`mail.record/insert`), so asserting presence of counter in discuss sidebar doesn't mean the handling of chat window / bubble to open has been performed. Test had race condition to open chat bubble just after openFormView. This commit fixes it by opening the conversation in discuss app and awaiting message is loaded. This should give enough confidence that logic to auto-open chat window / bubble has been performed and decided to not open the chat window / bubble as expected.

Fixes runbot-error-230138