### PR TITLE
[IMP] website: stop notifying when the content is saved on iframe reload

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -491,10 +491,6 @@ export class WebsiteBuilderClientAction extends Component {
         await this.reloadIframe(this.state.isEditing, param.url);
         // trigger an new instance of the builder menu
         this.state.key++;
-
-        this.notification.add(_t("Content saved"), {
-            type: "success",
-        });
     }
 
     async reloadIframeAndCloseEditor() {

--- a/addons/website/static/src/components/editor/editor.js
+++ b/addons/website/static/src/components/editor/editor.js
@@ -1,4 +1,3 @@
-import { _t } from "@web/core/l10n/translation";
 import { useService } from '@web/core/utils/hooks';
 import {
     markup,
@@ -18,7 +17,6 @@ export class WebsiteEditorComponent extends Component {
      */
     setup() {
         this.websiteService = useService('website');
-        this.notificationService = useService('notification');
 
         this.websiteContext = useState(this.websiteService.context);
         this.state = useState({
@@ -101,10 +99,6 @@ export class WebsiteEditorComponent extends Component {
      * @returns {Promise<void>}
      */
     async reload({ snippetOptionSelector, url } = {}) {
-        this.notificationService.add(_t("Your modifications were saved to apply this option."), {
-            title: _t("Content saved."),
-            type: 'success'
-        });
         this.state.showWysiwyg = false;
         await this.props.reloadIframe(url);
         this.reloadSelector = snippetOptionSelector;

--- a/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
+++ b/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
@@ -39,20 +39,14 @@ registerWebsitePreviewTour("dropdowns_and_header_hide_on_scroll", {
     selectHeader(),
     ...changeOptionInPopover("Header", "Scroll Effect", ".dropdown-item:contains('Fixed')"),
     {
-        content: "Wait for the modification has been applied",
-        trigger: ".o_notification .o_notification_content:contains('Content saved')",
+        content: "Wait for the option to be applied",
+        trigger: "[data-label='Scroll Effect'] .dropdown-toggle:contains('Fixed')",
         timeout: 30000,
     },
     {
         trigger: ":iframe #wrapwrap header.o_header_fixed",
     },
     selectHeader(),
-    {
-        // Checking step needed to make sure the builder DOM is up to date with
-        // the reloaded iframe.
-        content: "Expect Fixed scroll effect to be selected",
-        trigger: "[data-label='Scroll Effect'] .dropdown-toggle:contains('Fixed')",
-    },
     ...changeOptionInPopover("Header", "Template", ".dropdown-item[data-action-param*=sales_two]"),
     {
         trigger: ":iframe .o_header_sales_two_top",


### PR DESCRIPTION
Some options in edit mode require to reload the iframe, and in that case the content is saved beforehand. After the reload, the user was notified that the content was saved. True, this was annoying, but it was made so that the user understands that if it did not want to save the content, he has to undo the changes. Also, to try avoiding confusion that the discard button will have no effect about it afterwards.

FP decision: this is not needed, the user cannot do anything about it so best not notifying about it. Some options will thus now silently reload and save the content, it is now up to the user to understand which ones once they actually discard/save their changes themselves.

Hopefully, this kind of option is "rare" or at least are not commonly used options in a live (visited) website, as they mainly are about main design layout choices (e.g. header type).

Note that [1] recently simplified it, but it was "not enough".

[1]: https://github.com/odoo/odoo/commit/e7a68432fd7da666ed1214c4e2aa532a22e911fa

task-fp
