### PR TITLE
[FIX] point_of_sale: assign code to correct gift card program

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -892,7 +892,9 @@ patch(PosOrder.prototype, {
     processGiftCard(newGiftCardCode, points, expirationDate) {
         const partner_id = this.partner_id?.id || false;
         const product_id = this.get_selected_orderline().product_id.id;
-        const program = this.models["loyalty.program"].find((p) => p.program_type === "gift_card");
+        const program =
+            this.get_selected_orderline()._e_wallet_program_id ||
+            this.models["loyalty.program"].find((p) => p.program_type === "gift_card");
 
         let couponId;
         const couponData = {

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -128,6 +128,35 @@ registry.category("web_tour.tours").add("PhysicalGiftCardProgramSaleTour", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("MultiplePhysicalGiftCardProgramSaleTour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Gift Card"),
+            PosLoyalty.clickGiftCardProgram("Gift Cards1"),
+            PosLoyalty.createManualGiftCard("test-card-0000", 125),
+            PosLoyalty.clickGiftCardProgram("Gift Cards"),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "125"),
+            PosLoyalty.orderTotalIs("125"),
+            PosLoyalty.finalizeOrder("Cash", "125"),
+            ProductScreen.clickDisplayedProduct("Gift Card"),
+            PosLoyalty.clickGiftCardProgram("Gift Cards2"),
+            PosLoyalty.createManualGiftCard("test-card-0001", 125),
+            PosLoyalty.clickGiftCardProgram("Gift Cards2"),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "125"),
+            PosLoyalty.orderTotalIs("125"),
+            PosLoyalty.finalizeOrder("Cash", "125"),
+            ProductScreen.clickDisplayedProduct("Gift Card"),
+            PosLoyalty.clickGiftCardProgram("Gift Cards3"),
+            PosLoyalty.createManualGiftCard("test-card-0002", 125),
+            PosLoyalty.clickGiftCardProgram("Gift Cards3"),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "125"),
+            PosLoyalty.orderTotalIs("125"),
+            PosLoyalty.finalizeOrder("Cash", "125"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("GiftCardProgramInvoice", {
     steps: () =>
         [

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -180,6 +180,16 @@ export function createManualGiftCard(code, amount, date = false) {
     return steps;
 }
 
+export function clickGiftCardProgram(name) {
+    return [
+        {
+            content: `Click gift card program '${name}'`,
+            trigger: `button.selection-item:has(span:contains("${name}"))`,
+            run: "click",
+        },
+    ];
+}
+
 export function clickPhysicalGiftCard(code = "Sell physical gift card?") {
     return [
         {

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1813,6 +1813,33 @@ class TestUi(TestPointOfSaleHttpCommon):
         total_points = sum(coupon.points for coupon in gift_card_program.coupon_ids)
         self.assertEqual(total_points, 475, "Total points should be 425")
 
+    def test_gift_card_code_links_to_correct_program(self):
+        """
+        Test that the manual gift card sold has been correctly generated
+        with the correct assigned code.
+        """
+        LoyaltyProgram = self.env['loyalty.program']
+        # Deactivate all other programs to avoid interference and activate the gift_card_product_50
+        LoyaltyProgram.search([]).write({'pos_ok': False})
+        self.env.ref('loyalty.gift_card_product_50').write({'active': True})
+
+        # Create gift card programs
+        program1 = self.create_programs([('Gift Cards1', 'gift_card')])['Gift Cards1']
+        program2 = self.create_programs([('Gift Cards2', 'gift_card')])['Gift Cards2']
+        program3 = self.create_programs([('Gift Cards3', 'gift_card')])['Gift Cards3']
+
+        # Run the tour
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "MultiplePhysicalGiftCardProgramSaleTour",
+            login="pos_user"
+        )
+
+        self.assertTrue(len(program1.coupon_ids) == len(program2.coupon_ids) == len(program3.coupon_ids) == 1)
+        self.assertEqual(program1.coupon_ids.code, 'test-card-0000')
+        self.assertEqual(program2.coupon_ids.code, 'test-card-0001')
+        self.assertEqual(program3.coupon_ids.code, 'test-card-0002')
+
     def test_dont_grant_points_reward_order_lines(self):
         """
         Make sure that points granted per unit are only given


### PR DESCRIPTION
### Problem:
When selling a gift card via PoS, if multiple loyalty programs of type *Gift Card* exist, assigning a physical gift card code does not always link it to the correct program. As a result, the created gift card receives an automatically generated code instead of the one entered.

### How to reproduce:
* Create multiple loyalty programs of type *Gift Card*.
* Open a PoS session.
* Add a gift card product from one of the created programs.
* Assign a physical gift card code to it.
* Complete the sale.
* The created gift card will have a generated code.

opw-4910647
