### PR TITLE
[FIX] account_edi_ubl_cii: Prevent None value in passed cac:AllowanceCharge node

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -884,7 +884,9 @@ class AccountEdiXmlUbl_20(models.AbstractModel):
 
     def _add_document_line_allowance_charge_nodes(self, line_node, vals):
         if vals['document_type'] not in {'credit_note', 'debit_note'}:
-            line_node['cac:AllowanceCharge'] = [self._get_line_discount_allowance_charge_node(vals)]
+            line_node['cac:AllowanceCharge'] = []
+            if node := self._get_line_discount_allowance_charge_node(vals):
+                line_node['cac:AllowanceCharge'].append(node)
             if vals['fixed_taxes_as_allowance_charges']:
                 line_node['cac:AllowanceCharge'].extend(self._get_line_fixed_tax_allowance_charge_nodes(vals))
 

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
@@ -81,6 +81,8 @@ class AccountEdiXmlUbl_21(models.AbstractModel):
             }
 
     def _add_document_line_allowance_charge_nodes(self, line_node, vals):
-        line_node['cac:AllowanceCharge'] = [self._get_line_discount_allowance_charge_node(vals)]
+        line_node['cac:AllowanceCharge'] = []
+        if node := self._get_line_discount_allowance_charge_node(vals):
+            line_node['cac:AllowanceCharge'].append(node)
         if vals['fixed_taxes_as_allowance_charges']:
             line_node['cac:AllowanceCharge'].extend(self._get_line_fixed_tax_allowance_charge_nodes(vals))


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 

Fixes an issue in the _add_document_line_allowance_charge_nodes function in the account_edi_ubl_cii module. Previously, the function assigns a list containing None to the 'cac:AllowanceCharge' key when the discount node was not applicable. This led to errors when attempting to assign values to 'cbc:AllowanceChargeReasonCode', as accessing properties on a None object will cause an error in l10n_tr_nilvera_einvoice under the _add_document_line_allowance_charge_nodes function.

TypeError: 'NoneType' object does not support item assignment

Current behavior before PR:
The _add_document_line_allowance_charge_nodes function throws an error when generating or sending an E-Invoice to Nilvera, due to [None] being present in 'cac:AllowanceCharge'. 

Desired behavior after PR is merged: 
Ensure 'cac:AllowanceCharge' is only added to line_node when the returned node is valid or just an empty list. This avoids [None] values in the list and prevents assignment errors.

Task: 4886128

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
