### PR TITLE
[FIX] l10n_pe: Display translations correctly

### DIFF
--- a/addons/l10n_pe/i18n/es_419.po
+++ b/addons/l10n_pe/i18n/es_419.po
@@ -485,7 +485,7 @@ msgstr "Apongo"
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_isc_type__02
 msgid "Application of the Fixed Amount"
-msgstr "Aplicación del importe fijo"
+msgstr "Aplicación del Monto Fijo (Sistema específico, bienes en el apéndice III, Apéndice IV, lit. B – T.U.O IGV e ISC)"
 
 #. module: l10n_pe
 #: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_020504
@@ -7345,7 +7345,7 @@ msgstr "Requena"
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_isc_type__03
 msgid "Retail Price System"
-msgstr "Sistema de precios al por menor"
+msgstr "Sistema de Precios de Venta al Público (Apéndice IV, lit. C – T.U.O IGV e ISC)"
 
 #. module: l10n_pe
 #: model:l10n_pe.res.city.district,name:l10n_pe.district_pe_150714
@@ -8938,7 +8938,7 @@ msgstr "Suyo"
 #. module: l10n_pe
 #: model:ir.model.fields.selection,name:l10n_pe.selection__account_tax__l10n_pe_edi_isc_type__01
 msgid "System to value"
-msgstr "Sistema para valorar"
+msgstr "Sistema al valor (Apéndice IV, lit. A – T.U.O IGV e ISC)"
 
 #. module: l10n_pe
 #: model:res.city,name:l10n_pe.city_pe_1309


### PR DESCRIPTION
To reproduce:
=============
-1 Install Peru accounting
-2 Change language to Spanish PE
-3 Go to add a new Tax form
-4 Change code to ISC
-5 Debug mode you will see the selections are not well translated

Problem:
========
Translation team requested to change selections translations

Solution:
=========
Update translations

opw-4954487
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
