### PR TITLE
[FIX] mail: preventing call to exists when thread is undefined

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -40,7 +40,7 @@ export class Thread extends Record {
                 request_list: fieldNames,
             });
             thread = this.get(data);
-            if (!thread.exists() || !thread.hasReadAccess) {
+            if (!thread?.exists() || !thread.hasReadAccess) {
                 return;
             }
         }


### PR DESCRIPTION
This PR introduces a fix on the `Thread.getOrFetch()` method where an exception was thrown when trying to call the `exists` method of the thread if it was not defined.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
