### PR TITLE
[REF] web,*: cleanup ControlPanel buttons management

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -3,7 +3,7 @@
     <t t-name="ImportAction">
         <div t-ref="root" class="h-100 d-flex flex-column">
             <Layout className="'o_import_action d-flex h-100 overflow-auto'" display="display">
-                <t t-set-slot="control-panel-create-button">
+                <t t-set-slot="control-panel-buttons">
                     <t t-if="isPreviewing">
                         <t t-if="!state.isTested">
                             <button type="button" class="btn btn-primary" t-on-click="() => this.handleImport(true)">Test</button>

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="calendar.AttendeeCalendarController" t-inherit="web.CalendarController" t-inherit-mode="primary">
         <xpath expr="//Layout" position="inside">
-            <t t-set-slot="control-panel-create-button">
+            <t t-set-slot="control-panel-buttons">
                 <button class="btn btn-primary o-calendar-button-new" t-on-click="onClickAddButton">New</button>
             </t>
         </xpath>

--- a/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
@@ -82,7 +82,7 @@ export class CalendarQuickCreate extends FormViewDialog {
         super.setup();
         Object.assign(this.viewProps, {
             ...this.viewProps,
-            buttonTemplate: "calendar.CalendarQuickCreateButtons",
+            buttonDialogTemplate: "calendar.CalendarQuickCreateButtons",
         });
     }
 }

--- a/addons/hr_expense/static/src/views/kanban.js
+++ b/addons/hr_expense/static/src/views/kanban.js
@@ -24,10 +24,12 @@ registry.category('views').add('hr_expense_kanban', {
     ...kanbanView,
     Controller: ExpenseKanbanController,
     Renderer: ExpenseKanbanRenderer,
+    buttonTemplate: "hr_expense.KanbanView.Buttons"
 });
 
 registry.category('views').add('hr_expense_dashboard_kanban', {
     ...kanbanView,
     Controller: ExpenseKanbanController,
     Renderer: ExpenseDashboardKanbanRenderer,
+    buttonTemplate: "hr_expense.KanbanView.Buttons"
 });

--- a/addons/hr_expense/static/src/views/kanban.xml
+++ b/addons/hr_expense/static/src/views/kanban.xml
@@ -17,7 +17,7 @@
         </xpath>
     </t>
 
-    <t t-name="hr_expense.KanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
+    <t t-name="hr_expense.KanbanView.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
         <xpath expr="//button[hasclass('o-kanban-button-new')]" position="before">
             <input type="file" name="ufile" class="d-none" t-ref="fileInput" multiple="1" accept="*" t-on-change="onChangeFileInput" />
             <button t-if="!env.isSmall" type="button" class="o_button_upload_expense btn btn-primary" t-on-click.prevent="uploadDocument">
@@ -27,7 +27,9 @@
                 Scan
             </button>
         </xpath>
+    </t>
 
+    <t t-name="hr_expense.KanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
         <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
             <attribute name="uploadDocument.bind">uploadDocument</attribute>
         </xpath>

--- a/addons/hr_expense/static/src/views/list.xml
+++ b/addons/hr_expense/static/src/views/list.xml
@@ -12,9 +12,6 @@
                 Post Entries
             </button>
         </xpath>
-    </t>
-
-    <t t-name="hr_expense.ListView" t-inherit="web.ListView" t-inherit-mode="primary">
         <xpath expr="//button[hasclass('o_list_button_add')]" position="before">
             <input type="file" name="ufile" class="d-none" t-ref="fileInput" multiple="1" accept="*" t-on-change="onChangeFileInput"/>
             <button t-if="!env.isSmall" type="button" class="o_button_upload_expense btn btn-primary" t-on-click.prevent="uploadDocument">
@@ -24,7 +21,9 @@
                 Scan
             </button>
         </xpath>
+    </t>
 
+    <t t-name="hr_expense.ListView" t-inherit="web.ListView" t-inherit-mode="primary">
         <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
             <attribute name="uploadDocument.bind">uploadDocument</attribute>
         </xpath>

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
@@ -3,7 +3,7 @@
 
     <t t-name="hr_holidays.CalendarController" t-inherit="web.CalendarController" t-inherit-mode="primary">
         <xpath expr="//Layout" position="inside">
-            <t t-if="props.archInfo.canCreate" t-set-slot="control-panel-create-button">
+            <t t-if="props.archInfo.canCreate" t-set-slot="control-panel-buttons">
                 <span class="o_timeoff_buttons btn-group">
                     <div class="btn-group">
                         <button class="btn btn-primary btn-time-off " t-on-click="newTimeOffRequest" type="button">

--- a/addons/hr_holidays/static/src/views/view_dialog/allocation_form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/allocation_form_view_dialog.js
@@ -4,7 +4,7 @@ export class AllocationFormViewDialog extends FormViewDialog {
     setup() {
         super.setup();
         Object.assign(this.viewProps, {
-            buttonTemplate: 'hr_holidays.AllocationFormViewDialog.buttons',
+            buttonDialogTemplate: "hr_holidays.AllocationFormViewDialog.buttons",
         });
     }
 };

