### PR TITLE
[FIX] spreadsheet: apply filter on duplicated pivot

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_global_filter_plugin.js
@@ -134,6 +134,9 @@ export class PivotUIGlobalFilterPlugin extends OdooUIPlugin {
             case "UPDATE_ODOO_PIVOT_DOMAIN":
                 this._addDomain(cmd.pivotId);
                 break;
+            case "DUPLICATE_PIVOT":
+                this._addDomain(cmd.newPivotId);
+                break;
             case "UNDO":
             case "REDO": {
                 if (

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -36,7 +36,6 @@ import { localization } from "@web/core/l10n/localization";
 import { user } from "@web/core/user";
 
 import { Model } from "@odoo/o-spreadsheet";
-import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/helpers/global_filter";
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
@@ -1685,7 +1684,13 @@ test("can import a pivot with a calculated field", async function () {
 test("Can duplicate a pivot", async () => {
     const { model, pivotId } = await createSpreadsheetWithPivot();
     const matching = { chain: "product_id", type: "many2one" };
-    const filter = { ...THIS_YEAR_GLOBAL_FILTER, id: "42" };
+    const filter = {
+        id: "42",
+        type: "relation",
+        modelName: "product",
+        label: "Product",
+        defaultValue: [41],
+    };
     await addGlobalFilter(model, filter, {
         pivot: { [pivotId]: matching },
     });
@@ -1699,6 +1704,8 @@ test("Can duplicate a pivot", async () => {
 
     expect(model.getters.getPivotFieldMatching(pivotId, "42")).toEqual(matching);
     expect(model.getters.getPivotFieldMatching("2", "42")).toEqual(matching);
+    expect(model.getters.getPivotComputedDomain(pivotId)).toEqual([["product_id", "in", [41]]]);
+    expect(model.getters.getPivotComputedDomain("2")).toEqual([["product_id", "in", [41]]]);
 });
 
 test("Duplicate pivot respects the formula id increment", async () => {


### PR DESCRIPTION
Steps to reproduce:
- insert a pivot in a spreadsheet
- create a global filter matching one of the pivot fields
- use the global filter to restrict the values
- duplicate the pivot

=> the filter is not applied on the duplicated pivot

Task:4966634
opw-4950469

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
