### PR TITLE
[FIX] sale_purchase: no default dropship address on MTO purchases

### DIFF
--- a/addons/sale_purchase/models/purchase_order.py
+++ b/addons/sale_purchase/models/purchase_order.py
@@ -24,7 +24,7 @@ class PurchaseOrder(models.Model):
 
     @api.depends('order_line.sale_order_id.partner_shipping_id')
     def _compute_dest_address_id(self):
-        po_with_address = self.filtered(lambda po: len(po._get_sale_orders().partner_shipping_id) == 1)
+        po_with_address = self.filtered(lambda po: po.dest_address_id and len(po._get_sale_orders().partner_shipping_id) == 1)
         for order in po_with_address:
             order.dest_address_id = order._get_sale_orders().partner_shipping_id
         super(PurchaseOrder, self - po_with_address)._compute_dest_address_id()

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -53,6 +53,8 @@ class TestSalePurchaseStockFlow(TransactionCase):
         so.action_confirm()
 
         po = self.env['purchase.order'].search([('partner_id', '=', self.vendor.id)])
+        # dest_address_id should only be present for dropshipping
+        self.assertFalse(po.dest_address_id)
 
         so._action_cancel()
 


### PR DESCRIPTION
Issue
-----
POs created by a SO through the MTO route have the customer address set as if being dropshipped.

Steps to reproduce
-----
- Enable routes in settings
- Unarchive the MTO route
- Create a product "Prod"
	- Select both buy and MTO routes
	- Add a vendor line
- Create a SO for "Prod"
- Confirm the SO
- Go to the linked PO

When printing the RFQ, the address field is that of the customer as if the PO was a dropshipped one

Cause
-----
564b909 introduced an override of `_compute_dest_address_id` to update the delivery address of dropshipped purchases upon change of the SOL's `partner_shipping_id`.

The problem is that the field having a value means it is a dropshipped purchase

https://github.com/odoo/odoo/blob/35be5c9edf637fb813025f6817c16a9f50475fa8/addons/purchase/models/purchase_order.py#L89-L91

However, here, the value is set as long as the PO is linked to a SO, even if there was none to begin with. We can make sure that the field was already set via the vals when creating the PO, and that we just want to update it because the depends triggered the compute.

-----
Ticket:
opw-4925962
