### PR TITLE
[FIX] pos_restaurant: order synchronization test

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -6,7 +6,7 @@ import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
-import { notify } from "@pos_restaurant/../tests/tours/utils/devices_synchronization";
+import * as DeviceSynchronization from "@pos_restaurant/../tests/tours/utils/devices_synchronization";
 
 registry.category("web_tour.tours").add("PosResTicketScreenTour", {
     steps: () =>
@@ -56,16 +56,18 @@ registry.category("web_tour.tours").add("OrderSynchronisationTour", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            notify(),
-            Chrome.clickMenuOption("Orders"),
-            TicketScreen.selectFilter("All active orders"),
-            TicketScreen.checkStatus("002", "Ongoing"),
-            Chrome.clickPlanButton(),
-            notify(),
+            DeviceSynchronization.createNewOrderOnTable("4", [
+                ["Coca-Cola", 50],
+                ["Water", 30],
+            ]),
+            FloorScreen.clickTable("4"),
+            ProductScreen.orderLineHas("Coca-Cola", "50.0"),
+            DeviceSynchronization.markOrderAsPaid(),
+            ProductScreen.isShown(),
             Chrome.clickMenuOption("Orders"),
             TicketScreen.selectFilter("Paid"),
-            TicketScreen.checkStatus("002", "Paid"),
-            TicketScreen.selectOrder("002"),
+            TicketScreen.checkStatus("device_sync", "Paid"),
+            TicketScreen.selectOrder("device_sync"),
             TicketScreen.confirmRefund(),
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/utils/devices_synchronization.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/devices_synchronization.js
@@ -1,19 +1,125 @@
 /* global posmodel */
 
-export function notify() {
-    return {
-        trigger: "body",
-        run: async () => {
-            try {
-                const orm = posmodel.env.services.orm;
-                await orm.call("pos.config", "notify_synchronisation", [
-                    odoo.pos_config_id,
-                    odoo.pos_session_id,
-                    0,
-                ]);
-            } catch (error) {
-                console.log(error);
-            }
+const getData = ({ lineProductName, productName, partnerName } = {}) => {
+    const order = posmodel.models["pos.order"].find((o) => o.pos_reference === "device_sync");
+
+    let partner = null;
+    if (partnerName) {
+        partner = posmodel.models["res.partner"].find((p) => p.name === partnerName);
+    }
+
+    let line = null;
+    if (lineProductName) {
+        line = order.lines.find((l) => l.product_id.display_name === lineProductName);
+    }
+
+    let product = null;
+    if (productName) {
+        product = posmodel.models["product.product"].find((p) => p.display_name === productName);
+    }
+
+    return { order, line, product, partner };
+};
+
+const notify = async (orderIds = []) => {
+    const recordIds = {};
+    if (orderIds.lenght) {
+        recordIds["pos.order"] = orderIds;
+    }
+    const orm = posmodel.env.services.orm;
+    await orm.call("pos.config", "notify_synchronisation", [
+        posmodel.config.id,
+        posmodel.session.id,
+        999,
+        recordIds,
+    ]);
+};
+
+const getLineData = (product, order, quantity) => ({
+    name: product.display_name,
+    order_id: order.id,
+    product_id: product.id,
+    price_unit: product.lst_price,
+    price_subtotal: product.lst_price * quantity,
+    price_subtotal_incl: product.lst_price * quantity,
+    discount: 0,
+    qty: quantity,
+});
+
+// In the point-of-sale code, we consider that synchronization is necessary
+// when the write_date of the local order is smaller than that of the server.
+// To prevent the PoS from ignoring our synchronization.
+const writeOnOrder = async (order, data) => {
+    const sec = new Date(order.write_date).getMilliseconds() + 1010;
+    const timeout = Math.ceil(sec - new Date().getMilliseconds(), 0);
+    await new Promise((res) => setTimeout(res, timeout));
+    const orm = posmodel.env.services.orm;
+    await orm.write("pos.order", [order.id], data);
+    await notify([order.id]);
+};
+
+export function markOrderAsPaid() {
+    return [
+        {
+            trigger: "body",
+            run: async () => {
+                const { order } = getData({});
+                await writeOnOrder(order, {
+                    state: "paid",
+                    amount_paid: order.amount_total,
+                    amount_return: 0,
+                    amount_tax: 0,
+                    amount_total: 0,
+                });
+            },
         },
-    };
+    ];
+}
+
+export function createNewOrderOnTable(tableName, productTuple) {
+    return [
+        {
+            trigger: "body",
+            run: async () => {
+                const orm = posmodel.env.services.orm;
+                const prices = {
+                    amount_paid: 0,
+                    amount_return: 0,
+                    amount_tax: 0,
+                    amount_total: 0,
+                };
+                const lines = productTuple.map(([productName, quantity]) => {
+                    const product = posmodel.models["product.product"].find(
+                        (p) => p.display_name === productName
+                    );
+                    const lineData = getLineData(product, false, quantity);
+                    prices.amount_paid += lineData.price_subtotal;
+                    prices.amount_return += lineData.price_subtotal;
+                    return [
+                        0,
+                        0,
+                        {
+                            ...lineData,
+                            price_subtotal: lineData.price_subtotal,
+                            price_subtotal_incl: lineData.price_subtotal_incl,
+                        },
+                    ];
+                });
+                const table = posmodel.models["restaurant.table"].find(
+                    (t) => t.table_number === parseInt(tableName)
+                );
+                const [orderId] = await orm.create("pos.order", [
+                    {
+                        ...prices,
+                        pos_reference: `device_sync`,
+                        config_id: posmodel.config.id,
+                        session_id: posmodel.session.id,
+                        table_id: table.id,
+                        lines,
+                    },
+                ]);
+                await notify([orderId]);
+            },
+        },
+    ];
 }

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -526,45 +526,7 @@ class TestFrontend(TestFrontendCommon):
             First, an ongoing order is created on the server, and verify its presence in the POS UI.
             Then, the order is paid from the server, and confirm if the order state is updated correctly.
         """
-        notify_synchronisation_og = self.env.registry['pos.config'].notify_synchronisation
-        bank_payment_method = self.bank_payment_method
-        assertEqual = self.assertEqual
-
-        def notify_synchronisation_patch(self, session_id, login_number, records={}):
-            orders = self.env['pos.order'].search([('session_id', '=', session_id)])
-            if not orders:
-                product_desk_organizer = self.env["product.product"].search([('available_in_pos', '=', True), ('name', '=', 'Desk Organizer')], limit=1)
-                order = self.env["pos.order"].create({
-                    'company_id': self.env.company.id,
-                    'session_id': session_id,
-                    'partner_id': False,
-                    'lines': [(0, 0, {
-                        'name': 'OL/0001',
-                        'product_id': product_desk_organizer.id,
-                        'price_unit': 10.00,
-                        'tax_ids': False,
-                        'price_subtotal': 10.00,
-                        'price_subtotal_incl': 10.00,
-                    })],
-                    'amount_paid': 0,
-                    'amount_total': 10.00,
-                    'amount_tax': 0.0,
-                    'amount_return': 0.0,
-                    "pos_reference": "Order 00000-001-0002"
-                })
-            else:
-                order = orders[0]
-                payment_context = {"active_ids": order.ids, "active_id": order.id}
-                order_payment = self.env['pos.make.payment'].with_context(**payment_context).sudo().create({
-                    'amount': order.amount_total,
-                    'payment_method_id': bank_payment_method.id
-                })
-                order_payment.with_context(**payment_context).check()
-                assertEqual(order.state, "paid")
-            return notify_synchronisation_og(self, session_id, login_number)
-
-        with patch.object(self.env.registry.models['pos.config'], "notify_synchronisation", notify_synchronisation_patch):
-            self.start_pos_tour("OrderSynchronisationTour")
+        self.start_pos_tour("OrderSynchronisationTour")
 
     def test_book_and_release_table(self):
         self.pos_config.with_user(self.pos_user).open_ui()


### PR DESCRIPTION
Fixes the failing test `test_synchronisation_of_orders` by creating the order data through frontend `ORM` calls instead of patching the `notify_synchronisation` method.

Introduced here: https://github.com/odoo/odoo/pull/207406

Error-[230275](https://runbot.odoo.com/odoo/runbot.build.error/230275)


