### PR TITLE
[FIX] stock_delivery: fix error when validating delivery

### DIFF
--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -29,6 +29,7 @@ class StockPicking(models.Model):
     is_return_picking = fields.Boolean(compute='_compute_return_picking')
     return_label_ids = fields.One2many('ir.attachment', compute='_compute_return_label')
     destination_country_code = fields.Char(related='partner_id.country_id.code', string="Destination Country")
+    integration_level = fields.Selection(related='carrier_id.integration_level')
 
     @api.depends('partner_id', 'carrier_id.max_weight', 'carrier_id.max_volume', 'carrier_id.must_have_tag_ids', 'carrier_id.excluded_tag_ids', 'move_ids.product_id.product_tag_ids', 'move_ids.product_id.weight', 'move_ids.product_id.volume')
     def _compute_allowed_carrier_ids(self):

--- a/addons/stock_delivery/views/delivery_view.xml
+++ b/addons/stock_delivery/views/delivery_view.xml
@@ -21,6 +21,7 @@
                     <group name='carrier_data' string="Shipping Information">
                         <field name="is_return_picking" invisible="1"/>
                         <field name="carrier_id" readonly="state in ('done', 'cancel')" options="{'no_create': True, 'no_open': True}"/>
+                        <field name="integration_level" invisible="1"/>
                         <field name="delivery_type" invisible="True"/>
                         <label for="carrier_tracking_ref"/>
                         <div name="tracking">
@@ -50,7 +51,7 @@
                     <button name="print_return_label" string="Print Return Label" type="object" invisible="not is_return_picking or state == 'done' or picking_type_code != 'incoming'" data-hotkey="shift+o"/>
                 </xpath>
                 <xpath expr="//field[@name='partner_id']" position="attributes">
-                    <attribute name="required">carrier_id and carrier_id.integration_level == 'rate_and_ship'</attribute>
+                    <attribute name="required">carrier_id and integration_level == 'rate_and_ship'</attribute>
                 </xpath>
               </data>
             </field>


### PR DESCRIPTION
When User validates the delivery with ``Fedex International`` shipping method,
A traceback will appear.

Steps to reproduce the error:
- Install ``delivery_fedex_rest`` module
- Go to Inventory >  Create a delivery > Don't set Delivery Address >
  In Operations Tab > Add any product and demand
  In Additional Info Tab > Carrier: ``Fedex International`` > Save
- Validate

Traceback:
```
TypeError: 'bool' object is not subscriptable
```

The ``Delivery Address (partner_id)`` field is expected to be required when the user selects a Carrier with the Integration Level set to ``rate_and_ship``, as intended in the following line
https://github.com/odoo/odoo/blob/baf59e746c4a692938baa9789f953b2d950bcad4/addons/stock_delivery/views/delivery_view.xml#L52-L54

But above line will not work because we can not use ``carrier_id.integration_level`` relation in attribute. so, eventually ``partner_id`` field is not required.

https://github.com/odoo/enterprise/blob/5c2ca03972ce4842a5aaed11f7c6b563a0e4a471/delivery_fedex_rest/models/fedex_request.py#L253
So, this line will generate the traceback because ``partner.name`` is ``False``.

sentry-6769183067

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
