### PR TITLE
[FIX] mail: add inactive activity when filtering on date_done

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -482,3 +482,19 @@ class MailActivityMixin(models.AbstractModel):
             return False
         self.activity_search(act_type_xmlids, user_id=user_id).unlink()
         return True
+
+    @api.model
+    def search_fetch(self, domain, field_names, offset=0, limit=None, order=None):
+        """Include inactive activities when filtering on activity_ids.date_done."""
+        if any(isinstance(leaf, (list, tuple)) and len(leaf) == 3 and leaf[0] == 'activity_ids.date_done'
+            for leaf in domain or []):
+            return super(MailActivityMixin, self.with_context(active_test=False)).search_fetch(domain, field_names, offset, limit, order)
+        return super().search_fetch(domain, field_names, offset, limit, order)
+
+    @api.model
+    def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
+        """Include inactive activities when filtering on activity_ids.date_done."""
+        if any(isinstance(leaf, (list, tuple)) and len(leaf) == 3 and leaf[0] == 'activity_ids.date_done'
+            for leaf in domain or []):
+            return super(MailActivityMixin, self.with_context(active_test=False))._search(domain, offset, limit, order, access_rights_uid)
+        return super()._search(domain, offset, limit, order, access_rights_uid)

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -798,6 +798,27 @@ class TestActivityMixin(TestActivityCommon):
             ])
             self.assertFalse(record, "Should not find record if the only late activity is done")
 
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_activity_ids_done_date_filter(self):
+        activity_type = self.env.ref('test_mail.mail_act_test_todo')
+        activity_type.keep_done = True
+
+        test_activity = self.env['mail.activity'].create({
+            'activity_type_id': activity_type.id,
+            'res_model_id': self.env.ref('test_mail.model_mail_test_activity').id,
+            'res_id': self.test_record.id,
+        })
+
+        record = self.env['mail.test.activity'].search([('activity_ids.date_done', '!=', False)])
+        self.assertFalse(record, 'No done activity should be found')
+        test_activity.action_done()
+        record = self.env['mail.test.activity'].search([('activity_ids.date_done', '!=', False)])
+        self.assertTrue(record.activity_ids, 'An activity should be found')
+        self.assertRecordValues(record, [{
+            'activity_ids': test_activity.ids,
+            'activity_type_id': activity_type.id
+        }])
+
     @users('employee')
     def test_record_unlink(self):
         test_record = self.test_record.with_user(self.env.user)


### PR DESCRIPTION
## Issue: ##
When using a Custom Filter on Activities > Date Done on any record like in the CRM App, the inactive activities where not included in the search domain
The keep_done option on the activity_type should be activate to keep old activities
The same issue occured in Activities in the Settings App in Debug Mode, with the Custom Filter on Date Done

## Cause: ##
The domain in the search doesn't include inactive activities
There is a lot of active test in the query

## Fix: ##
When there is `date_done` in the filtered domain in functions `search_fetch()` and `_search()` in `mail_activity_mixin`, we add `active_test=False` to self context
We also do tha same in the `_search()` of `mail_activity` to handle the Settings case

The `search_fetch()` override is needed for App like CRM to make the full query to be executed with the `active_text` context or some informations are lost
If this method doesn't include the context, the lead appeared but the linked Activities aren't fetched completely

## Limitations: ##
Fixing that way can cause to get too many elements, because it will remove all the (active=True) from the all query
This can lead to display inactive or archived leads in CRM, or any archived and inactive data with done activities

## Steps to reproduce: ##
- Open the CRM App
- Go to Configuration > Activity Types
- Select Call
- Toggle Keep Done to enable
- Go in the CRM Pipeline
- Mark any Call activity as Done
- Add a Custom Filter
- Set to Activities > Done Date (keep the default value for today)
- Apply the filter using the Add button
- Before the fix, there is nothing in the filtered pipeline

opw-4744974