### PR TITLE
[IMP] orm: compare boolean fields with bool only

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6115,7 +6115,7 @@ class AccountMove(models.Model):
         domain = [('model', '=', 'account.move')]
 
         if is_invoice_report:
-            domain += [('is_invoice_report', '=', 'True')]
+            domain += [('is_invoice_report', '=', True)]
 
         model_reports = self.env['ir.actions.report'].search(domain)
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -600,7 +600,7 @@ class AccountMoveLine(models.Model):
                            ON account_companies.account_account_id = account.id
                      WHERE account_companies.res_company_id = ANY(%(company_ids)s)
                        AND account.account_type IN ('asset_receivable', 'liability_payable')
-                       AND account.active = 't'
+                       AND account.active IS TRUE
                 )
                 SELECT * FROM previous
                 UNION ALL

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -46,7 +46,7 @@ def preserve_existing_tags_on_taxes(env, module):
     ''' This is a utility function used to preserve existing previous tags during upgrade of the module.'''
     xml_records = env['ir.model.data'].search([('model', '=', 'account.account.tag'), ('module', 'like', module)])
     if xml_records:
-        env.cr.execute("update ir_model_data set noupdate = 't' where id in %s", [tuple(xml_records.ids)])
+        env.cr.execute("update ir_model_data set noupdate = TRUE where id in %s", [tuple(xml_records.ids)])
 
 
 def template(template=None, model='template_data', *, demo=False):

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -103,8 +103,8 @@
                     <filter string="Draft" name="state_draft" domain="[('state', '=', 'draft')]"/>
                     <filter string="In Process" name="state_in_process" domain="[('state', '=', 'in_process')]"/>
                     <separator/>
-                    <filter string="Sent" name="state_sent" domain="[('is_sent', '=', 'True')]"/>
-                    <filter string="Not Sent" name="state_sent" domain="[('is_sent', '=', 'False')]"/>
+                    <filter string="Sent" name="state_sent" domain="[('is_sent', '=', True)]"/>
+                    <filter string="Not Sent" name="state_sent" domain="[('is_sent', '=', False)]"/>
                     <filter string="No Bank Matching" name="unmatched" domain="[('is_matched', '=', False)]"/>
                     <filter string="Reconciled" name="reconciled" domain="[('is_reconciled', '=', True)]"/>
                     <separator/>

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -216,7 +216,7 @@ class AccountPayment(models.Model):
         if not report_action:
             msg = _("Something went wrong with Check Layout, please select another layout in Invoicing/Accounting Settings and try again.")
             raise RedirectWarning(msg, redirect_action.id, _('Go to the configuration panel'))
-        self.write({'is_sent': 'True'})
+        self.write({'is_sent': True})
         return report_action.report_action(self)
 
     #######################

