### PR TITLE
[FIX] survey: handle missing question/page ID on layout change

### DIFF
--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -643,6 +643,8 @@ class Survey(models.Model):
             if page_or_question_id == 0:
                 return pages_or_questions[0]
 
+        if page_or_question_id not in pages_or_questions.ids:
+            return pages_or_questions[0] if pages_or_questions else Question
         current_page_index = pages_or_questions.ids.index(page_or_question_id)
 
         # Get previous and we are on first page  OR Get Next and we are on last page


### PR DESCRIPTION
**Description**

When a user is taking a survey and an admin modifies the survey layout
while the user session is active, the user encounters a crash that
prevents them from continuing the survey.

---
**Steps to reproduce:**
1. User starts taking a survey with 'page_per_question' layout
2. Admin changes survey layout to 'page_per_section' while user is mid-survey
3. User tries to navigate (next/previous) or continue the survey
4. User gets "Internal Server Error" (500 error) instead of survey questions
---
**Problem:**
Users lose their survey progress and cannot complete surveys when admins
make layout changes during active user sessions.

---
**Solution:**
When layout conflicts occur, This commit adds a fallback to handle this case gracefully by defaulting
to the first valid question/page or returning True when checking for the last.

opw-4814177