### PR TITLE
[FIX] website: remove background color filter when removing bg image

### DIFF
--- a/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
@@ -100,6 +100,9 @@ export class BackgroundImageOptionPlugin extends Plugin {
         if (backgroundURL) {
             el.classList.add("oe_img_bg", "o_bg_img_center", "o_bg_img_origin_border_box");
         } else {
+            this.dependencies.builderActions.getAction("selectFilterColor").apply({
+                editingElement: el.classList.contains("s_parallax_bg") ? el.parentElement : el,
+            });
             el.classList.remove(
                 "oe_img_bg",
                 "o_bg_img_center",
@@ -183,7 +186,6 @@ export class ToggleBgImageAction extends BuilderAction {
         return !!getBgImageURLFromEl(editingElement);
     }
     clean({ editingElement }) {
-        editingElement.querySelector(".o_we_bg_filter")?.remove();
         this.dependencies.backgroundImageOption.applyReplaceBackgroundImage({
             editingElement: editingElement,
             loadResult: "",


### PR DESCRIPTION
Since the `html_builder`, when a block has a parallax background image and the image is removed, any applied color filter remains applied. This happens because the `editingElement` of the image toggle is the parallax span instead of the actual section - and therefore the color filter element is not properly located.

This commit finds out about that situation and removes the filter from the right element.

Steps to reproduce:
- Drop a "Cover" block
- Remove its background image

=> Its color filter remained present in the DOM.

task-4367641
