### PR TITLE
[IMP] {website_,}sale: overridable amount to pay

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -231,16 +231,17 @@ class CustomerPortal(payment_portal.PaymentPortal):
         logged_in = not request.env.user._is_public()
         partner_sudo = request.env.user.partner_id if logged_in else order_sudo.partner_id
         currency = order_sudo.currency_id
+        amount_total = order_sudo._get_amount_to_pay()['amount_total']
 
         if is_down_payment:
-            if payment_amount and payment_amount < order_sudo.amount_total:
+            if payment_amount and payment_amount < amount_total:
                 amount = payment_amount
             else:
                 amount = order_sudo._get_prepayment_required_amount()
         elif order_sudo.state == 'sale':
-            amount = payment_amount or order_sudo.amount_total
+            amount = payment_amount or amount_total
         else:
-            amount = order_sudo.amount_total
+            amount = amount_total
 
         availability_report = {}
         # Select all the payment methods and tokens that match the payment context.

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2025,6 +2025,22 @@ class SaleOrder(models.Model):
             'extra_tax_data': extra_tax_data,
         }
 
+    def _get_amount_to_pay(self):
+        """ Return the amount that needs to be paid for the order, including the untaxed
+        amount, tax, and total amount of the sale order. Overriden in other modules.
+
+        Note: self and self.ensure_one()
+
+        :return: dict with 'amount_untaxed', 'amount_tax', and 'amount_total'.
+        :rtype: dict
+        """
+        self and self.ensure_one()
+        return {
+            'amount_untaxed': self.amount_untaxed,
+            'amount_tax': self.amount_tax,
+            'amount_total': self.amount_total,
+        }
+
     def _get_prepayment_required_amount(self):
         """ Return the minimum amount needed to automatically confirm the quotation.
 
@@ -2038,7 +2054,7 @@ class SaleOrder(models.Model):
         if not self.require_payment:
             return 0
         else:
-            return self.currency_id.round(self.amount_total * self.prepayment_percent)
+            return self.currency_id.round(self._get_amount_to_pay()['amount_total'] * self.prepayment_percent)
 
     def _is_confirmation_amount_reached(self):
         """ Return whether `self.amount_paid` is higher than the prepayment required amount.

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -127,10 +127,11 @@
                 <!-- Uses backend_url provided in rendering values -->
                 <t t-call="portal.portal_back_in_edit_mode"/>
             </t>
+            <t t-set="amount_total" t-value="sale_order._get_amount_to_pay().get('amount_total')"/>
 
             <div
                 class="row o_portal_sale_sidebar"
-                t-att-data-order-amount-total="sale_order.amount_total"
+                t-att-data-order-amount-total="amount_total"
             >
                 <!-- Sidebar -->
                 <t t-call="portal.portal_record_sidebar">
@@ -149,11 +150,13 @@
                                 (<t t-out="sale_order.prepayment_percent * 100"/>%)
                             </h2>
                         </t>
-                        <h2 t-else="" t-field="sale_order.amount_total" class="mb-0 text-break"/>
+                        <t t-else="">
+                            <h2 t-field="sale_order.amount_total" class="mb-0 text-break"/>
+                        </t>
                     </t>
                     <t t-set="entries">
                         <div
-                            t-if="0 &lt; sale_order.amount_paid &lt; sale_order.amount_total
+                            t-if="0 &lt; sale_order.amount_paid &lt; amount_total
                                   and sale_order.state != 'cancel'"
                             class="alert alert-success mt-3"
                             role="alert"
@@ -186,7 +189,7 @@
                                     t-elif="sale_order._has_to_be_paid()
                                             or (
                                                 payment_amount
-                                                and sale_order.amount_paid &lt; sale_order.amount_total
+                                                and sale_order.amount_paid &lt; amount_total
                                                 and sale_order.state != 'cancel'
                                             )"
                                     id="o_sale_portal_paynow"
@@ -528,7 +531,7 @@
             <button name="o_sale_portal_amount_prepayment_button" class="btn btn-light active">
                 Down payment <br/>
                 <span
-                    t-if="not payment_amount or payment_amount == sale_order.amount_total"
+                    t-if="not payment_amount or payment_amount == amount_total"
                     t-out="prepayment_amount"
                     t-options="{
                         'widget': 'monetary',
