### PR TITLE
[FIX] base: ir_ui_view: invalid locators in nested move xpath

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -320,6 +320,20 @@ actual arch.
 
     @api.depends('arch', 'inherit_id')
     def _compute_invalid_locators(self):
+        def assess_locator(source, spec):
+            with suppress(ValidationError):  # Syntax error
+                # If locate_node returns None here:
+                # Invalid expression: Ok Syntax, but cannot be anchored to the parent view.
+                node = self.locate_node(source, spec)
+
+            if node is None:
+                return {
+                    "tag": spec.tag,
+                    "attrib": dict(spec.attrib),
+                    "sourceline": spec.sourceline,
+                }
+            return None
+
         self.invalid_locators = []
         for view in self:
             if not view.inherit_id or not view.arch:
@@ -347,23 +361,23 @@ actual arch.
                 if spec.tag == 'data':
                     specs.extend(spec)
                     continue
-                # Capture 'move' nodes to handles cases where move operations are nested within other xpath operations
-                # <xpath expr="parent" position="after">
-                #   <xpath expr="child" position="move"/>
-                # </xpath>
-                specs.extend(c for c in spec if c.get("position") == 'move')
-                node = None
-                with suppress(ValidationError):  # Syntax error
-                    # If locate_node returns None here:
-                    # Invalid expression: Ok Syntax, but cannot be anchored to the parent view.
-                    node = self.locate_node(source, spec)
-                if node is None:
-                    invalid_locators.append({
-                        "tag": spec.tag,
-                        "attrib": dict(spec.attrib),
-                        "sourceline": spec.sourceline
-                    })
+
+                if invalid_locator := assess_locator(source, spec):
+                    invalid_locators.append(invalid_locator)
                 else:
+                    position, mode = spec.get("position"), spec.get("mode")
+                    for sub_spec in spec:
+                        sub_position = sub_spec.get("position")
+                        if sub_position == "move" and (position != "replace" or mode != "inner"):
+                            if invalid_move := assess_locator(source, sub_spec):
+                                invalid_locators.append(invalid_move)
+                        elif sub_position:
+                            invalid_locators.append({
+                                "tag": sub_spec.tag,
+                                "attrib": dict(sub_spec.attrib),
+                                "sourceline": sub_spec.sourceline,
+                            })
+
                     try:
                         # Since subsequent xpaths may be dependent on previous xpaths, we apply the spec.
                         source = apply_inheritance_specs(source, spec)

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -543,6 +543,51 @@ class TestViewInheritance(ViewCase):
         self.assertEqual(child_view3.invalid_locators, [{'tag': 'xpath', 'attrib': {'expr': "//div[hasclass('parasite')]", 'position': 'inside'}, 'sourceline': 2}])
         self.assertEqual(child_view4.invalid_locators, False)
 
+    def test_nested_move_invalid_locator(self):
+        """ Check ir.ui.view's invalid_locators field is computed correctly."""
+        base_view_arch = """
+            <form string="View">
+                <div name="div1">
+                    <div>
+                        <span />
+                    </div>
+                </div>
+            </form>
+        """
+        base_view = self.makeView('invalid_xpath_base_view', arch=base_view_arch)
+
+        child_view = self.View.create({
+            'model': self.model,
+            'name': "child_view",
+            'inherit_id': base_view.id,
+            'priority': 10,
+            'active': False,
+            'arch': """
+            <data>
+                <xpath expr="/form/div/div" position="replace">
+                    <xpath expr="/form/div/div/span" position="move" />
+                </xpath>
+            </data>
+            """,
+        })
+        self.assertEqual(child_view.invalid_locators, False)
+
+        child_view.arch = """
+            <data>
+                <xpath expr="/form/div/div" position="replace">
+                    <xpath expr="/form/div/div/h1" position="move" />
+                </xpath>
+            </data>"""
+        self.assertEqual(child_view.invalid_locators,
+            [{
+                'attrib': {
+                    'expr': '/form/div/div/h1',
+                    'position': 'move',
+                },
+                'sourceline': 3,
+                'tag': 'xpath',
+            }])
+
     def test_broken_hierarchy_locators(self):
         self.patch(self.env.registry.get("ir.ui.view"), "_check_xml", lambda self: True)
         view = self.View.create({


### PR DESCRIPTION
Have an arch that will move a subchild of a parent effectively replacing the parent

```xml
<data>
	<xpath expr="/form/div/div" position="replace">
		<xpath expr="/form/div/div/span" position="move" />
	</xpath>
</data>
```

Before this commit, the move xpath was marked as faulty in the IrUiView's form in the interface.

After this commit, the xpath is not marked as invalid, because it is not. read `@def apply_inheritance_specs` to get a grasp on the supported semantics for xpaths arch.

opw-4965869

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
