### PR TITLE
[FIX] website: refresh ToC interaction on changing navbar's position

### DIFF
--- a/addons/website/static/src/builder/plugins/options/table_of_content_option.xml
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option.xml
@@ -14,11 +14,11 @@
 </t>
 
 <t t-name="website.TableOfContentNavbarOption">
-    <BuilderRow label.translate="Position">
+    <BuilderRow label.translate="Position" action="'navbarPosition'">
         <BuilderButtonGroup>
-            <BuilderButton icon="'fa-long-arrow-left'" title.translate="Left" action="'navbarPosition'" actionParam="'left'"/>
-            <BuilderButton icon="'fa-long-arrow-up'" title.translate="Top" action="'navbarPosition'" actionParam="'top'"/>
-            <BuilderButton icon="'fa-long-arrow-right'" title.translate="Right" action="'navbarPosition'" actionParam="'right'"/>
+            <BuilderButton icon="'fa-long-arrow-left'" title.translate="Left" actionParam="'left'"/>
+            <BuilderButton icon="'fa-long-arrow-up'" title.translate="Top" actionParam="'top'"/>
+            <BuilderButton icon="'fa-long-arrow-right'" title.translate="Right" actionParam="'right'"/>
         </BuilderButtonGroup>
     </BuilderRow>
     <BuilderRow label.translate="Sticky">

--- a/addons/website/static/src/snippets/s_table_of_content/table_of_content.edit.js
+++ b/addons/website/static/src/snippets/s_table_of_content/table_of_content.edit.js
@@ -1,0 +1,20 @@
+import { registry } from "@web/core/registry";
+import { TableOfContent } from "./table_of_content";
+
+export const TableOfContentEdit = (I) =>
+    class extends I {
+        getConfigurationSnapshot() {
+            let snapshot = super.getConfigurationSnapshot();
+            if (this.el.classList.contains("s_table_of_content_horizontal_navbar")) {
+                snapshot = JSON.parse(snapshot || "{}");
+                snapshot.horizontalNavbar = true;
+                snapshot = JSON.stringify(snapshot);
+            }
+            return snapshot;
+        }
+    };
+
+registry.category("public.interactions.edit").add("website.table_of_content", {
+    Interaction: TableOfContent,
+    mixin: TableOfContentEdit,
+});

--- a/addons/website/static/src/snippets/s_table_of_content/table_of_content.js
+++ b/addons/website/static/src/snippets/s_table_of_content/table_of_content.js
@@ -247,9 +247,3 @@ patch(AnchorSlide.prototype, {
 registry
     .category("public.interactions")
     .add("website.table_of_content", TableOfContent);
-
-registry
-    .category("public.interactions.edit")
-    .add("website.table_of_content", {
-        Interaction: TableOfContent,
-    });


### PR DESCRIPTION
To reproduce the issue:
- Open Website and start editing
- Drop a table of content snippet and click on its navbar
- Change the navbar's position from left to top
- Scroll down

=> Website's main navbar appears on top of the table's navbar and hides
it. We change the snapshot system's logic to refresh the table of content
interaction when we change the position (i.e. switch class from s_table_of_content_horizontal_navbar to s_table_of_content_vertical_navbar).
This commit follows the [html_builder refactoring].
Related to task-4367641

[html_builder refactoring]: odoo/odoo@9fe45e2b7ddb