### PR TITLE
[IMP] html_editor, *: improve MediaDialog accessibility

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/document_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/document_selector.xml
@@ -1,8 +1,10 @@
 <templates id="template" xml:space="preserve">
 <t t-name="html_editor.DocumentAttachment">
-    <div class="o_existing_attachment_cell o_we_attachment_highlight card col-2 position-relative mb-2 p-2 opacity-trigger-hover cursor-pointer" t-att-class="{ o_we_attachment_selected: props.selected }" t-on-click="props.selectAttachment">
+    <div class="o_existing_attachment_cell o_we_attachment_highlight card col-2 position-relative mb-2 p-2 opacity-trigger-hover"
+         t-att-class="{ o_we_attachment_selected: props.selected }">
         <RemoveButton remove="() => this.remove()"/>
         <div t-att-data-url="props.url" role="img" t-att-aria-label="props.name" t-att-title="props.name" t-att-data-mimetype="props.mimetype" class="o_image d-flex align-items-center justify-content-center"/>
+        <button class="o_btn_reset o_button_area cursor-pointer" t-on-click="props.selectAttachment" t-att-aria-label="props.name"/>
         <small class="o_file_name d-block text-truncate" t-esc="props.name"/>
     </div>
 </t>

--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
@@ -111,6 +111,16 @@ export class FileSelectorControlPanel extends Component {
         this.debouncedValidateUrl = useDebounced(this.props.validateUrl, 500);
 
         this.fileInput = useRef("file-input");
+        const urlInputRef = useRef("urlInput");
+
+        useEffect(
+            () => {
+                if (this.state.showUrlInput) {
+                    urlInputRef.el.focus();
+                }
+            },
+            () => [this.state.showUrlInput]
+        );
     }
 
     get showSearchServiceSelect() {

--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.xml
@@ -16,7 +16,7 @@
             </select>
         </div>
         <div class="col justify-content-end flex-nowrap input-group has-validation">
-            <input type="text" class="form-control o_input o_we_url_input o_we_transition_ease flex-grow-0" t-att-class="{ o_we_horizontal_collapse: !state.showUrlInput, 'w-auto': state.showUrlInput }" name="url" t-att-placeholder="props.urlPlaceholder" t-model="state.urlInput" t-on-input="onUrlInput" t-if="state.showUrlInput"/>
+            <input type="text" class="form-control o_input o_we_url_input o_we_transition_ease flex-grow-0" t-att-class="{ o_we_horizontal_collapse: !state.showUrlInput, 'w-auto': state.showUrlInput }" name="url" t-att-placeholder="props.urlPlaceholder" t-model="state.urlInput" t-on-input="onUrlInput" t-if="state.showUrlInput" t-ref="urlInput"/>
             <button type="button" class="btn o_upload_media_url_button text-nowrap" t-att-class="{ 'btn-primary': state.urlInput, 'btn-secondary': !state.urlInput}" t-on-click="onUrlUploadClick" t-att-disabled="!enableUrlUploadClick">
                     <t t-esc="props.addText"/>
             </button>

--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.xml
@@ -1,12 +1,23 @@
 <templates id="template" xml:space="preserve">
 <t t-name="html_editor.AutoResizeImage">
-    <div t-ref="auto-resize-image-container" class="o_existing_attachment_cell o_we_image align-items-center justify-content-center me-1 mb-1 opacity-trigger-hover opacity-0 cursor-pointer" t-att-class="{ o_we_attachment_optimized: props.isOptimized, 'o_loaded position-relative opacity-100': state.loaded, o_we_attachment_selected: props.selected, 'position-fixed': !state.loaded, 'cursor-pointer': !props.unselectable }" t-on-click="props.onImageClick">
+    <div t-ref="auto-resize-image-container"
+         class="o_existing_attachment_cell o_we_image align-items-center justify-content-center me-1 mb-1 opacity-trigger-hover opacity-0"
+         t-att-class="{
+            o_we_attachment_optimized: props.isOptimized,
+            'o_loaded position-relative opacity-100': state.loaded,
+            o_we_attachment_selected: props.selected,
+            'position-fixed': !state.loaded,
+         }">
         <RemoveButton t-if="props.isRemovable" model="props.model" remove="() => this.remove()"/>
         <div class="o_we_media_dialog_img_wrapper" t-att-class="{ 'bg-light': props.unselectable }">
              <t t-set="unselectable_attachment_title">You can not use this image in a field</t>
              <img t-ref="auto-resize-image" class="o_we_attachment_highlight img img-fluid w-100" t-att-class="{ 'opacity-25': props.unselectable}" t-att-src="props.src" t-att-alt="props.altDescription" loading="lazy" t-att-title="props.unselectable ? unselectable_attachment_title : props.title"/>
              <a t-if="props.author" class="o_we_media_author position-absolute start-0 bottom-0 end-0 text-truncate text-center text-primary fs-6 bg-white-50" t-att-href="props.authorLink" target="_blank" t-esc="props.author"/>
         </div>
