### PR TITLE
[IMP] iot_box_image: fixes for new image release

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -748,8 +748,8 @@ def reset_log_level():
         _logger.info("Resetting log level to default.")
         update_conf({
             'log_level_reset_timestamp': '',
-            'log_handler': ':WARNING',
-            'log_level': 'warn',
+            'log_handler': ':INFO',
+            'log_level': 'info',
         })
 
 

--- a/addons/iot_box_image/configuration/odoo.conf
+++ b/addons/iot_box_image/configuration/odoo.conf
@@ -1,7 +1,7 @@
 [options]
 data_dir = /var/run/odoo
-log_handler = :WARNING
-log_level = warn
+log_handler = :INFO
+log_level = info
 pidfile = /var/run/odoo/odoo.pid
 limit_time_cpu = 600
 limit_time_real = 1200

--- a/addons/iot_box_image/overwrite_after_init/etc/nginx/conf.d/iot.conf
+++ b/addons/iot_box_image/overwrite_after_init/etc/nginx/conf.d/iot.conf
@@ -23,10 +23,10 @@ server {
         root /var/www/html;
     }
 
-    # Expose the /var/log/odoo folder directly via nginx, so that
+    # Expose the /var/log/ folder directly via nginx, so that
     # it remains accessible even if Odoo is failing to start.
     location /odoo-logs {
-        alias /var/log/odoo/;
+        alias /var/log/;
         autoindex on;
     }
 }

--- a/addons/iot_box_image/overwrite_after_init/etc/rc.local
+++ b/addons/iot_box_image/overwrite_after_init/etc/rc.local
@@ -11,6 +11,9 @@
 #
 # By default this script does nothing.
 
+exec 1>/var/log/rc.local.log 2>&1  # send stdout and stderr from rc.local to a log file
+set -x                             # display commands before execution
+
 # Ensure Wi-Fi radio is enabled
 nmcli radio wifi on
 
@@ -29,10 +32,22 @@ if [ -f $start_wifi ]; then
   $start_wifi &
 fi
 
-update_odoo=/home/pi/odoo/addons/iot_box_image/configuration/checkout.sh
-if [ -f $update_odoo ]; then
-  printf "Updating Odoo service...\n"
-  $update_odoo &
-fi
+# Update current branch
+cd /home/pi/odoo
+localbranch=$(sudo -u odoo git symbolic-ref -q --short HEAD)
+localremote=$(sudo -u odoo git config branch.$localbranch.remote)
+
+# Enter write mode
+mount -o remount,rw /
+mount -o remount,rw /root_bypass_ramdisks
+
+sudo -u odoo git remote set-url "${localremote}" "https://github.com/odoo/odoo.git"
+
+sudo -u odoo GIT_SSL_NO_VERIFY=1 git fetch "${localremote}" "${localbranch}" --depth=1
+sudo -u odoo git reset --hard FETCH_HEAD
+
+# Enter read mode
+mount -o remount,ro /
+mount -o remount,ro /root_bypass_ramdisks
 
 exit 0

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -284,8 +284,8 @@ wget 'https://nightly.odoo.com/master/iotbox/eftapi.so' -P /usr/lib/
 # Create Odoo user for odoo service and disable password login
 adduser --disabled-password --gecos "" --shell /usr/sbin/nologin odoo
 
-# Replace pi user with odoo user in sudoers file: odoo user doesn't need to type its password to run sudo commands
-mv /etc/sudoers.d/010_pi-nopasswd /etc/sudoers.d/010_odoo-nopasswd
+# odoo user doesn't need to type its password to run sudo commands
+cp /etc/sudoers.d/010_pi-nopasswd /etc/sudoers.d/010_odoo-nopasswd
 sed -i 's/pi/odoo/g' /etc/sudoers.d/010_odoo-nopasswd
 
 # copy the odoo.conf file to the overwrite directory


### PR DESCRIPTION
This commit contains the following small changes:
- No longer require a sudo password for pi user (reverting to default Raspberry Pi OS behaviour). This is because if Odoo couldn't start there was no way to fix it if you didn't have the current password.
- Expose /var/log/ folder instead of just /var/log/odoo via nginx. This is useful because then we can see e.g. the nginx access logs.
- Fix rc.local git checkout on reboot. This wasn't working because the commands were not being run as the odoo user.
- Use INFO log level by default instead of WARNING.

task-4954737

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
