### PR TITLE
[IMP] pos_restaurant: add HOOT tests for core restaurant features

### DIFF
--- a/addons/pos_restaurant/static/tests/unit/components/floor_screen.test.js
+++ b/addons/pos_restaurant/static/tests/unit/components/floor_screen.test.js
@@ -1,0 +1,135 @@
+import { test, expect, describe } from "@odoo/hoot";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { FloorScreen } from "@pos_restaurant/app/screens/floor_screen/floor_screen";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("floor_screen.js", () => {
+    test("getPosTable", async () => {
+        const store = await setupPosEnv();
+        store.currentFloor = store.models["restaurant.floor"].getFirst();
+        const screen = await mountWithCleanup(FloorScreen, {});
+        const renderedComp = await screen.env.services.renderer.toHtml(FloorScreen, {});
+        const table = screen.getPosTable(renderedComp.querySelector(".tableId-2"));
+        expect(table.id).toBe(store.currentFloor.table_ids[0].id);
+    });
+
+    test.tags("desktop");
+    test("computeFloorSize", async () => {
+        const store = await setupPosEnv();
+        const floor = store.models["restaurant.floor"].get(2);
+        store.currentFloor = floor;
+        store.floorPlanStyle = "default";
+        const screen = await mountWithCleanup(FloorScreen, {});
+        screen.floorScrollBox = {
+            el: {
+                clientHeight: 500,
+                offsetWidth: 700,
+                scrollTop: 0,
+                scrollLeft: 0,
+            },
+        };
+        screen.state.floorMapOffset = { x: 0, y: 0 };
+        screen.computeFloorSize();
+        expect(screen.state.floorWidth).toBe("927px");
+        expect(screen.state.floorHeight).toBe("500px");
+    });
+
+    test("resetTable", async () => {
+        const store = await setupPosEnv();
+        const table = store.models["restaurant.table"].get(1);
+        const order = store.addNewOrder({ table_id: table });
+        store.setOrder(order);
+        const screen = await mountWithCleanup(FloorScreen, {});
+        await screen.resetTable();
+        expect(store.getOrder()).toBe(undefined);
+    });
+
+    test("pinch gesture computes scale and sets it", async () => {
+        await setupPosEnv();
+        const screen = await mountWithCleanup(FloorScreen, {});
+        screen.getScale = () => 1;
+        let scaleValue = null;
+        screen.setScale = (value) => {
+            scaleValue = value;
+        };
+        const startEvent = {
+            touches: [
+                { pageX: 0, pageY: 0 },
+                { pageX: 0, pageY: 100 },
+            ],
+            currentTarget: {
+                style: {
+                    setProperty: () => {},
+                },
+            },
+        };
+        screen._onPinchStart(startEvent);
+        const hypotStart = Math.hypot(0 - 0, 0 - 100);
+        expect(screen.scalehypot).toBe(hypotStart);
+        expect(screen.initalScale).toBe(1);
+        const moveEvent = {
+            touches: [
+                { pageX: 0, pageY: 0 },
+                { pageX: 0, pageY: 200 },
+            ],
+        };
+        screen._computePinchHypo(moveEvent, screen.movePinch.bind(screen));
+        expect(scaleValue).toBeCloseTo(2);
+    });
+
+    test.tags("desktop");
+    test("_createTableHelper", async () => {
+        const store = await setupPosEnv();
+        const floor = store.models["restaurant.floor"].get(2);
+        const screen = await mountWithCleanup(FloorScreen, {});
+        screen.selectFloor(floor);
+        const table = await screen._createTableHelper(null);
+        expect(Boolean(table)).toBe(true);
+        expect(table.floor_id.id).toBe(floor.id);
+        expect(table.table_number).toBe(4);
+        expect(table.height).toBe(table.width);
+        expect(table.position_v >= 0).toBe(true);
+        expect(table.position_h >= 10).toBe(true);
+    });
+
+    test("_getNewTableNumber", async () => {
+        const store = await setupPosEnv();
+        const floor = store.models["restaurant.floor"].getFirst();
+        const screen = await mountWithCleanup(FloorScreen, {});
+        screen.selectFloor(floor);
+        const newNumber = screen._getNewTableNumber();
+        expect(newNumber).toBe(4);
+    });
+
+    test("duplicateTable", async () => {
+        const store = await setupPosEnv();
+        const floor = store.models["restaurant.floor"].getFirst();
+        const screen = await mountWithCleanup(FloorScreen, {});
+        screen.selectFloor(floor);
+        screen.state.selectedTableIds = [floor.table_ids[0].id];
+        await screen.duplicateTable();
+        expect(screen.state.selectedTableIds.length).toBe(1);
+        const newTableId = screen.state.selectedTableIds[0];
+        expect(newTableId).not.toBe(floor.table_ids[0].id);
+    });
+
+    test("_isTableVisible", async () => {
+        const store = await setupPosEnv();
+        const floor = store.models["restaurant.floor"].getFirst();
+        const screen = await mountWithCleanup(FloorScreen, {});
+        screen.selectFloor(floor);
+        screen.floorScrollBox = {
+            el: {
+                scrollTop: 0,
+                scrollLeft: 0,
+                clientHeight: 500,
+                clientWidth: 500,
+            },
+        };
+        const table = store.models["restaurant.table"].get(2);
+        expect(screen._isTableVisible(table)).toBe(true);
+    });
+});

