### PR TITLE
[FIX] sale_stock: hide availability widget when move is cancelled

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -58,7 +58,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             line.qty_to_deliver = line.product_uom_qty - line.qty_delivered
             if line.state in ('draft', 'sent', 'sale') and line.is_storable and line.product_uom_id and line.qty_to_deliver > 0:
-                if line.state == 'sale' and not line.move_ids:
+                if line.state == 'sale' and all(m.state in ['done', 'cancel'] for m in line.move_ids):
                     line.display_qty_widget = False
                 else:
                     line.display_qty_widget = True


### PR DESCRIPTION
Issue
-----
The availability widget states "No future availability" when the backorder of a product has been cancelled, despite the product being available in stock.

Steps to reproduce
-----
- Create a stored product with some on hand quantity
- Create a SO for the product
- Register a partial delivery (or set the move quantity to 0)
- Cancel the backorder
- Go back to the SO

--> The widget is red and states that there is "No future availability". While the logic is sound, this is confusing the user because they have some qty in stock.

Solution
-----
The user has manually decided not to deliver the (full qty of) product. There is aready some logic to set the `display_qty_widget` field to False when the user deletes the move from the the picking.

https://github.com/odoo/odoo/blob/693e1ef2f934f58209a78787404d5c76be550af4/addons/sale_stock/models/sale_order_line.py#L61

Since the user specified that there is nothing left to deliver, we can extend the condition to include our use case. To do so, we can simply check the existence of a move that is not in a 'done' or 'cancel' state.

This will make the widget invisible because it is conditionally invisible.

https://github.com/odoo/odoo/blob/693e1ef2f934f58209a78787404d5c76be550af4/addons/sale_stock/static/src/widgets/qty_at_date_widget.xml#L7

-----
Ticket:
opw-4942277
