### PR TITLE
[FIX] test_testing_utilities: correct misspelled argument in freeze_time

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2620,7 +2620,7 @@ class freeze_time:
             time_to_freeze=time_to_freeze,
             tz_offset=tz_offset,
             tick=tick,
-            as_kwarg=as_kwarg,
+            as_arg=as_kwarg,
             auto_tick_seconds=auto_tick_seconds,
         )
 


### PR DESCRIPTION
Since [1], some tests have failed due to a misspelled argument passed to the static method `freeze_time`. This commit fixes the issue and restores test stability.

[1]: https://github.com/odoo/odoo/commit/96dbedb6deaf68e7c9c08eabe43e4a719cea5e9e
