### PR TITLE
[FIX] mrp_subcontracting_dropshipping: fixes test_kit_dropshipped_change_qty_SO

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
@@ -327,5 +327,8 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
         so.action_confirm()
 
         user_admin = self.env['res.users'].search([('login', '=', 'admin')])
+        self.env.ref('base.user_admin').write({
+            'email': 'mitchell.admin@example.com',
+        })
         sol.with_user(user_admin).write({'product_uom_qty': 10})
         self.assertEqual(sol.purchase_line_ids.mapped('product_uom_qty'), [10, 10])


### PR DESCRIPTION
This issue comes from [216633](https://github.com/odoo/odoo/pull/216633)

Administrator doesn't have an email address without demo data since [185809](https://github.com/odoo/odoo/pull/185809). This causes an error in no demo build for the test  `test_kit_dropshipped_change_qty_SO` because it requires a sender's email address configured.

Runbot - [229621](https://runbot.odoo.com/odoo/error/229621)
