### PR TITLE
[IMP] website_hr_recruitment: warning on appplication page

### DIFF
--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -207,66 +207,6 @@ class WebsiteHrRecruitment(WebsiteForm):
             'default': default,
         })
 
-    @http.route('/website_hr_recruitment/check_recent_application', type='jsonrpc', auth="public", website=True)
-    def check_recent_application(self, field, value, job_id):
-        def refused_applicants_condition(applicant):
-            return not applicant.active \
-                and applicant.job_id.id == int(job_id) \
-                and applicant.create_date >= (datetime.now() - relativedelta(months=6))
-
-        field_domain = {
-            'name': [('partner_name', '=ilike', escape_psql(value))],
-            'email': [('email_normalized', '=', email_normalize(value))],
-            'phone': [('partner_phone', '=', value)],
-            'linkedin': [('linkedin_profile', '=ilike', escape_psql(value))],
-        }.get(field, [])
-
-        applications_by_status = http.request.env['hr.applicant'].sudo().search(Domain.AND([
-            field_domain,
-            [
-                ('job_id.website_id', 'in', [http.request.website.id, False]),
-                '|',
-                    ('application_status', '=', 'ongoing'),
-                    '&',
-                        ('application_status', '=', 'refused'),
-                        ('active', '=', False),
-            ]
-        ]), order='create_date DESC').grouped('application_status')
-        refused_applicants = applications_by_status.get('refused', http.request.env['hr.applicant'])
-        if any(applicant for applicant in refused_applicants if refused_applicants_condition(applicant)):
-            return {
-                'message':  _(
-                    'We\'ve found a previous closed application in our system within the last 6 months.'
-                    ' Please consider before applying in order not to duplicate efforts.'
-                )
-            }
-
-        if 'ongoing' not in applications_by_status:
-            return {'message': None}
-
-        ongoing_application = applications_by_status.get('ongoing')[0]
-        if ongoing_application.job_id.id == int(job_id):
-            recruiter_contact = "" if not ongoing_application.user_id else _(
-                ' In case of issue, contact %(contact_infos)s',
-                contact_infos=", ".join(
-                    [value for value in itemgetter('name', 'email', 'phone')(ongoing_application.user_id) if value]
-                ))
-            return {
-                'message':  _(
-                    'An application already exists for %(value)s.'
-                    ' Duplicates might be rejected. %(recruiter_contact)s',
-                    value=value,
-                    recruiter_contact=recruiter_contact
-                )
-            }
-
-        return {
-            'message':  _(
-                'We found a recent application with a similar name, email, phone number.'
-                ' You can continue if it\'s not a mistake.'
-            )
-        }
-
     def extract_data(self, model_sudo, values):
         short_introduction = values.get("short_introduction", None)
         data = super().extract_data(model_sudo, values)

--- a/addons/website_hr_recruitment/models/hr_applicant.py
+++ b/addons/website_hr_recruitment/models/hr_applicant.py
@@ -1,8 +1,13 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from collections import defaultdict
+
+from dateutil.relativedelta import relativedelta
+from markupsafe import Markup
+
+from odoo import api, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Domain
 
 
 class HrApplicant(models.Model):
@@ -20,3 +25,103 @@ class HrApplicant(models.Model):
             if stage:
                 values['stage_id'] = stage.id
         return values
