### PR TITLE
[FIX] iot*: fix checkout pre 18.4, fix SSL verify

### DIFF
--- a/addons/iot_box_image/build_utils/sparse-checkout
+++ b/addons/iot_box_image/build_utils/sparse-checkout
@@ -2,6 +2,8 @@ addons/web
 addons/iot_base
 addons/iot_box_image/configuration
 addons/iot_drivers
+addons/hw_drivers
+addons/hw_posbox_homepage
 addons/point_of_sale/tools/posbox/configuration
 odoo/
 odoo-bin

--- a/addons/iot_drivers/__init__.py
+++ b/addons/iot_drivers/__init__.py
@@ -23,19 +23,20 @@ _get = requests.get
 _post = requests.post
 
 
-def set_user_agent(func):
+def set_default_options(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         headers = kwargs.pop('headers', None) or {}
+        verify = kwargs.pop('verify', False)
         headers['User-Agent'] = 'OdooIoTBox/1.0'
         server_url = tools.helpers.get_odoo_server_url()
         db_name = tools.helpers.get_conf('db_name')
         if server_url and db_name and args[0].startswith(server_url) and '/web/login?db=' not in args[0]:
             headers['X-Odoo-Database'] = db_name
-        return func(*args, headers=headers, **kwargs)
+        return func(*args, headers=headers, verify=verify, **kwargs)
 
     return wrapper
 
 
-requests.get = set_user_agent(_get)
-requests.post = set_user_agent(_post)
+requests.get = set_default_options(_get)
+requests.post = set_default_options(_post)

--- a/addons/iot_drivers/controllers/homepage.py
+++ b/addons/iot_drivers/controllers/homepage.py
@@ -299,15 +299,10 @@ class IotBoxOwlHomePage(http.Controller):
     def update_wifi(self, essid, password):
         if wifi.reconnect(essid, password, force_update=True):
             helpers.update_conf({'wifi_ssid': essid, 'wifi_password': password})
-            server = helpers.get_odoo_server_url()
 
             res_payload = {
                 'status': 'success',
                 'message': 'Connecting to ' + essid,
-                'server': {
-                    'url': server or 'http://' + helpers.get_ip() + ':8069',
-                    'message': 'Redirect to Odoo Server' if server else 'Redirect to IoT Box'
-                }
             }
         else:
             res_payload = {

--- a/addons/iot_drivers/tools/certificate.py
+++ b/addons/iot_drivers/tools/certificate.py
@@ -76,7 +76,7 @@ def download_odoo_certificate():
         response = requests.post(
             'https://www.odoo.com/odoo-enterprise/iot/x509',
             json={'params': {'db_uuid': db_uuid, 'enterprise_code': enterprise_code}},
-            timeout=5,
+            timeout=10,
         )
         response.raise_for_status()
         response_body = response.json()


### PR DESCRIPTION
This commit fixes the following issues:
- The hw_drivers and hw_posbox_homepage folders were missing from the sparse checkout, meaning that connected to version prior to 18.4 would prevent Odoo from starting.
- As the IoT box can only sync time with the network once it gets an internet connection, some early requests could fail due to it thinking the SSL certificates were invalid. We disable verification of the requests to bypass this.
- The request to download the certificate for the IoT box only had a timeout of 5 seconds, sometimes this could not be enough so the timeout has been increased to 10 seconds.
- Fix an error when calling the `update_wifi` route, caused by `helpers.get_ip()` now being able to return `None`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
