### PR TITLE
[IMP] website_event: use the current time as the starting time for filters

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -58,10 +58,13 @@ class WebsiteEventController(http.Controller):
         SudoEventType = request.env['event.type'].sudo()
 
         searches.setdefault('search', '')
-        searches.setdefault('date', 'upcoming')
+        searches.setdefault('date', 'scheduled')
         searches.setdefault('tags', '')
         searches.setdefault('type', 'all')
         searches.setdefault('country', 'all')
+        # The previous name of the 'scheduled' filter is 'upcoming' and may still be present in URL's saved by users.
+        if searches['date'] == 'upcoming':
+            searches['date'] = 'scheduled'
 
         website = request.website
 
@@ -69,7 +72,7 @@ class WebsiteEventController(http.Controller):
 
         options = self._get_events_search_options(slug_tags, **searches)
         order = 'date_begin'
-        if searches.get('date', 'upcoming') == 'old':
+        if searches.get('date', 'scheduled') == 'old':
             order = 'date_begin desc'
         order = 'is_published desc, ' + order + ', id desc'
         search = searches.get('search')
@@ -127,7 +130,7 @@ class WebsiteEventController(http.Controller):
             key: value for key, value in searches.items() if (
                 key != 'tags' and (
                     key == 'search' or
-                    (value != 'upcoming' if key == 'date' else value != 'all'))
+                    (value != 'scheduled' if key == 'date' else value != 'all'))
                 )
             })
 

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -515,12 +515,12 @@ class EventEvent(models.Model):
 
     @api.model
     def _search_build_dates(self):
-        # To fetch events of the user's current day. The start and the end of the user's day must
+        now = fields.Datetime.now()
+        # To fetch the remaining events of the user's current day, the end of the user's day must
         # be localized and then converted in UTC, as it is the timezone used to record dates and
         # times in db.
         tz = timezone(self.env.user.tz or self.env.context.get('tz') or 'UTC')
         localized_today_begin = tz.localize(fields.Datetime.today())
-        utc_today_begin = localized_today_begin.astimezone(utc)
         utc_today_end = localized_today_begin.replace(hour=23, minute=59, second=59).astimezone(utc)
 
         def sd(date):
@@ -528,29 +528,24 @@ class EventEvent(models.Model):
 
         def get_month_filter_domain(filter_name, months_delta):
             localized_month_begin = localized_today_begin.replace(day=1)
-            utc_month_begin = (localized_month_begin + relativedelta(months=months_delta)).astimezone(utc)
-            # As utc_month_begin may be the 30th day of the month, adding months may lead to miscalculation the
-            # last day of the interval since 31st day may be missing. Since localized_month_begin is always the
-            # first day of the month, it must be used to calculate the end of the interval and then the UTC
-            # conversion can be done.
             utc_months_delta_end = (localized_month_begin + relativedelta(months=months_delta + 1)).astimezone(utc)
             filter_string = _('This month') if months_delta == 0 \
                 else format_date(self.env, value=localized_today_begin + relativedelta(months=months_delta),
                     date_format='LLLL', lang_code=get_lang(self.env).code).capitalize()
             return [filter_name, filter_string, [
-                ("date_end", ">=", sd(utc_month_begin)),
+                ("date_end", ">=", sd(now)),
                 ("date_begin", "<", sd(utc_months_delta_end))],
                 0]
 
         return [
-            ['upcoming', _('Upcoming Events'), [("date_end", ">=", sd(utc_today_begin))], 0],
+            ['scheduled', _('Scheduled Events'), [("date_end", ">=", sd(now))], 0],
             ['today', _('Today'), [
-                ("date_end", ">", sd(utc_today_begin)),
+                ("date_end", ">", sd(now)),
                 ("date_begin", "<", sd(utc_today_end))],
                 0],
             get_month_filter_domain('month', 0),
             ['old', _('Past Events'), [
-                ("date_end", "<", sd(utc_today_begin))],
+                ("date_end", "<", sd(now))],
                 0],
             ['all', _('All Events'), [], 0]
         ]
@@ -600,7 +595,7 @@ class EventEvent(models.Model):
             if date == date_details[0]:
                 domain.append(date_details[2])
                 no_country_domain.append(date_details[2])
-                if date_details[0] != 'upcoming':
+                if date_details[0] != 'scheduled':
                     current_date = date_details[1]
 
         search_fields = ['name']

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -160,7 +160,7 @@
         <div class="dropdown d-none d-lg-block">
             <button role="button" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown" title="Filter by Date" aria-label="Filter by date" aria-expanded="false">
                 <t t-if="current_date" t-out="current_date"/>
-                <t t-else="">Upcoming</t>
+                <t t-else="">Scheduled Events</t>
             </button>
             <div class="dropdown-menu">
                 <t t-foreach="dates" t-as="date">


### PR DESCRIPTION
The "Upcoming Events", "Today", "The month" and "Past Events" filters do not use the current time to fetch events, thus some results displayed are not relevant. This commit improves that and allows users to see all finished events till the current time with the "Past Events" filter, and the three other filters only show the remaining events for the requested period. The "Upcoming Events" filter is renamed "Scheduled Events" as it also shows events in progress.

task-4796181
