### PR TITLE
[IMP] iot_box_image,hw*: logging tweaks

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -149,7 +149,7 @@ def check_certificate():
     server = get_odoo_server_url()
 
     if not server:
-        _logger.info('Ignoring the nginx certificate check without a connected database')
+        _logger.debug('Ignoring the nginx certificate check without a connected database')
         return {"status": CertificateStatus.ERROR,
                 "error_code": "ERR_IOT_HTTPS_CHECK_NO_SERVER"}
 
@@ -179,7 +179,7 @@ def check_certificate():
         return {"status": CertificateStatus.NEED_REFRESH}
     else:
         message = 'Your certificate %(certificate)s is valid until %(end_date)s' % {"certificate": cn, "end_date": cert_end_date}
-        _logger.info(message)
+        _logger.debug(message)
         return {"status": CertificateStatus.OK, "message": message}
 
 
@@ -758,7 +758,7 @@ def reset_log_level():
         _logger.info("Resetting log level to default.")
         update_conf({
             'log_level_reset_timestamp': '',
-            'log_handler': ':INFO',
+            'log_handler': ':INFO,werkzeug:WARNING',
             'log_level': 'info',
         })
 

--- a/addons/hw_drivers/tools/wifi.py
+++ b/addons/hw_drivers/tools/wifi.py
@@ -157,7 +157,8 @@ def reconnect(ssid=None, password=None, force_update=False):
         timer = time.time() + 10  # Required on boot: wait 10 sec (see: https://github.com/odoo/odoo/pull/187862)
         while time.time() < timer:
             if get_ip():
-                toggle_access_point(STOP)  # ensure access point is off
+                if is_access_point():
+                    toggle_access_point(STOP)
                 return True
             time.sleep(.5)
 
@@ -231,8 +232,8 @@ def _configure_access_point(on=True):
     """
     ssid = get_access_point_ssid()
 
-    _logger.info("Configuring access point with SSID %s", ssid)
     if on:
+        _logger.info("Starting access point with SSID %s", ssid)
         with writable(), open('/etc/hostapd/hostapd.conf', 'w', encoding='utf-8') as f:
             f.write(f"interface=wlan0\nssid={ssid}\nchannel=1\n")
     mode = 'add' if on else 'del'

--- a/addons/hw_posbox_homepage/static/src/app/components/FooterButtons.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/FooterButtons.js
@@ -19,15 +19,9 @@ export class FooterButtons extends Component {
         this.store = useStore();
     }
 
-    get url() {
-        const url = new URL(window.location.href);
-        const port = url.protocol === "https:" ? "" : ":8069";
-        return `${url.protocol}//${this.store.base.ip}${port}`;
-    }
-
     static template = xml`
     <div class="w-100 d-flex flex-wrap align-items-cente gap-2 justify-content-center">
-        <a t-if="store.isLinux and !store.base.is_access_point_up" class="btn btn-primary btn-sm" t-att-href="this.url + '/status'" target="_blank">
+        <a t-if="store.isLinux and !store.base.is_access_point_up" class="btn btn-primary btn-sm" href="/status" target="_blank">
             Status Display
         </a>
         <a t-if="store.isLinux and !store.base.is_access_point_up" class="btn btn-primary btn-sm" t-att-href="'http://' + this.store.base.ip + ':631'" target="_blank">
@@ -36,7 +30,7 @@ export class FooterButtons extends Component {
         <RemoteDebugDialog t-if="this.store.advanced and this.store.isLinux" />
         <CredentialDialog t-if="this.store.advanced" />
         <HandlerDialog t-if="this.store.advanced" />
-        <a t-if="this.store.advanced" class="btn btn-primary btn-sm" t-att-href="this.url + '/logs'" target="_blank">View Logs</a>
+        <a t-if="this.store.advanced" class="btn btn-primary btn-sm" href="/logs" target="_blank">View Logs</a>
     </div>
   `;
 }

--- a/addons/iot_box_image/configuration/odoo.conf
+++ b/addons/iot_box_image/configuration/odoo.conf
@@ -1,6 +1,6 @@
 [options]
 data_dir = /var/run/odoo
-log_handler = :INFO
+log_handler = :INFO,werkzeug:WARNING
 log_level = info
 pidfile = /var/run/odoo/odoo.pid
 limit_time_cpu = 600

--- a/addons/iot_box_image/configuration/setup_ramdisks.sh
+++ b/addons/iot_box_image/configuration/setup_ramdisks.sh
@@ -18,7 +18,7 @@ create_ramdisk () {
 echo "Creating ramdisks..."
 # Note: As of 2025 we are using 2 Gb ram rpi4 as basic IoT Boxes.
 # The 2 Gb limit applies here
-create_ramdisk "/var" "192M"
+create_ramdisk "/var" "512M"
 create_ramdisk "/etc" "64M"
 create_ramdisk "/tmp" "1G" # big size necessary for chromium kiosk usage
 

--- a/addons/iot_box_image/overwrite_after_init/var/www/html/502.html
+++ b/addons/iot_box_image/overwrite_after_init/var/www/html/502.html
@@ -18,12 +18,13 @@
                 display: flex;
                 justify-content: space-between;
                 align-items: center;
-
+                gap: 10px;
             }
 
             .header a {
                 color: white;
                 background-color: #714b67;
+                max-width: 100px;
                 padding: 8px 16px;
                 border-radius: 4px;
                 text-decoration: none;
@@ -33,6 +34,10 @@
             .header a:hover {
                 background-color: #52374B;
                 color: white;
+            }
+
+            h1 {
+                margin-right: auto;
             }
 
             h2 {
@@ -69,7 +74,8 @@
         <div class="container">
             <div class="header">
                 <h1>IoT Box is down</h1>
-                <a href="/odoo-logs/odoo-server.log">Download logs</a>
+                <a href="/odoo-logs/odoo/odoo-server.log">Download Odoo logs</a>
+                <a href="/odoo-logs/nginx/access.log">Download Nginx logs</a>
             </div>
             <h2>(502 Bad Gateway)</h2>
             <p>The IoT Box received the request but was not able to handle it. You can try to refresh the page to see if the request can now be handled.</p>

--- a/addons/iot_box_image/overwrite_before_init/etc/logrotate.conf
+++ b/addons/iot_box_image/overwrite_before_init/etc/logrotate.conf
@@ -2,8 +2,8 @@
 # rotate log files daily
 daily
 
-# keep 2 days worth of backlogs
-rotate 2
+# keep 3 days worth of backlogs
+rotate 3
 
 # create new (empty) log files after rotating old ones
 create


### PR DESCRIPTION
This commit contains the following small changes:
- Change the number of days of logs kept from 2 to 3. The reason for this is so that if a problem occurs on a Friday evening, it is still available to view on a Monday.
- Increase the size of the /var ramdisk to 512M, to ensure it will never be filled even if we end up with 3x100MB log files.
- Change various INFO logs to DEBUG, to clean-up the log output to be more useful.
- Change werkzeug log level to WARNING, to stop showing every HTTP request as a log.
- Add a link to the Nginx logs to the 502 error page.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
