### PR TITLE
[FIX] website, *: fix carousel slide in translation mode

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin_translate.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin_translate.js
@@ -1,10 +1,15 @@
 import { Plugin } from "@html_editor/plugin";
 
-export class BuilderOptionsPlugin extends Plugin {
+export class BuilderOptionsTranslationPlugin extends Plugin {
     static id = "builderOptions";
-    static shared = ["deactivateContainers", "getTarget", "updateContainers"];
+    static shared = ["deactivateContainers", "getTarget", "updateContainers", "setNextTarget"];
+    static dependencies = ["history"];
 
     deactivateContainers() {}
     getTarget() {}
     updateContainers() {}
+    setNextTarget(targetEl) {
+        // Store the next target to activate in the current step.
+        this.dependencies.history.setStepExtra("nextTarget", targetEl);
+    }
 }

--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -205,7 +205,7 @@ export class CarouselOptionPlugin extends Plugin {
 
                     resolve();
                 }, 0.2 * slideDuration);
-            });
+            }, { once: true });
 
             const carouselInstance = window.Carousel.getOrCreateInstance(editingElement, {
                 ride: false,

--- a/addons/website/static/src/builder/plugins/carousel_option_translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_translation_plugin.js
@@ -1,0 +1,6 @@
+import { CarouselOptionPlugin } from "./carousel_option_plugin";
+
+export class CarouselOptionTranslationPlugin extends CarouselOptionPlugin {
+    static id = "carouselOption";
+    static dependencies = ["builderOptions", "builderActions"];
+}

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -1,5 +1,5 @@
 import { Builder } from "@html_builder/builder";
-import { BuilderOptionsPlugin } from "@html_builder/core/builder_options_plugin_translate";
+import { BuilderOptionsTranslationPlugin } from "@html_builder/core/builder_options_plugin_translate";
 import { CORE_PLUGINS, MAIN_PLUGINS } from "@html_builder/core/core_plugins";
 import { DisableSnippetsPlugin } from "@html_builder/core/disable_snippets_plugin_translation";
 import { OperationPlugin } from "@html_builder/core/operation_plugin";
@@ -22,11 +22,12 @@ import { AnimateOptionPlugin } from "./plugins/options/animate_option_plugin";
 import { BuilderComponentPlugin } from "@html_builder/core/builder_component_plugin";
 import { BuilderActionsPlugin } from "@html_builder/core/builder_actions_plugin";
 import { CoreBuilderActionPlugin } from "@html_builder/core/core_builder_action_plugin";
+import { CarouselOptionTranslationPlugin } from "./plugins/carousel_option_translation_plugin";
 import { ThemeTab } from "./plugins/theme/theme_tab";
 import { BuilderContentEditablePlugin } from "@html_builder/core/builder_content_editable_plugin";
 
 const TRANSLATION_PLUGINS = [
-    BuilderOptionsPlugin,
+    BuilderOptionsTranslationPlugin,
     BuilderActionsPlugin,
     BuilderComponentPlugin,
     CoreBuilderActionPlugin,
@@ -44,6 +45,7 @@ const TRANSLATION_PLUGINS = [
     OperationPlugin,
     EditInteractionPlugin,
     BuilderContentEditablePlugin,
+    CarouselOptionTranslationPlugin,
 ];
 
 export class WebsiteBuilder extends Component {


### PR DESCRIPTION
*: html_builder

Since the website builder refactoring [1], carousel snippets could no longer slide when in translation mode - clicking the chevrons triggered a traceback.
This commit fixes the issue and restores expected navigation behavior.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