--- a/addons/board/static/tests/board.test.js
+++ b/addons/board/static/tests/board.test.js
@@ -89,7 +89,7 @@ describe("board_desktop", () => {
             };
         });
         onRpc("web_search_read", (args) => {
-            expect(args.kwargs.domain).toEqual([["foo", "!=", "False"]], {
+            expect(args.kwargs.domain).toEqual([["foo", "!=", false]], {
                 message: "the domain should be passed",
             });
             expect(args.kwargs.context.orderedBy).toEqual(
@@ -119,7 +119,7 @@ describe("board_desktop", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,
@@ -182,7 +182,7 @@ describe("board_desktop", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,
@@ -215,7 +215,7 @@ describe("board_desktop", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,
@@ -236,7 +236,7 @@ describe("board_desktop", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,
@@ -276,7 +276,7 @@ describe("board_desktop", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,
@@ -315,7 +315,7 @@ describe("board_desktop", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,
@@ -340,7 +340,7 @@ describe("board_desktop", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,
@@ -410,7 +410,7 @@ describe("board_desktop", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,
@@ -658,7 +658,7 @@ describe("board_mobile", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,
@@ -690,10 +690,10 @@ describe("board_mobile", () => {
                 <form string="My Dashboard" js_class="board">
                     <board style="2-1">
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                         <column>
-                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', 'False']]"></action>
+                            <action context="{&quot;orderedBy&quot;: [{&quot;name&quot;: &quot;foo&quot;, &quot;asc&quot;: True}]}" view_mode="list" string="ABC" name="51" domain="[['foo', '!=', False]]"></action>
                         </column>
                     </board>
                 </form>`,

--- a/addons/crm/data/digest_data.xml
+++ b/addons/crm/data/digest_data.xml
@@ -14,7 +14,7 @@
             <field name="group_id" ref="sales_team.group_sale_salesman_all_leads"/>
             <field name="tip_description" type="html">
 <div>
-    <t t-set="record" t-value="object.env['crm.team'].search([('alias_name', '!=', 'False')], limit=1)" />
+    <t t-set="record" t-value="object.env['crm.team'].search([('alias_name', '!=', False)], limit=1)" />
     <p class="tip_title">Tip: Convert incoming emails into opportunities</p>
     <t t-if="record.alias_email">
         <p class="tip_content">Did you know emails sent to <t t-out="record.alias_email"></t> generate opportunities in your pipeline?<br/>

--- a/addons/event_booth_sale/models/event_booth.py
+++ b/addons/event_booth_sale/models/event_booth.py
@@ -20,7 +20,7 @@ class EventBooth(models.Model):
         readonly=False, index='btree_not_null',
         groups='sales_team.group_sale_salesman', copy=False)
     sale_order_id = fields.Many2one(
-        related='sale_order_line_id.order_id', store='True', readonly=True, index='btree_not_null',
+        related='sale_order_line_id.order_id', store=True, readonly=True, index='btree_not_null',
         groups='sales_team.group_sale_salesman')
     is_paid = fields.Boolean('Is Paid', copy=False)
 

--- a/addons/fleet/models/fleet_vehicle_model_brand.py
+++ b/addons/fleet/models/fleet_vehicle_model_brand.py
@@ -18,7 +18,7 @@ class FleetVehicleModelBrand(models.Model):
     @api.depends('model_ids.active')
     def _compute_model_count(self):
         model_data = self.env['fleet.vehicle.model']._read_group([
-            ('brand_id', 'in', self.ids), ('active', '=', 'true')
+            ('brand_id', 'in', self.ids), ('active', '=', True)
         ], ['brand_id'], ['__count'])
         models_brand = {brand.id: count for brand, count in model_data}
 

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -69,7 +69,7 @@ class HrEmployee(models.Model):
         data = self.env['hr.leave.allocation']._read_group([
             ('employee_id', 'in', self.ids),
             ('holiday_status_id.active', '=', True),
-            ('holiday_status_id.requires_allocation', '=', 'yes'),
+            ('holiday_status_id.requires_allocation', '=', True),
             ('state', '=', 'validate'),
             ('date_from', '<=', current_date),
             '|',
@@ -90,7 +90,7 @@ class HrEmployee(models.Model):
             employee_remaining_leaves = 0
             employee_max_leaves = 0
             for leave_type in leaves_taken[employee]:
-                if leave_type.requires_allocation == 'no' or leave_type.hide_on_dashboard or not leave_type.active:
+                if not leave_type.requires_allocation or leave_type.hide_on_dashboard or not leave_type.active:
                     continue
                 for allocation in leaves_taken[employee][leave_type]:
                     if allocation and allocation.date_from <= current_date\

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -273,7 +273,7 @@ class HrLeaveType(models.Model):
 
     def _search_virtual_remaining_leaves(self, operator, value):
         def is_valid(leave_type):
-            return leave_type.requires_allocation != "yes" or op(leave_type.virtual_remaining_leaves, value)
+            return not leave_type.requires_allocation or op(leave_type.virtual_remaining_leaves, value)
         op = PY_OPERATORS.get(operator)
         if not op:
             return NotImplemented

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -39,7 +39,7 @@ class ResUsers(models.Model):
         self.env.cr.execute('''SELECT res_users.%s FROM res_users
                             JOIN hr_leave ON hr_leave.user_id = res_users.id
                             AND hr_leave.state = 'validate'
-                            AND res_users.active = 't'
+                            AND res_users.active IS TRUE
                             AND hr_leave.date_from <= %%s AND hr_leave.date_to >= %%s
                             RIGHT JOIN hr_leave_type ON hr_leave.holiday_status_id = hr_leave_type.id
                             AND hr_leave_type.time_type = 'leave';''' % field, (now, now))

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -4113,7 +4113,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             leave_type_day = self.env['hr.leave.type'].create({
                 'name': 'Test Leave Type',
                 'time_type': 'leave',
-                'requires_allocation': 'yes',
+                'requires_allocation': True,
                 'allocation_validation_type': 'no_validation',
                 'request_unit': 'day',
             })
@@ -4155,7 +4155,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             leave_type_day = self.env['hr.leave.type'].create({
                 'name': 'Test Leave Type',
                 'time_type': 'leave',
-                'requires_allocation': 'yes',
+                'requires_allocation': True,
                 'allocation_validation_type': 'no_validation',
                 'request_unit': 'half_day',
             })
@@ -4197,7 +4197,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             leave_type_day = self.env['hr.leave.type'].create({
                 'name': 'Test Leave Type',
                 'time_type': 'leave',
-                'requires_allocation': 'yes',
+                'requires_allocation': True,
                 'allocation_validation_type': 'no_validation',
                 'request_unit': 'day',
             })

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -390,7 +390,7 @@ class TestAllocations(TestHrHolidaysCommon):
         leave_type = self.env['hr.leave.type'].create({
             'name': 'Hourly Leave Type',
             'time_type': 'leave',
-            'requires_allocation': 'yes',
+            'requires_allocation': True,
             'allocation_validation_type': 'no_validation',
             'request_unit': 'hour',
         })

--- a/addons/l10n_br_website_sale/__init__.py
+++ b/addons/l10n_br_website_sale/__init__.py
@@ -4,7 +4,7 @@ from . import models
 
 def _set_tax_included_on_website_sale(env):
     # On the installation of the module, we want every brazilian companies' websites to have the show_line_subtotals_tax_selection set to 'tax_included'
-    websites = env['website'].search([('company_id', '!=', 'False')])
+    websites = env['website'].search([('company_id', '!=', False)])
     for website in websites:
         if website.company_id.country_id.code == 'BR':
             website.show_line_subtotals_tax_selection = 'tax_included'

--- a/addons/mass_mailing/views/mailing_trace_views.xml
+++ b/addons/mass_mailing/views/mailing_trace_views.xml
@@ -20,7 +20,7 @@
                 <filter string="Replied" name="filter_replied" domain="[('trace_status', '=', 'reply')]"/>
                 <filter string="Bounced" name="filter_bounced" domain="[('trace_status', '=', 'bounce')]"/>
                 <filter string="Failed" name="filter_failed" domain="[('trace_status', '=', 'error')]"/>
-                <filter string="Test Traces" name="filter_is_test_trace" domain="[('is_test_trace', '=', 'True')]"/>
+                <filter string="Test Traces" name="filter_is_test_trace" domain="[('is_test_trace', '=', True)]"/>
                 <group>
                     <filter string="State" name="state" domain="[]" context="{'group_by': 'trace_status'}"/>
                     <filter string="Open Date" name="group_open_date" domain="[('trace_status', 'in', ['open', 'reply'])]" context="{'group_by': 'open_datetime:day'}"/>

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -723,7 +723,7 @@ class MrpBomLine(models.Model):
     def _compute_attachments_count(self):
         for line in self:
             nbr_attach = self.env['product.document'].search_count([
-                '&', '&', ('attached_on_mrp', '=', 'bom'), ('active', '=', 't'),
+                '&', '&', ('attached_on_mrp', '=', 'bom'), ('active', '=', True),
                 '|',
                 '&', ('res_model', '=', 'product.product'), ('res_id', '=', line.product_id.id),
                 '&', ('res_model', '=', 'product.template'), ('res_id', '=', line.product_tmpl_id.id)])

--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -190,12 +190,12 @@ class ReportMrpReport_Bom_Structure(models.AbstractModel):
         has_attachments = False
         if not is_minimized:
             if product:
-                has_attachments = self.env['product.document'].search_count(['&', '&', ('attached_on_mrp', '=', 'bom'), ('active', '=', 't'), '|', '&', ('res_model', '=', 'product.product'),
+                has_attachments = self.env['product.document'].search_count(['&', '&', ('attached_on_mrp', '=', 'bom'), ('active', '=', True), '|', '&', ('res_model', '=', 'product.product'),
                                                                  ('res_id', '=', product.id), '&', ('res_model', '=', 'product.template'),
                                                                  ('res_id', '=', product.product_tmpl_id.id)], limit=1) > 0
             else:
                 # Use the product template instead of the variant
-                has_attachments = self.env['product.document'].search_count(['&', '&', ('attached_on_mrp', '=', 'bom'), ('active', '=', 't'),
+                has_attachments = self.env['product.document'].search_count(['&', '&', ('attached_on_mrp', '=', 'bom'), ('active', '=', True),
                                                                     '&', ('res_model', '=', 'product.template'), ('res_id', '=', bom.product_tmpl_id.id)], limit=1) > 0
 
         key = product.id

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -658,7 +658,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     def test_04_product_configurator(self):
         # Making one attribute inactive to verify that it doesn't show
-        configurable_product = self.env['product.product'].search([('name', '=', 'Configurable Chair'), ('available_in_pos', '=', 'True')], limit=1)
+        configurable_product = self.env['product.product'].search([('name', '=', 'Configurable Chair'), ('available_in_pos', '=', True)], limit=1)
         fabrics_line = configurable_product.attribute_line_ids[2]
         fabrics_line.product_template_value_ids[1].ptav_active = False
         self.pos_user.write({

--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -74,7 +74,7 @@ class ProductAttribute(models.Model):
         res = {
             attribute.id: count
             for attribute, count in self.env['product.template.attribute.line']._read_group(
-                domain=[('attribute_id', 'in', self.ids), ('product_tmpl_id.active', '=', 'True')],
+                domain=[('attribute_id', 'in', self.ids), ('product_tmpl_id.active', '=', True)],
                 groupby=['attribute_id'],
                 aggregates=['__count'],
             )
@@ -159,7 +159,7 @@ class ProductAttribute(models.Model):
             'name': _("Products"),
             'res_model': 'product.template.attribute.line',
             'view_mode': 'list,form',
-            'domain': [('attribute_id', '=', self.id), ('product_tmpl_id.active', '=', 'True')],
+            'domain': [('attribute_id', '=', self.id), ('product_tmpl_id.active', '=', True)],
         }
 
     # === TOOLING === #

--- a/addons/sale_project/data/sale_project_demo.xml
+++ b/addons/sale_project/data/sale_project_demo.xml
@@ -46,7 +46,7 @@
         <function model="project.project" name="write">
             <value model="project.project" search="[('id', '=', ref('project.project_home_construction'))]"/>
             <value eval="{
-                'allow_billable': 'True',
+                'allow_billable': True,
             }"/>
         </function>
 

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -71,7 +71,7 @@
                 <span t-else="">
                     starts on
                     <span t-field="track.event_id.with_context(tz=track.event_id.date_tz).date_begin"
-                        t-options="{'format': 'medium', 'tz_name': track.event_id.date_tz, 'hide_seconds': 'True'}"/>
+                        t-options="{'format': 'medium', 'tz_name': track.event_id.date_tz, 'hide_seconds': True}"/>
                     (<span t-out="track.event_id.date_tz"/>)
                 </span>
             </div>

--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -134,7 +134,7 @@
         <field name="res_model">sale.order</field>
         <field name="path">ecommerce-abandoned-carts</field>
         <field name="view_mode">list,kanban,form,activity</field>
-        <field name="domain">[('is_abandoned_cart', '=', 1)]</field>
+        <field name="domain">[('is_abandoned_cart', '=', True)]</field>
         <field name="context" eval="{'show_sale': True, 'create': False, 'public_partner_id': ref('base.public_partner'), 'search_default_recovery_email': True}"/>
         <field name="view_id" ref="sale.view_quotation_tree"/>
         <field name="search_view_id" ref="view_sales_order_filter_ecommerce_abondand"/>

--- a/addons/website_slides_forum/views/forum_forum_views.xml
+++ b/addons/website_slides_forum/views/forum_forum_views.xml
@@ -42,7 +42,7 @@
         <field name="name">Forums</field>
         <field name="res_model">forum.forum</field>
         <field name="view_mode">list,form</field>
-        <field name="domain">[('slide_channel_ids', '!=', 'False')]</field>
+        <field name="domain">[('slide_channel_ids', '!=', False)]</field>
         <field name="view_id" ref="forum_forum_view_tree_slides"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/website_slides_forum/views/forum_post_views.xml
+++ b/addons/website_slides_forum/views/forum_post_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Forum Posts</field>
         <field name="res_model">forum.post</field>
         <field name="view_mode">list,graph,pivot,form</field>
-        <field name="domain">[('forum_id.slide_channel_ids', '!=', 'False')]</field>
+        <field name="domain">[('forum_id.slide_channel_ids', '!=', False)]</field>
         <field name="context">{'search_default_questions': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -576,18 +576,6 @@ class TestDomainOptimize(TransactionCase):
             Domain.FALSE,
         )
         self.assertEqual(
-            Domain('important', 'in', [True, "yes"]).optimize(model),
-            is_important,
-        )
-        self.assertEqual(
-            Domain('important', 'in', ["yes"]).optimize(model),
-            is_important,
-        )
-        self.assertEqual(
-            Domain('important', 'in', [0, 2]).optimize_full(model),
-            Domain.TRUE,
-        )
-        self.assertEqual(
             list(Domain('active', 'in', [True, False]).optimize(model)),
             [('active', 'in', [True, False])],
             "the condition should not be reduced to a constant for active record",

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1453,9 +1453,7 @@ def _optimize_boolean_in(condition, model):
         condition._raise("Cannot compare %r to %s which is not a collection of length 1", condition.field_expr, type(value))
     if not all(isinstance(v, bool) for v in value):
         # parse the values
-        if any(isinstance(v, str) for v in value):
-            # TODO make a warning
-            _logger.debug("Comparing boolean with a string in %s", condition)
+        warnings.warn(f"Since 20.0, compare booleans only with booleans in {condition!r}", DeprecationWarning)
         value = {
             str2bool(v.lower(), False) if isinstance(v, str) else bool(v)
             for v in value

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1903,7 +1903,7 @@ def _get_translation_upgrade_queries(cr, field):
 
     # upgrade model_terms translation: one update per field per record
     if callable(field.translate):
-        cr.execute("SELECT code FROM res_lang WHERE active = 't'")
+        cr.execute("SELECT code FROM res_lang WHERE active IS TRUE")
         languages = {l[0] for l in cr.fetchall()}
         query = f"""
             SELECT t.res_id, m."{field.name}", t.value, t.noupdate


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When writing domains, use booleans for boolean fields. Fix usages where boolean should be passed, but a string is sent instead.

Current behavior before PR:
`('is_xxx', '=', 'yes')`

Desired behavior after PR is merged:
`('is_xxx', '=', True)`

odoo/enterprise#90815


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