--- a/addons/pos_restaurant/static/tests/unit/components/split_bill_screen.test.js
+++ b/addons/pos_restaurant/static/tests/unit/components/split_bill_screen.test.js
@@ -1,0 +1,118 @@
+import { describe, test, expect } from "@odoo/hoot";
+import { SplitBillScreen } from "@pos_restaurant/app/screens/split_bill_screen/split_bill_screen";
+import { setupPosEnv, getFilledOrder } from "@point_of_sale/../tests/unit/utils";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("split_bill_screen.js", () => {
+    test("_getSplitOrderName", async () => {
+        const store = await setupPosEnv();
+        await getFilledOrder(store);
+        const screen = await mountWithCleanup(SplitBillScreen, {});
+        const originalName = "T1";
+        const result = screen._getSplitOrderName(originalName);
+        expect(result).toBe("T1B");
+    });
+
+    describe("onClickLine", () => {
+        test("increments quantity and price tracker on regular line", async () => {
+            const store = await setupPosEnv();
+            const order = await getFilledOrder(store);
+            const screen = await mountWithCleanup(SplitBillScreen, {});
+            const line = order.getOrderlines()[0];
+            screen.onClickLine(line);
+            expect(screen.qtyTracker[line.uuid]).toBe(1);
+            expect(screen.priceTracker[line.uuid] > 0).toBe(true);
+            screen.onClickLine(line);
+            expect(screen.qtyTracker[line.uuid]).toBe(2);
+        });
+
+        test("handles combo line and its child lines", async () => {
+            const store = await setupPosEnv();
+            const order = store.addNewOrder();
+            const comboTemplate = store.models["product.template"].get(7);
+            const comboItem1 = store.models["product.combo.item"].get(1);
+            const comboItem2 = store.models["product.combo.item"].get(3);
+            const line = await store.addLineToOrder(
+                {
+                    product_tmpl_id: comboTemplate,
+                    payload: [
+                        [
+                            {
+                                combo_item_id: comboItem1,
+                                qty: 1,
+                            },
+                            {
+                                combo_item_id: comboItem2,
+                                qty: 1,
+                            },
+                        ],
+                        [],
+                    ],
+                    configure: true,
+                },
+                order
+            );
+            expect(order.lines.length).toBe(3);
+            expect(line.product_id.product_tmpl_id).toBe(comboTemplate);
+            expect(line.combo_line_ids.length).toBe(2);
+            expect(line.combo_line_ids[0].product_id.id).toBe(comboItem1.product_id.id);
+            expect(line.combo_line_ids[1].product_id.id).toBe(comboItem2.product_id.id);
+            const screen = await mountWithCleanup(SplitBillScreen, {});
+            screen.onClickLine(order.lines[0]);
+            expect(screen.qtyTracker[order.lines[0].uuid]).toBe(1);
+            expect(screen.qtyTracker[order.lines[1].uuid]).toBe(1);
+            expect(screen.qtyTracker[order.lines[2].uuid]).toBe(1);
+        });
+    });
+
+    test("_getSentQty", async () => {
+        const store = await setupPosEnv();
+        await getFilledOrder(store);
+        const screen = await mountWithCleanup(SplitBillScreen, {});
+        const ogLine = { qty: 3, preparationKey: "o1" };
+        const newLine = { qty: 2, preparationKey: "n1" };
+        const sent = screen._getSentQty(ogLine, newLine, 2);
+        expect(sent["o1"]).toBe(1);
+        expect(sent["n1"]).toBe(1);
+    });
+
+    test("_getOrderName", async () => {
+        const store = await setupPosEnv();
+        await getFilledOrder(store);
+        const screen = await mountWithCleanup(SplitBillScreen, {});
+        expect(screen._getOrderName({ table_id: { table_number: 3 } })).toBe("3");
+        expect(screen._getOrderName({ floatingOrderName: "ToGo" })).toBe("ToGo");
+        expect(screen._getOrderName({})).toBe("");
+    });
+
+    test("setLineQtyStr", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const screen = await mountWithCleanup(SplitBillScreen, {});
+        const line = order.getOrderlines()[0];
+        screen.qtyTracker[line.uuid] = 2;
+        screen.setLineQtyStr(line);
+        expect(line.uiState.splitQty).toBe("2 / 3");
+    });
+
+    test("createSplittedOrder", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const table = store.models["restaurant.table"].get(2);
+        order.table_id = table;
+        const screen = await mountWithCleanup(SplitBillScreen, {});
+        const line = order.getOrderlines()[0];
+        screen.qtyTracker[line.uuid] = 2;
+        const originalUUID = order.uuid;
+        await screen.createSplittedOrder();
+        const currentOrder = store.getOrder();
+        expect(currentOrder.floating_order_name).toBe("1B");
+        expect(currentOrder.uuid).not.toBe(originalUUID);
+        expect(currentOrder.getOrderlines().length).toBe(1);
+        expect(currentOrder.getOrderlines()[0].getQuantity()).toBe(2);
+        expect(order.getOrderlines()[0].getQuantity()).toBe(1);
+    });
+});

