### PR TITLE
[FIX] spreadsheet: remove uselss global filter input

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -22,7 +22,7 @@
                 <DateFilterValue value="filterValue"
                                  update.bind="(value) => this.onDateInput(filter.id, value)"/>
             </div>
-            <div t-if="filter.type === 'numeric'" class="w-100 d-flex align-items-center"
+            <div t-elif="filter.type === 'numeric'" class="w-100 d-flex align-items-center"
                  t-att-class="filterValue?.operator === 'between' ? 'justify-content-between' : ''">
                 <t t-if="filterValue?.operator === 'between'">
                     <NumericFilterValue

--- a/addons/spreadsheet/static/tests/global_filters/filter_search_dialog.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_search_dialog.test.js
@@ -386,3 +386,17 @@ test("Relational global filter with a parent/child model adds the child of opera
     await mountFiltersSearchDialog(env, { model });
     expect('option[value="child_of"]').toHaveCount(1);
 });
+
+test(`Relational global filter with "set" operator doesn't have a record selector input`, async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "relation",
+        label: "Filter",
+        modelName: "partner",
+        defaultValue: { operator: "set" },
+    });
+    await mountFiltersSearchDialog(env, { model });
+    expect(".o-filter-value input").toHaveCount(0);
+});


### PR DESCRIPTION
The global filters had wrong and useless inputs for the set/contains operators.

Task: [4968504](https://www.odoo.com/odoo/2328/tasks/4968504)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
