### PR TITLE
[FIX] l10n_es_edi_verifactu: post-merge fixes

### DIFF
--- a/addons/l10n_es_edi_verifactu/__init__.py
+++ b/addons/l10n_es_edi_verifactu/__init__.py
@@ -5,7 +5,7 @@ from . import wizard
 
 
 def _l10n_es_edi_verifactu_post_init_hook(env):
-    for company in env['res.company'].search([('chart_template', 'like', r'es\_%')], order="parent_path"):
+    for company in env['res.company'].search([('chart_template', 'like', r'es\_%'), ('parent_id', '=', False)]):
         Template = env['account.chart.template'].with_company(company)
         Template._load_data({
             'account.tax': Template._get_es_verifactu_account_tax(),

--- a/addons/l10n_es_edi_verifactu/__manifest__.py
+++ b/addons/l10n_es_edi_verifactu/__manifest__.py
@@ -5,6 +5,7 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/EDI',
     'summary': "Module for sending Spanish Veri*Factu XML to the AEAT",
+    'website': "https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations/spain.html#veri-factu",
     'depends': ['l10n_es'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/l10n_es_edi_verifactu/i18n/es.po
+++ b/addons/l10n_es_edi_verifactu/i18n/es.po
@@ -673,6 +673,13 @@ msgstr ""
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
+#: code:addons/l10n_es_edi_verifactu/wizard/account_move_send.py:0
+#, python-format
+msgid "The Veri*Factu document could not be created for all invoices."
+msgstr ""
+
+#. module: l10n_es_edi_verifactu
+#. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "The batch document could not be created"

--- a/addons/l10n_es_edi_verifactu/i18n/l10n_es_edi_verifactu.pot
+++ b/addons/l10n_es_edi_verifactu/i18n/l10n_es_edi_verifactu.pot
@@ -673,6 +673,13 @@ msgstr ""
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
+#: code:addons/l10n_es_edi_verifactu/wizard/account_move_send.py:0
+#, python-format
+msgid "The Veri*Factu document could not be created for all invoices."
+msgstr ""
+
+#. module: l10n_es_edi_verifactu
+#. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "The batch document could not be created"

--- a/addons/l10n_es_edi_verifactu/wizard/account_move_send.py
+++ b/addons/l10n_es_edi_verifactu/wizard/account_move_send.py
@@ -87,13 +87,11 @@ class AccountMoveSend(models.TransientModel):
         created_document = invoices_to_send._l10n_es_edi_verifactu_mark_for_next_batch()
 
         for invoice in invoices_to_send:
-            # The creation of a document is skipped for `invoice` in case there are waiting documents
-            document = created_document.get(invoice)
-            if document and document.state == 'creating_failed':
+            if not created_document[invoice].chain_index:
                 invoices_data[invoice]['error'] = {
-                    'error_title': _("The Veri*Factu record XML could not be created for all invoices."),
+                    'error_title': _("The Veri*Factu document could not be created for all invoices."),
                     'errors': [_("See the 'Veri*Factu' tab for more information.")],
                 }
 
-        if self._can_commit():
+        if created_document and self._can_commit():
             self._cr.commit()


### PR DESCRIPTION
- The document generation in the account.move.send wizard was corrected. It was forgotten after changing the other code.
  - Document (objects) are always generated. In case we could not generate the JSON the document is not chained.
  - We store JSON on the document and not XML.
  - The `commit` is unnecessary it is handled directly in the sending
- The way the taxes are loaded in the post init hook was adapted See commit 77243bc85db87fad2196052036390f65bd451eeb .
- Put a link to the documentation. I.e. so that the self-declaration is easier to find.

task-None