--- a/addons/pos_restaurant/static/tests/unit/components/tip_screen.test.js
+++ b/addons/pos_restaurant/static/tests/unit/components/tip_screen.test.js
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "@odoo/hoot";
+import { TipScreen } from "@pos_restaurant/app/screens/tip_screen/tip_screen";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { setupPosEnv, getFilledOrder } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("tip_screen.js", () => {
+    test("validateTip", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const cardPaymentMethod = store.models["pos.payment.method"].get(2);
+        order.addPaymentline(cardPaymentMethod);
+        await store.syncAllOrders();
+        TipScreen.prototype.printTipReceipt = async () => {};
+        const screen = await mountWithCleanup(TipScreen, {});
+        screen.state.inputTipAmount = "2";
+        await screen.validateTip();
+        expect(order.is_tipped).toBe(true);
+        expect(order.tip_amount).toBe(2);
+        const tipLine = order.lines.find(
+            (line) => line.product_id.id === store.config.tip_product_id.id
+        );
+        expect(Boolean(tipLine)).toBe(true);
+        expect(tipLine.price_unit).toBe(2);
+    });
+
+    test("overallAmountStr", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const cardPaymentMethod = store.models["pos.payment.method"].get(2);
+        order.addPaymentline(cardPaymentMethod);
+        await store.syncAllOrders();
+        TipScreen.prototype.printTipReceipt = async () => {};
+        const screen = await mountWithCleanup(TipScreen, {});
+        screen.state.inputTipAmount = "2";
+        const result = screen.overallAmountStr;
+        const total = order.getTotalWithTax();
+        const original = screen.env.utils.formatCurrency(total);
+        const tip = screen.env.utils.formatCurrency(2);
+        const overall = screen.env.utils.formatCurrency(total + 2);
+        expect(result).toBe(`${original} + ${tip} tip = ${overall}`);
+    });
+});

