### PR TITLE
[FIX] discuss: prevent traceback when rejecting camera access

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -926,6 +926,9 @@ export class Rtc extends Record {
         if (camera) {
             await this.toggleVideo("camera");
         }
+        if (!this.selfSession) {
+            return;
+        }
         await this._initConnection();
         await this.resetAudioTrack({ force: audio });
         if (!this.state.channel?.id) {
@@ -1258,6 +1261,10 @@ export class Rtc extends Record {
                     : _t('%s" requires "screen recording" access', window.location.host);
             this.notification.add(str, { type: "warning" });
             stopVideo();
+            return;
+        }
+        if (!this.selfSession) {
+            closeStream(sourceStream);
             return;
         }
         let outputTrack = sourceStream ? sourceStream.getVideoTracks()[0] : undefined;


### PR DESCRIPTION
Before this commit, a traceback would occur of the camera access was rejected after leaving a call that requested it.

This race condition could also happen in other cases where the call is left before the camera promise resolves.


