### PR TITLE
[FIX] l10n_es_edi_sii: Update name Retenciones IRPF 24%

### DIFF
--- a/addons/l10n_es_edi_sii/data/account_tax_data.xml
+++ b/addons/l10n_es_edi_sii/data/account_tax_data.xml
@@ -296,7 +296,7 @@
         <field name="l10n_es_type">retencion</field>
     </record>
     <record id="l10n_es.account_tax_template_p_irpf24" model="account.tax.template">
-        <field name="name">Retenciones IRPF 14%</field>
+        <field name="name">Retenciones IRPF 24%</field>
         <field name="l10n_es_type">retencion</field>
     </record>
     <record id="l10n_es.account_tax_template_s_irpf20" model="account.tax.template">


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

The tax template with xml_id "account_tax_template_p_irpf24" has the name "Retenciones IRPF 24%" in l10n_es but it is updated in l10n_es_edi_sii to "Retenciones IRPF 14%" but this updating is wrong.

The 14% rate doesn't exist as withholding tax. https://sede.agenciatributaria.gob.es/Sede/ayuda/manuales-videos-folletos/manuales-practicos/folleto-actividades-economicas/7-otras-obligaciones-fiscales-retenciones/7_1-cuadro-relacion-tipos-retencion-porcentaje.html

Current behavior before PR:

1. Create a database in version 16.
2. Activate module "Spain - Accounting (PGCE 2008)" (l10n_es).
3. Create new company with Spain as country.
4. Set any chart template from spanish localization, for example PGCE PYMEs 2008.
5. Go to Accounting > Configuration > Taxes and search tax "Retenciones IRPF 24%". You can find it because the tax exists.
6. Actiave module "Spain - SII EDI Suministro de Libros" (l10n_es_edi_sii).
7. Create new company with Spain as country again.
8. Set any chart template from spanish localization for this new company, for example PGCE PYMEs 2008.
9. Go to Accounting > Configuration > Taxes and search tax "Retenciones IRPF 24%". Now this can't be found because the name it's different. You can look for "Retenciones IRPF 14%".

Desired behavior after PR is merged:

If I activate the module "Spain - SII EDI Suministro de Libros" (l10n_es_edi_sii) and I create a new company, I should have the same taxes.

https://www.odoo.com/es_ES/my/tasks/4968916

@jco-odoo please review. Thank you.

MT-10913 @moduon


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