@@ -549,7 +552,7 @@
             <button name="o_sale_portal_amount_total_button" class="btn btn-light">
                 Full amount <br/>
                 <span
-                    t-out="sale_order.amount_total"
+                    t-out="amount_total"
                     t-options="{
                         'widget': 'monetary',
                         'display_currency': sale_order.currency_id,

--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -312,10 +312,10 @@ class Cart(PaymentPortal):
 
         values['cart_quantity'] = order_sudo.cart_quantity
         values['cart_ready'] = order_sudo._is_cart_ready()
-        values['amount'] = order_sudo.amount_total
+        values['amount'] = order_sudo._get_amount_to_pay()['amount_total']
         values['minor_amount'] = (
             order_sudo and payment_utils.to_minor_currency_units(
-                order_sudo.amount_total, order_sudo.currency_id
+                order_sudo._get_amount_to_pay()['amount_total'], order_sudo.currency_id
             )
         ) or 0.0
         values['website_sale.cart_lines'] = IrUiView._render_template(

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1620,6 +1620,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return {
             'order': order,
             'website_sale_order': order,
+            'amount_total': order.amount_total,
             'order_tracking_info': self.order_2_return_dict(order),
         }
 

--- a/addons/website_sale/controllers/payment.py
+++ b/addons/website_sale/controllers/payment.py
@@ -61,12 +61,12 @@ class PaymentPortal(payment_portal.PaymentPortal):
             'sale_order_id': order_id,  # Include the SO to allow Subscriptions to tokenize the tx
         })
         if not kwargs.get('amount'):
-            kwargs['amount'] = order_sudo.amount_total
+            kwargs['amount'] = order_sudo._get_amount_to_pay()['amount_total']
 
         compare_amounts = order_sudo.currency_id.compare_amounts
-        if compare_amounts(kwargs['amount'], order_sudo.amount_total):
+        if compare_amounts(kwargs['amount'], order_sudo._get_amount_to_pay()['amount_total']):
             raise ValidationError(_("The cart has been updated. Please refresh the page."))
-        if compare_amounts(order_sudo.amount_paid, order_sudo.amount_total) == 0:
+        if compare_amounts(order_sudo.amount_paid, order_sudo._get_amount_to_pay()['amount_total']) == 0:
             raise UserError(_("The cart has already been paid. Please refresh the page."))
 
         tx_sudo = self._create_transaction(

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3744,6 +3744,7 @@
                 t-value="True if show_mobile_cart_summary is None else show_mobile_cart_summary"
             />
             <t t-set="body_classname" t-value="'o_website_sale_checkout'"/>
+            <t t-set="amount_total" t-value="website_sale_order._get_amount_to_pay().get('amount_total')"/>
             <div id="wrap" class="d-flex flex-column flex-grow-1">
                 <div class="oe_website_sale o_website_sale_checkout_container container d-flex flex-column flex-grow-1 py-lg-2">
                     <div t-attf-class="row #{not show_wizard_checkout and 'mt32'} mb32">
@@ -3805,7 +3806,7 @@
                                 <span
                                     id="amount_total_summary"
                                     class="monetary_field ms-auto"
-                                    t-field="website_sale_order.amount_total"
+                                    t-out="amount_total"
                                     t-options='{"widget": "monetary", "display_currency": website_sale_order.currency_id}'
                                 />
                                 <span
@@ -3980,7 +3981,7 @@
 
             <t t-set="tx_sudo" t-value="order.get_portal_last_transaction()"/>
             <div
-                t-if="tx_sudo.state in ['pending', 'done'] or not order.amount_total"
+                t-if="tx_sudo.state in ['pending', 'done'] or not amount_total"
                 class="d-flex justify-content-between align-items-center"
             >
                 <h3>Thank you for your order.</h3>
@@ -4032,6 +4033,7 @@
             - _cart_total_classes: CSS classes to append on the root div of the total template;
                                    default `None`.
         -->
+        <t t-set="amounts" t-value="website_sale_order._get_amount_to_pay()"/>
         <div
             t-if="website_sale_order and website_sale_order.website_order_line"
             t-attf-class="o_cart_total #{_cart_total_classes}"
@@ -4067,7 +4069,7 @@
                         Subtotal
                     </td>
                     <td class="text-end border-0 pb-2 pe-0 pt-0">
-                        <span t-field="website_sale_order.amount_untaxed"
+                        <span t-out="amounts.get('amount_untaxed')"
                               class="monetary_field"
                               style="white-space: nowrap;"
                               t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
@@ -4076,7 +4078,7 @@
                 <tr name="o_order_total_taxes">
                     <td colspan="2" class="text-muted border-0 p-0 pe-3 pb-2">Taxes</td>
                     <td class="text-end border-0 p-0 ps-3 pb-2">
-                        <span t-field="website_sale_order.amount_tax"
+                        <span t-out="amounts.get('amount_tax')"
                               class="monetary_field"
                               style="white-space: nowrap;"
                               t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
@@ -4085,7 +4087,7 @@
                 <tr name="o_order_total" class="border-top">
                     <td colspan="2" class="border-0 ps-0 pt-2"><strong>Total</strong></td>
                     <td class="text-end border-0 px-0 pt-2">
-                        <strong t-field="website_sale_order.amount_total"
+                        <strong t-out="amounts.get('amount_total')"
                                 class="monetary_field text-end p-0"
                                 t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
                     </td>
@@ -4128,8 +4130,8 @@
                 t-if="tx_sudo"
                 t-attf-class="alert px-3 pb-0 pt-3 #{
                     (tx_sudo.state == 'pending' and 'alert-info') or
-                    (tx_sudo.state == 'done' and order.amount_total == tx_sudo.amount and 'alert-success') or
-                    (tx_sudo.state == 'done' and order.amount_total != tx_sudo.amount and 'alert-warning') or
+                    (tx_sudo.state == 'done' and amount_total == tx_sudo.amount and 'alert-success') or
+                    (tx_sudo.state == 'done' and amount_total != tx_sudo.amount and 'alert-warning') or
                     (tx_sudo.state == 'authorized' and 'alert-success') or
                     'alert-danger'}"
                 role="alert"