--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
@@ -116,7 +116,7 @@ export class TimeOffFormViewDialog extends FormViewDialog {
 
         this.viewProps = Object.assign(this.viewProps, {
             jsClass: "timeoff_dialog_form",
-            buttonTemplate: "hr_holidays.FormViewDialog.buttons",
+            buttonDialogTemplate: "hr_holidays.FormViewDialog.buttons",
             onCancelLeave: () => {
                 this.props.close();
             },

--- a/addons/mail/static/src/views/web/activity/activity_controller.xml
+++ b/addons/mail/static/src/views/web/activity/activity_controller.xml
@@ -6,7 +6,7 @@
                 <t t-set-slot="control-panel-additional-actions">
                     <CogMenu/>
                 </t>
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <SearchBar/>
                 </t>
                 <t t-component="props.Renderer" t-props="rendererProps" />

--- a/addons/mail/static/src/views/web/view_dialog/avatar_user_form_view_dialog.js
+++ b/addons/mail/static/src/views/web/view_dialog/avatar_user_form_view_dialog.js
@@ -5,7 +5,7 @@ export class AvatarUserFormViewDialog extends FormViewDialog {
     setup() {
         super.setup();
         Object.assign(this.viewProps, {
-            buttonTemplate: this.props.isToMany
+            buttonDialogTemplate: this.props.isToMany
                 ? "mail.UserFormViewDialog.ToMany.buttons"
                 : "mail.UserFormViewDialog.ToOne.buttons",
         });

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
@@ -3,10 +3,8 @@
 
     <t t-name="mrp.BomOverviewControlPanel">
         <ControlPanel display="controlPanelDisplay">
-            <t t-set-slot="control-panel-create-button">
+            <t t-set-slot="control-panel-buttons">
                 <button t-if="props.showOptions.mode == 'forecast'" t-on-click="manufactureFromBoM" type="button" class="btn btn-primary">Manufacture</button>
-            </t>
-            <t t-set-slot="control-panel-always-buttons">
                 <button t-on-click="() => this.props.print()" type="button" class="btn btn-secondary">Print</button>
                 <!-- <t t-if="props.showVariants"> commented, waiting for ui update
                     <button t-on-click="() => this.props.print(true)" type="button" class="btn btn-secondary text-nowrap">Print All Variants</button>
@@ -14,7 +12,7 @@
                 </t> -->
                 <button t-if="props.foldable" t-on-click="clickTogglefold" type="button" class="btn btn-secondary" t-esc="foldButtonText"/>
             </t>
-            <t t-set-slot="layout-actions">
+            <t t-set-slot="control-panel-actions">
                 <div t-if="props.showVariants" class="input-group align-items-center">
                     <div class="col-4 col-md-auto pe-2 fw-bold">Variant</div>
                     <div class="col">

--- a/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.xml
+++ b/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.xml
@@ -3,15 +3,13 @@
 
     <div t-name="mrp.MoOverview" class="o_action">
         <Layout display="{ controlPanel: {} }">
-            <t t-set-slot="layout-actions">
+            <t t-set-slot="control-panel-actions">
                 <MoOverviewDisplayFilter showOptions="state.showOptions" limited="isProductionDone" changeDisplay.bind="onChangeDisplay" isProductionDraft="isProductionDraft"/>
             </t>
 
-            <t t-set-slot="control-panel-create-button">
-                <div class="d-flex gap-1">
-                    <button class="btn btn-primary" t-on-click="onPrint">Print</button>
-                    <button class="btn btn-primary" t-on-click="onUnfold">Unfold</button>
-                </div>
+            <t t-set-slot="control-panel-buttons">
+                <button class="btn btn-primary" t-on-click="onPrint">Print</button>
+                <button class="btn btn-primary" t-on-click="onUnfold">Unfold</button>
             </t>
 
             <div class="overflow-auto border-bottom bg-view container-fluid">

--- a/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
+++ b/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
@@ -5,7 +5,7 @@
     <t t-name="product.ProductPricelistReport">
         <div class="o_action">
             <Layout display="{ controlPanel: {} }">
-                <t t-set-slot="control-panel-always-buttons">
+                <t t-set-slot="control-panel-buttons">
                     <button t-on-click="onClickPrint" type="button" class="btn btn-primary" title="Print">Print</button>
                     <select name="formats" id="formats" class="form-select border-1 w-auto">
                         <option value="pdf">pdf</option>
@@ -13,7 +13,7 @@
                         <option value="xlsx">xlsx</option>
                     </select>
                 </t>
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <form class="o_pricelist_report_form d-flex flex-row gap-1">
                         <div class="d-flex align-items-center gap-3 w-100">
                             <label class="visually-hidden" for="pricelists">Username</label>

--- a/addons/product/static/src/product_catalog/kanban_controller.js
+++ b/addons/product/static/src/product_catalog/kanban_controller.js
@@ -5,8 +5,6 @@ import { useDebounced } from "@web/core/utils/timing";
 import { _t } from "@web/core/l10n/translation";
 
 export class ProductCatalogKanbanController extends KanbanController {
-    static template = "ProductCatalogKanbanController";
-
     setup() {
         super.setup();
         this.orm = useService("orm");

--- a/addons/product/static/src/product_catalog/kanban_controller.xml
+++ b/addons/product/static/src/product_catalog/kanban_controller.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="ProductCatalogKanbanController" t-inherit="web.KanbanView" t-inherit-mode="primary">
+    <t t-name="ProductCatalogKanbanController.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
         <xpath expr="//button[hasclass('o-kanban-button-new')]" position="replace">
             <button t-out="this.buttonString" type="button" class="btn btn-primary o-kanban-button-back" t-on-click="this.backToQuotationDebounced"/>
         </xpath>

--- a/addons/product/static/src/product_catalog/kanban_view.js
+++ b/addons/product/static/src/product_catalog/kanban_view.js
@@ -11,6 +11,7 @@ export const productCatalogKanbanView = {
     Controller: ProductCatalogKanbanController,
     Model: ProductCatalogKanbanModel,
     Renderer: ProductCatalogKanbanRenderer,
+    buttonTemplate: "ProductCatalogKanbanController.Buttons",
 };
 
 registry.category("views").add("product_kanban_catalog", productCatalogKanbanView);

--- a/addons/project/static/src/views/project_form/project_project_form_controller.js
+++ b/addons/project/static/src/views/project_form/project_project_form_controller.js
@@ -4,7 +4,6 @@ import { FormControllerWithHTMLExpander } from '@resource/views/form_with_html_e
 import { ProjectTemplateDropdown } from "../components/project_template_dropdown";
 
 export class ProjectProjectFormController extends FormControllerWithHTMLExpander {
-    static template = "project.ProjectFormView";
     static components = {
         ...FormControllerWithHTMLExpander.components,
         ProjectTemplateDropdown,

--- a/addons/project/static/src/views/project_form/project_project_form_controller.xml
+++ b/addons/project/static/src/views/project_form/project_project_form_controller.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="project.ProjectFormView" t-inherit="resource.FormViewWithHtmlExpander" t-inherit-mode="primary">
+    <t t-name="project.ProjectFormView.Buttons" t-inherit="web.FormView.Buttons" t-inherit-mode="primary">
         <button class="btn btn-outline-primary o_form_button_create" position="replace">
             <ProjectTemplateDropdown t-if="canCreate"
                 onCreate="() => this.create()"

--- a/addons/project/static/src/views/project_form/project_project_form_view.js
+++ b/addons/project/static/src/views/project_form/project_project_form_view.js
@@ -5,6 +5,7 @@ import { ProjectProjectFormController } from "./project_project_form_controller"
 export const projectProjectFormView = {
     ...formViewWithHtmlExpander,
     Controller: ProjectProjectFormController,
+    buttonTemplate: "project.ProjectFormView.Buttons",
 };
 
 registry.category("views").add("project_project_form", projectProjectFormView);

--- a/addons/project/static/src/views/project_project_kanban/project_project_kanban_controller.js
+++ b/addons/project/static/src/views/project_project_kanban/project_project_kanban_controller.js
@@ -5,7 +5,6 @@ import { user } from "@web/core/user";
 import { ProjectTemplateDropdown } from "../components/project_template_dropdown";
 
 export class ProjectKanbanController extends KanbanController {
-    static template = "project.ProjectKanbanView";
     static components = {
         ...KanbanController.components,
         ProjectTemplateDropdown,

--- a/addons/project/static/src/views/project_project_kanban/project_project_kanban_controller.xml
+++ b/addons/project/static/src/views/project_project_kanban/project_project_kanban_controller.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="project.ProjectKanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
+    <t t-name="project.ProjectKanbanView.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
         <button class="btn btn-primary o-kanban-button-new" position="replace">
-            <ProjectTemplateDropdown t-if="canCreate and props.showButtons"
+            <ProjectTemplateDropdown t-if="!env.inDialog and canCreate"
                 onCreate="() => this.createRecord()"
                 newButtonClasses="'btn btn-primary o-kanban-button-new'"
                 context="props.context"

--- a/addons/project/static/src/views/project_project_kanban/project_task_kanban_view.js
+++ b/addons/project/static/src/views/project_project_kanban/project_task_kanban_view.js
@@ -9,6 +9,7 @@ export const projectProjectKanbanView = {
     Controller: ProjectKanbanController,
     Renderer: ProjectProjectKanbanRenderer,
     Model: ProjectRelationalModel,
+    buttonTemplate: "project.ProjectKanbanView.Buttons",
 };
 
 registry.category("views").add("project_project_kanban", projectProjectKanbanView);

--- a/addons/project/static/src/views/project_project_list/project_project_list_controller.js
+++ b/addons/project/static/src/views/project_project_list/project_project_list_controller.js
@@ -5,7 +5,6 @@ import { user } from "@web/core/user";
 import { ProjectTemplateDropdown } from "../components/project_template_dropdown";
 
 export class ProjectListController extends ListController {
-    static template = "project.ProjectListView";
     static components = {
         ...ListController.components,
         ProjectTemplateDropdown,

--- a/addons/project/static/src/views/project_project_list/project_project_list_controller.xml
+++ b/addons/project/static/src/views/project_project_list/project_project_list_controller.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="project.ProjectListView" t-inherit="web.ListView" t-inherit-mode="primary">
+    <t t-name="project.ProjectListView.Buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
         <button class="btn btn-primary o_list_button_add" position="replace">
-            <ProjectTemplateDropdown t-if="!editedRecord and activeActions.create and props.showButtons"
+            <ProjectTemplateDropdown t-if="!env.inDialog and !editedRecord and activeActions.create"
                 onCreate="() => this.onClickCreate()"
                 newButtonClasses="'btn btn-primary o_list_button_add'"
                 context="props.context"

--- a/addons/project/static/src/views/project_project_list/project_project_list_view.js
+++ b/addons/project/static/src/views/project_project_list/project_project_list_view.js
@@ -9,6 +9,7 @@ export const projectProjectListView = {
     Renderer: ProjectProjectListRenderer,
     Controller: ProjectListController,
     Model: ProjectRelationalModel,
+    buttonTemplate: "project.ProjectListView.Buttons",
 };
 
 registry.category("views").add("project_project_list", projectProjectListView);

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.js
@@ -16,7 +16,6 @@ Are you sure you want to proceed?`
 );
 
 export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
-    static template = "project.ProjectTaskFormView";
     static components = {
         ...FormControllerWithHTMLExpander.components,
         ProjectTaskTemplateDropdown,

--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.xml
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="project.ProjectTaskFormView" t-inherit="resource.FormViewWithHtmlExpander" t-inherit-mode="primary">
+    <t t-name="project.ProjectTaskFormView.Buttons" t-inherit="web.FormView.Buttons" t-inherit-mode="primary">
         <button class="btn btn-outline-primary o_form_button_create" position="replace">
             <ProjectTaskTemplateDropdown t-if="canCreate"
                 projectId="props.context.default_project_id"

--- a/addons/project/static/src/views/project_task_form/project_task_form_view.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_view.js
@@ -5,6 +5,7 @@ import { ProjectTaskFormController } from "./project_task_form_controller";
 export const projectTaskFormView = {
     ...formViewWithHtmlExpander,
     Controller: ProjectTaskFormController,
+    buttonTemplate: "project.ProjectTaskFormView.Buttons",
 };
 
 registry.category("views").add("project_task_form", projectTaskFormView);

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="project.ProjectTaskKanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
+    <t t-name="project.ProjectTaskKanbanView.Buttons" t-inherit="web.KanbanView.Buttons" t-inherit-mode="primary">
         <button class="btn btn-primary o-kanban-button-new" position="replace">
-            <ProjectTaskTemplateDropdown t-if="canCreate and props.showButtons"
+            <ProjectTaskTemplateDropdown t-if="canCreate"
                 projectId="props.context.default_project_id"
                 onCreate="() => this.createRecord()"
                 newButtonClasses="'btn btn-primary o-kanban-button-new'"
                 context="props.context"
             />
         </button>
+    </t>
+    <t t-name="project.ProjectTaskKanbanView" t-inherit="web.KanbanView" t-inherit-mode="primary">
         <t t-component="props.Renderer" position="attributes">
             <attribute name="hideKanbanStagesNocontent">hideKanbanStagesNocontent</attribute>
         </t>

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.js
@@ -12,6 +12,7 @@ export const projectTaskKanbanView = {
     Model: ProjectTaskKanbanModel,
     Renderer: ProjectTaskKanbanRenderer,
     Controller: ProjectTaskKanbanController,
+    buttonTemplate: "project.ProjectTaskKanbanView.Buttons",
 };
 
 registry.category('views').add('project_task_kanban', projectTaskKanbanView);

--- a/addons/project/static/src/views/project_task_list/project_task_list_controller.js
+++ b/addons/project/static/src/views/project_task_list/project_task_list_controller.js
@@ -4,7 +4,6 @@ import { subTaskDeleteConfirmationMessage } from "@project/views/project_task_fo
 import { ProjectTaskTemplateDropdown } from "../components/project_task_template_dropdown";
 
 export class ProjectTaskListController extends ListController {
-    static template = "project.ProjectTaskListView";
     static components = {
         ...ListController.components,
         ProjectTaskTemplateDropdown,

--- a/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
+++ b/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="project.ProjectTaskListView" t-inherit="web.ListView" t-inherit-mode="primary">
+    <t t-name="project.ProjectTaskListView.Buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
         <button class="btn btn-primary o_list_button_add" position="replace">
-            <ProjectTaskTemplateDropdown t-if="!editedRecord and activeActions.create and props.showButtons"
+            <ProjectTaskTemplateDropdown t-if="!editedRecord and activeActions.create"
                 projectId="props.context.default_project_id"
                 onCreate="() =&gt; this.onClickCreate()"
                 newButtonClasses="'btn btn-primary o_list_button_add'"

--- a/addons/project/static/src/views/project_task_list/project_task_list_view.js
+++ b/addons/project/static/src/views/project_task_list/project_task_list_view.js
@@ -11,6 +11,7 @@ export const projectTaskListView = {
     Controller: ProjectTaskListController,
     Model: ProjectTaskRelationalModel,
     Renderer: ProjectTaskListRenderer,
+    buttonTemplate: "project.ProjectTaskListView.Buttons",
 };
 
 registry.category("views").add("project_task_list", projectTaskListView);

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -2,7 +2,7 @@
 <templates>
     <div t-name="spreadsheet_dashboard.DashboardAction" class="o_action o_spreadsheet_dashboard_action o_field_highlight">
         <ControlPanel display="controlPanelDisplay">
-            <t t-set-slot="layout-actions" t-if="!loader.getActiveDashboard()?.isSample">
+            <t t-set-slot="control-panel-actions" t-if="!loader.getActiveDashboard()?.isSample">
                 <t t-set="status" t-value="loader.getActiveDashboard() and loader.getActiveDashboard().status"/>
                 <div class="d-flex flex-wrap w-100">
                     <DashboardSearchBar t-if="status === Status.Loaded and loader.getActiveDashboard().model.getters.getGlobalFilters().length"

--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
@@ -4,7 +4,7 @@
     <t t-name="stock.TraceabilityReport">
         <div class="o_action">
             <Layout display="display">
-                <t t-set-slot="layout-buttons">
+                <t t-set-slot="control-panel-buttons">
                     <div class="o_cp_buttons" role="toolbar" aria-label="Control panel buttons" t-ref="buttons">
                         <button type="button" class="btn btn-primary" t-on-click="() => this.onClickPrint()">Print</button>
                     </div>

--- a/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
+++ b/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
@@ -3,7 +3,7 @@
 
     <div t-name="stock.ReceptionReportMain" class="o_action">
         <ControlPanel display="controlPanelDisplay">
-            <t t-set-slot="control-panel-always-buttons">
+            <t t-set-slot="control-panel-buttons">
                 <button t-on-click="onClickPrint" type="button" class="btn btn-primary" title="Print">Print</button>
                 <button t-on-click="onClickAssignAll" class="btn btn-secondary" t-att-disabled="isAssignAllDisabled">Assign All</button>
                 <button t-on-click="onClickPrintLabels" class="btn btn-secondary" t-att-disabled="isPrintLabelDisabled">Print Labels</button>

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
@@ -2,10 +2,10 @@
 <templates id="template" xml:space="preserve">
     <div t-name="stock.Forecasted" class="o_action o_stock_forecast">
         <ControlPanel>
-            <t t-set-slot="layout-buttons">
+            <t t-set-slot="control-panel-buttons">
                 <ForecastedButtons action="props.action" reloadReport.bind="reloadReport" resModel="resModel"/>
             </t>
-            <t t-set-slot="layout-actions">
+            <t t-set-slot="control-panel-actions">
                 <div class="btn-group o_search_options position-static" role="search">
                     <ForecastedWarehouseFilter action="props.action" warehouses="warehouses" setWarehouseInContext.bind="updateWarehouse"/>
                 </div>

--- a/addons/stock_account/static/src/stock_valuation/stock_valuation_report.xml
+++ b/addons/stock_account/static/src/stock_valuation/stock_valuation_report.xml
@@ -4,7 +4,7 @@
         <div class="o_action account_report">
             <ControlPanel>
                 <!-- Buttons bar -->
-                <t t-set-slot="control-panel-create-button">
+                <t t-set-slot="control-panel-buttons">
                     <StockValuationReportButtonsBar/>
                 </t>
                 <!-- <t t-set-slot="control-panel-additional-actions">
@@ -12,7 +12,7 @@
                 </t> -->
 
                 <!-- Filters -->
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                    <div class="d-flex gap-1 flex-wrap">
                        <StockValuationReportFilters/>
                    </div>

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -303,7 +303,7 @@ export class ControlPanel extends Component {
      */
     get display() {
         return {
-            layoutActions: true,
+            controlPanelActions: true,
             ...this.props.display,
         };
     }

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -103,6 +103,12 @@ export class ControlPanel extends Component {
         display: { type: Object, optional: true },
         slots: { type: Object, optional: true },
     };
+    static defaultProps = {
+        display: {
+            actions: true,
+            buttons: true,
+        },
+    };
 
     setup() {
         this.actionService = useService("action");
@@ -303,7 +309,7 @@ export class ControlPanel extends Component {
      */
     get display() {
         return {
-            controlPanelActions: true,
+            ...this.constructor.defaultProps.display,
             ...this.props.display,
         };
     }

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -22,17 +22,13 @@
             <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-2 gap-lg-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-on-keydown="onMainButtonsKeydown">
-                        <t t-slot="control-panel-create-button"/>
-                        <t t-slot="layout-buttons"/>
-                        <t t-slot="control-panel-always-buttons"/>
+                        <t t-slot="control-panel-buttons"/>
                         <Dropdown t-if="env.isSmall" menuClass="'o-control-panel-adaptive-dropdown'" onOpened.bind="dropdownifyButtons">
                             <button class="btn btn-secondary o-control-panel-adaptive-dropdown" title="More">
                                 <i class="oi oi-fw oi-ellipsis-v" />
                             </button>
                             <t t-set-slot="content">
-                                <t t-slot="control-panel-create-button"/>
-                                <t t-slot="layout-buttons"/>
-                                <t t-slot="control-panel-always-buttons"/>
+                                <t t-slot="control-panel-buttons"/>
                             </t>
                         </Dropdown>
                     </div>
@@ -73,7 +69,7 @@
                 </div>
 
                 <div class="o_control_panel_actions d-empty-none d-flex align-items-center justify-content-start justify-content-lg-around order-2 order-lg-1 w-100 mw-100 w-lg-auto">
-                    <t t-if="display.layoutActions" t-slot="layout-actions"/>
+                    <t t-if="display.controlPanelActions" t-slot="control-panel-actions"/>
                     <t t-slot="control-panel-selection-actions"/>
                 </div>
 

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -22,13 +22,13 @@
             <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-2 gap-lg-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-on-keydown="onMainButtonsKeydown">
-                        <t t-slot="control-panel-buttons"/>
+                        <t t-if="display.buttons" t-slot="control-panel-buttons"/>
                         <Dropdown t-if="env.isSmall" menuClass="'o-control-panel-adaptive-dropdown'" onOpened.bind="dropdownifyButtons">
                             <button class="btn btn-secondary o-control-panel-adaptive-dropdown" title="More">
                                 <i class="oi oi-fw oi-ellipsis-v" />
                             </button>
                             <t t-set-slot="content">
-                                <t t-slot="control-panel-buttons"/>
+                                <t t-if="display.buttons" t-slot="control-panel-buttons"/>
                             </t>
                         </Dropdown>
                     </div>
@@ -69,7 +69,7 @@
                 </div>
 
                 <div class="o_control_panel_actions d-empty-none d-flex align-items-center justify-content-start justify-content-lg-around order-2 order-lg-1 w-100 mw-100 w-lg-auto">
-                    <t t-if="display.controlPanelActions" t-slot="control-panel-actions"/>
+                    <t t-if="display.actions" t-slot="control-panel-actions"/>
                     <t t-slot="control-panel-selection-actions"/>
                 </div>
 

--- a/addons/web/static/src/search/layout.js
+++ b/addons/web/static/src/search/layout.js
@@ -31,7 +31,7 @@ export class Layout extends Component {
     get controlPanelSlots() {
         const slots = { ...this.props.slots };
         if (this.env.inDialog) {
-            delete slots["layout-buttons"];
+            delete slots["control-panel-buttons"];
         }
         delete slots.default;
         return slots;

--- a/addons/web/static/src/search/layout.xml
+++ b/addons/web/static/src/search/layout.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.Layout">
         <t t-if="env.inDialog" t-portal="'#' + env.dialogId + ' .modal-footer'">
-            <t t-slot="layout-buttons"/>
+            <t t-slot="control-panel-buttons"/>
         </t>
         <t t-component="components.ControlPanel" slots="controlPanelSlots" t-if="props.display.controlPanel" display="props.display.controlPanel"/>
         <main t-ref="content" class="o_content" t-attf-class="{{props.className}}" t-att-class="{ 'o_component_with_search_panel': props.display.searchPanel }">

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -7,10 +7,10 @@
                 <t t-set-slot="control-panel-additional-actions">
                     <CogMenu/>
                 </t>
-                <t t-set-slot="layout-buttons">
+                <t t-set-slot="control-panel-buttons">
                     <t t-call="{{ props.buttonTemplate }}"/>
                 </t>
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -144,6 +144,7 @@ export class FormController extends Component {
         Compiler: Function,
         archInfo: Object,
         buttonTemplate: String,
+        buttonDialogTemplate: String,
         preventCreate: { type: Boolean, optional: true },
         preventEdit: { type: Boolean, optional: true },
         onDiscard: { type: Function, optional: true },

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -5,26 +5,21 @@
         <div t-att-class="className" t-ref="root">
             <div class="o_form_view_container">
                 <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
-                    <t t-set-slot="control-panel-create-button">
-                        <button t-if="canCreate" type="button" class="btn btn-outline-primary o_form_button_create" data-hotkey="c" t-on-click.stop="create">New</button>
-                    </t>
-
-                    <t t-set-slot="layout-buttons">
+                    <t t-set-slot="control-panel-buttons">
                         <t t-if="env.inDialog">
                             <t t-if="footerArchInfo">
                                 <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" archInfo="footerArchInfo">
                                     <t t-set-slot="default_buttons">
-                                        <t t-call="{{ props.buttonTemplate }}"/>
+                                        <t t-call="{{ props.buttonDialogTemplate }}"/>
                                     </t>
                                 </t>
                             </t>
-                            <t t-else="">
-                                <t t-call="{{ props.buttonTemplate }}"/>
-                            </t>
+                            <t t-else="" t-call="{{ props.buttonDialogTemplate }}"/>
                         </t>
+                        <t t-else="" t-call="{{ props.buttonTemplate }}"/>
                     </t>
 
-                    <t t-set-slot="layout-actions">
+                    <t t-set-slot="control-panel-actions">
                         <t t-if="!env.isSmall and buttonBoxTemplate">
                             <t t-call="{{ buttonBoxTemplate }}" t-call-context="{ __comp__: Object.assign(Object.create(this), { this, props: { ...this.props, record: this.model.root } }) }"/>
                         </t>
@@ -49,7 +44,7 @@
         </div>
     </t>
 
-    <t t-name="web.FormView.Buttons">
+    <t t-name="web.FormView.DialogButtons">
         <button t-if="model.root.isInEdition" type="button" class="btn btn-primary o_form_button_save" data-hotkey="s" t-on-click.stop="() => this.saveButtonClicked({closable: true})">
             Save
         </button>
@@ -62,6 +57,10 @@
         <button t-if="!model.root.isInEdition and canCreate" type="button" class="btn btn-secondary o_form_button_create" data-hotkey="c" t-on-click.stop="create">
             New
         </button>
+    </t>
+
+    <t t-name="web.FormView.Buttons">
+        <button t-if="canCreate" type="button" class="btn btn-outline-primary o_form_button_create" data-hotkey="c" t-on-click.stop="create">New</button>
     </t>
 
     <t t-name="web.DefaultButtonsSlot">

--- a/addons/web/static/src/views/form/form_view.js
+++ b/addons/web/static/src/views/form/form_view.js
@@ -14,6 +14,7 @@ export const formView = {
     Model: RelationalModel,
     Compiler: FormCompiler,
     buttonTemplate: "web.FormView.Buttons",
+    buttonDialogTemplate: "web.FormView.DialogButtons",
 
     props: (genericProps, view) => {
         const { ArchParser } = view;
@@ -28,6 +29,7 @@ export const formView = {
             Model: view.Model,
             Renderer: view.Renderer,
             buttonTemplate: genericProps.buttonTemplate || view.buttonTemplate,
+            buttonDialogTemplate: genericProps.buttonDialogTemplate || view.buttonDialogTemplate,
             Compiler: view.Compiler,
             archInfo,
         };

--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -57,7 +57,7 @@
                 <t t-set-slot="control-panel-additional-actions">
                     <CogMenu/>
                 </t>
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -56,7 +56,6 @@ export class KanbanController extends Component {
         forceGlobalClick: { type: Boolean, optional: true },
         onSelectionChanged: { type: Function, optional: true },
         readonly: { type: Boolean, optional: true },
-        showButtons: { type: Boolean, optional: true },
         Compiler: Function,
         Model: Function,
         Renderer: Function,
@@ -68,7 +67,6 @@ export class KanbanController extends Component {
         createRecord: () => {},
         forceGlobalClick: false,
         selectRecord: () => {},
-        showButtons: true,
     };
 
     setup() {
@@ -267,7 +265,7 @@ export class KanbanController extends Component {
             ...this.props.display,
             controlPanel: {
                 ...controlPanel,
-                controlPanelActions: !this.hasSelectedRecords,
+                actions: !this.hasSelectedRecords,
             },
         };
     }

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -267,7 +267,7 @@ export class KanbanController extends Component {
             ...this.props.display,
             controlPanel: {
                 ...controlPanel,
-                layoutActions: !this.hasSelectedRecords,
+                controlPanelActions: !this.hasSelectedRecords,
             },
         };
     }

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -4,7 +4,7 @@
     <t t-name="web.KanbanView">
         <div t-attf-class="{{ className }} {{ hasSelectedRecords ? 'o_kanban_selection_active' : 'o_kanban_selection_available' }}" t-ref="root">
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
-                <t t-if="props.showButtons" t-set-slot="control-panel-buttons">
+                <t t-set-slot="control-panel-buttons">
                     <t t-call="{{ props.buttonTemplate }}"/>
                     <t t-foreach="headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
                         <MultiRecordViewButton

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -4,15 +4,8 @@
     <t t-name="web.KanbanView">
         <div t-attf-class="{{ className }} {{ hasSelectedRecords ? 'o_kanban_selection_active' : 'o_kanban_selection_available' }}" t-ref="root">
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
-                <t t-set-slot="control-panel-create-button">
-                    <button t-if="canCreate and props.showButtons" type="button" t-att-disabled="isNewButtonDisabled" class="btn btn-primary o-kanban-button-new" accesskey="c" t-on-click="() => this.createRecord()" data-bounce-button="">
-                        New
-                    </button>
-                </t>
-                <t t-set-slot="layout-buttons">
-                    <t t-if="props.showButtons" t-call="{{ props.buttonTemplate }}"/>
-                </t>
-                <t t-set-slot="control-panel-always-buttons">
+                <t t-if="props.showButtons" t-set-slot="control-panel-buttons">
+                    <t t-call="{{ props.buttonTemplate }}"/>
                     <t t-foreach="headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
                         <MultiRecordViewButton
                             t-if="button.display === 'always'"
@@ -73,7 +66,7 @@
                         </t>
                     </CogMenu>
                 </t>
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <SearchBar toggler="searchBarToggler" autofocus="firstLoad"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
@@ -97,6 +90,10 @@
         </div>
     </t>
 
-    <t t-name="web.KanbanView.Buttons"/>
+    <t t-name="web.KanbanView.Buttons">
+        <button t-if="!env.inDialog and canCreate" type="button" t-att-disabled="isNewButtonDisabled" class="btn btn-primary o-kanban-button-new" accesskey="c" t-on-click="() => this.createRecord()" data-bounce-button="">
+            New
+        </button>
+    </t>
 
 </templates>

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -54,7 +54,6 @@ export class ListController extends Component {
         allowSelectors: { type: Boolean, optional: true },
         onSelectionChanged: { type: Function, optional: true },
         readonly: { type: Boolean, optional: true },
-        showButtons: { type: Boolean, optional: true },
         allowOpenAction: { type: Boolean, optional: true },
         Model: Function,
         Renderer: Function,
@@ -65,7 +64,6 @@ export class ListController extends Component {
         allowSelectors: true,
         createRecord: () => {},
         selectRecord: () => {},
-        showButtons: true,
         allowOpenAction: true,
     };
 
@@ -500,7 +498,7 @@ export class ListController extends Component {
             ...this.props.display,
             controlPanel: {
                 ...controlPanel,
-                controlPanelActions: !this.hasSelectedRecords,
+                actions: !this.hasSelectedRecords,
             },
         };
     }

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -500,7 +500,7 @@ export class ListController extends Component {
             ...this.props.display,
             controlPanel: {
                 ...controlPanel,
-                layoutActions: !this.hasSelectedRecords,
+                controlPanelActions: !this.hasSelectedRecords,
             },
         };
     }

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -4,7 +4,7 @@
     <t t-name="web.ListView">
         <div t-att-class="className" t-ref="root">
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
-                <t t-if="props.showButtons" t-set-slot="control-panel-buttons">
+                <t t-set-slot="control-panel-buttons">
                     <t t-call="{{ props.buttonTemplate }}"/>
                     <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
                         <MultiRecordViewButton

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -4,18 +4,8 @@
     <t t-name="web.ListView">
         <div t-att-class="className" t-ref="root">
             <Layout className="model.useSampleModel ? 'o_view_sample_data' : ''" display="display">
-                <t t-set-slot="control-panel-create-button">
-                    <button t-if="!editedRecord and activeActions.create and props.showButtons" type="button" class="btn btn-primary o_list_button_add" data-hotkey="c" t-on-click="onClickCreate" data-bounce-button="">
-                        New
-                    </button>
-                    <t t-if="props.showButtons and !env.inDialog" t-call="web.ListView.EditableButtons"/>
-                </t>
-
-                <t t-set-slot="layout-buttons">
-                    <t t-if="props.showButtons and env.inDialog" t-call="web.ListView.EditableButtons"/>
-                    <t t-if="props.showButtons" t-call="{{ props.buttonTemplate }}"/>
-                </t>
-                <t t-set-slot="control-panel-always-buttons">
+                <t t-if="props.showButtons" t-set-slot="control-panel-buttons">
+                    <t t-call="{{ props.buttonTemplate }}"/>
                     <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
                         <MultiRecordViewButton
                             t-if="button.display === 'always'"
@@ -32,7 +22,7 @@
                     </t>
                 </t>
 
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <SearchBar toggler="searchBarToggler" autofocus="firstLoad"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
@@ -102,9 +92,10 @@
         </div>
     </t>
 
-    <t t-name="web.ListView.Buttons"/>
-
-    <t t-name="web.ListView.EditableButtons">
+    <t t-name="web.ListView.Buttons">
+        <button t-if="!env.inDialog and !editedRecord and activeActions.create" type="button" class="btn btn-primary o_list_button_add" data-hotkey="c" t-on-click="onClickCreate" data-bounce-button="">
+            New
+        </button>
         <button t-if="editedRecord" type="button" class="btn btn-primary o_list_button_save" data-hotkey="s" t-on-click.stop="onClickSave">
             Save
         </button>

--- a/addons/web/static/src/views/pivot/pivot_controller.xml
+++ b/addons/web/static/src/views/pivot/pivot_controller.xml
@@ -25,7 +25,7 @@
                 <t t-set-slot="control-panel-additional-actions">
                     <CogMenu/>
                 </t>
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -44,7 +44,7 @@ export class FormViewDialog extends Component {
         this.modalRef = useChildRef();
         this.env.dialogData.dismiss = () => this.discardRecord();
 
-        const buttonTemplate = this.props.isToMany
+        const buttonDialogTemplate = this.props.isToMany
             ? "web.FormViewDialog.ToMany.buttons"
             : "web.FormViewDialog.ToOne.buttons";
 
@@ -56,7 +56,7 @@ export class FormViewDialog extends Component {
 
         this.viewProps = {
             type: "form",
-            buttonTemplate,
+            buttonDialogTemplate,
 
             context: this.props.context || {},
             display: { controlPanel: false },

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
@@ -15,14 +15,14 @@
     </Dialog>
   </t>
 
-  <t t-name="web.FormViewDialog.ToMany.buttons" t-inherit="web.FormView.Buttons">
+  <t t-name="web.FormViewDialog.ToMany.buttons" t-inherit="web.FormView.DialogButtons">
     <xpath expr="//button[hasclass('o_form_button_save')]" position="replace">
       <button class="btn btn-primary o_form_button_save" t-on-click="saveButtonClicked" data-hotkey="c">Save</button>
       <button t-if="!env.isSmall" class="btn btn-primary o_form_button_save_new" t-on-click="() => this.saveButtonClicked({saveAndNew: true})" data-hotkey="n">Save &amp; New</button>
     </xpath>
   </t>
 
-  <t t-name="web.FormViewDialog.ToOne.buttons" t-inherit="web.FormView.Buttons">
+  <t t-name="web.FormViewDialog.ToOne.buttons" t-inherit="web.FormView.DialogButtons">
     <xpath expr="//button[hasclass('o_form_button_save')]" position="replace">
       <button class="btn btn-primary o_form_button_save" t-on-click="saveButtonClicked" data-hotkey="c">Save</button>
     </xpath>

--- a/addons/web/static/src/views/view_dialogs/select_create_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/select_create_dialog.js
@@ -49,10 +49,9 @@ export class SelectCreateDialog extends Component {
         const noContentHelp = this.props.noContentHelp || getDefaultNoContentHelp();
         this.busy = false; // flag used to ensure we only call once the onSelected/onUnselect props
         this.baseViewProps = {
-            display: { searchPanel: false },
+            display: { searchPanel: false, controlPanel: { buttons: false } },
             noBreadcrumbs: true,
             noContentHelp,
-            showButtons: false,
             selectRecord: (resId) => this.select([resId]),
             onSelectionChanged: (resIds) => {
                 this.state.resIds = resIds;

--- a/addons/web/static/src/webclient/actions/blank_component.xml
+++ b/addons/web/static/src/webclient/actions/blank_component.xml
@@ -2,7 +2,7 @@
 <templates>
 <t t-name="web.BlankComponent">
     <ControlPanel display="{disableDropdown: true}" t-if="props.withControlPanel and !env.isSmall">
-        <t t-set-slot="layout-buttons">
+        <t t-set-slot="control-panel-buttons">
             <button class="btn btn-primary invisible"> empty </button>
         </t>
     </ControlPanel>

--- a/addons/web/static/src/webclient/actions/blank_component.xml
+++ b/addons/web/static/src/webclient/actions/blank_component.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <templates>
 <t t-name="web.BlankComponent">
-    <ControlPanel display="{disableDropdown: true}" t-if="props.withControlPanel and !env.isSmall">
+    <ControlPanel t-if="props.withControlPanel and !env.isSmall">
         <t t-set-slot="control-panel-buttons">
             <button class="btn btn-primary invisible"> empty </button>
         </t>

--- a/addons/web/static/src/webclient/actions/reports/report_action.xml
+++ b/addons/web/static/src/webclient/actions/reports/report_action.xml
@@ -4,7 +4,7 @@
     <t t-name="web.ReportAction">
         <div class="o_action">
             <Layout display="{ controlPanel: {} }">
-                <t t-set-slot="control-panel-create-button">
+                <t t-set-slot="control-panel-buttons">
                     <button t-on-click="print" type="button" class="btn btn-primary" title="Print">Print</button>
                 </t>
                 <iframe t-ref="iframe" t-on-load="onIframeLoaded" class="h-100 w-100 d-block" t-att-src="reportUrl" />

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.xml
@@ -4,8 +4,8 @@
         <xpath expr="./div[@t-ref='root']" position="attributes">
             <attribute name="class">o-settings-form-view o_field_highlight</attribute>
         </xpath>
-        <xpath expr="//Layout/t[@t-set-slot='layout-actions']" position="replace">
-            <t t-set-slot="layout-actions">
+        <xpath expr="//Layout/t[@t-set-slot='control-panel-actions']" position="replace">
+            <t t-set-slot="control-panel-actions">
                 <div class="o_cp_searchview d-flex w-100" role="search">
                     <div class="o_searchview form-control d-flex align-items-center py-1" role="search" aria-autocomplete="list">
                         <i class="o_searchview_icon oi oi-search me-2" role="img" aria-label="Search..." title="Search..." />
@@ -16,9 +16,9 @@
                 </div>
             </t>
         </xpath>
-        <xpath expr="//Layout/t[@t-set-slot='control-panel-create-button']" position="replace">
-            <t t-set-slot="control-panel-create-button">
-                <t t-call="{{ props.buttonTemplate }}"/>
+        <xpath expr="//Layout/t[@t-set-slot='control-panel-buttons']" position="replace">
+            <t t-set-slot="control-panel-buttons">
+                <t t-call="{{ props.buttonDialogTemplate }}"/>
             </t>
         </xpath>
         <xpath expr="//Layout/t[@t-set-slot='control-panel-status-indicator']" position="replace">

--- a/addons/web/static/tests/views/layout.test.js
+++ b/addons/web/static/tests/views/layout.test.js
@@ -289,7 +289,7 @@ test(`Simple rendering: with dynamically displayed search`, async () => {
                 ...this.props.display,
                 controlPanel: {
                     ...this.props.display.controlPanel,
-                    controlPanelActions: this.state.displayControlPanelActions,
+                    actions: this.state.displayControlPanelActions,
                 },
             };
         }

--- a/addons/web/static/tests/views/layout.test.js
+++ b/addons/web/static/tests/views/layout.test.js
@@ -78,7 +78,7 @@ test(`Simple rendering: with search`, async () => {
         static props = ["*"];
         static template = xml`
             <Layout display="props.display">
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <div class="toy_search_bar"/>
                 </t>
                 <div class="toy_content"/>
@@ -114,7 +114,7 @@ test(`Rendering with default ControlPanel and SearchPanel`, async () => {
             });
             useSubEnv({ searchModel: this.searchModel });
             onWillStart(async () => {
-                await this.searchModel.load({ resModel: "foo" , searchViewId: false});
+                await this.searchModel.load({ resModel: "foo", searchViewId: false });
             });
         }
     }
@@ -162,7 +162,7 @@ test(`Nested layouts`, async () => {
         static props = ["*"];
         static template = xml`
             <Layout className="'toy_b'" display="props.display">
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <div class="toy_b_breadcrumbs"/>
                 </t>
                 <ToyC/>
@@ -184,7 +184,7 @@ test(`Nested layouts`, async () => {
         static props = ["*"];
         static template = xml`
             <Layout className="'toy_a'" display="props.display">
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <div class="toy_a_search"/>
                 </t>
                 <ToyB display="props.display"/>
@@ -266,13 +266,13 @@ test(`Custom search panel`, async () => {
 });
 
 test(`Simple rendering: with dynamically displayed search`, async () => {
-    const state = reactive({ displayLayoutActions: true });
+    const state = reactive({ displayControlPanelActions: true });
 
     class ToyComponent extends Component {
         static props = ["*"];
         static template = xml`
             <Layout display="display">
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <div class="toy_search_bar"/>
                 </t>
                 <div class="toy_content"/>
@@ -289,7 +289,7 @@ test(`Simple rendering: with dynamically displayed search`, async () => {
                 ...this.props.display,
                 controlPanel: {
                     ...this.props.display.controlPanel,
-                    layoutActions: this.state.displayLayoutActions,
+                    controlPanelActions: this.state.displayControlPanelActions,
                 },
             };
         }
@@ -304,7 +304,7 @@ test(`Simple rendering: with dynamically displayed search`, async () => {
     expect(`.o_cp_searchview`).toHaveCount(0);
     expect(`.o_content > .toy_content`).toHaveCount(1);
 
-    state.displayLayoutActions = false;
+    state.displayControlPanelActions = false;
     await animationFrame();
     expect(`.o_control_panel .o_control_panel_actions .toy_search_bar`).toHaveCount(0);
     expect(`.o_component_with_search_panel .o_search_panel`).toHaveCount(1);

--- a/addons/web_hierarchy/static/src/hierarchy_controller.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_controller.xml
@@ -17,10 +17,10 @@
                 <t t-set-slot="control-panel-additional-actions">
                     <CogMenu/>
                 </t>
-                <t t-set-slot="layout-buttons">
+                <t t-set-slot="control-panel-buttons">
                     <t t-call="{{ props.buttonTemplate }}"/>
                 </t>
-                <t t-set-slot="layout-actions">
+                <t t-set-slot="control-panel-actions">
                     <SearchBar toggler="searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">

--- a/addons/website/static/src/client_actions/website_dashboard/website_dashboard.xml
+++ b/addons/website/static/src/client_actions/website_dashboard/website_dashboard.xml
@@ -14,7 +14,7 @@
                     </t>
                 </div>
             </t>
-            <t t-set-slot="control-panel-create-button">
+            <t t-set-slot="control-panel-buttons">
                 <a role="button" href="/" class="btn btn-primary" title="Go to Website">
                     Go to Website
                 </a>

--- a/addons/website/static/src/components/views/theme_preview.xml
+++ b/addons/website/static/src/components/views/theme_preview.xml
@@ -42,7 +42,7 @@
 
     <t t-name="website.ThemePreviewFormController" t-inherit="web.FormView" t-inherit-mode="primary">
         <xpath expr="//Layout" position="inside">
-            <t t-set-slot="layout-actions">
+            <t t-set-slot="control-panel-actions">
                 <ViewButton className="'btn btn-primary o_use_theme'"
                             clickParams="{type: 'object', name: 'button_choose_theme'}"
                             record="this.model.root">


### PR DESCRIPTION
tl;dr : if you want to customize view's buttons, look for
`buttonTemplate`.

Following last years development (MILK redesign, ControlPanel buttons
structure and cleanup, responsiveness...), the ControlPanel's slots
related to the main buttons (i.e. left part of the ControlPanel) became
redundant. Also, extending the views' buttons with custom JS ones (i.e.
not in the arch) wasn't the clearer to understand.

This commit's purpose is to both clean up and clarify how to manage
those buttons.

In a nutshell, the `control-panel-create-button`,
`control-panel-always-buttons` and `layout-buttons` slots have been
merged into a single `control-panel-buttons` slot. It makes it easier to
know where main buttons (in general) will go in the ControlPanel.

For the views, the goal was also to make it clearer how to extend/modify
the view's main buttons. The main customization point is the
`buttonTemplate` view's property as it allows to override the view's
buttons. Beside very specific case, the `control-panel-buttons`
shouldn't be touched for this purpose.

The Form view has its own specificity: it explicitly handles the buttons
used in dialog (also via the arch's `<footer>`) and in the ControlPanel.
To take this difference into account, a dedicated `buttonDialogTemplate`
property has been introduced for this view, allowing the same kind of
extension as the `buttonTemplate`.

Note: to match the global ControlPanel slots' naming scheme,
`layout-actions` has been renamed to `control-panel-actions`.

task-4277543