### PR TITLE
[FIX] point_of_sale: prevent duplicate preparation ticket

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -37,6 +37,7 @@ export class PosOrder extends Base {
         this.last_order_preparation_change = vals.last_order_preparation_change
             ? JSON.parse(vals.last_order_preparation_change)
             : {
+                  metadata: {},
                   lines: {},
                   generalNote: "",
                   sittingMode: "dine in",
@@ -364,6 +365,9 @@ export class PosOrder extends Base {
         }
         this.last_order_preparation_change.sittingMode = this.takeaway ? "takeaway" : "dine in";
         this.last_order_preparation_change.generalNote = this.general_note;
+        this.last_order_preparation_change.metadata = {
+            serverDate: serializeDateTime(DateTime.now()),
+        };
     }
 
     hasSkippedChanges() {

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -32,7 +32,7 @@ export class ReceiptScreen extends Component {
             const order = this.pos.get_order();
 
             if (!this.pos.config.module_pos_restaurant) {
-                this.pos.sendOrderInPreparation(order);
+                this.pos.checkPreparationStateAndSentOrderInPreparation(order);
             }
         });
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -444,7 +444,7 @@ export class PosStore extends Reactive {
                     typeof order.id === "number" &&
                     Object.keys(order.last_order_preparation_change.lines).length > 0
                 ) {
-                    await this.sendOrderInPreparation(order, true);
+                    await this.checkPreparationStateAndSentOrderInPreparation(order, true);
                 }
 
                 const cancelled = this.removeOrder(order, false);
@@ -1566,8 +1566,40 @@ export class PosStore extends Reactive {
     getOrderChanges(skipped = false, order = this.get_order()) {
         return getOrderChanges(order, skipped, this.orderPreparationCategories);
     }
+    async checkPreparationStateAndSentOrderInPreparation(order, cancelled = false) {
+        if (typeof order.id !== "number") {
+            return this.sendOrderInPreparation(order, cancelled);
+        }
+
+        const data = await this.data.call("pos.order", "get_preparation_change", [order.id]);
+        const rawchange = data.last_order_preparation_change || "{}";
+        const lastChanges = JSON.parse(rawchange);
+        const lastServerDate = DateTime.fromSQL(lastChanges.metadata?.serverDate).toUTC();
+        const lastLocalDate = DateTime.fromSQL(
+            order.last_order_preparation_change?.metadata?.serverDate
+        ).toUTC();
+
+        if (lastServerDate.isValid && lastServerDate.ts != lastLocalDate.ts) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Order Outdated"),
+                body: _t(
+                    "The order has been modified on another device. If you have modified existing " +
+                        "order lines, check that your changes have not been overwritten.\n\n" +
+                        "The order will be sent to the server with the last changes made on this device."
+                ),
+            });
+
+            // Update before syncing otherwise it will overwrite the last change
+            order.last_order_preparation_change = lastChanges;
+            await this.syncAllOrders({ orders: [order] });
+            return;
+        }
+
+        return this.sendOrderInPreparation(order, cancelled);
+    }
     // Now the printer should work in PoS without restaurant
     async sendOrderInPreparation(order, cancelled = false) {
+        let isPrinted = false;
         if (this.printers_category_ids_set.size) {
             try {
                 const orderChange = changesToOrder(
@@ -1576,13 +1608,19 @@ export class PosStore extends Reactive {
                     this.orderPreparationCategories,
                     cancelled
                 );
-                this.printChanges(order, orderChange);
+                isPrinted = await this.printChanges(order, orderChange);
             } catch (e) {
                 console.info("Failed in printing the changes in the order", e);
             }
         }
 
         order.updateLastOrderChange();
+        // Ensure that other devices are aware of the changes
+        // Otherwise several devices can print the same changes
+        // We need to check if a preparation display is configured to avoid unnecessary sync
+        if (isPrinted && !this.config["<-pos_preparation_display.display.pos_config_ids"]?.length) {
+            await this.syncAllOrders({ orders: [order] });
+        }
     }
     async sendOrderInPreparationUpdateLastChange(o, cancelled = false) {
         // Always display a "ConnectionLostError" when the user tries to send an order to the kitchen while offline
@@ -1590,10 +1628,11 @@ export class PosStore extends Reactive {
             this.data.network.warningTriggered = false;
             throw new ConnectionLostError();
         }
-        await this.sendOrderInPreparation(o, cancelled);
+        await this.checkPreparationStateAndSentOrderInPreparation(o, cancelled);
     }
 
     async printChanges(order, orderChange) {
+        let isPrinted = false;
         const unsuccedPrints = [];
         const isPartOfCombo = (line) =>
             line.isCombo || this.models["product.product"].get(line.product_id).type == "combo";
@@ -1629,6 +1668,8 @@ export class PosStore extends Reactive {
                 changes.new = [];
                 if (!printed) {
                     unsuccedPrints.push("Detailed Receipt");
+                } else {
+                    isPrinted = true;
                 }
             }
 
@@ -1638,6 +1679,8 @@ export class PosStore extends Reactive {
                 const printed = await this.printReceipts(order, printer, key, value, false);
                 if (!printed) {
                     unsuccedPrints.push(key);
+                } else {
+                    isPrinted = true;
                 }
             }
             // Print Order Note if changed
@@ -1645,6 +1688,8 @@ export class PosStore extends Reactive {
                 const printed = await this.printReceipts(order, printer, "Message", []);
                 if (!printed) {
                     unsuccedPrints.push("General Message");
+                } else {
+                    isPrinted = true;
                 }
             }
         }
@@ -1657,6 +1702,8 @@ export class PosStore extends Reactive {
                 body: _t("Failed in printing %s changes of the order", failedReceipts),
             });
         }
+
+        return isPrinted;
     }
 
     getPrintingChanges(order, diningModeUpdate) {


### PR DESCRIPTION
Before this change, when a device sent an order in preparation via the
ticket printer, this could result in the same order being printed by
multiple devices, as the order was not synchronized after it was sent.

The error is a bit tricky, because if the user had installed a
preparation screen, the order was sent to the preparation screen via
syncAllOrders. In this case, the order was correctly synchronized and
the other devices were informed of the changes.

This commit adds two things.
- We check the server before sending the order to preparation to make
sure it has not already been sent.
- Even when the user does not have a preparation display, the order
will be synchronized after being sent to a printer.