### PR TITLE
[FIX] im_livechat: no dirty form at end of test tour

### DIFF
--- a/addons/im_livechat/static/tests/tours/chatbot_step_type_clear_only.js
+++ b/addons/im_livechat/static/tests/tours/chatbot_step_type_clear_only.js
@@ -32,7 +32,7 @@ registry.category("web_tour.tours").add("change_chatbot_step_type", {
             run: "click",
         },
         {
-            trigger: ".o_form_view",
+            trigger: ".o_form_saved",
         },
     ],
 });


### PR DESCRIPTION
Tour "test_chatbot_clear_answers_on_step_type_change" could fail with following error before this commit:

```
Tour finished with a dirty form view being open.

Dirty form views are automatically saved when the page is closed,
which leads to stray network requests and inconsistencies.
```

The tour was saving the changes to form view but was not awaiting a trigger when the form is saved, thus the tour could end and still see form is dirty.

This commit replaces `.o_form_view` to `.o_form_saved` for awaiting the form is fully saved and not dirty at end of test tour.

Fixes runbot error 230296
