### PR TITLE
[FIX] website: reset condition if dependency field becomes unavailable

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -51,6 +51,7 @@ export class FormOptionPlugin extends Plugin {
         "applyFormModel",
         "addHiddenField",
         "fetchAuthorizedFields",
+        "loadFieldOptionData",
         "prepareFields",
         "replaceField",
         "prepareConditionInputs",
@@ -1077,7 +1078,8 @@ export class MultiCheckboxDisplayAction extends BuilderAction {
 }
 export class SetLabelTextAction extends BuilderAction {
     static id = "setLabelText";
-    apply({ editingElement: fieldEl, value }) {
+    static dependencies = ["websiteFormOption"];
+    async apply({ editingElement: fieldEl, value }) {
         const labelEl = fieldEl.querySelector(".s_website_form_label_content");
         labelEl.textContent = value;
         if (isFieldCustom(fieldEl)) {
@@ -1087,17 +1089,16 @@ export class SetLabelTextAction extends BuilderAction {
                 multiple.dataset.name = value;
             }
             const inputEls = fieldEl.querySelectorAll(".s_website_form_input");
-            const previousInputName = fieldEl.name;
+            const previousInputName = inputEls[0].name;
             inputEls.forEach((el) => (el.name = value));
 
             // Synchronize the fields whose visibility depends on this field
-            const dependentEls = fieldEl
-                .closest("form")
-                .querySelectorAll(
-                    `.s_website_form_field[data-visibility-dependency="${CSS.escape(
-                        previousInputName
-                    )}"]`
-                );
+            const dependentEls = fieldEl.closest("form").querySelectorAll(
+                `.s_website_form_field[data-visibility-dependency="${CSS.escape(
+                    previousInputName
+                )}"],
+                    .s_website_form_field[data-visibility-dependency="${CSS.escape(value)}"]`
+            );
             for (const dependentEl of dependentEls) {
                 if (findCircular(fieldEl, dependentEl)) {
                     // For all the fields whose visibility depends on this
@@ -1110,15 +1111,21 @@ export class SetLabelTextAction extends BuilderAction {
                     dependentEl.dataset.visibilityDependency = value;
                 }
             }
-            /* TODO: make sure this is handled on non-preview:
-            if (!previewMode) {
-                // TODO: @owl-options is this still true ?
-                // As the field label changed, the list of available visibility
-                // dependencies needs to be updated in order to not propose a
-                // field that would create a circular dependency.
-                this.rerender = true;
-            }
-            */
+            const fieldWithVisibilityDependencyEls = [
+                ...fieldEl.closest("form").querySelectorAll("[data-visibility-dependency]"),
+            ];
+            await Promise.all(
+                fieldWithVisibilityDependencyEls.map(async (fieldWithConditionEl) => {
+                    const conditionFieldName = fieldWithConditionEl.dataset.visibilityDependency;
+                    const fieldData = await this.dependencies.websiteFormOption.loadFieldOptionData(
+                        fieldWithConditionEl
+                    );
+                    const names = fieldData.conditionInputs.map((entry) => CSS.escape(entry.name));
+                    if (!names.includes(conditionFieldName)) {
+                        deleteConditionalVisibility(fieldWithConditionEl);
+                    }
+                })
+            );
         }
     }
     getValue({ editingElement: fieldEl }) {

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -203,3 +203,52 @@ test("Set 'Message' as form success action and show/hide the message preview", a
     await contains(".options-container [data-action-id='toggleEndMessage']").click();
     expect(":iframe .o_show_form_success_message").toHaveCount(0);
 });
+
+const formWithCondition = `
+<section class="s_website_form"><form data-model_name="mail.mail">
+     <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="char">
+         <div class="row s_col_no_resize s_col_no_bgcolor">
+             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="first">
+                 <span class="s_website_form_label_content">a</span>
+             </label>
+             <div class="col-sm">
+                 <input class="form-control s_website_form_input" type="text" name="a" id="first"/>
+             </div>
+         </div>
+     </div>
+     <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom s_website_form_field_hidden_if d-none" data-type="char" data-visibility-dependency="a" data-visibility-comparator="set">
+         <div class="row s_col_no_resize s_col_no_bgcolor">
+             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="second">
+                 <span class="s_website_form_label_content">b</span>
+             </label>
+             <div class="col-sm">
+                 <input class="form-control s_website_form_input" type="text" name="b" id="second"/>
+             </div>
+         </div>
+     </div>
+     <div class="s_website_form_submit">
+        <div class="s_website_form_label"/>
+        <a>Submit</a>
+    </div>
+</form></section>
+`;
+
+test("Remove visibility dependency on field unavailable (change first)", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    const { getEditor } = await setupWebsiteBuilder(formWithCondition);
+    getEditor();
+    await contains(":iframe input[name=a]").click();
+    await contains("[data-label=Label] input").click();
+    await contains("[data-label=Label] input").edit("b");
+    expect(":iframe .s_website_form_field:not([data-visibility-dependency])").toHaveCount(2);
+});
+
+test("Remove visibility dependency on field unavailable (change second)", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    const { getEditor } = await setupWebsiteBuilder(formWithCondition);
+    getEditor();
+    await contains(":iframe input[name=b]").click();
+    await contains("[data-label=Label] input").click();
+    await contains("[data-label=Label] input").edit("a");
+    expect(":iframe .s_website_form_field:not([data-visibility-dependency])").toHaveCount(2);
+});


### PR DESCRIPTION
Since the `html_builder`, the dependency field did not get unselected when it became unavailable for selection after a label rename.

This commit removes the conditional visibility on a field in such a case.

Steps to reproduce:
- Drop a Form snippet
- Add a text field named "A"
- Add a text field named "B"
- Add a conditional visibility on "B" that relies on "A"
- Rename "B" to "A"

=> The conditional visibility remained applied and, upon save, this led to errors because of the self-reference.

task-4367641
