### PR TITLE
[FIX] website: prevent crash editing job location

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
@@ -23,6 +23,7 @@ export class BuilderMany2One extends Component {
         allowUnselect: { type: Boolean, optional: true },
         defaultMessage: { type: String, optional: true },
         createAction: { type: String, optional: true },
+        nullText: { type: String, optional: true },
     };
     static defaultProps = {
         ...BuilderComponent.defaultProps,
@@ -50,16 +51,22 @@ export class BuilderMany2One extends Component {
             const selectedString = getValue(el);
             const selected = selectedString && JSON.parse(selectedString);
             if (selected && !("display_name" in selected && "name" in selected)) {
-                Object.assign(
-                    selected,
-                    (
+                let value;
+                if (!selected.id) {
+                    value = {
+                        display_name: this.props.nullText,
+                        name: this.props.nullText,
+                    };
+                } else {
+                    value = (
                         await this.cachedModel.ormRead(
                             this.props.model,
                             [selected.id],
                             ["display_name", "name"]
                         )
-                    )[0]
-                );
+                    )[0];
+                }
+                Object.assign(selected, value);
             }
 
             return { selected };

--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
@@ -7,6 +7,7 @@
             model="props.model"
             fields="props.fields"
             limit="props.limit"
+            nullText="props.nullText"
             domain="props.domain"
             selected="domState.selected ? [domState.selected] : []"
             select="select.bind(this)"

--- a/addons/html_builder/static/src/core/building_blocks/select_many2x.js
+++ b/addons/html_builder/static/src/core/building_blocks/select_many2x.js
@@ -40,6 +40,7 @@ export class SelectMany2X extends Component {
         closeOnEnterKey: { type: Boolean, optional: true },
         message: { type: String, optional: true },
         create: { type: Function, optional: true },
+        nullText: { type: String, optional: true },
     };
     static defaultProps = {
         fields: [],
@@ -100,11 +101,19 @@ export class SelectMany2X extends Component {
             limit: this.state.limit + 1,
         });
         this.state.hasMore = tuples.length > this.state.limit;
-        this.state.searchResults = await this.cachedModel.ormRead(
+        const results = await this.cachedModel.ormRead(
             this.props.model,
             tuples.slice(0, this.state.limit).map(([id, _name]) => id),
             [...new Set(this.props.fields).add("display_name").add("name")]
         );
+        if (this.props.nullText && (!results.length || results[0].id)) {
+            results.unshift({
+                id: 0,
+                name: this.props.nullText,
+                display_name: this.props.nullText,
+            });
+        }
+        this.state.searchResults = results;
     }
     filteredSearchResult() {
         const selectedIds = new Set(this.props.selected.map((e) => e.id));

--- a/addons/html_builder/static/src/plugins/many2one_option.js
+++ b/addons/html_builder/static/src/plugins/many2one_option.js
@@ -12,6 +12,8 @@ export class Many2OneOption extends BaseOptionComponent {
         this.orm = useService("orm");
         onWillStart(async () => {
             const el = this.env.getEditingElement();
+            const contactOpts = JSON.parse(el.dataset.oeContactOptions || "{}");
+            this.nullText = contactOpts.null_text;
             this.model = el.dataset.oeMany2oneModel;
             const searchResult = await this.orm.searchRead(
                 "ir.model",

--- a/addons/html_builder/static/src/plugins/many2one_option.xml
+++ b/addons/html_builder/static/src/plugins/many2one_option.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.Many2OneOption">
     <BuilderRow label="label">
-        <BuilderMany2One action="'many2One'" model="model" fields="['name']" allowUnselect="false"/>
+        <BuilderMany2One action="'many2One'" model="model" fields="['name']" nullText="nullText" allowUnselect="false"/>
     </BuilderRow>
 </t>
 

--- a/addons/html_builder/static/tests/many2one_field.test.js
+++ b/addons/html_builder/static/tests/many2one_field.test.js
@@ -55,3 +55,26 @@ test("Preview changes of many2one option", async () => {
     expect(":iframe span.span-2 > span").toHaveText("The Address of 3");
     expect(":iframe span.span-4").toHaveText("Other");
 });
+
+test("Many2OneOption: add null_text option in dropdown", async () => {
+    onRpc(
+        "ir.qweb.field.contact",
+        "get_record_to_html",
+        ({ args: [[id]], kwargs }) => `<span>The ${kwargs.options.option} of ${id}</span>`
+    );
+    await setupHTMLBuilder(`
+        <div class="many2oneoption_dropdown"
+            data-oe-many2one-id="1"
+            data-oe-many2one-model="res.partner"
+            data-oe-contact-options='{"null_text":"Remote"}'>
+            <span>location</span>
+        </div>
+    `);
+    await contains(":iframe .many2oneoption_dropdown").click();
+    expect("button.btn.dropdown").toHaveCount(1);
+    await contains("button.btn.dropdown").click();
+    await contains('input[placeholder="Search for records..."]').fill("R");
+    await advanceTime(250);
+    await contains("span.o-dropdown-item.dropdown-item:contains('Remote')").click();
+    expect(":iframe div.many2oneoption_dropdown").toHaveText("Remote");
+});


### PR DESCRIPTION
Steps to reproduce:
1. Go to Website → Jobs.
2. Open any job application.
3. Change the Job Location to the option "Remote".
4. A traceback occurs.

Before this commit:
When selecting a job location, initially no Many2One field is selected,
that's why no many2oneid is find. which results in a null value being
returned. This caused a traceback error

After this commit:
The "Remote" option is explicitly included in the dropdown, restoring
the previous behavior.