### PR TITLE
[FIX] project: fix test_add_customer_rating_project

### DIFF
--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -285,7 +285,7 @@ class TestProjectBase(TestProjectCommon):
 
         self.task_1.rating_apply(rating, token=rate.access_token)
 
-        self.project_pigs.rating_ids.invalidate_recordset()
+        self.project_pigs.invalidate_recordset(['rating_ids'])
         self.assertEqual(len(self.project_pigs.rating_ids), 1, "There should be 1 rating linked to the project")
 
     def test_planned_dates_consistency_for_project(self):


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/209895/commits/8462a726ba99e32bf17944b0774154a67682e76b, we don't invalidate all inverse fields if we used `invalidate_recordset` on an empty recordset. With only project installed, test_add_customer_rating_project failed because `self.project_pigs.rating_ids` returns a empty recordset and thus the behavior of `invalidate_recordset` change in this case. Fix it by explicitly invalidate the correct one2many.

See https://runbot.odoo.com/odoo/error/229965