### PR TITLE
[IMP] web: support navigation through Tab key in command palette

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -135,6 +135,10 @@ export class CommandPalette extends Component {
             bypassEditableProtection: true,
             allowRepeat: true,
         });
+        useHotkey("Tab", () => this.selectCommandAndScrollTo("NEXT"), {
+            bypassEditableProtection: true,
+            allowRepeat: true,
+        });
         useExternalListener(window, "mousedown", this.onWindowMouseDown);
 
         /**

--- a/addons/web/static/tests/core/commands/command_palette.test.js
+++ b/addons/web/static/tests/core/commands/command_palette.test.js
@@ -1203,6 +1203,52 @@ test("navigate in the command palette with the arrows", async () => {
     expect(".o_command.focused").toHaveText(commands[1].name);
 });
 
+test("navigate in the command palette with the Tab key", async () => {
+    expect.assertions(4);
+
+    await mountWithCleanup(MainComponentsContainer);
+    const action = () => {};
+    const commands = [
+        {
+            name: "Command1",
+            action,
+        },
+        {
+            name: "Command2",
+            action,
+        },
+        {
+            name: "Command3",
+            action,
+        },
+    ];
+    const providers = [
+        {
+            provide: () => commands,
+        },
+    ];
+    const config = {
+        providers,
+    };
+    getService("dialog").add(CommandPalette, {
+        config,
+    });
+    await animationFrame();
+    expect(".o_command.focused").toHaveText(commands[0].name);
+
+    await press("Tab");
+    await animationFrame();
+    expect(".o_command.focused").toHaveText(commands[1].name);
+
+    await press("Tab");
+    await animationFrame();
+    expect(".o_command.focused").toHaveText(commands[2].name);
+
+    await press("Tab");
+    await animationFrame();
+    expect(".o_command.focused").toHaveText(commands[0].name);
+});
+
 test("navigate in the command palette with an empty list", async () => {
     expect.assertions(6);
 


### PR DESCRIPTION
Steps to Reproduce:

- Open the command palette using the shortcut (e.g., Ctrl + K to Create Link)
- Press the Tab key to try navigating between the listed commands

Current behavior before PR:

- The Tab key was not supported for navigating the command palette.
- Only Arrow Up and Arrow Down keys were bound to move focus between commands.
- Pressing Tab would shift focus out of the palette.

Desired behavior after PR is merged:

- The Tab key now behaves the same as Arrow Down inside the command palette.
- Each press of Tab moves focus to the next command in the list.

task-4965566

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
