### PR TITLE
[IMP] project , *_ : separate task templates from regular tasks

### DIFF
--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -28,6 +28,7 @@ up a management by affair.
         'views/hr_timesheet_views.xml',
         'views/res_config_settings_views.xml',
         'views/project_project_views.xml',
+        'views/project_task_tempate_views.xml',
         'views/project_task_views.xml',
         'views/project_task_portal_templates.xml',
         'views/hr_timesheet_portal_templates.xml',

--- a/addons/hr_timesheet/models/__init__.py
+++ b/addons/hr_timesheet/models/__init__.py
@@ -10,6 +10,7 @@ from . import ir_ui_menu
 from . import res_company
 from . import res_config_settings
 from . import project_project
+from . import project_task_template
 from . import project_task
 from . import project_update
 from . import project_collaborator

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -62,7 +62,7 @@ class AccountAnalyticLine(models.Model):
     task_id = fields.Many2one(
         'project.task', 'Task', index='btree_not_null',
         compute='_compute_task_id', store=True, readonly=False,
-        domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('has_template_ancestor', '=', False)]")
+        domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id)]")
     parent_task_id = fields.Many2one('project.task', related='task_id.parent_id', store=True, index='btree_not_null')
     project_id = fields.Many2one(
         'project.project', 'Project', domain=_domain_project_id, index=True,

--- a/addons/hr_timesheet/models/project_task_template.py
+++ b/addons/hr_timesheet/models/project_task_template.py
@@ -1,0 +1,38 @@
+from odoo import models, fields, api
+
+
+class ProjectTaskTemplate(models.Model):
+    _inherit = "project.task.template"
+
+    allow_timesheets = fields.Boolean(
+        "Allow timesheets",
+        compute='_compute_allow_timesheets', search='_search_allow_timesheets',
+        compute_sudo=True, readonly=True, export_string_translation=False)
+
+    encode_uom_in_days = fields.Boolean(compute='_compute_encode_uom_in_days', default=lambda self: self._uom_in_days(), export_string_translation=False)
+    display_name = fields.Char(help="""Use these keywords in the title to set new tasks:\n
+        30h Allocate 30 hours to the task
+        #tags Set tags on the task
+        @user Assign the task to a user
+        ! Set the task a medium priority
+        !! Set the task a high priority
+        !!! Set the task a urgent priority\n
+        Make sure to use the right format and order e.g. Improve the configuration screen 5h #feature #v16 @Mitchell !""",
+    )
+
+    def _uom_in_days(self):
+        return self.env.company.timesheet_encode_uom_id == self.env.ref('uom.product_uom_day')
+
+    def _compute_encode_uom_in_days(self):
+        self.encode_uom_in_days = self._uom_in_days()
+
+    @api.depends('project_id.allow_timesheets')
+    def _compute_allow_timesheets(self):
+        for task in self:
+            task.allow_timesheets = task.project_id.allow_timesheets
+
+    def _search_allow_timesheets(self, operator, value):
+        query = self.env['project.project'].sudo()._search([
+            ('allow_timesheets', operator, value),
+        ])
+        return [('project_id', 'in', query)]

--- a/addons/hr_timesheet/views/project_task_tempate_views.xml
+++ b/addons/hr_timesheet/views/project_task_tempate_views.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_project_task_template_list_inherited" model="ir.ui.view">
+            <field name="name">project.task.template.list.inherited</field>
+            <field name="model">project.task.template</field>
+            <field name="inherit_id" ref="project.view_project_task_template_list"/>
+            <field name="arch" type="xml">
+                <field name="priority" position="before">
+                    <field name="allocated_hours"
+                        widget="timesheet_uom_no_toggle" sum="Total Allocated Time"
+                        invisible="allocated_hours == 0" optional="hide"
+                        groups="hr_timesheet.group_hr_timesheet_user"
+                        column_invisible="not context.get('allow_timesheets', True)"/>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="view_task_template_kanban_inherited_progress">
+            <field name="name">project.task.template.kanban.inherited.progress</field>
+            <field name="model">project.task.template</field>
+            <field name="inherit_id" ref="project.view_project_task_template_kanban"/>
+            <field name="arch" type="xml">
+                <templates position="before">
+                    <field name="allocated_hours" />
+                    <field name="allow_timesheets"/>
+                    <field name="encode_uom_in_days"/>
+                </templates>
+                <xpath expr="//footer//field[@name='priority']" position="before">
+                   <t name="allocated_hours" t-if="record.allocated_hours.raw_value &gt; 0 and record.allow_timesheets.raw_value" groups="hr_timesheet.group_hr_timesheet_user">
+                       <t t-set="badge" t-value="'border border-success'"/>
+                        <t t-set="badge" t-value="'border border-warning'" t-if="record.allocated_hours.raw_value &gt;= 0.8 and record.allocated_hours.raw_value &lt;= 1"/>
+                        <t t-set="title" t-if="record.encode_uom_in_days.raw_value">Remaining days</t>
+                        <t t-set="title" t-else="">Time Remaining</t>
+                        <div t-attf-class="bg-transparent badge {{ badge }} me-0" t-att-title="title">
+                            <field name="allocated_hours" widget="timesheet_uom" />
+                        </div>
+                   </t>
+                </xpath>
+             </field>
+         </record>
+
+        <record model="ir.ui.view" id="view_project_task_template_form_inherited">
+            <field name="name">project.task.template.form.inherited</field>
+            <field name="model">project.task.template</field>
+            <field name="inherit_id" ref="project.view_project_task_template_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//group/field[@name='allocated_hours']" position="replace">
+                    <field name="subtask_count" invisible="1"/>
+                    <label for="allocated_hours" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <div id="allocated_hours_container" class="text-nowrap" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
+                        <field name="allocated_hours" class="oe_inline o_field_float_time o_task_planned_hours" widget="timesheet_uom_no_toggle"/>
+                        <span invisible="not subtask_count">
+                            (incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
+                            <span class="fw-bold text-dark"> Sub-tasks</span>)
+                        </span>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -8,12 +8,11 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='child_ids']/list/field[@name='company_id']" position="after">
                     <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-tasks Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"  column_invisible="context.get('default_is_template', False)"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" groups="hr_timesheet.group_hr_timesheet_user"
-                    column_invisible="context.get('default_is_template', False)"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-tasks Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
                 <xpath expr="//group/field[@name='allocated_hours']" position="replace">
                     <field name="encode_uom_in_days" invisible="1"/>
@@ -25,13 +24,11 @@
                             (incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
                             <span class="fw-bold text-dark"> Sub-tasks</span>)
                         </span>
-                        <span invisible="is_template">
-                            (<field name="progress" invisible="not project_id" class="oe_inline" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>)
-                        </span>
+                        (<field name="progress" invisible="not project_id" class="oe_inline" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>)
                     </div>
                 </xpath>
                 <xpath expr="//t[@name='warning_section']" position="inside">
-                    <div class="alert alert-warning text-center mb-2" role="alert" invisible="analytic_account_active or not allow_timesheets or is_template" groups="hr_timesheet.group_hr_timesheet_user">
+                    <div class="alert alert-warning text-center mb-2" role="alert" invisible="analytic_account_active or not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
                         You cannot log timesheets on this project since it is linked to an inactive analytic account.<br/> Please change this account, or reactivate the current one to timesheet on the project.
                     </div>
                 </xpath>
@@ -40,7 +37,7 @@
                     <t groups="hr_timesheet.group_hr_timesheet_user">
                         <field name="analytic_account_active" invisible="1"/>
                     </t>
-                    <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets or has_template_ancestor or (not id and context.get('hide_timesheet_ids'))" groups="hr_timesheet.group_hr_timesheet_user">
+                    <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets or (not id and context.get('hide_timesheet_ids'))" groups="hr_timesheet.group_hr_timesheet_user">
                     <field name="timesheet_ids" mode="list,kanban" readonly="not analytic_account_active" context="{'default_project_id': project_id, 'default_name': '', 'form_view_ref': 'hr_timesheet.timesheet_view_form_user'}">
                         <list editable="top" string="Timesheet Activities" decoration-muted="readonly_timesheet == True">
                             <field name="readonly_timesheet" column_invisible="True"/>
@@ -124,11 +121,11 @@
                 <xpath expr="//field[@name='depend_on_ids']/list//field[@name='company_id']" position="after">
                     <field name="progress" column_invisible="True" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
-                    <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('default_is_template', False)"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
             </field>
         </record>
@@ -142,11 +139,11 @@
                     <field name="progress" column_invisible="True"/>
                     <field name="effective_hours" column_invisible="True"/>
                     <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" invisible="allocated_hours == 0" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True)"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Time Spent on Sub-Tasks" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining on SO" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" invisible="allocated_hours == 0" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
-                    <field name="progress" widget="project_task_progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" options="{'overflow_class': 'bg-danger'}" column_invisible="not context.get('allow_timesheets', True) or context.get('default_is_template', False)"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Time Spent on Sub-Tasks" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining on SO" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" invisible="allocated_hours == 0" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True)"/>
+                    <field name="progress" widget="project_task_progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" options="{'overflow_class': 'bg-danger'}" column_invisible="not context.get('allow_timesheets', True)"/>
                 </field>
             </field>
         </record>
@@ -188,10 +185,10 @@
                     <filter string="Timesheets 80%" name="timesheet_80"
                         domain="[('remaining_hours_percentage', '&gt;', 0.0), ('remaining_hours_percentage', '&lt;=', 0.2)]"
                         groups="hr_timesheet.group_hr_timesheet_user"
-                        invisible="not context.get('allow_timesheets') or context.get('default_is_template')"/>
+                        invisible="not context.get('allow_timesheets')"/>
                     <filter string="Timesheets &gt;100%" name="timesheet_exceeded" domain="[('overtime', '&gt;', 0)]"
                         groups="hr_timesheet.group_hr_timesheet_user"
-                        invisible="not context.get('allow_timesheets') or context.get('default_is_template')"/>
+                        invisible="not context.get('allow_timesheets')"/>
                     <separator/>
                 </xpath>
             </field>

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -35,6 +35,7 @@
         'views/project_task_type_views.xml',
         'views/project_project_views.xml',
         'views/project_task_views.xml',
+        'views/project_task_template_views.xml',
         'views/project_role_views.xml',
         'views/project_tags_views.xml',
         'views/project_milestone_views.xml',

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -478,7 +478,7 @@ class ProjectCustomerPortal(CustomerPortal):
 
     def _get_my_tasks_searchbar_filters(self, project_domain=None, task_domain=None):
         searchbar_filters = {
-            'all': {'label': _('All'), 'domain': [('project_id', '!=', False), ('is_template', '=', False)]},
+            'all': {'label': _('All'), 'domain': [('project_id', '!=', False)]},
         }
 
         # extends filterby criteria with project the customer has access to
