### PR TITLE
[FIX] base_import: fix error on bank statement import cancellation

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -98,6 +98,10 @@ export class ImportAction extends Component {
     }
 
     exit(resIds) {
+        if(!resIds){
+            this.env.config.historyBack();
+            return;
+        }
         this.actionService.doAction({
             type: "ir.actions.act_window",
             name: _t("Imported records"),


### PR DESCRIPTION
Before commit:
- After uploading an Excel file, when user cancels a bank statement import, it caused an `InvalidDomainError` due to an invalid `resIds` value in the domain.

After  commit:
- This error is resolved and now the `Cancel` button validates `resIds` before passing it into the domain. If `resIds` are invalid, the user is navigated back instead.

Task : 4974749

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