+
+    def _generate_duplicate_applicant_message(self, message, matching_applicants):
+        return Markup("<p>{message}</p><ul>{applicants}</ul>").format(
+            message=message,
+            applicants=Markup().join(
+                [
+                    Markup("<li><a href='/odoo/hr.applicant/{id}'>{name}</li>").format(
+                        id=applicant.id,
+                        name=applicant.partner_name,
+                    )
+                    for applicant in matching_applicants
+                ],
+            ),
+        )
+
+    def _handle_potential_duplicate_web_applications(self):
+        """
+        This method checks if any newly created applicants in self can be considered duplicates of existing applicants
+        and adds an activity on the duplicate record. An applicant is considered a duplicate if it belongs to the same
+        job position and shares any or all of the following fields: email address, phone number and linkedin profile.
+        """
+        existing_applicants_domain = Domain.AND(
+            [
+                self._get_similar_applicants_domain(ignore_talent=True),
+                Domain("job_id", "in", [job for job in self.mapped("job_id.id") if job]),
+                Domain.OR(
+                    [
+                        Domain("refuse_date", ">=", fields.Datetime.now() - relativedelta(months=6)),
+                        Domain("refuse_date", "=", False),
+                    ],
+                ),
+                Domain("id", "not in", self.ids),
+            ],
+        )
+        existing_applicants = self.with_context(active_test=False).search(
+            domain=existing_applicants_domain,
+            order="create_date desc",
+        )
+
+        refused_existing_applicants = defaultdict(lambda: defaultdict(lambda: self.env["hr.applicant"]))
+        ongoing_existing_applicants = defaultdict(lambda: defaultdict(lambda: self.env["hr.applicant"]))
+
+        for applicant in existing_applicants:
+            if applicant.application_status == "refused":
+                refused_existing_applicants[applicant.job_id.id][applicant.email_normalized] += applicant
+                refused_existing_applicants[applicant.job_id.id][applicant.partner_phone_sanitized] += applicant
+                refused_existing_applicants[applicant.job_id.id][applicant.linkedin_profile] += applicant
+            elif applicant.application_status == "ongoing":
+                ongoing_existing_applicants[applicant.job_id.id][applicant.email_normalized] += applicant
+                ongoing_existing_applicants[applicant.job_id.id][applicant.partner_phone_sanitized] += applicant
+                ongoing_existing_applicants[applicant.job_id.id][applicant.linkedin_profile] += applicant
+
+        for applicant in self:
+            refused_job_matches = refused_existing_applicants.get(applicant.job_id.id)
+            ongoing_job_matches = ongoing_existing_applicants.get(applicant.job_id.id)
+
+            if refused_job_matches:
+                if matching_applicants := (
+                    refused_job_matches.get(applicant.email_normalized, self.env["hr.applicant"])
+                    | refused_job_matches.get(applicant.partner_phone_sanitized, self.env["hr.applicant"])
+                    | refused_job_matches.get(applicant.linkedin_profile, self.env["hr.applicant"])
+                ):
+                    applicant.activity_schedule(
+                        act_type_xmlid="mail_activity_data_todo",
+                        summary=self.env._("Potential Duplicate Detected: Refused Application"),
+                        note=self._generate_duplicate_applicant_message(
+                            self.env._(
+                                "The following recently refused applications share an email address, phone number and/or linkedin profile with this application:",
+                            ),
+                            matching_applicants,
+                        ),
+                        user_id=applicant.recruiter_id.user_id.id or applicant.job_id.recruiter_id.user_id.id,
+                    )
+            elif ongoing_job_matches:
+                if matching_applicants := (
+                    ongoing_job_matches.get(applicant.email_normalized, self.env["hr.applicant"])
+                    | ongoing_job_matches.get(applicant.partner_phone_sanitized, self.env["hr.applicant"])
+                    | ongoing_job_matches.get(applicant.linkedin_profile, self.env["hr.applicant"])
+                ):
+                    applicant.activity_schedule(
+                        act_type_xmlid="mail_activity_data_todo",
+                        summary=self.env._("Potential Duplicate Detected: Ongoing Application"),
+                        note=self._generate_duplicate_applicant_message(
+                            self.env._(
+                                "The following ongoing applications share an email address, phone number and/or linkedin profile with this application:",
+                            ),
+                            matching_applicants,
+                        ),
+                        user_id=applicant.recruiter_id.user_id.id or applicant.job_id.recruiter_id.user_id.id,
+                    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        applicants = super().create(vals_list)
+
+        applicants_applied_through_website = "website_id" in self.env.context
+        if applicants_applied_through_website:
+            applicants._handle_potential_duplicate_web_applications()
+
+        return applicants

--- a/addons/website_hr_recruitment/static/src/interactions/hr_recruitment_form.js
+++ b/addons/website_hr_recruitment/static/src/interactions/hr_recruitment_form.js
@@ -2,15 +2,11 @@ import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
 import { _t } from "@web/core/l10n/translation";
-import { rpc } from "@web/core/network/rpc";
 
 export class HrRecruitmentForm extends Interaction {
     static selector = "#hr_recruitment_form";
     dynamicContent = {
         "#apply-btn": { "t-on-click": this.onApplyButtonClick },
-        "#recruitment1": { "t-on-focusout": (ev) => this.checkRedundant(ev.currentTarget, "name", this.warningMessageEl) },
-        "#recruitment2": { "t-on-focusout": (ev) => this.checkRedundant(ev.currentTarget, "email", this.warningMessageEl) },
-        "#recruitment3": { "t-on-focusout": (ev) => this.checkRedundant(ev.currentTarget, "phone", this.warningMessageEl) },
         "#recruitment4": {
             "t-on-focusout": this.onLinkedinFocusOut,
             "t-att-required": () => this.isIncomplete,
@@ -48,32 +44,6 @@ export class HrRecruitmentForm extends Interaction {
         messageContainerEl.classList.add("d-none");
     }
 
-    /**
-     * @param {HTMLElement} targetEl
-     * @param {string} field
-     * @param {HTMLElement} messageContainerEl
-     * @param {boolean} [keepPreviousWarningMessage=false]
-     */
-    async checkRedundant(targetEl, field, messageContainerEl, keepPreviousWarningMessage = false) {
-        const value = targetEl.value;
-        if (!value) {
-            this.hideWarningMessage(targetEl, messageContainerEl);
-            return;
-        }
-        const job_id = document.querySelector("#recruitment7").value;
-        const data = await this.waitFor(rpc("/website_hr_recruitment/check_recent_application", {
-            field: field,
-            value: value,
-            job_id: job_id,
-        }));
-
-        if (data.message) {
-            this.showWarningMessage(targetEl, messageContainerEl, data.message);
-        } else if (!keepPreviousWarningMessage) {
-            this.hideWarningMessage(targetEl, messageContainerEl);
-        }
-    }
-
     onApplyButtonClick() {
         const isEmptyLinkedin = !this.linkedinInputEl || this.linkedinInputEl.value.trim() === "";
         const isEmptyResume = !this.resumeInputEl || !this.resumeInputEl.files.length;
@@ -90,7 +60,6 @@ export class HrRecruitmentForm extends Interaction {
         } else {
             this.hideWarningMessage(this.linkedinInputEl, this.linkedinMessageEl);
         }
-        this.checkRedundant(this.linkedinInputEl, "linkedin", this.linkedinMessageEl, isLinkedinValid);
     }
 }
 

--- a/addons/website_hr_recruitment/tests/__init__.py
+++ b/addons/website_hr_recruitment/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_website_hr_recruitment
 from . import test_website_hr_recruitment_technical_page
+from . import test_website_hr_recruitment_duplicate_applications

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment_duplicate_applications.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment_duplicate_applications.py
@@ -1,0 +1,282 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestWebsiteHrRecruitmentDuplicateApplications(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.job_1, cls.job_2 = cls.env["hr.job"].create(
+            [
+                {"name": "job 1", "is_published": True},
+                {"name": "job 2", "is_published": True},
+            ],
+        )
+        cls.applicant_data_1 = {
+            "partner_name": "Test Applicant",
+            "email_from": "test@example.com",
+            "partner_phone": "1234",
+            "linkedin_profile": "linkedin.com/in/test-applicant",
+            "job_id": cls.job_1.id,
+        }
+        cls.applicant_data_2 = {
+            "partner_name": "Totally Not Test Applicant",
+            "email_from": "totally.not.test.applicant@example.com",
+            "partner_phone": "5678",
+            "linkedin_profile": "linkedin.com/in/totally-not-test-applicant",
+            "job_id": cls.job_1.id,
+        }
+        cls.test_applicant = cls.env["hr.applicant"].create(cls.applicant_data_1)
+
+        cls.refuse_reason = cls.env["hr.applicant.refuse.reason"].create([{"name": "Refused"}])
+
+    def test_detects_a_full_duplicate_of_an_ongoing_application(self):
+        """
+        Assert that a to-do activity is added to a new applicant if another
+        ongoing applicant with the same information exists.
+        """
+        res = self.url_open("/website/form/hr.applicant", data=self.applicant_data_1)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertTrue(applicant_activities, "The applicant should have a linked activity")
+        self.assertEqual(len(applicant_activities), 1, "The applicant should only have one linked activity")
+        self.assertEqual(
+            applicant_activities.mapped("summary")[0],
+            "Potential Duplicate Detected: Ongoing Application",
+            "The activity summary should indicate that this is a duplicate of an ongoing application",
+        )
+
+    def test_detects_an_email_duplicate_of_an_ongoing_application(self):
+        """
+        Assert that a to-do activity is added to a new applicant if another
+        ongoing applicant with the same email exists.
+        """
+        new_applicant_data = {
+            **self.applicant_data_2,
+            "email_from": self.applicant_data_1["email_from"],
+        }
+        res = self.url_open("/website/form/hr.applicant", data=new_applicant_data)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertTrue(applicant_activities, "The applicant should have a linked activity")
+        self.assertEqual(len(applicant_activities), 1, "The applicant should only have one linked activity")
+        self.assertEqual(
+            applicant_activities.mapped("summary")[0],
+            "Potential Duplicate Detected: Ongoing Application",
+            "The activity summary should indicate that this is a duplicate of an ongoing application",
+        )
+
+    def test_detects_a_phone_duplicate_of_an_ongoing_application(self):
+        """
+        Assert that a to-do activity is added to a new applicant if another
+        ongoing applicant with the same phone number exists.
+        """
+        new_applicant_data = {
+            **self.applicant_data_2,
+            "partner_phone": self.applicant_data_1["partner_phone"],
+        }
+        res = self.url_open("/website/form/hr.applicant", data=new_applicant_data)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertTrue(applicant_activities, "The applicant should have a linked activity")
+        self.assertEqual(len(applicant_activities), 1, "The applicant should only have one linked activity")
+        self.assertEqual(
+            applicant_activities.mapped("summary")[0],
+            "Potential Duplicate Detected: Ongoing Application",
+            "The activity summary should indicate that this is a duplicate of an ongoing application",
+        )
+
+    def test_detects_a_linkedin_duplicate_of_an_ongoing_application(self):
+        """
+        Assert that a to-do activity is added to a new applicant if another
+        ongoing applicant with the same linkedin exists.
+        """
+        new_applicant_data = {
+            **self.applicant_data_2,
+            "linkedin_profile": self.applicant_data_1["linkedin_profile"],
+        }
+        res = self.url_open("/website/form/hr.applicant", data=new_applicant_data)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertTrue(applicant_activities, "The applicant should have a linked activity")
+        self.assertEqual(len(applicant_activities), 1, "The applicant should only have one linked activity")
+        self.assertEqual(
+            applicant_activities.mapped("summary")[0],
+            "Potential Duplicate Detected: Ongoing Application",
+            "The activity summary should indicate that this is a duplicate of an ongoing application",
+        )
+
+    def test_detects_an_email_phone_duplicate_of_an_ongoing_application(self):
+        """
+        Assert that a to-do activity is added to a new applicant if another
+        ongoing applicant with the same email and phone exists.
+        """
+        new_applicant_data = {
+            **self.applicant_data_2,
+            "email_from": self.applicant_data_1["email_from"],
+            "partner_phone": self.applicant_data_1["partner_phone"],
+        }
+        res = self.url_open("/website/form/hr.applicant", data=new_applicant_data)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertTrue(applicant_activities, "The applicant should have a linked activity")
+        self.assertEqual(len(applicant_activities), 1, "The applicant should only have one linked activity")
+        self.assertEqual(
+            applicant_activities.mapped("summary")[0],
+            "Potential Duplicate Detected: Ongoing Application",
+            "The activity summary should indicate that this is a duplicate of an ongoing application",
+        )
+
+    def test_detects_an_email_linkedin_duplicate_of_an_ongoing_application(self):
+        """
+        Assert that a to-do activity is added to a new applicant if another
+        ongoing applicant with the same email and linkedin exists.
+        """
+        new_applicant_data = {
+            **self.applicant_data_2,
+            "email_from": self.applicant_data_1["email_from"],
+            "linkedin_profile": self.applicant_data_1["linkedin_profile"],
+        }
+        res = self.url_open("/website/form/hr.applicant", data=new_applicant_data)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertTrue(applicant_activities, "The applicant should have a linked activity")
+        self.assertEqual(len(applicant_activities), 1, "The applicant should only have one linked activity")
+        self.assertEqual(
+            applicant_activities.mapped("summary")[0],
+            "Potential Duplicate Detected: Ongoing Application",
+            "The activity summary should indicate that this is a duplicate of an ongoing application",
+        )
+
+    def test_detects_a_phone_linkedin_duplicate_of_an_ongoing_application(self):
+        """
+        Assert that a to-do activity is added to a new applicant if another
+        ongoing applicant with the same phone and linkedin exists.
+        """
+        new_applicant_data = {
+            **self.applicant_data_2,
+            "partner_phone": self.applicant_data_1["partner_phone"],
+            "linkedin_profile": self.applicant_data_1["linkedin_profile"],
+        }
+        res = self.url_open("/website/form/hr.applicant", data=new_applicant_data)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertTrue(applicant_activities, "The applicant should have a linked activity")
+        self.assertEqual(len(applicant_activities), 1, "The applicant should only have one linked activity")
+        self.assertEqual(
+            applicant_activities.mapped("summary")[0],
+            "Potential Duplicate Detected: Ongoing Application",
+            "The activity summary should indicate that this is a duplicate of an ongoing application",
+        )
+
+    def test_detects_a_full_duplicate_of_a_refused_application(self):
+        """
+        Assert that a to-do activity is added to a new applicant if another
+        refused applicant with the same information exists.
+        """
+        # Refuse the existing applicant
+        self.test_applicant.write(
+            {
+                "refuse_reason_id": self.refuse_reason,
+                "active": False,
+                "refuse_date": datetime.now(),
+            },
+        )
+
+        res = self.url_open("/website/form/hr.applicant", data=self.applicant_data_1)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertTrue(applicant_activities, "The applicant should have a linked activity")
+        self.assertEqual(len(applicant_activities), 1, "The applicant should only have one linked activity")
+        self.assertEqual(
+            applicant_activities.mapped("summary")[0],
+            "Potential Duplicate Detected: Refused Application",
+            "The activity summary should indicate that this is a duplicate of an refused application",
+        )
+
+    def test_does_not_detect_a_full_duplicate_of_a_refused_application_past_6_months(self):
+        """
+        Assert that a to-do activity is NOT added to a new applicant if another
+        refused applicant with the same information exists that was refused more
+        than six months ago.
+        """
+        # Refuse the existing applicant
+        self.test_applicant.write(
+            {
+                "refuse_reason_id": self.refuse_reason,
+                "active": False,
+                "refuse_date": datetime.now() - relativedelta(months=6, days=1),
+            },
+        )
+
+        res = self.url_open("/website/form/hr.applicant", data=self.applicant_data_1)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertFalse(applicant_activities, "The applicant should not have any linked activities")
+
+    def test_does_not_detect_a_full_duplicate_for_a_different_job(self):
+        """
+        Assert that a to-do activity is NOT added to a new applicant if another
+        refused applicant with the same information except a different job exists.
+        """
+        new_applicant_data = {
+            **self.applicant_data_1,
+            "job_id": self.job_2.id,
+        }
+        res = self.url_open("/website/form/hr.applicant", data=new_applicant_data)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+
+        self.assertEqual(new_applicant.application_count, 2, "The applicant should have 2 related applications")
+        self.assertFalse(applicant_activities, "The applicant should not have any linked activities")
+
+    def test_prioritizes_a_refused_message_over_ongoing(self):
+        """
+        Assert that if there are two existing applicants, and one of them is
+        refused, add only one activity and only for the refused applicant.
+        """
+        # Create a new ongoing applicant
+        self.env["hr.applicant"].create(self.applicant_data_1)
+        # Refuse the existing applicant
+        self.test_applicant.write(
+            {
+                "refuse_reason_id": self.refuse_reason,
+                "active": False,
+                "refuse_date": datetime.now(),
+            },
+        )
+
+        res = self.url_open("/website/form/hr.applicant", data=self.applicant_data_1)
+        new_applicant = self.env["hr.applicant"].browse(res.json().get("id"))
+        applicant_activities = new_applicant.activity_ids
+        self.assertEqual(new_applicant.application_count, 3, "The applicant should have 3 related applications")
+        self.assertTrue(applicant_activities, "The applicant should have a linked activity")
+        self.assertEqual(len(applicant_activities), 1, "The applicant should only have one linked activity")
+        self.assertEqual(
+            applicant_activities.mapped("summary")[0],
+            "Potential Duplicate Detected: Refused Application",
+            "The activity summary should indicate that this is a duplicate of a refused application",
+        )


### PR DESCRIPTION
When applying to a job with an email, phone number, or LinkedIn profile that is already associated with an applicant, a warning would appear showing that there is either an existing applicant or an existing refused applicant. This can cause problems as anyone can use this method to see if a person has applied and deduce the status of their application. This PR replaces these warnings in the frontend by creating activities on the applicant that are assigned to either the applicant's recruiter or the applicant's job's recruiter.

task-4943060

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
