### PR TITLE
[CLA] Luca-Policastro: sign Odoo Contributor License Agreement for Camptocamp

### DIFF
--- a/doc/cla/corporate/camptocamp.md
+++ b/doc/cla/corporate/camptocamp.md
@@ -54,3 +54,4 @@ Victor Vermot-Petit-Outhenin victor.vermot@camptocamp.com https://github.com/vic
 Sarah Jallon sarah.jallon@camptocamp.com https://github.com/sarsurgithub
 Ricardo Almeida Soares ricardo.almeidasoares@camptocamp.com https://github.com/ricardoalso
 Italo Lopes italo.lopes@camptocamp.com https://github.com/imlopes
+Luca Policastro luca.policastro@camptocamp.com https://github.com/Luca-Policastro


### PR DESCRIPTION
This pull request adds my Contributor License Agreement (CLA) as required by the Odoo contribution guidelines for Camptocamp company.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
