### PR TITLE
[FIX] spreadsheet_dashboard: Allow users to add filters

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_dialog/dashboard_search_dialog.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_dialog/dashboard_search_dialog.xml
@@ -18,9 +18,9 @@
                 </div>
                 <div class="d-flex">
                     <Dropdown t-if="hasUnusedGlobalFilters">
-                        <a href="#" class="pt-2">
+                        <button class="btn btn-link">
                             Add filter
-                        </a>
+                        </button>
                         <t t-set-slot="content">
                             <t t-foreach="unusedGlobalFilters" t-as="filter" t-key="filter.id">
                                 <DropdownItem onSelected="() => this.activateFilter(filter)">

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -359,7 +359,7 @@ test("Global filter with same id is not shared between dashboards", async functi
     expect(".o_searchview_facet").toHaveCount(0);
     await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
 
-    await contains(".o-dashboard-search-dialog a.dropdown-toggle").click();
+    await contains(".o-dashboard-search-dialog button.dropdown-toggle").click();
     await contains(".o-dropdown-item").click();
 
     await contains(".o-autocomplete--input.o_input").click();
@@ -399,11 +399,11 @@ test("Can add a new global filter from the search bar", async function () {
     await createSpreadsheetDashboard({ serverData });
 
     await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
-    expect(".o-dashboard-search-dialog a.dropdown-toggle").toHaveText("Add filter");
-    await contains(".o-dashboard-search-dialog a.dropdown-toggle").click();
+    expect(".o-dashboard-search-dialog button.dropdown-toggle").toHaveText("Add filter");
+    await contains(".o-dashboard-search-dialog button.dropdown-toggle").click();
     await contains(".o-dropdown-item").click();
 
-    expect(".o-dashboard-search-dialog a.dropdown-toggle").toHaveCount(0);
+    expect(".o-dashboard-search-dialog button.dropdown-toggle").toHaveCount(0);
 
     expect(".o-autocomplete--input.o_input").toHaveCount(1);
     expect(".o-autocomplete--input.o_input").toHaveValue("");
@@ -498,7 +498,7 @@ test("Changes of global filters are not dispatched while inside the dialog", asy
     expect(model.getters.getGlobalFilterValue("1")).toBe(undefined);
 
     await contains(".o_spreadsheet_dashboard_action .dropdown-toggle").click();
-    await contains(".o-dashboard-search-dialog a.dropdown-toggle").click();
+    await contains(".o-dashboard-search-dialog button.dropdown-toggle").click();
     await contains(".o-dropdown-item").click();
 
     await contains(".o-autocomplete--input.o_input").click();


### PR DESCRIPTION
steps:
- Install "spreadsheet_dashboard" with demo data
- Open filter
- Click Add Filter
- Traceback

The problem is due to the fact that initially the button is a <a> containing a href="#" which makes the code (popover.js) believe that a navigation is going to take place.

which causes unexpected behavior, such as the fact that in this case we expect to receive a valid target element in the event causing the clickAway (pointerdown, blur or popstate), since it's a popstate, it crashes.

The fix consists in replacing the a tag with a button tag, since there's no point in having an a href="#" tag.

opw-4964327