### PR TITLE
[FIX] spreadsheet: apply global filters on chart update

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
@@ -203,6 +203,7 @@ export class OdooChartUIPlugin extends UIPlugin {
         const definition = this.getters.getChart(chartId).getDefinitionForDataSource();
         const dataSourceId = this._getOdooChartDataSourceId(chartId);
         this.dataSources.add(dataSourceId, ChartDataSource, definition);
+        this._addDomain(chartId);
     }
 
     /**


### PR DESCRIPTION
The global filters were not re-applied when updating an oodo chart domain.

Task: [4965683](https://www.odoo.com/odoo/2328/tasks/4965683)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
