### PR TITLE
[FIX] account: preserve base after tax change (l10n_pt)

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1721,6 +1721,10 @@ class AccountTax(models.Model):
                 )
                 biggest_total_per_tax['raw_tax_amount_currency'] += delta_raw_tax_amount_currency
                 biggest_total_per_tax['raw_tax_amount'] += delta_raw_tax_amount
+                biggest_total_per_tax['raw_total_amount'] += delta_raw_tax_amount_currency
+                biggest_total_per_tax['raw_total_amount_currency'] += delta_raw_tax_amount
+                base_amounts['raw_total_amount'] += delta_raw_tax_amount_currency
+                base_amounts['raw_total_amount_currency'] += delta_raw_tax_amount
 
         # Dispatch the delta in term of tax amounts across the tax details when dealing with the 'round_globally' method.
         # Suppose 2 lines:

--- a/addons/account/static/tests/tours/tax_group_tests.js
+++ b/addons/account/static/tests/tours/tax_group_tests.js
@@ -126,3 +126,78 @@ registry.category("web_tour.tours").add('account_tax_group', {
         trigger: '.o_tax_group_amount_value:contains("120")',
     },
 ]});
+
+registry.category("web_tour.tours").add('pt_tax_base_amount_tour', {
+    url: "/odoo",
+    steps: () => [
+    ...accountTourSteps.goToAccountMenu("Go to Invoicing"),
+    {
+        content: "Go to Vendors",
+        trigger: 'span:contains("Vendors")',
+        run: "click",
+    },
+    {
+        content: "Go to Bills",
+        trigger: 'a:contains("Bills")',
+        run: "click",
+    },
+    {
+        trigger: ".o_breadcrumb .text-truncate:contains(Bills)",
+    },
+    {
+        content: "Create new bill",
+        trigger: '.o_control_panel_main_buttons .o_list_button_add',
+        run: "click",
+    },
+    {
+        content: "Add vendor",
+        trigger: 'div.o_field_widget.o_field_res_partner_many2one[name="partner_id"] div input',
+        run: "edit Portuguese Vendor",
+    },
+    {
+        content: "Valid vendor",
+        trigger: '.ui-menu-item a:contains("Portuguese Vendor")',
+        run: "click",
+    },
+    {
+        content: "Add items",
+        trigger: 'div[name="invoice_line_ids"] .o_field_x2many_list_row_add a:contains("Add a line")',
+        run: "click",
+    },
+    {
+        content: "Select input",
+        trigger: 'div[name="invoice_line_ids"] .o_selected_row .o_list_many2one[name="product_id"] input',
+        run: "edit Portuguese Product",
+    },
+    {
+        content: "Valid item",
+        trigger: '.ui-menu-item-wrapper:contains("Portuguese Product")',
+        run: "click",
+    },
+    ...stepUtils.saveForm(),
+    {
+        content: "Edit tax group amount",
+        trigger: '.o_tax_group_edit',
+        run: "click",
+    },
+    {
+        content: "Modify the input value",
+        trigger: '.o_tax_group_edit_input input',
+        run() {
+            this.anchor.value = 28.30;
+            this.anchor.select();
+            this.anchor.blur();
+        },
+    },
+    {
+        content: "Valid total amount",
+        trigger: 'span[name="amount_total"]:contains("151.30")',
+        run: "click",
+    },
+    ...stepUtils.saveForm(),
+    {
+        content: "Valid total amount",
+        trigger: 'span[name="amount_total"]:contains("151.30")',
+        run: "click",
+    },
+]});

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -87,3 +87,44 @@ class TestUi(AccountTestInvoicingHttpCommon):
         product.supplier_taxes_id = new_tax
 
         self.start_tour("/odoo", 'account_tax_group', login="admin")
+
+    def test_portuguese_company_tax_base_amount_computation(self):
+        self.env.ref('base.user_admin').write({
+            'company_id': self.env.company.id,
+            'company_ids': [(4, self.env.company.id)],
+        })
+
+        portugal = self.env.ref('base.pt')
+        self.env.company.write({
+            'country_id': portugal.id,
+            'account_fiscal_country_id': portugal.id,
+        })
+        self.env['res.partner'].create({
+            'name': 'Portuguese Vendor',
+            'email': 'azure.vendor@example.com',
+        })
+
+        product = self.env['product.product'].create({
+            'name': 'Portuguese Product',
+            'standard_price': 123.0,
+            'list_price': 123.0,
+            'type': 'consu',
+        })
+
+        tax_group = self.env['account.tax.group'].create({
+            'name': 'Purchases',
+            'sequence': 10,
+        })
+
+        new_tax = self.env['account.tax'].create({
+            'name': '23% Tax',
+            'type_tax_use': 'purchase',
+            'amount_type': 'percent',
+            'amount': 23,
+            'company_id': self.env.company.id,
+            'country_id': portugal.id,
+            'tax_group_id': tax_group.id,
+        })
+        product.supplier_taxes_id = new_tax
+
+        self.start_tour("/odoo", 'pt_tax_base_amount_tour', login="admin")


### PR DESCRIPTION
**Issue**
When using the Portuguese localization (`l10n_pt`), manually changing and resetting a tax amount on a vendor bill can incorrectly alter the base (untaxed) amount.

**Steps to Reproduce**
1. Install Accounting and Portuguese localization (`l10n_pt`)
2. Create a vendor bill with a line: price = 123, tax = 23%
3. Manually change the computed tax amount from 28.29 to 28.30
4. Change it back to 28.29
5. Save the invoice
6. Observe that the untaxed amount becomes 122.99 instead of 123.00

**Root Cause**
In the Portuguese localization, the tax delta logic compares `raw_total_amount` instead of `raw_base_amount` to detect rounding differences. However, the `raw_total_amount` field is not recomputed when the tax amount is manually edited. As a result, the system detects a false positive delta (0.01) and incorrectly subtracts it from the base amount to force reconciliation of totals.

**Fix**
Extend the delta correction loop to also update `raw_total_amount` and `raw_total_amount_currency`, not just `tax_amount` and `tax_amount_currency`. This ensures all totals are correctly adjusted after a manual tax change, and prevents the base amount from being unintentionally altered.

Opw-4943540
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
