### PR TITLE
[FIX] l10n_in_sale: error when creating down payment invoice with reseller

### DIFF
--- a/addons/l10n_in_sale/wizard/sale_make_invoice_advance.py
+++ b/addons/l10n_in_sale/wizard/sale_make_invoice_advance.py
@@ -12,5 +12,5 @@ class SaleAdvancePaymentInv(models.TransientModel):
         if order.country_code == 'IN':
             res['l10n_in_gst_treatment'] = order.l10n_in_gst_treatment
         if order.l10n_in_reseller_partner_id:
-            res['l10n_in_reseller_partner_id'] = order.l10n_in_reseller_partner_id
+            res['l10n_in_reseller_partner_id'] = order.l10n_in_reseller_partner_id.id
         return res


### PR DESCRIPTION
**Issue**
When creating a down payment invoice for a quotation that includes a reseller, an error is raised and the operation is aborted.

**Steps to Reproduce**
1. Install Accounting, Studio, and l10n_in_sale
2. Open the Quotation view in Studio
3. Set the "Referrer" field (i.e., l10n_in_reseller_partner_id) to be always visible and remove group restrictions
4. Create a new quotation and set a reseller in the Referrer field
5. Confirm the quotation
6. Click "Create Invoice"
7. Choose "Down Payment (percentage)" with 10%
8. Click "Create Draft"

**Root Cause**
The `_prepare_invoice_values()` method was assigning the full `res.partner` record to the `l10n_in_reseller_partner_id` field instead of its ID. Since the `account.move` model expects an integer ID for many2one fields, this caused a `psycopg2.ProgrammingError` due to the database adapter not being able to serialize a recordset.

**Fix**
Ensure the value passed to l10n_in_reseller_partner_id is the .id of the partner record, not the recordset itself.

Opw-4899919
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
