### PR TITLE
[IMP] mail: less spacing in discuss sidebar

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -81,81 +81,135 @@ $o-discuss-talkingColor: lighten($success, 10%);
     outline: 1px solid $o-gray-300;
 }
 
-.o-gap-0_5 {
-    gap: map-get($spacers, 1) / 2;
-}
+$o-mail-spacers-sizes: () !default;
+$o-mail-spacers-sizes: map-merge(
+    $o-mail-spacers-sizes,
+    (
+        "0_5": map-get($spacers, 1) / 2,
+        "1_5": (map-get($spacers, 1) + map-get($spacers, 2)) / 2,
+        "2_5": (map-get($spacers, 2) + map-get($spacers, 3)) / 2,
+        "3_5": (map-get($spacers, 3) + map-get($spacers, 4)) / 2,
+        "4_5": (map-get($spacers, 4) + map-get($spacers, 5)) / 2,
+    )
+);
 
-.o-mx-0_5 {
-    margin-left: map-get($spacers, 1) / 2;
-    margin-right: map-get($spacers, 1) / 2;
-}
+$o-mail-rounded-sizes: () !default;
+$o-mail-rounded-sizes: map-merge(
+    $o-mail-rounded-sizes,
+    (
+        "bubble": calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4),
+    )
+);
 
-.o-my-0_5 {
-    margin-top: map-get($spacers, 1) / 2;
-    margin-bottom: map-get($spacers, 1) / 2;
-}
+$o-mail-utilities: () !default;
+$o-mail-utilities: map-merge(
+    $o-mail-utilities,
+    (
+        "o-gap": (
+            property: gap,
+            class: o-gap,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-m": (
+            property: margin,
+            class: o-m,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-mx": (
+            property: margin-left margin-right,
+            class: o-mx,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-my": (
+            property: margin-top margin-bottom,
+            class: o-my,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-mt": (
+            property: margin-top,
+            class: o-mt,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-me": (
+            property: margin-right,
+            class: o-me,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-mb": (
+            property: margin-bottom,
+            class: o-mb,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-ms": (
+            property: margin-left,
+            class: o-ms,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-p": (
+            property: padding,
+            class: o-p,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-px": (
+            property: padding-left padding-right,
+            class: o-px,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-py": (
+            property: padding-top padding-bottom,
+            class: o-py,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-pt": (
+            property: padding-top,
+            class: o-pt,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-pe": (
+            property: padding-right,
+            class: o-pe,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-pb": (
+            property: padding-bottom,
+            class: o-pb,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-ps": (
+            property: padding-left,
+            class: o-ps,
+            values: $o-mail-spacers-sizes,
+        ),
+        "o-rounded": (
+            property: border-radius,
+            class: o-rounded,
+            values: $o-mail-rounded-sizes,
+        ),
+        "o-rounded-top": (
+            property: border-top-left-radius border-top-right-radius,
+            class: o-rounded-top,
+            values: $o-mail-rounded-sizes,
+        ),
+        "o-rounded-end": (
+            property: border-top-right-radius border-bottom-right-radius,
+            class: o-rounded-end,
+            values: $o-mail-rounded-sizes,
+        ),
+        "o-rounded-bottom": (
+            property: border-bottom-right-radius border-bottom-left-radius,
+            class: o-rounded-bottom,
+            values: $o-mail-rounded-sizes,
+        ),
+        "o-rounded-start": (
+            property: border-bottom-left-radius border-top-left-radius,
+            class: o-rounded-start,
+            values: $o-mail-rounded-sizes,
+        ),
+    ),
+);
 
