### PR TITLE
[FIX] website, *: support keyboard navigation on configurator

### DIFF
--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -30,7 +30,7 @@ registry.category("web_tour.tours").add("configurator_flow", {
         // Description screen
         {
             content: "select a website type",
-            trigger: "a.o_change_website_type",
+            trigger: "button.o_change_website_type",
             run: "click",
         },
         {
@@ -44,13 +44,8 @@ registry.category("web_tour.tours").add("configurator_flow", {
             run: "click",
         },
         {
-            content: "select an objective",
-            trigger: ".o_configurator_purpose_dd a",
-            run: "click",
-        },
-        {
             content: "choose from the objective list",
-            trigger: "a.o_change_website_purpose",
+            trigger: "button.o_change_website_purpose",
             run: "click",
         },
         // Palette screen
@@ -92,13 +87,13 @@ registry.category("web_tour.tours").add("configurator_flow", {
         // Online catalog screen
         {
             content: "Choose a shop page style",
-            trigger: ".o_configurator_screen:contains(online catalog) .theme_preview",
+            trigger: ".o_configurator_screen:contains(online catalog) .button_area",
             run: "click",
         },
         // Product page Screen
         {
             content: "Choose a product page style",
-            trigger: ".o_configurator_screen:contains(product page) .theme_preview",
+            trigger: ".o_configurator_screen:contains(product page) .button_area",
             run: "click",
         },
         {

--- a/addons/web/static/src/scss/ui.scss
+++ b/addons/web/static/src/scss/ui.scss
@@ -182,3 +182,14 @@ span.o_force_ltr {
         --oi-color: currentColor;
     }
  }
+
+// Remove default user-agent styles on buttons
+.o_btn_reset {
+    appearance: none;
+    margin: unset;
+    padding: unset;
+    background: unset;
+    border: unset;
+    font-family: inherit;
+    font-size: 100%;
+}

--- a/addons/website/static/src/client_actions/configurator/configurator.scss
+++ b/addons/website/static/src/client_actions/configurator/configurator.scss
@@ -54,10 +54,6 @@
             }
         }
 
-        .o_configurator_hide {
-            opacity: 0;
-        }
-
         .o_configurator_show {
             animation: configuratorFadeIn 1s;
         }
@@ -141,6 +137,10 @@
             .dropdown {
                 box-shadow: inset 0 -3px 0 map-get($theme-colors, primary);
 
+                .dropdown-menu button:focus {
+                    outline: unset;
+                }
+
                 &.o_step_todo .fa-angle-down {
                     transform: translateY(-0.26em);
                 }
@@ -153,8 +153,8 @@
                         opacity:0;
                     }
 
-                    &:hover, &.show {
-                        padding-right: 1.3rem!important;
+                    &:hover, &.show, &:has([data-bs-toggle]:focus-visible) {
+                        padding-right: 1.3rem !important;
 
                         .fa-angle-down {
                             transition: all 300ms ease 100ms;
@@ -245,7 +245,7 @@
                     padding-top: 20%;
                 }
 
-                &:hover, &.selected {
+                &:hover, &:focus-visible, &.selected {
                     box-shadow: 0 0 0 1px #FFF, 0 0 0 3px map-get($theme-colors, "primary")
                 }
             }

--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -29,56 +29,81 @@
             <div class="container align-self-center">
                 <div class="o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show">
                     <span>I want </span>
-                    <div t-attf-class="dropdown o_configurator_type_dd d-inline-block {{state.selectedType ? 'o_step_completed' : 'o_step_todo show'}}">
-                        <div class="w-100 px-2" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <a class="d-flex align-items-center">
+                    <div t-attf-class="dropdown o_configurator_type_dd d-inline-block {{state.selectedType ? 'o_step_completed' : 'o_step_todo show'}}"
+                         t-on-focusout="onDropdownFocusout">
+                        <button id="selectTypeToggle"
+                                class="o_btn_reset w-100 px-2"
+                                data-bs-toggle="dropdown"
+                                aria-haspopup="true"
+                                aria-expanded="true"
+                                aria-label="What type of website?"
+                                aria-controls="selectTypeMenu">
+                            <span class="d-flex align-items-center">
                                 <i class="text-primary" t-if="state.selectedType">
                                     <t t-esc="state.getSelectedType(state.selectedType).label"/>
                                 </i>
                                 <i class="fa fa-angle-down ms-auto ps-2" role="img"/>
-                            </a>
-                        </div>
-                        <div t-attf-class="dropdown-menu border-0 shadow-lg {{state.selectedType ? 'o_step_completed' : 'o_step_todo show'}}" role="menu">
+                            </span>
+                        </button>
+                        <div id="selectTypeMenu"
+                             t-attf-class="dropdown-menu border-0 shadow-lg {{state.selectedType ? 'o_step_completed' : 'o_step_todo show'}}"
+                             role="menu"
+                             aria-labelledby="selectTypeToggle">
                             <t t-foreach="state.getWebsiteTypes()" t-as="type" t-key="type.name">
-                                <a t-att-title="type.name" t-on-click="() => this.selectWebsiteType(type.id)" class="dropdown-item o_change_website_type" role="menuitem">
+                                <button t-att-title="type.name"
+                                        t-on-click="() => this.selectWebsiteType(type.id)"
+                                        class="dropdown-item o_change_website_type"
+                                        role="menuitem"
+                                        t-ref="{{type.id === 1 ? 'autofocus' : type.name}}">
                                     <t t-esc="type.label"/>
-                                </a>
+                                </button>
                             </t>
                         </div>
                     </div>
-                    <span t-attf-class="me-2 {{!state.selectedType ? 'o_configurator_hide' : 'o_configurator_show'}}"> for my</span>
+                    <span t-if="state.selectedType" class="me-2 o_configurator_show"> for my</span>
                 </div>
-                <div t-attf-class="o_configurator_typing_text d-inline d-md-flex align-items-center o_configurator_industry mb-md-2 mb-lg-4 {{!state.selectedType ? 'o_configurator_hide' : 'o_configurator_show'}}">
+                <div t-if="state.selectedType" class="o_configurator_typing_text d-inline d-md-flex align-items-center o_configurator_industry mb-md-2 mb-lg-4 o_configurator_show">
                     <!-- Use t-set in order to be able to translate, if put in the attribute directly then export POT file will not exist this text-->
                     <label class="o_configurator_industry_wrapper me-2" t-ref="industrySelection">
                         <AutoComplete
                             placeholder.translate="Clothes, Marketing, ..."
                             value="state.selectedIndustry?.label ?? ''"
                             sources="sources"
+                            onInput.bind="onAutocompleteInput"
                             inputDebounceDelay="400"
                             menuPositionOptions="{ position: 'bottom-fit' }"
                             menuCssClass="'custom-ui-autocomplete shadow-lg border-0 o_configurator_show_fast o_configurator_industry_dropdown'"
                         />
                     </label>
                     <span> business</span>
-                    <span t-att-class="!state.selectedIndustry ? 'o_configurator_hide' : 'o_configurator_show'">,</span>
+                    <span t-if="state.selectedIndustry" class="o_configurator_show">,</span>
                 </div>
-                <div t-attf-class="o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 {{!state.selectedIndustry ? 'o_configurator_hide' : 'o_configurator_show'}}">
+                <div t-if="state.selectedType and state.selectedIndustry" class="o_configurator_typing_text d-inline d-md-block mb-md-2 mb-lg-4 o_configurator_show">
                     <span>with the main objective to </span>
-                    <div t-attf-class="dropdown d-inline-block o_configurator_purpose_dd {{state.selectedPurpose ? 'o_step_completed' : 'o_step_todo'}}">
-                        <div class="w-100 px-2" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <a class="d-flex align-items-center">
+                    <div t-attf-class="dropdown d-inline-block o_configurator_purpose_dd {{state.selectedPurpose ? 'o_step_completed' : 'o_step_todo'}}"
+                         t-on-focusout="onDropdownFocusout">
+                        <button id="selectPurposeToggle"
+                                class="o_btn_reset w-100 px-2"
+                                data-bs-toggle="dropdown"
+                                aria-haspopup="true"
+                                aria-expanded="true"
+                                aria-label="To what purpose?"
+                                aria-controls="selectPurposeMenu">
+                            <span class="d-flex align-items-center">
                                 <t t-if="state.selectedPurpose">
                                     <t t-esc="state.getSelectedPurpose(state.selectedPurpose).label"/>
                                 </t>
                                 <i class="fa fa-angle-down ms-auto ps-2" role="img"/>
-                            </a>
-                        </div>
-                        <div class="dropdown-menu border-0 shadow-lg" role="menu">
+                            </span>
+                        </button>
+                        <div id="selectPurposeMenu" class="dropdown-menu border-0 shadow-lg show" role="menu" aria-labelledby="selectPurposeToggle">
                             <t t-foreach="state.getWebsitePurpose()" t-as="type" t-key="type.id">
-                                <a t-on-click="() => this.selectWebsitePurpose(type.id)" class="dropdown-item o_change_website_purpose">
+                                <button t-on-click="() => this.selectWebsitePurpose(type.id)"
+                                        class="dropdown-item o_change_website_purpose"
+                                        role="menuitem"
+                                        t-ref="{{type.id === 1 ? 'purposeSelection' : type.name}}">
                                     <t t-esc="type.label"/>
-                                </a>
+                                </button>
                             </t>
                         </div>
                     </div>
@@ -97,7 +122,7 @@
                     <div class="h2 text-center">
                         <b>Detect</b> from Logo</div>
                     <div class="d-flex flex-column flex-grow-1 py-4">
-                        <div t-on-click="uploadLogo" t-attf-class="o_configurator_logo_upload position-relative btn-link rounded bg-100 overflow-hidden d-flex flex-grow-1 justify-content-center align-items-center text-decoration-none {{state.logo? 'h-50' : ''}}">
+                        <button t-on-click="uploadLogo" t-attf-class="o_configurator_logo_upload position-relative btn btn-link rounded bg-100 overflow-hidden d-flex flex-grow-1 justify-content-center align-items-center text-decoration-none {{state.logo? 'h-50' : ''}}">
                             <input type="file" class="logo_selection_input" t-on-change="changeLogo" style="display:none" name="logo_selection" t-ref="logoSelectionInput" accept="image/*"/>
                             <div class="h3 o_configurator_logo_button text-center">
                                 <i t-attf-class="fa fa-cloud-upload {{state.logo? 'fa-4x' : 'fa-6x'}}"></i>
@@ -108,14 +133,14 @@
                                 <img style="height: 120px" t-attf-src="{{state.logo}}" alt="Logo"/>
                             </div>
                             <i t-if="state.logo" class="fa fa-2x fa-times-circle text-danger position-absolute top-0 end-0 pe-2 pt-2" t-on-click="removeLogo"/>
-                        </div>
+                        </button>
                         <div t-if="state.recommendedPalette" class="w-75 mx-auto px-2 pt-3" style="max-width: 184px;">
-                            <div t-attf-class="palette_card rounded-pill overflow-hidden d-flex {{state.getSelectedPaletteName() == 'recommendedPalette' ? 'selected' : ''}}"
+                            <button t-attf-class="palette_card o_btn_reset w-100 rounded-pill overflow-hidden d-flex {{state.getSelectedPaletteName() == 'recommendedPalette' ? 'selected' : ''}}"
                                  t-on-click="() => this.selectPalette('recommendedPalette')" t-attf-style="background-color: {{state.recommendedPalette.color3}}">
                                 <div class="color_sample w-100" t-attf-style="background-color: {{state.recommendedPalette.color1}}"/>
                                 <div class="color_sample w-100" t-attf-style="background-color: {{state.recommendedPalette.color3}}"/>
                                 <div class="color_sample w-100" t-attf-style="background-color: {{state.recommendedPalette.color2}}"/>
-                            </div>
+                            </button>
                             <button class="btn btn-primary btn-lg text-nowrap mt-3 d-block mx-auto" t-on-click="() => this.selectPalette('recommendedPalette')">
                                 Let's go!<i class="fa fa-angle-right text-white-50 ps-2" role="img"/>
                             </button>
@@ -133,12 +158,12 @@
                     <div class="d-flex flex-wrap align-items-end">
                         <t t-foreach="state.getPalettes()" t-as="palette" t-key="palette_index">
                             <div class="o_palette_card_container w-25 px-2 pt-3">
-                                <div t-attf-class="palette_card rounded-pill overflow-hidden d-flex {{state.getSelectedPaletteName() == palette.name ? 'selected' : ''}}"
+                                <button t-attf-class="palette_card o_btn_reset w-100 rounded-pill overflow-hidden d-flex {{state.getSelectedPaletteName() == palette.name ? 'selected' : ''}}"
                                      t-on-click="() => this.selectPalette(palette.name)" t-attf-style="background-color: {{palette.color3}}">
                                     <div class="color_sample w-100" t-attf-style="background-color: {{palette.color1}}"/>
                                     <div class="color_sample w-100" t-attf-style="background-color: {{palette.color3}}"/>
                                     <div class="color_sample w-100" t-attf-style="background-color: {{palette.color2}}"/>
-                                </div>
+                                </button>
                             </div>
                         </t>
                     </div>
@@ -160,7 +185,11 @@
                         <t t-foreach="state.getFeatures()" t-as="feature" t-key="feature_index">
                             <t t-set='isInstalled' t-value="feature.module_state == 'installed'"/>
                             <div class="o_feature_card_container p-2 w-25" t-if="feature.type != 'empty'">
-                                <div t-attf-class="card h-100 {{isInstalled ? 'card_installed' : (feature.selected ? 'border-success' : '')}}" t-on-click="() => state.toggleFeature(feature.id)">
+                                <div t-attf-class="card h-100 {{isInstalled ? 'card_installed' : (feature.selected ? 'border-success' : '')}}"
+                                     t-on-click="() => state.toggleFeature(feature.id)"
+                                     t-on-keydown="onKeydown"
+                                     tabindex="0"
+                                     role="button">
                                     <div class="h3 card-body py-3 px-4 mb-0">
                                         <t t-if="isInstalled">
                                             <i t-attf-class="o_configurator_feature_status fa fa-check-circle text-success" title="Already installed"/>
@@ -203,7 +232,7 @@
                                     <h6 class="theme_preview_tip text-center text-muted">Click to select</h6>
                                     <!-- Force LTR to prevent SVG issues in RTL languages -->
                                     <div class="theme_svg_container rounded overflow-hidden" t-ref="ThemePreview2" dir="ltr"/>
-                                    <div class="button_area" t-on-click="() => this.chooseTheme(state.getThemeName(1))"/>
+                                    <button class="o_btn_reset button_area" t-on-click="() => this.chooseTheme(state.getThemeName(1))"/>
                                 </div>
                             </t>
                         </div>
@@ -213,7 +242,7 @@
                                     <h6 class="theme_preview_tip text-center text-muted">Click to select</h6>
                                     <!-- Force LTR to prevent SVG issues in RTL languages -->
                                     <div class="theme_svg_container rounded overflow-hidden" t-ref="ThemePreview1" dir="ltr"/>
-                                    <div class="button_area" t-on-click="() => this.chooseTheme(state.getThemeName(0))"/>
+                                    <button class="o_btn_reset button_area" t-on-click="() => this.chooseTheme(state.getThemeName(0))"/>
                                 </div>
                             </t>
                         </div>
@@ -223,7 +252,7 @@
                                     <h6 class="theme_preview_tip text-center text-muted">Click to select</h6>
                                     <!-- Force LTR to prevent SVG issues in RTL languages -->
                                     <div class="theme_svg_container rounded overflow-hidden" t-ref="ThemePreview3" dir="ltr"/>
-                                    <div class="button_area" t-on-click="() => this.chooseTheme(state.getThemeName(2))"/>
+                                    <button class="o_btn_reset button_area" t-on-click="() => this.chooseTheme(state.getThemeName(2))"/>
                                 </div>
                             </t>
                         </div>
@@ -244,7 +273,7 @@
                                             <h6 class="theme_preview_tip text-center text-muted">Click to select</h6>
                                             <!-- Force LTR to prevent SVG issues in RTL languages -->
                                             <div class="theme_svg_container rounded overflow-hidden" t-ref="ExtraThemePreview{{extraThemeId}}" dir="ltr"/>
-                                            <div class="button_area" t-on-click="() => this.chooseTheme(extraThemeName)"/>
+                                            <button class="o_btn_reset button_area" t-on-click="() => this.chooseTheme(extraThemeName)"/>
                                         </div>
                                     </t>
                                 </div>

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -15,7 +15,7 @@ registry.category("web_tour.tours").add('configurator_translation', {
     // Make sure "Back" works
     {
         content: "use browser's Back",
-        trigger: 'a.o_change_website_type',
+        trigger: 'button.o_change_website_type',
         run() {
             window.history.back();
         },
@@ -27,7 +27,7 @@ registry.category("web_tour.tours").add('configurator_translation', {
     // Description screen
     {
         content: "select a website type",
-        trigger: 'a.o_change_website_type',
+        trigger: 'button.o_change_website_type',
         run: "click",
     }, {
         content: "insert a website industry",
@@ -38,12 +38,8 @@ registry.category("web_tour.tours").add('configurator_translation', {
         trigger: '.o_configurator_industry_wrapper ul li a:contains("in fr")',
         run: "click",
     }, {
-        content: "select an objective",
-        trigger: '.o_configurator_purpose_dd a',
-        run: "click",
-    }, {
         content: "choose from the objective list",
-        trigger: 'a.o_change_website_purpose',
+        trigger: 'button.o_change_website_purpose',
         run: "click",
     },
     // Palette screen

--- a/addons/website_sale/static/src/js/client_actions/configurator/productPageSelectionScreen.xml
+++ b/addons/website_sale/static/src/js/client_actions/configurator/productPageSelectionScreen.xml
@@ -14,10 +14,7 @@
                                 <div class="d-none d-lg-block col-2"/>
                             </t>
                             <div class="col-sm-6 col-lg-4">
-                                <div
-                                    class="theme_preview o_configurator_show_fast rounded position-relative button_area mt-3 mb-2"
-                                    t-on-click="() => this.selectStyle(style.option)"
-                                >
+                                <div class="theme_preview o_configurator_show_fast rounded position-relative mt-3 mb-2">
                                     <h6 class="theme_preview_tip text-center text-muted d-none d-lg-block">
                                         Click to select
                                     </h6>
@@ -29,6 +26,11 @@
                                             t-att-title="style.title"
                                         />
                                     </div>
+                                    <button
+                                        class="o_btn_reset button_area"
+                                        t-on-click="() => this.selectStyle(style.option)"
+                                        t-att-aria-label="style.title"
+                                    />
                                 </div>
                             </div>
                             <t t-if="style_index % 2 === 1 || style_index + 1 === this.productPageStyles.length">

--- a/addons/website_sale/static/src/js/client_actions/configurator/shopPageSelectionScreen.xml
+++ b/addons/website_sale/static/src/js/client_actions/configurator/shopPageSelectionScreen.xml
@@ -11,10 +11,7 @@
                     <div class="row row-cols-1 row-cols-lg-3 row-cols-sm-2 g-2 g-sm-3 g-lg-4">
                         <t t-foreach="this.shopPageStyles" t-as="style" t-key="style_index">
                             <div class="col">
-                                <div
-                                    class="theme_preview o_configurator_show_fast rounded position-relative button_area mt-3 mb-2"
-                                    t-on-click="() => this.selectStyle(style.option)"
-                                >
+                                <div class="theme_preview o_configurator_show_fast rounded position-relative mt-3 mb-2">
                                     <h6 class="theme_preview_tip text-center text-muted d-none d-lg-block">
                                         Click to select
                                     </h6>
@@ -26,6 +23,11 @@
                                             t-att-title="style.title"
                                         />
                                     </div>
+                                    <button
+                                        class="o_btn_reset button_area"
+                                        t-on-click="() => this.selectStyle(style.option)"
+                                        t-att-aria-label="style.title"
+                                    />
                                 </div>
                             </div>
                         </t>

--- a/addons/website_sale/static/tests/tours/configurator_translation.js
+++ b/addons/website_sale/static/tests/tours/configurator_translation.js
@@ -17,12 +17,12 @@ patch(registry.category('web_tour.tours').get('configurator_translation'), {
             0,
             {
                 content: "Choose a shop page style",
-                trigger: '.o_configurator_screen:contains(online catalog) .theme_preview',
+                trigger: '.o_configurator_screen:contains(online catalog) .button_area',
                 run: 'click',
             },
             {
                 content: "Choose a product page style",
-                trigger: '.o_configurator_screen:contains(product page) .theme_preview',
+                trigger: '.o_configurator_screen:contains(product page) .button_area',
                 run: 'click',
             },
         );


### PR DESCRIPTION
*: website_sale, test_website_modules

Keyboard navigation and validation was not possible on the configurator
pages. This commit makes sure it now behaves as expected and that
components behaving as buttons are semantically treated as buttons.

It also adds some quality-of-life improvements. On the 2nd page of the
configurator, the 1st field (type selection) is automatically focused.
Subsequently, for each field, once the user confirms their choice, the
focus is moved to the next field (type -> industry -> purpose).

task-3758859