### PR TITLE
[FIX] stock_account: Exclude rental lines from anglo-saxon COGS entries

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -277,7 +277,8 @@ class AccountMoveLine(models.Model):
 
     def _eligible_for_cogs(self):
         self.ensure_one()
-        return self.product_id.type == 'product' and self.product_id.valuation == 'real_time'
+        is_a_rental = self.sale_line_ids and any(getattr(sol, 'is_rental', False) for sol in self.sale_line_ids)
+        return self.product_id.type == 'product' and self.product_id.valuation == 'real_time' and not is_a_rental
 
     def _get_gross_unit_price(self):
         if float_is_zero(self.quantity, precision_rounding=self.product_uom_id.rounding):


### PR DESCRIPTION
Modified the COGS generation logic to skip any invoice lines that come from a rental sales order.

task-4919306

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
