### PR TITLE
[18.0] [4969713] [FIX] point_of_sale: Fixed singleton error

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -418,12 +418,13 @@ class PosConfig(models.Model):
 
     @api.constrains('payment_method_ids')
     def _check_payment_method_ids_journal(self):
-        for cash_method in self.payment_method_ids.filtered(lambda m: m.journal_id.type == 'cash'):
-            if self.env['pos.config'].search_count([('id', '!=', self.id), ('payment_method_ids', 'in', cash_method.ids)], limit=1):
-                raise ValidationError(_("This cash payment method is already used in another Point of Sale.\n"
-                                        "A new cash payment method should be created for this Point of Sale."))
-            if len(cash_method.journal_id.pos_payment_method_ids) > 1:
-                raise ValidationError(_("You cannot use the same journal on multiples cash payment methods."))
+        for config in self:
+            for cash_method in config.payment_method_ids.filtered(lambda m: m.journal_id.type == 'cash'):
+                if self.env['pos.config'].search_count([('id', '!=', config.id), ('payment_method_ids', 'in', cash_method.ids)], limit=1):
+                    raise ValidationError(_("This cash payment method is already used in another Point of Sale.\n"
+                                            "A new cash payment method should be created for this Point of Sale."))
+                if len(cash_method.journal_id.pos_payment_method_ids) > 1:
+                    raise ValidationError(_("You cannot use the same journal on multiples cash payment methods."))
 
     @api.constrains('trusted_config_ids')
     def _check_trusted_config_ids_currency(self):


### PR DESCRIPTION
### Steps to reproduce the issue:
1) In the Point of Sale app, when trying to duplicate more than two records from the list view, it gives a singleton error.

The implementation was added to the master branch from commit [1].

[1]: https://github.com/odoo/odoo/pull/92664/files#diff-4c6e412c7d8f4df2a05831547e7df93d0b91f510d03b7b3ed0d689a18f5dae44R360-R361

opw-4969713

### Description of the issue/feature this PR addresses:
#### Issue
Previously, when duplicating more than one pos.config record, it would give a singleton error.

#### Solution
Added a for loop to iterate over the config records individually.

### Current behavior before PR:
https://github.com/user-attachments/assets/ba5a3969-7647-4943-a0b1-12b1961f26cd

### Desired behavior after PR is merged:
https://github.com/user-attachments/assets/b952b711-7782-4e9d-b05a-e4019ab79d87


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr