### PR TITLE
[FIX] spreadsheet: make “Dashboard” tab visible for selector tests

### DIFF
--- a/addons/spreadsheet/static/tests/helpers/data.js
+++ b/addons/spreadsheet/static/tests/helpers/data.js
@@ -259,6 +259,11 @@ export class SpreadsheetMixin extends models.Model {
                 display_name: "Spreadsheets",
                 allow_create: true,
             },
+            {
+                model: "spreadsheet.dashboard",
+                display_name: "Dashboards",
+                allow_create: true,
+            },
         ];
     }
 }


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- Enterprise added a “blank dashboard” option in the spreadsheet selector so users can create a new dashboard directly; our community tests need to exercise that flow by exposing the dashboard in the selector.

**Current behavior before PR:**

- The spreadsheet selector in community tests does not expose the `spreadsheet.dashboard` page (its `allow_create` flag is false), so the “Dashboard” notebook tab is never rendered and the creation flow can’t be tested.

**Desired behavior after PR is merged:**

- In community tests we set `allow_create: true` for `spreadsheet.dashboard` in `static/tests/helpers/data.js`, causing the “Dashboard” tab to appear and allowing the selector‐to‐dashboard creation flow to be validated.


Task: [4948417](https://www.odoo.com/odoo/project/2328/tasks/4948417)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
