### PR TITLE
[FIX] website_sale_stock_wishlist: translate out of stock message

### DIFF
--- a/addons/website_sale_stock_wishlist/i18n/website_sale_stock_wishlist.pot
+++ b/addons/website_sale_stock_wishlist/i18n/website_sale_stock_wishlist.pot
@@ -17,9 +17,7 @@ msgstr ""
 
 #. module: website_sale_stock_wishlist
 #: model_terms:ir.ui.view,arch_db:website_sale_stock_wishlist.product_wishlist
-msgid ""
-"<i class=\"fa fa-bell\"/>\n"
-"                        We'll notify you once the product is back in stock."
+msgid "We'll notify you once the product is back in stock."
 msgstr ""
 
 #. module: website_sale_stock_wishlist


### PR DESCRIPTION
## Versions
18.0+

## Issue
The icon's class is changed from `fa fa-bell` to `fa fa-bell me-2` when rendering making the translation unable to find the spot

## Steps to reproduce
- Ensure at least 2 languages (with at least one different from English) are set for the website;
- Go to a published product without variants (e.g. "Office Chair"):
  - Ensure the "Track Inventory" checkbox is checked under "General Information" tab;
  - Set its stock quantity to 0 or less;
  - Under the "Sales" tab, ensure the "Out-of-Stock" checkbox ("Continue Selling") is unchecked;
- Click the "Go to website" smart button;
- Change the website's language for the non-English one;
- As out of stock, as to get notified when the product is back in stock:
  - Submit the email address.

opw-4955314