### PR TITLE
[IMP] iot_drivers: serial drivers compatible webrtc

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_base_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_base_driver.py
@@ -130,6 +130,8 @@ class SerialDriver(Driver):
         :param data: the `_actions` key mapped to the action method we want to call
         :type data: string
         """
+        self.data["owner"] = data.get('session_id')
+        self.data["action_args"] = {**data}
 
         if self._connection and self._connection.isOpen():
             self._do_action(data)


### PR DESCRIPTION
We now return action_args and session_id along with serial drivers responses in order to be readable by webrtc.
