### PR TITLE
[IMP] web: allow dynamic content in CopyButton

### DIFF
--- a/addons/web/static/src/core/copy_button/copy_button.js
+++ b/addons/web/static/src/core/copy_button/copy_button.js
@@ -11,7 +11,7 @@ export class CopyButton extends Component {
         disabled: { type: Boolean, optional: true },
         successText: { type: String, optional: true },
         icon: { type: String, optional: true },
-        content: { type: [String, Object], optional: true },
+        content: { type: [String, Object, Function], optional: true },
     };
 
     setup() {
@@ -25,16 +25,21 @@ export class CopyButton extends Component {
     }
 
     async onClick() {
-        let write;
+        let write, content;
+        if (typeof this.props.content === "function") {
+            content = this.props.content();
+        } else {
+            content = this.props.content;
+        }
         // any kind of content can be copied into the clipboard using
         // the appropriate native methods
-        if (typeof this.props.content === "string" || this.props.content instanceof String) {
+        if (typeof content === "string" || content instanceof String) {
             write = (value) => browser.navigator.clipboard.writeText(value);
         } else {
             write = (value) => browser.navigator.clipboard.write(value);
         }
         try {
-            await write(this.props.content);
+            await write(content);
         } catch (error) {
             return browser.console.warn(error);
         }

--- a/addons/web/static/tests/core/components/copy_button.test.js
+++ b/addons/web/static/tests/core/components/copy_button.test.js
@@ -1,0 +1,52 @@
+import { CopyButton } from "@web/core/copy_button/copy_button";
+import { browser } from "@web/core/browser/browser";
+import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { click } from "@odoo/hoot-dom";
+
+beforeEach(() => {
+    patchWithCleanup(browser.navigator.clipboard, {
+        async writeText(text) {
+            expect.step(`writeText: ${text}`);
+        },
+        async write(object) {
+            expect.step(
+                `write: {${Object.entries(object)
+                    .map(([k, v]) => k + ": " + v)
+                    .join(", ")}}`
+            );
+        },
+    });
+});
+
+test("copies a string to the clipboard", async () => {
+    await mountWithCleanup(CopyButton, { props: { content: "content to copy" } });
+    await click(".o_clipboard_button");
+    expect.verifySteps(["writeText: content to copy"]);
+});
+
+test("copies an object to the clipboard", async () => {
+    await mountWithCleanup(CopyButton, { props: { content: { oneKey: "oneValue" } } });
+    await click(".o_clipboard_button");
+    expect.verifySteps(["write: {oneKey: oneValue}"]);
+});
+
+test("copies a string via a function to the clipboard", async () => {
+    let contentToCopy = "content to copy 1";
+    const content = () => contentToCopy;
+    await mountWithCleanup(CopyButton, { props: { content } });
+    await click(".o_clipboard_button");
+    contentToCopy = "content to copy 2";
+    await click(".o_clipboard_button");
+    expect.verifySteps(["writeText: content to copy 1", "writeText: content to copy 2"]);
+});
+
+test("copies an object via a function to the clipboard", async () => {
+    let contentToCopy = { oneKey: "oneValue" };
+    const content = () => contentToCopy;
+    await mountWithCleanup(CopyButton, { props: { content } });
+    await click(".o_clipboard_button");
+    contentToCopy = { anotherKey: "anotherValue" };
+    await click(".o_clipboard_button");
+    expect.verifySteps(["write: {oneKey: oneValue}", "write: {anotherKey: anotherValue}"]);
+});


### PR DESCRIPTION
This allows to pass a function as content prop to the `CopyButton` component, that will be executed on click in order to retrieve the content to copy. This will be needed for the purposes of PR [1], in order to be able to edit the content of a code block before copying it.

task-4585835

[1]: https://github.com/odoo/odoo/pull/213300

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
