### PR TITLE
[FIX] im_livechat: leave warning only when livechat is active

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -76,7 +76,12 @@ patch(Thread.prototype, {
         }
     },
     async leaveChannel({ force = false } = {}) {
-        if (this.channel_type === "livechat" && this.channel_member_ids.length <= 2 && !force) {
+        if (
+            this.channel_type === "livechat" &&
+            this.channel_member_ids.length <= 2 &&
+            this.livechat_active &&
+            !force
+        ) {
             await this.askLeaveConfirmation(_t("Leaving will end the livechat. Proceed leaving?"));
         }
         super.leaveChannel(...arguments);

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -23,21 +23,38 @@ test("from the discuss app", async () => {
             .search_read([["id", "=", serverState.groupLivechatId]])
             .map(({ id }) => id),
     });
-    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const [guestId_1, guestId_2] = pyEnv["mail.guest"].create([
+        { name: "guest_1" },
+        { name: "guest_2" },
+    ]);
     const livechatChannelId = pyEnv["im_livechat.channel"].create({
         name: "HR",
         user_ids: [serverState.userId],
     });
-    pyEnv["discuss.channel"].create({
-        channel_type: "livechat",
-        channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ guest_id: guestId }),
-        ],
-        livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
-        create_uid: serverState.publicUserId,
-    });
+    pyEnv["discuss.channel"].create([
+        {
+            channel_type: "livechat",
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId }),
+                Command.create({ guest_id: guestId_1 }),
+            ],
+            livechat_active: true,
+            livechat_channel_id: livechatChannelId,
+            livechat_operator_id: serverState.partnerId,
+            create_uid: serverState.publicUserId,
+        },
+        {
+            channel_type: "livechat",
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId }),
+                Command.create({ guest_id: guestId_2 }),
+            ],
+            livechat_active: false,
+            livechat_channel_id: livechatChannelId,
+            livechat_operator_id: serverState.partnerId,
+            create_uid: serverState.publicUserId,
+        },
+    ]);
     await start();
     await openDiscuss();
     await click("[title='Leave HR']", {
@@ -47,10 +64,16 @@ test("from the discuss app", async () => {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });
     await click("[title='Chat Actions']", {
-        parent: [".o-mail-DiscussSidebarChannel", { text: "Visitor" }],
+        parent: [".o-mail-DiscussSidebarChannel", { text: "guest_1" }],
     });
     await click(".o-dropdown-item:contains('Leave Channel')");
     await click("button:contains(Leave Conversation)");
+    await contains(".o-mail-DiscussSidebarChannel", { text: "guest_1", count: 0 });
+    await click("[title='Chat Actions']", {
+        parent: [".o-mail-DiscussSidebarChannel", { text: "guest_2" }],
+    });
+    await click(".o-dropdown-item:contains('Leave Channel')");
+    await contains(".o-mail-DiscussSidebarChannel", { text: "guest_2", count: 0 });
     await click("[title='Leave HR']", {
         parent: [".o-mail-DiscussSidebarCategory-livechat", { text: "HR" }],
     });

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -348,6 +348,7 @@ test("Clicking on leave button leaves the channel", async () => {
             Command.create({ guest_id: pyEnv["mail.guest"].create({ name: "Visitor 11" }) }),
         ],
         channel_type: "livechat",
+        livechat_active: true,
         livechat_operator_id: serverState.partnerId,
         create_uid: serverState.publicUserId,
     });


### PR DESCRIPTION
Before this PR, when leaving a live chat from the discuss sidebar action as an agent, the user was always getting a warning that this action would end the livechat, even when the livechat has already ended!

task-4926337