### PR TITLE
[FIX] l10n_ae: use external id in csv data file

### DIFF
--- a/addons/l10n_ae/data/res.bank.csv
+++ b/addons/l10n_ae/data/res.bank.csv
@@ -1,175 +1,175 @@
-id,name,country
-l10n_ae_bank_1,"ROYAL BANK OF SCOTLAND",United Arab Emirates
-l10n_ae_bank_2,"NAT. BANK OF SHJ",United Arab Emirates
-l10n_ae_bank_3,"ABUDHABI COMML.BANK",United Arab Emirates
-l10n_ae_bank_4,"NAT. BANK OF UAQ",United Arab Emirates
-l10n_ae_bank_5,"AL AHLI BANK OF KUWAIT",United Arab Emirates
-l10n_ae_bank_6,"STANDARD CHARTERED",United Arab Emirates
-l10n_ae_bank_7,"Al RAFIDIAN",United Arab Emirates
-l10n_ae_bank_8,"UNION NATIONAL BANK",United Arab Emirates
-l10n_ae_bank_9,"ARAB AFRICAN INT’L",United Arab Emirates
-l10n_ae_bank_10,"UNITED ARAB BANK",United Arab Emirates
-l10n_ae_bank_11,"ARBIFT",United Arab Emirates
-l10n_ae_bank_12,"UNITED BANK LTD.",United Arab Emirates
-l10n_ae_bank_13,"ARAB BANK",United Arab Emirates
-l10n_ae_bank_14,"ARAB EMIRAES INVESTMENT BK",United Arab Emirates
-l10n_ae_bank_15,"BANK MELLI IRAN",United Arab Emirates
-l10n_ae_bank_16,"DEUTSCHE BK",United Arab Emirates
-l10n_ae_bank_17,"BANK OF BARODA",United Arab Emirates
-l10n_ae_bank_18,"ABU DHABI ISLAMIC BK",United Arab Emirates
-l10n_ae_bank_19,"BANK OF SHARJAH",United Arab Emirates
-l10n_ae_bank_20,"DUBAI BANK PJSC",United Arab Emirates
-l10n_ae_bank_21,"BANK OF SADERAT IRAN",United Arab Emirates
-l10n_ae_bank_22,"NOOR ISLAMIC BK",United Arab Emirates
-l10n_ae_bank_23,"BANQUE BANORABE",United Arab Emirates
-l10n_ae_bank_24,"Al HILAL BK",United Arab Emirates
-l10n_ae_bank_25,"BANK MISR",United Arab Emirates
-l10n_ae_bank_26,"DOHA BANK",United Arab Emirates
-l10n_ae_bank_27,"CREDIT AGRICOLE",United Arab Emirates
-l10n_ae_bank_28,"SAMBA",United Arab Emirates
-l10n_ae_bank_29,"BANQUE LIBAINAISE",United Arab Emirates
-l10n_ae_bank_30,"NAT. BK OF KUWAIT",United Arab Emirates
-l10n_ae_bank_31,"BANQUE PARIBAS",United Arab Emirates
-l10n_ae_bank_32,"AJMAN BK",United Arab Emirates
-l10n_ae_bank_33,"BARCLAYS BANK",United Arab Emirates
-l10n_ae_bank_34,"HABIB BANK ZURICH",United Arab Emirates
-l10n_ae_bank_35,"HSBC",United Arab Emirates
-l10n_ae_bank_36,"Abdul Latif Exchange - LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_37,"CITI BANK",United Arab Emirates
-l10n_ae_bank_38,"Ahmed Al Amery Exchange Est-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_39,"COMML. BANK INTL.",United Arab Emirates
-l10n_ae_bank_40,"Ahmed Al Hussain Exchange Est. - Dubai",United Arab Emirates
-l10n_ae_bank_41,"COMM. BANK OF DUBAI",United Arab Emirates
-l10n_ae_bank_42,"Ain Al Faydah Exchange-Al Ain",United Arab Emirates
-l10n_ae_bank_43,"DUBAI ISLAMIC BANK",United Arab Emirates
-l10n_ae_bank_44,"Al Ahalia Money Exchange BureauAbu Dhabi",United Arab Emirates
-l10n_ae_bank_45,"EL NILIEN BANK",United Arab Emirates
-l10n_ae_bank_46,"Al Ansari Exchange-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_47,"NAT. BANK OF DUBAI",United Arab Emirates
-l10n_ae_bank_48,"Al Ansari Exchange Services -Al Ain",United Arab Emirates
-l10n_ae_bank_49,"FIRST GULF BANK",United Arab Emirates
-l10n_ae_bank_50,"Al Azhar Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_51,"HABIB BANK LTD.",United Arab Emirates
-l10n_ae_bank_52,"Al Bader Exchange-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_53,"INVEST BANK",United Arab Emirates
-l10n_ae_bank_54,"Al Balooch Money Exchange- Al Ain",United Arab Emirates
-l10n_ae_bank_55,"JANATA BANK",United Arab Emirates
-l10n_ae_bank_56,"Al Dahab Exchange, Dubai",United Arab Emirates
-l10n_ae_bank_57,"LLOYDS BANK",United Arab Emirates
-l10n_ae_bank_58,"Al Darmaki Exchange Est. - Dubai",United Arab Emirates
-l10n_ae_bank_59,"MASHREQ BANK",United Arab Emirates
-l10n_ae_bank_60,"Al Dhahery Money Exchange- Al Ain",United Arab Emirates
-l10n_ae_bank_61,"EMIRATES ISLAMIC BANK",United Arab Emirates
-l10n_ae_bank_62,"Al Falah Exchange Company-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_63,"NAT. BANK OF ABU DHABI",United Arab Emirates
-l10n_ae_bank_64,"Al Fardan Exchange-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_65,"NAT. BANK OF BAHRAIN",United Arab Emirates
-l10n_ae_bank_66,"Al Fuad Exchange - Dubai",United Arab Emirates
-l10n_ae_bank_67,"Al Gergawi Exchange - LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_68,"NAT.BANK OF FUJAIRAH",United Arab Emirates
-l10n_ae_bank_69,"Al Ghurair Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_70,"NAT. BANK OF OMAN",United Arab Emirates
-l10n_ae_bank_71,"Al Ghurair International ExchangeDubai",United Arab Emirates
-l10n_ae_bank_72,"RAK BANK",United Arab Emirates
-l10n_ae_bank_73,"Al Hadha Exchange LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_74,"Al Hamed Exchange - Sharjah",United Arab Emirates
-l10n_ae_bank_75,"Habib Exchange Co. LLC. - Sharjah",United Arab Emirates
-l10n_ae_bank_76,"Al Hamriyah Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_77,"Hadi Express Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_78,"Al Jarwan Money Exchange-Sharjah",United Arab Emirates
-l10n_ae_bank_79,"Harib Sultan Exchange-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_80,"Al Masood Exchange-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_81,"Horizon Exchange - Dubai",United Arab Emirates
-l10n_ae_bank_82,"Al Mazroui Exchange Est-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_83,"International Developmentn Exchange-Dubai",United Arab Emirates
-l10n_ae_bank_84,"Al Modawallah Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_85,"Jumana Exchange Est. - Dubai",United Arab Emirates
-l10n_ae_bank_86,"Al Mona Exchange Co. - LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_87,"Kanoo Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_88,"Al Mussabah Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_89,"Khalil Al Fardan Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_90,"Al Nafees Exchange LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_91,"Khalili Exchange Co. LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_92,"Al Ne'emah Exchange Co. LLC- Dubai",United Arab Emirates
-l10n_ae_bank_93,"Lari Exchange Est-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_94,"Al Rajihi Exchange Company - LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_95,"Lee La Megh Exchange LLC- Dubai",United Arab Emirates
-l10n_ae_bank_96,"Al Razouki Int'l Exchange Co. LLC. - Dub",United Arab Emirates
-l10n_ae_bank_97,"Malik Exchange-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_98,"Al Zari & Al Fardan Exchange LLC. - Sharjah",United Arab Emirates
-l10n_ae_bank_99,"Multinet Trust Exchange - LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_100,"Al Zarooni Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_101,"Nanikdas Nathoomal Exchange Co. LLC- Dub",United Arab Emirates
-l10n_ae_bank_102,"Alukkass Exchange, Dubai",United Arab Emirates
-l10n_ae_bank_103,"Naser Khoory Exchange Est. - Abu Dhabi",United Arab Emirates
-l10n_ae_bank_104,"Arabian Exchange Co-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_105,"National Exchange Co.-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_106,"ARY International Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_107,"Oasis Exchange, Al Ain",United Arab Emirates
-l10n_ae_bank_108,"Asia Exchange Centre- Dubai",United Arab Emirates
-l10n_ae_bank_109,"Orient Exchange Co.- LLC- Dubai",United Arab Emirates
-l10n_ae_bank_110,"Aziz Exchange Co. LLC.- Dubai",United Arab Emirates
-l10n_ae_bank_111,"Pacific Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_112,"Bhagwandas Jethanand and SonsSharjah",United Arab Emirates
-l10n_ae_bank_113,"Redha Al Ansari Exchange Est. - Dubai",United Arab Emirates
-l10n_ae_bank_114,"Bin Bakheet Exchange Est.- Ajman",United Arab Emirates
-l10n_ae_bank_115,"Reems Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_116,"Bin Belaila Exchange Co.-LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_117,"Sa'ad Exchange-Fujairah",United Arab Emirates
-l10n_ae_bank_118,"Cash Express Exchange Est. - Dubai",United Arab Emirates
-l10n_ae_bank_119,"Sabah Exchange-Sharjah",United Arab Emirates
-l10n_ae_bank_120,"Central Exchange LLC Dubai",United Arab Emirates
-l10n_ae_bank_121,"Sajwani Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_122,"City Exchange - LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_123,"Salim Exchange-Sharjah",United Arab Emirates
-l10n_ae_bank_124,"Daniba International Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_125,"Sana'a Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_126,"Day Exchange LLC.- Dubai",United Arab Emirates
-l10n_ae_bank_127,"Sawan Exchange Co. - LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_128,"Dinar Exchange - Dubai",United Arab Emirates
-l10n_ae_bank_129,"Shaheen Money Exchange LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_130,"Dubai Exchange Centre - LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_131,"Sharjah International ExchangeSharjah",United Arab Emirates
-l10n_ae_bank_132,"Dubai Express Exchange, Dubai",United Arab Emirates
-l10n_ae_bank_133,"Tabra & Al Nebal Exchange - Dubai",United Arab Emirates
-l10n_ae_bank_134,"Emirates & East India Exchange - Sharjah",United Arab Emirates
-l10n_ae_bank_135,"Tahir Exchange Est. - Dubai",United Arab Emirates
-l10n_ae_bank_136,"Emirates India International Exchange-Sharjah",United Arab Emirates
-l10n_ae_bank_137,"Taymour & Abou Harb Exchange Co. LLC. -Sharjah",United Arab Emirates
-l10n_ae_bank_138,"Federal Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_139,"Al Rostamani Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_140,"First Gulf Exchange Centre- Dubai",United Arab Emirates
-l10n_ae_bank_141,"U.A.E. Exchange Centre - LLC.- Dubai",United Arab Emirates
-l10n_ae_bank_142,"Gomti Exchange - LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_143,"Union Exchange-Abu Dhabi",United Arab Emirates
-l10n_ae_bank_144,"Gulf Express Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_145,"Universal Exchange Centre - Dubai",United Arab Emirates
-l10n_ae_bank_146,"Gulf Int'l Exchange Co.-LLC. - Dubai",United Arab Emirates
-l10n_ae_bank_147,"Wall Street Exchange Centre - LLCDubai",United Arab Emirates
-l10n_ae_bank_148,"Zahra Al Yousuf Exchange- Dubai",United Arab Emirates
-l10n_ae_bank_149,"AL DINAR EXCHANGE COMPANY",United Arab Emirates
-l10n_ae_bank_150,"Global Exchange",United Arab Emirates
-l10n_ae_bank_151,"HSBC Financial Services",United Arab Emirates
-l10n_ae_bank_152,"Economic Exchange",United Arab Emirates
-l10n_ae_bank_153,"ALFA EXCHANGE",United Arab Emirates
-l10n_ae_bank_154,"Royal Exchange Co. LLC",United Arab Emirates
-l10n_ae_bank_155,"DELMA EXCHANGE",United Arab Emirates
-l10n_ae_bank_156,"Bin Belaila Exchange Co. L.L.C",United Arab Emirates
-l10n_ae_bank_157,"SHARAF EXCHANGE",United Arab Emirates
-l10n_ae_bank_158,"Alfalah Exchange Company",United Arab Emirates
-l10n_ae_bank_159,"LULU EXCHANGE",United Arab Emirates
-l10n_ae_bank_160,"GCC EXCHANGE",United Arab Emirates
-l10n_ae_bank_161,"C3",United Arab Emirates
-l10n_ae_bank_162,"Economic Exchange Centre",United Arab Emirates
-l10n_ae_bank_163,"Western Union",United Arab Emirates
-l10n_ae_bank_164,"Global Exchange",United Arab Emirates
-l10n_ae_bank_165,"Waseela Equity",United Arab Emirates
-l10n_ae_bank_166,"Zareen Exchange",United Arab Emirates
-l10n_ae_bank_167,"Workers Equity Holdings",United Arab Emirates
-l10n_ae_bank_168,"Future Exchange",United Arab Emirates
-l10n_ae_bank_169,"SEIDCO",United Arab Emirates
-l10n_ae_bank_170,"Nasim Al Barari Exchange",United Arab Emirates
-l10n_ae_bank_171,"Finance House",United Arab Emirates
-l10n_ae_bank_172,"Al Dhahery Exchange",United Arab Emirates
-l10n_ae_bank_173,"Dunia",United Arab Emirates
-l10n_ae_bank_174,"Al Nibal International Exchange",United Arab Emirates
+id,name,country:id
+l10n_ae_bank_1,"ROYAL BANK OF SCOTLAND",base.ae
+l10n_ae_bank_2,"NAT. BANK OF SHJ",base.ae
+l10n_ae_bank_3,"ABUDHABI COMML.BANK",base.ae
+l10n_ae_bank_4,"NAT. BANK OF UAQ",base.ae
+l10n_ae_bank_5,"AL AHLI BANK OF KUWAIT",base.ae
+l10n_ae_bank_6,"STANDARD CHARTERED",base.ae
+l10n_ae_bank_7,"Al RAFIDIAN",base.ae
+l10n_ae_bank_8,"UNION NATIONAL BANK",base.ae
+l10n_ae_bank_9,"ARAB AFRICAN INT’L",base.ae
+l10n_ae_bank_10,"UNITED ARAB BANK",base.ae
+l10n_ae_bank_11,"ARBIFT",base.ae
+l10n_ae_bank_12,"UNITED BANK LTD.",base.ae
+l10n_ae_bank_13,"ARAB BANK",base.ae
+l10n_ae_bank_14,"ARAB EMIRAES INVESTMENT BK",base.ae
+l10n_ae_bank_15,"BANK MELLI IRAN",base.ae
+l10n_ae_bank_16,"DEUTSCHE BK",base.ae
+l10n_ae_bank_17,"BANK OF BARODA",base.ae
+l10n_ae_bank_18,"ABU DHABI ISLAMIC BK",base.ae
+l10n_ae_bank_19,"BANK OF SHARJAH",base.ae
+l10n_ae_bank_20,"DUBAI BANK PJSC",base.ae
+l10n_ae_bank_21,"BANK OF SADERAT IRAN",base.ae
+l10n_ae_bank_22,"NOOR ISLAMIC BK",base.ae
+l10n_ae_bank_23,"BANQUE BANORABE",base.ae
+l10n_ae_bank_24,"Al HILAL BK",base.ae
+l10n_ae_bank_25,"BANK MISR",base.ae
+l10n_ae_bank_26,"DOHA BANK",base.ae
+l10n_ae_bank_27,"CREDIT AGRICOLE",base.ae
+l10n_ae_bank_28,"SAMBA",base.ae
+l10n_ae_bank_29,"BANQUE LIBAINAISE",base.ae
+l10n_ae_bank_30,"NAT. BK OF KUWAIT",base.ae
+l10n_ae_bank_31,"BANQUE PARIBAS",base.ae
+l10n_ae_bank_32,"AJMAN BK",base.ae
+l10n_ae_bank_33,"BARCLAYS BANK",base.ae
+l10n_ae_bank_34,"HABIB BANK ZURICH",base.ae
+l10n_ae_bank_35,"HSBC",base.ae
+l10n_ae_bank_36,"Abdul Latif Exchange - LLC. - Dubai",base.ae
+l10n_ae_bank_37,"CITI BANK",base.ae
+l10n_ae_bank_38,"Ahmed Al Amery Exchange Est-Abu Dhabi",base.ae
+l10n_ae_bank_39,"COMML. BANK INTL.",base.ae
+l10n_ae_bank_40,"Ahmed Al Hussain Exchange Est. - Dubai",base.ae
+l10n_ae_bank_41,"COMM. BANK OF DUBAI",base.ae
+l10n_ae_bank_42,"Ain Al Faydah Exchange-Al Ain",base.ae
+l10n_ae_bank_43,"DUBAI ISLAMIC BANK",base.ae
+l10n_ae_bank_44,"Al Ahalia Money Exchange BureauAbu Dhabi",base.ae
+l10n_ae_bank_45,"EL NILIEN BANK",base.ae
+l10n_ae_bank_46,"Al Ansari Exchange-Abu Dhabi",base.ae
+l10n_ae_bank_47,"NAT. BANK OF DUBAI",base.ae
+l10n_ae_bank_48,"Al Ansari Exchange Services -Al Ain",base.ae
+l10n_ae_bank_49,"FIRST GULF BANK",base.ae
+l10n_ae_bank_50,"Al Azhar Exchange- Dubai",base.ae
+l10n_ae_bank_51,"HABIB BANK LTD.",base.ae
+l10n_ae_bank_52,"Al Bader Exchange-Abu Dhabi",base.ae
+l10n_ae_bank_53,"INVEST BANK",base.ae
+l10n_ae_bank_54,"Al Balooch Money Exchange- Al Ain",base.ae
+l10n_ae_bank_55,"JANATA BANK",base.ae
+l10n_ae_bank_56,"Al Dahab Exchange,base.ae
+l10n_ae_bank_57,"LLOYDS BANK",base.ae
+l10n_ae_bank_58,"Al Darmaki Exchange Est. - Dubai",base.ae
+l10n_ae_bank_59,"MASHREQ BANK",base.ae
+l10n_ae_bank_60,"Al Dhahery Money Exchange- Al Ain",base.ae
+l10n_ae_bank_61,"EMIRATES ISLAMIC BANK",base.ae
+l10n_ae_bank_62,"Al Falah Exchange Company-Abu Dhabi",base.ae
+l10n_ae_bank_63,"NAT. BANK OF ABU DHABI",base.ae
+l10n_ae_bank_64,"Al Fardan Exchange-Abu Dhabi",base.ae
+l10n_ae_bank_65,"NAT. BANK OF BAHRAIN",base.ae
+l10n_ae_bank_66,"Al Fuad Exchange - Dubai",base.ae
+l10n_ae_bank_67,"Al Gergawi Exchange - LLC. - Dubai",base.ae
+l10n_ae_bank_68,"NAT.BANK OF FUJAIRAH",base.ae
+l10n_ae_bank_69,"Al Ghurair Exchange- Dubai",base.ae
+l10n_ae_bank_70,"NAT. BANK OF OMAN",base.ae
+l10n_ae_bank_71,"Al Ghurair International ExchangeDubai",base.ae
+l10n_ae_bank_72,"RAK BANK",base.ae
+l10n_ae_bank_73,"Al Hadha Exchange LLC. - Dubai",base.ae
+l10n_ae_bank_74,"Al Hamed Exchange - Sharjah",base.ae
+l10n_ae_bank_75,"Habib Exchange Co. LLC. - Sharjah",base.ae
+l10n_ae_bank_76,"Al Hamriyah Exchange- Dubai",base.ae
+l10n_ae_bank_77,"Hadi Express Exchange- Dubai",base.ae
+l10n_ae_bank_78,"Al Jarwan Money Exchange-Sharjah",base.ae
+l10n_ae_bank_79,"Harib Sultan Exchange-Abu Dhabi",base.ae
+l10n_ae_bank_80,"Al Masood Exchange-Abu Dhabi",base.ae
+l10n_ae_bank_81,"Horizon Exchange - Dubai",base.ae
+l10n_ae_bank_82,"Al Mazroui Exchange Est-Abu Dhabi",base.ae
+l10n_ae_bank_83,"International Developmentn Exchange-Dubai",base.ae
+l10n_ae_bank_84,"Al Modawallah Exchange- Dubai",base.ae
+l10n_ae_bank_85,"Jumana Exchange Est. - Dubai",base.ae
+l10n_ae_bank_86,"Al Mona Exchange Co. - LLC. - Dubai",base.ae
+l10n_ae_bank_87,"Kanoo Exchange- Dubai",base.ae
+l10n_ae_bank_88,"Al Mussabah Exchange- Dubai",base.ae
+l10n_ae_bank_89,"Khalil Al Fardan Exchange- Dubai",base.ae
+l10n_ae_bank_90,"Al Nafees Exchange LLC. - Dubai",base.ae
+l10n_ae_bank_91,"Khalili Exchange Co. LLC. - Dubai",base.ae
+l10n_ae_bank_92,"Al Ne'emah Exchange Co. LLC- Dubai",base.ae
+l10n_ae_bank_93,"Lari Exchange Est-Abu Dhabi",base.ae
+l10n_ae_bank_94,"Al Rajihi Exchange Company - LLC. - Dubai",base.ae
+l10n_ae_bank_95,"Lee La Megh Exchange LLC- Dubai",base.ae
+l10n_ae_bank_96,"Al Razouki Int'l Exchange Co. LLC. - Dub",base.ae
+l10n_ae_bank_97,"Malik Exchange-Abu Dhabi",base.ae
+l10n_ae_bank_98,"Al Zari & Al Fardan Exchange LLC. - Sharjah",base.ae
+l10n_ae_bank_99,"Multinet Trust Exchange - LLC. - Dubai",base.ae
+l10n_ae_bank_100,"Al Zarooni Exchange- Dubai",base.ae
+l10n_ae_bank_101,"Nanikdas Nathoomal Exchange Co. LLC- Dub",base.ae
+l10n_ae_bank_102,"Alukkass Exchange,base.ae
+l10n_ae_bank_103,"Naser Khoory Exchange Est. - Abu Dhabi",base.ae
+l10n_ae_bank_104,"Arabian Exchange Co-Abu Dhabi",base.ae
+l10n_ae_bank_105,"National Exchange Co.-Abu Dhabi",base.ae
+l10n_ae_bank_106,"ARY International Exchange- Dubai",base.ae
+l10n_ae_bank_107,"Oasis Exchange,base.ae
+l10n_ae_bank_108,"Asia Exchange Centre- Dubai",base.ae
+l10n_ae_bank_109,"Orient Exchange Co.- LLC- Dubai",base.ae
+l10n_ae_bank_110,"Aziz Exchange Co. LLC.- Dubai",base.ae
+l10n_ae_bank_111,"Pacific Exchange- Dubai",base.ae
+l10n_ae_bank_112,"Bhagwandas Jethanand and SonsSharjah",base.ae
+l10n_ae_bank_113,"Redha Al Ansari Exchange Est. - Dubai",base.ae
+l10n_ae_bank_114,"Bin Bakheet Exchange Est.- Ajman",base.ae
+l10n_ae_bank_115,"Reems Exchange- Dubai",base.ae
+l10n_ae_bank_116,"Bin Belaila Exchange Co.-LLC. - Dubai",base.ae
+l10n_ae_bank_117,"Sa'ad Exchange-Fujairah",base.ae
+l10n_ae_bank_118,"Cash Express Exchange Est. - Dubai",base.ae
+l10n_ae_bank_119,"Sabah Exchange-Sharjah",base.ae
+l10n_ae_bank_120,"Central Exchange LLC Dubai",base.ae
+l10n_ae_bank_121,"Sajwani Exchange- Dubai",base.ae
+l10n_ae_bank_122,"City Exchange - LLC. - Dubai",base.ae
+l10n_ae_bank_123,"Salim Exchange-Sharjah",base.ae
+l10n_ae_bank_124,"Daniba International Exchange- Dubai",base.ae
+l10n_ae_bank_125,"Sana'a Exchange- Dubai",base.ae
+l10n_ae_bank_126,"Day Exchange LLC.- Dubai",base.ae
+l10n_ae_bank_127,"Sawan Exchange Co. - LLC. - Dubai",base.ae
+l10n_ae_bank_128,"Dinar Exchange - Dubai",base.ae
+l10n_ae_bank_129,"Shaheen Money Exchange LLC. - Dubai",base.ae
+l10n_ae_bank_130,"Dubai Exchange Centre - LLC. - Dubai",base.ae
+l10n_ae_bank_131,"Sharjah International ExchangeSharjah",base.ae
+l10n_ae_bank_132,"Dubai Express Exchange,base.ae
+l10n_ae_bank_133,"Tabra & Al Nebal Exchange - Dubai",base.ae
+l10n_ae_bank_134,"Emirates & East India Exchange - Sharjah",base.ae
+l10n_ae_bank_135,"Tahir Exchange Est. - Dubai",base.ae
+l10n_ae_bank_136,"Emirates India International Exchange-Sharjah",base.ae
+l10n_ae_bank_137,"Taymour & Abou Harb Exchange Co. LLC. -Sharjah",base.ae
+l10n_ae_bank_138,"Federal Exchange- Dubai",base.ae
+l10n_ae_bank_139,"Al Rostamani Exchange- Dubai",base.ae
+l10n_ae_bank_140,"First Gulf Exchange Centre- Dubai",base.ae
+l10n_ae_bank_141,"U.A.E. Exchange Centre - LLC.- Dubai",base.ae
+l10n_ae_bank_142,"Gomti Exchange - LLC. - Dubai",base.ae
+l10n_ae_bank_143,"Union Exchange-Abu Dhabi",base.ae
+l10n_ae_bank_144,"Gulf Express Exchange- Dubai",base.ae
+l10n_ae_bank_145,"Universal Exchange Centre - Dubai",base.ae
+l10n_ae_bank_146,"Gulf Int'l Exchange Co.-LLC. - Dubai",base.ae
+l10n_ae_bank_147,"Wall Street Exchange Centre - LLCDubai",base.ae
+l10n_ae_bank_148,"Zahra Al Yousuf Exchange- Dubai",base.ae
+l10n_ae_bank_149,"AL DINAR EXCHANGE COMPANY",base.ae
+l10n_ae_bank_150,"Global Exchange",base.ae
+l10n_ae_bank_151,"HSBC Financial Services",base.ae
+l10n_ae_bank_152,"Economic Exchange",base.ae
+l10n_ae_bank_153,"ALFA EXCHANGE",base.ae
+l10n_ae_bank_154,"Royal Exchange Co. LLC",base.ae
+l10n_ae_bank_155,"DELMA EXCHANGE",base.ae
+l10n_ae_bank_156,"Bin Belaila Exchange Co. L.L.C",base.ae
+l10n_ae_bank_157,"SHARAF EXCHANGE",base.ae
+l10n_ae_bank_158,"Alfalah Exchange Company",base.ae
+l10n_ae_bank_159,"LULU EXCHANGE",base.ae
+l10n_ae_bank_160,"GCC EXCHANGE",base.ae
+l10n_ae_bank_161,"C3",base.ae
+l10n_ae_bank_162,"Economic Exchange Centre",base.ae
+l10n_ae_bank_163,"Western Union",base.ae
+l10n_ae_bank_164,"Global Exchange",base.ae
+l10n_ae_bank_165,"Waseela Equity",base.ae
+l10n_ae_bank_166,"Zareen Exchange",base.ae
+l10n_ae_bank_167,"Workers Equity Holdings",base.ae
+l10n_ae_bank_168,"Future Exchange",base.ae
+l10n_ae_bank_169,"SEIDCO",base.ae
+l10n_ae_bank_170,"Nasim Al Barari Exchange",base.ae
+l10n_ae_bank_171,"Finance House",base.ae
+l10n_ae_bank_172,"Al Dhahery Exchange",base.ae
+l10n_ae_bank_173,"Dunia",base.ae
+l10n_ae_bank_174,"Al Nibal International Exchange",base.ae


