### PR TITLE
[FIX] web: prevent unwanted situations with freezeTime in hoot

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/time.js
+++ b/addons/web/static/lib/hoot-dom/helpers/time.js
@@ -229,11 +229,12 @@ export function delay(duration) {
     return new Promise((resolve) => setTimeout(resolve, duration));
 }
 
-/**
- * @param {boolean} setFreeze
- */
-export function freezeTime(setFreeze) {
-    frozen = setFreeze ?? !frozen;
+export function freezeTime() {
+    frozen = true;
+}
+
+export function unfreezeTime() {
+    frozen = false;
 }
 
 export function getTimeOffset() {

--- a/addons/web/static/lib/hoot-dom/hoot-dom.js
+++ b/addons/web/static/lib/hoot-dom/hoot-dom.js
@@ -59,6 +59,7 @@ export {
     Deferred,
     delay,
     freezeTime,
+    unfreezeTime,
     microTick,
     setFrameRate,
     tick,

--- a/addons/web/static/lib/hoot/hoot-mock.js
+++ b/addons/web/static/lib/hoot/hoot-mock.js
@@ -12,6 +12,7 @@ export {
     Deferred,
     delay,
     freezeTime,
+    unfreezeTime,
     microTick,
     runAllTimers,
     setFrameRate,


### PR DESCRIPTION
The freezeTime utility function had a very strange behaviour: if it is called without an argument, it would toggle the current value. This means that if i read a test that calls freezeTime, i actually do not know if the time is frozen after that function call.

This could be a problem in many subtle situations. For example, if a test is using freezeTime, and then later, someone add a `beforeEach(freezeTime)` in that suite without removing the existing freezeTime, then weirdly, the test would no longer be "protected".

This commit simplifies the behaviour of freezeTime to make sure we know what we are doing in all cases.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
