### PR TITLE
[FIX] web: remove nested `o_input` padding

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -199,12 +199,6 @@
         flex: 1 1 auto;
     }
 
-    // rules for fields borders: only on hover/focus by default
-    // except when used with o_field_highlight (on parent or on the field)
-    .o_input {
-        padding: $o-input-padding-y $o-input-padding-x;
-    }
-
     &:not(.o_field_highlight) .o_field_widget:not(.o_field_invalid):not(.o_field_highlight) .o_input:not(:hover):not(:focus) {
         --o-input-border-color: transparent;
     }


### PR DESCRIPTION
Inside form views when an input is displayed next to an other which contains nested `o_input`, the border is misaligned.

This is due to a duplication of the `o_input` style in `form_controller.scss` which overrides the rule handling nested `o_input` in `fields.scss` resulting in 2x the necessary padding.

[task-4974502](https://www.odoo.com/web#id=4974502&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