--- a/addons/pos_restaurant/static/tests/unit/data/pos_config.data.js
+++ b/addons/pos_restaurant/static/tests/unit/data/pos_config.data.js
@@ -4,4 +4,8 @@ PosConfig._records = PosConfig._records.map((record) => ({
     ...record,
     module_pos_restaurant: true,
     floor_ids: [2, 3],
+    iface_tipproduct: true,
+    tip_product_id: 1,
+    set_tip_after_payment: true,
+    default_screen: "tables",
 }));

--- a/addons/pos_restaurant/static/tests/unit/data/pos_session.data.js
+++ b/addons/pos_restaurant/static/tests/unit/data/pos_session.data.js
@@ -3,6 +3,11 @@ import { patch } from "@web/core/utils/patch";
 
 patch(PosSession.prototype, {
     _load_pos_data_models() {
-        return [...super._load_pos_data_models(), "restaurant.floor", "restaurant.table"];
+        return [
+            ...super._load_pos_data_models(),
+            "restaurant.floor",
+            "restaurant.table",
+            "restaurant.order.course",
+        ];
     },
 });

--- a/addons/pos_restaurant/static/tests/unit/models/pos_order.test.js
+++ b/addons/pos_restaurant/static/tests/unit/models/pos_order.test.js
@@ -1,0 +1,74 @@
+import { test, describe, expect } from "@odoo/hoot";
+import { setupPosEnv, getFilledOrder } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("pos.order restaurant patches", () => {
+    test("customer count and amount per guest", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        order.setCustomerCount(3);
+        expect(order.getCustomerCount()).toBe(3);
+        order.setCustomerCount(4);
+        expect(order.amountPerGuest()).toBe(4.4625);
+    });
+
+    test("isDirectSale", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+        expect(order.isDirectSale).toBe(true);
+    });
+
+    test("setPartner", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+        const partner = store.models["res.partner"].get(18);
+        order.setPartner(partner);
+        expect(order.floating_order_name).toBe("Public user");
+    });
+
+    test("cleanCourses", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const course1 = store.addCourse();
+        const line = order.lines[0];
+        line.course_id = course1;
+        const course2 = store.addCourse();
+        course1.fired = true;
+        order.cleanCourses();
+        expect(order.course_ids.includes(course2)).toBe(false);
+        expect(order.course_ids.includes(course1)).toBe(true);
+    });
+
+    test("getNextCourseIndex", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        store.addCourse();
+        store.addCourse();
+        expect(order.getNextCourseIndex()).toBe(4);
+    });
+
+    test("getName returns formatted name for table + children", async () => {
+        const store = await setupPosEnv();
+        const table = store.models["restaurant.table"].get(2);
+        const order = store.addNewOrder({ table_id: table });
+        const child = store.models["restaurant.table"].get(3);
+        let name = order.getName();
+        expect(name).toBe("T 1");
+        child.parent_id = table;
+        name = order.getName();
+        expect(name).toBe("T 1 & 2");
+    });
+
+    test("ensureCourseSelection and getSelectedCourse", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+        const course1 = store.addCourse();
+        course1.fired = false;
+        const course2 = store.addCourse();
+        course2.fired = true;
+        order.ensureCourseSelection();
+        expect(order.getSelectedCourse().uuid).toBe(course1.uuid);
+    });
+});

