### PR TITLE
[FIX] partnership: show empty grades on grouped partner kanban view

### DIFF
--- a/addons/partnership/models/res_partner.py
+++ b/addons/partnership/models/res_partner.py
@@ -7,7 +7,7 @@ from odoo.exceptions import UserError
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    grade_id = fields.Many2one('res.partner.grade', 'Partner Level', tracking=True)
+    grade_id = fields.Many2one('res.partner.grade', 'Partner Level', tracking=True, group_expand='_read_group_expand_full')
 
     def write(self, vals):
         if vals.get('grade_id'):


### PR DESCRIPTION
This PR adds group_expand to the grade_id field of a partner to show all grades in a kanban view, even it they are empty.
