### PR TITLE
[FIX] mail: fix recipients for partner with multiple emails in chatter

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -479,12 +479,17 @@ class Base(models.AbstractModel):
                     not p.is_public
                 )
             ))
+            existing_mails = {
+                email_key(e)
+                for rec in (followers | partners)
+                for e in ([rec.email_normalized] if rec.email_normalized else []) + email_split_and_format(rec.email or '')
+            }
             email_to_lst = list(tools.misc.unique(
                 e for email_input in suggested[record.id]['email_to_lst'] for e in email_split_and_format(email_input)
                 if (
                     e and e.strip() and
                     email_key(e) not in ban_emails and
-                    email_key(e) not in ((followers | partners).mapped('email_normalized') + (followers | partners).mapped('email'))
+                    email_key(e) not in existing_mails
                 )
             ))
 

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -583,11 +583,18 @@ class TestAPI(ThreadRecipients):
             'email_from': self.partner_employee.email_formatted,
             'name': 'Partner follower (user)',
         })
+        # existing partner with multiple emails -> should propose only the first one
+        partner_multiemail = self.test_partner.copy({'email': 'test1.external@example.com,test2.external@example.com'})
+        ticket_partner_multiemail = self.env['mail.test.ticket.mc'].create({
+            'customer_id': partner_multiemail.id,
+            'email_from': partner_multiemail.email_formatted,
+            'name': 'Partner Multi-Emails',
+        })
         ticket_partner_fol.message_subscribe(partner_ids=self.test_partner.ids)
         ticket_partner_fol.message_subscribe(partner_ids=self.partner_employee.ids)
         for ticket, sugg_partner in zip(
-            ticket_partner_email + ticket_partner + ticket_partner_fol + ticket_partner_fol_user,
-            (self.test_partner, self.test_partner, self.test_partner, False),
+            ticket_partner_email + ticket_partner + ticket_partner_fol + ticket_partner_fol_user + ticket_partner_multiemail,
+            (self.test_partner, self.test_partner, self.test_partner, False, partner_multiemail),
             strict=True,
         ):
             with self.subTest(ticket=ticket.name):


### PR DESCRIPTION
**Steps to reproduce:**
- Go to the `Contacts` app
- Create a new contact
- Add multiple emails in the email field (e.g. `"test1@example.com,test2@example.com"`)
- Click on `Send Message` button in the chatter
- Default recipients are computed for each email
- One of them match the contact, the other doesn't but still pass to the badges list
- When sending a message, the second mail is considered as a new contact to create

**Issue:**
Emails coming from an email field with multiple emails are considered separately when added in the chatter recipients. The partner only match the first one which means that the second one creates a duplicate.

This seems to be the default behavior when receiving an email from the additional email address of a partner (`If an email is not unique (e.g. multi-email input), only the first found valid email in input is considered.`), but automatically filling the recipients badges in this way seemed unintended.

**Fix:**
Properly parsed the email field of recipients to match the partner and avoid creating a duplicate when sending a message on a contact page.

opw-4929564

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
