### PR TITLE
[IMP] html_editor: display font sizes from small to large in fontSizeSelector

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -360,21 +360,23 @@ export class FontPlugin extends Plugin {
     get fontSizeItems() {
         const style = getHtmlStyle(this.document);
         const nameAlreadyUsed = new Set();
-        return fontSizeItems.flatMap((item) => {
-            const strValue = getCSSVariableValue(item.variableName, style);
-            if (!strValue) {
-                return [];
-            }
-            const remValue = parseFloat(strValue);
-            const pxValue = convertNumericToUnit(remValue, "rem", "px", style);
-            const roundedValue = Math.round(pxValue);
-            if (nameAlreadyUsed.has(roundedValue)) {
-                return [];
-            }
-            nameAlreadyUsed.add(roundedValue);
+        return fontSizeItems
+            .flatMap((item) => {
+                const strValue = getCSSVariableValue(item.variableName, style);
+                if (!strValue) {
+                    return [];
+                }
+                const remValue = parseFloat(strValue);
+                const pxValue = convertNumericToUnit(remValue, "rem", "px", style);
+                const roundedValue = Math.round(pxValue);
+                if (nameAlreadyUsed.has(roundedValue)) {
+                    return [];
+                }
+                nameAlreadyUsed.add(roundedValue);
 
-            return [{ ...item, tagName: "span", name: roundedValue }];
-        });
+                return [{ ...item, tagName: "span", name: roundedValue }];
+            })
+            .sort((a, b) => a.name - b.name);
     }
 
     blockFormatIsAvailable(selection) {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -346,9 +346,9 @@ test("toolbar works: can select font size", async () => {
     expect(inputEl).toHaveValue(getFontSizeFromVar("body-font-size").toString());
 
     await contains(".o-we-toolbar [name='font_size_selector'].dropdown-toggle").click();
-    const sizes = new Set(
-        fontSizeItems.map((item) => getFontSizeFromVar(item.variableName).toString())
-    );
+    const sizes = [...new Set(fontSizeItems.map((item) => getFontSizeFromVar(item.variableName)))]
+        .sort((a, b) => a - b)
+        .map(String);
     expect(queryAllTexts(".o_font_size_selector_menu .dropdown-item")).toEqual([...sizes]);
     const h1Size = getFontSizeFromVar("h1-font-size").toString();
     await contains(`.o_font_size_selector_menu .dropdown-item:contains('${h1Size}')`).click();
@@ -377,9 +377,9 @@ test("toolbar works: change font size correctly when closest block element has a
     expect(inputEl).toHaveValue(getFontSizeFromVar("h3-font-size").toString());
 
     await contains(".o-we-toolbar [name='font_size_selector'].dropdown-toggle").click();
-    const sizes = new Set(
-        fontSizeItems.map((item) => getFontSizeFromVar(item.variableName).toString())
-    );
+    const sizes = [...new Set(fontSizeItems.map((item) => getFontSizeFromVar(item.variableName)))]
+        .sort((a, b) => a - b)
+        .map(String);
     expect(queryAllTexts(".o_font_size_selector_menu .dropdown-item")).toEqual([...sizes]);
     const h1Size = getFontSizeFromVar("h1-font-size").toString();
     await contains(`.o_font_size_selector_menu .dropdown-item:contains('${h1Size}')`).click();


### PR DESCRIPTION
Current behavior before PR:

- The font size dropdown in the toolbar listed sizes from large to small.

Desired behavior after PR is merged:

- The font size dropdown now displays sizes from small to large, top to bottom.
- This follows a more natural reading flow and helps users quickly choose the desired font size in increasing order.

task-4951351

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
