### PR TITLE
[FIX] l10n_es: Correct vendor refund reporting & line 64 totals.

### DIFF
--- a/addons/l10n_es/data/mod390/mod390_section2.xml
+++ b/addons/l10n_es/data/mod390/mod390_section2.xml
@@ -1587,9 +1587,9 @@
                                 <field name="expression_ids">
                                     <record id="mod_390_casilla_639_balance" model="account.report.expression">
                                         <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">aeat_mod_303_40.balance</field>
-                                        <field name="subformula">cross_report</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
                                     </record>
                                 </field>
                             </record>
@@ -1599,9 +1599,9 @@
                                 <field name="expression_ids">
                                     <record id="mod_390_casilla_62_balance" model="account.report.expression">
                                         <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">aeat_mod_303_41.balance</field>
-                                        <field name="subformula">cross_report</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
                                     </record>
                                 </field>
                             </record>
@@ -1671,7 +1671,8 @@
                             aeat_mod_390_57.balance + aeat_mod_390_59.balance +
                             aeat_mod_390_598.balance + aeat_mod_390_61.balance +
                             aeat_mod_390_652.balance + aeat_mod_390_63.balance +
-                            aeat_mod_390_522.balance
+                            aeat_mod_390_522.balance + aeat_mod_390_661.balance +
+                            aeat_mod_390_62.balance
                         </field>
                     </record>
                     <record id="mod_390_casilla_65" model="account.report.line">


### PR DESCRIPTION
This commit addresses two issues in the Mod 390 report:
---
1. Vendor refunds were being reported twice:
   - Once correctly via the tax grid.
   - And again incorrectly through the cross-formula on lines 639 and 62, which are meant for special manual adjustments only.

   ➤ Fix: Lines 639 and 62 are now treated as external values, making them
     editable and excluding them from automatic computation.

2. Line 64 was missing part of the total:
   - It did not include balances from lines 661 and 62, resulting in an incomplete total.

   ➤ Fix: Updated the computation of line 64 to sum all relevant manual lines.
---
task-4972473