### PR TITLE
[FIX] hr_holiday_attendance: Recreate attendance overtime on leave reset

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -71,7 +71,7 @@ class HRLeave(models.Model):
     def action_reset_confirm(self):
         overtime_leaves = self.filtered('overtime_deductible')
         res = super().action_reset_confirm()
-        overtime_leaves.overtime_id.sudo().unlink()
+        self._check_overtime_deductible(self)
         return res
     
     def action_confirm(self):

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -121,8 +121,8 @@ class TestHolidaysOvertime(TransactionCase):
         self.assertEqual(self.employee.total_overtime, 8)
 
         leave.action_reset_confirm()
-        self.assertFalse(leave.overtime_id.exists(), "Overtime should not be created")
-        self.assertEqual(self.employee.total_overtime, 8)
+        self.assertTrue(leave.overtime_id.exists(), "Overtime should created")
+        self.assertEqual(self.employee.total_overtime, 0)
 
         overtime = leave.overtime_id
         leave.unlink()


### PR DESCRIPTION
When refusing or cancelling a time off request of type Extra Hours, the linked hr.attendance.overtime record was hard deleted. As a result, if the leave was later reset, the extra hours were not deducted again.
This fix ensures that a new hr.attendance.overtime record is recreated when resetting the leave, restoring the correct impact on the employee's extra hours balance.
Related task: 4966880.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
