### PR TITLE
[FIX] website: avoid cdnifying `None` as an empty string

### DIFF
--- a/addons/test_website/tests/template_qweb_test.xml
+++ b/addons/test_website/tests/template_qweb_test.xml
@@ -21,4 +21,12 @@
 </html>
     </template>
 
+    <template id="test_website.test_template_tatt_qweb" name="t-att template">
+        <a t-att-href='"/"'>1</a>
+        <a t-att-href='False'>2</a>
+        <a t-att-href='None'>3</a>
+        <a t-att-href=''>4</a>
+        <a t-att-href='""'>5</a>
+    </template>
+
 </odoo>

--- a/addons/test_website/tests/test_qweb.py
+++ b/addons/test_website/tests/test_qweb.py
@@ -6,6 +6,7 @@ import re
 
 from odoo import tools
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
+from odoo.addons.website.tools import MockRequest
 
 
 class TestQweb(TransactionCaseWithUserDemo):
@@ -77,3 +78,15 @@ class TestQweb(TransactionCaseWithUserDemo):
         <div widget="image"><img src="http://test.cdn/web/image/res.users/%(user_id)s/avatar_1920/%(filename)s" class="img img-fluid" alt="%(alt)s" loading="lazy"/></div>
     </body>
 </html>""" % format_data).encode('utf8'))
+
+        with MockRequest(self.env, website=website):
+            html = demo_env['ir.qweb']._render('test_website.test_template_tatt_qweb', {}, website_id=website.id)
+            self.assertHTMLEqual(html, ("""
+    <html>
+       <body><a href="/">1</a>
+        <a>2</a>
+        <a>3</a>
+        <a>4</a>
+        <a href="">5</a></body>
+    </html>
+    """))

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -167,7 +167,7 @@ class IrQWeb(models.AbstractModel):
         name = self.URL_ATTRS.get(tagName)
         if request:
             value = atts.get(name) if name else None
-            if value is not None and value is not False:
+            if value not in (None, False, ()):
                 atts[name] = self.env['ir.http']._url_for(str(value))
 
             # Adapt background-image URL in the same way as image src.
@@ -179,9 +179,9 @@ class IrQWeb(models.AbstractModel):
         data_name = f'data-{name}'
         if name and (name in atts or data_name in atts):
             atts = OrderedDict(atts)
-            if name in atts:
+            if name in atts and atts[name] not in (False, None, ()):
                 atts[name] = website.get_cdn_url(atts[name])
-            if data_name in atts:
+            if data_name in atts and atts[data_name] not in (False, None, ()):
                 atts[data_name] = website.get_cdn_url(atts[data_name])
         atts = self._adapt_style_background_image(atts, website.get_cdn_url)
 


### PR DESCRIPTION
In QWeb, when using `t-att-href='None'`, the attribute is omitted from the DOM.

However, when a CDN is used, `None` is converted to an empty string (`''`) by `get_cdn_url`.

This is a follow-up to commit 3e9c953.

This fix addresses an issue on the `/shop/address` page where the "Submit" button had `href=''`, causing JavaScript event handling to break due to a race condition triggered by a page refresh during form submission (POST).
