### PR TITLE
[FIX] test_website_slides_full: change outstanding account in new company

### DIFF
--- a/addons/test_website_slides_full/tests/test_ui_wslides.py
+++ b/addons/test_website_slides_full/tests/test_ui_wslides.py
@@ -39,6 +39,7 @@ class TestUi(AccountTestInvoicingCommon, TestUICommon):
             'website_id': self.env.ref('website.default_website').id,
             'company_id': self.env.company.id,
         })
+        cash_journal.inbound_payment_method_line_ids.filtered(lambda l: l.code == 'demo').payment_account_id = self.env['account.chart.template'].ref('account_journal_payment_debit_account_id')
         a_recv = self.env['account.account'].create({
             'code': 'X1012',
             'name': 'Debtors - (test)',


### PR DESCRIPTION
Steps to reproduce:-
- Install `account` module.
- Invoicing > Configuration > Payment Providers
- Install `Demo` payment provider, check state `Test Mode` and is `Published`.
- Run `test_course_certification_employee` test case.

Error:  “Draft Payment” belongs to company “company_1_data” and “Outstanding Account” (outstanding_account_id: 'Outstanding Receipts') belongs to another company.

Cause:-
- When `Demo` provider is activated, `account.payment.method.line` is created with `payment_account_id` of company `YourCompany`, but that account was not changed in the test.

Solution: In `test_course_certification_employee` test, set outstanding account of company `company_1_data` for `account.payment.method.line` with code `Demo`.

Runbot Build Error-229953