### PR TITLE
[IMP] website, html_builder, *: improve tablist accessibility (AddPageTemplates + AddSnippetDialog)

### DIFF
--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.xml
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.xml
@@ -6,7 +6,8 @@
         title.translate="Insert a block"
         contentClass="'o_add_snippet_dialog h-100'"
         footer="false"
-        size="'xl'">
+        size="'xl'"
+        modalRef="modalRef">
         <div class="overflow-hidden w-100">
             <div class="d-flex w-100 h-100 vertical flex-row">
                 <aside class="border-end overflow-auto">
@@ -17,11 +18,21 @@
                             <i class="oi oi-search" aria-hidden="true"></i>
                         </span>
                     </div>
-                    <div class="list-group list-group-flush flex-column flex-nowrap overflow-y-auto" role="tablist">
+                    <div class="list-group list-group-flush flex-column flex-nowrap overflow-y-auto"
+                         role="tablist"
+                         aria-orientation="vertical"
+                         aria-label="Block Categories">
                         <t t-if="!state.search" t-foreach="snippetGroups" t-as="snippetGroup" t-key="snippetGroup.id">
-                            <button class="list-group-item list-group-item-light list-group-item-action p-3" role="tab"
-                                t-att-class="{ 'active': this.state.groupSelected === snippetGroup.groupName}"
-                                t-on-click="() => this.selectGroup(snippetGroup)">
+                            <t t-set="isActive" t-value="state.groupSelected === snippetGroup.groupName"/>
+                            <button class="list-group-item list-group-item-light list-group-item-action p-3"
+                                    role="tab"
+                                    t-att-class="{ 'active': isActive }"
+                                    t-att-id="'tab_' + snippetGroup.groupName"
+                                    t-att-aria-controls="'tabpanel_' + snippetGroup.groupName"
+                                    t-att-aria-selected="isActive ? 'true' : 'false'"
+                                    t-att-tabindex="isActive ? '0' : '-1'"
+                                    t-on-click="() => this.selectGroup(snippetGroup)"
+                                    t-on-keydown="onTabKeydown">
                                 <t t-out="snippetGroup.title"/>
                             </button>
                         </t>
@@ -43,7 +54,14 @@
                             </p>
                         </div>
                     </t>
-                    <iframe class="border-0 fade bg-200 position-relative o_add_snippet_iframe" t-att-class="state.showIframe ? ' show' : '' " tabindex="-1" t-ref="iframe" src="about:blank" height="333%" width="333%" />
+                    <iframe class="border-0 fade bg-200 position-relative o_add_snippet_iframe"
+                            t-ref="iframe"
+                            role="tabpanel"
+                            t-att-aria-labelledby="'tab_' + state.groupSelected"
+                            t-att-id="'tabpanel_' + state.groupSelected"
+                            t-att-class="state.showIframe ? 'show' : '' "
+                            src="about:blank"
+                            height="333%" width="333%"/>
                 </div>
             </div>
         </div>

--- a/addons/html_builder/static/src/snippets/input_confirmation_dialog.xml
+++ b/addons/html_builder/static/src/snippets/input_confirmation_dialog.xml
@@ -11,8 +11,8 @@
         </div>
 
         <t t-set-slot="footer">
-          <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel"/>
-          <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel" t-esc="props.cancelLabel"/>
+          <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel" data-hotkey="q"/>
+          <button t-if="props.cancel" class="btn btn-secondary" t-on-click="_cancel" t-esc="props.cancelLabel" data-hotkey="x"/>
         </t>
     </Dialog>
 </t>

--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -20,6 +20,13 @@ export class SnippetViewer extends Component {
         this.content = useRef("content");
     }
 
