### PR TITLE
[FIX] website: prevent removal of oe_unremovable with seo dialog

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -746,7 +746,7 @@ export class SeoChecks extends Component {
         this.state.checkingLinks = true;
         this.state.counterLinks = 0;
         const hrefEls =
-            this.website.pageDocument.documentElement.querySelectorAll("#wrapwrap a[href]");
+            this.website.pageDocument.documentElement.querySelectorAll("#wrapwrap a[href]:not(.oe_unremovable)");
         let links = Array.from(hrefEls)
             .filter((a) => {
                 const href = a.href;


### PR DESCRIPTION
Steps to reproduce:

- Open website builder
- Site > Pages and delete "contact us" page
- Go to home page
- Site > Optimize SEO > Check broken links
- Remove the broken links "contact us"
- Save
- Observe : Website is dead, and really dead...
