### PR TITLE
[FIX] im_livechat: fix session navigation tour

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
@@ -4,30 +4,6 @@ import { delay } from "@web/core/utils/concurrency";
 registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour", {
     steps: () => [
         {
-            isActive: ["enterprise"],
-            content: "open command palette",
-            trigger: ".o_home_menu",
-            run: "click && press ctrl+k",
-        },
-        {
-            isActive: ["community"],
-            content: "open command palette",
-            trigger: "body:has(.o_action_manager)",
-            run: "press ctrl+k",
-        },
-        {
-            trigger: ".o_command_palette_search input",
-            run: "fill /",
-        },
-        {
-            trigger: ".o_command_palette_search input",
-            run: "fill Live Chat",
-        },
-        {
-            trigger: ".o_command:contains(Sessions History)",
-            run: "click",
-        },
-        {
             trigger: "button.o_switch_view.o_list",
             run: "click",
         },
@@ -52,7 +28,7 @@ registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour
         {
             trigger: ".o-mail-DiscussSidebar-item:contains(Visitor).o-active",
             async run(helpers) {
-                await delay(0)
+                await delay(0);
                 await helpers.click();
             },
         },

--- a/addons/im_livechat/tests/test_session_history.py
+++ b/addons/im_livechat/tests/test_session_history.py
@@ -18,4 +18,9 @@ class TestImLivechatSessionHistory(TestImLivechatCommon):
         })
         channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         channel.with_user(operator).message_post(body="Hello, how can I help you?")
-        self.start_tour("/odoo", "im_livechat_history_back_and_forth_tour", login="operator")
+        action = self.env.ref("im_livechat.discuss_channel_action_from_livechat_channel")
+        self.start_tour(
+            f"/odoo/livechat/{self.livechat_channel.id}/action-{action.id}",
+            "im_livechat_history_back_and_forth_tour",
+            login="operator",
+        )


### PR DESCRIPTION
The `test_session_history_navigation_back_and_forth` test sometimes fail. The test ensures we can navigate between the session list view and discuss using the browser history.

To do so, the tour first accesses the list view using the command palette. However, command palette sometimes doesn't open.

The command palette part of the tour is useless as the view can directly be accessed by passing the correct url to the `start_tour` function.

This commit removes the command palette part of the tour thus fixing the issue.

fixes runbot-108129

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
