### PR TITLE
[FIX] sale: ensure method receives a recordset, not a dictionary

### DIFF
--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -147,9 +147,7 @@ class TestAccruedSaleOrders(AccountTestInvoicingCommon):
             'amount': 50.0,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
-        invoice = downpayment._create_invoices({
-            'sale_orders': so_context,
-        })
+        invoice = downpayment._create_invoices(self.sale_order)
         invoice.invoice_date = self.wizard.date
         invoice.action_post()
         self.wizard.create_entries()


### PR DESCRIPTION
At [1], `_create_invoices()` expects a recordset, not a dictionary. The test case currently passes because the `advance_payment_method` is set to `percentage`. However, if someone overrides `_create_invoices()` and uses a different `advance_payment_method` (e.g., 'delivered'), it will fail.

Traceback:
---
`AttributeError: 'dict' object has no attribute '_create_invoices'`

[1]- https://github.com/odoo/odoo/blob/4cd24dc73d46b714cd5a764ed3f003e9507b0777/addons/sale/tests/test_accrued_sale_orders.py#L150-L152

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
