### PR TITLE
[REM] stock: remove unused _compute_ready_items_label method dead code

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -386,16 +386,6 @@ class StockPickingType(models.Model):
 
         self._prepare_graph_data(summaries)
 
-    def _compute_ready_items_label(self):
-        for pt in self:
-            label = _('To Process')
-            match pt.code:
-                case 'incoming':
-                    label = _('To Receive')
-                case 'outgoing':
-                    label = _('To Deliver')
-            pt.ready_items_label = label
-
     @api.onchange('sequence_code')
     def _onchange_sequence_code(self):
         if not self.sequence_code:


### PR DESCRIPTION
The `_compute_ready_items_label` method in `stock.picking` was never used
 in the stock module. So, this method is unused and has no functional impact.

`_compute_ready_items_label` method is added in this [PR](https://github.com/odoo/odoo/pull/166495).
This method is never used in any functional or technical logic in that PR.

This commit removes the dead code to keep the codebase clean.
