### PR TITLE
[FIX] account: use parent contact invoice sending method

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -19,8 +19,10 @@ class AccountMoveSend(models.AbstractModel):
 
     @api.model
     def _get_default_sending_method(self, move) -> set:
-        """ By default, we use the sending method set on the partner or email. """
-        return move.partner_id.with_company(move.company_id).invoice_sending_method or 'email'
+        """ By default, use the sending method set on the partner's parent contact, partner, or email. """
+        partner = move.partner_id.with_company(move.company_id)
+        partner_invoice_sending_method = partner.parent_id.invoice_sending_method or partner.invoice_sending_method
+        return partner_invoice_sending_method or 'email'
 
     @api.model
     def _get_all_extra_edis(self) -> dict:


### PR DESCRIPTION
Problem: When an individual has an invoice sending method set before being assigned to a company parent contact, the account move sending wizard will not send the invoice based on the parent contact's sending method. The user expects the invoice to be sent based on the parent contact's invoice sending method when the individual's accounting setting is managed by the company.

Steps to Reproduce on Runbot:
1. Install sale, subscription, accounting.
2. Enable Customer addresses in Accounting > Settings
3. Create a company contact > set the "Invoice sending=By email" 4- Create a child billing contact > unlink it from the company
 > set the "Invoice sending=Manual"
 > link it back to the company.
 At this point, the billing contact should follow the parent company settings
5. Create a subscription > set the company as the customer. Note: deactivate the "Online payment" and set the "Start date" in the past, so you can generate the invoice with the cron "Sale Subscription: generate recurring invoices and payments". 6  Generate the invoice.

opw-4812984
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
