### PR TITLE
[FIX] mail: correct extra parameter in rtc session mock server store

### DIFF
--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
@@ -59,9 +59,10 @@ export class DiscussChannelRtcSession extends models.ServerModel {
      * @param {number} id
      * @param {{ extra?; boolean }} options
      */
-    _to_store(store, { extra } = {}) {
-        const kwargs = getKwArgs(arguments, "store", "extra");
-        extra = kwargs.extra;
+    _to_store(store, fields, extra) {
+        const kwargs = getKwArgs(arguments, "store", "fields", "extra");
+        fields = kwargs.fields;
+        extra = kwargs.extra ?? false;
 
         store._add_record_fields(this, []);
         for (const rtcSession of this) {
@@ -109,7 +110,10 @@ export class DiscussChannelRtcSession extends models.ServerModel {
         const [member] = DiscussChannelMember.browse(session.channel_member_id);
         const [channel] = DiscussChannel.search_read([["id", "=", member.channel_id]]);
         BusBus._sendone(channel, "discuss.channel.rtc.session/update_and_broadcast", {
-            data: new mailDataHelpers.Store(DiscussChannelRtcSession.browse(id)).get_result(),
+            data: new mailDataHelpers.Store(
+                DiscussChannelRtcSession.browse(id),
+                makeKwArgs({ extra: true })
+            ).get_result(),
             channelId: channel.id,
         });
     }


### PR DESCRIPTION
Before this commit, the `_to_store` function of the DiscussChannelRtcSession in the mock server had the parameter incorrectly defined (modifined in [1]) , causing the `extra` parameter to always be true.
This led to information about the session like `is_camera_on` to be sent on session creation, which caused an incorrect UI state when such notification was processed late.

This commit fixes the issue by introducing the correct usage of `getKwArgs`.
This commit also adds the missing parameter to the `_to_store` call in the `_update_and_broadcast` method.

[1] https://github.com/odoo/odoo/issues/218376

fixes the following runbot errors:
runbot-229896
runbot-229898
runbot-229899
