### PR TITLE
[IMP] base: clarify currency exchange rate labels

### DIFF
--- a/odoo/addons/base/tests/test_res_currency.py
+++ b/odoo/addons/base/tests/test_res_currency.py
@@ -1,28 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from lxml import etree
 from odoo import Command
 from odoo.tests.common import TransactionCase
 
 
 class TestResCurrency(TransactionCase):
-    def test_view_company_rate_label(self):
-        """Tests the label of the company_rate and inverse_company_rate fields
-        are well set according to the company currency in the currency form view and the currency rate list view.
-        e.g. in the currency rate list view of a company using EUR, the company_rate label must be `Unit per EUR`"""
-        company_foo, company_bar = self.env['res.company'].create([
-            {'name': 'foo', 'currency_id': self.env.ref('base.EUR').id},
-            {'name': 'bar', 'currency_id': self.env.ref('base.USD').id},
-        ])
-        for company, expected_currency in [(company_foo, 'EUR'), (company_bar, 'USD')]:
-            for model, view_type in [('res.currency', 'form'), ('res.currency.rate', 'list')]:
-                arch = self.env[model].with_company(company).get_view(view_type=view_type)['arch']
-                tree = etree.fromstring(arch)
-                node_company_rate = tree.find('.//field[@name="company_rate"]')
-                node_inverse_company_rate = tree.find('.//field[@name="inverse_company_rate"]')
-                self.assertEqual(node_company_rate.get('string'), f'Unit per {expected_currency}')
-                self.assertEqual(node_inverse_company_rate.get('string'), f'{expected_currency} per Unit')
-
     def test_currency_cache(self):
         currencyA, currencyB = self.env['res.currency'].create([{
             'name': 'AAA',

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -161,9 +161,10 @@
                                     <list string="Rates"  editable="top" limit="25">
                                         <field name="name"/>
                                         <field name="company_id" groups="base.group_multi_company" placeholder="Visible to all"/>
-                                        <field name="company_rate" digits="[12,12]"/>
-                                        <field name="inverse_company_rate" digits="[12,12]"/>
-                                        <field name="rate" digits="[12,12]" optional="hide"/>
+                                        <field name="company_currency_id" string="Base Currency"/>
+                                        <field name="company_rate" width="120" digits="[12,12]" string="Unit/Base"/>
+                                        <field name="inverse_company_rate" width="120" digits="[12,12]" string="Base/Unit"/>
+                                        <field name="rate" digits="[12,12]" string="Unit/Base" optional="hide"/>
                                         <field name="write_date" optional="hide"/>
                                     </list>
                                 </field>


### PR DESCRIPTION
This commit improves the readability and consistency of exchange rate labels in the res.currency form view. Specifically:

- Replaces the custom _get_views logic that dynamically altered exchange rate labels with standardized Unit/Base and Base/Unit labels. 
- Adds the company currency field to the view to clearly indicate which currency serves as the base.

This allows to get rid of unnecessary _get_view logic inside the model.

task-4900037
