### PR TITLE
[FIX] html_editor: fix the selection after redo

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -824,6 +824,9 @@ export class HistoryPlugin extends Plugin {
 
         currentStep.previousStepId = this.steps.at(-1)?.id;
 
+        currentStep.selectionAfter = this.serializeSelection(
+            this.dependencies.selection.getEditableSelection()
+        );
         this.steps.push(currentStep);
         // @todo @phoenix add this in the linkzws plugin.
         // this._setLinkZws();
@@ -876,6 +879,7 @@ export class HistoryPlugin extends Plugin {
             this.stepsStates.set(revertedStep.id, "consumed");
             this.revertMutations(revertedStep.mutations, { forNewStep: true });
             this.setSerializedSelection(revertedStep.selection);
+            this.currentStep.selection = revertedStep.selectionAfter;
             this.addStep({ stepState: "undo", extraStepInfos: revertedStep.extraStepInfos });
             // Consider the last position of the history as an undo.
         }
@@ -899,6 +903,7 @@ export class HistoryPlugin extends Plugin {
             this.stepsStates.set(revertedStep.id, "consumed");
             this.revertMutations(revertedStep.mutations, { forNewStep: true });
             this.setSerializedSelection(revertedStep.selection);
+            this.currentStep.selection = revertedStep.selectionAfter;
             this.addStep({ stepState: "redo", extraStepInfos: revertedStep.extraStepInfos });
         }
         this.dispatchTo("post_redo_handlers", revertedStep);

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -210,6 +210,38 @@ describe("redo", () => {
         undo(editor);
         expect(getContent(el)).toBe(`<p>[]c</p>`);
     });
+
+    test("undo then redo, then re-undo, then re-redo and set the selection where we expect it", async () => {
+        const { editor, el } = await setupEditor("<p>a</p><p>b</p>");
+        const [p1, p2] = editor.editable.querySelectorAll("p");
+        editor.shared.selection.setCursorEnd(p1);
+        // DO
+        await insertText(editor, "A");
+        expect(getContent(el)).toBe("<p>aA[]</p><p>b</p>", { message: "insert A" });
+        editor.shared.selection.setCursorEnd(p2);
+        await insertText(editor, "B");
+        expect(getContent(el)).toBe("<p>aA</p><p>bB[]</p>", { message: "insert B" });
+        // UNDO
+        await press(["ctrl", "z"]);
+        expect(getContent(el)).toBe("<p>aA</p><p>b[]</p>", { message: "undo insert B" });
+        await press(["ctrl", "z"]);
+        expect(getContent(el)).toBe("<p>a[]</p><p>b</p>", { message: "undo insert A" });
+        // REDO
+        await press(["ctrl", "y"]);
+        expect(getContent(el)).toBe("<p>aA[]</p><p>b</p>", { message: "redo insert A" });
+        await press(["ctrl", "y"]);
+        expect(getContent(el)).toBe("<p>aA</p><p>bB[]</p>", { message: "redo insert B" });
+        // REUNDO
+        await press(["ctrl", "z"]);
+        expect(getContent(el)).toBe("<p>aA</p><p>b[]</p>", { message: "undo insert B" });
+        await press(["ctrl", "z"]);
+        expect(getContent(el)).toBe("<p>a[]</p><p>b</p>", { message: "undo insert A" });
+        // REREDO
+        await press(["ctrl", "y"]);
+        expect(getContent(el)).toBe("<p>aA[]</p><p>b</p>", { message: "redo insert A" });
+        await press(["ctrl", "y"]);
+        expect(getContent(el)).toBe("<p>aA</p><p>bB[]</p>", { message: "redo insert B" });
+    });
 });
 
 describe("selection", () => {


### PR DESCRIPTION
Every time we add a history step, right after it we stage the selection. But that staged selection generally gets overridden before the next step, and that information is lost. But when we `redo`, we expect the selection to be where it was at the end of the original action, not at the moment we performed the `undo` that we are cancelling off. So when we add a history step at the end of `undo` (or `redo`), we need to save the lost selection mentioned above instead.

task-4585835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
