### PR TITLE
[FIX] web: add attributes in list rng

### DIFF
--- a/odoo/addons/base/rng/list_view.rng
+++ b/odoo/addons/base/rng/list_view.rng
@@ -29,6 +29,9 @@
             <rng:optional><rng:attribute name="edit"/></rng:optional>
             <rng:optional><rng:attribute name="multi_edit"/></rng:optional>
             <rng:optional><rng:attribute name="export_xlsx"/></rng:optional>
+            <rng:optional><rng:attribute name="group_create"/></rng:optional>
+            <rng:optional><rng:attribute name="group_edit"/></rng:optional>
+            <rng:optional><rng:attribute name="group_delete"/></rng:optional>
             <rng:optional><rng:attribute name="duplicate"/></rng:optional>
             <rng:optional><rng:attribute name="import"/></rng:optional>
             <rng:optional><rng:attribute name="string"/></rng:optional> <!-- deprecated, has no effect anymore -->


### PR DESCRIPTION
   Forgot to add the attributes `group_create`, `group_edit`, and `group_delete` in the list `rng`, which was causing an
   error when they are used.

   In this commit added attributes.
    https://github.com/odoo/odoo/commit/0c18c0ee29458ed4724dc4337d9f6a060d09165f
    https://github.com/odoo/odoo/commit/224d592ca3093b0a79c5866a3845ea171252d4b4

 task-4489162
