### PR TITLE
[FIX] web: prevent crash occuring when using SelectMenu with groups

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -282,7 +282,7 @@ export class SelectMenu extends Component {
     }
 
     getSelectedChoice(props) {
-        const choices = [...props.choices, ...props.groups.flatMap((g) => g.choices)];
+        const choices = [...props.choices, ...props.groups.flatMap((g) => g.choices || [])];
         if (!this.props.multiSelect) {
             return choices.find((c) => c.value === props.value);
         }
@@ -331,16 +331,15 @@ export class SelectMenu extends Component {
         this.state.choices = [];
 
         for (const group of groupsList) {
-            let filteredOptions = [];
+            let filteredOptions = group.choices || [];
 
             if (searchString) {
                 filteredOptions = fuzzyLookup(
                     searchString.trim(),
-                    group.choices,
+                    filteredOptions,
                     (choice) => choice.label
                 );
             } else {
-                filteredOptions = group.choices || [];
                 if (this.props.autoSort) {
                     filteredOptions.sort((optionA, optionB) =>
                         optionA.label.localeCompare(optionB.label)

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -1102,6 +1102,34 @@ test("search value is cleared when reopening the menu", async () => {
     expect(".o_select_menu input").toHaveValue("");
 });
 
+test("Groups can be used without choices", async () => {
+    class Parent extends Component {
+        static props = ["*"];
+        static components = { SelectMenu };
+        static template = xml`
+            <SelectMenu choices="choices" groups="groups" />
+        `;
+        setup() {
+            this.choices = [{ label: "Hello", value: "hello" }];
+            this.groups = [
+                { label: "Group A" },
+                {
+                    label: "Subgroup 1",
+                    choices: [
+                        { label: "Option I", value: "optionI" },
+                        { label: "Option II", value: "optionII" },
+                    ],
+                },
+                { label: "Subgroup 2", choices: [] },
+            ];
+        }
+    }
+    await mountSingleApp(Parent);
+    await open();
+    expect(".o_select_menu_group").toHaveCount(2);
+    expect(".o_select_menu_item").toHaveCount(3);
+});
+
 test("Can add custom data to choices", async () => {
     class Parent extends Component {
         static props = ["*"];


### PR DESCRIPTION
This commit fixes an issue that caused a crash, when groups with no choices were being used.

Since commit (1), it is possible to use such groups for adding some type of separation in the menu (subgroups for example). For those, the 'choices' are not needed, but the SelectMenu was still expecting an array in the flatMap call of the getSelectedChoice method.

Now, it no longer crashes, and a test has been added to cover such use case.

1) https://github.com/odoo/odoo/commit/0923409082ead5ffdf2c28f3b063fbd91ebce553