### PR TITLE
[FIX] web: fix indeterministic test on interactions

### DIFF
--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -1,5 +1,13 @@
 import { before, beforeEach, describe, expect, test } from "@odoo/hoot";
-import { animationFrame, click, dblclick, queryAll, queryFirst, queryOne } from "@odoo/hoot-dom";
+import {
+    animationFrame,
+    click,
+    dblclick,
+    queryAll,
+    queryFirst,
+    queryOne,
+    freezeTime,
+} from "@odoo/hoot-dom";
 import { advanceTime, Deferred } from "@odoo/hoot-mock";
 import { Component, onWillDestroy, markup, xml } from "@odoo/owl";
 import { clearRegistry, patchWithCleanup } from "@web/../tests/web_test_helpers";
@@ -1583,7 +1591,7 @@ describe("t-att-style", () => {
                 span: {
                     "t-att-style": () => ({
                         "background-color": this.bgColor,
-                        "color": this.color,
+                        color: this.color,
                     }),
                 },
             };
@@ -1598,10 +1606,16 @@ describe("t-att-style", () => {
                 }, 1000);
             }
         }
-        await startInteraction(Test, `<div class="test" style="color: black;"><span style="background-color: rgb(0, 0, 255);">Hi</span></div>`);
-        expect("span").toHaveStyle({ "background-color": "rgb(0, 255, 0)", "color": "rgb(255, 0, 0)" });
+        await startInteraction(
+            Test,
+            `<div class="test" style="color: black;"><span style="background-color: rgb(0, 0, 255);">Hi</span></div>`
+        );
+        expect("span").toHaveStyle({
+            "background-color": "rgb(0, 255, 0)",
+            color: "rgb(255, 0, 0)",
+        });
         await advanceTime(1000);
-        expect("span").toHaveStyle({ "background-color": "rgb(0, 0, 255)", "color": "rgb(0, 0, 0)" });
+        expect("span").toHaveStyle({ "background-color": "rgb(0, 0, 255)", color: "rgb(0, 0, 0)" });
     });
 });
 
@@ -1804,8 +1818,10 @@ describe("t-att and t-out", () => {
                             return markup(this.tOut);
                         },
                     },
-                    "span": {
-                        "t-on-click.noUpdate": () => { expect.step("clicked") },
+                    span: {
+                        "t-on-click.noUpdate": () => {
+                            expect.step("clicked");
+                        },
                     },
                 };
                 setup() {
@@ -1888,7 +1904,6 @@ describe("t-att and t-out", () => {
         expect("span").not.toHaveAttribute("animal");
         expect("span").toHaveAttribute("egg", "mysterious");
     });
-
 });
 
 describe("components", () => {
@@ -2488,6 +2503,7 @@ describe("debounced (2)", () => {
     });
 
     test("debounced is not called if the interaction is destroyed in the meantime", async () => {
+        freezeTime();
         let debounceTimer;
 
         class Test extends Interaction {


### PR DESCRIPTION
Hoot provides us with "time control" features such as "advanceTime", which is useful for testing scenarios where we want to wait for some events to happen (such as a debounced function), but without actually waiting too much.

The way it works is that hoot simply override setTimeout and related functions to keep track of all handlers and their scheduled time. However, this is not enough, as the real setTimeout is still by default called, so it can happen in some tests that when we advance the time by some amount, say 500ms, if the cpu load is very high, then other handlers that are scheduled AFTER the 500ms may have run as well.

To fix this, we can use the freezeTime feature from hoot. It simply give the full control to hoot, and do not call the real setTimeout function.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
