### PR TITLE
[REF] *_fleet: merge plan_to_change car and bike into a same field

### DIFF
--- a/addons/account_fleet/tests/test_account_fleet.py
+++ b/addons/account_fleet/tests/test_account_fleet.py
@@ -21,7 +21,7 @@ class TestAccountFleet(AccountTestInvoicingCommon):
         })
         car_1 = self.env["fleet.vehicle"].create({
             "model_id": model.id,
-            "plan_to_change_car": False,
+            "plan_to_change_vehicle": False,
         })
 
         bill = self.init_invoice('in_invoice', products=self.product_a, invoice_date='2021-09-01', post=False)

--- a/addons/account_fleet/tests/test_fleet_vehicle_log_services.py
+++ b/addons/account_fleet/tests/test_fleet_vehicle_log_services.py
@@ -24,12 +24,12 @@ class TestFleetVehicleLogServices(AccountTestInvoicingCommon):
             {
                 "model_id": model.id,
                 "driver_id": cls.purchaser.id,
-                "plan_to_change_car": False
+                "plan_to_change_vehicle": False
             },
             {
                 "model_id": model.id,
                 "driver_id": cls.purchaser.id,
-                "plan_to_change_car": False
+                "plan_to_change_vehicle": False
             }
         ])
         cls.bill = cls.env['account.move'].create({
@@ -147,7 +147,7 @@ class TestFleetVehicleLogServices(AccountTestInvoicingCommon):
         })
         car = self.env["fleet.vehicle"].create({
             "model_id": model.id,
-            "plan_to_change_car": False
+            "plan_to_change_vehicle": False
         })
 
         partner = self.env['res.partner'].create({

--- a/addons/fleet/tests/test_access_rights.py
+++ b/addons/fleet/tests/test_access_rights.py
@@ -31,48 +31,48 @@ class TestFleet(common.TransactionCase):
         car = self.env["fleet.vehicle"].with_user(self.manager).create({
             "model_id": self.car_model.id,
             "driver_id": self.user.partner_id.id,
-            "plan_to_change_car": False
+            "plan_to_change_vehicle": False
         })
-        car.with_user(self.manager).plan_to_change_car = True
+        car.with_user(self.manager).plan_to_change_vehicle = True
 
     def test_change_future_driver(self):
         car1, car2, bike1, bike2 = self.env["fleet.vehicle"].create([
             {
                 "model_id": self.car_model.id,
                 "driver_id": self.user.partner_id.id,
-                "plan_to_change_car": False,
+                "plan_to_change_vehicle": False,
             },
             {
                 "model_id": self.car_model.id,
                 "driver_id": self.manager.partner_id.id,
-                "plan_to_change_car": False,
+                "plan_to_change_vehicle": False,
             },
             {
                 "model_id": self.bike_model.id,
                 "driver_id": self.user.partner_id.id,
-                "plan_to_change_car": False,
+                "plan_to_change_vehicle": False,
             },
             {
                 "model_id": self.bike_model.id,
                 "driver_id": self.manager.partner_id.id,
-                "plan_to_change_car": False,
+                "plan_to_change_vehicle": False,
             },
         ])
         self.assertFalse(car1.future_driver_id)
         self.assertFalse(bike1.future_driver_id)
-        self.assertFalse(car1.plan_to_change_car)
-        self.assertFalse(bike1.plan_to_change_bike)
+        self.assertFalse(car1.plan_to_change_vehicle)
+        self.assertFalse(bike1.plan_to_change_vehicle)
         self.assertFalse(car2.future_driver_id)
         self.assertFalse(bike2.future_driver_id)
-        self.assertFalse(car2.plan_to_change_car)
-        self.assertFalse(bike2.plan_to_change_bike)
+        self.assertFalse(car2.plan_to_change_vehicle)
+        self.assertFalse(bike2.plan_to_change_vehicle)
 
         (car1 + bike1).write({"future_driver_id": self.manager.partner_id.id})
         self.assertEqual(car1.future_driver_id, self.manager.partner_id)
         self.assertEqual(bike1.future_driver_id, self.manager.partner_id)
-        self.assertFalse(bike1.plan_to_change_bike)
-        self.assertFalse(car1.plan_to_change_car)
+        self.assertFalse(bike1.plan_to_change_vehicle)
+        self.assertFalse(car1.plan_to_change_vehicle)
         self.assertFalse(car2.future_driver_id)
         self.assertFalse(bike2.future_driver_id)
-        self.assertTrue(car2.plan_to_change_car)
-        self.assertTrue(bike2.plan_to_change_bike)
+        self.assertTrue(car2.plan_to_change_vehicle)
+        self.assertTrue(bike2.plan_to_change_vehicle)

--- a/addons/fleet/tests/test_overdue.py
+++ b/addons/fleet/tests/test_overdue.py
@@ -22,13 +22,13 @@ class TestFleet(common.TransactionCase):
         car_1 = self.env["fleet.vehicle"].create({
             "model_id": model.id,
             "driver_id": user.partner_id.id,
-            "plan_to_change_car": False
+            "plan_to_change_vehicle": False
         })
 
         car_2 = self.env["fleet.vehicle"].create({
             "model_id": model.id,
             "driver_id": user.partner_id.id,
-            "plan_to_change_car": False
+            "plan_to_change_vehicle": False
         })
         Log = self.env['fleet.vehicle.log.contract']
         Log.create({
@@ -61,7 +61,7 @@ class TestFleet(common.TransactionCase):
         car_1 = self.env["fleet.vehicle"].create({
             "model_id": model.id,
             "driver_id": user.partner_id.id,
-            "plan_to_change_car": False
+            "plan_to_change_vehicle": False
         })
 
         Log = self.env['fleet.vehicle.log.contract']

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -108,11 +108,8 @@
                             </div>
                             <field name="manager_id" widget="many2one_avatar_user"/>
                             <field name="location"/>
-                            <label string="Make Vehicle Available" for="plan_to_change_car" class="text-nowrap" invisible="vehicle_type != 'car'"/>
-                            <field name="plan_to_change_car" groups="fleet.fleet_group_manager" invisible="vehicle_type != 'car'" nolabel="1"
-                                help="This will allow this vehicle to be selectable for the Salary Configurator" class="text-nowrap"/>
-                            <label string="Make Vehicle Available" for="plan_to_change_bike" class="text-nowrap" invisible="vehicle_type != 'bike'"/>
-                            <field name="plan_to_change_bike" groups="fleet.fleet_group_manager"  invisible="vehicle_type != 'bike'" nolabel="1"
+                            <label string="Make Vehicle Available" for="plan_to_change_vehicle" class="text-nowrap"/>
+                            <field name="plan_to_change_vehicle" groups="fleet.fleet_group_manager" nolabel="1"
                                 help="This will allow this vehicle to be selectable for the Salary Configurator"/>
                         </group>
                     </group>
@@ -235,11 +232,11 @@
                 <field string="Status" name="state_id"/>
                 <field string="Properties" name="vehicle_properties"/>
                 <filter string="Available" name="available"
-                    domain="['&amp;', ('future_driver_id', '=', False), '|', ('driver_id', '=', False), '|', '&amp;', ('plan_to_change_car', '=', True), ('vehicle_type', '=', 'car'), '&amp;', ('plan_to_change_bike', '=', True), ('vehicle_type', '=', 'bike')]"/>
+                    domain="['&amp;', ('future_driver_id', '=', False), '|', ('driver_id', '=', False), '|', ('plan_to_change_vehicle', '=', True)]"/>
                 <filter string="Bikes" name="bikes" domain="[('vehicle_type', '=', 'bike')]"/>
                 <filter string="Cars" name="cars" domain="[('vehicle_type', '=', 'car')]"/>
                 <filter string="Trailer Hook" name="trailer_hook" domain="[('trailer_hook', '=', True)]"/>
-                <filter name="planned" string="Planned for Change" domain="['|', '&amp;', ('vehicle_type', '=', 'bike'), ('plan_to_change_bike', '=', True), '&amp;', ('vehicle_type', '=', 'car'), ('plan_to_change_car', '=', True)]"/>
+                <filter name="planned" string="Planned for Change" domain="[('plan_to_change_vehicle', '=', True)]"/>
                 <separator/>
                 <filter string="Need Action" name="alert_true" domain="['|', ('contract_renewal_due_soon', '=', True), ('contract_renewal_overdue', '=', True)]"/>
                 <separator/>

--- a/addons/hr_fleet/tests/test_hr_fleet_driver.py
+++ b/addons/hr_fleet/tests/test_hr_fleet_driver.py
@@ -32,13 +32,13 @@ class TestHrFleetDriver(common.TransactionCase):
         cls.car = cls.env["fleet.vehicle"].create({
             "model_id": cls.model.id,
             "future_driver_id": cls.test_employee.work_contact_id.id,
-            "plan_to_change_car": False,
+            "plan_to_change_vehicle": False,
             "fuel_type": "diesel"
         })
 
         cls.car2 = cls.env["fleet.vehicle"].create({
             "model_id": cls.model.id,
-            "plan_to_change_car": False,
+            "plan_to_change_vehicle": False,
             "fuel_type": "diesel"
         })
 

--- a/addons/hr_fleet/tests/test_mail_activity_plan.py
+++ b/addons/hr_fleet/tests/test_mail_activity_plan.py
@@ -32,7 +32,7 @@ class TestActivitySchedule(ActivityScheduleHRCase):
                     "name": "A3",
                 }).id,
                 "manager_id": cls.user_manager.id,
-                "plan_to_change_car": False,
+                "plan_to_change_vehicle": False,
             })
             employee.car_ids = car
 


### PR DESCRIPTION
Before https://github.com/odoo/odoo/commit/078fbba4decb32ae4b5d9878ee3788f7042382e8, plan_to_change_car and plan_to_change_bike were historically related from the driver that could have both car and bike so it made sense to have them separated. Since they are now stored on vehicle model directly, there is no reason to keep them separated anymore. The vehicle is either a car or a bike (or whatever it could be) and the concept of planning to change the vehicle is not dependant of the type of the current vehicle.

This commit merges both fields into a single one.

Task-4966460