### PR TITLE
[FIX] point_of_sale: add check on empty categories list

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -39,8 +39,8 @@ class PosCategory(models.Model):
     def _load_pos_data_domain(self, data):
         domain = []
         limited_categories = data['pos.config'][0]['limit_categories']
-        if limited_categories:
-            available_category_ids = data['pos.config'][0]['iface_available_categ_ids']
+        available_category_ids = data['pos.config'][0]['iface_available_categ_ids']
+        if limited_categories and available_category_ids:
             domain += [('id', 'in', available_category_ids)]
         return domain
 

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -49,8 +49,8 @@ class ProductTemplate(models.Model):
             ('sale_ok', '=', True),
         ]
         limited_categories = data['pos.config'][0]['limit_categories']
-        if limited_categories:
-            available_category_ids = data['pos.config'][0]['iface_available_categ_ids']
+        available_category_ids = data['pos.config'][0]['iface_available_categ_ids']
+        if limited_categories and available_category_ids:
             category_ids = self.env['pos.category'].browse(available_category_ids)._get_descendants().ids
             domain += [('pos_categ_ids', 'in', category_ids)]
         return domain


### PR DESCRIPTION
Steps to Reproduce:
1. Go to the POS Settings
2. Enable the "Restrict Categories" option
3. Leave the categories M2M field empty
4. Open the POS store
5. No products will be loaded

<img width="483" height="162" alt="empty categories" src="https://github.com/user-attachments/assets/2c932954-e67a-4faa-8915-b0ebacc57525" />

Issue:
The _load_pos_data_domain functions do not check on the size of the available_categories array before attempting to create a domain. As such, a domain entry `["category_ids", "in", []]` will be added, preventing any products from being loaded. This wasn't the case in version 18.0, which had a check on the array.

Fix:
Add an extra check on the existence of the available_categories array before attempting to create a domain.

Addendum:
Field "Restrict Categories" description is: 
> If no category is specified, all available products will be shown

task-4962323

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
