### PR TITLE
[FIX] l10n_fr_hr_holidays: improve time-off duration calculation

### DIFF
--- a/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
+++ b/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
@@ -294,8 +294,8 @@ class TestFrenchLeaves(TransactionCase):
         """
         Test Case:
         ==========
-        - Employee works from 8 to 12 and 14 to 17 Monday to Wednesday
-        - Company works from 9 to 12 and 13 to 18 Monday to Friday
+        - Employee works from 8 to 12 and 14 to 17 Monday to Wednesday -> 7h/d
+        - Company works from 9 to 12 and 13 to 18 Monday to Friday -> 8h/d
         - Employee requests 1 day off on Monday -> duration should be 1.0
         - Employee requests 0.5 day off on Monday morning or afternoon -> duration should be 0.5
         """
@@ -346,6 +346,7 @@ class TestFrenchLeaves(TransactionCase):
             'request_date_to': '2024-07-22',
         })
         self.assertEqual(leave.number_of_days, 1, 'The duration should be 1 day.')
+        self.assertNotEqual(leave.number_of_hours, 8.0, 'Company and employee hours per day should not match in this case')
 
         leave = self.env['hr.leave'].create({
             'name': 'Test',
@@ -359,11 +360,13 @@ class TestFrenchLeaves(TransactionCase):
         self.assertEqual(leave.number_of_days, 0.5, 'The duration should be 0.5 day.')
         self.assertEqual(leave.date_from.date(), date(2024, 7, 29))
         self.assertEqual(leave.date_to.date(), date(2024, 7, 29))
+        self.assertNotEqual(leave.number_of_hours, 8.0, 'Company and employee hours per day should not match in this case')
 
         leave.request_date_from_period = 'pm'
         self.assertEqual(leave.number_of_days, 0.5, 'The duration should be 0.5 day.')
         self.assertEqual(leave.date_from.date(), date(2024, 7, 29))
         self.assertEqual(leave.date_to.date(), date(2024, 7, 29))
+        self.assertNotEqual(leave.number_of_hours, 8.0, 'Company and employee hours per day should not match in this case')
 
     def test_leave_full_day_different_working_hours(self):
         """Check full days leave creation for an employee with different working hours than the 2 weeks company's calendar."""


### PR DESCRIPTION
With the French fiscal localization:
When an employee has a different working schedule than the company’s default one. If the employee’s daily working hours are greater than the company’s default hours. The timesheet for paid time off only displays the company’s default hours instead of the employee’s actual hours.

Steps to reproduce:
-------------------
* Install l10n_fr_hr_holidays
* Set the French fiscal localization
* Working schedule of the company -> 7:30 per day
* Working schedule of the employee -> 8 per day
* Create a paid time-off with this employee
* Check the Timesheet of this employee

> Observation:
Timesheet shows 7:30 instead of 8

Why the fix:
------------
We needed to ensure the hours are always calculated correctly (using the employee’s or company’s calendar when appropriate) while still forcing the correct day count (1 or 0.5) and extending it according to French law.

✅ Day count is forced (0.5 or 1) depending on the leave type.
✅ Hours are fetched from  `super()._get_durations()` so the timesheet keeps accurate hours.

This prevents timesheets from showing incorrect hours when the employee's work schedule differs from the company's work schedule.

opw-4744516

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
