### PR TITLE
[IMP] various: improve eInvoice format labels for clarity

### DIFF
--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -13,12 +13,12 @@ class ResPartner(models.Model):
 
     invoice_edi_format = fields.Selection(
         selection_add=[
-            ('facturx', "Factur-X (CII)"),
-            ('ubl_bis3', "BIS Billing 3.0"),
-            ('xrechnung', "XRechnung CIUS"),
-            ('nlcius', "NLCIUS"),
-            ('ubl_a_nz', "BIS Billing 3.0 A-NZ"),
-            ('ubl_sg', "BIS Billing 3.0 SG"),
+            ('facturx', "France (FacturX)"),
+            ('ubl_bis3', "EU Standard (Peppol Bis 3.0)"),
+            ('xrechnung', "Germany (XRechnung)"),
+            ('nlcius', "Netherlands (NLCIUS)"),
+            ('ubl_a_nz', "Australia BIS Billing 3.0 A-NZ"),
+            ('ubl_sg', "Singapore BIS Billing 3.0 SG"),
         ],
     )
     is_ubl_format = fields.Boolean(compute='_compute_is_ubl_format')

--- a/addons/l10n_anz_ubl_pint/models/res_partner.py
+++ b/addons/l10n_anz_ubl_pint/models/res_partner.py
@@ -5,7 +5,7 @@ from odoo import models, fields
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    invoice_edi_format = fields.Selection(selection_add=[('pint_anz', "PINT Australia & New Zealand")])
+    invoice_edi_format = fields.Selection(selection_add=[('pint_anz', "Australia (Peppol Pint AU)")])
 
     def _get_edi_builder(self, invoice_edi_format):
         # EXTENDS 'account_edi_ubl_cii'

--- a/addons/l10n_dk_oioubl/models/res_partner.py
+++ b/addons/l10n_dk_oioubl/models/res_partner.py
@@ -4,7 +4,7 @@ from odoo import models, fields
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    invoice_edi_format = fields.Selection(selection_add=[('oioubl_201', "OIOUBL 2.01")])
+    invoice_edi_format = fields.Selection(selection_add=[('oioubl_201', "Denmark (Oioubl)")])
 
     def _get_edi_builder(self, invoice_edi_format):
         # EXTENDS 'account_edi_ubl_cii'

--- a/addons/l10n_es_edi_facturae/models/res_partner.py
+++ b/addons/l10n_es_edi_facturae/models/res_partner.py
@@ -14,7 +14,7 @@ class AcRoleType(models.Model):
 class Partner(models.Model):
     _inherit = 'res.partner'
 
-    invoice_edi_format = fields.Selection(selection_add=[('es_facturae', 'Facturae')])
+    invoice_edi_format = fields.Selection(selection_add=[('es_facturae', 'Spain (FacturaE)')])
     type = fields.Selection(selection_add=[('facturae_ac', 'FACe Center'), ('other',)])
     l10n_es_edi_facturae_ac_center_code = fields.Char(string='Code', size=10, help="Code of the issuing department.")
     l10n_es_edi_facturae_ac_role_type_ids = fields.Many2many(

--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -10,7 +10,7 @@ class ResPartner(models.Model):
     _name = 'res.partner'
     _inherit = 'res.partner'
 
-    invoice_edi_format = fields.Selection(selection_add=[('it_edi_xml', 'FatturaPA')])
+    invoice_edi_format = fields.Selection(selection_add=[('it_edi_xml', 'Italy (Factura PA)')])
     l10n_it_pec_email = fields.Char(string="PEC e-mail")
     l10n_it_codice_fiscale = fields.Char(string="Codice Fiscale", size=16)
     l10n_it_pa_index = fields.Char(

--- a/addons/l10n_jp_ubl_pint/models/res_partner.py
+++ b/addons/l10n_jp_ubl_pint/models/res_partner.py
@@ -4,7 +4,7 @@ from odoo import models, fields
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    invoice_edi_format = fields.Selection(selection_add=[('pint_jp', "PINT Japan")])
+    invoice_edi_format = fields.Selection(selection_add=[('pint_jp', "Japan (Peppol PINT JP)")])
 
     def _get_edi_builder(self, invoice_edi_format):
         # EXTENDS 'account_edi_ubl_cii'

--- a/addons/l10n_my_ubl_pint/models/res_partner.py
+++ b/addons/l10n_my_ubl_pint/models/res_partner.py
@@ -5,7 +5,7 @@ from odoo import models, fields, api
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    invoice_edi_format = fields.Selection(selection_add=[('pint_my', "PINT Malaysia")])
+    invoice_edi_format = fields.Selection(selection_add=[('pint_my', "Malaysia (Peppol PINT MY)")])
     sst_registration_number = fields.Char(
         string="SST",
         help="Malaysian Sales and Service Tax Number",

--- a/addons/l10n_ro_edi/models/res_partner.py
+++ b/addons/l10n_ro_edi/models/res_partner.py
@@ -4,7 +4,7 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    invoice_edi_format = fields.Selection(selection_add=[('ciusro', "CIUSRO")])
+    invoice_edi_format = fields.Selection(selection_add=[('ciusro', "Romania (CIUS RO)")])
 
     def _get_edi_builder(self, invoice_edi_format):
         # EXTENDS 'account_ubl_cii'

--- a/addons/l10n_sg_ubl_pint/models/res_partner.py
+++ b/addons/l10n_sg_ubl_pint/models/res_partner.py
@@ -5,7 +5,7 @@ from odoo import models, fields
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    invoice_edi_format = fields.Selection(selection_add=[('pint_sg', "PINT Singapore")])
+    invoice_edi_format = fields.Selection(selection_add=[('pint_sg', "Singapore (Peppol PINT SG)")])
 
     def _get_edi_builder(self, invoice_edi_format):
         # EXTENDS 'account_edi_ubl_cii'

--- a/addons/l10n_tr_nilvera/models/res_partner.py
+++ b/addons/l10n_tr_nilvera/models/res_partner.py
@@ -13,7 +13,7 @@ class ResPartner(models.Model):
     _name = 'res.partner'
     _inherit = ['res.partner']
 
-    invoice_edi_format = fields.Selection(selection_add=[('ubl_tr', "UBL TR 1.2")])
+    invoice_edi_format = fields.Selection(selection_add=[('ubl_tr', "Turkyie (UBL TR 1.2)")])
     l10n_tr_nilvera_customer_status = fields.Selection(
         selection=[
             ('not_checked', "Not Checked"),

--- a/addons/l10n_vn_edi_viettel/models/res_partner.py
+++ b/addons/l10n_vn_edi_viettel/models/res_partner.py
@@ -6,7 +6,7 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    invoice_edi_format = fields.Selection(selection_add=[('vn_sinvoice', 'SInvoice file')])
+    invoice_edi_format = fields.Selection(selection_add=[('vn_sinvoice', 'Vietnam (SInvoice)')])
     l10n_vn_edi_symbol = fields.Many2one(
         comodel_name='l10n_vn_edi_viettel.sinvoice.symbol',
         string='Default Symbol',


### PR DESCRIPTION
Renamed the selection labels for invoice_edi_format field to make them easier to understand based on the user's country context when choosing format inside customer's account tab.

This improves the usability of the dropdown when selecting an eInvoicing format, especially for users in localizations where the technical name was unclear or confusing.

4889699
shzi