### PR TITLE
[FIX] pos_restaurant: always write deleted lines to backend when back to floor page

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -53,4 +53,15 @@ patch(OrderSummary.prototype, {
             !currentOrder.hasCourses()
         );
     },
+    _setValue(val) {
+        if (
+            this.currentOrder.getSelectedOrderline() &&
+            this.pos.numpadMode === "quantity" &&
+            val === "remove" &&
+            typeof this.currentOrder.id === "number"
+        ) {
+            this.pos.addPendingOrder([this.currentOrder.id]);
+        }
+        return super._setValue(val);
+    },
 });

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -16,7 +16,7 @@ import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { delay } from "@odoo/hoot-dom";
 import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
 import { generatePreparationReceiptElement } from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
-import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
+import { negate, negateStep, run } from "@point_of_sale/../tests/generic_helpers/utils";
 
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
@@ -655,5 +655,25 @@ registry.category("web_tour.tours").add("test_customer_alone_saved", {
             Chrome.clickOrders(),
             Chrome.clickRegister(),
             ProductScreen.customerIsSelected("Deco Addict"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_lines_deleted_from_first_try", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickLine("Coca-Cola"),
+            ProductScreen.selectedOrderlineHasDirect("Coca-Cola"),
+            ...["⌫", "⌫"].map(Numpad.click),
+            ProductScreen.releaseTable(),
+            FloorScreen.clickTable("5"),
+            run(() => delay(500)),
+            negateStep(...Order.hasLine({ productName: "Coca-Cola" })),
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -79,3 +79,12 @@ export function setTab(name) {
         Dialog.confirm(),
     ];
 }
+export function releaseTable() {
+    return [
+        {
+            content: "release table",
+            trigger: ".product-screen .leftpane .unbook-table",
+            run: "click",
+        },
+    ];
+}

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -616,3 +616,7 @@ class TestFrontend(TestFrontendCommon):
         Tests that when a customer is set, it will be saved and not be reset even if this is the only thing that changed in the order
         """
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_customer_alone_saved', login="pos_user")
+
+    def test_lines_deleted_from_first_try(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_lines_deleted_from_first_try')


### PR DESCRIPTION
Steps to reproduce
------------------
1. Click on an unreserved table and add some lines.
2. Click on the "Tables" button to go back to floor page.
3. Click back on that same table, and delete all the lines.
4. Click on "Release Table". You will be redirected to floor page.
5. Click back on that same table.

Observe that the old lines (the ones deleted in step 3) are now all back!!

Why the issue
-------------
When going back to the floor page on step 2, we a call to `sync_from_ui` is made to write the new order with all of its orderlines to the backend, as expected. We can also expect that on step 4, when clicking "Release table", a call to `sync_from_ui` is made with the updated order, i.e. the order with no orderlines. However, that is not happening!! Because when we are removing the lines in step 3, we are not marking the order as 'pending' and hence, the call to `syncAllOrders` [1] is skipping calling the `sync_from_ui` API [2] since `orderToUpdate` is empty [3], so our deleted lines are not written to the backend on the first time. So when we open the table again, we sync the current order (the empty one) with the backend order (the one that still has the lines), which results in a new local order having all the lines from the backend!!!

The fix
-------
When removing a line, we also mark the order as pending. Note that idealy we would want to override `removeOrderline` [4] as it would be much simpler, however, since in `removeOrderline`, we don't have access to the `PosStore`, and hence we cannot call `this.pos.addPendingOrder`, we had to override `_setValue` instead, which added slightly more complexity in the form of few `if` checks (matching the ones in the original `_setValue` that lead to calling `removeOrderline` [5]).

[1]: https://github.com/odoo/odoo/blob/7b8699dc07daeeb261bd880d969321f7e94f23f0/addons/pos_restaurant/static/src/app/services/pos_store.js#L472
[2]: https://github.com/odoo/odoo/blob/1d12dd16b1bed4e6a6fe8c1eb9823f89a5ee8e97/addons/point_of_sale/static/src/app/services/pos_store.js#L1229
[3]: https://github.com/odoo/odoo/blob/1d12dd16b1bed4e6a6fe8c1eb9823f89a5ee8e97/addons/point_of_sale/static/src/app/services/pos_store.js#L1198
[4]: https://github.com/odoo/odoo/blob/45e300461c299796313c46c469b548cc438a18cd/addons/point_of_sale/static/src/app/models/pos_order.js#L493
[5]: https://github.com/odoo/odoo/blob/76a4fb579c34e0d82b07a44cbca3679f4cc2ac74/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js#L136

opw-4922152
opw-4938953
