### PR TITLE
[FIX] sale_project: fix the issue of missing required field error while creating milestone

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -174,7 +174,7 @@
                 </button>
             </xpath>
             <xpath expr="//field[@name='milestone_id']" position="attributes">
-                <attribute name="context">{'default_project_id': context.get('default_project_id'), 'default_sale_line_id': sale_line_id}</attribute>
+                <attribute name="context">{'default_project_id': project_id, 'default_sale_line_id': sale_line_id}</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
                 <attribute name="invisible">not allow_billable or has_template_ancestor</attribute>


### PR DESCRIPTION
### Steps to Reproduce:
- Install sale project
- Go to All Tasks
- Open any task create and edit a new milestone and click on save

### Issue:
- A required field error is raised because `project_id` is not set by default.
- It should not be the case.

### Cause:
- The `milestone_id` field's attributes are overridden in `sale_project`.
- The context is missing `default_project_id` when accessing the milestone from the "All Tasks" view.

### Fix:
- Passed project_id as default_project_id when opening milestone form.

task-4953620





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
