### PR TITLE
[FIX] website: fix indeterministic test BuilderNumberInput

### DIFF
--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
@@ -1,6 +1,14 @@
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { describe, expect, test } from "@odoo/hoot";
-import { advanceTime, animationFrame, clear, click, fill, queryFirst } from "@odoo/hoot-dom";
+import {
+    advanceTime,
+    animationFrame,
+    clear,
+    click,
+    fill,
+    freezeTime,
+    queryFirst,
+} from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
@@ -454,6 +462,7 @@ describe("keyboard triggers", () => {
         expect(":iframe .test-options-target").toHaveAttribute("data-number", "-1");
     });
     test("apply preview on keydown and debounce commit operation", async () => {
+        freezeTime();
         addActionOption({
             customAction: class extends BuilderAction {
                 static id = "customAction";
@@ -479,9 +488,9 @@ describe("keyboard triggers", () => {
         await contains(".options-container input").keyDown("ArrowUp");
         await advanceTime(500); // Default browser delay between 1st & 2nd keydown.
         await contains(".options-container input").keyDown("ArrowUp");
-        await advanceTime();
+        await advanceTime(50);
         await contains(".options-container input").keyDown("ArrowUp");
-        await advanceTime();
+        await advanceTime(50);
         expect(":iframe .test-options-target").toHaveInnerHTML("13");
         // 3 previews
         expect.verifySteps(["customAction 11", "customAction 12", "customAction 13"]);


### PR DESCRIPTION
Hoot provides us with "time control" features such as "advanceTime", which is useful for testing scenarios where we want to wait for some events to happen (such as a debounced function), but without actually waiting too much.

The way it works is that hoot simply override setTimeout and related functions to keep track of all handlers and their scheduled time. However, this is not enough, as the real setTimeout is still by default called, so it can happen in some tests that when we advance the time by some amount, say 500ms, if the cpu load is very high, then other handlers that are scheduled AFTER the 500ms may have run as well.

To fix this, we can use the freezeTime feature from hoot. It simply give the full control to hoot, and do not call the real setTimeout function.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