### PR DESCRIPTION
upg-3028498

`res.country` records are noupdate by default, which means that changes such as the following are not reverted:

```SQL
pied@(none):pied_3028498> SELECT c.name, d.name FROM res_country c JOIN ir_model_data d ON d.res_id = c.id AND d.model
 = 'res.country' AND d.name = 'ae'
+------------------+------+
| name             | name |
|------------------+------|
| {"en_US": "UAE"} | ae   |
+------------------+------+
```

Which results in the following error when trying to parse the csv data file of interest:

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-18.3/odoo/service/server.py", line 1400, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
  File "<decorator-gen-6>", line 2, in new
  File "/home/odoo/src/odoo/saas-18.3/odoo/tools/func.py", line 83, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/registry.py", line 169, in new
    load_modules(
  File "/home/odoo/src/odoo/saas-18.3/odoo/modules/loading.py", line 450, in load_modules
    load_module_graph(
  File "/home/odoo/src/odoo/saas-18.3/odoo/modules/loading.py", line 226, in load_module_graph
    load_data(env, idref, 'update', kind='data', package=package)
  File "/home/odoo/src/odoo/saas-18.3/odoo/modules/loading.py", line 79, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "/home/odoo/src/odoo/saas-18.3/odoo/tools/convert.py", line 628, in convert_file
    convert_csv_import(env, module, pathname, fp.read(), idref, mode, noupdate)
  File "/home/odoo/src/odoo/saas-18.3/odoo/tools/convert.py", line 684, in convert_csv_import
    raise Exception(env._(
Exception: Module loading l10n_ae failed: file l10n_ae/data/res.bank.csv could not be processed:
No matching record found for name 'United Arab Emirates' in field 'Country'
```