### PR TITLE
[FIX] l10n_es_edi_tbai_pos: Retry failed uploads with cron

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/__manifest__.py
+++ b/addons/l10n_es_edi_tbai_pos/__manifest__.py
@@ -9,6 +9,7 @@
     ],
     'data': [
         'views/pos_order_view.xml',
+        'data/ir_cron_data.xml',
     ],
     'assets': {
         'point_of_sale._assets_pos': [

--- a/addons/l10n_es_edi_tbai_pos/data/ir_cron_data.xml
+++ b/addons/l10n_es_edi_tbai_pos/data/ir_cron_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_retry_tbai_upload" model="ir.cron">
+            <field name="name">TicketBAI: Retry unfinished uploads</field>
+            <field name="model_id" ref="model_pos_order"/>
+            <field name="state">code</field>
+            <field name="code">model._l10n_es_tbai_retry_cron()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Currently if any PoS order uploads to TicketBAI fail, all future uploads will also silently fail since the chain head was never posted.

Steps to reproduce
-----
1. Send a PoS order to TicketBAI have the upload fail
2. Validate another PoS order
3. The upload for the second order is never attempted

Cause
-----
The first order creates a `l10n_es_tbai_post_document_id` and chain index it is uploaded, but the document's state will remain rejected if the upload is unsuccessful. Any subsequent orders will fail the `_check_can_post()` check since the chain head is not accepted.

Solution
-----
Create a cron to automatically retry uploading the chain head if it's not posted, and retry any other uploads that were not sent.

opw-4669823