-.o-mt-0_5 {
-    margin-top: map-get($spacers, 1) / 2;
-}
-
-.o-px-0_5 {
-    padding-left: map-get($spacers, 1) / 2;
-    padding-right: map-get($spacers, 1) / 2;
-}
-
-.o-py-0_5 {
-    padding-top: map-get($spacers, 1) / 2;
-    padding-bottom: map-get($spacers, 1) / 2;
-}
-
-.o-ps-1_5 {
-    padding-left: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
-}
-
-.o-py-1_5 {
-    padding-top: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
-    padding-bottom: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
-}
-
-.o-p-1_5 {
-    padding: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
-}
-
-.o-pt-0_5 {
-    padding-top: map-get($spacers, 1) / 2;
-}
-
-.o-p-1_5 {
-    padding: (map-get($spacers, 1) + map-get($spacers, 2)) / 2 !important;
-}
-
-.o-hover-text-underline:hover {
-    text-decoration: underline;
-}
-
-.o-rounded-bubble {
-    border-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
-}
-
-.o-rounded-top-bubble {
-    border-top-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
-    border-top-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
-}
-
-.o-rounded-end-bubble {
-    border-top-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
-    border-bottom-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
-}
-
-.o-rounded-bottom-bubble {
-    border-bottom-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
-    border-bottom-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
-}
-
-.o-rounded-start-bubble {
-    border-bottom-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
-    border-top-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
+@each $key, $utility in $o-mail-utilities {
+    @include generate-utility($utility)
 }
 
 .o-scrollbar-thin {

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -21,6 +21,7 @@
     padding: 3px 4px;
 
     &.o-compact {
+        top: -4px;
         right: -2px;
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto o-scrollbar-thin flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor gap-1" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto o-scrollbar-thin flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor o-gap-0_5" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
             <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 mt-1 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
                 <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss.isSidebarCompact }">
                     <t name="options-btn">

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.DiscussSidebarMailboxes">
-        <div class="d-flex flex-column flex-grow-0 o-gap-0_5 mt-1 bg-inherit">
+        <div class="d-flex flex-column flex-grow-0 o-gap-0_5 bg-inherit">
             <Mailbox mailbox="store.inbox"/>
             <Mailbox mailbox="store.starred"/>
             <Mailbox mailbox="store.history"/>
@@ -23,7 +23,7 @@
 
     <t t-name="mail.Mailbox.main">
         <button
-            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-baseline px-0 mx-2 border-0 rounded-3 fw-normal text-reset"
+            class="o-mail-DiscussSidebar-item o-mail-Mailbox btn d-flex align-items-baseline px-0 o-mx-2_5 border-0 rounded-3 fw-normal text-reset"
             t-att-class="{
                 'bg-inherit': mailbox.notEq(store.discuss.thread),
                 'o-active': mailbox.eq(store.discuss.thread),
@@ -36,14 +36,14 @@
             t-on-click="(ev) => this.openThread(ev)"
             t-ref="root"
         >
-            <ThreadIcon className="'bg-inherit opacity-75 ' + (store.discuss.isSidebarCompact ? '' : 'mx-2 pt-1')" thread="mailbox" size="store.discuss.isSidebarCompact ? 'large' : 'medium'"/>
+            <ThreadIcon className="'bg-inherit opacity-75 ' + (store.discuss.isSidebarCompact ? '' : 'mx-2 pt-1')" thread="mailbox" size="'medium'"/>
             <t t-if="!store.discuss.isSidebarCompact">
                 <div class="me-2 text-truncate text-muted small" t-esc="mailbox.display_name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>
             </t>
             <t t-if="mailbox.counter > 0" t-call="mail.discuss_badge">
                 <t t-set="counter" t-value="mailbox.counter"/>
-                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebar-badge shadow-sm ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'mx-1')"/>
+                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebar-badge shadow-sm ' + (store.discuss.isSidebarCompact ? 'position-absolute o-compact' : 'mx-1')"/>
                 <t t-set="counterClass" t-value="(mailbox.id === 'starred' ? 'o-muted' : '')"/>
                 <t t-set="floating" t-value="store.discuss.isSidebarCompact"/>
             </t>

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -15,6 +15,6 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.startMeetingButton">
-        <button class="btn btn-primary rounded-3 d-flex align-items-center gap-1" t-att-class="{ 'px-1 py-2': store.discuss.isSidebarCompact, 'btn-sm mx-5': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75" t-att-class="{ 'fa-lg': store.discuss.isSidebarCompact }"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
+        <button class="btn btn-primary rounded-3 d-flex align-items-center gap-1" t-att-class="{ 'o-px-1_5 py-2': store.discuss.isSidebarCompact, 'btn-sm mx-5': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -17,7 +17,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCallParticipants.main">
-        <div class="o-mail-DiscussSidebarCallParticipants d-flex py-1 bg-inherit" t-ref="root" t-att-class="{
+        <div class="o-mail-DiscussSidebarCallParticipants d-flex pb-1 bg-inherit" t-ref="root" t-att-class="{
             'justify-content-center': compact,
             'ps-3 pe-2': props.compact === undefined and !compact,
             'px-2': props.compact === false,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -77,7 +77,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 
 .o-mail-DiscussSidebar-unreadIndicator {
     font-size: 0.4rem;
-    left: -3px;
+    left: 0px;
 
     .o-mail-DiscussSidebarChannel-container.o-bordered & {
         &.o-mail-DiscussSidebarChannel, &.o-compact {
@@ -86,7 +86,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
     }
 
     .o-mail-DiscussSidebarSubchannel &:not(.o-compact) {
-        left: map-get($spacers, 2) + map-get($spacers, 1) / 2;
+        left: (map-get($spacers, 2) + map-get($spacers, 3)) / 2;
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
         <Dropdown t-if="store.discuss.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm o-rounded-bubble'" manual="true">
-            <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75 bg-transparent" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-lg fa-fw fa-search"/></button>
+            <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75 bg-transparent" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-fw fa-search"/></button>
             <t t-set-slot="content">
                 <div class="p-2" t-ref="search-floating">
                     <span class="text-muted user-select-none">Find or start a conversation</span>
@@ -43,14 +43,14 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory.main">
-        <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'm-2 position-relative': store.discuss.isSidebarCompact, 'mt-1 ms-1 me-2 pe-1': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
+        <div class="o-mail-DiscussSidebarCategory d-flex align-items-center" t-att-class="{ 'mx-2 my-1 position-relative': store.discuss.isSidebarCompact, 'mt-1 ms-1 me-2 pe-1': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
             <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start opacity-100-hover" t-att-class="{ 'align-items-baseline opacity-75 o-gap-0_5': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact opacity-50 gap-1': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
                 <t t-if="store.discuss.isSidebarCompact">
                     <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xxsmaller" t-att-class="{
                         'oi oi-chevron-down opacity-75': category.open,
                         'oi oi-chevron-right opacity-50': !category.open,
                     }"/>
-                    <span class="rounded p-1" t-att-class="{ 'opacity-50': !category.open }"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin fs-3"/><i t-else="" class="fa-fw fa-lg fs-3" t-att-class="category.icon ?? 'fa fa-user'"/></span>
+                    <span class="rounded p-1" t-att-class="{ 'opacity-50': !category.open }"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin"/><i t-else="" class="fa-fw fa-lg" t-att-class="category.icon ?? 'fa fa-user'"/></span>
                 </t>
                 <t t-else="">
                     <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa fa-fw fa-circle-o-notch fa-spin opacity-50"/></span>
@@ -59,7 +59,7 @@
                 </t>
             </button>
             <t t-if="actions.length and !store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarCategory.actions"/>
-            <div t-if="!category.open and store.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge shadow-sm badge rounded-pill o-discuss-badge fw-bold" t-att-class="{ 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact, 'me-1': !store.discuss.isSidebarCompact }">
+            <div t-if="!category.open and store.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge shadow-sm badge rounded-pill o-discuss-badge fw-bold" t-att-class="{ 'position-absolute o-compact': store.discuss.isSidebarCompact, 'me-1': !store.discuss.isSidebarCompact }">
                 <t t-esc="store.getDiscussSidebarCategoryCounter(category.id)"/>
             </div>
         </div>
@@ -95,7 +95,7 @@
                     </t>
                 </Dropdown>
                 <t t-else="" t-call="mail.DiscussSidebarChannel.main"/>
-                <ul t-if="subChannels.length > 0" class="list-unstyled position-relative flex-grow-1 my-0 d-flex flex-column gap-1" t-att-class="{ 'mb-1': store.discuss.isSidebarCompact }">
+                <ul t-if="subChannels.length > 0" class="list-unstyled position-relative flex-grow-1 my-0 d-flex flex-column o-gap-0_5">
                     <t t-foreach="subChannels" t-as="sub" t-key="sub.localId">
                         <DiscussSidebarSubchannel t-if="showThread(sub)" thread="sub" isFirst="sub_first or !thread.discussAppCategory.open"/>
                     </t>
@@ -122,11 +122,11 @@
     <t t-name="mail.DiscussSidebarSubchannel.main">
         <li class="o-mail-DiscussSidebarSubchannel d-flex align-items-center flex-grow-1 position-relative" t-att-class="{ 'p-0': !store.discuss.isSidebarCompact, 'pt-1': !store.discuss.isSidebarCompact and props.isFirst }" t-ref="root">
             <t t-if="!store.discuss.isSidebarCompact">
-                <svg t-if="props.isFirst" class="position-absolute opacity-75" style="top: -4px;" xmlns="http://www.w3.org/2000/svg" width="10" height="20" viewBox="0 0 10 20">
+                <svg t-if="props.isFirst" class="position-absolute opacity-75" style="top: -8px;" xmlns="http://www.w3.org/2000/svg" width="10" height="25" viewBox="0 0 10 25">
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
-                <svg t-else="" class="position-absolute opacity-75" style="top: -20px;" xmlns="http://www.w3.org/2000/svg" width="10" height="34" viewBox="0 0 10 34">
+                <svg t-else="" class="position-absolute opacity-75" style="top: -16px;" xmlns="http://www.w3.org/2000/svg" width="10" height="29" viewBox="0 0 10 29">
                     <line x1="0" y1="3" x2="0" y2="100%" stroke="currentColor" stroke-width="3"/>
                     <line x1="0" y1="100%" x2="100%" y2="100%" stroke="currentColor" stroke-width="3"/>
                 </svg>
@@ -144,7 +144,7 @@
                 }" t-att-style="store.discuss.isSidebarCompact ? 'text-overflow: clip;' : ''"/>
                 <span class="flex-grow-1"/>
                 <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.actions"/>
-                <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge shadow-sm badge rounded-pill o-discuss-badge fw-bold top-0 {{thread.selfMember?.mute_until_dt ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
+                <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge shadow-sm badge rounded-pill o-discuss-badge fw-bold {{thread.selfMember?.mute_until_dt ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
             </button>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.selfMember?.mute_until_dt and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
         </li>
@@ -161,7 +161,7 @@
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0" t-att-class="{ 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : thread.displayName">
-                <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-3" style="width:32px;height:32px;" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
+                <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-3" style="width:26px;height:26px;" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded-3 object-fit-cover shadow-sm" t-att-class="threadAvatarAttClass" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.group_public_id)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                     <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border shadow-sm'"/>
@@ -177,7 +177,7 @@
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.selfMember?.mute_until_dt and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
             <t t-if="thread.importantCounter > 0 and (showingActions.isOpen or store.discuss.isSidebarCompact or !hover.isHover)" t-call="mail.discuss_badge">
                 <t t-set="counter" t-value="thread.importantCounter"/>
-                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge shadow-sm flex-shrink-0 fw-bold ' + (thread.selfMember?.mute_until_dt ? 'o-muted' : '') + ' ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : showingActions.isOpen ? 'ms-1 me-0' : 'ms-1 me-2')"/>
+                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge shadow-sm flex-shrink-0 fw-bold ' + (thread.selfMember?.mute_until_dt ? 'o-muted' : '') + ' ' + (store.discuss.isSidebarCompact ? 'position-absolute o-compact' : showingActions.isOpen ? 'ms-1 me-0' : 'ms-1 me-2')"/>
                 <t t-set="floating" t-value="store.discuss.isSidebarCompact"/>
             </t>
             <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.actions"/>


### PR DESCRIPTION
Before this commit, discuss sidebar content took a lot of space. This mostly comes from big avatar and lots of spacing.

This commit improves sidebar UI as follow:
- smaller avatars, from 32px to 26px, matching systray user avatar.
- reduced spacing between sidebar items and categories

Compact mode of sidebar has also smaller avatars, therefore icons and buttons have spacing adjusted to match overall sizing of items.
Channel sub-thread svg lines have been adapted with reduced spacing.
Unread indicator have been moved closer to avatar to compensate with reduced avatar, and discuss badges have also their size reduced, again to accomodate with smaller avatar in order to not overlap with IM status. The size now matches the systray counters, as they were bigger before this commit.

Part of Task-4967071

Before / After
<img width="296" height="893" alt="Screenshot 2025-07-28 at 21 59 48" src="https://github.com/user-attachments/assets/904b75fe-4a35-4690-b33c-d9137ada2c7c" /> <img width="299" height="889" alt="Screenshot 2025-07-28 at 22 33 00" src="https://github.com/user-attachments/assets/92493591-4585-4c78-80ee-5e827eed1a43" />


Before / After
<img width="63" height="891" alt="Screenshot 2025-07-28 at 21 59 55" src="https://github.com/user-attachments/assets/3dff2b5d-ee6e-4c51-ac75-af564e060e9c" /> <img width="55" height="895" alt="Screenshot 2025-07-28 at 22 32 48" src="https://github.com/user-attachments/assets/73b1185d-bac6-4ca3-9036-ae46e14cec05" />
