### PR TITLE
[FIX] payment_razorpay: prevent error on secret not existing

### DIFF
--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -227,6 +227,9 @@ class PaymentProvider(models.Model):
         """
         if is_redirect:
             secret = self.razorpay_key_secret
+            if not secret:
+                _logger.warning("Missing webhook secret; aborting signature calculation.")
+                return None
             signing_string = f'{data["razorpay_order_id"]}|{data["razorpay_payment_id"]}'
             return hmac.new(
                 secret.encode(), msg=signing_string.encode(), digestmod=hashlib.sha256


### PR DESCRIPTION
An error is expected to occur at line [1] if the secret is missing when a transaction is processed through Razorpay and the page is redirected.

**Error:**
`AttributeError:'bool' object has no attribute 'encode'`

**Solution:**
* Added a check to log a warning and return None to abort signature calculation if the secret is missing similar to [2].

[1]: https://github.com/odoo/odoo/blob/bb37b3e320395c6e96b6a0c0c96367bd87d1c702/addons/payment_razorpay/models/payment_provider.py#L232
[2]: https://github.com/odoo/odoo/blob/bb37b3e320395c6e96b6a0c0c96367bd87d1c702/addons/payment_razorpay/models/payment_provider.py#L236-L238

**Sentry-6767571136**