### PR TITLE
[IMP] pos_discount : numpad for discount orderline

### DIFF
--- a/addons/pos_discount/__manifest__.py
+++ b/addons/pos_discount/__manifest__.py
@@ -28,6 +28,9 @@ discount to a customer.
         'web.assets_tests': [
             'pos_discount/static/tests/tours/**/*',
         ],
+        'web.assets_unit_tests': [
+            'pos_discount/static/tests/unit/**/*'
+        ],
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/pos_discount/static/src/app/models/pos_order_line.js
+++ b/addons/pos_discount/static/src/app/models/pos_order_line.js
@@ -17,4 +17,10 @@ patch(PosOrderline.prototype, {
             )
         );
     },
+    get isDiscountLine() {
+        return (
+            this.config.module_pos_discount &&
+            this.product_id.id === this.config.discount_product_id?.id
+        );
+    },
 });

--- a/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -73,6 +73,7 @@ patch(ControlButtons.prototype, {
             if (line) {
                 tobeRemoved?.delete();
             }
+            this.pos.numpadMode = "price";
         }
     },
 });

--- a/addons/pos_discount/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_discount/static/src/app/screens/product_screen/product_screen.js
@@ -1,0 +1,18 @@
+import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
+import { patch } from "@web/core/utils/patch";
+
+patch(ProductScreen.prototype, {
+    getNumpadButtons() {
+        const buttons = super.getNumpadButtons();
+        if (!this.currentOrder?.getSelectedOrderline()?.isDiscountLine) {
+            return buttons;
+        }
+        const toDisable = new Set(["quantity", "discount"]);
+        return buttons.map((button) => {
+            if (toDisable.has(button.value)) {
+                return { ...button, disabled: true };
+            }
+            return button;
+        });
+    },
+});

--- a/addons/pos_discount/static/src/app/services/pos_store.js
+++ b/addons/pos_discount/static/src/app/services/pos_store.js
@@ -1,0 +1,12 @@
+import { patch } from "@web/core/utils/patch";
+import { PosStore } from "@point_of_sale/app/services/pos_store";
+
+patch(PosStore.prototype, {
+    selectOrderLine(order, line) {
+        super.selectOrderLine(order, line);
+        // Ensure the numpadMode should be `price` when the discount line is selected
+        if (line?.isDiscountLine) {
+            this.numpadMode = "price";
+        }
+    },
+});

--- a/addons/pos_discount/static/tests/tours/test_pos_global_discount_flow.js
+++ b/addons/pos_discount/static/tests/tours/test_pos_global_discount_flow.js
@@ -56,7 +56,7 @@ registry.category("web_tour.tours").add("test_pos_global_discount_sell_and_refun
             PaymentScreen.clickBack(),
             ProductScreen.clickLine("discount"),
             ProductScreen.clickNumpad("1"),
-            Dialog.is({ title: "quantity update not allowed" }),
+            Dialog.is({ title: "price update not allowed" }),
             Dialog.confirm(),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),

--- a/addons/pos_discount/static/tests/unit/components/product_screen.test.js
+++ b/addons/pos_discount/static/tests/unit/components/product_screen.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+import { applyDiscount } from "../utils";
+
+definePosModels();
+
+describe("product_screen.js", () => {
+    test("getNumpadButtons", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+        const product1 = store.models["product.template"].get(5);
+        await store.addLineToOrder(
+            {
+                product_tmpl_id: product1,
+                qty: 1,
+            },
+            order
+        );
+        const productScreen = await mountWithCleanup(ProductScreen, {
+            props: { orderUuid: order.uuid },
+        });
+        await applyDiscount(10);
+        const receivedButtonsDisableStatue = productScreen
+            .getNumpadButtons()
+            .filter((button) => ["quantity", "discount"].includes(button.value))
+            .map((button) => button.disabled);
+        const orderline = order.getSelectedOrderline();
+        expect(Math.abs(orderline.price_subtotal_incl).toString()).toBe(
+            ((order.amount_total + order.amount_tax) * 0.1).toPrecision(2)
+        );
+        expect(receivedButtonsDisableStatue).toEqual([true, true]);
+    });
+});

--- a/addons/pos_discount/static/tests/unit/data/pos_config.data.js
+++ b/addons/pos_discount/static/tests/unit/data/pos_config.data.js
@@ -1,0 +1,7 @@
+import { PosConfig } from "@point_of_sale/../tests/unit/data/pos_config.data";
+
+PosConfig._records = PosConfig._records.map((record) => ({
+    ...record,
+    module_pos_discount: true,
+    discount_product_id: 151,
+}));

--- a/addons/pos_discount/static/tests/unit/data/product_product.data.js
+++ b/addons/pos_discount/static/tests/unit/data/product_product.data.js
@@ -1,0 +1,17 @@
+import { ProductProduct } from "@point_of_sale/../tests/unit/data/product_product.data";
+
+ProductProduct._records = [
+    ...ProductProduct._records,
+    {
+        id: 151,
+        product_tmpl_id: 151,
+        lst_price: 1,
+        standard_price: 0,
+        display_name: "Discount",
+        product_tag_ids: [],
+        barcode: false,
+        default_code: false,
+        product_template_attribute_value_ids: [],
+        product_template_variant_value_ids: [],
+    },
+];

--- a/addons/pos_discount/static/tests/unit/data/product_template.data.js
+++ b/addons/pos_discount/static/tests/unit/data/product_template.data.js
@@ -1,0 +1,19 @@
+import { ProductTemplate } from "@point_of_sale/../tests/unit/data/product_template.data";
+
+ProductTemplate._records = [
+    ...ProductTemplate._records,
+    {
+        id: 151,
+        name: "Discount",
+        display_name: "Discount",
+        list_price: 0,
+        standard_price: 0,
+        type: "consu",
+        service_tracking: "none",
+        pos_categ_ids: [1],
+        categ_id: false,
+        uom_id: 1,
+        available_in_pos: true,
+        active: true,
+    },
+];

--- a/addons/pos_discount/static/tests/unit/models/pos_order_line.test.js
+++ b/addons/pos_discount/static/tests/unit/models/pos_order_line.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { applyDiscount } from "../utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("pos_order_line.js", () => {
+    test("isDiscountLine", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+        const product1 = store.models["product.template"].get(5);
+        await store.addLineToOrder(
+            {
+                product_tmpl_id: product1,
+                qty: 1,
+            },
+            order
+        );
+        await applyDiscount(10);
+        const orderline = order.getSelectedOrderline();
+        expect(Math.abs(orderline.price_subtotal_incl).toString()).toBe(
+            ((order.amount_total + order.amount_tax) * 0.1).toPrecision(2)
+        );
+        expect(orderline.isDiscountLine).toBe(true);
+    });
+});

--- a/addons/pos_discount/static/tests/unit/utils.js
+++ b/addons/pos_discount/static/tests/unit/utils.js
@@ -1,0 +1,7 @@
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
+
+export const applyDiscount = async (percent) => {
+    const comp = await mountWithCleanup(ControlButtons, {});
+    await comp.applyDiscount(percent);
+};


### PR DESCRIPTION
In this commit:
=======
- We are restricting the user from updating the quantity of the discount line and adding the extra discount on the discount line from the numpad.
- Users can update the discount line price using the numpad, which will reflect the sign (positive or negative) of the order line price.

task-4941627