### PR TITLE
[FIX] mail: prevent error when changing others volume in call

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -655,8 +655,8 @@ export class Rtc extends Record {
     setVolume(session, volume) {
         session.volume = volume;
         this.store.settings.saveVolumeSetting({
-            guestId: session?.guest_id.id,
-            partnerId: session?.partner_id.id,
+            guestId: session?.guest_id?.id,
+            partnerId: session?.partner_id?.id,
             volume,
         });
         this._postToTabs({

--- a/addons/mail/static/src/discuss/call/common/settings_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/settings_model_patch.js
@@ -13,8 +13,8 @@ const SettingsPatch = {
             rtcSession.volume ??
             this.volumes.find(
                 (volume) =>
-                    volume.partner_id.eq(rtcSession.partner_id) ||
-                    volume.guest_id.eq(rtcSession.guest_id)
+                    volume.partner_id?.eq(rtcSession.partner_id) ||
+                    volume.guest_id?.eq(rtcSession.guest_id)
             )?.volume ??
             0.5
         );

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -533,6 +533,7 @@ test("Use saved volume settings", async () => {
     await contains(".o-discuss-CallContextMenu");
     const rangeInput = queryFirst(".o-discuss-CallContextMenu input[type='range']");
     expect(rangeInput.value).toBe(expectedVolume.toString());
+    rangeInput.dispatchEvent(new Event("change")); // to trigger the volume change
     await click(".o-discuss-CallActionList button[aria-label='Disconnect']");
 });
 


### PR DESCRIPTION
**Current behavior before PR:**

When a user was in a call and tried to change the volume of other participants using the participant options, it caused a traceback. This was due to missing optional chaining while checking `volume.partner_id.eq(rtcSession.partner_id)`.
since https://github.com/odoo/odoo/pull/214943

**Desired behavior after PR is merged:**

This PR fixes the issue by adding optional chaining to prevent errors when `volume.partner_id` is undefined.

Task- 4967202


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
