### PR TITLE
[FIX] html_builder: keep builder open in case of error during save

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -239,13 +239,24 @@ export class Builder extends Component {
         // TODO: handle the urgent save and the fail of the save operation
         const snippetMenuEl = this.builder_sidebarRef.el;
         // Add a loading effect on the save button and disable the other actions
-        addButtonLoadingEffect(snippetMenuEl.querySelector("[data-action='save']"));
+        const removeLoadingEffect = addButtonLoadingEffect(
+            snippetMenuEl.querySelector("[data-action='save']")
+        );
         const actionButtonEls = snippetMenuEl.querySelectorAll("[data-action]");
         for (const actionButtonEl of actionButtonEls) {
             actionButtonEl.disabled = true;
         }
-        await this.editor.shared.savePlugin.save();
-        this.props.closeEditor();
+        try {
+            await this.editor.shared.savePlugin.save();
+            this.props.closeEditor();
+        } catch (error) {
+            for (const actionButtonEl of actionButtonEls) {
+                actionButtonEl.removeAttribute("disabled");
+            }
+            removeLoadingEffect();
+            this.editor.shared.edit_interaction.restartInteractions();
+            throw error;
+        }
     }
 
     /**

--- a/addons/web/static/lib/hoot/core/expect.js
+++ b/addons/web/static/lib/hoot/core/expect.js
@@ -736,6 +736,8 @@ export function makeExpect(params) {
      * of the test or the last call to {@link verifyErrors}. Calling this matcher
      * will reset the list of current errors.
      *
+     * `expect.errors(...)` should be called before function
+     *
      * @param {unknown[]} errors
      * @param {VerifierOptions} [options]
      * @returns {boolean}


### PR DESCRIPTION
With the initial website builder refactor, if there is an error during save, the editor stays in the "saving state".

Steps to reproduce:
- On `/blog`, open website builder
- Change a date to an invalid value
- Save
- Close the error dialog about the invalid date
- Bug: the save button is still spining

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641