### PR TITLE
[FIX] purchase: prevent traceback if creating bill for multiple vendors

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -926,7 +926,8 @@ class PurchaseOrder(models.Model):
             result = {'type': 'ir.actions.act_window_close'}
 
         result['context'] = literal_eval(result['context'])
-        result['context']['default_partner_id'] = self.partner_id.id
+        if len(self.partner_id) == 1:
+            result['context']['default_partner_id'] = self.partner_id.id
         return result
 
     @api.model


### PR DESCRIPTION
Bug introduced by: https://github.com/odoo/odoo/commit/b75394102bec3e25b23c75fd82ca0d8dec2726c5#diff-1281da5f4d0a3daaf162a2e6456469537d1b74b8034437783c9c717307aa8fcdR859

Steps to reproduce:
- Create two purchase orders with different vendors
- Add any product and confirm both orders
- From the purchase order list view, select both orders
- Click on "Create Bill"

Problem:
A traceback occurs when selecting multiple purchase orders with
different vendors and clicking Create Bill from the list view. This
is due to default_partner_id being forcibly set in the context, which
assumes a single vendor.

This bug was introduced by commit b753941, where default_partner_id is
always injected into the context, even when multiple vendors are
involved: https://github.com/odoo/odoo/commit/b75394102bec3e25b23c75fd82ca0d8dec2726c5#diff-1281da5f4d0a3daaf162a2e6456469537d1b74b8034437783c9c717307aa8fcdR714

Why it breaks:
When creating a bill, action_view_invoice() is called without verifying
that only one vendor is selected. Setting a default_partner_id in such
cases leads to invalid assumptions and crashes.

Difference with attachments case:
When uploading bills from attachments, a check does ensure a single
vendor is selected before calling action_view_invoice() (see b753941#R714).

Fix:
Only inject default_partner_id into the context if all selected
purchase orders share the same vendor.

opw-4948142
