### PR TITLE
[FIX] l10n_ro_edi: Fix legacy web tests

### DIFF
--- a/addons/l10n_ro_edi/__manifest__.py
+++ b/addons/l10n_ro_edi/__manifest__.py
@@ -24,5 +24,8 @@ E-invoice implementation for Romania
         'web.assets_backend': [
             'l10n_ro_edi/static/src/components/*',
         ],
+        'web.tests_assets': [
+            'l10n_ro_edi/static/tests/legacy/helpers/mock_server.js',
+        ],
     }
 }

--- a/addons/l10n_ro_edi/static/src/components/fetch_invoices.js
+++ b/addons/l10n_ro_edi/static/src/components/fetch_invoices.js
@@ -4,6 +4,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useService } from "@web/core/utils/hooks";
 import { user } from "@web/core/user";
 
+
 export class FetchInvoicesCogMenu extends Component {
     static template = "l10n_ro_edi.FetchInvoices";
     static props = {};
@@ -11,7 +12,6 @@ export class FetchInvoicesCogMenu extends Component {
 
     setup() {
         this.action = useService("action");
-        this.orm = useService("orm");
     }
 
     async fetchInvoices() {
@@ -28,13 +28,10 @@ export class FetchInvoicesCogMenu extends Component {
 export const CogMenuItem = {
     Component: FetchInvoicesCogMenu,
     groupNumber: 20,
-    isDisplayed: async ({ config, searchModel, services }) => {
-        const orm = services.orm;
-        const data = await orm.searchRead("res.company", [["id", "=", user.activeCompany.id]], ["country_code"]);
-        const countryCode = data[0]?.country_code;
-
+    isDisplayed: async ({ config, searchModel }) => {
+        const data = await searchModel.orm.read("res.company", [user.activeCompany.id], ["country_code"]);
         return (
-            countryCode === "RO" &&
+            data[0]?.country_code === 'RO' &&
             searchModel.resModel === "account.move" &&
             ["kanban", "list"].includes(config.viewType) &&
             config.actionType === "ir.actions.act_window"

--- a/addons/l10n_ro_edi/static/src/components/fetch_invoices.xml
+++ b/addons/l10n_ro_edi/static/src/components/fetch_invoices.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="l10n_ro_edi.FetchInvoices" owl="1">
-         <DropdownItem class="'o_cog_menu'" onSelected.bind="fetchInvoices">
-             Synchronize with ANAF
+        <DropdownItem class="'o_cog_menu'" onSelected.bind="fetchInvoices">
+            Synchronize with ANAF
         </DropdownItem>
     </t>
 </templates>

--- a/addons/l10n_ro_edi/static/tests/legacy/helpers/mock_server.js
+++ b/addons/l10n_ro_edi/static/tests/legacy/helpers/mock_server.js
@@ -1,0 +1,11 @@
+import { patch } from "@web/core/utils/patch";
+import { MockServer } from "@web/../tests/helpers/mock_server";
+
+patch(MockServer.prototype, {
+    async _performRPC(_route, { model, method, args }) {
+        if (model === "res.company" && method === "read") {
+            return [];
+        }
+        return super._performRPC(...arguments);
+    },
+});


### PR DESCRIPTION
A legacy JS test is currently failing due to a server request not being mocked.

This commit thus adds the mocked request.

Run the following test to trigger the error:
.test_qunit_desktop[web_editor > web_editor > insert a new banner]

error-build-230029

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
