### PR TITLE
[FIX] account: fix "group By" tax reports with analytics

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -150,7 +150,7 @@ class AccountMoveLine(models.Model):
                         OR (tax.tax_exigibility = 'on_payment' AND tax.cash_basis_transition_account_id IS NOT NULL)
                     )
                     AND (
-                        (tax.analytic IS NULL OR tax.analytic = FALSE)
+                        (tax.analytic IS NOT TRUE AND tax_rep.use_in_tax_closing IS TRUE)
                         OR (base_line.analytic_distribution IS NULL AND account_move_line.analytic_distribution IS NULL)
                         OR base_line.analytic_distribution = account_move_line.analytic_distribution
                     )
@@ -400,7 +400,6 @@ class AccountMoveLine(models.Model):
                     tax_line.tax_line_id AS tax_id,
                     tax_line.group_tax_id,
                     tax_line.tax_repartition_line_id,
-                    tax_line.analytic_distribution,
 
                     tax_line.company_id,
                     tax_line.display_type AS display_type,
@@ -471,7 +470,6 @@ class AccountMoveLine(models.Model):
                 sub.tax_line_id,
                 sub.display_type,
                 sub.src_line_id,
-                sub.analytic_distribution,
 
                 sub.tax_id,
                 sub.group_tax_id,


### PR DESCRIPTION
### Issue:
When having two lines on an invoice with the same tax and different analytic distribution, the base value is doubled on the tax report.

### Steps to reproduce:
- Create a new tax on sales (eg 10%)
- Make sure the option "Analytic Accounting" is ticked in the settings
- Create an invoice with a line, add the tax on it and change the analytic distribution
- Do the same for another invoice with another analytic distribution
- Confirm the invoices
- Go to the tax report
- Select the report "Group By: Account > Tax"
- On the report the "Net" amount is only the one of the first invoice, the tax amount is correct

### Cause:
The bug appeared after this [commit](https://github.com/odoo-dev/enterprise/commit/9a7142ef57503efad9538e571d2e35c4aaa59531) which fixed another issue with analytics. Now several lines with the same tax can be returned by the query if they have different analytics. This was used to avoid having the base amount doubled on the invoice when several lines from the same move had with different analytics: there is a line for each analytic but they all have the same base, in the end the base amounts was doubled for each different analytic. Now the query returns multiple lines but as they all have the same key the base amounts are not added together.

This fixes the previous issue when several lines from the same move but with different analytics were added but it creates another issue when different invoices have the same tax and different analytic because these lines also have the same key. This result in only the base amount of the first invoice to be taken into account.

### Solution:
The previous fix was incorrect.

The correct fix is to not join the lines when there are two tax lines. To do this the [condition](https://github.com/odoo/odoo/blob/cf8d38205c09a2724f41907fa07c5f23ff2d46a3/addons/account/models/account_move_line_tax_details.py#L153) in the query needs to be the same as the [condition](https://github.com/odoo/odoo/blob/cf8d38205c09a2724f41907fa07c5f23ff2d46a3/addons/account/models/account_move_line.py#L984) that will duplicate the lines in python.

The check on `use_in_tax_closing` was missing so we add it.

opw-4766421