### PR TITLE
[16.0][FIX] crm: Display the appropriate stages taking into account the user's team

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -924,7 +924,7 @@ class Lead(models.Model):
         # - ('id', 'in', stages.ids): add columns that should be present
         # - OR ('fold', '=', False): add default columns that are not folded
         # - OR ('team_ids', '=', team_id), ('fold', '=', False) if team_id: add team columns that are not folded
-        team_id = self._context.get('default_team_id')
+        team_id = self._context.get('default_team_id') or self.env.user.sale_team_id.id
         if team_id:
             search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_id', '=', False), ('team_id', '=', team_id)]
         else:


### PR DESCRIPTION
Display the appropriate stages taking into account the user's team

Use case:

- Marc Demo is part of the Pre-sales team
- Modify the Qualified stage and define the Pre-Sales team
- Modify the necessary leads so that there are none at that stage.
- [Marc Demo]: Go to Crm > Sales > My Pipeline: The "Qualified" stage is not displayed
- [Marc Demo]: Go to any lead form view: The "Qualified" stage is displayed and we can switch to it.
- [Marc Demo]: Go to Crm > Sales > Teams and click on the "Pipeline" button in the "Pre-sales" team will we see the "Qualified" stage in the kanban view.

Now, when accessing Crm > Sales > My Pipeline, the "Qualified" stage will also be displayed even if there are no leads in that stage (expected behavior).

Ping @pedrobaeza 

@Tecnativa TT57357

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
