### PR TITLE
[REV] mrp_subcontracting: mark subcontracted moves as picked

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -58,10 +58,6 @@ class StockMove(models.Model):
             move.show_details_visible = True
         return res
 
-    def _compute_picked(self):
-        subcontracted_moves = self.filtered(lambda m: m.is_subcontract and float_compare(m.product_uom_qty, m.quantity, precision_rounding=m.product_uom.rounding) != 0)
-        super(StockMove, self - subcontracted_moves)._compute_picked()
-
     def _set_quantity_done(self, qty):
         to_set_moves = self
         for move in self:

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -635,45 +635,6 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         avail_qty_comp1 = self.env['stock.quant']._get_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)
         self.assertEqual(avail_qty_comp1, -5)
 
-    def test_backorder_with_subcontracting(self):
-        """Test that a subcontracted move is not marked as picked when its quantity is updated.
-        """
-        self.bom.consumption = 'warning'
-        # Create incoming shipment.
-        with Form(self.env['stock.picking']) as picking_form:
-            picking_form.picking_type_id = self.warehouse.in_type_id
-            picking_form.partner_id = self.subcontractor_partner1
-            with picking_form.move_ids_without_package.new() as move:
-                move.product_id = self.finished
-                move.product_uom_qty = 5
-            with picking_form.move_ids_without_package.new() as move:
-                move.product_id = self.comp1
-                move.product_uom_qty = 5
-            receipt = picking_form.save()
-        receipt.action_confirm()
-
-        # Record the over-consumption of a component
-        self.assertTrue(receipt._get_subcontract_production())
-        action_record = receipt.action_record_components()
-        sbc_mo = self.env['mrp.production'].browse(action_record['res_id'])
-
-        self.assertEqual(receipt.move_ids.mapped('picked'), [False, False])
-        self.assertEqual(receipt.move_ids.mapped('quantity'), [5.0, 5.0])
-        receipt.move_ids[0].quantity = 2
-        receipt.move_ids[1].quantity = 4
-        self.assertEqual(receipt.move_ids.mapped('picked'), [False, False])
-        self.assertEqual(receipt.move_ids.mapped('quantity'), [2.0, 4.0])
-        res = receipt.button_validate()
-        wizard = Form(self.env[res['res_model']].with_context(res['context'])).save()
-        wizard.process()
-        backorder = receipt.backorder_ids
-        self.assertEqual(receipt.move_ids.mapped('quantity'), [2.0, 4.0])
-        self.assertEqual(backorder.move_ids.mapped('quantity'), [3.0, 1.0])
-        backorder.button_validate()
-        self.assertEqual(backorder.state, 'done')
-        self.assertEqual(backorder.move_ids.mapped('quantity'), [3.0, 1.0])
-        self.assertEqual(backorder.move_ids.mapped('picked'), [True, True])
-
     def test_flow_warning_bom_2(self):
         """ For an initial demand of 10 subcontracted products
             - The production of 3 is recorded, with an over-consumption of its components

--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -187,14 +187,12 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
         purchase_order.button_confirm()
         dropship_transfer = purchase_order.picking_ids[0]
         dropship_transfer.move_ids[0].quantity = 50
-        res = dropship_transfer.button_validate()
-        wizard = Form(self.env[res['res_model']].with_context(res['context'])).save()
-        wizard.process()
+        dropship_transfer.with_context(cancel_backorder=False)._action_done()
         account_move_1 = sale_order._create_invoices()
         account_move_1.action_post()
         dropship_backorder = dropship_transfer.backorder_ids[0]
         dropship_backorder.move_ids[0].quantity = 50
-        dropship_backorder.button_validate()
+        dropship_backorder._action_done()
         account_move_2 = sale_order._create_invoices()
         account_move_2.action_post()
 


### PR DESCRIPTION
This commit reverts db8b33e (and the wrong follow-up fix of 2755c09) because it breaks backorders for pickings that mix regular and subcontrcted products. We'd rather the flow has problems in back end where the user can manually uncheck the picked box rather than in barcode where there is no work around.

We keep the enterprise test introduced in [792c968](https://github.com/odoo/enterprise/commit/792c968) to protect the barcode flow.