### PR TITLE
[FIX] account: Fix custom tax amounts from tax lines in Portugal

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1722,6 +1722,18 @@ class AccountTax(models.Model):
                 biggest_total_per_tax['raw_tax_amount_currency'] += delta_raw_tax_amount_currency
                 biggest_total_per_tax['raw_tax_amount'] += delta_raw_tax_amount
 
+                # Suppose a vendor bill of 123.0 with 23% tax.
+                # Your total amounts are 123.0 for the base, 28.29 for the tax and a total of 151.29.
+                # If the tax line says a tax amount of 28.30, we want the total to be 151.30.
+                # So we have to increase the total too since the Portugal computation is based on it.
+                if country_code == 'PT' and delta_raw_tax_amount_currency:
+                    total_per_tax[tax_rounding_key]['raw_total_amount_currency'] += delta_raw_tax_amount_currency
+                    total_per_tax[tax_rounding_key]['raw_total_amount'] += delta_raw_tax_amount
+
+                    base_rounding_key = (tax_line_key[1], tax_rep.document_type == 'refund')
+                    total_per_base[base_rounding_key]['raw_total_amount_currency'] += delta_raw_tax_amount_currency
+                    total_per_base[base_rounding_key]['raw_total_amount'] += delta_raw_tax_amount
+
         # Dispatch the delta in term of tax amounts across the tax details when dealing with the 'round_globally' method.
         # Suppose 2 lines:
         # - quantity=12.12, price_unit=12.12, tax=23%


### PR DESCRIPTION
Create a vendor bill with a base of 123 and 23% tax. => untaxed_amount = 123 & amount_tax = 28.29
Edit the tax amount to be 28.30
=> The tax totals shows an untaxed_amount of 122.99 but the accounting entries say 123.0

This is because during the rounding, since the tax computation is custom in Portugal, we subtract the tax amount from the total amount to get the expected base amount. Since the total is not updated according the tax lines, the base amount takes the difference instead of the total.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
