### PR TITLE
[FIX] hr_holidays: skip public holidays in leave calculation for flexible hours

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -12,7 +12,7 @@ from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 from odoo import api, Command, fields, models, tools
 from odoo.addons.base.models.res_partner import _tz_get
-from odoo.addons.resource.models.utils import float_to_time, HOURS_PER_DAY
+from odoo.addons.resource.models.utils import float_to_time, HOURS_PER_DAY, Intervals
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools.float_utils import float_round, float_compare
 from odoo.tools.misc import format_date
@@ -426,11 +426,26 @@ class HolidaysRequest(models.Model):
             if leave.employee_id:
                 # For flexible employees, if it's a single day leave, we force it to the real duration since the virtual intervals might not match reality on that day, especially for custom hours
                 if leave.employee_id.is_flexible and leave.date_to.date() == leave.date_from.date():
-                    hours = (leave.date_to - leave.date_from).total_seconds() / 3600
-                    if not leave.request_unit_hours:
+                    public_holidays = self.env['resource.calendar.leaves'].search([
+                        ('resource_id', '=', False),
+                        ('date_from', '<', leave.date_to),
+                        ('date_to', '>', leave.date_from),
+                        ('calendar_id', 'in', [False, calendar.id]),
+                        ('company_id', '=', leave.company_id.id)
+                    ])
+                    if public_holidays:
+                        public_holidays_intervals = Intervals([(ph.date_from, ph.date_to, ph) for ph in public_holidays])
+                        leave_intervals = Intervals([(leave.date_from, leave.date_to, leave)])
+                        real_leave_intervals = leave_intervals - public_holidays_intervals
+                        hours = 0
+                        for start, stop, meta in real_leave_intervals:
+                            hours += (stop - start).total_seconds() / 3600
+                    else:
+                        hours = (leave.date_to - leave.date_from).total_seconds() / 3600
+                    if not leave.request_unit_hours and not public_holidays:
                         days = 1 if not leave.request_unit_half else 0.5
                     else:
-                        days = (leave.date_to - leave.date_from).total_seconds() / 3600 / 24
+                        days = hours / 24
                 elif leave.leave_type_request_unit == 'day' and check_leave_type:
                     # list of tuples (day, hours)
                     work_time_per_day_list = work_time_per_day_mapped[(leave.date_from, leave.date_to, calendar)][leave.employee_id.id]

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1447,3 +1447,79 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'request_date_from': '2024-07-01',
                 'request_date_to': '2024-07-02',
             })
+
+    def test_leave_duration_on_public_holiday_with_flexible_request(self):
+        """
+            Test the cases with flexible request and having no calendar in public holidays
+            Scenarios covered:
+            - Leave fully on a public holiday: duration should be 0.
+            - Leave partially overlapping with a multi-day public holiday: only working days should count.
+            - Leave fully outside any public holidays: all days should count.
+            - Single-day leave that falls entirely on a public holiday: duration should be 0.
+            - Leave starting before and ending during a public holiday: only non-overlapping portion counts.
+        """
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Test calendar',
+            'hours_per_day': 8,
+            'full_time_required_hours': 56,
+            'flexible_hours': True
+        })
+        self.employee_emp.resource_calendar_id = calendar
+        self.env['resource.calendar.leaves'].create([
+            {
+                'date_from': datetime(2022, 3, 8, 0, 0, 0),
+                'date_to': datetime(2022, 3, 10, 23, 59, 59),
+                'calendar_id': calendar.id,
+                'company_id': self.employee_emp.company_id.id,
+                'resource_id': False,
+            },
+            {
+                'date_from': datetime(2022, 3, 15, 0, 0, 0),
+                'date_to': datetime(2022, 3, 17, 23, 59, 59),
+                'calendar_id': calendar.id,
+                'company_id': self.employee_emp.company_id.id,
+                'resource_id': False,
+            }
+        ])
+        leave_data = [
+            {
+                'name': 'Leave fully on first public holiday (Mar 9)',
+                'request_date_from': date(2022, 3, 9),
+                'request_date_to': date(2022, 3, 9),
+            },
+            {
+                'name': 'Leave partially overlapping first holiday (Mar 7 to Mar 9)',
+                'request_date_from': date(2022, 3, 7),
+                'request_date_to': date(2022, 3, 9),
+            },
+            {
+                'name': 'Leave fully outside holidays (Mar 11 to Mar 14)',
+                'request_date_from': date(2022, 3, 11),
+                'request_date_to': date(2022, 3, 14),
+            },
+            {
+                'name': 'Single day leave overlapping second holiday (Mar 16)',
+                'request_date_from': date(2022, 3, 16),
+                'request_date_to': date(2022, 3, 16),
+            },
+            {
+                'name': 'Leave partially overlapping second holiday (Mar 14 to Mar 16)',
+                'request_date_from': date(2022, 3, 14),
+                'request_date_to': date(2022, 3, 16),
+            }
+        ]
+        leaves = self.env["hr.leave"].with_user(self.user_employee_id).create([
+            {
+                **data,
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.holidays_type_1.id,
+            }
+            for data in leave_data
+        ])
+        expected_days_list = [0, 1, 4, 0, 1]
+        for leave, expected_days, data in zip(leaves, expected_days_list, leave_data):
+            self.assertEqual(
+                leave.number_of_days,
+                expected_days,
+                f"{data['name']} should have {expected_days} days duration"
+            )


### PR DESCRIPTION
**Steps to reproduce:**

1) Create a flexible working schedule.
2) Assign this schedule to an employee.
3) Create a public holiday.
4) Create a leave request for the flexible employee on the public holiday. 
5) Notice that the duration of the leave is 1 instead of 0.

**Issue:**
Due to recent changes in the [commit](https://github.com/odoo/odoo/commit/a826f65c2d95b796f919023d560ec9f0801090d8#diff-38469def2f870bb866f971f57797dd7c21b6a95d52a8eae72f832f0eea2434f9R427-R433) ,

When a single-day flexible leave is taken, the duration is always set to the real duration. 
However, we do not check if the leave falls on a public holiday, 
which results in the leave being set to 1 day, even on holidays.
https://github.com/odoo/odoo/blob/8f24da78f60529ea0b1840e48de30e15d17ddb77/addons/hr_holidays/models/hr_leave.py#L427-L433
**For example:**

If Christmas is marked as a public holiday and an employee with a flexible schedule 
requests a one-day leave on Christmas, the leave is recorded with a duration of 1 day.

**Fix:**
Check for a public holiday on leave date; if yes, set leave duration to 0.

opw-4963122
