### PR TITLE
[FIX] account_check_printing: ensure JE label matches payment check

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -965,6 +965,8 @@ class AccountPayment(models.Model):
             return
 
         for pay in self:
+            if pay.move_id.state == 'posted':
+                continue
             liquidity_lines, counterpart_lines, writeoff_lines = pay._seek_for_lines()
             # Make sure to preserve the write-off amount.
             # This allows to create a new payment with custom 'line_ids'.

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -121,6 +121,10 @@ class AccountPayment(models.Model):
             field_desc['readonly'] = True
         return result
 
+    @api.model
+    def _get_trigger_fields_to_synchronize(self):
+        return super()._get_trigger_fields_to_synchronize() + ('check_number',)
+
     def _get_aml_default_display_name_list(self):
         # Extends 'account'
         self.ensure_one()


### PR DESCRIPTION
Steps to reproduce:
1. Install `accounting` and `account_check_printing` modules.
2. Configure a bank journal:
   - Enable the `Manual Numbering` option for checks.
   - Set an `Outstanding Payments Account` for checks under the `outgoing payments` tab on the journal.
   - Ensure the Check Sequence is properly configured.
3. Create three vendor bills (two for the same vendor and one for a different vendor).
4. Go to the list view of vendor bills and select all three of them.
5. Click the `Pay` button and in the payment wizard:
   - Enable the `Group Payments` option.
   - Choose `Checks` as the payment method.
   - Confirm the wizard to register the payment.

Observed Behavior:
- Multiple payments are created simultaneously.
- Each payment has its own check number (e.g., 0001, 0002), correctly assigned.
- However, all the related journal entries (account.move) have journal item labels that incorrectly use the same check number (e.g., all journal items have label Check - 0001 instead of Check - 0001, Check - 0002, etc.).

Issue:
- Journal entries are created during payment creation `create()`, at which point the payments are still in draft state.
- The check_number is only computed and the check sequence is incremented when the payment is posted `action_post()`.
- As a result, all journal entries generated during draft state receive the same initial check number.

Solution:
- Override the `_get_trigger_fields_to_synchronize` method to include the `check number`, ensuring that any updates to the check number on a payment are also reflected in the related journal entries.

opw-4886452