### PR TITLE
[FIX] html_editor, *: reintroduce conversion of absolute to relative URL

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -137,6 +137,9 @@ export class LinkPlugin extends Plugin {
         "baseContainer",
         "feff",
     ];
+    static defaultConfig = {
+        allowStripDomain: true,
+    };
     // @phoenix @todo: do we want to have createLink and insertLink methods in link plugin?
     static shared = ["createLink", "insertLink", "getPathAsUrlCommand"];
     resources = {
@@ -593,6 +596,7 @@ export class LinkPlugin extends Plugin {
             showReplaceTitleBanner: this.newlyInsertedLinks.has(linkElement),
             allowCustomStyle: this.config.allowCustomStyle,
             allowTargetBlank: this.config.allowTargetBlank,
+            allowStripDomain: this.config.allowStripDomain,
         };
 
         const popover = this.getActivePopover(linkElement);

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -114,6 +114,14 @@
                                 </CheckBox>
                             </t>
                         </t>
+                        <t t-if="props.allowStripDomain and isAbsoluteURLInCurrentDomain()">
+                            <CheckBox
+                                value="state.stripDomain"
+                                onChange="onClickStripDomain.bind(this)"
+                                className="'strip-domain-option'">
+                                Autoconvert to relative link
+                            </CheckBox>
+                        </t>
                         <div class="mt-3">
                             <button class="o_we_apply_link btn btn-sm btn-primary" t-att-disabled="!state.url" t-on-click="onClickApply">Apply</button>
                             <button class="o_we_discard_link btn btn-sm btn-dark ms-1" t-on-click="props.onDiscard">Discard</button>


### PR DESCRIPTION
*: html_builder

This commit restores the feature (lost during the website builder refactoring [1]) that automatically converts absolute URLs pointing to the origin domain into relative URLs.

It also introduces a heuristic to detect links pointing to the user's own Odoo instance domain (e.g., https://mydb.odoo.com/...) and treats them as internal links. In both cases, a checkbox (enabled by default) allows the user to opt into this conversion.

Mentioning .odoo.com instance domains (especially one’s own) in published URLs is discouraged and considered bad practice.

ex:

url: http://localhost:8069/contactus
[x] Autoconvert to relative link

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
