### PR TITLE
[FIX] project,test_lint: Remove idx on `project.collaborator.project_id`

### DIFF
--- a/addons/project/models/project_collaborator.py
+++ b/addons/project/models/project_collaborator.py
@@ -7,7 +7,7 @@ class ProjectCollaborator(models.Model):
     _name = 'project.collaborator'
     _description = 'Collaborators in project shared'
 
-    project_id = fields.Many2one('project.project', 'Project Shared', domain=[('privacy_visibility', '=', 'portal')], required=True, readonly=True, export_string_translation=False, index=True)
+    project_id = fields.Many2one('project.project', 'Project Shared', domain=[('privacy_visibility', '=', 'portal')], required=True, readonly=True, export_string_translation=False)
     partner_id = fields.Many2one('res.partner', 'Collaborator', required=True, readonly=True, export_string_translation=False)
     partner_email = fields.Char(related='partner_id.email', export_string_translation=False)
     limited_access = fields.Boolean('Limited Access', default=False, export_string_translation=False)

--- a/odoo/addons/test_lint/tests/test_index.py
+++ b/odoo/addons/test_lint/tests/test_index.py
@@ -34,6 +34,7 @@ BTREE_INDEX_IGNORE_FIELDS = {  # str(field)  (fully-qualified field name)
     'mail.presence.guest_id',                           # covered by _guest_unique
     'res.users.settings.user_id',                       # covered by _unique_user_id
     'res.users.log.create_uid',                         # TODO(master): move the field definition in the base module instead of hr_presence, and remove this line
+    'project.collaborator.project_id',                  # covered by first key of _unique_collaborator
 }
 
 @common.tagged('post_install', '-at_install')


### PR DESCRIPTION
There is a unique constraint `_unique_collaborator`, whos first key is `project_id`, which will cover the necessity for an explicit index on `project_id`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
