### PR TITLE
[FIX] sale_project: Fix tour for project sale orderline

### DIFF
--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -119,6 +119,11 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         self.start_tour('/odoo', 'task_create_sol_tour', login='admin')
 
     def test_project_create_sol_ui(self):
+        self.product_order_service5 = self.env['product.product'].create({
+            'name': 'New Sale order line',
+            'type': 'service',
+            'invoice_policy': 'delivery',
+        })
         self.start_tour('/odoo', 'project_create_sol_tour', login='admin')
 
     def test_sale_order_with_project_task(self):


### PR DESCRIPTION
Steps to reproduce the issue:
1- install sale_project without demo data
2- as the test is not deterministic, adding step_delay may help reproducing it

The test was failing because the tour was not waiting for the modal to close before trying to click on the created sale order line.

so accoding to this line https://github.com/odoo/odoo/blob/18.0/addons/sale_project/models/sale_order_line.py#L63-L63 the New Sale order line have in it a default product which doesnt open a modal

build_error-163102

