### PR TITLE
[FIX] website: seo auto-fill crash on system pages

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -27,7 +27,8 @@ const seoContext = reactive({
 });
 
 const getSeo = async (self, onlyKeywords = false) => {
-    const pageTextContentEl = self.website.pageDocument.documentElement.querySelector("#wrap");
+    const pageTextContentEl =
+        self.website.pageDocument.documentElement.querySelector("#wrap, main, body");
     const lang = self.state.language || "en";
     const tagWeights = {
         h1: 5,


### PR DESCRIPTION
Steps to Reproduce:

1.Go to the website and open a system page such as:
/web/login
/web/signup
/web/reset_password
/donation/pay
2.In the top menu, go to Site → Optimize SEO.
3.Click the Auto-Fill button.
4.Observe that a traceback appears.

Before this commit:
Clicking the Auto-Fill button caused a traceback error because
pageTextContentEl was null due to wrong selector. As a result,
getElementsByTagName could not be accessed.

In this commit:
We provide the correct querySelector value so that pageTextContentEl
properly references the intended DOM element. This fix prevents the
error and ensures that the SEO Auto-Fill button works correctly,
populating all required fields without issue.

task-4974618