### PR TITLE
[IMP] base: root check on server start should rely on UID

### DIFF
--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -30,10 +30,9 @@ _logger = logging.getLogger('odoo')
 
 def check_root_user():
     """Warn if the process's user is 'root' (on POSIX system)."""
-    if os.name == 'posix':
-        import getpass
-        if getpass.getuser() == 'root':
-            sys.stderr.write("Running as user 'root' is a security risk.\n")
+    if os.name == 'posix' and os.getuid() == 0:
+        sys.stderr.write("Running as user 'root' is a security risk.\n")
+
 
 def check_postgres_user():
     """ Exit if the configured database user is 'postgres'.


### PR DESCRIPTION
On POSIX systems, we check that we're running the server does not run with `sudo` access. But the `getpass` check only checks environment variables, which are not safe, and do not actually work with `su` for instance.

See refs:
Origin PR: https://github.com/odoo/odoo/pull/207044
https://docs.python.org/3/library/getpass.html#getpass.getuser
https://www.baeldung.com/linux/get-current-user