+        <button class="o_btn_reset o_button_area"
+                t-att-class="{ 'cursor-pointer': !props.unselectable }"
+                t-on-click="props.onImageClick"
+                t-att-aria-label="props.unselectable ? unselectable_attachment_title : props.title"/>
         <span t-if="props.isOptimized" class="badge position-absolute bottom-0 end-0 m-1 text-bg-success">Optimized</span>
     </div>
 </t>

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.xml
@@ -6,8 +6,8 @@
         modalRef="modalRef">
         <Notebook pages="notebookPages" onPageUpdate.bind="onTabChange" defaultPage="state.activeTab"/>
         <t t-set-slot="footer">
-            <button class="btn btn-primary" t-on-click="() => this.save()" t-ref="add-button">Add</button>
-            <button class="btn btn-secondary" t-on-click="() => this.props.close()">Discard</button>
+            <button class="btn btn-primary" t-on-click="() => this.save()" t-ref="add-button" data-hotkey="q">Add</button>
+            <button class="btn btn-secondary" t-on-click="() => this.props.close()" data-hotkey="x">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -591,7 +591,7 @@ test("replace an image with a caption", async () => {
             await waitFor(".o-we-toolbar button[name='replace_image']");
             await click("button[name='replace_image']");
             await waitFor(".o_select_media_dialog");
-            await click("img.o_we_attachment_highlight");
+            await click(".o_existing_attachment_cell .o_button_area");
             await animationFrame();
             expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
             expect("img[src='/web/static/img/logo2.png']").toHaveCount(1);

--- a/addons/html_editor/static/tests/file.test.js
+++ b/addons/html_editor/static/tests/file.test.js
@@ -101,7 +101,7 @@ describe("document tab in media dialog", () => {
             await animationFrame();
             await click(".nav-link:contains('Documents')");
             await animationFrame();
-            await click(".o_we_attachment_highlight");
+            await click(".o_we_attachment_highlight .o_button_area");
             // wait for the embedded component to be mounted
             await waitFor('[data-embedded="file"] .o_file_name:contains("file.txt")');
             expect('[data-embedded="file"]').toHaveCount(1);
@@ -117,7 +117,7 @@ describe("document tab in media dialog", () => {
             await animationFrame();
             await click(".nav-link:contains('Documents')");
             await animationFrame();
-            await click(".o_we_attachment_highlight");
+            await click(".o_we_attachment_highlight .o_button_area");
             expect(".odoo-editor-editable .o_file_box a:contains('file.txt')").toHaveCount(1);
         });
     });

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -32,7 +32,7 @@ test("Can replace an image", async () => {
     expect("button[name='replace_image']").toHaveCount(1);
     await click("button[name='replace_image']");
     await animationFrame();
-    await click("img.o_we_attachment_highlight");
+    await click(".o_existing_attachment_cell .o_button_area");
     await animationFrame();
     expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
     expect("img[src='/web/static/img/logo2.png']").toHaveCount(1);
@@ -62,7 +62,7 @@ test("Replace an image with link by a document should remove the link", async ()
     await animationFrame();
     await click(".nav-link:contains('Documents')");
     await animationFrame();
-    await click(".o_we_attachment_highlight");
+    await click(".o_we_attachment_highlight .o_button_area");
     expect(".odoo-editor-editable .o_file_box a:contains('file.txt')").toHaveCount(1);
     expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
     expect("p a[href='http://test.com']").toHaveCount(0);
@@ -90,7 +90,7 @@ test("Selection is collapsed after the image after replacing it", async () => {
     expect("button[name='replace_image']").toHaveCount(1);
     await click("button[name='replace_image']");
     await animationFrame();
-    await click("img.o_we_attachment_highlight");
+    await click(".o_existing_attachment_cell .o_button_area");
     await animationFrame();
     expect(getContent(el).replace(/<img.*?>/, "<img>")).toBe("<p>abc<img>[]def</p>");
 });
@@ -114,7 +114,7 @@ test("Can insert an image, and selection should be collapsed after it", async ()
     await expectElementCount(".o-we-powerbox", 1);
     await press("Enter");
     await animationFrame();
-    await click("img.o_we_attachment_highlight");
+    await click(".o_existing_attachment_cell .o_button_area");
     await animationFrame();
     expect("img[src='/web/static/img/logo2.png']").toHaveCount(1);
     expect(getContent(el).replace(/<img.*?>/, "<img>")).toBe("<p>a<img>[]bc</p>");

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -214,7 +214,7 @@ registerWebsitePreviewTour('test_image_upload_progress_unsplash', {
         run: "edit fox",
     }, {
         content: "click on unsplash result", // note that unsplash is mocked
-        trigger: "img[alt~=fox]",
+        trigger: ".o_we_media_dialog_img_wrapper:has(img[alt~=fox]) + .o_button_area",
         run: "click",
     },
     {

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -61,7 +61,7 @@ registerWebsitePreviewTour('test_replace_media', {
     },
     {
         content: "select svg",
-        trigger: ".o_select_media_dialog img[title='sample.svg']",
+        trigger: ".o_select_media_dialog .o_button_area[aria-label='sample.svg']",
         run: "click",
     },
     {

--- a/addons/web/static/src/scss/ui.scss
+++ b/addons/web/static/src/scss/ui.scss
@@ -183,6 +183,10 @@ span.o_force_ltr {
     }
  }
 
+.o_button_area {
+    @include o-position-absolute(0, 0, 0, 0);
+}
+
 // Remove default user-agent styles on buttons
 .o_btn_reset {
     appearance: none;

--- a/addons/web_unsplash/static/tests/unsplash.test.js
+++ b/addons/web_unsplash/static/tests/unsplash.test.js
@@ -58,7 +58,7 @@ test("Unsplash is inserted in the Media Dialog", async () => {
     await fetchDef;
     expect.verifySteps(["fetch_images"]);
     await waitFor("img[title='Username']");
-    await click("img[title='Username']");
+    await click(".o_button_area[aria-label='Username']");
     await waitFor(".o-wysiwyg img[alt='unsplash_image']");
     expect(".o-wysiwyg img[alt='unsplash_image']").toHaveCount(1);
 });

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -51,7 +51,7 @@ test("Double click on image and replace it", async () => {
     await animationFrame();
     expect(".modal-content:contains(Select a media) .o_upload_media_button").toHaveCount(1);
     expect("div.o-tooltip").toHaveCount(0);
-    await contains(".o_select_media_dialog img[title='logo']").click();
+    await contains(".o_select_media_dialog .o_button_area[aria-label='logo']").click();
     await waitForNone(".o_select_media_dialog");
     expect(":iframe img").toHaveClass("o_modified_image_to_save");
     expect(".options-container[data-container-title='Image']").toHaveCount(1);

--- a/addons/website/static/tests/builder/website_builder/cover_properties_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/cover_properties_option.test.js
@@ -82,7 +82,7 @@ test("Add image as cover", async () => {
     await contains("[data-action-id='setCoverBackground'][data-action-param]").click();
     // We use "click" instead of contains.click because contains wait for the image to be visible.
     // In this test we don't want to wait ~800ms for the image to be visible but we can still click on it
-    await click("img.o_we_attachment_highlight");
+    await click(".o_existing_attachment_cell .o_button_area");
     await animationFrame();
     await waitFor(":iframe .o_record_cover_container.o_record_has_cover .o_record_cover_image");
     expect(":iframe .o_record_cover_image").toHaveStyle({

--- a/addons/website/static/tests/builder/website_builder/image_gallery.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_gallery.test.js
@@ -63,7 +63,7 @@ test("Add image in gallery", async () => {
     await contains("[data-action-id='addImage']").click();
     // We use "click" instead of contains.click because contains wait for the image to be visible.
     // In this test we don't want to wait ~800ms for the image to be visible but we can still click on it
-    await click("img.o_we_attachment_highlight");
+    await click(".o_existing_attachment_cell .o_button_area");
     await waitDomUpdated();
     await contains(".modal-footer button").click();
     await waitFor(":iframe .o_masonry_col img[data-index='6']");

--- a/addons/website/static/tests/builder/website_builder/image_snippet_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_snippet_option.test.js
@@ -41,7 +41,7 @@ test("Drag & drop an 'Image' snippet opens the dialog to select an image", async
     expect(".o_select_media_dialog").toHaveCount(1);
     expect(".o-website-builder_sidebar .fa-undo").not.toBeEnabled();
 
-    await contains(".o_select_media_dialog img[title='logo']").click();
+    await contains(".o_select_media_dialog .o_button_area[aria-label='logo']").click();
     await waitForEndOfOperation();
     expect(".o_select_media_dialog").toHaveCount(0);
 

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -35,7 +35,7 @@ registerWebsitePreviewTour('website_replace_grid_image', {
     },
     {
         content: "Pick new image",
-        trigger: '.o_select_media_dialog img[title="s_banner_default_image.jpg"]',
+        trigger: '.o_select_media_dialog .o_button_area[aria-label="s_banner_default_image.jpg"]',
         run: "click",
     },
     {
@@ -45,7 +45,7 @@ registerWebsitePreviewTour('website_replace_grid_image', {
     },
     {
         content: "Pick new image",
-        trigger: '.o_select_media_dialog img[title="s_banner_default_image2.webp"]',
+        trigger: '.o_select_media_dialog .o_button_area[aria-label="s_banner_default_image2.webp"]',
         run: "click",
     },
     {
@@ -55,7 +55,7 @@ registerWebsitePreviewTour('website_replace_grid_image', {
     },
     {
         content: "Pick new image",
-        trigger: '.o_select_media_dialog img[title="s_banner_default_image.jpg"]',
+        trigger: '.o_select_media_dialog .o_button_area[aria-label="s_banner_default_image.jpg"]',
         run: "click",
     },
     ...clickOnSave()
@@ -76,7 +76,7 @@ registerWebsitePreviewTour("scroll_to_new_grid_item", {
     changeOption("Text - Image", "[data-action-id='addGridElement'][data-action-param='image']"),
     {
         content: "Select the new image in the media dialog",
-        trigger: '.o_select_media_dialog img[title="s_banner_default_image.jpg"]',
+        trigger: '.o_select_media_dialog .o_button_area[aria-label="s_banner_default_image.jpg"]',
         run: "click",
     }, {
         content: "Check that the page scrolled to the new grid item",

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -124,7 +124,7 @@ registerWebsitePreviewTour('snippet_background_edition', {
 changeOption("Text - Image", "button[data-action-id='toggleBgImage']"),
 {
     content: "Click on image",
-    trigger: ".o_select_media_dialog img[title='test.png']",
+    trigger: ".o_select_media_dialog .o_button_area[aria-label='test.png']",
     run: "click",
 },
 ...clickOnSave(),
@@ -222,7 +222,7 @@ changeOption("Text - Image", "button[data-action-id='toggleBgImage']"),
 // Now, add an image on top of that color combination + gradient
 changeOption("Text - Image", "button[data-action-id='toggleBgImage']"),
 {
-    trigger: '.o_existing_attachment_cell img',
+    trigger: '.o_existing_attachment_cell .o_button_area',
     content: "Select an image in the media dialog",
     run: "click",
 },

--- a/addons/website/static/tests/tours/snippet_image.js
+++ b/addons/website/static/tests/tours/snippet_image.js
@@ -25,7 +25,7 @@ registerWebsitePreviewTour("snippet_image", {
 },
 {
     content: "Click on the image",
-    trigger: ".o_select_media_dialog .o_we_media_dialog_img_wrapper img",
+    trigger: ".o_select_media_dialog .o_existing_attachment_cell .o_button_area",
     run: "click",
 },
 {

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -47,11 +47,11 @@ registerWebsitePreviewTour("snippet_image_gallery_remove", {
     run: "click",
 }, {
     content: "Click on the first new image",
-    trigger: ".o_select_media_dialog img[title='s_default_image.jpg']",
+    trigger: ".o_select_media_dialog .o_button_area[aria-label='s_default_image.jpg']",
     run: "click",
 }, {
     content: "Click on the second new image",
-    trigger: ".o_select_media_dialog img[title='s_default_image2.webp']",
+    trigger: ".o_select_media_dialog .o_button_area[aria-label='s_default_image2.webp']",
     run: "click",
 },
     addMedia(),
@@ -140,7 +140,7 @@ registerWebsitePreviewTour("snippet_image_gallery_thumbnail_update", {
     changeOption("Image Gallery", "addImage"),
 {
     content: "Click on the default image",
-    trigger: ".o_select_media_dialog img[title='s_default_image.jpg']",
+    trigger: ".o_select_media_dialog .o_button_area[aria-label='s_default_image.jpg']",
     run: "click",
 },
     addMedia(),

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -46,7 +46,7 @@ const replaceIconByImage = function (url) {
     },
     {
         content: "Select the image",
-        trigger: ".o_select_media_dialog img[title='s_banner_default_image.jpg']",
+        trigger: ".o_select_media_dialog .o_button_area[aria-label='s_banner_default_image.jpg']",
         run: "click",
     },
     ...preventRaceConditionStep,

--- a/addons/website_blog/static/src/tours/website_blog.js
+++ b/addons/website_blog/static/src/tours/website_blog.js
@@ -63,7 +63,7 @@ registerWebsitePreviewTour("blog", {
     tooltipPosition: "top",
 },
 {
-    trigger: ".o_select_media_dialog .o_existing_attachment_cell:first img",
+    trigger: ".o_select_media_dialog .o_existing_attachment_cell:first .o_button_area",
     content: _t("Choose an image from the library."),
     tooltipPosition: "top",
     run: "click",


### PR DESCRIPTION
*: web, website

**[IMP] html_editor: autofocus URL input of media dialog**
    
    Inside the MediaDialog, you have to click on the "Add URL" button to
    display the URL input, and then click on the input (or shift+tab to
    focus it) to write or paste the URL.
    This commit improves the feature by automatically focusing the input
    when clicking on the button.

**[IMP] html_editor, \*: improve MediaDialog accessibility**
    
    *: web, website
    
    This commit adds a transparent button overlay over the media within the
    MediaDialog to be able to select files/images/etc. through the keyboard.
    We also add hotkeys on the two main buttons of the dialog.
    
    Note that the delete button remains unfocusable with the keyboard: this
    is deemed a secondary action which does not _need_ to be accessible with
    the keyboard. Making it focusable would add twice as many buttons in the
    dialog and in the focus flow, making it less practical and defeating the
    purpose of this commit. The MediaDialog is also, by nature, unlikely to
    be used with screen reading technologies, so the semantics may slightly
    diverge from the best practice.
    
task-3680626
