### PR TITLE
[IMP] website_sale(_wishlist): fine-tune product page

### DIFF
--- a/addons/website_sale/static/src/scss/product_configurator.scss
+++ b/addons/website_sale/static/src/scss/product_configurator.scss
@@ -1,39 +1,44 @@
 .css_attribute_color {
-    --o-wsale-css-attribute-color__height: 1.6rem;
-    --o-wsale-css-attribute-color__border-width: .25rem;
+    --o-wsale-css-attribute-color__size: 1.6rem;
+
+    @include media-breakpoint-down(sm) {
+        --o-wsale-css-attribute-color__size: 2rem;
+    }
 
     position: relative;
     display: inline-block;
-    height: calc(var(--o-wsale-css-attribute-color__height) - var(--o-wsale-css-attribute-color__border-width));
-    width: calc(var(--o-wsale-css-attribute-color__height) - var(--o-wsale-css-attribute-color__border-width));
-    border: var(--o-wsale-css-attribute-color__border-width) solid var(--body-bg);
+    height: var(--o-wsale-css-attribute-color__size);
+    width: var(--o-wsale-css-attribute-color__size);
+    border: $border-width solid var(--o-wsale-attribute-color-border-color, #{$border-color});
     border-radius: 50%;
     transition: $transition-base;
-    outline: $border-width solid var(--o-wsale-css-attribute-color__outline-color, transparent);
-    outline-offset: calc(var(--o-wsale-css-attribute-color__border-width) * -0.5) ;
-    box-shadow: inset 0 0 0 $border-width $border-color;
-    box-sizing: content-box;
 
     input {
         opacity: 0;
     }
 
+    &:hover, &.active, &.active:hover {
+        box-shadow: inset 0 0 0 ($border-width * 2) $body-bg;
+    }
+
     &:hover {
-        --o-wsale-css-attribute-color__outline-color: var(--body-color);
-        outline-offset: $border-width * -1;
+        // Let borders color adapt according to body and CCs. Also, set a fallback
+        // value for browsers that don't support the color-mix function (used by
+        // 'fade-currentColor').
+        --o-wsale-attribute-color-border-color: #{o-color('600')};
+        --o-wsale-attribute-color-border-color: #{fade-currentColor(60%)};
     }
 
     &.active, &.active:hover {
-        --o-wsale-css-attribute-color__outline-color: #{map-get($theme-colors, 'primary')};
-        outline-offset: $border-width * -1;
+        --o-wsale-attribute-color-border-color: #{$primary};
     }
 
     &:has(input:focus-visible)::before {
         @include o-position-absolute($top: 50%, $left: 50%);
 
         content:" ";
-        width: 160%;
-        height: 160%;
+        width: 140%;
+        height: 140%;
         border-radius: 100%;
         z-index: -1;
         background-color: $focus-ring-color;

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -223,6 +223,12 @@
                 border-color: map-get($theme-colors, "primary");
             }
         }
+
+        @include media-breakpoint-down(sm) {
+            .css_attribute_color {
+                --o-wsale-css-attribute-color__size: 1.6rem;
+            }
+        }
     }
 
     .o_wsale_product_information_text {
@@ -804,7 +810,7 @@
         }
 
         .css_attribute_color {
-            --o-wsale-css-attribute-color__height: calc(var(--o-wsale-product-variant-preview-height) - var(--o-wsale-css-attribute-color__border-width));
+            --o-wsale-css-attribute-color__size: var(--o-wsale-product-variant-preview-height);
         }
 
         span[name="hidden_ptavs_count"] {

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -30,11 +30,6 @@
             top: $-container-top-gap;
         }
 
-        .css_attribute_color {
-            height: 32px;
-            width: 32px;
-        }
-
         .o_wsale_products_grid_before_rail{
             scrollbar-width: none;
             -ms-overflow-style: none;
@@ -1110,6 +1105,13 @@ $-product-radius-map: (
                 --o-wsale-product-col-details-padding-left: #{$grid-gutter-width * 2};
             }
         }