--- a/addons/pos_restaurant/static/tests/unit/models/restaurant_order_course.test.js
+++ b/addons/pos_restaurant/static/tests/unit/models/restaurant_order_course.test.js
@@ -1,0 +1,47 @@
+import { test, describe, expect } from "@odoo/hoot";
+import { setupPosEnv, getFilledOrder } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("restaurant.order.course", () => {
+    test("name returns localized name with index", async () => {
+        const store = await setupPosEnv();
+        store.addNewOrder();
+        const course = store.addCourse();
+        expect(course.name).toBe("Course 1");
+    });
+
+    test("isSelected", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+        const course = store.addCourse();
+        order.selectCourse(course);
+        expect(course.isSelected()).toBe(true);
+    });
+
+    test("isEmpty", async () => {
+        const store = await setupPosEnv();
+        store.addNewOrder();
+        const course = store.addCourse();
+        course.line_ids = [];
+        expect(course.isEmpty()).toBe(true);
+    });
+
+    test("isReadyToFire", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const course = store.addCourse();
+        const line = order.lines[0];
+        line.course_id = course;
+        course.line_ids = [line];
+        expect(course.isReadyToFire()).toBe(true);
+    });
+
+    test("isNew", async () => {
+        const store = await setupPosEnv();
+        store.addNewOrder();
+        const course = store.addCourse();
+        expect(course.isNew()).toBe(true);
+    });
+});

--- a/addons/pos_restaurant/static/tests/unit/models/restaurant_table.test.js
+++ b/addons/pos_restaurant/static/tests/unit/models/restaurant_table.test.js
@@ -1,0 +1,64 @@
+import { test, describe, expect } from "@odoo/hoot";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("restaurant.table", () => {
+    test("getOrders", async () => {
+        const store = await setupPosEnv();
+        const table = store.models["restaurant.table"].get(2);
+        const order = store.addNewOrder({ table_id: table });
+        const tableOrders = table.getOrders();
+        expect(tableOrders.length).toBe(1);
+        expect(tableOrders[0].id).toBe(order.id);
+    });
+
+    test("getParent and isParent", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const parent = models["restaurant.table"].get(2);
+        const child = models["restaurant.table"].get(3);
+        child.parent_id = parent;
+        const result = child.getParent();
+        expect(parent.isParent(child)).toBe(true);
+        expect(result.id).toBe(2);
+    });
+
+    test("getParentSide", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const parent = models["restaurant.table"].get(2);
+        const child = models["restaurant.table"].get(3);
+        child.parent_id = parent;
+        child.position_h = parent.position_h + 50;
+        child.position_v = parent.position_v;
+        const side = child.getParentSide();
+        expect(side).toBe("left");
+    });
+
+    test("getX and getY", async () => {
+        const store = await setupPosEnv();
+        const table1 = store.models["restaurant.table"].get(2);
+        const table2 = store.models["restaurant.table"].get(3);
+        expect(table1.getX()).toBe(407);
+        expect(table1.getY()).toBe(88);
+        table2.parent_id = table1;
+        table2.parent_side = "left";
+        expect(table2.getX()).toBe(497);
+        expect(table2.getY()).toBe(88);
+        table2.parent_side = "top";
+        expect(table2.getX()).toBe(407);
+        expect(table2.getY()).toBe(-2);
+    });
+
+    test("rootTable", async () => {
+        const store = await setupPosEnv();
+        const table1 = store.models["restaurant.table"].get(2);
+        const table2 = store.models["restaurant.table"].get(3);
+        const table3 = store.models["restaurant.table"].get(4);
+        table2.parent_id = table1;
+        table3.parent_id = table2;
+        expect(table3.rootTable.id).toBe(table1.id);
+    });
+});

--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -7,7 +7,52 @@ const { DateTime } = luxon;
 
 definePosModels();
 
