### PR TITLE
[FIX] purchase_requisition: Explicitly add company_id to generated vendor pricelist

### DIFF
--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -223,6 +223,7 @@ class PurchaseRequisitionLine(models.Model):
                 'product_id': self.product_id.id,
                 'product_tmpl_id': self.product_id.product_tmpl_id.id,
                 'price': self.price_unit,
+                'company_id': self.requisition_id.company_id.id,
                 'currency_id': self.requisition_id.currency_id.id,
                 'purchase_requisition_line_id': self.id,
             })


### PR DESCRIPTION
…
Description of the issue/feature this PR addresses: When creating a purchase requisition line to a purchase requisition, in the background a vendor pricelist item is generated. However, the company is not taken into account explicitly, but it defaults to the currently active company. Steps to reproduce:
- Create a blanket order (purchase requisition) in company A
- Add a line
- Confirm the blanket order
- Switch to company B, but keep company A active as well
- Add another line and save

Current behavior before PR:
The second line generated a vendor pricelist item is generated in company B.

Desired behavior after PR is merged:
The second line generated a vendor pricelist item is generated in company A.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
