### PR TITLE
[FIX] core: run tests

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1348,8 +1348,8 @@ def preload_registries(dbnames):
     for dbname in dbnames:
         try:
             threading.current_thread().dbname = dbname
-            update_module = config['init'] or config['update']
-            if not update_module:
+            update_from_config = update_module = config['init'] or config['update']
+            if not update_from_config:
                 with sql_db.db_connect(dbname).cursor() as cr:
                     cr.execute("SELECT 1 FROM ir_module_module WHERE state IN ('to remove', 'to upgrade', 'to install') FETCH FIRST 1 ROW ONLY")
                     update_module = bool(cr.rowcount)
@@ -1360,7 +1360,7 @@ def preload_registries(dbnames):
                 from odoo.tests import loader  # noqa: PLC0415
                 t0 = time.time()
                 t0_sql = sql_db.sql_counter
-                module_names = (registry.updated_modules if update_module else
+                module_names = (registry.updated_modules if update_from_config else
                                 sorted(registry._init_modules))
                 _logger.info("Starting post tests")
                 tests_before = registry._assertion_report.testsRun


### PR DESCRIPTION
Since e4ca53b0a3780c298c280988997321c2be8e7d3f we compute `updated_modules` from information in the DB. This leads to an empty `module_names` list if there are custom modules after an upgrade.

Since the `to upgrade` modules is non-empty, `module_names` gets the list of `registry.updated_modules` which is empty when we are just running post upgrade tests.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
