### PR TITLE
[IMP] website: fix parallax type options in the builder

### DIFF
--- a/addons/website/static/src/builder/plugins/options/parallax_option.xml
+++ b/addons/website/static/src/builder/plugins/options/parallax_option.xml
@@ -8,15 +8,15 @@
             <BuilderSelectItem actionValue="'fixed'">Fixed</BuilderSelectItem>
             <BuilderSelectItem id="'parallax_top_opt'" actionValue="'top'">Parallax to Top</BuilderSelectItem>
             <BuilderSelectItem id="'parallax_bottom_opt'" actionValue="'bottom'">Parallax to Bottom</BuilderSelectItem>
-            <BuilderSelectItem id="'parallax_zoom_in_opt'" actionValue="'zoom_in'">Zoom In</BuilderSelectItem>
-            <BuilderSelectItem id="'parallax_zoom_out_opt'" actionValue="'zoom_out'">Zoom Out</BuilderSelectItem>
+            <BuilderSelectItem id="'parallax_zoom_in_opt'" actionValue="'zoomIn'">Zoom In</BuilderSelectItem>
+            <BuilderSelectItem id="'parallax_zoom_out_opt'" actionValue="'zoomOut'">Zoom Out</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
     <BuilderContext preview="false">
         <BuilderRow t-if="isActiveItem('parallax_top_opt')" level="3" label.translate="Intensity">
             <BuilderRange
                 dataAttributeAction="'scrollBackgroundRatio'"
-                min="0"
+                min="0.15"
                 max="3"
                 step="0.15"
             />
@@ -24,7 +24,7 @@
         <BuilderRow t-if="isActiveItem('parallax_bottom_opt')" level="3" label.translate="Intensity">
             <BuilderRange
                 dataAttributeAction="'scrollBackgroundRatio'"
-                min="0"
+                min="-0.15"
                 max="-3"
                 step="0.15"
             />
@@ -32,17 +32,17 @@
         <BuilderRow t-if="isActiveItem('parallax_zoom_in_opt')" level="3" label.translate="Intensity">
             <BuilderRange
                 dataAttributeAction="'scrollBackgroundRatio'"
-                min="0"
-                max="3"
-                step="0.15"
+                min="0.05"
+                max="0.95"
+                step="0.05"
             />
         </BuilderRow>
         <BuilderRow t-if="isActiveItem('parallax_zoom_out_opt')" level="3" label.translate="Intensity">
             <BuilderRange
                 dataAttributeAction="'scrollBackgroundRatio'"
-                min="0"
-                max="0.95"
-                step="0.05"
+                min="0.15"
+                max="3"
+                step="0.15"
             />
         </BuilderRow>
     </BuilderContext>

--- a/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
@@ -34,14 +34,14 @@ class WebsiteParallaxPlugin extends Plugin {
             fixed: 1,
             top: 1.5,
             bottom: -1.5,
-            zoom_in: 1.2,
-            zoom_out: 0.2,
+            zoomIn: 0.2,
+            zoomOut: 1.2,
         };
         editingElement.dataset.scrollBackgroundRatio = typeValues[value];
         // Set a parallax type only if there is a zoom option selected.
         // This is to avoid useless element in the DOM since in the animation
         // we need the type only for zoom options.
-        if (value === "zoom_in" || value === "zoom_out") {
+        if (value === "zoomIn" || value === "zoomOut") {
             editingElement.dataset.parallaxType = value;
         } else {
             delete editingElement.dataset.parallaxType;
@@ -105,6 +105,15 @@ export class SetParallaxTypeAction extends BuilderAction {
         }
         const parallaxType = editingElement.dataset.parallaxType;
         if (parallaxType) {
+            // Compatibility: Previously, "zoom_out" and "zoom_in" had their
+            // behavior reversed. The previous "zoom_out" correspond to the
+            // current "zoomIn" type.
+            if (parallaxType === "zoom_out") {
+                return value === "zoomIn";
+            }
+            if (parallaxType === "zoom_in") {
+                return value === "zoomOut";
+            }
             return value === parallaxType;
         }
         return attributeValue > 0 ? value === "top" : value === "bottom";

--- a/addons/website/static/src/interactions/parallax/parallax.js
+++ b/addons/website/static/src/interactions/parallax/parallax.js
@@ -60,8 +60,11 @@ export class Parallax extends Interaction {
         this.styleBottom = -Math.abs(this.ratio) + "px";
 
         const parallaxType = this.el.dataset.parallaxType;
-        this.isZoomIn = parallaxType === "zoom_in";
-        this.isZoomOut = parallaxType === "zoom_out";
+        // Compatibility: Previously, "zoom_out" and "zoom_in" had their
+        // behavior reversed. The previous "zoom_out" correspond to the
+        // current "zoomIn" type.
+        this.isZoomIn = parallaxType === "zoomIn" || parallaxType === "zoom_out";
+        this.isZoomOut = parallaxType === "zoomOut" || parallaxType === "zoom_in";
 
         this.onScroll();
     }
@@ -83,12 +86,12 @@ export class Parallax extends Interaction {
             Math.max(0, (currentPosition - this.minScrollPos) / scrollRange)
         );
 
-        if (this.isZoomIn) {
+        if (this.isZoomOut) {
             const initialZoom = 1;
             const maxZoom = this.speed + 1;
 
             this.styleTransform = `scale(${initialZoom + (maxZoom - initialZoom) * progress})`;
-        } else if (this.isZoomOut) {
+        } else if (this.isZoomIn) {
             const initialZoom = this.speed + 1;
 
             this.styleTransform = `scale(${initialZoom - (initialZoom - 1) * progress})`;

--- a/addons/website/static/tests/builder/website_builder/background.test.js
+++ b/addons/website/static/tests/builder/website_builder/background.test.js
@@ -7,7 +7,7 @@ defineWebsiteModels();
 
 test("test parallax zoom", async () => {
     await setupWebsiteAndOpenParallaxOptions();
-    await contains("[data-action-value='zoom_in']").click();
+    await contains("[data-action-value='zoomOut']").click();
     await waitFor("[data-label='Intensity'] input");
     expect(":iframe section").not.toHaveStyle("background-image", { inline: true });
     expect("[data-label='Intensity'] input").toBeVisible();

--- a/addons/website/views/snippets/s_banner_connected.xml
+++ b/addons/website/views/snippets/s_banner_connected.xml
@@ -6,7 +6,7 @@
         class="s_banner_connected o_cc o_cc5 pt128 pb136 parallax"
         data-oe-shape-data="{'shape':'web_editor/Connections/13','colors':{'c5':'rgb(255, 255, 255)'},'showOnMobile':true}"
         data-scroll-background-ratio="0.75"
-        data-parallax-type="zoom_in"
+        data-parallax-type="zoomOut"
         >
         <span
             class="s_parallax_bg oe_img_bg"


### PR DESCRIPTION
Before this commit, the parallax type would be reset to "None" if the
intensity was set to the min value (0). The user would have to change
the type back, which was not convenient.

This commit changes the min values for the intensity to avoid resetting
the parallax type.

Steps to reproduce:
- Drop a parallax block
- Set the scroll effect to "Parallax to Top"
- Set the intensity to the minimal value
The scroll effect is automatically set to "None"

Before this commit, the "zoom_in" and "zoom_out" options were reversed.
The "zoom_in" option would make the background zoom out on scroll and
vice versa.

This commit corrects the behavior of the zoom options while keeping the
previous names valid for compatibility reason.

task-4981566
