### PR TITLE
[FIX] mail: fix next activity type filtering with keep_done=True

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -147,7 +147,7 @@ class MailActivityMixin(models.AbstractModel):
     def _inverse_activity_type_id(self):
         for record in self:
             if record.activity_type_id:
-                activities = record.activity_ids.filtesored(lambda a: a.state != 'done')
+                activities = record.activity_ids.filtered(lambda a: a.state != 'done')
                 if activities:
                     first = min(activities, key=lambda a: a.date_deadline or fields.Date.max)
                     first.activity_type_id = record.activity_type_id

--- a/addons/mail/static/tests/mock_server/mock_models/mail_activity_mixin.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_activity_mixin.js
@@ -1,0 +1,33 @@
+import { fields } from "@web/../tests/web_test_helpers";
+
+export function makeMailActivityMixin(modelClass) {
+    return class extends modelClass {
+        activity_type_id = fields.Many2one({
+            relation: "mail.activity.type",
+            string: "Next Activity Type",
+            compute: "_compute_activity_type_id",
+        });
+
+        _compute_activity_type_id() {
+            for (const record of this) {
+                const activities =
+                    record.activity_ids?.filter((activity) => {
+                        const activityRecord = this.env["mail.activity"].browse(activity)[0];
+                        return activityRecord?.state !== "done";
+                    }) || [];
+
+                if (activities.length > 0) {
+                    const activityRecords = this.env["mail.activity"].browse(activities);
+                    const firstActivity = activityRecords.reduce((earliest, current) => {
+                        const earliestDate = earliest.date_deadline || "9999-12-31";
+                        const currentDate = current.date_deadline || "9999-12-31";
+                        return currentDate < earliestDate ? current : earliest;
+                    });
+                    record.activity_type_id = firstActivity.activity_type_id;
+                } else {
+                    record.activity_type_id = false;
+                }
+            }
+        }
+    };
+}

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -1,4 +1,5 @@
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+import { makeMailActivityMixin } from "@mail/../tests/mock_server/mock_models/mail_activity_mixin";
 import {
     fields,
     getKwArgs,
@@ -9,7 +10,7 @@ import {
 
 /** @typedef {import("@web/../tests/web_test_helpers").ModelRecord} ModelRecord */
 
-export class ResPartner extends webModels.ResPartner {
+class ResPartner extends webModels.ResPartner {
     _inherit = ["mail.thread"];
 
     description = fields.Char({ string: "Description" });
@@ -388,3 +389,6 @@ export class ResPartner extends webModels.ResPartner {
         return [this.browse(this.env.user.partner_id)[0], null];
     }
 }
+
+const ResPartnerActivityMixin = makeMailActivityMixin(ResPartner);
+export { ResPartnerActivityMixin as ResPartner };

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -1,9 +1,10 @@
 import { DISCUSS_ACTION_ID, mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+import { makeMailActivityMixin } from "@mail/../tests/mock_server/mock_models/mail_activity_mixin";
 
 import { fields, makeKwArgs, serverState, webModels } from "@web/../tests/web_test_helpers";
 import { serializeDate, today } from "@web/core/l10n/dates";
 
-export class ResUsers extends webModels.ResUsers {
+class ResUsers extends webModels.ResUsers {
     im_status = fields.Char({ default: "online" });
     notification_type = fields.Selection({
         selection: [
@@ -185,3 +186,6 @@ export class ResUsers extends webModels.ResUsers {
         return Object.values(userActivitiesByModelName);
     }
 }
+
+const ResUsersActivityMixin = makeMailActivityMixin(ResUsers);
+export { ResUsersActivityMixin as ResUsers };


### PR DESCRIPTION
Prior to this fix, filtering on "Next Activity Type" incorrectly
included records with only done activities when the activity type had
keep_done=True. This occurred because activity_type_id was a related
field using _search_related, which doesn't re-evaluate active_test in
nested queries.

Steps to reproduce:
1. Set keep_done=True on an activity type (e.g., "To-do")
2. Complete a "To-do" activity on a record
3. Filter by "Next Activity Type = To-do"
Result: The record appears despite having only done activities

Solution:
Changed activity_type_id from a related field to a computed field with
inverse and search methods. The compute method selects the earliest
non-done activity by deadline, and the search method filters records
to only those with active activities of the specified type.

Mock server updates:
Created makeMailActivityMixin to replicate the compute behavior in
JavaScript tests to match the new computed field logic.

opw-4843918