### PR TITLE
[IMP] account: reco models uniqueness

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -84,11 +84,6 @@ class AccountReconcileModel(models.Model):
     _order = 'sequence, id'
     _check_company_auto = True
 
-    _name_unique = models.Constraint(
-        'unique(name, company_id)',
-        'A reconciliation model already bears this name.',
-    )
-
     # Base fields.
     active = fields.Boolean(default=True)
     name = fields.Char(string='Name', required=True, translate=True)


### PR DESCRIPTION
Removing the uniqueness constraint on the name of a reco model. Indeed, when doing a set account on multiple statement line, we check if there is a common substring and create a reco model if there is one. But the reco model created has the name of the account. Which means that we couldn't have two automatically generated reco model for the same account.

task-4876374




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
