### PR TITLE
[FIX] stock: display stock_package_type ordered by sequence

### DIFF
--- a/addons/stock/models/stock_package_type.py
+++ b/addons/stock/models/stock_package_type.py
@@ -7,6 +7,7 @@ from odoo import models, fields, _
 class PackageType(models.Model):
     _name = 'stock.package.type'
     _description = "Stock package type"
+    _order = "sequence, id"
 
     def _get_default_length_uom(self):
         return self.env['product.template']._get_length_uom_name_from_ir_config_parameter()


### PR DESCRIPTION
#### Step to reproduce:
- Go to Inventory > Configuration > Settings  and enable Packages
- Go to Inventory > Configuration > Package Types
- Inverse the order of two packages types. The goal is for the sequence order to differ from the id order. (you can display id with studio)
- Go to Inventory > Overview > Delivery Orders
- Create a new delivery order
- Add a line
- In 'Additional Info' add a Carrier
- Go to Barcode > Operations > Delivery Orders
- Select the delivery order (you might need to remove filters)
- With the 'Add Product' button add a product
- Click on 'Put in Pack'
- A 'Package Details' wizard should have opened. In this wizard there is a field 'Delivery Package Type'.

#### Current behavior:
- In the delivery package type dropdown list, packages are ordered by id

#### Expected behavior:
- In the delivery package type dropdown list, packages should be ordered by sequence

#### Cause of the issue:
As no order was defined, stock.package.type was ordered by id which is the default behavior

opw-4824064

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