+    getRenameBtnLabel(snippetName) {
+        return _t("Rename %(snippetName)s", { snippetName });
+    }
+    getDeleteBtnLabel(snippetName) {
+        return _t("Delete %(snippetName)s", { snippetName });
+    }
+
     onClickRename(snippet) {
         this.dialog.add(InputConfirmationDialog, {
             title: _t("Rename the block"),

--- a/addons/html_builder/static/src/snippets/snippet_viewer.scss
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.scss
@@ -117,7 +117,7 @@
                 pointer-events: none;
                 z-index: 1;
             }
-            &:hover {
+            &:hover, &:focus-visible {
                 box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.2);
                 &::after {
                     outline: 6px solid $o-we-handles-accent-color;
@@ -127,7 +127,7 @@
                 .s_dialog_preview_image {
                     filter: saturate(0) blur(5px);
                 }
-                &:hover {
+                &:hover, &:focus-within {
                     .s_dialog_preview_image {
                         opacity: 1;
                         filter: saturate(0) brightness(0.6) blur(5px);
@@ -136,6 +136,11 @@
                         opacity: 1;
                      }
                 }
+
+                &:focus-within > .o_snippet_preview_install_btn {
+                    outline: 6px solid $o-we-handles-accent-color;
+                }
+
                 > .o_snippet_preview_install_btn {
                     z-index: 1;
                     @include o-position-absolute(auto, 0, 0, 0);

--- a/addons/html_builder/static/src/snippets/snippet_viewer.xml
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.xml
@@ -9,18 +9,28 @@
                 <div t-on-click="() => this.onClick(snippet)"
                      t-att-data-snippet-id="snippet.key"
                      t-att-data-label="snippet.label ? snippet.label : ''"
-                     t-attf-class="o_snippet_preview_wrap position-relative #{ snippet.isCustom ? 'mb-0' : '' } #{snippet.moduleId ? 'o_snippet_preview_install' : '' }">
-                    <div t-if="snippet.imagePreviewSrc" class="s_dialog_preview s_dialog_preview_image">
-                        <img t-att-src="snippet.imagePreviewSrc" loading="eager"/>
+                     t-attf-class="o_snippet_preview_wrap position-relative #{ snippet.isCustom ? 'mb-0' : '' } #{snippet.moduleId ? 'o_snippet_preview_install' : '' }"
+                     t-att-tabindex="snippet.moduleId ? '-1' : '0'"
+                     t-att-aria-label="snippet.label || snippet.title">
+                    <div inert="inert">
+                        <div t-if="snippet.imagePreviewSrc" class="s_dialog_preview s_dialog_preview_image">
+                            <img t-att-src="snippet.imagePreviewSrc" loading="eager"/>
+                        </div>
+                        <t t-else="" t-out="this.getContent(snippet.content)"/>
                     </div>
-                    <t t-else="" t-out="this.getContent(snippet.content)"/>
                     <button t-if="snippet.moduleId" class="o_snippet_preview_install_btn btn text-white rounded-1 mx-auto p-2 bottom-50"
                             t-esc="this.getButtonInstallName(snippet)"/>
                 </div>
                 <div t-if="snippet.isCustom" class="d-grid mt-2 mx-5 gap-2 d-md-flex justify-content-md-end o_custom_snippet_edit">
                     <span class="w-100" t-esc="snippet.title"></span>
-                    <button class="btn fa fa-pencil me-md-2" t-on-click="() => this.onClickRename(snippet)"></button>
-                    <button class="btn fa fa-trash" t-on-click="() => this.onClickDelete(snippet)"></button>
+                    <button class="o_btn_reset me-md-2" t-on-click="() => this.onClickRename(snippet)">
+                        <span class="visually-hidden" t-esc="getRenameBtnLabel(snippet.title)"/>
+                        <span class="fa fa-pencil"/>
+                    </button>
+                    <button class="o_btn_reset" t-on-click="() => this.onClickDelete(snippet)">
+                        <span class="visually-hidden" t-esc="getDeleteBtnLabel(snippet.title)"/>
+                        <span class="fa fa-trash"/>
+                    </button>
                 </div>
             </t>
         </div>

--- a/addons/html_builder/static/tests/block_tab/snippet_groups.test.js
+++ b/addons/html_builder/static/tests/block_tab/snippet_groups.test.js
@@ -166,7 +166,7 @@ test("open add snippet dialog + switch snippet category", async () => {
         ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap"
     ).toHaveCount(2);
     expect(
-        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap").map(
+        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div").map(
             (el) => el.innerHTML
         )
     ).toEqual(
@@ -179,7 +179,7 @@ test("open add snippet dialog + switch snippet category", async () => {
     await animationFrame();
     expect(".o_add_snippet_dialog aside .list-group .list-group-item.active").toHaveText("B");
     expect(
-        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap").map(
+        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div").map(
             (el) => el.innerHTML
         )
     ).toEqual(
@@ -217,7 +217,7 @@ test("search snippet in add snippet dialog", async () => {
     expect("aside .list-group .list-group-item").toHaveCount(2);
     const snippetsDescriptionProcessed = createTestSnippets({ snippets, withName: true });
     expect(
-        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap").map(
+        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div").map(
             (el) => el.innerHTML
         )
     ).toEqual(
@@ -228,7 +228,7 @@ test("search snippet in add snippet dialog", async () => {
     await contains(".o_add_snippet_dialog aside input[type='search']").edit("Ban");
     expect("aside .list-group .list-group-item").toHaveCount(0);
     expect(
-        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap").map(
+        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div").map(
             (el) => el.innerHTML
         )
     ).toEqual(
@@ -239,7 +239,7 @@ test("search snippet in add snippet dialog", async () => {
     await contains(".o_add_snippet_dialog aside input[type='search']").edit("gra");
     expect("aside .list-group .list-group-item").toHaveCount(0);
     expect(
-        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap").map(
+        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div").map(
             (el) => el.innerHTML
         )
     ).toEqual(
@@ -250,7 +250,7 @@ test("search snippet in add snippet dialog", async () => {
     await contains(".o_add_snippet_dialog aside input[type='search']").edit("or");
     expect("aside .list-group .list-group-item").toHaveCount(0);
     expect(
-        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap").map(
+        queryAll(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div").map(
             (el) => el.innerHTML
         )
     ).toEqual(
@@ -305,20 +305,20 @@ test("search snippet by class", async () => {
     // Search among classes of root node
     await contains(".o_add_snippet_dialog aside input[type='search']").edit("s_bar");
     expect(
-        queryFirst(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap")
+        queryFirst(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div")
             .innerHTML
     ).toEqual(snippetsDescriptionProcessed[2].content);
 
     await contains(".o_add_snippet_dialog aside input[type='search']").edit("s_additional_class");
     expect(
-        queryFirst(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap")
+        queryFirst(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div")
             .innerHTML
     ).toEqual(snippetsDescriptionProcessed[0].content);
 
     // Search among classes of child nodes
     await contains(".o_add_snippet_dialog aside input[type='search']").edit("s_class_on_child");
     expect(
-        queryFirst(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap")
+        queryFirst(".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div")
             .innerHTML
     ).toEqual(snippetsDescriptionProcessed[1].content);
 });
@@ -346,7 +346,7 @@ test("add snippet dialog with imagePreview", async () => {
     await waitForSnippetDialog();
     expect(`${previewSnippetIframeSelector}`).toHaveCount(2);
     const snippetsDescriptionProcessed = createTestSnippets({ snippets, withName: true });
-    expect(`${previewSnippetIframeSelector}:first`).toHaveInnerHTML(
+    expect(`${previewSnippetIframeSelector}:first > div`).toHaveInnerHTML(
         snippetsDescriptionProcessed[0].content
     );
     expect(
@@ -507,7 +507,7 @@ test("Renaming custom snippets don't make an orm call", async () => {
     });
 
     await contains(
-        ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_custom_snippet_edit button.fa-pencil"
+        ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_custom_snippet_edit button > .fa-pencil"
     ).click();
     expect(".o-overlay-item .modal-dialog:contains('Rename the block')").toHaveCount(1);
     await contains(".o-overlay-item .modal-dialog input#inputConfirmation").fill("new custom name");

--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -10,7 +10,7 @@ import { EventBus, reactive, useEffect, useRef } from "@odoo/owl";
 
 export const SIZES = { XS: 0, SM: 1, MD: 2, LG: 3, XL: 4, XXL: 5 };
 
-function getFirstAndLastTabableElements(el) {
+export function getFirstAndLastTabableElements(el) {
     const tabableEls = getTabableElements(el);
     return [tabableEls[0], tabableEls[tabableEls.length - 1]];
 }

--- a/addons/web/static/src/core/utils/ui.js
+++ b/addons/web/static/src/core/utils/ui.js
@@ -140,7 +140,9 @@ const TABABLE_SELECTOR = [
  * @param {HTMLElement} [container=document.body]
  */
 export function getTabableElements(container = document.body) {
-    const elements = [...container.querySelectorAll(TABABLE_SELECTOR)].filter(isVisible);
+    const elements = [...container.querySelectorAll(TABABLE_SELECTOR)].filter(
+        (el) => isVisible(el) && !el.closest("[inert]")
+    );
     /** @type {Record<number, HTMLElement[]>} */
     const byTabIndex = {};
     for (const el of [...elements]) {

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -360,10 +360,12 @@ class AddPageTemplates extends Component {
         const activePaneEl = this.panesRef.el.querySelector(".active");
         activeTabEl?.classList?.remove("active");
         activePaneEl?.classList?.remove("active");
+        activePaneEl?.setAttribute("inert", "inert"); // Make sure trapFocus() works.
         const tabEl = this.tabsRef.el.querySelector(`[data-id=${id}]`);
         const paneEl = this.panesRef.el.querySelector(`[data-id=${id}]`);
         tabEl.classList.add("active");
         paneEl.classList.add("active");
+        paneEl.removeAttribute("inert");
         this.props.onTemplatePageChanged(tabEl.dataset.id === "basic" ? "" : tabEl.textContent);
     }
 }

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -1,4 +1,5 @@
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { rpc } from "@web/core/network/rpc";
 import { renderToElement } from "@web/core/utils/render";
 import { useAutofocus, useService } from '@web/core/utils/hooks';
@@ -295,6 +296,7 @@ class AddPageTemplates extends Component {
         this.website = useService("website");
         this.tabsRef = useRef("tabs");
         this.panesRef = useRef("panes");
+        useAutofocus();
 
         this.state = useState({
             pages: [{
@@ -350,7 +352,7 @@ class AddPageTemplates extends Component {
         return pages;
     }
 
-    onTabClick(id) {
+    onTabListBtnClick(id) {
         for (const page of this.state.pages) {
             if (page.id === id) {
                 page.isAccessed = true;
@@ -359,14 +361,29 @@ class AddPageTemplates extends Component {
         const activeTabEl = this.tabsRef.el.querySelector(".active");
         const activePaneEl = this.panesRef.el.querySelector(".active");
         activeTabEl?.classList?.remove("active");
+        activeTabEl?.setAttribute("tabIndex", "-1");
         activePaneEl?.classList?.remove("active");
         activePaneEl?.setAttribute("inert", "inert"); // Make sure trapFocus() works.
         const tabEl = this.tabsRef.el.querySelector(`[data-id=${id}]`);
         const paneEl = this.panesRef.el.querySelector(`[data-id=${id}]`);
         tabEl.classList.add("active");
+        tabEl.tabIndex = 0;
         paneEl.classList.add("active");
         paneEl.removeAttribute("inert");
         this.props.onTemplatePageChanged(tabEl.dataset.id === "basic" ? "" : tabEl.textContent);
+    }
+
+    onTabListBtnKeydown(ev) {
+        const hotkey = getActiveHotkey(ev);
+        if (!["arrowleft", "arrowright", "arrowdown", "arrowup"].includes(hotkey)) {
+            return;
+        }
+        const currentTabEl = this.tabsRef.el.querySelector(`[data-id=${ev.target.dataset.id}]`);
+        if (["arrowleft", "arrowup"].includes(hotkey)) {
+            currentTabEl.previousElementSibling?.focus();
+        } else {
+            currentTabEl.nextElementSibling?.focus();
+        }
     }
 }
 

--- a/addons/website/static/src/components/dialog/add_page_dialog.scss
+++ b/addons/website/static/src/components/dialog/add_page_dialog.scss
@@ -84,7 +84,7 @@
                 opacity: 1;
             }
 
-            &:hover {
+            &:hover, &:focus-within {
                 box-shadow: 0 .5rem 2rem rgba(0, 0, 0, 0.2);
 
                 .o_button_area {

--- a/addons/website/static/src/components/dialog/add_page_dialog.xml
+++ b/addons/website/static/src/components/dialog/add_page_dialog.xml
@@ -20,11 +20,11 @@
 
 <t t-name="website.AddPageTemplatePreviewWrapper">
     <div t-ref="holder" class="o_page_template position-relative placeholder-glow mx-auto transition-base" t-att-class="{ 'mt-4': !props.firstRow }">
-        <div t-ref="preview" class="o_page_template_preview border border-white bg-white rounded" t-out="0"/>
+        <div t-ref="preview" class="o_page_template_preview border border-white bg-white rounded" t-out="0" inert="inert"/>
         <span class="placeholder position-absolute top-0 w-100 h-100 rounded" t-attf-style="animation-duration: #{props.animationDelay + 500}ms"/>
-        <div class="o_button_area position-absolute top-0 w-100 h-100 start-0 cursor-pointer rounded" t-on-click="select">
+        <button class="btn o_button_area position-absolute top-0 w-100 h-100 start-0 cursor-pointer rounded" t-on-click="select">
             <div t-if="props.template and props.template.name" class="position-absolute start-0 bottom-100 w-100 fw-bold lh-1 pb-1 pe-none text-center o_page_name" t-out="props.template.name"/>
-        </div>
+        </button>
     </div>
 </t>
 
@@ -98,6 +98,7 @@
                     <div t-att-data-id="page.id"
                         class="o_website_page_templates_pane position-absolute top-0 start-0 w-100 h-100 overflow-y-scroll bg-200"
                         t-att-class="{active: page_first}"
+                        tabindex="-1"
                     >
                         <AddPageTemplatePreviews t-if="page_first or page.isAccessed"
                             templates="page.props.templates" isCustom="page.props.is_custom"

--- a/addons/website/static/src/components/dialog/add_page_dialog.xml
+++ b/addons/website/static/src/components/dialog/add_page_dialog.xml
@@ -76,29 +76,38 @@
     <div class="overflow-hidden w-100" t-att-class="{o_loading: state.loading}">
         <!-- Do not rely on Notebook to avoid pages from needing reload -->
         <div class="d-flex w-100 h-100 vertical flex-row">
-            <ul t-ref="tabs" class="nav nav-pills flex-column flex-nowrap overflow-y-auto">
+            <div t-ref="tabs"
+                class="nav nav-pills flex-column flex-nowrap overflow-y-auto"
+                role="tablist"
+                aria-orientation="vertical"
+                aria-label="Page categories">
                 <t t-foreach="state.pages" t-as="page" t-key="page.id">
-                    <li class="nav-item">
-                        <a t-att-data-id="page.id"
-                            t-on-click="() => this.onTabClick(page.id)"
-                            class="nav-link p-3 rounded-0"
-                            t-att-class="{active: page_first}"
-                            href="#"
-                            role="tab"
-                            tabindex="0"
-                        >
-                            <span t-if="page.isPreloading" class="fa fa-spin fa-circle-o-notch me-1"/>
-                            <t t-out="page.title"/>
-                        </a>
-                    </li>
+                    <button t-att-data-id="page.id"
+                        t-on-click="() => this.onTabListBtnClick(page.id)"
+                        t-on-keydown="onTabListBtnKeydown"
+                        class="nav-item nav-link p-3 rounded-0"
+                        t-att-class="{active: page_first}"
+                        role="tab"
+                        t-att-tabindex="page_first ? 0 : -1"
+                        t-att-aria-selected="page_first ? 'true' : 'false'"
+                        t-att-aria-controls="'pane_' + page.id"
+                        t-ref="{{page_first ? 'autofocus' : page.id}}"
+                    >
+                        <span t-if="page.isPreloading" class="fa fa-spin fa-circle-o-notch me-1"/>
+                        <t t-out="page.title"/>
+                    </button>
                 </t>
-            </ul>
+            </div>
             <div t-ref="panes" class="position-relative flex-grow-1 flex-shrink-1 bg-200">
                 <t t-foreach="state.pages" t-as="page" t-key="page.id">
                     <div t-att-data-id="page.id"
+                        t-att-id="'pane_' + page.id"
                         class="o_website_page_templates_pane position-absolute top-0 start-0 w-100 h-100 overflow-y-scroll bg-200"
                         t-att-class="{active: page_first}"
                         tabindex="-1"
+                        role="tabpanel"
+                        t-att-aria-label="page.id"
+                        t-att-inert="!page_first ? 'inert' : undefined"
                     >
                         <AddPageTemplatePreviews t-if="page_first or page.isAccessed"
                             templates="page.props.templates" isCustom="page.props.is_custom"

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -172,7 +172,7 @@ test("Use the sidebar 'save snippet' buttons", async () => {
     await contains(customGroupSelector).click();
     await waitForSnippetDialog();
     expect(
-        ".o_add_snippet_dialog .o_add_snippet_iframe:iframe span:contains('Custom Dummy Section')"
+        ".o_add_snippet_dialog .o_add_snippet_iframe:iframe span:not(.visually-hidden):contains('Custom Dummy Section')"
     ).toHaveCount(1);
 });
 

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -481,7 +481,7 @@ export async function setupWebsiteBuilderWithDummySnippet(content) {
 export async function confirmAddSnippet(snippetName) {
     let previewSelector = `.o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap`;
     if (snippetName) {
-        previewSelector += " [data-snippet='" + snippetName + "']";
+        previewSelector += ":has([data-snippet='" + snippetName + "'])";
     }
     await waitForSnippetDialog();
     await contains(previewSelector).click();


### PR DESCRIPTION
*: web

**[IMP] website, web: improve new page dialog accessibility**
    
    This commit uses buttons for interactive elements and traps the focus
    inside the modal.
    
    `web.AddPageTemplates` explicitly does not hide inactive tabpanels to
    avoid recomputing the iframes height everytime, so to make sure their
    content is not focusable, they are marked with the `inert` attribute.
    
    The preview wrapper is also marked `inert` so that the iframe and all
    its content are not focusable.
    
    The `getTabableElements()` util did not check for that attribute before,
    so we add it to its filtering. See the [HTML specs] for reference.
    
    [HTML specs]: https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees
    
    task-3680626

**[IMP] website: use a WCAG-compliant tablist for New Page**
    
    `website.AddPageTemplates` uses tabs, but they did not react to keyboard
    interactions as would be expected. Incidentally, the `role="tab"` was
    not enough in itself. (See WAI ARIA [documentation] and [patterns].)
    
    The true goal of this commit is to enhance keyboard usability. ARIA
    configuration is done as a best effort, but in the end the button around
    the template iframe lacks an accessible name as there is no way to
    describe the iframes in a meaningful way.
    
    [documentation]: https://www.w3.org/TR/wai-aria-1.0/roles#tab
    [patterns]: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
    
    task-3680626

**[IMP] html_builder, web: improve add snippet dialog accessibility**
    
    This commit makes sure the snippets within the AddSnippetDialog are
    focusable and can be selected through the keyboard.
    
    It also implements the expected keyboard behavior and ARIA attributes
    for a tablist (See WAI ARIA [documentation] and [patterns].)
    
    [documentation]: https://www.w3.org/TR/wai-aria-1.0/roles#tab
    [patterns]: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
    
    task-4072655