### PR TITLE
[FIX] website_sale: avoid redirect on submit form

### DIFF
--- a/addons/portal/static/src/interactions/address.js
+++ b/addons/portal/static/src/interactions/address.js
@@ -132,6 +132,7 @@ export class CustomerAddress extends Interaction {
      * @param {Event} ev
      */
     async saveAddress(ev) {
+        ev.preventDefault();  // avoid potential redirect if href set on link
         if (!this.addressForm.reportValidity()) return;
 
         const result = await this.waitFor(this.http.post(


### PR DESCRIPTION
On checkout step /shop/address, if you have an href on the button, during the post to /shop/address/submit, you will be redirected in GET to the href value.

opw-discord-internal
