### PR TITLE
[IMP] website: added the sale order snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -147,6 +147,7 @@
         'views/snippets/s_text_highlight.xml',
         'views/snippets/s_pricelist_cafe.xml',
         'views/snippets/s_progress_bar.xml',
+        'views/snippets/s_sale_order_display.xml',
         'views/snippets/s_blockquote.xml',
         'views/snippets/s_badge.xml',
         'views/snippets/s_color_blocks_2.xml',

--- a/addons/website/static/src/builder/plugins/sale_order_display_options.js
+++ b/addons/website/static/src/builder/plugins/sale_order_display_options.js
@@ -1,0 +1,22 @@
+/** @odoo-module **/
+
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BuilderSelect } from "@html_builder/core/building_blocks/builder_select";
+import { BuilderSelectItem } from "@html_builder/core/building_blocks/builder_select_item";
+import { BuilderRow } from "@html_builder/core/building_blocks/builder_row";
+import { BuilderCheckbox } from "@html_builder/core/building_blocks/builder_checkbox";
+
+export class SaleOrderDisplayOptions extends BaseOptionComponent {
+    static template = "website.SaleOrderDisplayOptions";
+
+    static components = {
+        BuilderRow,
+        BuilderSelect,
+        BuilderSelectItem,
+        BuilderCheckbox,
+    };
+
+    setup() {
+        super.setup();
+    }
+}

--- a/addons/website/static/src/builder/plugins/sale_order_display_options.xml
+++ b/addons/website/static/src/builder/plugins/sale_order_display_options.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website.SaleOrderDisplayOptions">
+        <BuilderRow label.translate="Confirmed Orders">
+            <BuilderCheckbox dataAttributeAction="'confirmedorders'" dataAttributeActionValue="true"/>
+        </BuilderRow>
+
+        <BuilderRow label.translate="View Type">
+            <BuilderSelect dataAttributeAction="'viewchange'">
+                <BuilderSelectItem label.translate="List" t-out="'List'" dataAttributeActionValue="'list'"/>
+                <BuilderSelectItem label.translate="Card" t-out="'Card'" dataAttributeActionValue="'card'"/>
+            </BuilderSelect>
+        </BuilderRow>
+
+        <BuilderRow label.translate="Limit">
+            <BuilderSelect dataAttributeAction="'limitchange'">
+                <BuilderSelectItem label.translate="3" t-out="'3'" dataAttributeActionValue="'3'"/>
+                <BuilderSelectItem label.translate="6" t-out="'6'" dataAttributeActionValue="'6'"/>
+                <BuilderSelectItem label.translate="9" t-out="'9'" dataAttributeActionValue="'9'"/>
+            </BuilderSelect>
+        </BuilderRow>
+    </t>
+</templates>

--- a/addons/website/static/src/builder/plugins/sale_order_display_options_plugin.js
+++ b/addons/website/static/src/builder/plugins/sale_order_display_options_plugin.js
@@ -1,0 +1,48 @@
+import { Plugin } from "@html_editor/plugin";
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { SaleOrderDisplayOptions } from "./sale_order_display_options";
+import { registry } from "@web/core/registry";
+
+
+export class SaleOrderDisplayPlugin extends Plugin {
+    static id = "SaleOrderDisplay";
+    static dependencies = ["builderOptions", "builderActions"];
+
+    resources = {
+        builder_options: [
+            {
+                OptionComponent: SaleOrderDisplayOptions,
+                selector: ".s_sale_order_display",
+            }
+        ],
+        builder_actions: {
+            ConfirmedOrders,
+            ViewChange,
+            LimitChange,
+        }
+    }
+}
+
+export class ConfirmedOrders extends BuilderAction {
+    static id = "confirmedorders"
+    setup() {
+        super.setup();
+    }
+}
+
+export class ViewChange extends BuilderAction {
+    static id = "viewchange"
+    setup() {
+        super.setup();
+    }
+}
+
+
+export class LimitChange extends BuilderAction {
+    static id = "limitchange"
+    setup() {
+        super.setup();
+    }
+}
+
+registry.category("website-plugins").add(SaleOrderDisplayPlugin.id, SaleOrderDisplayPlugin);

