### PR TITLE
[FIX] html_editor: always insert two zwnbsp inside empty link

### DIFF
--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -66,7 +66,10 @@ export class LinkSelectionPlugin extends Plugin {
             ["append", "lastChild"],
         ]) {
             const candidate = link[relation];
-            const feff = isZwnbsp(candidate) ? candidate : addFeff(position);
+            const feff =
+                isZwnbsp(candidate) && !zwnbspNodes.includes(candidate)
+                    ? candidate
+                    : addFeff(position);
             zwnbspNodes.push(feff);
         }
         return zwnbspNodes;

--- a/addons/html_editor/static/tests/link/existing.test.js
+++ b/addons/html_editor/static/tests/link/existing.test.js
@@ -122,8 +122,8 @@ test("should remove an empty link on save", async () => {
     });
     await testEditor({
         contentBefore: '<p>a<a href="http://test.test/"></a>b</p>',
-        contentBeforeEdit: '<p>a\ufeff<a href="http://test.test/">\ufeff</a>\ufeffb</p>',
-        contentAfterEdit: '<p>a\ufeff<a href="http://test.test/">\ufeff</a>\ufeffb</p>',
+        contentBeforeEdit: '<p>a\ufeff<a href="http://test.test/">\ufeff\ufeff</a>\ufeffb</p>',
+        contentAfterEdit: '<p>a\ufeff<a href="http://test.test/">\ufeff\ufeff</a>\ufeffb</p>',
         contentAfter: "<p>ab</p>",
     });
 });

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2663,7 +2663,7 @@ describe("link", () => {
                 `<p>xy<a href="http://test.test/">[]</a>z</p>`
             );
             expect(getContent(el)).toBe(
-                `<p>xy\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]</a>\ufeffz</p>`
+                `<p>xy\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffz</p>`
             );
             pasteText(editor, imgUrl);
             await animationFrame();


### PR DESCRIPTION
In case a link is unremovable, the `zwnbsp`s (aka feffs) added on the edges of a link may be missing one inside if the link is empty. With only one feff inside the link, the user cannot move the cursor inside it

Steps to reproduce:
- Delete the content of an unremovable link (for example the "Contact Us" button in header of website)
- Use the arrows with shift key to extend selection (`shift+right`)
- Press delete
- Bug: user cannot write anything inside the button

Alternative:
- Delete the content of an unremovable link
- Save and reopen
- Bug: user cannot write anything inside the button

task-4954763