+    }
+
+    .breadcrumb .breadcrumb-item {
+        padding-top: calc(#{$btn-padding-y} + #{$btn-border-width});
+        padding-bottom: calc(#{$btn-padding-y} + #{$btn-border-width});
+        font-size: $btn-font-size;
+        line-height: $btn-line-height;
     }
 }
 #product_detail_main:where(.flex-lg-row-reverse) #product_details {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -994,10 +994,11 @@
                t-value="'background: ' + str(v.html_color or v.name if not v.is_custom else '')"
             />
             <label t-attf-style="#{img_style or color_style}"
-                   t-attf-class="css_attribute_color mb-1 #{'active' if v.id in attrib_set else ''}"
+                   t-attf-class="css_attribute_color cursor-pointer #{'active' if v.id in attrib_set else ''}"
             >
                 <input type="checkbox"
                        name="attribute_value"
+                       class="cursor-pointer"
                        t-att-value="'%s-%s' % (a.id, v.id)"
                        t-att-checked="'checked' if v.id in attrib_set else None"
                        t-att-title="v.name"
@@ -1226,7 +1227,7 @@
                             </div>
                             <div
                                 t-elif="a.display_type == 'color'"
-                                t-attf-class="{{'pt-1 pb-3' if isMobile else 'mb-3'}}"
+                                t-attf-class="d-flex flex-wrap gap-2 {{'pt-1 pb-3' if isMobile else 'mb-3'}}"
                             >
                                 <t t-call="website_sale.filter_color_attributes"/>
                             </div>
@@ -1974,7 +1975,7 @@
                          "
                          t-att-data-view-track="view_track and '1' or '0'"
                 >
-                    <div class="o_wsale_content_contained container d-flex flex-wrap align-items-center py-2 mb-lg-2">
+                    <div class="o_wsale_content_contained container d-flex flex-wrap align-items-center py-3">
                         <div class="d-flex align-items-center flex-grow-1">
                             <ol class="o_wsale_breadcrumb breadcrumb m-0 p-0">
                                 <li class="breadcrumb-item d-none d-lg-inline-block">
@@ -2252,10 +2253,15 @@
 
     <template id="website_sale.product_title">
         <div
-            class="o_wsale_product_details_content_section o_wsale_product_details_content_section_title mb-4"
+            t-attf-class="o_wsale_product_details_content_section o_wsale_product_details_content_section_title {{'mb-3' if not product.description_ecommerce else ''}}"
         >
             <t t-set="base_url" t-value="website.get_base_url()"/>
-            <h1 class="h3" t-field="product.name">Product Name</h1>
+            <h1
+                t-attf-class="h3 {{'mb-3' if not product.description_ecommerce and not is_view_active('website_sale.product_comment') else ''}}"
+                t-field="product.name"
+            >
+                Product Name
+            </h1>
             <t t-if="is_view_active('website_sale.product_comment')">
                 <a
                     href="#o_product_page_reviews"
@@ -2275,7 +2281,7 @@
             </t>
             <div
                 t-field="product.description_ecommerce"
-                t-attf-class="oe_structure text-muted {{not product.description_ecommerce and 'mb-0'}}"
+                t-attf-class="oe_structure mb-3 text-muted"
                 placeholder="A detailed, formatted description to promote your product on this page. Use '/' to discover more features."
             />
             <t
@@ -2321,7 +2327,7 @@
             </div>
             <div
                 id="product_option_block"
-                t-attf-class="d-flex d-empty-none flex-wrap gap-2 {{'' if is_50_pc and not (is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large')) else ' w-100'}}"
+                t-attf-class="d-flex d-empty-none flex-wrap gap-2 w-100 {{'w-sm-auto' if is_50_pc and not (is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large')) else ''}}"
             />
         </div>
     </template>
@@ -2613,7 +2619,7 @@
         <xpath expr="//div[@id='product_option_block']" position="before">
             <a
                 role="button"
-                t-attf-class="btn btn-outline-primary o_we_buy_now {{'w-100' if is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large') else ''}} {{'flex-grow-1' if not is_50_pc else ''}}"
+                t-attf-class="btn btn-outline-primary o_we_buy_now w-100 {{'' if is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large') or not is_50_pc else 'w-sm-auto'}} {{'flex-grow-1' if not is_50_pc else ''}}"
                 href="#"
             >
                 <i class="fa fa-bolt me-2"/>
@@ -2648,17 +2654,17 @@
     <template id="product_price">
         <div
             name="product_price"
-            t-attf-class="product_price {{'' if is_view_active('website_sale.cta_wrapper_boxed') else 'mt-2'}} {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-block'}}"
+            t-attf-class="product_price {{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-block'}}"
         >
             <div
                 name="product_price_container"
-                class="css_editable_mode_hidden d-flex align-items-center justify-content-end gap-2 flex-wrap h4 mb-0 text-wrap"
+                class="css_editable_mode_hidden d-flex align-items-baseline justify-content-end gap-2 flex-wrap h5 mb-0 text-wrap"
             >
                 <span class="oe_price"
                       style="white-space: nowrap;"
                       t-out="combination_info['price']"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
-                <span t-attf-class="text-muted oe_default_price ms-1 h5 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
+                <span t-attf-class="text-muted oe_default_price mb-0 h6 {{'' if combination_info['has_discounted_price'] else 'd-none'}}"
                       style="text-decoration: line-through; white-space: nowrap;"
                       t-out="combination_info['list_price']"
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
@@ -2668,7 +2674,7 @@
                 <del
                     name="product_price_strikethrough"
                     t-if="combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])"
-                    class="text-muted ms-1 h5 oe_compare_list_price"
+                    class="text-muted ms-1 h6 oe_compare_list_price"
                 >
                     <bdi dir="inherit">
                     <span t-out="combination_info['compare_list_price']"
@@ -2679,7 +2685,7 @@
             <div
                 t-if="editable"
                 name="product_list_price_container"
-                class="css_non_editable_mode_hidden decimal_precision h4"
+                class="css_non_editable_mode_hidden decimal_precision h5"
                 t-att-data-precision="str(website.currency_id.decimal_places)"
             >
                 <span t-field="product.list_price"

--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -192,7 +192,7 @@
         </ul>
         <ul
             t-if="product._has_multiple_uoms()"
-            t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants mt-4 pt-3 #{ul_class}"
+            t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants mt-4 #{ul_class}"
             t-att-data-attribute_exclusions="json.dumps(attribute_exclusions)"
         >
             <!-- NOTE: the t-att-data-attribute_exclusions is only there to match existing events selectors -->

--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="website_sale_collect.ClickAndCollectAvailability">
-        <div class="border rounded p-3 w-100 w-lg-75">
+        <div class="border rounded p-3 w-100">
             <div
                 name="click_and_collect_availability"
                 t-on-click="openLocationSelector"

--- a/addons/website_sale_collect/views/templates.xml
+++ b/addons/website_sale_collect/views/templates.xml
@@ -36,7 +36,7 @@
                     'inStoreStockData': combination_info.get('in_store_stock_data', {}),
                     'deliveryStockData': combination_info.get('delivery_stock_data', {}),
                 })"
