### PR TITLE
[FIX] account: Only consider lines with suspense account on widget

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1385,6 +1385,7 @@ class AccountMove(models.Model):
                     ])),
                     ('balance', '>' if move.is_inbound() else '<', 0.0),
                     ('statement_line_id', '!=', False),
+                    ('move_id.line_ids', 'any', [('account_id', '=', move.company_id.account_journal_suspense_account_id.id)])
                 ])
 
             payments_widget_vals = {

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -5762,6 +5762,9 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
             partials.exchange_move_id.id: 1666.67,
         })
 
+        statement_line.set_account_bank_statement_line(statement_line.line_ids[-1].id, self.company_data['default_account_revenue'].id)
+        self.assertFalse(invoice.invoice_outstanding_credits_debits_widget, "Only statement lines with suspense account should be considered")
+
     def test_reconcile_refund_with_bank_statement_line(self):
         """
         Test reconcile refund with bank statement line. with foreign currency on the refund.


### PR DESCRIPTION
Create a bank statement line with partner A
Assign it to a random account
Create an invoice with partner A
Confirm it.
=> The statement line appears

It should not, it has been assigned.
Only lines that are still on the suspense account should be taken into account




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