-describe("pos_store.js", () => {
+describe("restaurant pos_store.js", () => {
+    test("restoreOrdersToOriginalTable", async () => {
+        const store = await setupPosEnv();
+        const table1 = store.models["restaurant.table"].get(1);
+        const table2 = store.models["restaurant.table"].get(2);
+        const sourceOrder = store.addNewOrder({ table_id: table1 });
+        const product = store.models["product.template"].get(5);
+        await store.addLineToOrder(
+            {
+                product_tmpl_id: product,
+                qty: 3,
+            },
+            sourceOrder
+        );
+        const line = sourceOrder.lines[0];
+        sourceOrder.uiState.unmerge = {
+            [line.uuid]: {
+                table_id: table2.id,
+                quantity: 1,
+            },
+        };
+        const newOrder = await store.restoreOrdersToOriginalTable(sourceOrder, table2);
+        expect(newOrder.table_id.id).toBe(table2.id);
+        expect(newOrder.lines.length).toBe(1);
+    });
+
+    test("fireCourse", async () => {
+        const store = await setupPosEnv();
+        store.addNewOrder();
+        const course = store.addCourse();
+        store.printCourseTicket = async () => true;
+        const result = await store.fireCourse(course);
+        expect(course.fired).toBe(true);
+        expect(result).toBe(true);
+    });
+
+    test("setTable", async () => {
+        const store = await setupPosEnv();
+        const table = store.models["restaurant.table"].get(2);
+        const blankOrder = store.addNewOrder();
+        expect(blankOrder.table_id).toBe(undefined);
+        await store.setTable(table);
+        expect(blankOrder.table_id.id).toBe(table.id);
+        expect(store.getOrder().id).toBe(blankOrder.id);
+    });
+
     test("computeTableCount", async () => {
         const store = await setupPosEnv();
         const order1 = store.addNewOrder();
@@ -204,6 +249,168 @@ describe("pos_store.js", () => {
             }
 
             expect(store.models["pos.order"].length).toEqual(1);
+        });
+    });
+
+    test("categoryCount", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        order.lines[0].note = '[{"text":"Test Note","colorIndex":0}]';
+        order.lines[1].note = '[{"text":"Test 1","colorIndex":0},{"text":"Test 2","colorIndex":0}]';
+        order.general_customer_note = '[{"text":"General Note","colorIndex":0}]';
+        const changes = store.categoryCount;
+        expect(changes).toEqual([
+            { count: 3, name: "Category 1" },
+            { count: 2, name: "Category 2" },
+            { count: 1, name: "Message" },
+        ]);
+    });
+
+    test("getDefaultSearchDetails", async () => {
+        const store = await setupPosEnv();
+        const result = store.getDefaultSearchDetails();
+        expect(result).toEqual({
+            fieldName: "REFERENCE",
+            searchTerm: "",
+        });
+    });
+
+    test("findTable", async () => {
+        const store = await setupPosEnv();
+        const table1 = store.models["restaurant.table"].get(2);
+        const floor = store.models["restaurant.floor"].get(2);
+        store.currentFloor = floor;
+        const result = store.findTable("1");
+        expect(result.id).toBe(table1.id);
+    });
+
+    test("searchOrder", async () => {
+        const store = await setupPosEnv();
+        const floor = store.models["restaurant.floor"].get(2);
+        store.currentFloor = floor;
+        const found = store.searchOrder("2");
+        expect(found).toBe(true);
+        const notFound = store.searchOrder("999");
+        expect(notFound).toBe(false);
+    });
+
+    test("getTableOrders", async () => {
+        const store = await setupPosEnv();
+        const table = store.models["restaurant.table"].get(2);
+        store.addNewOrder({ table_id: table });
+        const orders = store.getTableOrders(table.id);
+        expect(orders.length).toBe(1);
+    });
+
+    test("getActiveOrdersOnTable", async () => {
+        const store = await setupPosEnv();
+        const table = store.models["restaurant.table"].get(2);
+        store.addNewOrder({ table_id: table });
+        store.addNewOrder({ table_id: table });
+        const orders = await store.getActiveOrdersOnTable(table);
+        expect(orders.length).toBe(2);
+    });
+
+    test("prepareOrderTransfer", async () => {
+        const store = await setupPosEnv();
+        const tableSrc = store.models["restaurant.table"].get(1);
+        const tableDst = store.models["restaurant.table"].get(2);
+        const order = store.addNewOrder({ table_id: tableSrc });
+        store.alert = {
+            dismiss: () => {},
+        };
+        const result = store.prepareOrderTransfer(order, tableDst);
+        expect(result).toBe(false);
+        expect(order.table_id).toBe(tableDst);
+        expect(store.getOrder()).toBe(order);
+    });
+
+    test("transferOrder", async () => {
+        const store = await setupPosEnv();
+        const tableSrc = store.models["restaurant.table"].get(1);
+        const tableDst = store.models["restaurant.table"].get(2);
+        const sourceOrder = store.addNewOrder({ table_id: tableSrc });
+        const product1 = store.models["product.template"].get(5);
+        await store.addLineToOrder(
+            {
+                product_tmpl_id: product1,
+                qty: 2,
+            },
+            sourceOrder
+        );
+        const order = store.addNewOrder({ table_id: tableDst });
+        await store.transferOrder(sourceOrder.uuid, tableDst);
+        expect(sourceOrder.lines.length).toBe(0);
+        expect(order.lines.length).toBe(1);
+        expect(order.table_id.id).toBe(tableDst.id);
+    });
+
+    test("mergeOrders merges lines and courses", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const table1 = models["restaurant.table"].get(2);
+        const table2 = models["restaurant.table"].get(3);
+        const order1 = store.addNewOrder({ table_id: table1 });
+        const course1 = store.addCourse();
+        const product1 = models["product.template"].get(5);
+        const line1 = await store.addLineToOrder({ product_tmpl_id: product1, qty: 1 }, order1);
+        line1.course_id = course1;
+        course1.line_ids = [line1];
+        const order2 = store.addNewOrder({ table_id: table2 });
+        const course2 = store.addCourse();
+        const product2 = models["product.template"].get(6);
+        const line2 = await store.addLineToOrder({ product_tmpl_id: product2, qty: 2 }, order2);
+        line2.course_id = course2;
+        course2.line_ids = [line2];
+        await store.mergeOrders(order1, order2);
+        expect(order2.lines.length).toBe(2);
+        expect(order1.lines.length).toBe(0);
+        expect(order1.table_id).toBe(undefined);
+        expect(order2.table_id.id).toBe(table2.id);
+        expect(order2.course_ids.length).toBe(1);
+        expect(line2.course_id.id).toBe(course2.id);
+    });
+
+    test("getCustomerCount", async () => {
+        const store = await setupPosEnv();
+        const table = store.models["restaurant.table"].get(2);
+        store.addNewOrder({ table_id: table }).setCustomerCount(3);
+        store.addNewOrder({ table_id: table }).setCustomerCount(6);
+        const count = store.getCustomerCount(table.id);
+        expect(count).toBe(9);
+    });
+
+    test("firstScreen", async () => {
+        const store = await setupPosEnv();
+        expect(store.firstScreen).toBe("FloorScreen");
+    });
+
+    test("setFloatingOrder", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+        store.setFloatingOrder(order);
+        expect(store.getOrder().id).toBe(order.id);
+    });
+
+    describe("addCourse", () => {
+        test("creates first course and selects it", async () => {
+            const store = await setupPosEnv();
+            const order = store.addNewOrder();
+            const course = store.addCourse();
+            expect(course.order_id).toBe(order);
+            expect(order.getSelectedCourse()).toBe(course);
+        });
+
+        test("creates second course and assigns existing lines to first", async () => {
+            const store = await setupPosEnv();
+            const order = store.addNewOrder();
+            const product = store.models["product.template"].get(5);
+            await store.addLineToOrder({ product_tmpl_id: product, qty: 1 }, order);
+            const course1 = store.addCourse();
+            const course2 = order.getSelectedCourse();
+            expect(order.course_ids.length).toBe(2);
+            expect(course1).not.toBe(course2);
+            expect(order.lines[0].course_id).toBe(course1);
         });
     });
 });


### PR DESCRIPTION
This commit introduces HOOT test coverage for the POS Restaurant module:
- Added tests for primary models: restaurant.table, restaurant.order.course, and patched pos.order
- Added tests for patched pos_store.js.
- Added component tests for SplitBillScreen, FloorScreen and TipScreen.

task-4945629