### PR TITLE
[FIX] sale: avoid invoice email being sent from and to same author

### DIFF
--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -163,7 +163,7 @@ class PaymentTransaction(models.Model):
                 if mail_template.exists():
                     send_context['mail_template'] = mail_template
 
-            self.env['account.move.send']._generate_and_send_invoices(
+            tx.env['account.move.send']._generate_and_send_invoices(
                 invoice_to_send,
                 **send_context,
             )

--- a/addons/sale/tests/test_payment_flow.py
+++ b/addons/sale/tests/test_payment_flow.py
@@ -639,3 +639,40 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon, MailC
             notification_mail_mock.assert_called_with(
                 self.env.ref('sale.mail_template_sale_confirmation'))
             self.assertEqual(self.sale_order.state, 'sale')
+
+    def test_automatic_invoice_mail_author(self):
+        self.env['ir.config_parameter'].sudo().set_param('sale.automatic_invoice', 'True')
+
+        portal_user = self.env['res.users'].create({
+            'name': 'Portal Customer',
+            'login': 'portal@test.com',
+            'email': 'portal@test.com',
+            'partner_id': self.partner_a.id,
+            'groups_id': [(6, 0, [self.env.ref('base.group_portal').id])],
+        })
+        portal_user.partner_id.invoice_sending_method = 'email'
+
+        sale_order = self.env['sale.order'].with_user(portal_user).sudo().create({
+            'partner_id': portal_user.partner_id.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product_a.id,
+                'product_uom_qty': 1,
+                'price_unit': 100.0,
+            })],
+        })
+
+        self.amount = sale_order.amount_total
+        tx = self._create_transaction(
+            flow='redirect',
+            sale_order_ids=[sale_order.id],
+            state='done'
+        )
+
+        with mute_logger('odoo.addons.sale.models.payment_transaction'):
+            tx.with_user(portal_user).sudo()._post_process()
+
+        # Verify invoice was created and sent successfully
+        invoice = sale_order.invoice_ids[0]
+        self.assertTrue(invoice.is_move_sent, "Invoice should be marked as sent")
+        invoice_sent_mail = invoice.message_ids[0]
+        self.assertTrue(invoice_sent_mail.author_id.id not in invoice_sent_mail.notified_partner_ids.ids)


### PR DESCRIPTION
**Steps to reproduce**:
1. Enable automatic invoicing
   `Settings -> Sales -> Invoicing -> Automatic Invoice`
2. Configure a payment provider like `Stripe` (not demo)
3. Open the website in an incognito browser and log in as a portal user
4. Add a product to cart and checkout with the portal user's delivery address
5. Complete payment using test card credentials
6. Navigate to the created invoice in Sales

**Observed behavior:**
The invoice email is sent to both the portal user (customer) and the system admin, appearing as if the email is sent "from admin to admin" instead of from the assigned salesperson.

**Root cause:**
When automatic invoicing is enabled and a portal user completes a website purchase, the `_send_invoice()` method uses `self.env['account.move.send']` which runs in the portal user context. The portal user is selected as author, and the email template uses `partner_to` so it is also selected as partner. While sending mail, this triggers the `mail_notify_author` context. Additionally, due to the portal user not having proper email sending permissions, the system adds admin as fallback. As a result, emails are sent by admin, and because of `mail_notify_author`, mail is also sent to admin.

**Solution:**
Changed `self.env['account.move.send']` to `tx.env['account.move.send']` in the `_send_invoice()` method. Since `tx` is created with `SUPERUSER_ID` context, this ensures the invoice sending runs with proper system permissions and uses the transaction's context instead of the portal user's context.
This ensures emails are authored by the correct salesperson, not the portal user.

opw-4760568