### PR TITLE
[FIX] website: fix snippet image gallery tour

### DIFF
--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -60,8 +60,8 @@ registerWebsitePreviewTour("snippet_image_gallery_remove", {
     trigger: ":iframe .s_image_gallery .carousel-item.active  img",
     run: "click",
 }, {
-    content: "Check that the Snippet Editor of the clicked image has been loaded",
-    trigger: ".o-tab-content [data-container-title='Image Gallery']",
+    content: "Check that the Snippet Editor of the clicked image has been loaded with its size",
+    trigger: ".o-tab-content [data-container-title='Image']:has([title='Size']:contains(/^.+ kB$/)",
 }, {
     content: "Click on Remove Block",
     trigger: ".o_customize_tab .options-container[data-container-title='Image Gallery'] .oe_snippet_remove",

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -89,8 +89,8 @@ class TestSnippets(HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_table_of_content', login='admin')
 
     def test_09_snippet_image_gallery(self):
-        create_image_attachment(self.env, '/web/image/website.s_banner_default_image.jpg', 's_default_image.jpg')
-        create_image_attachment(self.env, '/web/image/website.s_banner_default_image.jpg', 's_default_image2.jpg')
+        create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_default_image.jpg')
+        create_image_attachment(self.env, '/web/image/website.s_banner_default_image_2', 's_default_image2.jpg')
         self.start_tour("/", "snippet_image_gallery_remove", login='admin')
 
     def test_10_parallax(self):


### PR DESCRIPTION
This commit fixes an unstable tour related to the image gallery snippet,
which could fail intermittently.

The failure was not only caused by the image being removed before its
size was computed, but also by a race condition where
`activateCropper()` was triggered before the
`html_editor.assets_image_cropper` bundle finished loading.

runbot-229949