@@ -4152,7 +4154,7 @@
                     <t t-if="tx_sudo.state == 'done'">
                         <span t-if='tx_sudo.provider_id.sudo().done_msg' t-out="tx_sudo.provider_id.sudo().done_msg"/>
                     </t>
-                    <t t-if="tx_sudo.state == 'done' and order.amount_total != tx_sudo.amount">
+                    <t t-if="tx_sudo.state == 'done' and amount_total != tx_sudo.amount">
                         <span>Unfortunately your order can not be confirmed as the amount of your payment does not match the amount of your cart.
                         Please contact the responsible of the shop for more information.</span>
                     </t>
@@ -4172,7 +4174,7 @@
                         <b>Communication: </b><span t-out='order.reference'/>
                     </div>
                     <div t-if="tx_sudo.provider_id.sudo().qr_code">
-                        <t t-set="qr_code" t-value="tx_sudo.company_id.partner_id.bank_ids[:1].build_qr_code_base64(order.amount_total,tx_sudo.reference, None, tx_sudo.currency_id, tx_sudo.partner_id)"/>
+                        <t t-set="qr_code" t-value="tx_sudo.company_id.partner_id.bank_ids[:1].build_qr_code_base64(amount_total, tx_sudo.reference, None, tx_sudo.currency_id, tx_sudo.partner_id)"/>
                         <div class="mt-2" t-if="qr_code">
                             <h3>Or scan me with your banking app.</h3>
                             <img class="border border-dark rounded" t-att-src="qr_code"/>


### PR DESCRIPTION
Before this commit. there was a disconnect between how subscriptions and sales orders handled pricing. While the subscription system could correctly calculate a prorated price for a customer starting mid-period, the core `sale` and `website_sale` modules were not aware of it. This caused the system to use the full product price when a sales quote was confirmed or when a customer proceeded to the online checkout, leading to an incorrect total amount.

After this commit, this change aligns the sales and e-commerce modules with the subscription logic. Now, when a customer confirms a quote or checks out online with a prorated subscription, the system correctly uses the prorated amount. This ensures that the price displayed and charged is accurate and consistent throughout the entire process, from initial selection to final confirmation.

Co-authored-by: Darshan Patel <dvpa@odoo.com>
Co-authored-by: Gabriel Felix <gdpf@odoo.com>

task-4930807