### PR TITLE
[FIX] base_iban: missing fr_BE translation for IBAN error

### DIFF
--- a/addons/base_iban/i18n/fr_BE.po
+++ b/addons/base_iban/i18n/fr_BE.po
@@ -60,7 +60,7 @@ msgstr ""
 #: code:addons/base_iban/models/res_partner_bank.py:0
 #, python-format
 msgid "The IBAN is invalid, it should begin with the country code"
-msgstr ""
+msgstr "L'IBAN est invalide, il doit commencer par le code du pays"
 
 #. module: base_iban
 #: code:addons/base_iban/models/res_partner_bank.py:0


### PR DESCRIPTION
Adds the missing Belgian French translation for the IBAN validation message: "THE IBAN IS Invalid, it should begin with the country code"

opw-4868395




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
