### PR TITLE
[FIX] html_editor: preserve textarea selections and focus

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -166,6 +166,7 @@ function scrollToSelection(selection) {
  * @property { SelectionPlugin['getTargetedBlocks'] } getTargetedBlocks
  * @property { SelectionPlugin['getTargetedNodes'] } getTargetedNodes
  * @property { SelectionPlugin['modifySelection'] } modifySelection
+ * @property { SelectionPlugin['preserveFocus'] } preserveFocus
  * @property { SelectionPlugin['preserveSelection'] } preserveSelection
  * @property { SelectionPlugin['rectifySelection'] } rectifySelection
  * @property { SelectionPlugin['areNodeContentsFullySelected'] } areNodeContentsFullySelected
@@ -187,6 +188,7 @@ export class SelectionPlugin extends Plugin {
         "setCursorStart",
         "setCursorEnd",
         "extractContent",
+        "preserveFocus",
         "preserveSelection",
         "resetSelection",
         "getTargetedNodes",
@@ -208,7 +210,7 @@ export class SelectionPlugin extends Plugin {
 
     setup() {
         this.resetSelection();
-        this.addDomListener(this.document, "selectionchange", () => {
+        this.addGlobalDomListener("selectionchange", () => {
             this.updateActiveSelection();
             const selection = this.document.getSelection();
             if (this.isSelectionInEditable(selection)) {
@@ -643,14 +645,34 @@ export class SelectionPlugin extends Plugin {
             direction: textarea.selectionDirection,
         }));
         return () => {
+            if (
+                this.activeSelection?.isCollapsed &&
+                this.activeSelection.anchorNode?.nodeName === "TEXTAREA"
+            ) {
+                // If a textarea is targeted, focus it so its selection is active.
+                this.activeSelection.anchorNode.focus();
+            }
             for (const { textarea, start, end, direction } of selections) {
-                if (
-                    textarea.selectionStart !== start ||
-                    textarea.selectionEnd !== end ||
-                    textarea.selectionDirection !== direction
-                ) {
-                    textarea.setSelectionRange(start, end, direction);
-                }
+                textarea.setSelectionRange(start, end, direction);
+            }
+        };
+    }
+
+    /**
+     * Take the current active element and return a function that restores the
+     * focus in it if its content is editable.
+     *
+     * @returns {() => void}
+     */
+    preserveFocus() {
+        const activeElement = this.document.activeElement;
+        return () => {
+            if (
+                activeElement &&
+                activeElement !== this.document.activeElement &&
+                this.isNodeEditable(activeElement)
+            ) {
+                activeElement.focus();
             }
         };
     }


### PR DESCRIPTION
`textarea` elements have their own focus and their own selection mechanism. This PR ensures that these are properly handled and preserved when needed when `textarea` elements are encountered in the editor. It will be needed for the purposes of PR [1], which introduces `textarea` elements in an embedded component.

-----

If the selection was in a `textarea` element`, it was lost after every `normalize`. This is because the `toggle_block` plugin calls `preserveSelection` in its `normalize` handler, which calls `setSelection`. `textarea` elements use their own mechanism for their internal selection, and it seems to get lost when we set a new DOM selection.

This adds a function to preserve and restore the selections within all `textarea` elements in the editable, which is called by `setSelection` so nothing gets lost.

-----

When writing inside a protected textarea, the focus was lost at every action because the "selectionchange" event listener in charge of updating the active selection was not global (and therefore inactive in a protected node).

In the case of history actions, we also lost the focus. The reason is two-fold:

(1) Similarly to "selectionchange", the history plugin's "pointerup" event listener in charge of staging the selection was not global. This makes it global but since it was restricted to the editable's contents, it makes sure to preserve that restriction before staging the selection.

(2) We always reset the selection to the last recorded _editable_ selection, which automatically sets the focus in said editable and therefore out of the textarea. This introduces a mechanism to stage the focus besides the selection so we can reset them alongside each other.

Note: for this to work in the case of the embedded syntax highlighting block (in a later commit of this PR), its textarea element will be marked as editable.

task-458583

[1]: https://github.com/odoo/odoo/pull/213300

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
