### PR TITLE
[FIX] hr_recruitment, point_of_sale, pos_loyalty: use candidate name when creating partner from candidate

### DIFF
--- a/addons/hr_recruitment/models/hr_candidate.py
+++ b/addons/hr_recruitment/models/hr_candidate.py
@@ -116,7 +116,9 @@ class HrCandidate(models.Model):
             if not candidate.partner_id:
                 if not candidate.partner_name:
                     raise UserError(_('You must define a Contact Name for this candidate.'))
-                candidate.partner_id = self.env['res.partner'].with_context(default_lang=self.env.lang).find_or_create(candidate.email_from)
+                contact_email_normalized = tools.email_normalize(candidate.email_from)
+                contact_name_email = tools.formataddr((candidate.partner_name, contact_email_normalized))
+                candidate.partner_id = self.env['res.partner'].with_context(default_lang=self.env.lang).find_or_create(contact_name_email)
             if candidate.partner_name and not candidate.partner_id.name:
                 candidate.partner_id.name = candidate.partner_name
             if tools.email_normalize(candidate.email_from) != tools.email_normalize(candidate.partner_id.email):

--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -201,3 +201,19 @@ class TestRecruitment(TransactionCase):
         application2.action_archive()
         self.env.invalidate_all()
         self.assertEqual(candidate.application_count, 2, 'The applications_count should not change after archiving an application')
+
+    def test_partner_name_from_candidate_name(self):
+        """
+        Test that when a candidate is created with an email, the related partner
+        is created with the candidate's name as the contact name, not the email.
+        """
+        candidate = self.env['hr.candidate'].create({
+            'partner_name': "testCandidate",
+            'email_from': "test@candidate.com",
+        })
+
+        self.assertEqual(
+            candidate.partner_id.name,
+            candidate.partner_name,
+            "The partner name should be the same as the candidate's name, not the email."
+        )

--- a/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/product_screen_util.js
@@ -1,6 +1,10 @@
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
-import { back as utilsBack, inLeftSide } from "@point_of_sale/../tests/tours/utils/common";
+import {
+    back as utilsBack,
+    inLeftSide,
+    selectButton,
+} from "@point_of_sale/../tests/tours/utils/common";
 import * as PartnerList from "@point_of_sale/../tests/tours/utils/partner_list_util";
 import * as TextInputPopup from "@point_of_sale/../tests/tours/utils/text_input_popup_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
@@ -163,7 +167,12 @@ export function clickPartnerButton() {
     ];
 }
 export function clickCustomer(name) {
-    return [PartnerList.clickPartner(name), { ...back(), isActive: ["mobile"] }];
+    return [
+        ...inputCustomerSearchbar(name),
+        ...[selectButton("Search more")],
+        ...[PartnerList.clickPartner(name)],
+        { ...back(), isActive: ["mobile"] },
+    ];
 }
 export function customerIsSelected(name) {
     return [

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -588,6 +588,6 @@ registry.category("web_tour.tours").add("test_scan_loyalty_card_select_customer"
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             scan_barcode("0444-e050-4548"),
-            ProductScreen.customerIsSelected("Test Partner"),
+            ProductScreen.customerIsSelected("AA Test Partner"),
         ].flat(),
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2866,7 +2866,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     def test_scan_loyalty_card_select_customer(self):
         self.env['loyalty.program'].search([]).write({'active': False})
-        self.test_partner = self.env['res.partner'].create({'name': 'Test Partner'})
+        self.test_partner = self.env['res.partner'].create({'name': 'AA Test Partner'})
 
         loyalty_program = self.env['loyalty.program'].create({
             'name': 'Loyalty Program',


### PR DESCRIPTION
**Steps to reproduce:**
1. Install hr_recruitment
2. Go to the Candidates menu from Applications in recruitment
3. Create a candidate with both a name and an email
4. Search for the email in Contacts

**Issue:**
The created contact uses the email address as the name instead of the candidate’s name.

**Cause:**
The `find_or_create` method for partners was called without passing the candidate’s name in the parameter.

**Solution:**
Embed the candidate’s name into the email string ('Name <email>') so `find_or_create` creates the partner with the correct name.

**Additonally** some test cases were failing in pos_loyalty due to not loaded partners
so added the extra step to search customer before clicking in on the customer.
Ref commit with same issue where alphabatically low ranked partners doesn't loaded:
https://github.com/odoo/odoo/commit/25e31ac6b7966da73dcdd858322e52d5310cbd98

opw-4953299