### PR TITLE
[FIX] stock: ZPL closure command

### DIFF
--- a/addons/stock/report/product_templates.xml
+++ b/addons/stock/report/product_templates.xml
@@ -20,7 +20,7 @@
                             <t t-elif="'small' in zpl_template" t-call="stock.small_zpl_label" />
                             <t t-elif="'alternative' in zpl_template" t-call="stock.alternative_zpl_label" />
                             <t t-elif="'jewelry' in zpl_template" t-call="stock.jewelry_zpl_label" />
-^XZj
+^XZ
                         </t>
                     </t>
                 </t>


### PR DESCRIPTION
In the ZPL, the `^XZ` command indicates the end of a label. For an unknown reason (a typo ?), the PR [1] replaces some of them by `^XZj` which is not a valid ZPL command.

[1]: https://github.com/odoo/odoo/pull/187225