### PR TITLE
[IMP] html_editor: restrict most shortcuts to editable content

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -192,9 +192,9 @@ export class HistoryPlugin extends Plugin {
             ],
         }),
         shortcuts: [
-            { hotkey: "control+z", commandId: "historyUndo" },
-            { hotkey: "control+y", commandId: "historyRedo" },
-            { hotkey: "control+shift+z", commandId: "historyRedo" },
+            { hotkey: "control+z", commandId: "historyUndo", global: true },
+            { hotkey: "control+y", commandId: "historyRedo", global: true },
+            { hotkey: "control+shift+z", commandId: "historyRedo", global: true },
         ],
         start_edition_handlers: () => {
             this.enableObserver();

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -1,4 +1,4 @@
-import { Plugin } from "../plugin";
+import { Plugin, isValidTargetForDomListener } from "../plugin";
 
 /**
  * @typedef {Object} Shortcut
@@ -37,20 +37,22 @@ export class ShortCutPlugin extends Plugin {
                 () => {
                     command.run(shortcut.commandParams);
                 },
-                { isAvailable: command.isAvailable }
+                {
+                    isAvailable: command.isAvailable,
+                    global: !!shortcut.global,
+                }
             );
         }
     }
 
-    addShortcut(hotkey, action, { isAvailable }) {
+    addShortcut(hotkey, action, { isAvailable, global }) {
         this.services.hotkey.add(hotkey, action, {
             area: () => this.editable,
             bypassEditableProtection: true,
             allowRepeat: true,
-            isAvailable: () =>
-                isAvailable
-                    ? isAvailable(this.dependencies.selection.getEditableSelection())
-                    : true,
+            isAvailable: (target) =>
+                (!isAvailable || isAvailable(this.dependencies.selection.getEditableSelection())) &&
+                (global || isValidTargetForDomListener(target)),
         });
     }
 }

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -1,5 +1,8 @@
 import { isProtected, isProtecting, isUnprotecting } from "./utils/dom_info";
 
+export const isValidTargetForDomListener = (target) =>
+    !isProtecting(target) && (!isProtected(target) || isUnprotecting(target));
+
 /**
  * @typedef { import("./editor").Editor } Editor
  * @typedef { import("./plugin_sets").SharedMethods } SharedMethods
@@ -41,7 +44,7 @@ export class Plugin {
     setup() {}
 
     isValidTargetForDomListener(ev) {
-        return !isProtecting(ev.target) && (!isProtected(ev.target) || isUnprotecting(ev.target));
+        return isValidTargetForDomListener(ev.target);
     }
 
     /**


### PR DESCRIPTION
With this commit, shortcuts are now by default only available when used within content that can be edited. Prior to this commit, many shortcuts would do nothing in this context but since they were available, the events were stopped, while they should be able to perform their default behavior instead, or be intercepted elsewhere.

This also adds an `allowInProtected` property to editor shortcuts, to declare exceptions to the above rule. We apply that exception to the history shortcuts for `undo` and `redo`.

task-4585835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
