### PR TITLE
[IMP] core: deprecate ormcache_context

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -40,7 +40,7 @@ class HrVersion(models.Model):
         for version in self:
             version.work_entry_source_calendar_invalid = version.work_entry_source == 'calendar' and not version.resource_calendar_id
 
-    @ormcache('self.structure_type_id')
+    @ormcache()
     def _get_default_work_entry_type_id(self):
         attendance = self.env.ref('hr_work_entry.work_entry_type_attendance', raise_if_not_found=False)
         return attendance.id if attendance else False

--- a/addons/website/models/ir_ui_menu.py
+++ b/addons/website/models/ir_ui_menu.py
@@ -8,7 +8,7 @@ class IrUiMenu(models.Model):
     _inherit = 'ir.ui.menu'
 
     @api.model
-    @tools.ormcache_context('self.env.uid', keys=('lang', 'force_action'))
+    @tools.ormcache('self.env.uid', 'self.env.lang', 'self.env.context.get("force_action")')
     def load_menus_root(self):
         root_menus = super().load_menus_root()
         if self.env.context.get('force_action'):

--- a/addons/website/models/res_lang.py
+++ b/addons/website/models/res_lang.py
@@ -15,7 +15,7 @@ class ResLang(models.Model):
                 raise UserError(_("Cannot deactivate a language that is currently used on a website."))
         return super().write(vals)
 
-    @tools.ormcache_context(keys=("website_id", "web_force_installed_langs"))
+    @tools.ormcache('self.env.context.get("website_id")', 'self.env.context.get("web_force_installed_langs")')
     def _get_frontend(self) -> LangDataDict:
         """ Return the available languages for current request
         :return: LangDataDict({code: LangData})

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1398,8 +1398,8 @@ class Website(models.Model):
         website_id = self.sudo()._get_current_website_id(domain_name, fallback=fallback)
         return self.browse(website_id)
 
-    @tools.ormcache('domain_name', 'fallback')
     @api.model
+    @tools.ormcache('domain_name', 'fallback')
     def _get_current_website_id(self, domain_name, fallback=True):
         """Get the current website id.
 

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -268,8 +268,3 @@ class WebsitePage(models.Model):
             'view_mode': 'form',
             'view_id': self.env.ref('website.view_view_form_extend').id,
         }
-
-
-# this is just a dummy function to be used as ormcache key
-def _cached_response():
-    pass

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1347,7 +1347,7 @@ class IrModelFields(models.Model):
         return self._get_fields_cached(model_name).get(field_name, {}).get('selection', [])
 
     @api.model
-    @tools.ormcache_context('model_name', keys=('lang',))
+    @tools.ormcache('model_name', 'self.env.lang')
     def _get_fields_cached(self, model_name):
         """ Return the translated information of all model field's in the context's language.
         Note that the result contains the available translations only.
@@ -2054,7 +2054,7 @@ class IrModelAccess(models.Model):
 
     # The context parameter is useful when the method translates error messages.
     # But as the method raises an exception in that case,  the key 'lang' might
-    # not be really necessary as a cache key, unless the `ormcache_context`
+    # not be really necessary as a cache key, unless the `ormcache`
     # decorator catches the exception (it does not at the moment.)
 
     @tools.ormcache('self.env.uid', 'mode')

--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -211,7 +211,7 @@ class IrUiMenu(models.Model):
         return []
 
     @api.model
-    @tools.ormcache_context('self.env.uid', keys=('lang',))
+    @tools.ormcache('self.env.uid', 'self.env.lang')
     def load_menus_root(self):
         fields = ['name', 'sequence', 'parent_id', 'action', 'web_icon_data']
         menu_roots = self.get_user_roots()
@@ -232,7 +232,7 @@ class IrUiMenu(models.Model):
         return menu_root
 
     @api.model
-    @tools.ormcache_context('self.env.uid', 'debug', keys=('lang',))
+    @tools.ormcache('self.env.uid', 'debug', 'self.env.lang')
     def load_menus(self, debug):
         blacklisted_menu_ids = self._load_menus_blacklist()
         visible_menus = self.search_fetch(

--- a/odoo/tools/cache.py
+++ b/odoo/tools/cache.py
@@ -102,10 +102,7 @@ class ormcache:
                 str(params.replace(annotation=Parameter.empty, default=Parameter.empty))
                 for params in signature(self.method).parameters.values()
             )
-            if self.args:
-                code = "lambda %s: (%s,)" % (args, ", ".join(self.args))
-            else:
-                code = "lambda %s: ()" % (args,)
+            code = f"lambda {args}: ({''.join(a for arg in self.args for a in (arg, ','))})"
             self.key = unsafe_eval(code)
         else:
             # backward-compatible function that uses self.skiparg
@@ -146,6 +143,7 @@ class ormcache_context(ormcache):
     """
     def __init__(self, *args: str, keys, skiparg=None, **kwargs):
         assert skiparg is None, "ormcache_context() no longer supports skiparg"
+        warnings.warn("Since 19.0, use ormcache directly, context values are available as `self.env.context.get`", DeprecationWarning)
         super().__init__(*args, **kwargs)
         self.keys = keys
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The helper is not that useful and the same is achieved by using
`ormcache` with getting a value from the context.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
