### PR TITLE
[IMP] website_sale(_*): harmonize product buttons labels and titles

### DIFF
--- a/addons/website_sale/static/src/interactions/cart_line.js
+++ b/addons/website_sale/static/src/interactions/cart_line.js
@@ -12,7 +12,7 @@ export class CartLine extends Interaction {
         '.css_quantity > input.js_quantity': {
             't-on-change.withTarget': this.locked(this.debounced(this.changeQuantity, 500)),
         },
-        '.css_quantity > a': {
+        '.css_quantity > button': {
             't-on-click.prevent.withTarget': this.locked(this.incOrDecQuantity),
         },
         '.js_delete_product': { 't-on-click.prevent': this.locked(this.deleteProduct) },

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -17,7 +17,7 @@ export class ProductPage extends Interaction {
     static selector = '.o_wsale_product_page';
     dynamicContent = {
         '.js_product input[name="add_qty"]': { 't-on-change': this.onChangeAddQuantity },
-        'a.js_add_cart_json': { 't-on-click.prevent': this.incOrDecQuantity },
+        '.css_quantity > button': { 't-on-click.prevent': this.incOrDecQuantity },
         '.o_wsale_product_page_variants': { 't-on-change': this.onChangeVariant },
         '.o_product_page_reviews_link': { 't-on-click': this.onClickReviewsLink },
         '.css_attribute_color input': { 't-on-change': this.onChangeColorAttribute },

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -23,7 +23,7 @@ export function goToProductPage({
 export function increaseProductPageQuantity() {
     return {
         content: "Increase product quantity",
-        trigger: '.css_quantity a.js_add_cart_json i.oi-plus',
+        trigger: '.css_quantity button:has(i.oi-plus)',
         run: "click",
     }
 }

--- a/addons/website_sale/static/tests/tours/update_cart.js
+++ b/addons/website_sale/static/tests/tours/update_cart.js
@@ -45,8 +45,7 @@ registry.category("web_tour.tours").add("website_sale.update_cart", {
         },
         {
             content: "remove Storage Box",
-            trigger:
-                '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Storage Box")) a:has(i.oi-minus)',
+            trigger: '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Storage Box")) button:has(i.oi-minus)',
             run: "click",
         },
         {
@@ -56,7 +55,7 @@ registry.category("web_tour.tours").add("website_sale.update_cart", {
         {
             content: "add one more",
             trigger:
-                '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Conference Chair")) a:has(i.oi-plus)',
+                '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Conference Chair")) button:has(i.oi-plus)',
             run: "click",
         },
         {

--- a/addons/website_sale/templates/checkout/cart_templates.xml
+++ b/addons/website_sale/templates/checkout/cart_templates.xml
@@ -136,7 +136,6 @@
                                     <button
                                         class="js_delete_product btn btn-link btn-sm p-0"
                                         aria-label="Remove from cart"
-                                        title="Remove from cart"
                                     >
                                         Remove
                                     </button>
@@ -158,6 +157,7 @@
                             <button
                                 class="js_delete_product btn btn-link d-inline-block d-md-none px-2"
                                 title="Remove"
+                                aria-label="Remove"
                             >
                                 <i class="fa fa-fw fa-trash-o"/>
                             </button>
@@ -178,20 +178,21 @@
             t-attf-name="{{'website_sale_cart_line_quantity' if not is_mobile else 'website_sale_cart_line_quantity_mobile'}}"
         >
             <t t-if="should_show_quantity_selector and line._is_sellable()">
-                <a
-                    href="#"
+                <button
                     class="btn btn-link d-inline-block border-end-0"
                     aria-label="Remove one"
                     title="Remove one"
                 >
                     <i class="oi oi-minus position-relative z-1"/>
-                </a>
+                </button>
                 <input
                     type="text"
                     class="js_quantity quantity form-control border-0"
                     t-att-data-line-id="line.id"
                     t-att-data-product-id="line.product_id.id"
                     t-att-value="line._get_displayed_quantity()"
+                    t-attf-name="cart-quantity-{{line.id}}{{'-mobile' if is_mobile else ''}}"
+                    aria-label="Quantity"
                 />
                 <t t-if="line._get_shop_warning(clear=False)">
                     <a href="#" class="btn btn-link">
@@ -203,15 +204,14 @@
                         />
                     </a>
                 </t>
-                <a
+                <button
                     t-else=""
-                    href="#"
                     class="btn btn-link d-inline-block border-start-0"
                     aria-label="Add one"
                     title="Add one"
                 >
                     <i class="oi oi-plus position-relative z-1"/>
-                </a>
+                </button>
             </t>
             <t t-else="">
                 <input
@@ -220,7 +220,9 @@
                     t-att-data-line-id="line.id"
                     t-att-data-product-id="line.product_id.id"
                     t-att-value="line._get_displayed_quantity()"
+                    t-attf-name="cart-quantity-{{line.id}}{{'-mobile' if is_mobile else ''}}"
                     readonly="True"
+                    aria-label="Quantity"
                 />
             </t>
         </div>
@@ -576,6 +578,7 @@
                 t-att-data-product-id="line.product_id.id"
                 t-att-data-product-template-id="line.product_id.product_tmpl_id.id"
                 title="Wishlist"
+                aria-label="Wishlist"
             >
                 <i class="fa fa-fw fa-heart-o"/>
             </button>

--- a/addons/website_sale/templates/checkout/checkout_templates.xml
+++ b/addons/website_sale/templates/checkout/checkout_templates.xml
@@ -279,7 +279,6 @@
                                     class="btn btn-light w-100"
                                     type="button"
                                     data-bs-dismiss="offcanvas"
-                                    aria-label="Close"
                                 >
                                     Close
                                 </button>

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -849,30 +849,28 @@
                 t-attf-class="css_quantity input-group {{'d-none' if combination_info['prevent_sale'] else 'd-inline-flex order-first'}} align-middle border"
                 contenteditable="false"
             >
-                <a
-                    t-attf-href="#"
-                    class="btn btn-link pe-2 js_add_cart_json border-0"
+                <button
+                    class="btn btn-link pe-2 border-0"
                     aria-label="Remove one"
                     title="Remove one"
-                    name="remove_one"
                 >
                     <i class="oi oi-minus text-600"/>
-                </a>
+                </button>
                 <input
                     type="text"
                     t-attf-class="form-control quantity text-center border-0"
                     data-min="1"
                     name="add_qty"
                     t-att-value="1"
+                    aria-label="Quantity"
                 />
-                <a
-                    t-attf-href="#"
-                    class="btn btn-link ps-2 js_add_cart_json border-0"
+                <button
+                    class="btn btn-link ps-2 border-0"
                     aria-label="Add one"
                     title="Add one"
                 >
                     <i class="oi oi-plus text-600"/>
-                </a>
+                </button>
             </div>
         </div>
     </template>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -50,7 +50,7 @@
                         t-if="ptav.attribute_id.is_thumbnail_visible"
                         class="d-flex"
                     >
-                        <label
+                        <i
                             class="css_attribute_preview_thumbnail cursor-pointer d-block"
                             t-att-style="'background:url(%s); background-size:cover; background-position: center center;' % previewed_ptav['variant_image_url']"
                             t-att-title="ptav.name"
@@ -70,7 +70,7 @@
                             t-set="background_style"
                             t-value="'background: ' + str(ptav.html_color or ptav.name)"
                         />
-                        <label
+                        <i
                             t-att-style="background_style"
                             class="css_attribute_color cursor-pointer d-block"
                             t-att-title="ptav.name"
@@ -1109,15 +1109,6 @@
                             role="menuitem"
                             t-att-aria-label="c.name"
                         >
-                            <input
-                                type="radio"
-                                t-attf-name="wsale_categories_top_radios_{{parentCategoryId}}"
-                                class="btn-check pe-none"
-                                t-att-id="c.id"
-                                t-att-value="c.id"
-                                t-att-checked="'true' if c.id == category.id else None"
-                                tabindex="-1"
-                            />
                             <div
                                 t-att-class="'o_wsale_filmstrip_item position-relative d-flex w-100 h-100'
                                     + (c.id == category.id and ' active' or '')"
@@ -1534,6 +1525,7 @@
                             t-att-min="'%f' % (available_min_price)"
                             t-att-max="'%f' % (available_max_price)"
                             t-att-value="'%f,%f' % (min_price, max_price)"
+                            aria-label="Price Range"
                         />
                     </div>
                 </div>
@@ -1553,6 +1545,7 @@
                     t-att-min="'%f' % (available_min_price)"
                     t-att-max="'%f' % (available_max_price)"
                     t-att-value="'%f,%f' % (min_price, max_price)"
+                    aria-label="Price Range"
                 />
             </t>
         </div>

--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
@@ -8,14 +8,14 @@
                 t-on-click="openLocationSelector"
                 class="cursor-pointer"
             >
-                <h6>
+                <div class="h6">
                     <i class="fa fa-fw fa-map-marker text-muted"/>
                     <t
                         t-if="this.state.selectedLocationData.id"
                         t-out="this.state.selectedLocationData.name"
                     />
                     <t t-else="" t-out="this.props.deliveryMethodName"/>
-                </h6>
+                </div>
                 <div class="d-flex justify-content-between">
                     <t t-if="this.state.inStoreStockData?.in_stock">
                         <div
@@ -45,7 +45,7 @@
                 class="flex-row"
             >
                 <hr/>
-                <h6>
+                <div class="h6">
                     <i class="fa fa-fw fa-truck text-muted"/>
                     Delivery
                     <i
@@ -53,7 +53,7 @@
                         data-tooltip="Restrictions may apply"
                         data-tooltip-delay="0"
                     />
-                </h6>
+                </div>
                 <div t-if="this.state.deliveryStockData.in_stock">
                     <div
                         t-if="this.state.deliveryStockData.show_quantity"

--- a/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
+++ b/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
@@ -14,7 +14,7 @@ registry.category('web_tour.tours').add('website_sale_collect_widget', {
         clickOnElement("Choose location", '#submit_location_large'),
         {
             content: "Check pickup location is set",
-            trigger: '[name="click_and_collect_availability"] h6:contains("Shop 1")',
+            trigger: '[name="click_and_collect_availability"] div:contains("Shop 1")',
         },
     ],
 });

--- a/addons/website_sale_collect/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect/views/delivery_form_templates.xml
@@ -63,7 +63,6 @@
                             <span class="small">|</span>
                             <button
                                 t-if="not in_wishlist"
-                                title="Add to Wishlist"
                                 class="o_add_wishlist_dyn alert-link btn btn-link btn-sm p-0"
                                 t-att-data-product-id="order_line.product_id.id"
                                 t-att-data-product-template-id="order_line.product_id.product_tmpl_id.id"
@@ -73,7 +72,7 @@
                                     t-att-data-line-id="order_line.id"
                                     t-att-data-product-id="order_line.product_id.id"
                                 >
-                                    <i class="fa fa-fw fa-heart-o" role="presentation" aria-label="Add to Wishlist"/>
+                                    <i class="fa fa-fw fa-heart-o" role="presentation" aria-label="Add to wishlist"/>
                                     Wishlist
                                 </span>
                             </button>


### PR DESCRIPTION
Improve accessibility on some e-commerce pages.

1) Focus first on some issues spotted through Lighthouse

* Form elements have no associated labels
  * price range filter (/shop)
  * useless category inputs (/shop)
  * quantity input (product page)

* Heading elements are not in a sequentially-descending order
  * click & collect h6 elements (product page)

increases the lighthouse accessibility score:
* for the /shop page from 94 to 99
* for the product page from 94 to 99

2) Fixes some generic accessibility/html guidelines:

* missing aria-label
* a behaving as buttons and not links
* label without linked elements to display the variant preview
* inputs must have name or id

task-5089699