### PR TITLE
[IMP] iot_drivers: add uptime stats on homepage

### DIFF
--- a/addons/iot_drivers/controllers/homepage.py
+++ b/addons/iot_drivers/controllers/homepage.py
@@ -162,6 +162,8 @@ class IotBoxOwlHomePage(http.Controller):
         six_terminal = helpers.get_conf('six_payment_terminal') or 'Not Configured'
         network_qr_codes = wifi.generate_network_qr_codes() if platform.system() == 'Linux' else {}
         odoo_server_url = helpers.get_odoo_server_url() or ''
+        odoo_uptime_seconds = time.monotonic() - helpers.odoo_start_time
+        system_uptime_seconds = time.monotonic() - helpers.system_start_time
 
         return json.dumps({
             'db_uuid': helpers.get_conf('db_uuid'),
@@ -179,6 +181,8 @@ class IotBoxOwlHomePage(http.Controller):
             'network_interfaces': network_interfaces,
             'version': helpers.get_version(),
             'system': platform.system(),
+            'odoo_uptime_seconds': odoo_uptime_seconds,
+            'system_uptime_seconds': system_uptime_seconds,
             'certificate_end_date': certificate.get_certificate_end_date(),
             'wifi_ssid': helpers.get_conf('wifi_ssid'),
             'qr_code_wifi': network_qr_codes.get('qr_wifi'),

--- a/addons/iot_drivers/static/src/app/components/FooterButtons.js
+++ b/addons/iot_drivers/static/src/app/components/FooterButtons.js
@@ -4,6 +4,7 @@ import useStore from "../hooks/useStore.js";
 import { CredentialDialog } from "./dialog/CredentialDialog.js";
 import { HandlerDialog } from "./dialog/HandlerDialog.js";
 import { RemoteDebugDialog } from "./dialog/RemoteDebugDialog.js";
+import { TimeDialog } from "./dialog/TimeDialog.js";
 
 const { Component, xml } = owl;
 
@@ -13,6 +14,7 @@ export class FooterButtons extends Component {
         RemoteDebugDialog,
         HandlerDialog,
         CredentialDialog,
+        TimeDialog,
     };
 
     setup() {
@@ -37,6 +39,7 @@ export class FooterButtons extends Component {
         <CredentialDialog t-if="this.store.advanced" />
         <HandlerDialog t-if="this.store.advanced" />
         <a t-if="this.store.advanced" class="btn btn-primary btn-sm" t-att-href="this.url + '/logs'" target="_blank">View Logs</a>
+        <TimeDialog/>
     </div>
   `;
 }

--- a/addons/iot_drivers/static/src/app/components/dialog/TimeDialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/TimeDialog.js
@@ -1,0 +1,74 @@
+/* global owl */
+
+import useStore from "../../hooks/useStore.js";
+import { BootstrapDialog } from "./BootstrapDialog.js";
+
+const { Component, useState, xml } = owl;
+
+export class TimeDialog extends Component {
+    static props = {};
+    static components = { BootstrapDialog };
+
+    setup() {
+        this.store = useStore();
+        this.state = useState({
+            odooUptimeSeconds: this.store.base.odoo_uptime_seconds,
+            systemUptimeSeconds: this.store.base.system_uptime_seconds,
+        });
+        setInterval(() => {
+            this.state.odooUptimeSeconds += 1;
+            this.state.systemUptimeSeconds += 1;
+        }, 1000);
+    }
+
+    startDateFromSeconds(uptimeInSeconds) {
+        const currentTimeMs = new Date().getTime();
+        const odooUptimeMs = uptimeInSeconds * 1000;
+        return new Date(currentTimeMs - odooUptimeMs).toUTCString();
+    }
+
+    secondsToHumanReadable(periodInSeconds) {
+        const SECONDS_PER_HOUR = 3600;
+        const SECONDS_PER_DAY = SECONDS_PER_HOUR * 24;
+        const days = Math.floor(periodInSeconds / SECONDS_PER_DAY);
+        periodInSeconds = periodInSeconds % SECONDS_PER_DAY;
+        const hours = Math.floor(periodInSeconds / SECONDS_PER_HOUR);
+        periodInSeconds = periodInSeconds % SECONDS_PER_HOUR;
+        const minutes = Math.floor(periodInSeconds / 60);
+        const seconds = Math.floor(periodInSeconds % 60);
+
+        const formatAmount = (amount, name) => `${amount} ${name}${amount === 1 ? "" : "s"}`;
+        const timeParts = [
+            formatAmount(days, "day"),
+            formatAmount(hours, "hour"),
+            formatAmount(minutes, "minute"),
+            formatAmount(seconds, "second"),
+        ];
+        return timeParts.join(", ");
+    }
+
+    static template = xml`
+        <BootstrapDialog identifier="'time-dialog'" btnName="'View Uptime'">
+            <t t-set-slot="header">
+                IoT Box Uptime
+            </t>
+            <t t-set-slot="body">
+                <div class="d-flex flex-column gap-4">
+                  <div>
+                    <h5>Odoo Service</h5>
+                    <div>Running for <b t-out="secondsToHumanReadable(state.odooUptimeSeconds)"/></div>
+                    <div class="text-secondary">Started at <b t-out="startDateFromSeconds(state.odooUptimeSeconds)"/></div>
+                  </div>
+                  <div t-if="store.isLinux">
+                    <h5>Operating System</h5>
+                    <div>Running for <b t-out="secondsToHumanReadable(state.systemUptimeSeconds)"/></div>
+                    <div class="text-secondary">Started at <b t-out="startDateFromSeconds(state.systemUptimeSeconds)"/></div>
+                  </div>
+                </div>
+            </t>
+            <t t-set-slot="footer">
+                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Close</button>
+            </t>
+        </BootstrapDialog>
+    `;
+}

--- a/addons/iot_drivers/tools/helpers.py
+++ b/addons/iot_drivers/tools/helpers.py
@@ -573,6 +573,13 @@ def reset_log_level():
         })
 
 
+def _get_system_uptime():
+    if platform.system() == 'Windows':
+        return 0
+    uptime_string = read_file_first_line("/proc/uptime")
+    return float(uptime_string.split(" ")[0])
+
+
 def _get_raspberry_pi_model():
     """Returns the Raspberry Pi model number (e.g. 4) as an integer
     Returns 0 if the model can't be determined, or -1 if called on Windows
@@ -587,3 +594,5 @@ def _get_raspberry_pi_model():
 
 
 raspberry_pi_model = _get_raspberry_pi_model()
+odoo_start_time = time.monotonic()
+system_start_time = odoo_start_time - _get_system_uptime()


### PR DESCRIPTION
Before this commit, the only way to check how long the IoT box had been running was to SSH into it and run a command.

After this commit, the uptime of both the Odoo service and the OS is available in the homepage. On Windows only the Odoo service time is shown.

task-4954737

<img width="651" height="600" alt="image" src="https://github.com/user-attachments/assets/f3144545-0696-4dd9-937b-0e82e196def3" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
