### PR TITLE
[FIX] account: prevent error when currency rate is not positive

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2447,6 +2447,19 @@ class AccountMove(models.Model):
                     raise ValidationError(_("This entry contains taxes that are not compatible with your fiscal position. Check the country set in fiscal position and in your tax configuration."))
                 raise ValidationError(_("This entry contains one or more taxes that are incompatible with your fiscal country. Check company fiscal country in the settings and tax country in taxes configuration."))
 
+    @api.constrains('invoice_currency_rate')
+    def _check_invoice_currency_rate(self):
+        """Ensure the currency rate is strictly positive when invoice currency differs from company currency."""
+        for move in self:
+            if (
+                move.currency_id
+                and move.company_id
+                and move.currency_id != move.company_id.currency_id
+                and move.is_invoice(include_receipts=True)
+                and move.invoice_currency_rate <= 0
+            ):
+                raise ValidationError(_("The currency rate must be strictly positive."))
+
     # -------------------------------------------------------------------------
     # CATALOG
     # -------------------------------------------------------------------------

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -661,7 +661,7 @@ class AccountMoveLine(models.Model):
     def _compute_currency_rate(self):
         for line in self:
             if line.move_id.is_invoice(include_receipts=True):
-                line.currency_rate = line.move_id.invoice_currency_rate
+                line.currency_rate = line.move_id.invoice_currency_rate or 1.0
             elif line.currency_id:
                 line.currency_rate = self.env['res.currency']._get_conversion_rate(
                     from_currency=line.company_currency_id,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3,7 +3,7 @@
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import Form, tagged
 from odoo import fields, Command
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 from collections import defaultdict
 from unittest.mock import patch
@@ -4792,3 +4792,20 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             for currency in (currency_a, currency_b):
                 move_form.currency_id = currency
         self.assertEqual(invoice.line_ids[0].balance, initial_balance, "Balance with original currency should be the same.")
+
+    def test_invoice_currency_rate_onchange_sets_to_one(self):
+        """ Ensure that invoice_currency_rate is set to 1 if set to 0 or negative for foreign currency invoices. """
+        invoice = self.invoice
+        invoice.currency_id = self.other_currency
+
+        # Test invoice_currency_rate with 0 value
+        with self.assertRaises(ValidationError):
+            with Form(invoice) as move_form:
+                move_form.invoice_currency_rate = 0
+        self.assertEqual(invoice.invoice_currency_rate, 2.0)
+
+        # Test invoice_currency_rate with negative value
+        with self.assertRaises(ValidationError):
+            with Form(invoice) as move_form:
+                move_form.invoice_currency_rate = -420
+        self.assertEqual(invoice.invoice_currency_rate, 2.0)


### PR DESCRIPTION
Currently, an error occurs when a user tries to save an invoice with a currency rate of 0.

Steps to reproduce:
- Install `Invoicing` and enable at least 2 currencies.
- Open an Invoice and change currency to something other than USD.
- Now change the currency rate displayed to 0 and save.

Error:
`ZeroDivisionError: float division by zero`

Cause:
- Error occurs due to a recent [feature](https://github.com/odoo/odoo/pull/214308) that allows changing currency rate.
- Error occurred because the user set the currency rate to `0`, and line [1] attempted a division by zero, resulting in the error.

Solution:
- Added a constraint that restricts the currency rate and raise validation.
- Added a default value for the currency rate in cases where the rate might be 0.

[1]:
https://github.com/odoo/odoo/blob/698e71b3a5b35fec5c7a27f2487df0e368c541b3/addons/account/models/account_move_line.py#L1505

sentry-6762861372,6787738443
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
