### PR TITLE
[FIX] mail: fix getOrFetch inconsistency

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -50,7 +50,7 @@ export class Thread extends Record {
                 request_list: fieldNames,
             });
             thread = this.get(data);
-            if (!thread.exists() || !thread.hasReadAccess) {
+            if (!thread?.exists()) {
                 return;
             }
         }


### PR DESCRIPTION
1. Ensure the thread is not undefined before calling exists.

2. `hasReadAccess` was only checked after the RPC, but if the thread data was already fetched the condition was not checked. The choice is made to remove the condition as it makes the code more flexible. The caller can always decide to check `hasReadAccess` afterwards if necessary.

How to reproduce: https://github.com/odoo/odoo/pull/220605