### PR TITLE
[FIX] sign: signature wizard tweaks

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.scss
+++ b/addons/web/static/src/core/signature/name_and_signature.scss
@@ -17,3 +17,7 @@
     width: 72%;
     left: 14%;
 }
+
+.o_font_dropdown_item {
+    max-height: 5vh;
+}

--- a/addons/web/static/src/core/signature/name_and_signature.xml
+++ b/addons/web/static/src/core/signature/name_and_signature.xml
@@ -76,7 +76,7 @@
                                 <t t-set-slot="content">
                                     <t t-foreach="fonts" t-as="font" t-key="font_index">
                                         <DropdownItem onSelected="() => this.onSelectFont(font_index)">
-                                            <img class="img-fluid" t-att-src="getSVGTextFont(font)"/>
+                                            <img class="o_font_dropdown_item img-fluid" t-att-src="getSVGTextFont(font)"/>
                                         </DropdownItem>
                                     </t>
                                 </t>


### PR DESCRIPTION
This PR is linked to another on enterprise and together they aim at fixing some issues with the signature adoption dialog window/wizard. The observed problems are:

- Only the default font appears in the font dropdown menu when first opening the wizard. If one switches to one of the other two modes (Draw or Load) and then goes back to Auto, all fonts are available.

- Font previews take up too much space in the dropdown and often go off screen. Such big previews are not needed.

- In some cases, when adopting a signature and reopening the wizard, the signature shrinks in size, both inside the wizard and from the document view.

This commit solves the second issue listed.

[Enterprise PR](https://github.com/odoo/enterprise/pull/90791)
Task: 4948325