### PR TITLE
[REM] mail: remove `pin()` as dead code

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -751,19 +751,6 @@ export class Thread extends Record {
         await chatWindow?.close({ notifyState: false, ...options });
     }
 
-    pin() {
-        if (this.model !== "discuss.channel" || !this.store.self_partner) {
-            return;
-        }
-        this.is_pinned = true;
-        return this.store.env.services.orm.silent.call(
-            "discuss.channel",
-            "channel_pin",
-            [this.id],
-            { pinned: true }
-        );
-    }
-
     /** @param {string} name */
     async rename(name) {
         const newName = name.trim();


### PR DESCRIPTION
Since odoo/enterprise#69648 the usage of the `openWhatsAppChannel()` has been removed. This method was the only one that used `pin()` method of thread model. This change removes `pin()` method as it's now dead code.

Related to: odoo/enterprise#91022