### PR TITLE
[FIX] mass_mailing: hide cancel button on immediate schedule_type

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -70,7 +70,7 @@
                         <button name="action_duplicate" type="object" class="btn-secondary" string="Duplicate"
                             data-hotkey="d" invisible="state != 'done'"/>
                         <button name="action_test" type="object" class="btn-secondary" string="Test" data-hotkey="k"/>
-                        <button name="action_cancel" type="object" invisible="state != 'in_queue'" class="btn-secondary" string="Cancel" data-hotkey="x"/>
+                        <button name="action_cancel" type="object" invisible="state != 'in_queue' or schedule_type == 'now'" class="btn-secondary" string="Cancel" data-hotkey="x"/>
                         <button name="action_retry_failed" type="object" invisible="state != 'done' or failed == 0" class="oe_highlight" string="Retry" data-hotkey="y"/>
                         <button type="object"
                             name="action_set_favorite"


### PR DESCRIPTION
**Steps to reproduce:**
- Go to `Email Marketing` app
- Create a new marketing campaign
- Click on `Send` button
- `Cancel` button appears during `In Queue` state
- Clicking `Cancel` set the state back to draft
- Mails are sent out anyway

**Issue:**
As the mails are added directly when clicking the `Send` button, they are sent out immediately (added to the queue and cron job is triggered).
While `Cancel` button is still clickable (unless the page is refreshed), it has no effect on the mailing itself (it just changes the state to `Draft`).

**Fix:**
Hide `Cancel` button when sending directly.

We could also consider adding a short delay to allow users to cancel their campaign.

opw-4937725

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
