### PR TITLE
[FIX] sale_loyalty: cleanup coupon when canceling reward wizard

### DIFF
--- a/addons/sale_loyalty/__manifest__.py
+++ b/addons/sale_loyalty/__manifest__.py
@@ -27,6 +27,9 @@
         'web.assets_backend': [
             'sale_loyalty/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'sale_loyalty/static/tests/tours/**/*',
+        ],
     },
     'uninstall_hook': 'uninstall_hook',
     'license': 'LGPL-3',

--- a/addons/sale_loyalty/static/src/views/components/sale_loyalty_reward_wizard_form.js
+++ b/addons/sale_loyalty/static/src/views/components/sale_loyalty_reward_wizard_form.js
@@ -1,0 +1,32 @@
+import { formView } from "@web/views/form/form_view";
+import { FormController } from "@web/views/form/form_controller";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+
+export class SaleLoyaltyRewardWizardFormController extends FormController {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.env.dialogData.dismiss = () => this.discard();
+    }
+
+    async discard() {
+        if (this.props.context?.coupon_code?.length > 0) {
+            // FIX ME: this.props.resId is always false, so though the method is called, we get empty object at python side
+            await this.orm.call(
+                "sale.loyalty.reward.wizard",
+                "action_discard",
+                [this.props.resId],
+                {
+                    context: this.props.context,
+                }
+            );
+        }
+        this.env.dialogData.close();
+    }
+}
+
+export const form = { ...formView, Controller: SaleLoyaltyRewardWizardFormController };
+
+registry.category("views").add("sale_loyalty_reward_wizard_form", form);

