### PR TITLE
[FIX] web: restore badge selection style

### DIFF
--- a/addons/web/static/src/views/fields/badge_selection/badge_selection.scss
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection.scss
@@ -1,6 +1,6 @@
-.o_field_selection_badge {
+.o_list_renderer .o_field_selection_badge {
     .o_badge_border {
-        outline: 2px solid #02c7b5;
+        outline: 2px solid $o-enterprise-action-color;
         outline-offset: -1px;
     }
 }

--- a/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
@@ -16,7 +16,6 @@ export class BadgeSelectionField extends Component {
             validate: (s) => ["sm", "md", "lg"].includes(s),
             default: "md",
         },
-        colorField: { type: String, optional: true },
     };
 
     setup() {
@@ -64,18 +63,6 @@ export class BadgeSelectionField extends Component {
         return JSON.stringify(value);
     }
 
-    get badgeColor() {
-        if (this.props.record.data[this.props.name]) {
-            if (this.props.colorField) {
-                return `o_badge_color_${
-                    this.props.record.data[this.props.colorField]
-                }`;
-            }
-            return "btn btn-secondary";
-        }
-        return "";
-    }
-
     /**
      * @param {string | number | false} value
      */
@@ -85,7 +72,7 @@ export class BadgeSelectionField extends Component {
                 if (value === false) {
                     this.props.record.update({ [this.props.name]: false });
                 } else {
-                    const option =  this.options.find((option) => option[0] === value);
+                    const option = this.options.find((option) => option[0] === value);
                     this.props.record.update({
                         [this.props.name]: { id: option[0], display_name: option[1] },
                     });
@@ -121,19 +108,11 @@ export const badgeSelectionField = {
             ],
             default: "md",
         },
-        {
-            label: _t("Color field"),
-            name: "color_field",
-            type: "field",
-            availableTypes: ["integer"],
-            help: _t("Set an integer field to use colors with the badge."),
-        },
     ],
     isEmpty: (record, fieldName) => record.data[fieldName] === false,
     extractProps: (fieldInfo, dynamicInfo) => ({
         domain: dynamicInfo.domain,
         size: fieldInfo.options.size,
-        colorField: fieldInfo.options.color_field,
     }),
 };
 

--- a/addons/web/static/src/views/fields/badge_selection/badge_selection_field.xml
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection_field.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <div t-name="web.BadgeSelectionField" class="d-flex flex-wrap gap-1">
-        <t t-if="props.readonly">
-            <span t-esc="string" class="badge rounded-pill" t-att-class="badgeColor" t-att-raw-value="value" />
-        </t>
-        <t t-else="">
-            <t t-foreach="options" t-as="option" t-key="option[0]">
-                <span
-                    class="o_selection_badge btn btn-secondary mb-1 badge rounded-pill"
-                    t-att-class="{ 'o_badge_border active': value === option[0], 'btn-sm': props.size === 'sm', 'btn-lg': props.size === 'lg' }"
-                    t-att-value="stringify(option[0])"
-                    t-esc="option[1]"
-                    t-on-click="() => this.onChange(option[0])"
-                />
+    <t t-name="web.BadgeSelectionField">
+        <div class="d-flex flex-wrap gap-1 mb-3">
+            <t t-if="props.readonly">
+                <span t-esc="string" t-att-raw-value="value" />
             </t>
-        </t>
-    </div>
+            <t t-else="">
+                <t t-foreach="options" t-as="option" t-key="option[0]">
+                    <span
+                        class="o_selection_badge btn btn-secondary mb-1"
+                        t-att-class="{ 'active': value === option[0], 'btn-sm': props.size === 'sm', 'btn-lg': props.size === 'lg' }"
+                        t-att-value="stringify(option[0])"
+                        t-esc="option[1]"
+                        t-on-click="() => this.onChange(option[0])"
+                    />
+                </t>
+            </t>
+        </div>
+    </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/badge_selection/list_badge_selection_field.js
+++ b/addons/web/static/src/views/fields/badge_selection/list_badge_selection_field.js
@@ -1,0 +1,49 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { mergeClasses } from "@web/core/utils/classname";
+import { badgeSelectionField, BadgeSelectionField } from "./badge_selection_field";
+
+export class ListBadgeSelectionField extends BadgeSelectionField {
+    static template = "web.ListBadgeSelectionField";
+    static props = {
+        ...BadgeSelectionField.props,
+        colorField: { type: String, optional: true },
+    };
+    getBadgeClassNames(option = false) {
+        if (this.props.readonly) {
+            if (
+                this.props.colorField &&
+                Number.isInteger(this.props.record.data[this.props.colorField])
+            ) {
+                return `o_badge_color_${this.props.record.data[this.props.colorField]}`;
+            }
+            return mergeClasses({ "btn btn-secondary": this.value });
+        }
+        return mergeClasses({
+            "active o_badge_border": this.value === option[0],
+            "btn-sm": this.props.size === "sm",
+            "btn-lg": this.props.size === "lg",
+        });
+    }
+}
+
+export const listBadgeSelectionField = {
+    ...badgeSelectionField,
+    component: ListBadgeSelectionField,
+    supportedOptions: [
+        ...badgeSelectionField.supportedOptions,
+        {
+            label: _t("Color field"),
+            name: "color_field",
+            type: "field",
+            availableTypes: ["integer"],
+            help: _t("Set an integer field to use colors with the badge."),
+        },
+    ],
+    extractProps: (fieldInfo, dynamicInfo) => ({
+        ...badgeSelectionField.extractProps(fieldInfo, dynamicInfo),
+        colorField: fieldInfo.options.color_field,
+    }),
+};
+
+registry.category("fields").add("list.selection_badge", listBadgeSelectionField);

--- a/addons/web/static/src/views/fields/badge_selection/list_badge_selection_field.xml
+++ b/addons/web/static/src/views/fields/badge_selection/list_badge_selection_field.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.ListBadgeSelectionField" t-inherit="web.BadgeSelectionField" t-inherit-mode="primary">
+        <xpath expr="//div" position="attributes">
+            <attribute name="class" separator=" " remove="mb-3"/>
+        </xpath>
+        <xpath expr="//t[@t-if='props.readonly']/span[@t-esc='string']" position="attributes">
+            <attribute name="class">badge rounded-pill</attribute>
+            <attribute name="t-att-class">getBadgeClassNames()</attribute>
+        </xpath>
+        <xpath expr="//t[@t-if='props.readonly']/following-sibling::t[@t-else='']//span[@t-esc='option[1]']" position="attributes">
+            <attribute name="class" separator=" " add="badge rounded-pill"/>
+            <attribute name="t-att-class">getBadgeClassNames(option)</attribute>
+        </xpath>
+    </t>
+
+</templates>


### PR DESCRIPTION
PR [1] introduced the ability to set a color field to selection_badge
fields. This change breaks the badge selection style in various places.

Since the intended purpose of [1] was to introduce colors for this field
in the list views only, the current commit splits the intended changes
into a specialized field used in list views only.

[1]: https://github.com/odoo/odoo/pull/202908

## Before
<img width="872" height="516" alt="image" src="https://github.com/user-attachments/assets/414f0c75-ddf4-4b77-bfb2-62740c2bf826" />


## After
<img width="843" height="540" alt="image" src="https://github.com/user-attachments/assets/23d1ad47-9edb-41af-8409-2aa454be7ea0" />