-                class="d-flex o_not_editable m-2"
+                t-attf-class="d-flex o_not_editable mb-4 #{'w-100' if not is_50_pc else 'w-100 w-sm-75'}"
             />
         </xpath>
     </template>

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -61,12 +61,12 @@
             <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
             <t
                 t-set="_button_classes"
-                t-valuef="o_add_compare_dyn btn btn-outline-primary order-last"
+                t-valuef="o_add_compare_dyn btn btn-outline-primary order-last flex-grow-1 flex-sm-grow-0"
             />
             <t
-                t-if="not is_view_active('website_sale_wishlist.product_add_to_wishlist')"
+                t-if="not is_view_active('website_sale_wishlist.product_add_to_wishlist') and not is_view_active('website_sale.cta_wrapper_default')"
                 t-set="_button_classes"
-                t-value="_button_classes + ' flex-grow-1'"
+                t-value="_button_classes + ' w-100'"
             />
             <t
                 t-if="is_view_active('website_sale.cta_wrapper_large')"
@@ -85,7 +85,7 @@
                 data-action="o_comparelist"
             >
                 <span class="fa fa-exchange"/>
-                <span t-att-class="'d-inline' + (' d-lg-none' if website.product_page_image_width == '50_pc' and not (is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large')) or is_view_active('website_sale_wishlist.product_add_to_wishlist') else '')">Add to Compare</span>
+                <span t-att-class="'d-inline ms-2' + (' d-lg-none' if website.product_page_image_width == '50_pc' and not (is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large')) or is_view_active('website_sale_wishlist.product_add_to_wishlist') else '')">Add to Compare</span>
             </button>
         </xpath>
     </template>

--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -5,10 +5,9 @@
         <div
             t-if="is_storable and !prevent_zero_price_sale"
             id="product_stock_availability"
-            class="my-3"
         >
-            <div t-if="free_qty lte 0 and !cart_qty" t-attf-class="availability_message_#{product_template} mb-1">
-                <div id="out_of_stock_message" class="mb-3">
+            <div t-if="free_qty lte 0 and !cart_qty" t-attf-class="availability_message_#{product_template} d-flex flex-column gap-2">
+                <div id="out_of_stock_message">
                     <t t-if="has_out_of_stock_message">
                         <div class="d-flex align-items-center badge text-bg-danger">
                             <i class="fa fa-circle text-danger me-2"/>
@@ -52,7 +51,7 @@
             <div
                 id="threshold_message"
                 t-elif="show_availability and free_qty lte available_threshold"
-                t-attf-class="availability_message_#{product_template} badge text-bg-warning"
+                t-attf-class="availability_message_#{product_template} my-3 badge text-bg-warning"
             >
                 <i class="fa fa-circle text-warning me-2" role="presentation"/>
                 <t t-out="formatQuantity(free_qty)"/> <t t-out="uom_name" /> in stock

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -90,7 +90,7 @@
             <t
                 t-if="website.product_page_image_width == '50_pc' and not (is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large'))"
                 t-set="_button_classes"
-                t-value="_button_classes + ' flex-grow-0'"
+                t-value="_button_classes + ' flex-grow-1 flex-sm-grow-0'"
             />
             <t
                 t-else=""


### PR DESCRIPTION
This commit improves several visual aspects on the product page:

- Adjusts spacing above the packaging (UoM) section
- Adjust behavior of CTA buttons on mobile for better fit
- Aligns all price-related elements to the same baseline
- Makes the breadcrumb spacing more consistent
- Improves color attribute picker hover behavior and size
- Fixes several spacing issues between sections in the product infos

task-4936240

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
