### PR TITLE
[IMP] web: align fold and quick create buttons in kanban

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
+++ b/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
@@ -4,11 +4,11 @@
     <t t-name="web.KanbanColumnQuickCreate">
         <div class="o_column_quick_create d-print-none flex-shrink-0 flex-grow-1 flex-md-grow-0" t-attf-class="{{ props.folded ? 'o_quick_create_folded' : 'o_quick_create_unfolded' }}" t-ref="root">
             <div t-if="props.folded" class="z-1 px-3 pt-2 text-nowrap position-sticky top-0 d-flex lh-lg cursor-pointer" t-on-click="unfold">
-                <div class="o_quick_create_title d-md-none align-items-center fs-4 lh-1 text-nowrap flex-grow-1 gap-1">
+                <div class="o_quick_create_title d-md-none align-items-center fs-4 lh-1 text-nowrap flex-grow-1 gap-1 pt-1">
                     Add <t t-out="relatedFieldName"/>
                 </div>
-                <button class="btn d-flex align-items-center justify-content-between flex-nowrap pt-2 pb-3 px-1">
-                    <i class="fa fa-angle-double-right lh-lg" role="img" aria-label="Add column" title="Add column" />
+                <button class="o_quick_create_button btn d-flex align-items-center justify-content-between flex-nowrap py-0 px-1">
+                    <i class="fa fa-angle-double-right" role="img" aria-label="Add column" title="Add column" />
                 </button>
             </div>
             <div t-else="" class="pt-3 pb-2">

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -264,10 +264,14 @@
             display: flex !important;
         }
         .o_quick_create_title {
-            @include o-position-absolute(36px);
+            @include o-position-absolute(map-get($spacers, 4));
             transform-origin: left bottom 0;
             transform: rotate(90deg);
             overflow: visible;
+        }
+
+        .o_quick_create_button {
+            height: map-get($font-sizes, 4) * $line-height-lg;
         }
     }
 
@@ -304,6 +308,7 @@
 
             button.o_column_unfold {
                 padding: 0 .15rem;
+                height: map-get($font-sizes, 4) * $line-height-lg;
 
                 .fa-caret-left {
                     margin-right: 0.2rem;
@@ -319,7 +324,7 @@
             }
 
             .o_column_title {
-                @include o-position-absolute(map-get($spacers, 4));
+                @include o-position-absolute(map-get($spacers, 3));
                 transform-origin: left bottom 0;
                 transform: rotate(90deg);
                 overflow: visible;

--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -22,9 +22,9 @@
                         <i class="fa fa-plus opacity-75 opacity-100-hover" role="img" aria-label="Quick add" title="Quick add"/>
                     </button>
                 </t>
-                <button t-else="" class="o_column_unfold btn d-flex align-items-center justify-content-between flex-nowrap pt-2 pb-3 transition-base">
-                    <i class="fa fa-caret-left lh-lg transition-base" role="img" aria-label="Unfold" title="Unfold" />
-                    <i class="fa fa-caret-right lh-lg" role="img" aria-label="Unfold" title="Unfold" />
+                <button t-else="" class="o_column_unfold btn d-flex align-items-center justify-content-between flex-nowrap transition-base">
+                    <i class="fa fa-caret-left transition-base" role="img" aria-label="Unfold" title="Unfold" />
+                    <i class="fa fa-caret-right" role="img" aria-label="Unfold" title="Unfold" />
                 </button>
             </div>
             <div t-if="(env.isSmall or !group.isFolded) and progressBar" class="o_kanban_counter position-relative d-flex align-items-center justify-content-between" t-att-class="{ 'opacity-25': !group.count }">


### PR DESCRIPTION
The `.o_column_unfold` and `.o_quick_create` buttons are not aligned due to a difference of height with the `.o_column_title`. `.o_column_title` have text with a font-size of `1.05 rem` and a line-height of `2` (`fs-6`, `lh-lg`).

This commit applies a replication of this height for these elements to be aligned with the rest.

task-4970613

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
