### PR TITLE
[FIX] pos_self_order: display product name in header with correct color

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -11,9 +11,9 @@
                         <i class="oi oi-close fa-fw" aria-hidden="true"/>
                         <span  t-att-class="{'invisible': state.showStickyTitle}">Discard</span>
                     </button>
-                    <div class="o_self_combo_name position-absolute fw-bold fs-2 text-truncate text-center" t-att-class="{'d-none': !state.showStickyTitle}"   >
+                    <h2 class="o_self_combo_name position-absolute mb-0 text-truncate text-center" t-att-class="{'d-none': !state.showStickyTitle}"   >
                          <t t-esc="currentCombo.name" />
-                    </div>
+                    </h2>
                 </div>
             </div>
 

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -5,15 +5,13 @@
             <t t-set="product" t-value="productTemplate"/>
 
             <!-- Header -->
-            <div class="o_self_product_page_header text-bg-primary text-reset" t-att-class="{'o_self_shadow_top': scrollShadow.top}">
+            <div class="o_self_product_page_header text-bg-primary" t-att-class="{'o_self_shadow_top': scrollShadow.top}">
                 <div class="container o_self_container py-3 d-flex align-items-center position-relative" >
                     <button class="btn btn-link btn-lg d-inline-flex align-items-center gap-2 p-0" t-on-click="() => this.goBack()">
                         <i class="oi oi-close fa-fw" aria-hidden="true"/>
                         <span  t-att-class="{'invisible': state.showStickyTitle}">Discard</span>
                     </button>
-                    <div class="o_self_product_name position-absolute fw-bold fs-2 text-truncate text-center" t-att-class="{'d-none': !state.showStickyTitle}"   >
-                         <t t-esc="product.name" />
-                    </div>
+                    <h2 class="o_self_product_name position-absolute mb-0 text-truncate text-center" t-att-class="{'d-none': !state.showStickyTitle}" t-esc="product.name"/>
                 </div>
             </div>
 


### PR DESCRIPTION
Previously, the product name in the header was displayed in black. This commit ensures that the correct color is applied when displaying the product name in the header.

<img width="865" height="328" alt="image" src="https://github.com/user-attachments/assets/48aee736-be5a-48fb-84f6-0b2a32ae7dcd" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
