### PR TITLE
[FIX] payment_paypal: display payment button on mobile

### DIFF
--- a/addons/payment_paypal/__manifest__.py
+++ b/addons/payment_paypal/__manifest__.py
@@ -21,6 +21,9 @@
         'web.assets_frontend': [
             'payment_paypal/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'payment_paypal/static/tests/tours/**/*',
+        ],
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/payment_paypal/static/src/js/payment_button.js
+++ b/addons/payment_paypal/static/src/js/payment_button.js
@@ -5,7 +5,7 @@ import paymentButton from '@payment/js/payment_button';
 paymentButton.include({
 
     /**
-     * Hide the disabled PayPal button and show the enabled one.
+     * Hide the disabled PayPal buttons and show the enabled ones.
      *
      * @override method from @payment/js/payment_button
      * @private
@@ -17,12 +17,17 @@ paymentButton.include({
             return;
         }
 
-        document.getElementById('o_paypal_disabled_button').classList.add('d-none');
-        document.getElementById('o_paypal_enabled_button').classList.remove('d-none');
+        const paypalButtons = document.querySelectorAll(
+            '[id^="o_paypal_disabled_button"], [id^="o_paypal_enabled_button"]'
+        );
+        paypalButtons.forEach(button => {
+            const action = button.id.startsWith('o_paypal_disabled_button') ? 'add' : 'remove';
+            button.classList[action]('d-none');
+        });
     },
 
     /**
-     * Hide the enabled PayPal button and show the disabled one.
+     * Hide the enabled PayPal buttons and show the disabled ones.
      *
      * @override method from @payment/js/payment_button
      * @private
@@ -34,8 +39,13 @@ paymentButton.include({
             return;
         }
 
-        document.getElementById('o_paypal_disabled_button').classList.remove('d-none');
-        document.getElementById('o_paypal_enabled_button').classList.add('d-none');
+        const paypalButtons = document.querySelectorAll(
+            '[id^="o_paypal_disabled_button"], [id^="o_paypal_enabled_button"]'
+        );
+        paypalButtons.forEach(button => {
+            const action = button.id.startsWith('o_paypal_enabled_button') ? 'add' : 'remove';
+            button.classList[action]('d-none');
+        });
     },
 
     /**

--- a/addons/payment_paypal/static/tests/tours/test_paypal_mobile_available_button.js
+++ b/addons/payment_paypal/static/tests/tours/test_paypal_mobile_available_button.js
@@ -1,0 +1,27 @@
+import { waitUntil } from '@odoo/hoot-dom';
+import { registry } from '@web/core/registry';
+
+registry.category('web_tour.tours').add('test_paypal_buttons_rendered_on_mobile_checkout', {
+    steps: () => [
+        {
+            content: "Select PayPal payment method",
+            trigger: '[name="o_payment_radio"][data-provider-code="paypal"]',
+            async run() {
+                try {
+                    document.querySelector(
+                        '[name="o_payment_radio"][data-provider-code="paypal"]'
+                    ).click();
+                    await waitUntil(() => {
+                        const paypalButtons = document.querySelectorAll(
+                            '[id^="o_paypal_enabled_button"]'
+                        );
+                        return [...paypalButtons].some(button => button.offsetParent !== null);
+                    }, { timeout: 1000 });
+                } catch (error) {
+                    // PayPal SDK will not be loaded w/o credentials; handle the error gracefully.
+                    console.error("Error selecting PayPal payment method:", error);
+                }
+            },
+        },
+    ],
+});

--- a/addons/payment_paypal/tests/__init__.py
+++ b/addons/payment_paypal/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import common
 from . import test_paypal
+from . import test_paypal_buttons

--- a/addons/payment_paypal/tests/test_paypal_buttons.py
+++ b/addons/payment_paypal/tests/test_paypal_buttons.py
@@ -1,0 +1,39 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.payment.tests.http_common import PaymentHttpCommon
+from odoo.addons.payment_paypal.tests.common import PaypalCommon
+
+
+@tagged('post_install', '-at_install')
+class TestPaypalButtons(PaypalCommon, PaymentHttpCommon):
+
+    def test_paypal_buttons_rendered_on_mobile_checkout(self):
+        """Check for the presence of the PayPal button on the shop checkout page in mobile."""
+        if self.env['ir.module.module']._get('website_sale').state != 'installed':
+            self.skipTest("This test requires the website_sale module to be installed.")
+
+        user_admin = self.quick_ref('base.user_admin')
+        user_admin.write({
+            'street': '215 Vine St',
+            'city': 'Scranton',
+            'zip': '18503',
+            'country_id': self.quick_ref('base.us'),
+            'state_id': self.env['ir.model.data']._xmlid_to_res_id('base.state_us_39'),
+            'phone': '+1 555-555-5555',
+            'email': 'admin@yourcompany.example.com',
+        })
+        product = self.env['product.product'].create({'name': "$5", 'list_price': 5.0})
+        self.env['sale.order'].create({
+            'partner_id': user_admin.partner_id.id,
+            'order_line': [Command.create({'product_id': product.id})],
+            'website_id': self.env['website'].get_current_website().id,
+        })
+
+        self.browser_size = '375x667'
+        self.touch_enabled = True
+        self.start_tour(
+            '/shop/payment', 'test_paypal_buttons_rendered_on_mobile_checkout', login='admin',
+        )


### PR DESCRIPTION
## Version
saas-18.4+

## Issue
*Use mobile device or mobile view*
- Configure Paypal as a Payment Provider;
- Go to the shop and buy an article;
- Move to checkout and select PayPal;
- No PayPal button is displayed.

## Cause
In saas-18.4, a refactoring of the checkout layout (7a564237579603bcaef46efd6ffaaaffefb54b11) introduced the `o_mobile_summary` block which results in the full payment form being duplicated in the DOM:
- One copy for desktop:
  - https://github.com/odoo/odoo/blob/de3d09ab8592c87b9d747a33cded93a90387b797/addons/website_sale/views/templates.xml#L3524-L3529
- One copy inside `.o_mobile_summary` for mobile:
  - https://github.com/odoo/odoo/blob/de3d09ab8592c87b9d747a33cded93a90387b797/addons/website_sale/views/templates.xml#L3557-L3560

This causes the `payment.submit_button` template (and its extension by PayPal) to be injected twice.
As a result, the DOM ends up with two elements sharing the same IDs (`o_paypal_button_container`) which breaks PayPal’s SDK rendering logic.

## Fix
JavaScript logic based on cca908741c7fdd701a4539e5d43c71248b73b14f has been added to detect and rename the duplicated DOM structure:
The PayPal button can be rendered everywhere based on unique IDs.

opw-4942831