### PR TITLE
[IMP] l10n_jo_edi: clean up buyer phone for e‑invoices

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -1,4 +1,5 @@
 from lxml import etree
+import re
 from types import SimpleNamespace
 
 from odoo import models
@@ -104,6 +105,9 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
 
         vals['monetary_total_vals']['tax_inclusive_amount'] = vals['monetary_total_vals']['payable_amount'] = tax_inclusive_amount
         vals['monetary_total_vals']['tax_exclusive_amount'] = tax_exclusive_amount
+
+    def _sanitize_phone(self, raw):
+        return re.sub(r'[^0-9]', '', raw or '')[:15]
 
     ########################################################
     # overriding vals methods of account_edi_xml_ubl_20 file
@@ -406,7 +410,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
             'accounting_customer_party_vals': {
                 'party_vals': self._get_empty_party_vals() if is_refund else self._get_partner_party_vals(customer, role='customer'),
                 'accounting_contact': {
-                    'telephone': '' if is_refund else invoice.partner_id.phone or invoice.partner_id.mobile,
+                    'telephone': '' if is_refund else self._sanitize_phone(invoice.partner_id.phone or invoice.partner_id.mobile),
                 },
             },
             'seller_supplier_party_vals': {

--- a/addons/l10n_jo_edi/tests/test_files/type_1.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_1.xml
@@ -57,7 +57,7 @@
 			</cac:PartyLegalEntity>
 		</cac:Party>
 		<cac:AccountingContact>
-			<cbc:Telephone>+962 795-5585-949</cbc:Telephone>
+			<cbc:Telephone>9627955585949</cbc:Telephone>
 		</cac:AccountingContact>
 	</cac:AccountingCustomerParty>
 	<cac:SellerSupplierParty>

--- a/addons/l10n_jo_edi/tests/test_files/type_3.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_3.xml
@@ -57,7 +57,7 @@
 			</cac:PartyLegalEntity>
 		</cac:Party>
 		<cac:AccountingContact>
-			<cbc:Telephone>+962 795-5585-949</cbc:Telephone>
+			<cbc:Telephone>9627955585949</cbc:Telephone>
 		</cac:AccountingContact>
 	</cac:AccountingCustomerParty>
 	<cac:SellerSupplierParty>

--- a/addons/l10n_jo_edi/tests/test_files/type_5.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_5.xml
@@ -56,7 +56,7 @@
 			</cac:PartyLegalEntity>
 		</cac:Party>
 		<cac:AccountingContact>
-			<cbc:Telephone>+962 795-5585-949</cbc:Telephone>
+			<cbc:Telephone>9627955585949</cbc:Telephone>
 		</cac:AccountingContact>
 	</cac:AccountingCustomerParty>
 	<cac:SellerSupplierParty>

--- a/addons/l10n_jo_edi/tests/test_files/type_7.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_7.xml
@@ -56,7 +56,7 @@
             </cac:PartyLegalEntity>
         </cac:Party>
         <cac:AccountingContact>
-            <cbc:Telephone>+962 795-5585-949</cbc:Telephone>
+            <cbc:Telephone>9627955585949</cbc:Telephone>
         </cac:AccountingContact>
     </cac:AccountingCustomerParty>
     <cac:SellerSupplierParty>

--- a/addons/l10n_jo_edi/tests/test_files/type_8.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_8.xml
@@ -54,7 +54,7 @@
             </cac:PartyLegalEntity>
         </cac:Party>
         <cac:AccountingContact>
-            <cbc:Telephone>+962 795-5585-949</cbc:Telephone>
+            <cbc:Telephone>9627955585949</cbc:Telephone>
         </cac:AccountingContact>
     </cac:AccountingCustomerParty>
     <cac:SellerSupplierParty>


### PR DESCRIPTION
Strip all non-digit characters from the partner phone so that the UBL XML complies with JoFotara’s XSD which requires `^[0-9]{1,15}$`. This prevents validation errors when submitting e‑invoices.

Steps to reproduce:
- Install l10n_jo_edi
- Set partner phone to “+962 79 123 4567”
- Create & post an invoice
- Send to JoFotara

OPW-[4945688](https://www.odoo.com/odoo/my-tasks/4945688)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
