### PR TITLE
[FIX] html_builder: BuilderNumberInput loaded with correct unit

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -74,7 +74,7 @@ export class BuilderNumberInput extends Component {
             const { savedValue, savedUnit } = value.match(
                 /(?<savedValue>[\d.e+-]+)(?<savedUnit>\w*)/
             ).groups;
-            if (savedUnit) {
+            if (savedUnit || this.props.saveUnit) {
                 // Convert value from saveUnit to unit
                 value = convertNumericToUnit(
                     savedValue,

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
@@ -549,6 +549,29 @@ describe("unit & saveUnit", () => {
         expect.verifySteps(["customAction 57000ms"]);
         expect(":iframe .test-options-target").toHaveInnerHTML("57000ms");
     });
+    test("should handle saveUnit even without explicit unit", async () => {
+        addActionOption({
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                getValue({ editingElement }) {
+                    return editingElement.innerHTML;
+                }
+            },
+        });
+        addOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" unit="'s'" saveUnit="'ms'"/>`,
+        });
+        // note that 5000 has no unit of measure
+        await setupWebsiteBuilder(`
+                    <div class="test-options-target">5000</div>
+                `);
+        await contains(":iframe .test-options-target").click();
+        expect(".options-container").toBeDisplayed();
+        await click(".options-container input");
+        const input = queryFirst(".options-container input");
+        expect(input).toHaveValue("5");
+    });
     test("should handle empty saveUnit", async () => {
         addActionOption({
             customAction: class extends BuilderAction {


### PR DESCRIPTION
This commit fixes a bug where the value of a BuilderNumberInput would not load with the assigned unit of measure.

Steps to reproduce
- add a carousel snippet
- edit Transition/Speed to be 1s
- save
- the speed is correctly saved as 1000ms
- reopen editor and check the carousel snippet again => the speed is 1000s instead of 1s
