### PR TITLE
[FIX] hr_holidays: fix leave request bugs and improve calendar computation

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -337,35 +337,42 @@ class HrLeave(models.Model):
         query = self.sudo()._search(domain)
         return [('id', 'in', query)]
 
-
-    @api.depends('employee_id')
+    @api.depends('employee_id', 'request_date_from', 'request_date_to')
     def _compute_resource_calendar_id(self):
-        # YTI TODO: Clean that brol to improve performance
+        leaves_without_emp_or_date = self.filtered(
+            lambda leave: not (leave.employee_id and leave.request_date_from and leave.request_date_to)
+        )
+        valid_leaves = self - leaves_without_emp_or_date
+        leaves_without_emp_or_date.resource_calendar_id = self.env.company.resource_calendar_id
+        if not valid_leaves:
+            return
         employees_by_dates = defaultdict(lambda: self.env['hr.employee'])
-        for leave in self:
-            if leave.employee_id and leave.request_date_from:
-                employees_by_dates[leave.request_date_from] += leave.employee_id
+        contracts_by_employee = dict(
+            self.env['hr.version']._read_group(
+                domain=[('employee_id', 'in', self.employee_id.ids)],
+                groupby=['employee_id'],
+                aggregates=['id:recordset']
+            )
+        )
+        for leave in valid_leaves:
+            employees_by_dates[leave.request_date_from] += leave.employee_id
         calendar_by_dates = {date_from: employees._get_calendars(date_from) for date_from, employees in employees_by_dates.items()}
-        for leave in self:
-            calendar = False
-            if leave.employee_id and leave.request_date_from:
-                calendar = calendar_by_dates[leave.request_date_from][leave.employee_id.id]
-            leave.resource_calendar_id = calendar or self.env.company.resource_calendar_id
-        for leave in self:
+        for leave in valid_leaves:
+            calendar = calendar_by_dates.get(leave.request_date_from, {}).get(leave.employee_id.id) \
+                        or self.env.company.resource_calendar_id
             # We use the request dates to find the contracts, because date_from
             # and date_to are not set yet at this point. Since these dates are
             # used to get the contracts for which these leaves apply and
             # contract start- and end-dates are just dates (and not datetimes)
             # these dates are comparable.
-            if not leave.employee_id:
-                continue
-            contracts = self.env['hr.version'].search([('employee_id', '=', leave.employee_id.id)]).filtered(
+            contracts = contracts_by_employee.get(leave.employee_id, self.env['hr.version']).filtered(
                 lambda c: c.date_start <= leave.request_date_to and
                           (not c.date_end or c.date_end >= leave.request_date_from))
             if contracts:
                 # If there are more than one contract they should all have the
                 # same calendar, otherwise a constraint is violated.
-                leave.resource_calendar_id = contracts[:1].resource_calendar_id
+                calendar = contracts[:1].resource_calendar_id or calendar  # resource_calendar_id is not required on version
+            leave.resource_calendar_id = calendar
 
     def _get_overlapping_contracts(self):
         self.ensure_one()

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1563,3 +1563,21 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'request_date_from': '2024-07-01',
                 'request_date_to': '2024-07-02',
             })
+
+    def test_leave_request_by_removing_dates_holiday_status_id(self):
+        """
+        Test that removing the dates of a leave request or a holiday_status_id
+        does not raise a traceback.
+        """
+        with Form(self.env['hr.leave']) as leave_form:
+            leave_form.name = 'Test leave'
+            leave_form.employee_id = self.employee_emp
+            leave_form.holiday_status_id = self.holidays_type_1
+            leave_form.request_date_from = date(2022, 3, 11)
+            leave_form.request_date_to = date(2022, 3, 11)
+            leave_form.request_date_from = False
+            leave_form.request_date_to = False
+            leave_form.holiday_status_id = self.env['hr.leave.type']
+            leave_form.request_date_from = date(2022, 3, 11)
+            leave_form.request_date_to = date(2022, 3, 11)
+            leave_form.holiday_status_id = self.holidays_type_1


### PR DESCRIPTION
Bug 1 - traceback on removing end date
  Steps to reproduce:
   - open the time off request form
   - remove the end date

  Cause:
   - bool comparison with date

  Fix:
   - add a check before using the request_date_from or request_date_to

Bug 2 - inappropriate resource calendar use
  Steps to reproduce:
   - Create two different version with different working calendar.
   - now while creating leave record it uses correct resource calendar as per
     request dates.
   - but after saving the leave record, if try to change the request dates
     it does not use correct resource calendar.

  Cause:
   - resource calendar compute method is not dependent on request dates.

  Fix:
   - updated the depends of compute method.

moreover refactored the method to improve the performance.

task-4965122

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
