### PR TITLE
[FIX] hr_attendance : Avoid checking password if the user is public

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -98,7 +98,7 @@ class HrAttendance(http.Controller):
             has_password = self.has_password()
             if not from_trial_mode and has_password:
                 request.session.logout(keep_db=True)
-            if (from_trial_mode or not has_password):
+            if (from_trial_mode or (not has_password and not request.env.user.is_public)):
                 kiosk_mode = "settings"
             else:
                 kiosk_mode = company.attendance_kiosk_mode


### PR DESCRIPTION
### Steps to reproduce:
	- Install Attendance and Website modules
	- Have a company 'Company A'
	- Create a new company 'Company B'
	- Set the Attendance kiosk mode to 'Barcode / RFID' for both companies
	- Update all websites to be related to Company B
	- Go to the Kiosk mode for Company B
	- Notice it makes you choose between the 3 check in types while we only chose 'Barcode / RFID'

### Cause:
When openning the kiosk mode it will check if the database is a trial one or if the user doesn't have a password and if so we assume that the database is a trial one. If it is a trial database we set the kiosk mode as 'settings' which shows all check in types when openning the kiosk mode.

https://github.com/odoo/odoo/blob/9ec4e0d3c5f1aaff0b36dc5def1e69b8285c3be1/addons/hr_attendance/controllers/main.py#L101-L102

https://github.com/odoo/odoo/blob/9ec4e0d3c5f1aaff0b36dc5def1e69b8285c3be1/addons/hr_attendance/controllers/main.py#L185-L196

When creating a new company and set website for it we create a public user for this company and normally we don't set password for this user as no one is gonna login using it.

### Fix:
We check if the user doesn't have a password and if he is not a public user. As we assume that if he is a public user he won't have a password anyways.

opw-4916329