### PR TITLE
[FIX] pos_restaurant: correctly sync edited lines

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -752,6 +752,7 @@ export class PosOrderline extends Base {
         for (const line of linesToSetDirty) {
             line.setDirty(processedLines);
         }
+        this.order_id?.setDirty();
     }
 }
 

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -171,6 +171,10 @@ export class Base extends WithLazyGetterTrap {
         }
     }
 
+    isDirty() {
+        return this.models.commands[this.model.name].update.has(this.id);
+    }
+
     formatDateOrTime(field, type = "datetime") {
         if (type == "date") {
             return this[field].toLocaleString(DateTime.DATE_SHORT);
@@ -201,10 +205,15 @@ export class Base extends WithLazyGetterTrap {
      * @param {boolean} options.orm - [true] if result is to be sent to the server
      */
     serialize(options = {}) {
-        return recursiveSerialization(this, options, {
+        const result = recursiveSerialization(this, options, {
             X2MANY_TYPES,
             DATE_TIME_TYPE,
         });
+
+        if (options.orm && options.clear) {
+            this.models.commands[this.model.name].update.delete(this.id);
+        }
+        return result;
     }
     getIndexMaps(fieldName) {
         if (!this._indexMaps[fieldName]) {

--- a/addons/point_of_sale/static/tests/generic_helpers/utils.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/utils.js
@@ -56,3 +56,14 @@ export function elementDoesNotExist(selector) {
         trigger: negate(selector),
     };
 }
+
+export function assertCurrentOrderDirty(dirty = true) {
+    return {
+        trigger: "body",
+        run() {
+            if (posmodel.getOrder().isDirty() !== dirty) {
+                throw new Error("Order should be " + (dirty ? "dirty" : "not dirty"));
+            }
+        },
+    };
+}

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -651,6 +651,9 @@ patch(PosStore.prototype, {
         if (order && !order.isBooked) {
             this.removeOrder(order);
         } else if (order) {
+            if (order.isDirty()) {
+                this.addPendingOrder([order.id]);
+            }
             if (!this.isOrderTransferMode) {
                 this.syncAllOrders();
             } else if (order && this.previousScreen !== "ReceiptScreen") {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -16,7 +16,11 @@ import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { delay } from "@odoo/hoot-dom";
 import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
 import { generatePreparationReceiptElement } from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
-import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
+import {
+    negate,
+    negateStep,
+    assertCurrentOrderDirty,
+} from "@point_of_sale/../tests/generic_helpers/utils";
 
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
@@ -758,5 +762,136 @@ registry.category("web_tour.tours").add("test_transfering_orders", {
             ProductScreen.clickLine("Minute Maid", "3"),
             Chrome.clickOrders(),
             TicketScreen.nbOrdersIs(1),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_sync_lines_qty_update", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickLine("Coca-Cola"),
+            Chrome.waitRequest(), // Wait for sync request (the order is created)
+            assertCurrentOrderDirty(false),
+            Numpad.click("3"),
+            Order.hasLine({ productName: "Coca-Cola", quantity: 3 }),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+            FloorScreen.clickTable("5"),
+            ProductScreen.isShown(),
+            assertCurrentOrderDirty(false),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_sync_set_partner", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(), // Wait for sync request
+            assertCurrentOrderDirty(false),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Deco Addict"),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_sync_set_note", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(), // Wait for sync request
+            assertCurrentOrderDirty(false),
+            ProductScreen.isShown(),
+            ProductScreen.addInternalNote("Hello world"),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_sync_set_line_note", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(), // Wait for sync request
+            assertCurrentOrderDirty(false),
+            ProductScreen.isShown(),
+            ProductScreen.clickLine("Coca-Cola"),
+            ProductScreen.addInternalNote("Demo note"),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_sync_set_pricelist", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(), // Wait for sync request
+            assertCurrentOrderDirty(false),
+            ProductScreen.isShown(),
+            ProductScreen.clickLine("Coca-Cola"),
+            ProductScreen.clickPriceList("Restaurant Pricelist"),
+            assertCurrentOrderDirty(true),
+            Chrome.clickPlanButton(),
+            FloorScreen.isShown(),
+            Chrome.waitRequest(), // Wait for sync request
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_delete_line_release_table", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Order.hasLine({ productName: "Coca-Cola" }),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickLine("Coca-Cola"),
+            ProductScreen.selectedOrderlineHasDirect("Coca-Cola"),
+            ...["⌫", "⌫"].map(Numpad.click),
+            ProductScreen.releaseTable(),
+            FloorScreen.clickTable("5"),
+            Chrome.waitRequest(),
+            negateStep(...Order.hasLine({ productName: "Coca-Cola" })),
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -79,3 +79,13 @@ export function setTab(name) {
         Dialog.confirm(),
     ];
 }
+
+export function releaseTable() {
+    return [
+        {
+            content: "release table",
+            trigger: ".product-screen .leftpane .unbook-table",
+            run: "click",
+        },
+    ];
+}

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -632,3 +632,39 @@ class TestFrontend(TestFrontendCommon):
             Then, the order is paid from the server, and confirm if the order state is updated correctly.
         """
         self.start_pos_tour("OrderSynchronisationTour")
+
+    def test_sync_lines_qty_update(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_lines_qty_update')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.lines[0].qty, 3)
+
+    def test_sync_set_partner(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_set_partner')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.partner_id.name, "Deco Addict")
+
+    def test_sync_set_note(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_set_note')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.internal_note, "Hello world")
+
+    def test_sync_set_line_note(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_set_line_note')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.lines[0].note, "Demo note")
+
+    def test_sync_set_pricelist(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_set_pricelist')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.pricelist_id.name, "Restaurant Pricelist")
+
+    def test_delete_line_release_table(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_delete_line_release_table')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(len(order.lines), 0)


### PR DESCRIPTION
Previously, changes made to an order did not trigger synchronization when navigating back to the floor screen. These changes include:
•	Adding a note or customer note to a line or order •	Setting a customer
•	Modifying quantity, price, or discount via the numpad •	Setting a pricelist

This commit ensures the order is marked as dirty, which triggers the sync when returning to the floor screen.

task.4946929


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
