### PR TITLE
[FIX] html_editor: fix misaligned transform container during scroll

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -179,6 +179,7 @@ export class ImageTransformation extends Component {
         settings.angle = Math.round(settings.angle);
         settings.translatex = Math.round(settings.translatex);
         settings.translatey = Math.round(settings.translatey);
+        this.transfo.settings.pos = this.getOffset(this.image);
         this.positionTransfoContainer();
         this.props.onChange();
     }


### PR DESCRIPTION
Problem:
While transforming an image, the transform container can become incorrectly positioned.

Cause:
The transform container calculates its `top` and `left` positions on `mousedown`. However, the image’s `top` position may change during transformation due to scrolling, leading to a mismatch between the image and the transform container.

Solution:
Recalculate the transform container position (`pos`) on every `mousemove` to ensure alignment.

Steps to reproduce:
- Sales > Create a new Sales Order
- In the description, add an image
- Transform the image until the parent becomes scrollable 
-> The transform container becomes misaligned

opw-4968922


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