--- a/addons/website/static/src/snippets/s_sale_order_display/sale_order_display.js
+++ b/addons/website/static/src/snippets/s_sale_order_display/sale_order_display.js
@@ -1,0 +1,88 @@
+/** @odoo-module **/
+
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+import { renderToFragment } from "@web/core/utils/render";
+
+export class SaleOrderDisplay extends Interaction {
+    static selector = ".s_sale_order_display";
+
+    dynamicContent = {
+        ".load-more-btn": {
+            "t-on-click": () => this.loadOrders(),
+        },
+    };
+
+    setup() {
+        this.orm = this.env.services.orm;
+        this.offset = 0;
+        this.orders = [];
+        this.loadOrders({ reset: true });
+    }
+
+    async loadOrders({ reset = false } = {}) {
+        const showConfirm = this.el.dataset.confirmedorders === "true";
+        const view = this.el.dataset.viewchange || "list";
+        const limit = parseInt(this.el.dataset.limitchange || "3", 10);
+
+        if (reset) {
+            this.offset = 0;
+            this.orders = [];
+        }
+
+        const domain = showConfirm
+            ? [["state", "=", "sale"]]
+            : [["state", "in", ["sale", "draft", "sent"]]];
+    
+
+        const result = await this.orm.searchRead(
+            "sale.order",
+            domain,
+            ["name", "partner_id", "state"],
+            { offset: this.offset, limit, order: "id asc" }
+        );
+
+        const mapped = result.map((r) => ({
+            name: r.name,
+            partner_name: r.partner_id?.[1] || "",
+            state: r.state,
+        }));
+
+        this.orders.push(...mapped);
+        this.offset += mapped.length;
+
+        const templateName = view === "list"
+            ? "website.s_sale_order_display_list"
+            : "website.s_sale_order_display_card";
+
+        const content = await renderToFragment(templateName, {
+            sale_orders: this.orders,
+        });
+
+        const container = this.el.querySelector(".container");
+        container.replaceChildren(content);
+
+        if (mapped.length >= limit) {
+            this._addLoadMoreButton(container);
+        }
+    }
+
+    _addLoadMoreButton(container) {
+        const btnWrapper = document.createElement("div");
+        btnWrapper.className = "text-center mt-3";
+
+        const btn = document.createElement("button");
+        btn.className = "btn btn-primary load-more-btn";
+        btn.textContent = "Load More";
+
+        btn.addEventListener("click", () => {
+            this.loadOrders();
+        });
+
+        btnWrapper.appendChild(btn);
+        container.appendChild(btnWrapper);
+    }
+}
+
+registry.category("public.interactions").add("sale_order_display", SaleOrderDisplay);
+registry.category("public.interactions.edit").add("sale_order_display",{Interaction:SaleOrderDisplay});

--- a/addons/website/static/src/snippets/s_sale_order_display/sale_order_display.xml
+++ b/addons/website/static/src/snippets/s_sale_order_display/sale_order_display.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+
+    <t t-name="website.s_sale_order_display_list">
+        <div class="row sale-order-list">
+            <t t-foreach="sale_orders" t-as="order" t-key="order.id">
+                <div class="col-12 mb-2">
+                    <div class="border p-2">
+                        <strong t-esc="order.name" /> - <t t-esc="order.partner_name" /> (<em t-esc="order.state" />)
+                    </div>
+                </div>
+            </t>
+        </div>
+    </t>
+
+    <t t-name="website.s_sale_order_display_card">
+        <div class="row sale-order-card">
+            <t t-foreach="sale_orders" t-as="order" t-key="order.id">
+                <div class="col-md-4 mb-3">
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title" t-esc="order.name" />
+                            <p class="card-text">
+                                <strong>Customer:</strong>
+                                <t t-esc="order.partner_name" />
+                            </p>
+                            <span class="badge bg-info" t-esc="order.state" />
+                        </div>
+                    </div>
+                </div>
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/addons/website/views/snippets/s_sale_order_display.xml
+++ b/addons/website/views/snippets/s_sale_order_display.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <!-- Snippet Template -->
+    <template id="s_sale_order_display" name="Sale Order Display Snippet">
+        <section class="s_sale_order_display" data-name="Sale Order Display"
+            data-viewchange="list" data-confirmedorders="false" data-limitchange="3">
+            <div class="container">
+                <div class="row sale-order-list">
+                    <div class="border p-2">
+                        <strong>S000001</strong> - Mitchell Admin (<em>sale</em>) </div>
+                </div>
+                <div class="row sale-order-card"></div>
+                <div class="text-center mt-3 load-btn-class">
+                    <button class="btn btn-primary load-more-btn" type="button">Load More</button>
+                </div>
+            </div>
+        </section>
+    </template>
+    <record id="website.s_sale_order_display_js" model="ir.asset">
+        <field name="name">Sale Order Display JS</field>
+        <field name="bundle">web.assets_frontend</field>
+        <field name="path">website/static/src/snippets/s_sale_order_display/sale_order_display.js</field>
+    </record>
+
+    <record id="website.s_sale_order_display_templates" model="ir.asset">
+        <field name="name">Sale Order Display Templates</field>
+        <field name="bundle">web.assets_frontend</field>
+        <field name="path">website/static/src/snippets/s_sale_order_display/sale_order_display.xml</field>
+    </record>
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -475,6 +475,7 @@
                 <t t-snippet="website.s_text_highlight" string="Text Highlight" t-thumbnail="/website/static/src/img/snippets_thumbs/s_text_highlight.svg"/>
                 <t t-snippet="website.s_chart" string="Chart" t-thumbnail="/website/static/src/img/snippets_thumbs/s_chart.svg"/>
                 <t t-snippet="website.s_progress_bar" string="Progress Bar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_progress_bar.svg"/>
+                <t t-install="sale_management" t-snippet="website.s_sale_order_display" string="Sale Order Display" t-thumbnail="/website/static/src/img/snippets_thumbs/s_hr.svg"/>
                 <t t-snippet="website.s_badge" string="Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_badge.svg"/>
                 <t t-snippet="website.s_cta_badge" string="CTA Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_cta_badge.svg"/>
                 <t t-snippet="website.s_blockquote" string="Blockquote" t-thumbnail="/website/static/src/img/snippets_thumbs/s_blockquote.svg"/>


### PR DESCRIPTION
Created a custom website snippet to display Sale Order details with dynamic frontend behavior. The snippet allows toggling between list & card views, configuring the initial data fetch limit, using the plugin, and includes a load More button to retrieve additional records on demand. Moreover, there is an option to display only confirmed sale orders.