### PR TITLE
[FIX] website_event_track: correct layout when no location

### DIFF
--- a/addons/website_event_track/static/src/scss/event_track_templates.scss
+++ b/addons/website_event_track/static/src/scss/event_track_templates.scss
@@ -160,6 +160,10 @@
             }
         }
     }
+
+    .table-layout-fixed {
+        table-layout: fixed;
+    }
 }
 
 .o_weagenda_index {

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -102,7 +102,7 @@
         <!-- Day Agenda -->
         <div t-attf-class="{{event_has_complex_day and 'container-fluid' or 'container-xl'}} pe-0">
             <div class="o_we_online_agenda mb-3">
-                <table id="table_search" class="table table-sm border-0 h-100">
+                <table id="table_search" t-attf-class="table table-sm border-0 h-100 {{'table-layout-fixed' if len(locations) == 1 else ''}}">
                     <!--Header-->
                     <tr>
                         <th class="border-0 position-sticky"/>


### PR DESCRIPTION
This PR ensures that all <td> have the same width when there is no location defined.

task-4954689


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
