### PR TITLE
[IMP] pos_event: add hoot test cases

### DIFF
--- a/addons/point_of_sale/static/tests/unit/utils.js
+++ b/addons/point_of_sale/static/tests/unit/utils.js
@@ -1,6 +1,10 @@
 import { uuidv4 } from "@point_of_sale/utils";
-import { getService, makeDialogMockEnv } from "@web/../tests/web_test_helpers";
+import { getService, makeDialogMockEnv, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { tick, waitUntil } from "@odoo/hoot-dom";
+import { Deferred } from "@odoo/hoot-mock";
+import { MainComponentsContainer } from "@web/core/main_components_container";
+import { patch } from "@web/core/utils/patch";
+import { onMounted } from "@odoo/owl";
 
 const { DateTime } = luxon;
 
@@ -56,3 +60,45 @@ export async function waitUntilOrdersSynced(store, options) {
     await waitUntil(() => !store.syncingOrders.size, options);
     await tick();
 }
+
+export const mountPosDialog = async (component, props) => {
+    patchDialogComponent(component);
+    const dialog = getService("dialog");
+    const root = await mountWithCleanup(MainComponentsContainer);
+    const deferred = new Deferred();
+
+    const getComponentInstance = (root) => {
+        const flattenedChildren = (comp, acc = {}) => {
+            const array = Object.values(comp.children);
+            for (const child of array) {
+                acc[child.name] = child;
+                flattenedChildren(child, acc);
+            }
+            return acc;
+        };
+        const components = flattenedChildren(root);
+        return components[component.name];
+    };
+
+    dialog.add(component, {
+        ...props,
+        onMounted() {
+            const dialogComponent = getComponentInstance(root.__owl__);
+            deferred.resolve(dialogComponent.component);
+        },
+    });
+    return await deferred;
+};
+
+export const patchDialogComponent = (component) => {
+    component.props = [...component.props, "onMounted?"];
+    patch(component.prototype, {
+        setup() {
+            super.setup();
+
+            onMounted(() => {
+                this.props.onMounted && this.props.onMounted();
+            });
+        },
+    });
+};

--- a/addons/pos_event/__manifest__.py
+++ b/addons/pos_event/__manifest__.py
@@ -28,7 +28,7 @@
             'pos_event/static/tests/tours/**/*',
         ],
         'web.assets_unit_tests': [
-            'pos_event/static/tests/unit/data/**/*'
+            'pos_event/static/tests/unit/**/*'
         ],
     },
     'author': 'Odoo S.A.',

