### PR TITLE
[FIX] website_blog: ensure modal opens on click

### DIFF
--- a/addons/website_blog/static/tests/tours/blog_context.js
+++ b/addons/website_blog/static/tests/tours/blog_context.js
@@ -31,7 +31,9 @@ registerWebsitePreviewTour(
         {
             content: "Click on Blog Post",
             trigger: "#o_new_content_menu_choices button[title='Blog Post']",
-            run: "click",
+            run() {
+                this.anchor.click();
+            },
         },
         {
             content: "Check in dialog current Selected Blog is 'aaa Blog Test'",


### PR DESCRIPTION
Test failure: TestWebsiteBlogUi.test_blog_context_and_social_media.

The tour 'blog_context_and_social_media' did not complete successfully because the `.modal-dialog .o_field_widget[name='blog_id']` selector was not found. Investigation revealed that using the standard `"click"` action failed to trigger the modal, likely due to the button being dynamically rendered or not fully ready when the step executed. Additionally, Odoo UI widgets and custom event handlers may require a direct DOM `.click()` call for proper interaction, as they can be sensitive to how events are dispatched.

To address this, we replaced the `"click"` action with `this.anchor.click()`, ensuring the click event is performed in a way that reliably opens the modal and allows the tour to proceed as expected.

runbot-226540
