### PR TITLE
[IMP] spreadsheet: improve global filter dialog

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.scss
+++ b/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.scss
@@ -1,0 +1,6 @@
+.o-filters-search-dialog{
+    .o-filter-clear {
+        width: 8%;
+        height: 36px;
+    }
+}

--- a/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.xml
@@ -1,10 +1,14 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
     <t t-name="spreadsheet_dashboard.FiltersSearchDialog">
         <Dialog title.translate="Global Filters" size="md">
             <div class="d-flex flex-column o-filters-search-dialog">
-                <div t-foreach="state.activeFilters" t-as="item" t-key="item_index" class="d-flex o-filter-item align-items-center">
+                <div t-foreach="state.filtersAndValues"
+                     t-as="item"
+                     t-key="item_index"
+                     class="d-flex o-filter-item align-items-center"
+                     t-att-data-id="item.globalFilter.id">
                     <div class="me-1 w-25">
                         <t t-esc="getTranslatedFilterLabel(item.globalFilter)"/>
                     </div>
@@ -19,31 +23,22 @@
                                  model="props.model"
                                  setGlobalFilterValue="(id, value) => this.setGlobalFilterValue(item, value)"
                                  globalFilterValue="item.value"/>
-                    <button class="btn btn-link px-2 text-danger fs-4" t-on-click="() => this.removeFilter(item.globalFilter.id)">
-                        <i class="fa fa-trash"></i>
-                    </button>
-                </div>
-                <div class="d-flex">
-                    <Dropdown t-if="hasUnusedGlobalFilters">
-                        <button class="btn btn-link o-add-global-filter">
-                            Add filter
+                    <div class="o-filter-clear">
+                        <button t-if="filterHasClearButton(item)"
+                            class="btn btn-link px-2 text-danger fs-4"
+                            t-on-click="() => this.clearFilter(item.globalFilter.id)">
+                            <i class="fa fa-times"></i>
                         </button>
-                        <t t-set-slot="content">
-                            <t t-foreach="unusedGlobalFilters" t-as="filter" t-key="filter.id">
-                                <DropdownItem onSelected="() => this.activateFilter(filter)">
-                                    <span class="o-add-global-filter-label" t-esc="getTranslatedFilterLabel(filter)"/>
-                                </DropdownItem>
-                            </t>
-                        </t>
-                    </Dropdown>
-                    <a href="#" t-if="props.openFiltersEditor" class="pt-2 ps-4 o-edit-global-filters" t-on-click="() => this.props.openFiltersEditor()">
-                        <i class="fa fa-pencil"/>
-                        Edit filters
-                    </a>
+                    </div>
                 </div>
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="onConfirm">Filter</button>
+                <button t-if="props.openFiltersEditor"
+                        class="btn btn-secondary o-edit-global-filters"
+                        t-on-click="props.openFiltersEditor">
+                    Edit
+                </button>
                 <button class="btn btn-secondary" t-on-click="onDiscard">Discard</button>
             </t>
         </Dialog>

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -816,7 +816,7 @@ export function isSetOperator(operator) {
 }
 
 export function getDefaultValue(type) {
-    if (type === "date") {
+    if (type === "date" || type === "boolean") {
         return undefined;
     }
     const defaultOperator = FILTERS_BEHAVIORS[type][0].operators[0];

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -218,7 +218,7 @@ test("Can clear filter date filter value that defaults to current period", async
     const year = luxon.DateTime.local().year;
     expect(".o_control_panel_actions .o_facet_value").toHaveText(String(year));
     await contains(".o_searchview_facet_label").click();
-    await contains(".o-filter-value input").click();
+    await contains('.o-filter-item[data-id="2"] input').click();
     await contains(".o-dropdown-item[data-id='year'] .btn-previous").click();
     await contains(".modal-footer .btn-primary").click();
 
@@ -359,9 +359,6 @@ test("Global filter with same id is not shared between dashboards", async functi
     expect(".o_searchview_facet").toHaveCount(0);
     await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
 
-    await contains(".o-filters-search-dialog button.dropdown-toggle").click();
-    await contains(".o-dropdown-item").click();
-
     await contains(".o-autocomplete--input.o_input").click();
     expect(".o-filter-value .o_tag_badge_text").toHaveCount(0);
     await contains(".dropdown-item:first").click();
@@ -399,11 +396,6 @@ test("Can add a new global filter from the search bar", async function () {
     await createSpreadsheetDashboard({ serverData });
 
     await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
-    expect(".o-filters-search-dialog button.dropdown-toggle").toHaveText("Add filter");
-    await contains(".o-filters-search-dialog button.dropdown-toggle").click();
-    await contains(".o-dropdown-item").click();
-
-    expect(".o-filters-search-dialog button.dropdown-toggle").toHaveCount(0);
 
     expect(".o-autocomplete--input.o_input").toHaveCount(1);
     expect(".o-autocomplete--input.o_input").toHaveValue("");
@@ -414,32 +406,6 @@ test("Can add a new global filter from the search bar", async function () {
     expect(".o_searchview_facet").toHaveCount(1);
     expect(".o_searchview_facet .o_searchview_facet_label").toHaveText("Relation Filter");
     expect(".o_searchview_facet .o_facet_value").toHaveText("xphone");
-});
-
-test("Can remove a global filter from the dialog", async function () {
-    const spreadsheetData = {
-        globalFilters: [
-            {
-                id: "1",
-                type: "relation",
-                label: "Relation Filter",
-                modelName: "product",
-                defaultValue: { operator: "in", ids: [37] }, // xphone
-            },
-        ],
-    };
-    const serverData = getServerData(spreadsheetData);
-    await createSpreadsheetDashboard({ serverData });
-
-    expect(".o_searchview_facet").toHaveCount(1);
-    expect(".o_searchview_facet .o_searchview_facet_label").toHaveText("Relation Filter");
-    expect(".o_searchview_facet .o_facet_value").toHaveText("xphone");
-
-    await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
-    await contains(".fa-trash").click();
-    await contains(".modal-footer .btn-primary").click();
-
-    expect(".o_searchview_facet").toHaveCount(0);
 });
 
 test("Can open the dialog by clicking on a facet", async function () {
@@ -498,8 +464,6 @@ test("Changes of global filters are not dispatched while inside the dialog", asy
     expect(model.getters.getGlobalFilterValue("1")).toBe(undefined);
 
     await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
-    await contains(".o-filters-search-dialog button.dropdown-toggle").click();
-    await contains(".o-dropdown-item").click();
 
     await contains(".o-autocomplete--input.o_input").click();
     await contains(".o-autocomplete--dropdown-item").click();


### PR DESCRIPTION
This commit make it so the global filter dialog always displays all of the filter, instead of having to click on the "Add filter" button.

Task: [4948791](https://www.odoo.com/odoo/2328/tasks/4948791)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