@@ -491,7 +491,7 @@ class ProjectCustomerPortal(CustomerPortal):
         # extends filterby criteria with project (criteria name is the project id)
         # Note: portal users can't view projects they don't follow
         project_groups = request.env['project.task']._read_group(
-            Domain.AND([[('project_id', 'not in', projects.ids), ('is_template', '=', False), ('project_id', '!=', False)], task_domain or []]),
+            Domain.AND([[('project_id', 'not in', projects.ids), ('project_id', '!=', False)], task_domain or []]),
             ['project_id'])
         for [project] in project_groups:
             searchbar_filters.update({

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -847,7 +847,7 @@
             <field name="parent_id" ref="project.project_1_task_16"/>
             <field name="stage_id" ref="project_stage_2"/>
         </record>
-        <record id="project_1_task_18" model="project.task">
+        <record id="project_1_task_18" model="project.task.template">
             <field name="name">[Room Name] Layout Planning</field>
             <field name="description">
                 <![CDATA[
@@ -870,9 +870,8 @@
             <field name="project_id" ref="project.project_project_1"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
             <field name="tag_ids" eval="[Command.set([ref('project_tags_08')])]"/>
-            <field name="is_template">True</field>
         </record>
-        <record id="project_1_task_19" model="project.task">
+        <record id="project_1_task_19" model="project.task.template">
             <field name="name">[Vendor Name] Furniture Coordination</field>
             <field name="description">
                 <![CDATA[
@@ -882,19 +881,18 @@
             <field name="project_id" ref="project.project_project_1"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
             <field name="tag_ids" eval="[Command.set([ref('project_tags_05'), ref('project_tags_09')])]"/>
-            <field name="is_template">True</field>
         </record>
-        <record id="project_1_task_19_subtask_1" model="project.task">
+        <record id="project_1_task_19_subtask_1" model="project.task.template">
             <field name="name">Confirm Order and Delivery Date</field>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="parent_id" ref="project_1_task_19"/>
         </record>
-        <record id="project_1_task_19_subtask_2" model="project.task">
+        <record id="project_1_task_19_subtask_2" model="project.task.template">
             <field name="name">Prepare Site for Delivery</field>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="parent_id" ref="project_1_task_19"/>
         </record>
-        <record id="project_1_task_19_subtask_3" model="project.task">
+        <record id="project_1_task_19_subtask_3" model="project.task.template">
             <field name="name">Log Delivery and Report Issues</field>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="parent_id" ref="project_1_task_19"/>

--- a/addons/project/models/__init__.py
+++ b/addons/project/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import project_task_template
 from . import account_analytic_account
 from . import mail_message
 from . import project_project_stage

--- a/addons/project/models/project_milestone.py
+++ b/addons/project/models/project_milestone.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from odoo import api, fields, models
 from odoo.tools import format_date
 
-from .project_task import CLOSED_STATES
+from .project_task_template import CLOSED_STATES
 
 
 class ProjectMilestone(models.Model):

--- a/addons/project/models/project_task_template.py
+++ b/addons/project/models/project_task_template.py
@@ -1,0 +1,766 @@
+import re
+from collections import defaultdict
+
+from odoo import api, fields, models, SUPERUSER_ID
+from odoo.fields import Command, Domain
+from odoo.addons.web_editor.tools import handle_history_divergence
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools import LazyTranslate
+
+_lt = LazyTranslate(__name__)
+
+CLOSED_STATES = {
+    '1_done': 'Done',
+    '1_canceled': 'Cancelled',
+}
+
+
+class ProjectTaskTemplate(models.Model):
+    _name = "project.task.template"
+    _description = "Task Template"
+    _inherit = 'html.field.history.mixin'
+    _systray_view = 'list'
+    _order = "priority desc, sequence, date_deadline asc, id desc"
+
+    def _get_versioned_fields(self):
+        return [ProjectTaskTemplate.description.name]
+
+    def _get_default_stage_id(self):
+        """ Gives default stage_id """
+        project_id = self.env.context.get('default_project_id')
+        if not project_id:
+            return False
+        return self.stage_find(project_id, order="fold, sequence, id")
+
+    @api.model
+    def _default_user_ids(self):
+        return self.env.user.ids if any(key in self.env.context for key in ('default_personal_stage_type_ids', 'default_personal_stage_type_id')) else ()
+
+    @api.model
+    def _read_group_stage_ids(self, stages, domain):
+        search_domain = [('id', 'in', stages.ids)]
+        if 'default_project_id' in self.env.context and not self.env.context.get('subtask_action') and 'project_kanban' in self.env.context:
+            search_domain = ['|', ('project_ids', '=', self.env.context['default_project_id'])] + search_domain
+
+        stage_ids = stages._search(search_domain, order=stages._order)
+        return stages.browse(stage_ids)
+
+    @api.model
+    def _default_company_id(self):
+        if self.env.context.get('default_project_id'):
+            return self.env['project.project'].browse(self.env.context['default_project_id']).company_id
+        return False
+
+    active = fields.Boolean(default=True, export_string_translation=False)
+    name = fields.Char(string='Title', required=True, index='trigram')
+    description = fields.Html(string='Description', sanitize_attributes=False)
+    priority = fields.Selection([
+        ('0', 'Low priority'),
+        ('1', 'Medium priority'),
+        ('2', 'High priority'),
+        ('3', 'Urgent'),
+    ], default='0', index=True, string="Priority")
+    sequence = fields.Integer(string='Sequence', default=10, export_string_translation=False)
+    stage_id = fields.Many2one('project.task.type', string='Stage', compute='_compute_stage_id',
+        store=True, readonly=False, index=True,
+        default=_get_default_stage_id, group_expand='_read_group_stage_ids',
+        domain="[('project_ids', '=', project_id)]")
+    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
+    tag_ids = fields.Many2many('project.tags', string='Tags')
+
+    state = fields.Selection([
+        ('01_in_progress', 'In Progress'),
+        ('02_changes_requested', 'Changes Requested'),
+        ('03_approved', 'Approved'),
+        *CLOSED_STATES.items(),
+        ('04_waiting_normal', 'Waiting'),
+    ], string='State', copy=False, default='01_in_progress', required=True, compute='_compute_state', readonly=False, store=True, index=True, recursive=True)
+    is_closed = fields.Boolean("Closed state", compute='_compute_is_closed', search='_search_is_closed')
+
+    create_date = fields.Datetime("Created On", readonly=True, index=True)
+    write_date = fields.Datetime("Last Updated On", readonly=True)
+    date_end = fields.Datetime(string='Ending Date', index=True)
+    date_deadline = fields.Datetime(string='Deadline', index=True)
+
+    date_last_stage_update = fields.Datetime(string='Last Stage Update',
+        index=True,
+        copy=False,
+        readonly=True,
+        help="Date on which the state of your task has last been modified.\n"
+            "Based on this information you can identify tasks that are stalling and get statistics on the time it usually takes to move tasks from one stage/state to another.")
+
+    project_id = fields.Many2one('project.project', string='Project', domain="['|', ('company_id', '=', False), ('company_id', '=?',  company_id)]",
+                                 compute="_compute_project_id", store=True, precompute=True, recursive=True, readonly=False, index=True, change_default=True, required=True)
+    has_project_template = fields.Boolean(related='project_id.is_template', string="Has Project Template", export_string_translation=False)
+    display_in_project = fields.Boolean(compute='_compute_display_in_project', store=True, export_string_translation=False)
+    task_properties = fields.Properties('Properties', definition='project_id.task_properties_definition', copy=True)
+    allocated_hours = fields.Float("Allocated Time")
+    subtask_allocated_hours = fields.Float("Sub-tasks Allocated Time", compute='_compute_subtask_allocated_hours', export_string_translation=False,
+        help="Sum of the hours allocated for all the sub-tasks (and their own sub-tasks) linked to this task. Usually less than or equal to the allocated hours of this task.")
+    role_ids = fields.Many2many(
+        'project.role',
+        string='Project Roles',
+        help="When you create a project from a template, you can choose which employee takes each role. These employees will be added to the tasks, along with anyone already assigned.",
+    )
+    # Tracking of this field is done in the write function
+    user_ids = fields.Many2many('res.users', string='Assignees', context={'active_test': False}, default=_default_user_ids, domain="[('share', '=', False), ('active', '=', True)]", falsy_value_label=_lt("👤 Unassigned"))
+    company_id = fields.Many2one('res.company', string='Company', compute='_compute_company_id', store=True, readonly=False, recursive=True, copy=True, default=_default_company_id)
+    color = fields.Integer(string='Color Index', export_string_translation=False)
+    attachment_ids = fields.One2many(
+        'ir.attachment',
+        compute='_compute_attachment_ids',
+        string="Attachments",
+        export_string_translation=False,
+        help="Attachments that don't come from a message",
+    )
+    # In the domain of displayed_image_id, we couln't use attachment_ids because a one2many is represented as a list of commands so we used res_model & res_id
+    displayed_image_id = fields.Many2one('ir.attachment', domain="[('res_model', '=', 'project.task.template'), ('res_id', '=', id), ('mimetype', 'ilike', 'image')]", string='Cover Image')
+
+    parent_id = fields.Many2one('project.task.template', string='Parent Task', inverse="_inverse_parent_id", index=True, domain="['!', ('id', 'child_of', id)]", copy=False)
+    child_ids = fields.One2many('project.task.template', 'parent_id', string="Sub-tasks", domain="[('recurring_task', '=', False)]", export_string_translation=False)
+    subtask_count = fields.Integer("Sub-task Count", compute='_compute_subtask_count', export_string_translation=False)
+    closed_subtask_count = fields.Integer("Closed Sub-tasks Count", compute='_compute_subtask_count', export_string_translation=False)
+    subtask_completion_percentage = fields.Float(compute="_compute_subtask_completion_percentage", export_string_translation=False)
+    allow_milestones = fields.Boolean(related='project_id.allow_milestones', export_string_translation=False)
+    milestone_id = fields.Many2one(
+        'project.milestone',
+        'Milestone',
+        domain="[('project_id', '=', project_id)]",
+        compute='_compute_milestone_id',
+        readonly=False,
+        store=True,
+        index='btree_not_null',
+        help="Deliver your services automatically when a milestone is reached by linking it to a sales order item.",
+    )
+    has_late_and_unreached_milestone = fields.Boolean(
+        compute='_compute_has_late_and_unreached_milestone',
+        search='_search_has_late_and_unreached_milestone',
+        export_string_translation=False,
+    )
+    # Task Template Dependencies fields
+    allow_task_dependencies = fields.Boolean(related='project_id.allow_task_dependencies', export_string_translation=False)
+    # Tracking of this field is done in the write function
+    depend_on_ids = fields.Many2many('project.task')
+
+    # recurrence fields
+    recurring_task = fields.Boolean(string="Recurrent")
+    repeat_interval = fields.Integer(string='Repeat Every', default=0)
+    repeat_unit = fields.Selection([
+        ('day', 'Days'),
+        ('week', 'Weeks'),
+        ('month', 'Months'),
+        ('year', 'Years'),
+    ], default='week')
+    repeat_type = fields.Selection([
+        ('forever', 'Forever'),
+    ], default="forever", string="Until", readonly=True)
+
+    # Quick creation shortcuts
+    display_name = fields.Char(
+        inverse='_inverse_display_name',
+        help="""Use these keywords in the title to set new tasks:\n
+            #tags Set tags on the task
+            @user Assign the task to a user
+            ! Set the task a high priority
+            !! Set the task a high priority
+            !!! Set the task a urgent priority\n
+            Make sure to use the right format and order e.g. Improve the configuration screen #feature #v16 @Mitchell !""",
+    )
+
+    @api.depends('parent_id.project_id')
+    def _compute_project_id(self):
+        self.env.remove_to_compute(self._fields['display_in_project'], self)
+        for task_template in self:
+            if not task_template.display_in_project and task_template.parent_id and task_template.parent_id.project_id != task_template.project_id:
+                task_template.project_id = task_template.parent_id.project_id
+
+    @api.depends('project_id', 'parent_id')
+    def _compute_display_in_project(self):
+        for task_template in self:
+            task_template.display_in_project = not task_template.project_id or (
+                not task_template.parent_id or task_template.project_id != task_template.parent_id.project_id
+            )
+
+    def _inverse_parent_id(self):
+        for task_template in self.sudo():
+            if not task_template.parent_id:
+                task_template.display_in_project = True
+            elif task_template.display_in_project and task_template.project_id == task_template.parent_id.sudo().project_id:
+                task_template.display_in_project = False
+
+    @api.depends('stage_id', 'depend_on_ids.state')
+    def _compute_state(self):
+        for task_template in self:
+            dependent_open_tasks = []
+            if task_template.allow_task_dependencies:
+                dependent_open_tasks = [dependent_task for dependent_task in task_template.depend_on_ids if dependent_task.state not in CLOSED_STATES]
+            # if one of the blocking task is in a blocking state
+            if dependent_open_tasks:
+                # here we check that the blocked task is not already in a closed state (if the task is already done we don't put it in waiting state)
+                if task_template.state not in CLOSED_STATES:
+                    task_template.state = '04_waiting_normal'
+            # if the task as no blocking dependencies and is in waiting_normal, the task goes back to in progress
+            elif task_template.state not in CLOSED_STATES:
+                task_template.state = '01_in_progress'
+
+    @api.depends('state')
+    def _compute_is_closed(self):
+        for task_template in self:
+            task_template.is_closed = task_template.state in CLOSED_STATES
+
+    def _search_is_closed(self, operator, value):
+        if operator == 'in':
+            searched_states = list(CLOSED_STATES.keys())
+        elif operator == 'not in':
+            searched_states = self.OPEN_STATES
+        else:
+            return NotImplemented
+        return [('state', 'in', searched_states)]
+
+    @property
+    def OPEN_STATES(self):
+        """ Return a list of the technical names complementing the CLOSED_STATES, a.k.a the open states """
+        return list(set(self._fields['state'].get_values(self.env)) - set(CLOSED_STATES))
+
+    @api.onchange('project_id')
+    def _onchange_project_id(self):
+        if self.state != '04_waiting_normal':
+            self.state = '01_in_progress'
+
+    @api.model
+    def _get_recurrence_fields(self):
+        return [
+            'repeat_interval',
+            'repeat_unit',
+            'repeat_type',
+        ]
+
+    @api.constrains('parent_id')
+    def _check_parent_id(self):
+        if self._has_cycle():
+            raise ValidationError(self.env._('Error! You cannot create a recursive hierarchy of tasks.'))
+
+    def _get_attachments_search_domain(self):
+        self.ensure_one()
+        return [('res_id', '=', self.id), ('res_model', '=', self._name)]
+
+    def _compute_attachment_ids(self):
+        for task_template in self:
+            attachment_ids = self.env['ir.attachment'].search(task_template._get_attachments_search_domain()).ids
+            message_attachment_ids = task_template.mapped('message_ids.attachment_ids').ids  # from mail_thread
+            task_template.attachment_ids = [(6, 0, list(set(attachment_ids) - set(message_attachment_ids)))]
+
+    @api.depends('child_ids.allocated_hours')
+    def _compute_subtask_allocated_hours(self):
+        for task_template in self:
+            task_template.subtask_allocated_hours = sum(task_template.child_ids.mapped('allocated_hours'))
+
+    @api.depends('child_ids')
+    def _compute_subtask_count(self):
+        if not any(self._ids):
+            for task_template in self:
+                task_template.subtask_count, task_template.closed_subtask_count = len(task_template.child_ids), len(task_template.child_ids.filtered(lambda r: r.state in CLOSED_STATES))
+            return
+        total_and_closed_subtask_count_per_parent_id = {
+            parent.id: (count, sum(s in CLOSED_STATES for s in states))
+            for parent, states, count in self._read_group(
+                [('parent_id', 'in', self.ids)],
+                ['parent_id'],
+                ['state:array_agg', '__count'],
+            )
+        }
+        for task_template in self:
+            task_template.subtask_count, task_template.closed_subtask_count = total_and_closed_subtask_count_per_parent_id.get(task_template.id, (0, 0))
+
+    @api.onchange('company_id')
+    def _onchange_task_company(self):
+        if self.project_id.company_id and self.project_id.company_id != self.company_id:
+            self.project_id = False
+
+    @api.depends('project_id.company_id', 'parent_id.company_id')
+    def _compute_company_id(self):
+        for task_template in self:
+            if not task_template.parent_id and not task_template.project_id:
+                continue
+            task_template.company_id = task_template.project_id.company_id or task_template.parent_id.company_id
+
+    @api.depends('project_id')
+    def _compute_stage_id(self):
+        for task_template in self:
+            project = task_template.project_id or task_template.parent_id.project_id
+            if project:
+                if project not in task_template.stage_id.project_ids:
+                    task_template.stage_id = task_template.stage_find(project.id, [('fold', '=', False)])
+            else:
+                task_template.stage_id = False
+
+    def _get_group_pattern(self):
+        return {
+            'tags_and_users': r'\s([#@]%s[^\s]+)',
+            'priority': r'(?:^|\s)(!{1,3})(?=\s|$)',
+        }
+
+    def _prepare_pattern_groups(self):
+        group = self._get_group_pattern()
+        return [
+            group['tags_and_users'] % '',
+            group['priority'],
+        ]
+
+    def _get_groups_patterns(self):
+        return [
+            r'(?:%s)*' % ('|').join(self._prepare_pattern_groups()),
+        ]
+
+    def _get_cannot_start_with_patterns(self):
+        return [r'(?![#!@\s])']
+
+    def _extract_tags_and_users(self):
+        tags = []
+        users = []
+        tags_and_users_group = self._get_group_pattern()['tags_and_users']
+        for word in re.findall(tags_and_users_group % '', self.display_name):
+            (tags if word.startswith('#') else users).append(word[1:])
+        users_to_keep = []
+        user_ids = []
+        for user in users:
+            matched_users = self.env['res.users'].name_search(user)
+            if len(matched_users) == 1:
+                user_ids.append(Command.link(matched_users[0][0]))
+            else:
+                users_to_keep.append(r'%s\b' % user)
+        self.user_ids = user_ids
+        if tags:
+            domain = Domain.OR(Domain('name', '=ilike', tag) for tag in tags)
+            existing_tags = self.env['project.tags'].search(domain)
+            existing_tags_names = {tag.name.lower() for tag in existing_tags}
+            new_tags_names = {tag for tag in tags if tag.lower() not in existing_tags_names}
+            self.tag_ids = [Command.set(existing_tags.ids)] + [Command.create({'name': name}) for name in new_tags_names]
+        pattern = tags_and_users_group % ('(?!%s)' % ('|').join(users_to_keep) if users_to_keep else '')
+        self.display_name, _ = re.subn(pattern, '', self.display_name)
+
+    def _extract_priority(self):
+        priority_group = self._get_group_pattern()['priority']
+        match = re.search(priority_group, self.display_name)
+        if match:
+            self.priority = str(min(len(match.group(1)), 3))
+            self.display_name, _dummy = re.subn(priority_group, '', self.display_name)
+
+    def _get_groups(self):
+        return [
+            lambda task: task._extract_tags_and_users(),
+            lambda task: task._extract_priority(),
+        ]
+
+    def _inverse_display_name(self):
+        for task_template in self:
+            pattern = re.compile(r'^%s.+?%s$' % (
+                ('').join(task_template._get_cannot_start_with_patterns()),
+                ('').join(task_template._get_groups_patterns()))
+            )
+            match = pattern.match(task_template.display_name)
+            if match:
+                for group, extract_data in enumerate(task_template._get_groups(), start=1):
+                    if match.group(group):
+                        extract_data(task_template)
+                task_template.name = task_template.display_name.strip()
+
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        if not self.env.context.get('is_copy_depend_task'):
+            default.update({
+                'depend_on_ids': False,
+            })
+        vals_list = super().copy_data(default=default)
+        # filter only readable fields
+        vals_list = [
+            {
+                k: v
+                for k, v in vals.items()
+                if k in self._fields and self._has_field_access(self._fields[k], 'read')
+            }
+            for vals in vals_list
+        ]
+
+        active_users = self.env['res.users']
+        has_default_users = 'user_ids' in default
+        if not has_default_users:
+            active_users = self.user_ids.filtered('active')
+        milestone_mapping = self.env.context.get('milestone_mapping', {})
+        for task, vals in zip(self, vals_list):
+
+            if not default.get('stage_id'):
+                vals['stage_id'] = task.stage_id.id
+            if 'active' not in default and not task['active'] and not self.env.context.get('copy_project'):
+                vals['active'] = True
+            if not default.get('name'):
+                vals['name'] = task.name if self.env.context.get('copy_project') or self.env.context.get('copy_from_template') else self.env._("%s (copy)", task.name)
+            if task.allow_milestones:
+                vals['milestone_id'] = milestone_mapping.get(vals['milestone_id'], vals['milestone_id'])
+            if not self.env.context.get('copy_from_project_template'):
+                if not default.get('child_ids') and task.child_ids:
+                    default = {
+                        'parent_id': False,
+                    }
+                    current_task = task
+                    if self.env.context.get('copy_from_template'):
+                        current_task = current_task.with_context(active_test=True)
+                    child_ids = current_task.child_ids
+                    vals['child_ids'] = [Command.create(child_id.copy_data(default)[0]) for child_id in child_ids]
+            if not has_default_users and vals['user_ids']:
+                task_active_users = task.user_ids & active_users
+                vals['user_ids'] = [Command.set(task_active_users.ids)]
+            if not self.env.context.get('is_copy_depend_task') and task.depend_on_ids:
+                vals['depend_on_ids'] = [Command.clear()]
+
+        return vals_list
+
+    # ----------------------------------------
+    # Case management
+    # ----------------------------------------
+
+    def stage_find(self, section_id, domain=[], order='sequence, id'):
+        """ Override of the base.stage method
+            Parameter of the stage search taken from the lead:
+            - section_id: if set, stages must belong to this section or
+              be a default stage; if not set, stages must be default
+              stages
+        """
+        # collect all section_ids
+        section_ids = []
+        if section_id:
+            section_ids.append(section_id)
+        section_ids.extend(self.mapped('project_id').ids)
+        search_domain = []
+        if section_ids:
+            search_domain = [('|')] * (len(section_ids) - 1)
+            for section_id in section_ids:
+                search_domain.append(('project_ids', '=', section_id))
+        search_domain += list(domain)
+        # perform search, return the first found
+        return self.env['project.task.type'].search(search_domain, order=order, limit=1).id
+
+    # ------------------------------------------------
+    # CRUD overrides
+    # ------------------------------------------------
+
+    @api.model
+    def default_get(self, fields):
+        vals = super().default_get(fields)
+
+        if project_id := self.env.context.get('default_create_in_project_id'):
+            vals['project_id'] = project_id
+
+        # prevent creating new task in the waiting state
+        if 'state' in fields and vals.get('state') == '04_waiting_normal':
+            vals['state'] = '01_in_progress'
+
+        project_id = vals.get('project_id', self.env.context.get('default_project_id'))
+        if project_id:
+            project = self.env['project.project'].browse(project_id)
+            if 'company_id' in fields and 'default_project_id' not in self.env.context:
+                vals['company_id'] = project.sudo().company_id.id
+        elif 'default_user_ids' not in self.env.context and 'user_ids' in fields:
+            user_ids = vals.get('user_ids', [])
+            user_ids.append(Command.link(self.env.user.id))
+            vals['user_ids'] = user_ids
+
+        parent_id = vals.get('parent_id', self.env.context.get('default_parent_id'))
+        if parent_id:
+            parent = self.env[self._name].browse(parent_id)
+            if not vals.get('tag_ids'):
+                vals['tag_ids'] = parent.tag_ids
+
+        return vals
+
+    def _set_stage_on_project_from_task(self):
+        stage_ids_per_project = defaultdict(list)
+        for task_template in self:
+            if task_template.stage_id and task_template.stage_id not in task_template.project_id.type_ids and task_template.stage_id.id not in stage_ids_per_project[task_template.project_id]:
+                stage_ids_per_project[task_template.project_id].append(task_template.stage_id.id)
+
+        for project, stage_ids in stage_ids_per_project.items():
+            project.write({'type_ids': [Command.link(stage_id) for stage_id in stage_ids]})
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Some values are determined by this override and must be written as
+        # sudo for portal users, because they do not have access to these
+        # fields. Other values must not be written as sudo.
+        additional_vals_list = [{} for _ in vals_list]
+
+        new_context = dict(self.env.context)
+        default_project_id = new_context.pop('default_project_id', False)
+        if not default_project_id:
+            parent_task = self.browse({parent_id for vals in vals_list if (parent_id := vals.get('parent_id'))})
+            if len(parent_task) == 1:
+                default_project_id = parent_task.sudo().project_id.id
+        # (portal) users that don't have write access can still create a task
+        # in the project that will be checked using record rules
+        new_context["default_create_in_project_id"] = default_project_id
+        if not self._has_field_access(self._fields['user_ids'], 'write'):
+            # remove user_ids if we have no access to it
+            new_context.pop('default_user_ids', False)
+        self_ctx = self.with_context(new_context)
+
+        self_ctx.browse().check_access('create')
+        default_stage = dict()
+        for vals, additional_vals in zip(vals_list, additional_vals_list):
+            project_id = vals.get('project_id') or default_project_id
+
+            if vals.get('user_ids'):
+                if not (vals.get('parent_id') or project_id):
+                    user_ids = self_ctx._fields['user_ids'].convert_to_cache(vals.get('user_ids', []), self_ctx.env['project.task'])
+                    if self_ctx.env.user.id not in list(user_ids) + [SUPERUSER_ID]:
+                        additional_vals['user_ids'] = [Command.set(list(user_ids) + [self_ctx.env.user.id])]
+            if not vals.get('name') and vals.get('display_name'):
+                vals['name'] = vals['display_name']
+
+            if project_id and not "company_id" in vals:
+                additional_vals["company_id"] = self_ctx.env["project.project"].browse(
+                    project_id
+                ).company_id.id
+            if not project_id and ("stage_id" in vals or self_ctx.env.context.get('default_stage_id')):
+                vals["stage_id"] = False
+
+            if project_id and "stage_id" not in vals:
+                # 1) Allows keeping the batch creation of tasks
+                # 2) Ensure the defaults are correct (and computed once by project),
+                # by using default get (instead of _get_default_stage_id or _stage_find),
+                if project_id not in default_stage:
+                    default_stage[project_id] = self_ctx.with_context(
+                        default_project_id=project_id
+                    ).default_get(['stage_id']).get('stage_id')
+                vals["stage_id"] = default_stage[project_id]
+
+            # Stage change: Update date_end if folded stage and date_last_stage_update
+            if vals.get('stage_id'):
+                additional_vals.update(self_ctx.update_date_end(vals['stage_id']))
+                additional_vals['date_last_stage_update'] = fields.Datetime.now()
+
+        # create the task, write computed inaccessible fields in sudo
+        for vals, computed_vals in zip(vals_list, additional_vals_list):
+            for field_name in list(computed_vals):
+                if self_ctx._has_field_access(self_ctx._fields[field_name], 'write'):
+                    vals[field_name] = computed_vals.pop(field_name)
+        # no track when the portal user create a task to avoid using during tracking
+        # process since the portal does not have access to tracking models
+        task_templates = super(ProjectTaskTemplate, self_ctx.with_context(mail_create_nosubscribe=True, mail_notrack=not self_ctx.env.su and self_ctx.env.user._is_portal())).create(vals_list)
+        for task, computed_vals in zip(task_templates.sudo(), additional_vals_list):
+            if computed_vals:
+                task.write(computed_vals)
+        if task_templates.project_id:
+            task_templates.sudo()._set_stage_on_project_from_task()
+        return task_templates
+
+    def write(self, vals):
+        if len(self) == 1:
+            handle_history_divergence(self, 'description', vals)
+        # Some values are determined by this override and must be written as
+        # sudo for portal users, because they do not have access to these
+        # fields. Other values must not be written as sudo.
+        additional_vals = {}
+
+        if 'milestone_id' in vals:
+            # WARNING: has to be done after 'project_id' vals is written on subtasks
+            milestone = self.env['project.milestone'].browse(vals['milestone_id'])
+
+            # 1. Task for which the milestone is unvalid -> milestone_id is reset
+            if 'project_id' not in vals:
+                unvalid_milestone_tasks = self.filtered(lambda task: task.project_id != milestone.project_id) if vals['milestone_id'] else self.env[self._name]
+            else:
+                unvalid_milestone_tasks = self if not vals['milestone_id'] or milestone.project_id.id != vals['project_id'] else self.env[self._name]
+            valid_milestone_tasks = self - unvalid_milestone_tasks
+            if unvalid_milestone_tasks:
+                unvalid_milestone_tasks.sudo().write({'milestone_id': False})
+                if valid_milestone_tasks:
+                    valid_milestone_tasks.sudo().write({'milestone_id': vals['milestone_id']})
+                del vals['milestone_id']
+
+            # 2. Parent's milestone is set to subtask with no milestone recursively
+            subtasks_to_update = valid_milestone_tasks.child_ids.filtered(
+                lambda task_template: (
+                    task_template not in self and
+                    not task_template.milestone_id and
+                    task_template.project_id == milestone.project_id and
+                    task_template.state not in CLOSED_STATES
+                )
+            )
+            # 3. If parent and child task share the same milestone, child task's milestone is updated when the parent one is changed
+            # No need to check if state is changed in vals as it won't affect the subtasks selected for update
+            if 'project_id' not in vals:
+                subtasks_to_update |= valid_milestone_tasks.child_ids.filtered(
+                    lambda task_template: (
+                        task_template not in self and
+                        task_template.milestone_id == task_template.parent_id.milestone_id and
+                        task_template.state not in CLOSED_STATES
+                    )
+                )
+            else:
+                subtasks_to_update |= valid_milestone_tasks.child_ids.filtered(
+                    lambda task_template: (
+                        task_template not in self and
+                        (not task_template.display_in_project or task_template.project_id.id == vals['project_id']) and
+                        task_template.milestone_id == task_template.parent_id.milestone_id and
+                        task_template.state not in CLOSED_STATES
+                    )
+                )
+            if subtasks_to_update:
+                subtasks_to_update.sudo().write({'milestone_id': vals['milestone_id']})
+
+        if vals.get('parent_id') in self.ids:
+            raise UserError(self.env._("Sorry. You can't set a task as its parent task."))
+
+        # stage change: update date_last_stage_update
+        now = fields.Datetime.now()
+        if 'stage_id' in vals:
+            if not 'project_id' in vals and self.filtered(lambda t: not t.project_id):
+                raise UserError(self.env._('You can only set a personal stage on a private task.'))
+
+            additional_vals.update(self.update_date_end(vals['stage_id']))
+            additional_vals['date_last_stage_update'] = now
+
+        if vals.get('parent_id') is False:
+            additional_vals['display_in_project'] = True
+        if 'description' in vals:
+            # the portal user cannot access to html_field_history and so it would be
+            # better to write in sudo for description field to avoid giving access to html_field_history
+            additional_vals['description'] = vals.pop('description')
+
+        # write changes
+        if self.env.su or not self.env.user._is_portal():
+            vals.update(additional_vals)
+        elif additional_vals:
+            super(ProjectTaskTemplate, self.sudo()).write(additional_vals)
+        result = super().write(vals)
+
+        if 'project_id' in vals:
+            self.filtered(lambda t: t.state != '04_waiting_normal').state = '01_in_progress'
+
+        # Do not recompute the state when changing the parent (to avoid resetting the state)
+        if 'parent_id' in vals:
+            self.env.remove_to_compute(self._fields['state'], self)
+
+        return result
+
+    def update_date_end(self, stage_id):
+        project_task_type = self.env['project.task.type'].browse(stage_id)
+        if project_task_type.fold:
+            return {'date_end': fields.Datetime.now()}
+        return {'date_end': False}
+
+    @api.depends('project_id')
+    def _compute_milestone_id(self):
+        for task_template in self:
+            if task_template.project_id != task_template.milestone_id.project_id:
+                task_template.milestone_id = task_template.parent_id.project_id == task_template.project_id and task_template.parent_id.milestone_id
+
+    def _compute_has_late_and_unreached_milestone(self):
+        if all(not task_template.allow_milestones for task_template in self):
+            self.has_late_and_unreached_milestone = False
+            return
+        late_milestones = self.env['project.milestone'].sudo()._search([  # sudo is needed for the portal user in Project Sharing.
+            ('id', 'in', self.milestone_id.ids),
+            ('is_reached', '=', False),
+            ('deadline', '<=', fields.Date.today()),
+        ])
+        for task_template in self:
+            task_template.has_late_and_unreached_milestone = task_template.allow_milestones and task_template.milestone_id.id in late_milestones
+
+    def _search_has_late_and_unreached_milestone(self, operator, value):
+        if operator != 'in':
+            return NotImplemented
+        return [
+            ('allow_milestones', '=', True),
+            ('milestone_id', 'any', [
+                ('is_reached', '=', False),
+                ('deadline', '<', fields.Date.today()),
+            ]),
+        ]
+    # ---------------------------------------------------
+    # Subtasks
+    # ---------------------------------------------------
+
+    def _get_all_subtasks(self):
+        return self.browse(set.union(set(), *self._get_subtask_ids_per_task_id().values()))
+
+    def _get_subtask_ids_per_task_id(self):
+        if not self:
+            return {}
+        res = {id_: [] for id_ in self._ids}
+        if all(self._ids):
+            query = f"""
+                WITH RECURSIVE task_tree AS (
+                    SELECT id, id as supertask_id
+                      FROM {self._table}
+                     WHERE id IN %(ancestor_ids)s
+                    UNION
+                    SELECT t.id, tree.supertask_id
+                      FROM {self._table} t
+                      JOIN task_tree tree
+                        ON tree.id = t.parent_id
+                       AND t.active in (TRUE, %(active)s)
+                     WHERE t.parent_id IS NOT NULL
+                )
+                SELECT supertask_id, ARRAY_AGG(id)
+                  FROM task_tree
+                 WHERE id != supertask_id
+                GROUP BY supertask_id
+                """
+
+            self.env.cr.execute(
+                query,
+                {
+                    "ancestor_ids": tuple(self.ids),
+                    "active": self.env.context.get('active_test', True),
+                }
+            )
+
+            res.update(dict(self.env.cr.fetchall()))
+        else:
+            res.update({
+                task_template.id: task_template._get_subtasks_recursively().ids
+                for task_template in self
+            })
+        return res
+
+    def _get_subtasks_recursively(self):
+        children = self.child_ids
+        if not children:
+            return self.env[self._name]
+        return children + children._get_subtasks_recursively()
+
+    @api.depends('subtask_count', 'closed_subtask_count')
+    def _compute_subtask_completion_percentage(self):
+        for task_template in self:
+            task_template.subtask_completion_percentage = task_template.subtask_count and task_template.closed_subtask_count / task_template.subtask_count
+
+    def action_open_parent_task(self):
+        return {
+            'name': self.env._('Parent Task'),
+            'view_mode': 'form',
+            'res_model': self._name,
+            'res_id': self.parent_id.id,
+            'type': 'ir.actions.act_window',
+            'context': self.env.context,
+        }
+
+    def action_create_from_template(self, values=None):
+        self.ensure_one()
+        values = values or {}
+        task_template_data = self.with_context(copy_from_template=True).copy_data(values)
+        if task_template_data[0].get('recurring_task') and not task_template_data[0].get('repeat_interval'):
+            task_template_data[0]['recurring_task'] = False
+        task = self.env['project.task'].with_context(
+            mail_create_nosubscribe=True,
+            mail_create_nolog=True,
+        ).sudo().create(task_template_data)
+        task.message_post(subtype_xmlid='project.mt_task_new')
+        return task.id
+
+    def action_archive(self):
+        child_task_template = self.child_ids.filtered(lambda child_task: not child_task.display_in_project)
+        if child_task_template:
+            child_task_template.action_archive()
+        self.filtered(lambda t: not t.display_in_project and t.parent_id).display_in_project = True
+        return super().action_archive()

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -65,8 +65,6 @@ class ReportProjectTaskUser(models.Model):
         column2='task_id', string='Block', readonly=True,
         domain="[('allow_task_dependencies', '=', True), ('id', '!=', id)]")
     description = fields.Text(readonly=True)
-    # We exclude template tasks, but we still need the field for the views
-    is_template = fields.Boolean(readonly=True)
 
     def _select(self):
         return """
@@ -98,8 +96,7 @@ class ReportProjectTaskUser(models.Model):
                 NULLIF(t.working_hours_open, 0) as working_hours_open,
                 NULLIF(t.working_hours_close, 0) as working_hours_close,
                 (extract('epoch' from (t.date_deadline-(now() at time zone 'UTC'))))/(3600*24) as delay_endings_days,
-                COUNT(td.task_id) as dependent_ids_count,
-                t.is_template
+                COUNT(td.task_id) as dependent_ids_count
         """
 
     def _group_by(self):
@@ -145,8 +142,6 @@ class ReportProjectTaskUser(models.Model):
     def _where(self):
         return """
                 t.project_id IS NOT NULL
-                AND t.is_template IS NOT TRUE
-                AND p.is_template IS NOT TRUE
         """
 
     def init(self):

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -8,6 +8,7 @@ access_project_task_type_project_user,project.task.type.project.user,model_proje
 access_project_task_type_manager,project.task.type manager,model_project_task_type,project.group_project_manager,1,1,1,1
 access_project_task_type_portal,task_type_portal,project.model_project_task_type,base.group_portal,1,0,0,0
 access_project_task,project.task,model_project_task,project.group_project_user,1,1,1,1
+access_project_task_template,project.task.template,model_project_task_template,project.group_project_user,1,1,1,1
 access_report_project_task_user,report.project.task.user,model_report_project_task_user,project.group_project_manager,1,0,0,0
 access_report_project_task_user_project_user,report.project.task.user.project.user,model_report_project_task_user,project.group_project_user,1,0,0,0
 access_partner_task_user,base.res.partner user,base.model_res_partner,project.group_project_user,1,0,0,0

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -81,6 +81,11 @@
         <field name="model_id" ref="model_project_task"/>
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
+    <record model="ir.rule" id="task_template_comp_rule">
+        <field name="name">Project/Task Template: multi-company</field>
+        <field name="model_id" ref="model_project_task_template"/>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+    </record>
 
     <record model="ir.rule" id="task_visibility_rule">
         <field name="name">Project/Task: employees: follow required for follower-only projects</field>
@@ -111,6 +116,16 @@
                  ('user_ids', 'in', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+    </record>
+
+    <record model="ir.rule" id="project_manager_all_task_template_rule">
+        <field name="name">Project/Task Template: project manager: see all task template linked to a project or its own templates</field>
+        <field name="model_id" ref="model_project_task"/>
+        <field name="domain_force">[
+            '|', ('project_id', '!=', False),
+                 ('user_ids', 'in', user.id),
+        ]</field>
+        <field name="groups" eval="[(4, ref('project.group_project_manager'))]"/>
     </record>
 
     <record model="ir.rule" id="task_type_manager_rule">

--- a/addons/project/static/src/actions/client_actions.js
+++ b/addons/project/static/src/actions/client_actions.js
@@ -2,6 +2,15 @@ import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_d
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 
+export async function openFormView(env, { resModel, resId }) {
+    await env.services.action.doAction({
+        type: "ir.actions.act_window",
+        res_model: resModel,
+        views: [[false, "form"]],
+        res_id: resId,
+    });
+}
+
 export function showTemplateUndoNotification(
     env,
     {
@@ -11,6 +20,8 @@ export function showTemplateUndoNotification(
         undoMethod = "action_undo_convert_to_template",
         actionType = "success",
         undoCallback,
+        templateResId,
+        templateResModel,
     }
 ) {
     const undoNotification = env.services.notification.add(_t(message), {
@@ -27,10 +38,20 @@ export function showTemplateUndoNotification(
                     if (res && undoMethod !== "unlink") {
                         env.services.action.doAction(res);
                     } else if (undoMethod === "unlink") {
-                        // Taking out the controller to be restored after unlinking the record
-                        const restoreController =
-                            env.services.action.currentController.config.breadcrumbs?.at(-2);
-                        restoreController?.onSelected();
+                        if (model === 'project.task.template') {
+                            env.services.notification.add(_t('Removed from templates'), {
+                                type: "success",
+                            });
+                            env.services.action.doAction({
+                                type: "ir.actions.client",
+                                tag: "soft_reload",
+                            });
+                        } else {
+                            // Taking out the controller to be restored after unlinking the record
+                            const restoreController =
+                                env.services.action.currentController.config.breadcrumbs?.at(-2);
+                            restoreController?.onSelected();
+                        }
                     }
                     undoNotification();
                 },
@@ -56,6 +77,11 @@ export function showTemplateUndoConfirmationDialog(
         confirm: async () => {
             const action = await env.services.orm.call(model, undoMethod, [recordId]);
             await env.services.action.doAction(action);
+            if (action.params.type == 'success') {
+                const { res_id, res_model } = action.params;
+                await openFormView(env, { resModel: res_model, resId: res_id });
+                env.services.action.currentController.config.breadcrumbs?.pop()
+            }
             if (confirmationCallback) {
                 await env.services.orm.call(
                     model,
@@ -74,12 +100,7 @@ export async function showTemplateFormView(
     { model, recordId, method = "action_create_template_from_project" }
 ) {
     const action = await env.services.orm.call(model, method, [recordId]);
-    await env.services.action.doAction({
-        type: "ir.actions.act_window",
-        res_model: model,
-        views: [[false, "form"]],
-        res_id: action.params.project_id,
-    });
+    await openFormView(env, { resModel: model, resId: action.params.project_id });
     await env.services.action.doAction(action);
 }
 
@@ -87,28 +108,13 @@ export async function showTemplateFormView(
 registry.category("actions").add("project_show_template_notification", (env, action) => {
     const params = action.params || {};
     showTemplateUndoNotification(env, {
-        model: "project.task",
-        recordId: params.task_id,
-        message: _t("Task converted to template"),
+        model: "project.task.template",
+        recordId: params.res_id,
+        undoMethod: params.undo_method,
+        message: _t("Saved as template"),
     });
     return params.next;
 });
-
-// Task → Template Undo Confirmation Dialog
-registry
-    .category("actions")
-    .add("project_show_template_undo_confirmation_dialog", (env, action) => {
-        const params = action.params || {};
-        showTemplateUndoConfirmationDialog(env, {
-            model: "project.task",
-            recordId: params.task_id,
-            bodyMessage: _t(
-                "This task is currently a template. Would you like to convert it back into a regular task?"
-            ),
-            confirmLabel: _t("Convert to Task"),
-        });
-        return params.next;
-    });
 
 // Project → Template Create Redirection
 registry.category("actions").add("project_to_template_redirection_action", (env, action) => {

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
@@ -96,7 +96,7 @@ export class SubtaskKanbanList extends Component {
             const sequences = this.list.records.map(r => r.data.sequence);
             const nextSequence = (sequences.length ? Math.max(...sequences) : 0) + 1;
 
-            await this.orm.create("project.task", [{
+            await this.orm.create(this.list.resModel, [{
                 display_name: name,
                 parent_id: this.props.record.resId,
                 project_id: this.props.record.data.project_id.id,

--- a/addons/project/static/src/views/components/project_task_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.js
@@ -63,7 +63,7 @@ export class ProjectTaskTemplateDropdown extends Component {
         }
         this.action.switchView("form", {
             resId: await this.orm.call(
-                "project.task",
+                "project.task.template",
                 "action_create_from_template",
                 [templateId],
                 {

--- a/addons/project/tests/test_project_template.py
+++ b/addons/project/tests/test_project_template.py
@@ -1,7 +1,6 @@
 from datetime import date
 
 from odoo import Command
-from odoo.exceptions import UserError
 from odoo.tests import freeze_time
 
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
@@ -17,7 +16,7 @@ class TestProjectTemplates(TestProjectCommon):
             "date_start": date(2025, 6, 1),
             "date": date(2025, 6, 11),
         })
-        cls.task_inside_template = cls.env["project.task"].create({
+        cls.task_inside_template = cls.env["project.task.template"].create({
             "name": "Task in Project Template",
             "project_id": cls.project_template.id,
         })
@@ -31,7 +30,8 @@ class TestProjectTemplates(TestProjectCommon):
         self.assertFalse(project.is_template, "The created Project should be a normal project and not a template.")
         self.assertFalse(project.partner_id, "The created Project should not have a customer.")
 
-        self.assertEqual(len(project.task_ids), 1, "The tasks of the template should be copied too.")
+        template_task_count = self.env['project.task.template'].search_count([('project_id', '=', project.id)])
+        self.assertEqual(template_task_count, 0, "The tasks of the template should be copied too.")
 
     def test_copy_template(self):
         """
@@ -40,7 +40,8 @@ class TestProjectTemplates(TestProjectCommon):
         copied_template = self.project_template.copy()
         self.assertEqual(copied_template.name, "Project Template (copy)", "The project name should be `Project Template` (copy).")
         self.assertTrue(copied_template.is_template, "The copy of the template should also be a template.")
-        self.assertEqual(len(copied_template.task_ids), 1, "The child of the template should be copied too.")
+        task_count = self.env['project.task.template'].search_count([('project_id', '=', copied_template.id)])
+        self.assertEqual(task_count, 1, "The child of the template should be copied too.")
 
     def test_revert_template(self):
         """
@@ -48,14 +49,6 @@ class TestProjectTemplates(TestProjectCommon):
         """
         self.project_template.action_undo_convert_to_template()
         self.assertFalse(self.project_template.is_template, "The reverted template should become a normal template.")
-
-    def test_revert_task_template(self):
-        """
-        A template task should not be reverted to a regular task.
-        """
-        self.task_inside_template.is_template = True
-        with self.assertRaises(UserError, msg="A UserError should be raised when attempting to revert a template task to a regular one."):
-            self.task_inside_template.action_convert_to_template()
 
     def test_tasks_dispatching_from_template(self):
         """
@@ -72,7 +65,7 @@ class TestProjectTemplates(TestProjectCommon):
         project_template = self.env['project.project'].create({
             'name': 'Project template',
             'is_template': True,
-            'task_ids': [
+            'task_template_ids': [
                 Command.create({
                     'name': 'Task 1',
                     'role_ids': [role1.id, role3.id],
@@ -214,3 +207,143 @@ class TestProjectTemplates(TestProjectCommon):
 
         self.assertEqual(new_project.date_start, new_start, "Start date should be the one provided")
         self.assertEqual(new_project.date, new_end, "End date should be the one provided")
+
+    def test_project_template_convert_regular_project_with_sub_task_template(self):
+        """
+        Test converting a project template into a regular project and ensure that
+        sub-task templates are also copied correctly
+
+            Project Template A
+               |
+               └── Task Template A
+                        |
+                        └── Task Template B
+                            |
+                            ├── Task Template C
+                            └── Task Template D
+                                |
+                                └── Task Template E
+        """
+        project_template = self.env["project.project"].create({
+            "name": "Project Template",
+            "is_template": True,
+        })
+
+        self.env["project.task.template"].create({
+            "name": "Task Template A",
+            "project_id": project_template.id,
+            "child_ids": [
+                Command.create({
+                    "name": "Task Template B",
+                    "child_ids": [
+                        Command.create({
+                            "name": "Task Template C"
+                        }),
+                        Command.create({
+                            "name": "Task Template D",
+                            "child_ids": [
+                                Command.create({"name": "Task Template E"})
+                            ]
+                        }),
+                    ]
+                }),
+            ],
+        })
+        project = project_template.action_create_from_template()
+        expected_hierarchy = {
+            "Task Template A": None,
+            "Task Template B": "Task Template A",
+            "Task Template C": "Task Template B",
+            "Task Template D": "Task Template B",
+            "Task Template E": "Task Template D",
+        }
+        self.assertEqual(project.task_count, len(expected_hierarchy), "Unexpected number of tasks created")
+
+        for task in project.task_ids:
+            expected_parent_name = expected_hierarchy[task.name]
+            if expected_parent_name:
+                self.assertEqual(
+                    task.parent_id.name,
+                    expected_parent_name,
+                    f"Task '{task.name}' should have parent '{expected_parent_name}'",
+                )
+            else:
+                self.assertFalse(
+                    task.parent_id,
+                    f"Task '{task.name}' should not have a parent",
+                )
+        project_template_data = project.action_create_template_from_project()
+        project_id = project_template_data.get('params')['project_id']
+        project_template = self.env['project.project'].browse(project_id)
+        self.assertEqual(len(project_template.task_template_ids), len(expected_hierarchy), "Unexpected number of tasks created")
+
+        for task_template in project_template.task_template_ids:
+            expected_parent_name = expected_hierarchy[task_template.name]
+            if expected_parent_name:
+                self.assertEqual(
+                    task_template.parent_id.name,
+                    expected_parent_name,
+                    f"Task Template '{task_template.name}' should have parent '{expected_parent_name}'",
+                )
+            else:
+                self.assertFalse(
+                    task_template.parent_id,
+                    f"Task Template '{task_template.name}' should not have a parent",
+                )
+
+    def test_project_create_from_project_template_with_dependent_task(self):
+        """
+        Steps:
+        1. Create a project template.
+        2. Create a task template.
+        4. Generate a project from the project template.
+        5. Ensure the dependency is preserved in the new project.
+        """
+        project_template = self.env["project.project"].create({
+            "name": "Project Template",
+            "is_template": True,
+        })
+
+        self.env["project.task.template"].create({
+            "name": "Task Template A",
+            "project_id": project_template.id,
+            "depend_on_ids": [Command.set(self.task_2.ids)],
+        })
+
+        project = project_template.action_create_from_template()
+        new_task_a = project.task_ids.filtered(lambda t: t.name == "Task Template A")
+        self.assertEqual(
+            new_task_a.depend_on_ids.ids,
+            self.task_2.ids,
+            "Dependency mismatch: Task Template A should depend on Task 2 in the generated project."
+        )
+
+    def test_recurrence_project_template_convert_regular_project(self):
+        """
+        Test recurrence of project template when converting to regular project
+        Steps:
+            - Create a project template.
+            - Create a task template with recurring.
+            - Convert the project template into a regular project.
+            - Verify tasks in the created project.
+        """
+        project_template_recurring = self.env['project.project'].with_context({'mail_create_nolog': True}).create({
+            "name": 'Project Template Recurring',
+            "is_template": True,
+        })
+        task_template_recurring = self.env['project.task.template'].create({
+            'name': "Recurring Task template",
+            'project_id': project_template_recurring.id,
+            'recurring_task': True,
+            'repeat_interval': 2,
+            'repeat_unit': 'week',
+            'repeat_type': 'forever',
+        })
+        project = project_template_recurring.action_create_from_template()
+        recurring_task = project.task_ids
+
+        self.assertEqual(task_template_recurring.name, recurring_task.name, "Task name mismatch")
+        self.assertTrue(task_template_recurring.recurring_task, "Task should be recurring")
+        self.assertEqual(task_template_recurring.repeat_unit, recurring_task.repeat_unit, "Task repeat unit mismatch")
+        self.assertEqual(task_template_recurring.repeat_type, recurring_task.repeat_type, "Task repeat type mismatch")
+        self.assertEqual(task_template_recurring.repeat_interval, recurring_task.repeat_interval, "Task repeat interval mismatch")

--- a/addons/project/tests/test_task_templates.py
+++ b/addons/project/tests/test_task_templates.py
@@ -8,18 +8,15 @@ class TestTaskTemplates(TestProjectCommon):
         cls.project_with_templates = cls.env["project.project"].create({
             "name": "Project with Task Template",
         })
-        cls.template_task = cls.env["project.task"].create({
+        cls.template_task = cls.env["project.task.template"].create({
             "name": "Template",
             "project_id": cls.project_with_templates.id,
-            "is_template": True,
             "description": "Template description",
-            "partner_id": cls.partner_1.id,
         })
-        cls.child_task = cls.env["project.task"].create({
+        cls.child_task = cls.env["project.task.template"].create({
             "name": "Child Task",
             "parent_id": cls.template_task.id,
             "description": "Child description",
-            "partner_id": cls.partner_2.id,
         })
 
     def test_create_from_template(self):
@@ -28,12 +25,10 @@ class TestTaskTemplates(TestProjectCommon):
         """
         task_id = self.template_task.action_create_from_template()
         task = self.env["project.task"].browse(task_id)
-        self.assertFalse(task.is_template, "The created task should be a normal task and not a template.")
         self.assertFalse(task.partner_id, "The created task should not have a partner.")
 
         self.assertEqual(len(task.child_ids), 1, "The child of the template should be copied too.")
         child_task = task.child_ids
-        self.assertFalse(child_task.is_template, "The child task should still not be a template.")
         self.assertFalse(child_task.partner_id, "The child task should also not have a partner.")
 
         # With a partner set on the project, new tasks should get the partner too, even if created from a template
@@ -50,47 +45,13 @@ class TestTaskTemplates(TestProjectCommon):
         A copy of a template should be a template
         """
         copied_template = self.template_task.copy()
-        self.assertTrue(copied_template.is_template, "The copy of the template should also be a template.")
         self.assertEqual(len(copied_template.child_ids), 1, "The child of the template should be copied too.")
-        copied_template_child_task = copied_template.child_ids
-        self.assertFalse(copied_template_child_task.is_template, "The child of the copy should still not be a template.")
 
     def test_copy_project_with_templates(self):
         """
         Copying a project should also copy its task templates
         """
+        self.project_with_templates.is_template = True
         copied_project = self.project_with_templates.copy()
-        task = self.env["project.task"].search([("project_id", "=", copied_project.id)], order="id asc", limit=1)
-        self.assertTrue(task, "The copied project should contain a copy of the template.")
-        self.assertTrue(task.is_template, "The copied template should still be a template.")
-
-    def test_has_template_ancestor(self):
-        self.assertTrue(self.template_task.has_template_ancestor, "The template is a template.")
-        self.assertTrue(self.child_task.has_template_ancestor, "The child of the template has a template ancestor.")
-
-        task = self.env["project.task"].create({
-            "name": "Task",
-            "project_id": self.project_with_templates.id,
-        })
-        self.assertFalse(task.has_template_ancestor, "The task does not have ancestors and is not a template.")
-
-        child = self.env["project.task"].create({
-            "name": "Child",
-            "parent_id": task.id,
-        })
-        self.assertFalse(child.has_template_ancestor, "The task has ancestors, but none of them are templates.")
-
-        self.assertCountEqual(
-            self.env["project.task"].search(
-                [('project_id', '=', self.project_with_templates.id), ('has_template_ancestor', '=', True)],
-            ),
-            self.template_task | self.child_task,
-            "The search should find the template and its child",
-        )
-        self.assertCountEqual(
-            self.env["project.task"].search(
-                [('project_id', '=', self.project_with_templates.id), ('has_template_ancestor', '=', False)],
-            ),
-            task | child,
-            "The search should find the non template task and its child",
-        )
+        task_template = self.env["project.task.template"].search([("project_id", "=", copied_project.id)], order="id asc", limit=1)
+        self.assertTrue(task_template, "The copied project should contain a copy of the template.")

--- a/addons/project/tests/test_task_templates_ui.py
+++ b/addons/project/tests/test_task_templates_ui.py
@@ -13,10 +13,9 @@ class TestTaskTemplatesTour(HttpCase):
                 "name": "New",
             })],
         })
-        cls.template_task = cls.env["project.task"].create({
+        cls.template_task = cls.env["project.task.template"].create({
             "name": "Template",
             "project_id": cls.project_with_templates.id,
-            "is_template": True,
             "description": "Template description",
         })
 

--- a/addons/project/views/project_milestone_views.xml
+++ b/addons/project/views/project_milestone_views.xml
@@ -14,6 +14,7 @@
                                 context="{'default_project_id': project_id}"
                                 groups="project.group_project_milestone"
                                 close="1"
+                                invisible="not task_count"
                         >
                             <div class="o_form_field o_stat_info">
                                 <span class="o_stat_value">

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -153,11 +153,11 @@
                         <h1 class="d-flex w-100">
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
                         </h1>
-                        <div class="d-flex justify-content-end align-items-center px-1" invisible="not active or is_template">
+                        <div class="d-flex justify-content-end align-items-center px-1" invisible="not active">
                             <field name="priority" class="h3 pe-2" widget="priority"/>
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>
-                        <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active and not is_template">
+                        <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active">
                             <field name="priority" class="h3 pe-2" widget="priority"/>
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>

--- a/addons/project/views/project_task_template_views.xml
+++ b/addons/project/views/project_task_template_views.xml
@@ -1,0 +1,424 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_project_task_template_list" model="ir.ui.view">
+        <field name="name">project.task.template.list</field>
+        <field name="model">project.task.template</field>
+        <field name="arch" type="xml">
+            <list string="Task Templates" js_class="project_task_list" open_form_view="True"
+                sample="1" default_order="priority desc, sequence, state, date_deadline asc, id desc">
+                <field name="sequence" readonly="1" column_invisible="True"/>
+                <field name="allow_milestones" column_invisible="True"/>
+                <field name="subtask_count" column_invisible="True"/>
+                <field name="closed_subtask_count" column_invisible="True"/>
+                <field name="id" optional="hide" options="{'enable_formatting': False}"/>
+                <field name="name" string="Title" widget="name_with_subtask_count"/>
+                <field name="project_id" widget="project" optional="show"
+                    options="{'no_open': 1}" column_invisible="context.get('default_project_id')" required="1"/>
+                <field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}"
+                    groups="project.group_project_milestone" optional="hide"/>
+                <field name="parent_id" optional="hide"/>
+                <field name="user_ids" optional="show" widget="many2many_avatar_user"/>
+                <field name="role_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                <field name="company_id" groups="base.group_multi_company" optional="show"
+                    column_invisible="context.get('default_project_id')" options="{'no_create': True}"/>
+                <field name="company_id" column_invisible="True"/>
+                <field name="date_deadline" optional="hide" widget="remaining_days"
+                    invisible="state in ['1_done', '1_canceled']"/>
+                <field name="priority" widget="priority" optional="hide" width="70px"/>
+                <field name="tag_ids" widget="many2many_tags"
+                    options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
+                <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"
+                    options="{'is_toggle_mode': false}"/>
+                <field name="stage_id_color" column_invisible="1"/>
+                <field name="stage_id" column_invisible="context.get('set_visible', False)"
+                    optional="show" widget="selection_badge" options="{'color_field': 'stage_id_color'}"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_project_task_template_search" model="ir.ui.view">
+        <field name="name">project.task.template.search.form</field>
+        <field name="model">project.task.template</field>
+        <field name="arch" type="xml">
+            <search string="Tasks Template">
+                <field name="name" string="Template" filter_domain="['|', ('name', 'ilike', self), ('id', 'ilike', self)]"/>
+                <field name="tag_ids"/>
+                <field name="user_ids"/>
+                <field name="role_ids"/>
+                <field name="stage_id"/>
+                <field name="project_id"/>
+                <field name="milestone_id" groups="project.group_project_milestone"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+                <field string="Properties" name="task_properties"/>
+                <group>
+                    <filter string="Assignees" name="user" context="{'group_by': 'user_ids'}"/>
+                    <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
+                    <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
+                    <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}"
+                        groups="project.group_project_milestone"/>
+                    <filter string="Priority" name="groupby_priority" context="{'group_by': 'priority'}"/>
+                    <filter string="Tags" name="tags" context="{'group_by': 'tag_ids'}"/>
+                    <filter string="Company" name="company_id" context="{'group_by': 'company_id'}"
+                        groups="base.group_multi_company"/>
+                    <separator/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="project_template_task_action_sub_task" model="ir.actions.act_window">
+        <field name="name">Sub-tasks</field>
+        <field name="res_model">project.task.template</field>
+        <field name="view_mode">list,kanban,form</field>
+        <field name="search_view_id" ref="project.view_project_task_template_search"/>
+        <field name="domain">[('id', 'child_of', active_id), ('id', '!=', active_id)]</field>
+        <field name="context">{'default_parent_id': active_id, 'search_default_stage': 1, 'default_is_template': True}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No tasks found. Let's create one!
+            </p>
+            <p>
+                Keep track of the progress of your template tasks from creation to completion.<br/>
+                Collaborate efficiently by chatting in real-time or via email.
+            </p>
+        </field>
+    </record>
+
+    <record id="view_project_task_template_form" model="ir.ui.view">
+        <field name="name">project.task.template.form</field>
+        <field name="model">project.task.template</field>
+        <field name="arch" type="xml">
+            <form string="Task Template" class="o_form_project_tasks" js_class="project_task_form">
+                <field name="allow_task_dependencies" invisible="1" />
+                <field name="allow_milestones" invisible="1" />
+                <field name="parent_id" invisible="1"/>
+                <field name="company_id" invisible="1"/>
+                <field name="is_closed" invisible="1"/>
+                <field name="html_field_history_metadata" invisible="1"/>
+                <header>
+                    <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not project_id and not stage_id" col="6"/>
+                    <field name="state" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="1"/>
+                </header>
+                <sheet string="Task Templates">
+                <t name="warning_section"/>
+                <div class="oe_button_box" name="button_box" groups="base.group_user">
+                    <button name="action_open_parent_task" type="object" class="oe_stat_button" icon="fa-check" invisible="not parent_id">
+                        <div class="o_stat_info">
+                            <span class="o_stat_text">Parent Task</span>
+                        </div>
+                    </button>
+                    <button name="%(project_template_task_action_sub_task)d" type="action" class="oe_stat_button" icon="fa-check"
+                        invisible="not id or subtask_count == 0"
+                        context="{
+                            'default_project_id': project_id,
+                            'default_user_ids': user_ids,
+                            'default_milestone_id': milestone_id,
+                            'subtask_action': True,
+                        }"
+                    >
+                        <div class="o_field_widget o_stat_info">
+                            <span class="o_stat_text">Sub-tasks</span>
+                            <span class="o_stat_value">
+                                <field name="closed_subtask_count"/> / <field name="subtask_count"/>
+                                (<field name="subtask_completion_percentage" widget="percentage" options="{'digits': [1, 0]}"/>)
+                            </span>
+                        </div>
+                    </button>
+                    <!-- Dummy tag used to organize buttons -->
+                    <span id="end_button_box" invisible="1"/>
+                </div>
+                <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                <widget name="web_ribbon" title="Template" bg_color="text-bg-info" invisible="not active"/>
+                <div class="d-flex justify-content-between align-items-center">
+                    <h1 class="d-flex w-100">
+                        <field name="name" options="{'line_breaks': False}" widget="text" string="Task Template"
+                            class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Template Title..."/>
+                    </h1>
+                    <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25"
+                        invisible="not active" style="margin-right: 96px">
+                        <field name="priority" class="h3 pe-2" widget="priority_switch"/>
+                        <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
+                    </div>
+                    <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active">
+                        <field name="priority" class="h3 pe-2" widget="priority_switch"/>
+                        <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
+                    </div>
+                </div>
+                <group>
+                    <group>
+                        <field name="project_id"
+                            domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
+                            required="1"
+                            widget="project"/>
+                        <field name="milestone_id"
+                            placeholder="e.g. Product Launch"
+                            context="{'default_project_id': project_id}"
+                            invisible="not project_id or not allow_milestones"/>
+                        <field name="user_ids"
+                            class="o_task_user_field"
+                            options="{'no_open': True}"
+                            widget="many2many_avatar_user"/>
+                        <field name="role_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"
+                            placeholder="Assign at project creation" invisible="not has_project_template"/>
+                    </group>
+                    <group>
+                        <field name="active" invisible="1"/>
+                        <field name="tag_ids" widget="many2many_tags"
+                            options="{'color_field': 'color', 'no_create_edit': True}"
+                            context="{'project_id': project_id}"/>
+                        <label for="date_deadline" invisible="not has_project_template"/>
+                        <div id="date_deadline_and_recurring_task" class="d-inline-flex w-100" invisible="not has_project_template">
+                            <field name="date_deadline" nolabel="1" decoration-danger="date_deadline and date_deadline &lt; current_date and state not in ['1_done', '1_canceled']"/>
+                            <field name="recurring_task" nolabel="1" class="ms-0" style="width: fit-content; margin-right: 54px;"
+                                   widget="boolean_icon" options="{'icon': 'fa-repeat'}"
+                                   invisible="not active or parent_id"
+                                   groups="project.group_project_recurring_tasks"/>
+                        </div>
+                        <label for="repeat_interval" groups="project.group_project_recurring_tasks"
+                            invisible="has_project_template and not recurring_task"/>
+                        <div class="d-flex" groups="project.group_project_recurring_tasks" name="repeat_intervals"
+                            invisible="has_project_template and not recurring_task">
+                            <field name="repeat_interval" required="recurring_task"
+                                   class="me-2" style="max-width: 2rem !important;" />
+                            <field name="repeat_unit" required="recurring_task"
+                                   class="me-2" style="max-width: 4rem !important;" />
+                            <field name="repeat_type" required="recurring_task"
+                                   class="me-2 mt-1" style="max-width: 15rem !important;" />
+                        </div>
+                        <field name="allocated_hours" invisible="1"/>
+                    </group>
+                </group>
+                <field name="task_properties" columns="2"/>
+                <notebook>
+                    <page name="description_page" string="Description">
+                        <field name="description" type="html" options="{'collaborative': true, 'resizable': false}"
+                            placeholder="Add details about this Template task..."/>
+                    </page>
+                   <page name="sub_tasks_page" string="Sub-tasks" invisible="not project_id">
+                        <field name="child_ids"
+                               mode="list,kanban"
+                               context="{
+                                    'default_project_id': project_id,
+                                    'default_user_ids': user_ids,
+                                    'default_parent_id': id,
+                                    'default_milestone_id': allow_milestones and milestone_id,
+                                    'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
+                                    'closed_X2M_count': closed_subtask_count,
+                                    'default_tag_ids': tag_ids,
+                               }"
+                               widget="subtasks_one2many">
+                            <list editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
+                                <field name="active" column_invisible="True"/>
+                                <field name="allow_milestones" column_invisible="True"/>
+                                <field name="display_in_project" column_invisible="True" force_save="1"/>
+                                <field name="sequence" widget="handle"/>
+                                <field name="id" optional="hide" options="{'enable_formatting': False}"/>
+                                <field name="parent_id" column_invisible="True"/>
+                                <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
+                                <field name="name" widget="name_with_subtask_count"/>
+                                <field name="subtask_count" column_invisible="True"/>
+                                <field name="closed_subtask_count" column_invisible="True"/>
+                                <field name="project_id" string="Project" optional="hide" required="1" options="{'no_open': 1}" widget="project"/>
+                                <field name="milestone_id"
+                                    optional="hide"
+                                    context="{'default_project_id': project_id}"
+                                    column_invisible="not parent.allow_milestones"
+                                    invisible="not allow_milestones"/>
+                                <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
+                                <field name="company_id" groups="base.group_multi_company" optional="hide"/>
+                                <field name="company_id" column_invisible="True"/>
+                                <field name="date_deadline" invisible="state in ['1_done', '1_canceled']"
+                                    optional="hide"
+                                    decoration-danger="date_deadline and date_deadline &lt; current_date"/>
+                                <field name="priority" widget="priority" optional="hide" width="70px"/>
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                <field name="stage_id" optional="hide" context="{'default_project_id': project_id}"/>
+                            </list>
+                        </field>
+                    </page>
+                   <page name="task_dependencies" string="Blocked By" invisible="not allow_task_dependencies" groups="project.group_project_task_dependencies">
+                        <field name="depend_on_ids"
+                           nolabel="1"
+                           mode="list,kanban"
+                           context="{
+                                'default_project_id': project_id,
+                                'search_view_ref' : 'project.view_task_search_form',
+                                'search_default_project_id': project_id,
+                                'list_view_ref': 'project.open_view_all_tasks_list_view',
+                                'search_default_open_tasks': 1,
+                                'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
+                                'closed_X2M_count': 0,
+                           }"
+                           widget="notebook_task_one2many">
+                            <list editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
+                                <field name="allow_milestones" column_invisible="True"/>
+                                <field name="parent_id" column_invisible="True" />
+                                <field name="subtask_count" column_invisible="True"/>
+                                <field name="closed_subtask_count" column_invisible="True"/>
+                                <field name="id" optional="hide" options="{'enable_formatting': False}"/>
+                                <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
+                                <field name="name" widget="name_with_subtask_count"/>
+                                <field name="project_id" optional="hide" options="{'no_open': 1}" />
+                                <field name="milestone_id"
+                                    optional="hide"
+                                    context="{'default_project_id': project_id}"
+                                    column_invisible="not parent.allow_milestones"
+                                    invisible="not allow_milestones"/>
+                                <field name="parent_id" optional="hide" groups="base.group_no_one"/>
+                                <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
+                                <field name="company_id" optional="hide" groups="base.group_multi_company" />
+                                <field name="company_id" column_invisible="True"/>
+                                <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" optional="hide"
+                                    decoration-danger="date_deadline and date_deadline &lt; current_date"/>
+                                <field name="priority" widget="priority" nolabel="1" width="70px"/>
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                <field name="stage_id" optional="hide"/>
+                            </list>
+                        </field>
+                    </page>
+                   <page name="extra_info" string="Extra Info" groups="base.group_no_one">
+                        <group>
+                            <group>
+                                <field name="parent_id" groups="base.group_no_one"
+                                    context="{'search_view_ref' : 'project.view_project_task_template_search','search_default_project_id': project_id, 'search_default_open_tasks': 1}"/>
+                                <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" placeholder="Visible to all"/>
+                                <field name="sequence" groups="base.group_no_one"/>
+                            </group>
+                        </group>
+                    </page>
+                </notebook>
+            </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="quick_create_template_task_form" model="ir.ui.view">
+        <field name="name">project.task.template.form.quick_create</field>
+        <field name="model">project.task.template</field>
+        <field name="priority">1000</field>
+        <field name="arch" type="xml">
+            <form class="o_form_project_tasks">
+                <group>
+                    <field name="display_name" string= "Task Template Title" placeholder="e.g. Send Invitations" required="1"/>
+                    <field name="project_id"
+                           widget="project"
+                           invisible="context.get('default_project_id', False)"
+                           required="1"
+                           class="o_project_task_project_field"
+                    />
+                    <field name="user_ids" options="{'no_open': True, 'no_quick_create': True}"
+                        widget="many2many_avatar_user"/>
+                    <field name="company_id" invisible="1"/>
+                    <field name="parent_id" invisible="1" groups="base.group_no_one"/>
+                    <field name="description" invisible="1"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_project_task_template_kanban" model="ir.ui.view">
+        <field name="name">project.task.template.kanban</field>
+        <field name="model">project.task.template</field>
+        <field name="arch" type="xml">
+            <kanban
+                highlight_color="color"
+                default_group_by="project_id"
+                class="o_kanban_small_column o_kanban_project_tasks"
+                on_create="quick_create"
+                quick_create_view="project.quick_create_template_task_form"
+                examples="project"
+                js_class="project_task_kanban" sample="1"
+                default_order="priority desc, sequence, state, date_deadline asc, id desc"
+            >
+                <field name="stage_id"/>
+                <field name="has_late_and_unreached_milestone" />
+                <field name="allow_milestones" />
+                <field name="state" />
+                <field name="subtask_count"/>
+                <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "200" }'/>
+                <templates>
+                    <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
+                        <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>
+                        <a class="dropdown-item" role="menuitem" type="object" name="copy">Duplicate</a>
+                        <div role="separator" class="dropdown-divider"></div>
+                        <field name="color" widget="kanban_color_picker"/>
+                    </t>
+                    <t t-name="card">
+                        <main t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
+                            <field name="name" class="fw-bold fs-5"/>
+                            <div class="text-muted d-flex flex-column">
+                                <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
+                                <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
+                                <field t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value"
+                                    t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''"
+                                    name="milestone_id" options="{'no_open': True}"/>
+                            </div>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field t-if="record.date_deadline.raw_value" invisible="state in ['1_done', '1_canceled']" name="date_deadline"
+                                widget="remaining_days"/>
+                            <field name="task_properties" widget="properties"/>
+                            <field name="displayed_image_id" widget="attachment_image"/>
+                            <footer t-if="!selection_mode" class="pt-1">
+                                <div class="d-flex align-items-center gap-1">
+                                    <a t-if="!record.project_id.raw_value" class="text-muted" style="font-size: 17px; margin-left: 1.5px">
+                                        <i title="Private Task" class="fa fa-lock"/>
+                                    </a>
+                                    <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
+                                        <widget name="subtask_counter" class="me-1"/>
+                                    </t>
+                                    <field name="priority" class="pt-1" widget="priority"/>
+                                </div>
+                                <div class="d-flex ms-auto">
+                                    <field name="user_ids" widget="many2many_avatar_user"/>
+                                    <field name="state" class="ms-1" widget="project_task_state_selection" options="{'is_toggle_mode': false}"/>
+                                </div>
+                            </footer>
+                        </main>
+                        <widget name="subtask_kanban_list"/>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_task_template_kanban_default_groupby_stage_id">
+        <field name="name">project.task.template.kanban</field>
+        <field name="model">project.task.template</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="project.view_project_task_template_kanban"/>
+        <field name="arch" type="xml">
+            <kanban position="attributes">
+                <attribute name="default_group_by">stage_id</attribute>
+            </kanban>
+         </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_task_template_list_default_groupby_stage_id">
+        <field name="name">project.task.template.list</field>
+        <field name="model">project.task.template</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="project.view_project_task_template_list"/>
+        <field name="arch" type="xml">
+            <list position="attributes">
+                <attribute name="default_group_by">stage_id</attribute>
+            </list>
+         </field>
+    </record>
+
+    <record id="project_task_templates_action" model="ir.actions.act_window">
+        <field name="name">Task Templates</field>
+        <field name="res_model">project.task.template</field>
+        <field name="view_mode">list,kanban,form</field>
+        <field name="domain">[('project_id', '!=', False)]</field>
+        <field name="context">{'default_is_template': True}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No task templates found. Let's create one!
+            </p>
+            <p>
+                Save time by using task templates with pre-filled details.<br/>
+                Standardize workflows and ensure consistency across tasks.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -11,7 +11,7 @@
                     <field name="tag_ids"/>
                     <field name="stage_id"/>
                     <field name="milestone_id" groups="project.group_project_milestone"/>
-                    <field name="partner_id" operator="child_of" invisible="context.get('default_is_template')"/>
+                    <field name="partner_id" operator="child_of"/>
                     <filter string="Unassigned" name="unassigned" domain="[('user_ids', '=', False)]"/>
                     <separator invisible="context.get('default_project_id')"/>
                     <filter string="Favorite Projects" name="favorite_projects" domain="[('project_id.is_favorite', '=', True)]" invisible="context.get('default_project_id')"/>
@@ -23,8 +23,7 @@
                     <separator/>
                     <filter string="Open" name="open_tasks" domain="[('is_closed', '=', False)]"/>
                     <filter string="Closed" name="closed_tasks" domain="[('is_closed', '=', True)]"/>
-                    <filter string="Closed On" name="closed_on" domain="[('is_closed', '=', True)]" date="date_last_stage_update"
-                        invisible="context.get('default_is_template')">
+                    <filter string="Closed On" name="closed_on" domain="[('is_closed', '=', True)]" date="date_last_stage_update">
                         <filter name="create_date_last_30_days" string="Last 30 Days" domain="[('date_last_stage_update', '&gt;=', 'today -30d +1d')]"/>
                         <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('date_last_stage_update', '&gt;=', 'today -365d +1d')]"/>
                     </filter>
@@ -33,8 +32,7 @@
                         <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}" groups="project.group_project_milestone"/>
                         <filter string="Priority" name="groupby_priority" context="{'group_by': 'priority'}"/>
                         <filter string="Tags" name="tags" context="{'group_by': 'tag_ids'}"/>
-                        <filter string="Customer" name="customer" context="{'group_by': 'partner_id'}"
-                            invisible="context.get('default_is_template')"/>
+                        <filter string="Customer" name="customer" context="{'group_by': 'partner_id'}"/>
                         <filter string="Company" name="company_id" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                         <filter string="Creation Date" name="create_date" context="{'group_by': 'create_date'}"/>
                     </group>
@@ -206,7 +204,7 @@
             <field name="path">tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
-            <field name="domain">[('project_id', '=', active_id), ('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('project_id', '=', active_id)]</field>
             <field name="context">{
                 'default_project_id': active_id,
                 'show_project_update': True,
@@ -333,7 +331,6 @@
                     <field name="depend_on_count" invisible="1"/>
                     <field name="closed_depend_on_count" invisible="1"/>
                     <field name="html_field_history_metadata" invisible="1"/>
-                    <field name="is_template" invisible="1"/>
                     <field name="is_rotting" invisible="1"/>
                     <field name="rotting_days" invisible="1"/>
                     <header>
@@ -352,7 +349,7 @@
                         <span id="start_rating_buttons" invisible="1"/>
                         <field name="rating_avg" invisible="1"/>
                         <field name="rating_active" invisible="1"/>
-                        <button name="action_open_ratings" type="object" invisible="rating_count == 0 or not rating_active or has_template_ancestor" class="oe_stat_button" groups="project.group_project_rating">
+                        <button name="action_open_ratings" type="object" invisible="rating_count == 0 or not rating_active" class="oe_stat_button" groups="project.group_project_rating">
                             <i class="fa fa-fw o_button_icon fa-smile-o text-success" invisible="rating_avg &lt; 3.66" title="Happy"/>
                             <i class="fa fa-fw o_button_icon fa-meh-o text-warning" invisible="rating_avg &lt; 2.33 or rating_avg &gt;= 3.66" title="Neutral"/>
                             <i class="fa fa-fw o_button_icon fa-frown-o text-danger" invisible="rating_avg &gt;= 2.33" title="Unhappy"/>
@@ -378,7 +375,6 @@
                                 'default_user_ids': user_ids,
                                 'default_milestone_id': milestone_id,
                                 'subtask_action': True,
-                                'default_is_template': is_template,
                             }"
                         >
                             <div class="o_field_widget o_stat_info">
@@ -395,19 +391,16 @@
                         <!-- Dummy tag used to organize buttons -->
                         <span id="end_button_box" invisible="1"/>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or is_template"/>
-                    <widget name="web_ribbon" title="Template" bg_color="text-bg-info" invisible="not is_template"/>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <div class="d-flex justify-content-between align-items-center">
                         <h1 class="d-flex w-100">
                             <field name="name" options="{'line_breaks': False}" widget="text" class="o_task_name text-truncate w-md-75 w-100 pe-2" placeholder="Task Title..."/>
                         </h1>
-                        <div class="d-flex justify-content-end align-items-center px-1" invisible="not active or is_template">
+                        <div class="d-flex justify-content-end align-items-center px-1" invisible="not active">
                             <field name="priority" class="h3 pe-2" widget="priority_switch"/>
-                        </div>
-                        <div class="d-flex justify-content-end o_state_container" invisible="not active or is_template">
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>
-                        <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active and not is_template">
+                        <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active">
                             <field name="priority" class="h3 pe-2" widget="priority_switch"/>
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>
@@ -415,8 +408,8 @@
                     <group>
                         <group>
                             <field name="project_id"
-                                domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id), ('is_template', 'in', [is_template, False])]"
-                                required="parent_id or child_ids or is_template"
+                                domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
+                                required="parent_id or child_ids"
                                 widget="project"/>
                             <field name="milestone_id"
                                 placeholder="e.g. Product Launch"
@@ -426,12 +419,11 @@
                                 class="o_task_user_field"
                                 options="{'no_open': True}"
                                 widget="many2many_avatar_user"/>
-                            <field name="role_ids" invisible="not (is_template and has_project_template)" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" placeholder="Assign at project creation"/>
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
-                            <field name="partner_id" nolabel="0" widget="res_partner_many2one" class="o_task_customer_field" invisible="not project_id or has_template_ancestor"/>
+                            <field name="partner_id" nolabel="0" widget="res_partner_many2one" class="o_task_customer_field" invisible="not project_id"/>
                             <label for="date_deadline"/>
                             <div id="date_deadline_and_recurring_task" class="d-inline-flex w-100">
                                 <field name="date_deadline" nolabel="1" decoration-danger="date_deadline and date_deadline &lt; current_date and state not in ['1_done', '1_canceled']"/>
@@ -469,16 +461,13 @@
                                         'default_parent_id': id,
                                         'default_partner_id': partner_id,
                                         'default_milestone_id': allow_milestones and milestone_id,
-                                        'default_is_template': False,
                                         'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
                                         'closed_X2M_count': closed_subtask_count,
-                                        'default_is_template': is_template,
                                         'default_tag_ids': tag_ids,
                                    }"
                                    widget="subtasks_one2many">
                                 <list editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
                                     <field name="active" column_invisible="True"/>
-                                    <field name="is_template" column_invisible="True"/>
                                     <field name="allow_milestones" column_invisible="True"/>
                                     <field name="display_in_project" column_invisible="True" force_save="1"/>
                                     <field name="sequence" widget="handle"/>
@@ -494,7 +483,7 @@
                                         context="{'default_project_id': project_id}"
                                         column_invisible="not parent.allow_milestones"
                                         invisible="not allow_milestones"/>
-                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="parent.has_template_ancestor"/>
+                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id"/>
                                     <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
                                     <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                                     <field name="company_id" column_invisible="True"/>
@@ -523,7 +512,6 @@
                                         'search_default_open_tasks': 1,
                                         'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
                                         'closed_X2M_count': closed_depend_on_count,
-                                        'default_is_template': is_template,
                                    }"
                                    widget="notebook_task_one2many">
                                 <list editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
@@ -540,7 +528,7 @@
                                         context="{'default_project_id': project_id}"
                                         column_invisible="not parent.allow_milestones"
                                         invisible="not allow_milestones"/>
-                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="parent.has_template_ancestor"/>
+                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id"/>
                                     <field name="parent_id" optional="hide" groups="base.group_no_one"/>
                                     <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
                                     <field name="company_id" optional="hide" groups="base.group_multi_company" />
@@ -564,9 +552,9 @@
                                     <field name="parent_id" invisible="not project_id" groups="base.group_no_one" context="{'search_view_ref' : 'project.view_task_search_form', 'search_default_project_id': project_id, 'default_project_id': project_id}"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" placeholder="Visible to all"/>
                                     <field name="sequence" groups="base.group_no_one"/>
-                                    <field name="email_cc" groups="base.group_no_one" invisible="is_template"/>
+                                    <field name="email_cc" groups="base.group_no_one"/>
                                 </group>
-                                <group invisible="is_template">
+                                <group>
                                     <field name="date_assign" groups="base.group_no_one"/>
                                     <field name="date_last_stage_update" groups="base.group_no_one"/>
                                 </group>
@@ -597,6 +585,15 @@
             <field name="binding_view_types">form</field>
         </record>
 
+        <record id="model_project_task_action_save_as_temlate" model="ir.actions.server">
+            <field name="name">Save as template</field>
+            <field name="model_id" ref="project.model_project_task"/>
+            <field name="binding_model_id" ref="project.model_project_task"/>
+            <field name="binding_view_types">form</field>
+            <field name="state">code</field>
+            <field name="code">action = record.action_generate_task_template()</field>
+        </record>
+
         <record id="quick_create_task_form" model="ir.ui.view">
             <field name="name">project.task.form.quick_create</field>
             <field name="model">project.task</field>
@@ -610,8 +607,7 @@
                                invisible="context.get('default_project_id', False)"
                                placeholder="Private"
                                class="o_project_task_project_field"
-                               domain="[('type_ids', 'in', context.get('default_stage_id')), ('is_template', 'in', [is_template, False])] if context.get('default_stage_id') else [('is_template', 'in', [is_template, False])]"
-                               required="is_template"
+                               domain="[('type_ids', 'in', context.get('default_stage_id'))] if context.get('default_stage_id') else []"
                         />
                         <field name="user_ids" options="{'no_open': True}"
                             widget="many2many_avatar_user"/>
@@ -634,7 +630,7 @@
                     <group>
                         <field name="project_id" invisible="1" />
                         <field name="company_id" invisible="1" />
-                        <field name="parent_id" domain="[('id', '!=', id), '!', ('id', 'child_of', id)]" context="{'search_default_project_id': project_id, 'search_default_open_tasks': 1, 'default_is_template': is_template}"/>
+                        <field name="parent_id" domain="[('id', '!=', id), '!', ('id', 'child_of', id)]" context="{'search_default_project_id': project_id, 'search_default_open_tasks': 1}"/>
                     </group>
                     <footer>
                         <button string="Convert Task" class="btn-primary" special="save" data-hotkey="q"/>
@@ -666,7 +662,6 @@
                     <field name="allow_milestones" />
                     <field name="state" />
                     <field name="subtask_count"/>
-                    <field name="is_template"/>
                     <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "200" }'/>
                     <templates>
                         <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
@@ -682,7 +677,7 @@
                                 <div class="text-muted d-flex flex-column">
                                     <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
                                     <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
-                                    <field name="partner_id" invisible="context.get('default_is_template', False)"/>
+                                    <field name="partner_id"/>
                                     <field t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''" name="milestone_id" options="{'no_open': True}"/>
                                 </div>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
@@ -704,8 +699,6 @@
                                             <widget name="subtask_counter" class="me-1"/>
                                         </t>
                                         <field name="priority" class="pt-1" widget="priority"/>
-                                        <field name="is_rotting" invisible="1"/>
-                                        <field name="rotting_days" widget="rotting" class="ms-1 d-flex"/>
                                     </div>
                                     <div class="d-flex ms-auto">
                                         <field name="user_ids" widget="many2many_avatar_user"/>
@@ -748,7 +741,7 @@
                     <field name="name" string="Title" widget="name_with_subtask_count"/>
                     <field name="project_id" widget="project" optional="show" options="{'no_open': 1}" readonly="1" column_invisible="context.get('default_project_id')"/>
                     <field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}" groups="project.group_project_milestone" optional="hide"/>
-                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" options="{'no_open': True}" column_invisible="context.get('default_is_template', False)"/>
+                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" options="{'no_open': True}"/>
                     <field name="user_ids" optional="show" widget="many2many_avatar_user"/>
                     <field name="company_id" groups="base.group_multi_company" optional="hide" column_invisible="context.get('default_project_id')" options="{'no_create': True}"/>
                     <field name="company_id" column_invisible="True"/>
@@ -756,7 +749,7 @@
                     <field name="priority" widget="priority" optional="show" width="70px"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
                     <field name="create_date" optional="hide"/>
-                    <field name="date_last_stage_update" optional="hide" column_invisible="context.get('default_is_template', False)"/>
+                    <field name="date_last_stage_update" optional="hide"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
                     <field name="stage_id_color" column_invisible="1"/>
                     <field name="is_rotting" column_invisible="True"/>
@@ -784,8 +777,7 @@
                     <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                         invisible="not rating_active or rating_last_text == 'none'"
-                        class="fw-bold" widget="badge" optional="hide" groups="project.group_project_rating"
-                        column_invisible="context.get('default_is_template', False)"/>
+                        class="fw-bold" widget="badge" optional="hide" groups="project.group_project_rating"/>
                 </field>
                 <list position="inside">
                     <field name="task_properties"/>
@@ -795,8 +787,7 @@
                     <field name="parent_id" optional="hide" invisible="not project_id" context="{'search_view_ref': 'project.view_task_search_form', 'search_default_project_id': project_id, 'default_project_id': project_id}" groups="base.group_no_one"/>
                 </xpath>
                 <xpath expr="//field[@name='stage_id']" position="after">
-                    <field name="personal_stage_type_id" string="Personal Stage" optional="hide"
-                        column_invisible="context.get('default_is_template', False)"/>
+                    <field name="personal_stage_type_id" string="Personal Stage" optional="hide"/>
                 </xpath>
             </field>
         </record>
@@ -891,7 +882,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
             <field name="context">{'search_default_my_tasks': 1}</field>
-            <field name="domain">[('project_id', '!=', False), ('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('project_id', '!=', False)]</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
@@ -1042,7 +1033,7 @@
                 'default_user_ids': [(4, uid)],
             }</field>
             <field name="search_view_id" ref="view_task_search_form"/>
-            <field name="domain">[('user_ids', 'in', uid), ('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('user_ids', 'in', uid)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No tasks found. Let's create one!
@@ -1092,7 +1083,7 @@
             <field name="res_model">project.task</field>
             <field name="path">all-tasks</field>
             <field name="view_mode">list,kanban,form,calendar,activity,pivot,graph</field>
-            <field name="domain">[('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[]</field>
             <field name="context">{'search_default_open_tasks': 1, 'default_user_ids': [(4, uid)]}</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
@@ -1135,18 +1126,6 @@
             <field name="state">code</field>
             <field name="code">
                 action = record.action_convert_to_subtask()
-            </field>
-        </record>
-
-        <record id="action_server_convert_to_template" model="ir.actions.server">
-            <field name="name">Convert to Template</field>
-            <field name="model_id" ref="project.model_project_task"/>
-            <field name="binding_model_id" ref="project.model_project_task"/>
-            <field name="binding_view_types">form</field>
-            <field name="group_ids" eval="[Command.link(ref('project.group_project_manager'))]"/>
-            <field name="state">code</field>
-            <field name="code">
-                action = record.action_convert_to_template()
             </field>
         </record>
 
@@ -1193,7 +1172,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">list,kanban,form,calendar,pivot,graph,activity</field>
             <field name="search_view_id" ref="view_task_search_form"/>
-            <field name="domain">[('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No tasks found. Let's create one!
@@ -1233,7 +1212,7 @@
             <field name="name">Overpassed Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">list,form,calendar,graph,kanban</field>
-            <field name="domain">[('is_closed', '=', False), ('date_deadline', '&lt;', 'today'), ('project_id', '!=', False), ('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('is_closed', '=', False), ('date_deadline', '&lt;', 'today'), ('project_id', '!=', False)]</field>
             <field name="filter" eval="True"/>
             <field name="search_view_id" ref="view_task_search_form"/>
         </record>
@@ -1243,7 +1222,7 @@
             <field name="res_model">project.task</field>
             <field name="name">Project's tasks</field>
             <field name="view_mode">list,form,calendar,graph,kanban</field>
-            <field name="domain">[('project_id', '=', active_id), ('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('project_id', '=', active_id)]</field>
             <field name="context">{'project_id':active_id}</field>
         </record>
 
@@ -1279,7 +1258,7 @@
             <field name="name">Tasks.test</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">kanban,list,form,calendar,pivot,graph,activity</field>
-            <field name="domain">[('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[]</field>
             <field name="context">{'default_project_id': active_id}</field>
         </record>
 
@@ -1316,84 +1295,6 @@
             <field name="sequence" eval="70"/>
             <field name="view_mode">graph</field>
             <field name="view_id" ref="project_task_graph_view_project_milestone"/>
-        </record>
-
-        <record id="project_task_templates_list" model="ir.ui.view">
-            <field name="name">project.task.templates.list</field>
-            <field name="model">project.task</field>
-            <field name="inherit_id" ref="project_task_view_tree_base"/>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <field name="project_id" position="attributes">
-                    <attribute name="readonly">False</attribute>
-                    <attribute name="required">is_template</attribute>
-                </field>
-                <field name="partner_id" position="replace"/>
-                <field name="user_ids" position="after">
-                    <field name="role_ids" optional="hide" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" invisible="not (is_template and has_project_template)"/>
-                </field>
-            </field>
-        </record>
-
-        <record id="project_task_templates_kanban" model="ir.ui.view">
-            <field name="name">project.task.templates.list</field>
-            <field name="model">project.task</field>
-            <field name="inherit_id" ref="view_task_kanban"/>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <kanban position="attributes">
-                    <attribute name="default_group_by">project_id</attribute>
-                </kanban>
-                <xpath expr="//templates//field[@name='partner_id']" position="replace"/>
-            </field>
-        </record>
-
-        <record id="view_task_template_search_form" model="ir.ui.view">
-            <field name="name">project.task.search.form</field>
-            <field name="model">project.task</field>
-            <field name="inherit_id" ref="view_task_search_form"></field>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <filter name="private_tasks" position="replace"/>
-                <filter name="closed_on" position="replace"/>
-                <filter name="customer" position="replace"/>
-                <filter name="unassigned" position="after">
-                    <filter name="task_templates" string="Task Templates" domain="[('has_project_template', '=', False)]" invisible="1"/>
-                </filter>
-                <field name="user_ids" position="after">
-                   <field name="role_ids"/>
-                </field>
-            </field>
-        </record>
-
-        <record id="project_task_templates_action" model="ir.actions.act_window">
-            <field name="name">Task Templates</field>
-            <field name="res_model">project.task</field>
-            <field name="view_mode">list,kanban,form</field>
-            <field name="domain">[('is_template', '=', True)]</field>
-            <field name="context">{'default_is_template': True, 'hide_kanban_stages_nocontent': True, 'search_default_task_templates': True}</field>
-            <field name="search_view_id" ref="view_task_template_search_form"/>
-            <field name="help" type="html">
-                <p class="o_view_nocontent_smiling_face">
-                    No task templates found. Let's create one!
-                </p>
-                <p>
-                    Save time by using task templates with pre-filled details.<br/>
-                    Standardize workflows and ensure consistency across tasks.
-                </p>
-            </field>
-        </record>
-
-        <record id="project_task_templates_action_list" model="ir.actions.act_window.view">
-            <field name="act_window_id" ref="project_task_templates_action"/>
-            <field name="view_mode">list</field>
-            <field name="view_id" ref="project.project_task_templates_list"/>
-        </record>
-
-        <record id="project_task_templates_action_kanban" model="ir.actions.act_window.view">
-            <field name="act_window_id" ref="project_task_templates_action"/>
-            <field name="view_mode">kanban</field>
-            <field name="view_id" ref="project.project_task_templates_kanban"/>
         </record>
 
 </odoo>

--- a/addons/project/wizard/project_template_create_wizard.py
+++ b/addons/project/wizard/project_template_create_wizard.py
@@ -9,7 +9,7 @@ class ProjectTemplateCreateWizard(models.TransientModel):
         res = []
         template = self.env['project.project'].browse(self.env.context.get('template_id'))
         if template:
-            res = [Command.create({'role_id': role.id}) for role in template.task_ids.role_ids]
+            res = [Command.create({'role_id': role.id}) for role in template.task_template_ids.role_ids]
         return res
 
     name = fields.Char(string="Name", required=True)

--- a/addons/project_sms/models/project_task.py
+++ b/addons/project_sms/models/project_task.py
@@ -9,7 +9,7 @@ class ProjectTask(models.Model):
 
     def _send_sms(self):
         for task in self:
-            if task.partner_id and task.stage_id and task.stage_id.sms_template_id and not task.is_template:
+            if task.partner_id and task.stage_id and task.stage_id.sms_template_id:
                 task._message_sms_with_template(
                     template=task.stage_id.sms_template_id,
                     partner_ids=task.partner_id.ids,

--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -10,7 +10,7 @@ class AccountAnalyticLine(models.Model):
 
     holiday_id = fields.Many2one("hr.leave", string='Time Off Request', copy=False, index='btree_not_null', export_string_translation=False)
     global_leave_id = fields.Many2one("resource.calendar.leaves", string="Global Time Off", index='btree_not_null', ondelete='cascade', export_string_translation=False)
-    task_id = fields.Many2one(domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('has_template_ancestor', '=', False), ('is_timeoff_task', '=', False)]")
+    task_id = fields.Many2one(domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('is_timeoff_task', '=', False)]")
 
     _timeoff_timesheet_idx = models.Index('(task_id) WHERE (global_leave_id IS NOT NULL OR holiday_id IS NOT NULL) AND project_id IS NOT NULL')
 

--- a/addons/project_timesheet_holidays/models/res_config_settings.py
+++ b/addons/project_timesheet_holidays/models/res_config_settings.py
@@ -14,7 +14,7 @@ class ResConfigSettings(models.TransientModel):
              " You can specify another project on each time off type individually.")
     leave_timesheet_task_id = fields.Many2one(
         related='company_id.leave_timesheet_task_id', string="Time Off Task", readonly=False,
-        domain="[('company_id', '=', company_id), ('project_id', '=?', internal_project_id), ('has_template_ancestor', '=', False)]",
+        domain="[('company_id', '=', company_id), ('project_id', '=?', internal_project_id)]",
         help="The default task used when automatically generating timesheets via time off requests."
              " You can specify another task on each time off type individually.")
 

--- a/addons/sale_project/models/product_template.py
+++ b/addons/sale_project/models/product_template.py
@@ -37,8 +37,8 @@ class ProductTemplate(models.Model):
         'project.project', 'Project Template', company_dependent=True, copy=True,
         domain='[("is_template", "=", True)]',
     )
-    task_template_id = fields.Many2one('project.task', 'Task Template',
-        domain="[('is_template', '=', True), ('project_id', '=', project_id)]",
+    task_template_id = fields.Many2one('project.task.template', 'Task Template',
+        domain="[('project_id', '=', project_id)]",
         company_dependent=True, copy=True, compute='_compute_task_template', store=True, readonly=False
     )
     service_policy = fields.Selection('_selection_service_policy', string="Service Invoicing Policy", compute_sudo=True, compute='_compute_service_policy', inverse='_inverse_service_policy', tracking=True)

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from odoo import api, fields, models, _
 from odoo.fields import Command, Domain
 from odoo.exceptions import UserError
-from odoo.addons.project.models.project_task import CLOSED_STATES
+from odoo.addons.project.models.project_task_template import CLOSED_STATES
 
 
 class SaleOrder(models.Model):
@@ -205,7 +205,7 @@ class SaleOrder(models.Model):
         return action
 
     def _tasks_ids_domain(self):
-        return ['&', ('is_template', '=', False), ('project_id', '!=', False), '|', ('sale_line_id', 'in', self.order_line.ids), ('sale_order_id', 'in', self.ids), ('has_template_ancestor', '=', False)]
+        return [('project_id', '!=', False), '|', ('sale_line_id', 'in', self.order_line.ids), ('sale_order_id', 'in', self.ids)]
 
     def action_create_project(self):
         self.ensure_one()

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -296,8 +296,6 @@ class SaleOrderLine(models.Model):
             'name': '%s - %s' % (self.order_id.name, template.name),
             'allocated_hours': allocated_hours,
             'project_id': project.id,
-            'sale_line_id': self.id,
-            'sale_order_id': self.order_id.id,
         }
 
     def _get_sale_order_partner_id(self, project):
@@ -312,6 +310,8 @@ class SaleOrderLine(models.Model):
             vals = self._prepare_task_template_vals(template, project)
             task_id = template.with_context(
                 default_partner_id=self._get_sale_order_partner_id(project),
+                default_sale_line_id=self.id,
+                default_sale_order_id=self.order_id.id,
             ).action_create_from_template(vals)
             task = self.env['project.task'].sudo().browse(task_id)
         else:
@@ -341,7 +341,7 @@ class SaleOrderLine(models.Model):
         """
         so_line_task_global_project = self._get_so_lines_task_global_project()
         so_line_new_project = self._get_so_lines_new_project()
-        task_templates = self.env['project.task']
+        task_templates = self.env['project.task.template']
 
         # search so lines from SO of current so lines having their project generated, in order to check if the current one can
         # create its own project, or reuse the one of its order.

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -44,10 +44,9 @@ class TestSaleProject(TestSaleProjectCommon):
             'sequence': 1,
             'project_ids': [(4, cls.project_template.id)]
         })
-        cls.task_template = cls.env['project.task'].create({
+        cls.task_template = cls.env['project.task.template'].create({
             'name': 'test task template',
             'project_id': cls.project_template.id,
-            'is_template': True,
         })
 
         # Create service products
@@ -433,12 +432,6 @@ class TestSaleProject(TestSaleProjectCommon):
         self.assertFalse(sale_order_2.show_project_button, "There is no project on the sale order, the button should be hidden")
         self.assertTrue(sale_order_2.show_task_button, "There is no project on the sale order and there is a task whose sale item is one of the sale_line of the SO, the button should be displayed")
         self.assertEqual(sale_order_2.tasks_ids, task)
-        task.action_convert_to_template()
-        sale_order_2._compute_tasks_ids()
-        sale_order_2._compute_show_project_and_task_button()
-        self.assertFalse(sale_order_2.show_task_button, 'The button should no longer be visible since no tasks are linked to the SO.')
-        self.assertFalse(sale_order_2.tasks_ids, 'No tasks should be linked to the SO since the task has been converted into a template.')
-
         # add a manual service product
         self.env['sale.order.line'].create({
             'product_id': self.product_service_delivered_manual.id,

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -23,7 +23,7 @@
         <field name="inherit_id" ref="project.view_project_project_filter"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="sale_order_id" invisible="context.get('default_is_template')"/>
+                <field name="sale_order_id"/>
             </xpath>
         </field>
     </record>
@@ -161,7 +161,7 @@
             <xpath expr="//span[@id='start_rating_buttons']" position="before">
                 <button class="oe_stat_button"
                         type="object" name="action_view_so" icon="fa-dollar"
-                        invisible="not sale_order_id or has_template_ancestor"
+                        invisible="not sale_order_id"
                         groups="sales_team.group_sale_salesman">
                         <div class="o_stat_info">
                             <span class="o_stat_text">Sales Order</span>
@@ -172,16 +172,16 @@
                 <attribute name="context">{'default_project_id': project_id, 'default_sale_line_id': sale_line_id}</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
-                <attribute name="invisible">not allow_billable or has_template_ancestor</attribute>
+                <attribute name="invisible">not allow_billable</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="project_sale_order_id" invisible="1"/>
                 <field name="sale_order_id" invisible="True" groups="sales_team.group_sale_salesman"/>
-                <label for="sale_line_id" invisible="not allow_billable or not project_id or not partner_id or has_template_ancestor"/>
+                <label for="sale_line_id" invisible="not allow_billable or not project_id or not partner_id"/>
                 <div 
                     name="sale_line_div"
                     class="o_row"
-                    invisible="not allow_billable or not project_id or not partner_id or has_template_ancestor">
+                    invisible="not allow_billable or not project_id or not partner_id">
                     <field name="sale_line_id"
                         groups="!sales_team.group_sale_salesman"
                         string="Sales Order Item"
@@ -219,9 +219,8 @@
                        context="{'create': False, 'edit': False, 'delete': False, 'with_price_unit': True}"
                        placeholder="Non-billable"
                        groups="sales_team.group_sale_salesman"
-                       invisible="not allow_billable"
-                       column_invisible="parent.has_template_ancestor"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor"/>
+                       invisible="not allow_billable"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman"/>
                 <field name="allow_billable" column_invisible="True"/>
             </xpath>
             <xpath expr="//field[@name='child_ids']/list/field[@name='partner_id']" position="attributes">
@@ -229,8 +228,8 @@
                 <attribute name="invisible">not allow_billable</attribute>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/list/field[@name='partner_id']" position="after">
-                <field name="sale_line_id" optional="hide" readonly="1" groups="sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="parent.has_template_ancestor"/>
+                <field name="sale_line_id" optional="hide" readonly="1" groups="sales_team.group_sale_salesman"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman"/>
                 <field name="allow_billable" column_invisible="True"/>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/list/field[@name='partner_id']" position="attributes">
@@ -252,7 +251,7 @@
                 <field name="allow_billable" column_invisible="True"/>
             </field>
             <field name="partner_id" position="attributes">
-                <attribute name="column_invisible">context.get('hide_partner') or context.get('default_is_template')</attribute>
+                <attribute name="column_invisible">context.get('hide_partner')</attribute>
                 <attribute name="invisible">not allow_billable</attribute>
             </field>
         </field>
@@ -264,8 +263,8 @@
         <field name="inherit_id" ref="project.project_task_view_tree_base"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_id']" position="after">
-                <field name="sale_line_id" optional="hide" groups="sales_team.group_sale_salesman" options="{'no_create': True}" column_invisible="not context.get('allow_billable') or context.get('default_is_template')"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="not context.get('allow_billable') or context.get('default_is_template')"/>
+                <field name="sale_line_id" optional="hide" groups="sales_team.group_sale_salesman" options="{'no_create': True}" column_invisible="not context.get('allow_billable')"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman" column_invisible="not context.get('allow_billable')"/>
             </xpath>
         </field>
     </record>
@@ -277,14 +276,13 @@
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
                 <field name="sale_order_id"
-                    filter_domain="['|', ('sale_order_id', 'ilike', self), ('sale_line_id', 'ilike', self)]"
-                    invisible="context.get('default_is_template')"/>
+                    filter_domain="['|', ('sale_order_id', 'ilike', self), ('sale_line_id', 'ilike', self)]"/>
             </field>
             <field name="partner_id" position="attributes">
-                <attribute name="invisible">context.get('hide_partner') or context.get('default_is_template')</attribute>
+                <attribute name="invisible">context.get('hide_partner')</attribute>
             </field>
             <filter name="customer" position="attributes">
-                <attribute name="invisible">context.get('hide_partner') or context.get('default_is_template')</attribute>
+                <attribute name="invisible">context.get('hide_partner')</attribute>
             </filter>
         </field>
     </record>

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -159,7 +159,7 @@
                     <field name="sale_line_id" column_invisible="True"/>
                     <field name="remaining_hours_available" column_invisible="True"/>
                     <field name="remaining_hours_so" invisible="not sale_line_id or not remaining_hours_available" widget="timesheet_uom" optional="hide"
-                        groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not (context.get('allow_billable', True) and context.get('allow_timesheets', True)) or context.get('default_is_template', False)"/>
+                        groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not (context.get('allow_billable', True) and context.get('allow_timesheets', True))"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
_*= hr_timesheet, project_sms, project_timesheet_holidays, sale_project, sale_timesheet

### Purpose:
--------
   Previously, both regular tasks and task templates were stored in the same `project.task` model and distinguished using the `is_template` field. This caused unnecessary domain filters and confusion across features where task templates were not expected. Every task-related action required an explicit domain to exclude task templates. If the domain was missing, both records would appear, leading to confusion and potential misuse.

### In this improvement:
------------
   - We introduced a new model `project.task.template` for storing task templates.
   - All existing tasks with `is_template=True` have been moved to the new model.
   - Removed the chatter from project.task.template to keep the interface clean and reduce unnecessary activity logs.
   - Archived task templates older than 3 months as part of routine system cleanup

### Example (Before):
  **Model**: `project.task`

| Name             | Allocated Hour | Worksheet         | Subtask     | Priority | Template |
|------------------|----------------|-------------------|-------------|----------|----------|
| Task A           | 20             | Default Worksheet | Subtask 1   | High     | False    |
| Template Task B  | 20             | Default Worksheet | Subtask 2   | Low      | True     |

-----------
### Now:
   **Model**: `project.task`

| Name    | Allocated Hour | Worksheet         | Subtask   | Priority |
|---------|----------------|-------------------|-----------|----------|
| Task A  | 20             | Default Worksheet | Subtask 1 | High     |



**Model**: `project.task.template`

| Name             | Allocated Hour | Worksheet         | Subtask     | Priority |
|------------------|----------------|-------------------|-------------|----------|
| Template Task B  | 20             | Default Worksheet | Subtask 2   | Low      |

This separation ensures clearer architecture and avoids accidental inclusion of templates in task operations.

task-4919945
