### PR TITLE
[IMP] l10n_fr_account: remove exclude lines at 0 option from FEC export

### DIFF
--- a/addons/l10n_fr_account/i18n/fr.po
+++ b/addons/l10n_fr_account/i18n/fr.po
@@ -185,11 +185,6 @@ msgid "End Date"
 msgstr "Date de fin"
 
 #. module: l10n_fr_account
-#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__exclude_zero
-msgid "Exclude lines at 0"
-msgstr "Exclure les lignes à 0"
-
-#. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__excluded_journal_ids
 msgid "Excluded Journals"
 msgstr "Journaux exclus"

--- a/addons/l10n_fr_account/i18n/l10n_fr_account.pot
+++ b/addons/l10n_fr_account/i18n/l10n_fr_account.pot
@@ -185,11 +185,6 @@ msgid "End Date"
 msgstr ""
 
 #. module: l10n_fr_account
-#: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__exclude_zero
-msgid "Exclude lines at 0"
-msgstr ""
-
-#. module: l10n_fr_account
 #: model:ir.model.fields,field_description:l10n_fr_account.field_l10n_fr_fec_export_wizard__excluded_journal_ids
 msgid "Excluded Journals"
 msgstr ""

--- a/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
+++ b/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
@@ -16,7 +16,6 @@ class L10n_FrFecExportWizard(models.TransientModel):
     date_to = fields.Date(string='End Date', required=True, default=lambda self: self.env.context.get('report_dates', {}).get('date_to'))
     filename = fields.Char(string='Filename', size=256, readonly=True)
     test_file = fields.Boolean()
-    exclude_zero = fields.Boolean(string="Exclude lines at 0")
     export_type = fields.Selection([
         ('official', 'Official FEC report (posted entries only)'),
         ('nonofficial', 'Non-official FEC report (posted and unposted entries)'),
@@ -30,14 +29,12 @@ class L10n_FrFecExportWizard(models.TransientModel):
             self.export_type = 'official'
 
     def _get_base_domain(self):
-        domain = [('company_id', 'in', tuple(self.env.company._accessible_branches().ids))]
+        domain = [('company_id', 'in', tuple(self.env.company._accessible_branches().ids)), ('balance', '!=', 0.0)]
         # For official report: only use posted entries
         if self.export_type == "official":
             domain.append(('parent_state', '=', 'posted'))
         if self.excluded_journal_ids:
             domain.append(('journal_id', 'not in', self.excluded_journal_ids.ids))
-        if self.exclude_zero:
-            domain.append(('balance', '!=', 0.0))
         return domain
 
     def _do_query_unaffected_earnings(self):

--- a/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard_view.xml
+++ b/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard_view.xml
@@ -18,7 +18,6 @@
                         <field name="date_from"/>
                         <field name="date_to"/>
                         <field name="test_file"/>
-                        <field name="exclude_zero"/>
                         <field name="export_type" invisible="not test_file"/>
                         <field name="excluded_journal_ids" widget="many2many_tags" options="{'no_create': True}"/>
                     </group>


### PR DESCRIPTION
Before:
- Users could choose whether to exclude lines with zero balance in the FEC export.

After:
- The FEC export will now always exclude lines with zero balance.

Related Upgrade PR: https://github.com/odoo/upgrade/pull/8115

task-4963034