### PR TITLE
eCommerce categories in the mega menu fix

### DIFF
--- a/addons/website_sale/static/src/website_builder/mega_menu_option.xml
+++ b/addons/website_sale/static/src/website_builder/mega_menu_option.xml
@@ -3,7 +3,7 @@
 
 <t t-inherit="website.MegaMenuOption" t-inherit-mode="extension">
     <xpath expr="//BuilderRow[last()]" position="after">
-        <BuilderRow t-if="productCategories" label.translate="eCommerce Categories">
+        <BuilderRow t-if="productCategories.length" label.translate="eCommerce Categories">
             <div class="o_switch ms-4">
                 <BuilderCheckbox id="'fetch_ecom_categories_opt'"
                     classAction="'fetchEcomCategories'"


### PR DESCRIPTION
To reproduce the issue:
1. Delete all ecommerce categories if you have any.
2. Open website and add a Mega Menu
3. Start editing and click on the mega Menu
4. eCommerce categories option is available which shouldn't be the
case as we currently don't have any category.

This commmit follows the [html_builder refactoring].
Related to task-4367641

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb