### PR TITLE
[FIX] web_tour: backward when action running

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_interactive.js
+++ b/addons/web_tour/static/src/tour_service/tour_interactive.js
@@ -27,13 +27,17 @@ export class TourInteractive {
         Object.assign(this, data);
         this.steps = this.steps.map((step) => new TourStep(step, this));
         this.actions = this.steps.flatMap((s) => this.getSubActions(s));
+        this.isBusy = false;
     }
 
     /**
      * @param {import("@web_tour/tour_pointer/tour_pointer").TourPointer} pointer
      * @param {Function} onTourEnd
      */
-    start(pointer, onTourEnd) {
+    start(env, pointer, onTourEnd) {
+        env.bus.addEventListener("ACTION_MANAGER:UPDATE", () => (this.isBusy = true));
+        env.bus.addEventListener("ACTION_MANAGER:UI-UPDATED", () => (this.isBusy = false));
+
         this.pointer = pointer;
         this.debouncedToggleOpen = debounce(this.pointer.showContent, 50, true);
         this.onTourEnd = onTourEnd;
@@ -457,7 +461,8 @@ export class TourInteractive {
                 this.pointer.hide();
                 if (
                     !hoot.queryFirst(".o_home_menu", { visible: true }) &&
-                    !hoot.queryFirst(".dropdown-item.o_loading", { visible: true })
+                    !hoot.queryFirst(".dropdown-item.o_loading", { visible: true }) &&
+                    !this.isBusy
                 ) {
                     this.backward();
                 }

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -56,7 +56,7 @@ const userMenuRegistry = registry.category("user_menuitems");
 export const tourService = {
     // localization dependency to make sure translations used by tours are loaded
     dependencies: ["orm", "effect", "overlay", "localization"],
-    start: async (_env, { orm, effect, overlay }) => {
+    start: async (env, { orm, effect, overlay }) => {
         await whenReady();
         let toursEnabled = session?.tour_enabled;
         const tourRegistry = registry.category("web_tour.tours");
@@ -181,7 +181,7 @@ export const tourService = {
             if (tourConfig.mode === "auto") {
                 new TourAutomatic(tour).start();
             } else {
-                new TourInteractive(tour).start(pointer, async () => {
+                new TourInteractive(tour).start(env, pointer, async () => {
                     pointer.stop();
                     tourState.clear();
                     browser.console.log("tour succeeded");

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -1137,3 +1137,58 @@ test("Tour don't backward when dropdown loading", async () => {
     await contains(".o_form_button_save").click();
     expect(".o_tour_pointer").toHaveCount(0);
 });
+
+test("Don't backward when action manager is busy", async () => {
+    registry.category("web_tour.tours").add("tour1", {
+        steps: () => [
+            { trigger: "button.foo", run: "click" },
+            { trigger: "button.bar", run: "click" },
+        ],
+    });
+
+    class Dummy extends Component {
+        static props = ["*"];
+        state = useState({ bool: true });
+        static components = {};
+        static template = xml`
+            <button class="fool w-100" t-on-click="() => { state.bool = true; }">You fool</button>
+            <button class="foo w-100" t-if="state.bool" t-on-click="() => { state.bool = false; }">Foo</button>
+            <button class="bar w-100" t-if="!state.bool">Bar</button>
+        `;
+    }
+
+    const comp = await mountWithCleanup(Dummy);
+
+    await getService("tour_service").startTour("tour1", { mode: "manual" });
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(1);
+
+    await contains("button.foo").click();
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(1);
+
+    comp.env.bus.trigger("ACTION_MANAGER:UPDATE");
+    await animationFrame();
+
+    await contains("button.fool").click();
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(0);
+
+    await contains("button.foo").click();
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(1);
+
+    comp.env.bus.trigger("ACTION_MANAGER:UI-UPDATED");
+
+    await contains("button.fool").click();
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(1);
+
+    await contains("button.foo").click();
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(1);
+
+    await contains("button.bar").click();
+    await animationFrame();
+    expect(".o_tour_pointer").toHaveCount(0);
+});


### PR DESCRIPTION
Step to reproduce:
- Create a tour
- Add a step that click on a menuitem on the systray with
a view already opened
- Then add a step that click on the search bar of the view

Before this commit, if the step of a tour was triggering an
action (e.g.: a menuitem) and that the next step's trigger was
finding an element on the view before the action has finished
to update the view, then the tour was backwarding because the
found element diseppeared when the new action loaded the new view.

Now, the tour interactive wait that the action manager finish to
update the view to be sure the get the right element for the step trigger.

ISSUE: https://github.com/odoo/odoo/issues/214652




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
