### PR TITLE
[FIX] purchase: The Company Total does not update when the currency is changed

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -22,7 +22,7 @@ class PurchaseOrder(models.Model):
     _rec_names_search = ['name', 'partner_ref']
     _order = 'priority desc, id desc'
 
-    @api.depends('order_line.price_subtotal', 'company_id')
+    @api.depends('order_line.price_subtotal', 'company_id', 'currency_id')
     def _amount_all(self):
         AccountTax = self.env['account.tax']
         for order in self:


### PR DESCRIPTION
**Steps to reproduce:**

1. Create a Purchase Order (PO) with a non-company currency (e.g., EUR if the main currency is USD).

2. Add at least one order line so the "Amount Total" is greater than zero.

3. Change the currency of the PO to a different one and save the record.

**Expected behavior:**

The `Company Total` field is recomputed using the new currency's exchange rate.

**Actual behavior:**

The `Company Total` remains unchanged, still showing the value in the original currency.

**Fix:**

Add `currency_id` to the `@api.depends` decorator of the `_amount_all` compute method.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
