### PR TITLE
[FIX] loyalty: unable to archive pricelists

### DIFF
--- a/addons/loyalty/models/product_pricelist.py
+++ b/addons/loyalty/models/product_pricelist.py
@@ -6,7 +6,7 @@ class ProductPricelist(models.Model):
     _inherit = 'product.pricelist'
 
     def action_archive(self):
-        loyalty_programs = self.env['loyalty.program'].search([
+        loyalty_programs = self.env['loyalty.program'].sudo().search([
             ('active', '=', True),
             ('pricelist_ids', 'in', self.ids)
         ])


### PR DESCRIPTION
Finetuning of d20b6f6407f49f9bff8cf3677b2fe07cb3588298, if a user had access rights on the pricelist model but not on loyalty programs, he wouldn't be able to archive a given pricelist.

Has already been fixed in the aforementionned commit forward-port, starting from 18.2.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
