### PR TITLE
[IMP] hr_timesheet: add notification when creating timesheets in calendar

### DIFF
--- a/addons/hr_timesheet/static/src/views/timesheet_calendar/timesheet_calendar_model.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_calendar/timesheet_calendar_model.js
@@ -8,7 +8,7 @@ export class TimesheetCalendarModel extends TimesheetCalendarMyTimesheetsModel {
         this.notification = services.notification;
     }
 
-    multiCreateRecords(multiCreateData, dates) {
+    async multiCreateRecords(multiCreateData, dates) {
         const [section] = this.filterSections;
         if (section.filters.filter((filter) => filter.active).length === 0) {
             this.notification.add(_t("Choose an employee to create their timesheet."), {
@@ -16,6 +16,19 @@ export class TimesheetCalendarModel extends TimesheetCalendarMyTimesheetsModel {
             });
             return;
         }
-        super.multiCreateRecords(multiCreateData, dates);
+        const records = await super.multiCreateRecords(multiCreateData, dates);
+        if (records.length) {
+            this.notification.add(_t("Timesheets successfully created"), {
+                type: "success",
+            });
+        } else {
+            this.notification.add(
+                _t("Timesheets could not be created for any of the selected days"),
+                {
+                    type: "danger",
+                }
+            );
+        }
+        return records;
     }
 }

--- a/addons/hr_timesheet/static/src/views/timesheet_calendar_my_timesheets/timesheet_calendar_my_timesheets_model.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_calendar_my_timesheets/timesheet_calendar_my_timesheets_model.js
@@ -7,6 +7,6 @@ export class TimesheetCalendarMyTimesheetsModel extends CalendarModel {
     async multiCreateRecords(multiCreateData, dates) {
         this.meta.context = this.meta.context || {};
         this.meta.context.timesheet_calendar = true;
-        super.multiCreateRecords(multiCreateData, dates);
+        return await super.multiCreateRecords(multiCreateData, dates);
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -269,8 +269,11 @@ export class CalendarModel extends Model {
             }
         }
         if (records.length) {
-            await this.orm.create(this.meta.resModel, records, { context: this.meta.context });
-            return this.load();
+            const createdRecords = await this.orm.create(this.meta.resModel, records, {
+                context: this.meta.context,
+            });
+            this.load();
+            return createdRecords;
         }
     }
 


### PR DESCRIPTION
When creating timesheets using the multi create feature of the calendar view, it can happen that timesheets cannot be created for some or even any of the selected days. It is also possible that the created timesheets won't be displayed, because they don't fit the domain of the view or the action.

This commit adds some visual feedback in the form of two notifications to tell the user whether at least one timesheet has been created from their action.

Task-4916256