--- a/addons/pos_event/static/tests/unit/components/event_configurator_popup.test.js
+++ b/addons/pos_event/static/tests/unit/components/event_configurator_popup.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { EventConfiguratorPopup } from "@pos_event/app/components/popup/event_configurator_popup/event_configurator_popup";
+import { mountPosDialog, setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("event_configurator_popup", () => {
+    test("confirm payload and getTicketMaxQty and ticketIsAvailable", async () => {
+        const store = await setupPosEnv();
+        const tickets = [store.models["event.event.ticket"].get(1)];
+        const avaibilityByTicket = { 1: tickets[0].seats_available || "unlimited" };
+        let payload = [];
+
+        const comp = await mountPosDialog(EventConfiguratorPopup, {
+            availabilityPerTicket: avaibilityByTicket,
+            slotResult: {},
+            tickets: tickets,
+            close: () => {},
+            getPayload: (data) => {
+                payload = data;
+            },
+        });
+
+        expect(comp.getTicketMaxQty(tickets[0])).toBe(5);
+        expect(comp.ticketIsAvailable(tickets[0])).toBe(true);
+
+        comp.state[1] = { qty: 1 };
+        comp.confirm();
+
+        expect(payload).toHaveLength(1);
+        expect(payload[0].qty).toBe(1);
+        expect(payload[0].ticket_id).toEqual(tickets[0]);
+        expect(payload[0].product_id).toEqual(tickets[0].product_id);
+    });
+});

--- a/addons/pos_event/static/tests/unit/components/event_registration_popup.test.js
+++ b/addons/pos_event/static/tests/unit/components/event_registration_popup.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { EventRegistrationPopup } from "@pos_event/app/components/popup/event_registration_popup/event_registration_popup";
+import { mountPosDialog, setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("event_registration_popup", () => {
+    test("confirm payload", async () => {
+        const store = await setupPosEnv();
+        const event = store.models["event.event"].get(1);
+        const tickets = [store.models["event.event.ticket"].get(1)];
+        let payload = [];
+        const data = [
+            {
+                qty: 1,
+                ticket_id: tickets[0],
+                product_id: tickets[0].product_id,
+            },
+        ];
+        const comp = await mountPosDialog(EventRegistrationPopup, {
+            event: event,
+            data: data,
+            getPayload: (data) => {
+                payload = data;
+            },
+            close: () => {},
+        });
+
+        comp.state.byRegistration[0].questions = {
+            1: "Test User",
+            2: "test@test.com",
+            3: "+911234567890",
+            4: "1",
+        };
+        comp.confirm();
+
+        const receivedValues = Object.values(payload.byRegistration[1][0]);
+        expect(payload.byRegistration).toHaveLength(1);
+        expect(parseInt(Object.keys(payload.byRegistration)[0])).toBe(tickets[0].id);
+        expect(receivedValues).toEqual([
+            "Test User",
+            "test@test.com",
+            "+911234567890",
+            "1", // Received value is the ID of the answer `Male`, not the name.
+        ]);
+    });
+});

--- a/addons/pos_event/static/tests/unit/components/event_slot_selection_popup.test.js
+++ b/addons/pos_event/static/tests/unit/components/event_slot_selection_popup.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { EventSlotSelectionPopup } from "@pos_event/app/components/popup/event_slot_selection_popup/event_slot_selection_popup";
+import { mountPosDialog, setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { click } from "@odoo/hoot-dom";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("event_slot_selection_popup", () => {
+    test("confirm payload", async () => {
+        const store = await setupPosEnv();
+        const event = store.models["event.event"].get(1);
+        let payload = [];
+        const comp = await mountPosDialog(EventSlotSelectionPopup, {
+            event: event,
+            availabilityPerSlot: [event.event_slot_ids[0].id, 10],
+            getPayload: (data) => {
+                payload = data;
+            },
+            close: () => {},
+        });
+
+        await click(`button.o_event_slot_btn`);
+        comp.confirm();
+
+        expect(payload).toHaveLength(3);
+        expect(payload).toEqual({
+            slotAvailability: 10,
+            slotId: 1,
+            slotName: "Mar 11 2019, Monday, 12:00 PM",
+        });
+    });
+});

--- a/addons/pos_event/static/tests/unit/data/event_event.data.js
+++ b/addons/pos_event/static/tests/unit/data/event_event.data.js
@@ -23,6 +23,29 @@ export class EventEvent extends models.ServerModel {
             "event_slot_ids",
         ];
     }
+
+    _records = [
+        {
+            id: 1,
+            name: "Odoo Community Days",
+            seats_available: 10,
+            event_ticket_ids: [1],
+            registration_ids: [],
+            seats_limited: true,
+            write_date: "2019-03-10 11:00:00",
+            question_ids: [1, 2, 3, 4],
+            general_question_ids: [],
+            specific_question_ids: [],
+            badge_format: "A6",
+            seats_max: 10,
+            is_multi_slots: true,
+            event_slot_ids: [1],
+        },
+    ];
+
+    get_slot_tickets_availability_pos(self, slot_ticket_ids) {
+        return [5];
+    }
 }
 
 patch(hootPosModels, [...hootPosModels, EventEvent]);

--- a/addons/pos_event/static/tests/unit/data/event_event_ticket.data.js
+++ b/addons/pos_event/static/tests/unit/data/event_event_ticket.data.js
@@ -19,6 +19,21 @@ export class EventEventTicket extends models.ServerModel {
             "end_sale_datetime",
         ];
     }
+
+    _records = [
+        {
+            id: 1,
+            name: "Standard",
+            event_id: 1,
+            seats_used: 0,
+            seats_available: 5,
+            price: 100,
+            product_id: 106,
+            seats_max: 5,
+            start_sale_datetime: "2019-03-10 11:00:00",
+            end_sale_datetime: "2019-03-15 12:00:00",
+        },
+    ];
 }
 
 patch(hootPosModels, [...hootPosModels, EventEventTicket]);

--- a/addons/pos_event/static/tests/unit/data/event_question.data.js
+++ b/addons/pos_event/static/tests/unit/data/event_question.data.js
@@ -17,6 +17,49 @@ export class EventQuestion extends models.ServerModel {
             "answer_ids",
         ];
     }
+
+    _records = [
+        {
+            id: 1,
+            title: "Name",
+            question_type: "name",
+            event_id: 1,
+            sequence: 1,
+            once_per_order: false,
+            is_mandatory_answer: true,
+            answer_ids: [],
+        },
+        {
+            id: 2,
+            title: "Email",
+            question_type: "email",
+            event_id: 1,
+            sequence: 2,
+            once_per_order: false,
+            is_mandatory_answer: true,
+            answer_ids: [],
+        },
+        {
+            id: 3,
+            title: "Phone",
+            question_type: "phone",
+            event_id: 1,
+            sequence: 3,
+            once_per_order: false,
+            is_mandatory_answer: true,
+            answer_ids: [],
+        },
+        {
+            id: 4,
+            title: "Gender",
+            question_type: "simple_choice",
+            event_id: 1,
+            sequence: 4,
+            once_per_order: false,
+            is_mandatory_answer: false,
+            answer_ids: [1, 2],
+        },
+    ];
 }
 
 patch(hootPosModels, [...hootPosModels, EventQuestion]);

