### PR TITLE
[FIX] base_import: invalid domain in `ir.actions.act_window`

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -107,7 +107,7 @@ export class ImportAction extends Component {
                 [false, "list"],
                 [false, "form"],
             ],
-            domain: [["id", "in", resIds]],
+            domain: resIds != null ? [["id", "in", resIds]] : [],
             target: "current",
         });
     }


### PR DESCRIPTION
Steps to reproduce:
- Go to Inventory > Products
- Click "Import"
- Cancel the import wizard before uploading any file
- Odoo crashes with `InvalidDomainError` due to domain [['id', 'in', undefined]]

This commit ensures that the domain is only set when resIds is valid.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
