### PR TITLE
[FIX] account,account_edi_ubl_cii: Fix get invoice legal document

### DIFF
--- a/addons/account/controllers/download_docs.py
+++ b/addons/account/controllers/download_docs.py
@@ -50,8 +50,9 @@ class AccountDocumentDownloadController(http.Controller):
         invoices.line_ids.check_access('read')
         docs_data = []
         for invoice in invoices:
-            doc_data = invoice._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback)
-            if doc_data:
+            if filetype == 'all' and (doc_data := invoice._get_invoice_legal_documents_all(allow_fallback=allow_fallback)):
+                docs_data += doc_data
+            elif doc_data := invoice._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback):
                 docs_data.append(doc_data)
         if len(docs_data) == 1:
             doc_data = docs_data[0]

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5852,7 +5852,7 @@ class AccountMove(models.Model):
 
     def _get_invoice_legal_documents(self, filetype, allow_fallback=False):
         """ Retrieve the invoice legal document of type filetype.
-        :param filetype: the type of legal document to retrieve. Example: 'pdf', 'all'.
+        :param filetype: the type of legal document to retrieve. Example: 'pdf'.
         :param bool allow_fallback: if True, returns a Proforma if the PDF invoice doesn't exist.
         :return dict: the invoice PDF data such as
         {'filename': 'INV_2024_0001.pdf', 'filetype': 'pdf', 'content':...}
@@ -5868,8 +5868,6 @@ class AccountMove(models.Model):
                 }
             elif allow_fallback:
                 return self._get_invoice_pdf_proforma()
-        elif filetype == 'all':
-            return self._get_invoice_legal_documents_all(allow_fallback=allow_fallback)
 
     def _get_invoice_legal_documents_all(self, allow_fallback=False):
         """ Retrieve the invoice legal attachments: PDF, XML, ...

--- a/addons/account/tests/test_download_docs.py
+++ b/addons/account/tests/test_download_docs.py
@@ -72,3 +72,14 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
             self.assertEqual(len(zip_file.filelist), 2)
             self.assertTrue(zip_file.NameToInfo.get(self.invoices[0].invoice_pdf_report_id.name))
             self.assertTrue(zip_file.NameToInfo.get(self.invoices[1].invoice_pdf_report_id.name))
+
+    def test_download_invoice_documents_filetype_all(self):
+        self.authenticate(self.env.user.login, self.env.user.login)
+        url = f'/account/download_invoice_documents/{",".join(map(str, self.invoices.ids))}/all'
+        res = self.url_open(url)
+        self.assertEqual(res.status_code, 200)
+        with ZipFile(BytesIO(res.content)) as zip_file:
+            file_names = zip_file.namelist()
+            self.assertEqual(len(file_names), 2)
+            self.assertTrue(self.invoices[0].invoice_pdf_report_id.name in file_names)
+            self.assertTrue(self.invoices[1].invoice_pdf_report_id.name in file_names)

--- a/addons/account_edi_ubl_cii/tests/__init__.py
+++ b/addons/account_edi_ubl_cii/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_autopost_bills
 from . import test_partner_peppol_fields
 from . import test_ubl_cii
 from . import test_ubl_bis3
+from . import test_download_docs

--- a/addons/account_edi_ubl_cii/tests/test_download_docs.py
+++ b/addons/account_edi_ubl_cii/tests/test_download_docs.py
@@ -1,0 +1,66 @@
+from io import BytesIO
+from zipfile import ZipFile
+
+from odoo.fields import Command
+from odoo.tests.common import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
+
+
+@tagged('post_install', '-at_install')
+class TestDownloadDocs(AccountTestInvoicingHttpCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_a.country_id = cls.env.ref('base.be')
+        cls.partner_a.invoice_edi_format = 'ubl_bis3'
+        invoice_1 = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': cls.partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'price_unit': 100,
+                    'product_id': cls.product_a.id,
+                    'tax_ids': cls.tax_sale_a.ids,
+                })
+            ]
+        })
+        invoice_2 = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': cls.partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'price_unit': 20,
+                    'product_id': cls.product_a.id,
+                    'tax_ids': cls.tax_sale_a.ids,
+                })
+            ]
+        })
+        invoice_3 = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': cls.partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'price_unit': 300,
+                    'product_id': cls.product_a.id,
+                    'tax_ids': cls.tax_sale_a.ids,
+                })
+            ]
+        })
+        cls.invoices = invoice_1 + invoice_2
+        cls.invoices.action_post()
+        cls.invoices._generate_and_send(sending_methods=['manual'])
+        cls.invoices += invoice_3
+        assert invoice_1.invoice_pdf_report_id and invoice_2.invoice_pdf_report_id and not invoice_3.invoice_pdf_report_id
+        assert invoice_1.ubl_cii_xml_id and invoice_2.ubl_cii_xml_id and not invoice_3.ubl_cii_xml_id
+
+    def test_download_invoice_documents_filetype_all(self):
+        self.authenticate(self.env.user.login, self.env.user.login)
+        url = f'/account/download_invoice_documents/{",".join(map(str, self.invoices.ids))}/all'
+        res = self.url_open(url)
+        self.assertEqual(res.status_code, 200)
+        with ZipFile(BytesIO(res.content)) as zip_file:
+            files = zip_file.namelist()
+            self.assertEqual(len(files), 5)
+            xml_files = sum(file.endswith('.xml') for file in files)
+            self.assertEqual(xml_files, 2)


### PR DESCRIPTION
`_get_invoice_legal_documents` should, and is expected to, return a dict. however, if called with `filetype = all`, it returns, because of `_get_invoice_legal_documents_all`, a list which breaks calling code as they expect a dict not a list, and this part of the code is not used anywhere nor tested.

- remove the line causing `_get_invoice_legal_documents` to return a list.

- make `download_invoice_documents_filetype` work with multiple filetypes

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
