### PR TITLE
[IMP] sale_gelato: depend on sale

### DIFF
--- a/addons/sale_gelato/__manifest__.py
+++ b/addons/sale_gelato/__manifest__.py
@@ -4,7 +4,7 @@
     'name': "Gelato",
     'summary': "Place orders through Gelato's print-on-demand service",
     'category': 'Sales/Sales',
-    'depends': ['sale_management', 'delivery'],
+    'depends': ['sale', 'delivery'],
     'data': [
         'data/product_data.xml',
         'data/delivery_carrier_data.xml',  # Depends on product_data.xml


### PR DESCRIPTION
By changing the dependence from 'sale_management' to 'sale' module, Gelato
can be installed on e-commerce without installing Sale app. Users on free
plan won't be moved to paid plan after enabling Gelato module as no second
app will be installed.