--- a/addons/sale_loyalty/static/tests/tours/program_coupon_reward.js
+++ b/addons/sale_loyalty/static/tests/tours/program_coupon_reward.js
@@ -1,0 +1,63 @@
+import { delay } from "@odoo/hoot-dom";
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import tourUtils from '@sale/js/tours/tour_utils';
+
+registry.category("web_tour.tours").add('program_coupon_reward_tour', {
+    url: '/odoo',
+    steps: () => [
+        ...stepUtils.goToAppSteps('sale.sale_menu_root', "Open the sales app"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("Test Partner"),
+        ...tourUtils.addProduct("Product A"),
+        // need to delay for onchange to finish first
+        {
+            content: "Apply For Coupon",
+            trigger: "div[name='so_button_below_order_lines'] > button:nth-child(1)",
+            async run(helpers) {
+                await delay(50);
+                await helpers.click();
+            },
+        },
+        {
+            content: "Enter Coupon",
+            trigger: "div[name='coupon_code'] input",
+            run: "edit test_10dis"
+        },
+        {
+            content: "Apply Coupon Code",
+            trigger: "button[name='action_apply']",
+            run: "click"
+        },
+        {
+            content: "Close Reward Dialog Box",
+            trigger: "header.modal-header button.btn-close",
+            run: "click"
+        },
+        {
+            content: "Apply For Coupon Again",
+            trigger: "div[name='so_button_below_order_lines'] > button:nth-child(1)",
+            run: "click"
+        },
+        {
+            content: "Enter Same Coupon Code",
+            trigger: "div[name='coupon_code'] input",
+            run: "edit test_10dis"
+        },
+        {
+            content: "Apply",
+            trigger: "button[name='action_apply']",
+            run: "click"
+        },
+        {
+            content: "Choose Reward",
+            trigger: "input[name='radio_field_1']",
+            run: "check"
+        },
+        {
+            content: "Apply Reward",
+            trigger: "button[name='action_apply']",
+            run: "click"
+        },
+    ]
+});

--- a/addons/sale_loyalty/tests/__init__.py
+++ b/addons/sale_loyalty/tests/__init__.py
@@ -4,6 +4,7 @@
 from . import test_buy_gift_card
 from . import test_loyalty
 from . import test_pay_with_gift_card
+from . import test_program_coupon_reward
 from . import test_program_multi_company
 from . import test_program_numbers
 from . import test_program_rules

--- a/addons/sale_loyalty/tests/test_program_coupon_reward.py
+++ b/addons/sale_loyalty/tests/test_program_coupon_reward.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.sale_loyalty.tests.common import TestSaleCouponNumbersCommon
+
+
+@tagged('post_install', '-at_install')
+class TestSaleLoyaltyCouponReward(HttpCase, TestSaleCouponNumbersCommon):
+
+    def test_program_coupon_reward_tour(self):
+
+        self.immediate_promotion_program.active = False
+        self.env['loyalty.program'].create({
+            'name': "Get 10% discount on buying Product A",
+            'program_type': "coupons",
+            'applies_on': "current",
+            'trigger': "with_code",
+            'rule_ids': [Command.create({
+                'product_ids': self.product_A,
+                'minimum_qty': 1,
+                'code': "test_10dis",
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': "discount",
+                'discount_mode': "percent",
+                'discount': 10,
+                'discount_applicability': "order",
+            })],
+        })
+        self.start_tour("/", "program_coupon_reward_tour", login="admin")

--- a/addons/sale_loyalty/wizard/sale_loyalty_coupon_wizard.py
+++ b/addons/sale_loyalty/wizard/sale_loyalty_coupon_wizard.py
@@ -26,5 +26,6 @@ class SaleLoyaltyCouponWizard(models.TransientModel):
         action['context'] = {
             'active_id': self.order_id.id,
             'default_reward_ids': all_rewards.ids,
+            'coupon_code': self.coupon_code
         }
         return action

--- a/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard.py
+++ b/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard.py
@@ -53,3 +53,9 @@ class SaleLoyaltyRewardWizard(models.TransientModel):
         self.order_id._apply_program_reward(self.selected_reward_id, coupon, product=self.selected_product_id)
         self.order_id._update_programs_and_rewards()
         return True
+
+    def action_discard(self):
+        if coupon_code := self.env.context.get("coupon_code"):
+            # In case `self` is empty (when triggered via X btn from dialog)
+            sale_order = self.order_id or self.env["sale.order"].browse(self.env.context.get("active_id"))
+            sale_order.code_enabled_rule_ids = sale_order.code_enabled_rule_ids.filtered(lambda c: c.code != coupon_code)

--- a/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard_views.xml
+++ b/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard_views.xml
@@ -4,7 +4,7 @@
         <field name="name">sale.loyalty.reward.wizard.view.form</field>
         <field name="model">sale.loyalty.reward.wizard</field>
         <field name="arch" type="xml">
-            <form>
+            <form js_class="sale_loyalty_reward_wizard_form">
                 <sheet>
                     <group>
                         <field name="order_id" invisible="1"/>
@@ -28,10 +28,10 @@
                     <!-- Has rewards -->
                     <button type="object" name="action_apply" string="Apply" class="btn btn-primary"
                         invisible="not reward_ids" data-hotkey="q"/>
-                    <button special="cancel" string="Discard" class="btn btn-secondary"
+                    <button name="action_discard" type="object" string="Discard" class="btn btn-secondary"
                         invisible="not reward_ids" data-hotkey="x"/>
                     <!-- No rewards -->
-                    <button special="cancel" string="Discard" class="btn btn-primary"
+                    <button name="action_discard" type="object" string="Discard" class="btn btn-primary"
                         invisible="reward_ids" data-hotkey="x"/>
                     <button type="action" name="%(loyalty.loyalty_program_discount_loyalty_action)d" string="Coupons &amp; Loyalty" class="btn btn-secondary float-end"
                         invisible="reward_ids" groups="sales_team.group_sale_manager" data-hotkey="q"/>


### PR DESCRIPTION
Issue:
currently, when a user initiates applying a promo code but then discards
it before completing the process. the system still marks the
code as used,

https://github.com/odoo/odoo/blob/204eb9b0737634826c4666f85d0b9d39aeed0ee6/addons/sale_loyalty/models/sale_order.py#L1378-L1379

resulting in a false-positive validation on subsequent attempts
https://github.com/odoo/odoo/blob/204eb9b0737634826c4666f85d0b9d39aeed0ee6/addons/sale_loyalty/models/sale_order.py#L1352-L1355

to reapply the same code.

Steps to reproduce:
- Create a record in "Discount & Loyalty"
- select "Discount Code" in program type field.
- From the conditional rules, copy the discount code.
- Create a sale order and select a product.
- Click on Coupon Code button and paste the code copied in step 3 in Coupon Code
 field.
- Click Apply.
- A wizard of Available Rewards will be opened. Now click the Discard button.
- Repeat last 3 steps

Observation:
- It gives a Validation Error: "This promo code is already applied."

Fix:
- we introduce action_discard() method, which will un-use the coupon , in case user discard the reward dialog box.

opw-4961738

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
