### PR TITLE
[FIX] website: adapt test test_01_client_action_redirect

### DIFF
--- a/addons/website/static/tests/tours/client_action_redirect.js
+++ b/addons/website/static/tests/tours/client_action_redirect.js
@@ -41,6 +41,7 @@ registry.category("web_tour.tours").add('client_action_redirect', {
         content: "Click on the link to frontend",
         trigger: '#test_contact_FE',
         run: "click",
+        expectUnloadPage: true,
     },
     ...checkEditorSteps,
 
@@ -50,6 +51,7 @@ registry.category("web_tour.tours").add('client_action_redirect', {
         content: "Click on the link to backend",
         trigger: ':iframe #test_contact_BE',
         run: "click",
+        expectUnloadPage: true,
     },
     ...checkEditorSteps,
 
@@ -69,6 +71,7 @@ registry.category("web_tour.tours").add('client_action_redirect', {
         content: "Click on the link to backend (2)",
         trigger: ':iframe #test_contact_BE',
         run: "click",
+        expectUnloadPage: true,
     },
     ...checkEditorSteps,
 ]});

--- a/addons/website/tests/test_client_action.py
+++ b/addons/website/tests/test_client_action.py
@@ -1,14 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
-import unittest
 from odoo.addons.website.tests.common import HttpCaseWithWebsiteUser
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestClientAction(HttpCaseWithWebsiteUser):
 
-    @unittest.skip
     def test_01_client_action_redirect(self):
         page = self.env['website.page'].create({
             'name': 'Base',


### PR DESCRIPTION
`test_01_client_action_redirect` tests was broken and disabled after the new website builder changes.

This PR adapts the tour steps accordingly and re-enables the related test.