--- a/addons/pos_event/static/tests/unit/data/event_question_answer.data.js
+++ b/addons/pos_event/static/tests/unit/data/event_question_answer.data.js
@@ -8,6 +8,21 @@ export class EventQuestionAnswer extends models.ServerModel {
     _load_pos_data_fields() {
         return ["question_id", "name", "sequence"];
     }
+
+    _records = [
+        {
+            id: 1,
+            question_id: 4,
+            name: "Male",
+            sequence: 1,
+        },
+        {
+            id: 2,
+            question_id: 4,
+            name: "Female",
+            sequence: 2,
+        },
+    ];
 }
 
 patch(hootPosModels, [...hootPosModels, EventQuestionAnswer]);

--- a/addons/pos_event/static/tests/unit/data/event_slot.data.js
+++ b/addons/pos_event/static/tests/unit/data/event_slot.data.js
@@ -16,6 +16,18 @@ export class EventSlot extends models.ServerModel {
             "start_datetime",
         ];
     }
+
+    _records = [
+        {
+            id: 1,
+            date: "2019-03-11",
+            display_name: "Event Slot 1",
+            event_id: 1,
+            registration_ids: [],
+            seats_available: 5,
+            start_datetime: "2019-03-11 11:00:00",
+        },
+    ];
 }
 
 patch(hootPosModels, [...hootPosModels, EventSlot]);

--- a/addons/pos_event/static/tests/unit/data/pos_session.data.js
+++ b/addons/pos_event/static/tests/unit/data/pos_session.data.js
@@ -1,0 +1,17 @@
+import { PosSession } from "@point_of_sale/../tests/unit/data/pos_session.data";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosSession.prototype, {
+    _load_pos_data_models() {
+        return [
+            ...super._load_pos_data_models(),
+            "event.event.ticket",
+            "event.event",
+            "event.question.answer",
+            "event.question",
+            "event.registration.answer",
+            "event.registration",
+            "event.slot",
+        ];
+    },
+});

--- a/addons/pos_event/static/tests/unit/data/product_product.data.js
+++ b/addons/pos_event/static/tests/unit/data/product_product.data.js
@@ -1,0 +1,15 @@
+import { ProductProduct } from "@point_of_sale/../tests/unit/data/product_product.data";
+
+ProductProduct._records = [
+    ...ProductProduct._records,
+    {
+        id: 106,
+        name: "Event Registration",
+        display_name: "Event Registration",
+        lst_price: 30.0,
+        standard_price: 30.0,
+        type: "service",
+        service_tracking: "event",
+        product_tmpl_id: 108,
+    },
+];

--- a/addons/pos_event/static/tests/unit/data/product_template.data.js
+++ b/addons/pos_event/static/tests/unit/data/product_template.data.js
@@ -1,0 +1,19 @@
+import { ProductTemplate } from "@point_of_sale/../tests/unit/data/product_template.data";
+
+ProductTemplate._records = [
+    ...ProductTemplate._records,
+    {
+        id: 108,
+        name: "Event Registration",
+        display_name: "Event Registration",
+        list_price: 30.0,
+        standard_price: 30.0,
+        type: "service",
+        service_tracking: "event",
+        pos_categ_ids: [1],
+        categ_id: false,
+        uom_id: 1,
+        available_in_pos: true,
+        active: true,
+    },
+];

--- a/addons/pos_event/static/tests/unit/services/pos_store.test.js
+++ b/addons/pos_event/static/tests/unit/services/pos_store.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+describe("pos_store", () => {
+    test("createDummyProductForEvents", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const eventProducts = models["product.template"].filter((product) => product._event_id);
+        const event = models["event.event"].get(1);
+
+        // Check if a dummy product for the event is created
+        expect(eventProducts).toHaveLength(1);
+        expect(eventProducts[0].event_id).toEqual(event);
+    });
+});


### PR DESCRIPTION
In this commit:
------------
- We are adding hoot test cases to verify that components return values according to the passed parameters for components like `event_configurator_popup`, `event_registration_popup`, and `event_slot_selection_popup`.
- Also, we are adding a test for the `addProductToOrder` method available in the `product_screen` component to ensure the order line is added to the order seamlessly.
- Then, we are adding a test for the `createDummyProductForEvents` method available in the `pos_store` service to verify that the products are created for all the loaded events in the POS.

task-4945631