### PR TITLE
[FIX] hr_holidays: fix shown hour timezone in tree and kanban views

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -116,8 +116,10 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" create="0" sample="1">
                 <field name="employee_id"/>
-                <field name="date_from"/>
-                <field name="date_to"/>
+                <field name="date_from_display" string="Start Date"/>
+                <field name="date_to_display" string="End Date"/>
+                <field name="date_to" invisible="True"/>
+                <field name="date_from" invisible="True"/>
                 <field name="name"/>
                 <field name="number_of_days"/>
                 <field name="can_approve"/>
@@ -516,8 +518,10 @@
                 <field name="holiday_type" string="Mode" groups="base.group_no_one" readonly="state not in ['confirm', 'draft']"/>
                 <field name="holiday_status_id" class="fw-bold" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
                 <field name="name"/>
-                <field name="date_from" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
-                <field name="date_to" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
+                <field name="date_from_display" string="Start Date"/>
+                <field name="date_to_display" string="End Date"/>
+                <field name="date_to" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']" invisible="True"/>
+                <field name="date_from" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']" invisible="True"/>
                 <field name="duration_display" string="Duration"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state in ('confirm','validate1')" decoration-success="state == 'validate'"/>
                 <field name="active_employee" column_invisible="True"/>


### PR DESCRIPTION
To reproduce:

1- Go to Time off app --> Mangement tab -> Time Off
2- Create a new time off for an employee with different
timezone from user
3- Check the custom hour in the form. The start and end hour
will be in employee timezone
3- Go back to the list of allocations
4- As you can see the start datetime and end datetime are
shown in user timezone in the list (while the entered hours
were in employee timezone)
5- The same behavior is observed in kanban, calender, and ohter views.

As discussed with the PO, this is not a bug, but a confusing
case. This is already improved in master.
In master's improvement, to avoid confusion, both timezones
are shown to user when creating the timeoff.
However, the improvements from master are not backportable to
previous versions.
Therefore this PR is proposed for previous versions.
In this PR, the datetime shown in list and kanban views are
converted to employee timezone.

opw-4702376