### PR TITLE
[FIX] website: stop interactions on page edit

### DIFF
--- a/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
+++ b/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
@@ -28,7 +28,6 @@ export class EditInteractionPlugin extends Plugin {
 
     setup() {
         this.websiteEditService = undefined;
-        this.areInteractionsStartedInEditMode = false;
 
         window.parent.document.addEventListener(
             "transfer_website_edit_service",
@@ -54,15 +53,10 @@ export class EditInteractionPlugin extends Plugin {
             throw new Error("website edit service not loaded");
         }
         this.websiteEditService.update(element, "edit");
-        this.areInteractionsStartedInEditMode = true;
     }
 
     refreshInteractions(element) {
-        if (this.areInteractionsStartedInEditMode) {
-            this.websiteEditService.refresh(element);
-        } else {
-            this.restartInteractions(element);
-        }
+        this.websiteEditService.refresh(element);
     }
 
     stopInteractions(element) {

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -259,6 +259,13 @@ export class WebsiteBuilderClientAction extends Component {
         this.websiteContext.showResourceEditor = false;
         this.blockIframe();
         await this.loadIframeAndBundles(true);
+        window.document.dispatchEvent(
+            new CustomEvent("edit_page", {
+                detail: {
+                    iframeDocument: this.websiteContent.el.contentDocument.document,
+                },
+            })
+        );
         this.unblockIframe();
         this.state.isEditing = true;
     }

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -78,9 +78,7 @@ registry.category("services").add("website_edit", {
             } else {
                 publicInteractions.startInteractions(target);
             }
-            
         };
-        
 
         const refresh = (target) => {
             publicInteractions.isRefreshing = true;
@@ -285,6 +283,10 @@ registry.category("services").add("website_edit", {
             applyAction,
             callShared,
         };
+
+        window.parent.document.addEventListener("edit_page", (ev) => {
+            stop(ev.detail.iframeDocument);
+        });
 
         // Transfer the iframe website_edit service to the EditInteractionPlugin
         window.parent.document.addEventListener("edit_interaction_plugin_loaded", (ev) => {

--- a/addons/website/static/tests/builder/edit_interaction.test.js
+++ b/addons/website/static/tests/builder/edit_interaction.test.js
@@ -21,13 +21,12 @@ test("dropping a new snippet starts its interaction", async () => {
     patchWithCleanup(EditInteractionPlugin.prototype, {
         setup() {
             super.setup();
-            this.websiteEditService.update = () => expect.step("update");
             this.websiteEditService.refresh = () => expect.step("refresh");
         },
     });
     await openBuilderSidebar();
     await waitFor(".o-website-builder_sidebar.o_builder_sidebar_open");
-    expect.verifySteps(["update"]);
+    expect.verifySteps(["refresh"]);
     await contains(
         `.o-snippets-menu #snippet_groups .o_snippet[data-snippet-group='text'] .o_snippet_thumbnail_area`
     ).click();
@@ -54,15 +53,15 @@ test("ensure order of operations when hovering an option", async () => {
         template: xml`<BuilderButton action="'customAction'"/>`,
     });
     patchWithCleanup(EditInteractionPlugin.prototype, {
-        restartInteractions() {
-            expect.step("restartInteractions");
+        refreshInteractions(element) {
+            expect.step("refreshInteractions");
         },
     });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
-    expect.verifySteps(["restartInteractions"]);
+    expect.verifySteps(["refreshInteractions"]);
     await contains(":iframe .test-options-target").click();
     await contains("[data-action-id='customAction']").hover();
-    expect.verifySteps(["load", "apply", "restartInteractions"]);
+    expect.verifySteps(["load", "apply", "refreshInteractions"]);
 });
 
 describe("exit builder", () => {


### PR DESCRIPTION
**[FIX] website: stop interactions on page edit**
    
    Since [1], interactions are restarted (stopped and started again) when
    the first normalize is triggered in edit. This means that all the
    plugins are started while the interactions are still in their "public"
    state, potentially causing issues down the line.
    By stopping all interactions as soon as the website builder switches to
    edit, we ensure that the DOM is in a valid state for the edition
    plugins.
    
    Note that some edit interactions trigger some plugins shared methods
    (in the website edit service, either through the `shared` object, or
    through the `applyAction` method, whose action itself might then call a
    shared method).
    This is the reason why we do not restart them immediately. They will be
    restarted with the 1st normalize anyways, which happens just after the
    plugins' setup.
    
    [1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2