### PR TITLE
[FIX] stock: fix traceback on picking report with zero-qty moves

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -122,7 +122,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <t t-foreach="o.move_ids_without_package" t-as="move">
+                                    <t t-foreach="o.move_ids_without_package.filtered(lambda x: x.quantity)" t-as="move">
                                         <!-- This flag is true if there are multiple move lines in a move, or if there is at least one tracked move line -->
                                         <t t-set="move_has_multiple_lines" t-value="len(move.move_line_ids) > 1 or any(move_line.lot_id or move_line.lot_name for move_line in move.move_line_ids)"/>
                                         <tr>
@@ -140,18 +140,18 @@
                                             </td>
                                             <!-- If a move contains only one move line, the move is summarized in the heading only -->
                                             <td class="text-start" t-if="from_col_exists" groups="stock.group_stock_multi_locations">
-                                                <div t-if="not move_has_multiple_lines">
+                                                <div t-if="move.move_line_ids and not move_has_multiple_lines">
                                                     <span t-field="move.move_line_ids[0].location_id.display_name">WH/Stock</span>
-                                                    <t t-if="move.move_line_ids and move.move_line_ids[0].package_id">
+                                                    <t t-if="move.move_line_ids[0].package_id">
                                                         <span t-field="move.move_line_ids[0].package_id">Package A</span>
                                                     </t>
                                                 </div>
                                             </td>
                                             <!-- If a move contains only one move line, the move is summarized in the heading only -->
                                             <td class="text-start" t-if="to_col_exists" groups="stock.group_stock_multi_locations">
-                                                <div t-if="not move_has_multiple_lines">
+                                                <div t-if="move.move_line_ids and not move_has_multiple_lines">
                                                     <span t-field="move.move_line_ids[0].location_dest_id.display_name">WH/Outgoing</span>
-                                                    <t t-if="move.move_line_ids and move.move_line_ids[0].result_package_id">
+                                                    <t t-if="move.move_line_ids[0].result_package_id">
                                                         <span t-field="move.move_line_ids[0].result_package_id">Package B</span>
                                                     </t>
                                                 </div>


### PR DESCRIPTION
**Steps to reproduce:**
1. Install Inventory > Go to Inventory > Configuration > Tick Storage Locations.
2. Go to Operations > Deliveries > create a new delivery.
3. Add two products: one with on-hand quantity, one without.
4. Set demand quantities > mark as To Do, check availability, and try to print.

**Issue:**
- A traceback (IndexError: tuple index out of range) occurs when printing picking report if a product has 
  no reserved quantity, due to missing move lines.

**Cause:**
- The template attempts to access `move.move_line_ids[0]` without checking if `move_line_ids` is non-empty. 
  This raises an IndexError if there's no move lines.
https://github.com/odoo/odoo/blob/f539705023993e284dce5dc1027c3c3af9c42d75/addons/stock/report/report_stockpicking_operations.xml#L143-L146

- Also, move lines with zero quantity are displayed in the picking operation report.
<img width="529" height="94" alt="image" src="https://github.com/user-attachments/assets/61c439a2-16c4-44aa-a664-fbec672f6226" />

**Solution:**
- Add a check to ensure `move.move_line_ids` is non-empty before accessing the first element.
- Add filter to avoid rendering move lines with zero `quantity` in the delivery.


**opw-4961985**
