### PR TITLE
[FIX] auth_signup:  correct the grammatical mistake in notification

### DIFF
--- a/addons/auth_signup/i18n/auth_signup.pot
+++ b/addons/auth_signup/i18n/auth_signup.pot
@@ -308,13 +308,13 @@ msgstr ""
 #. module: auth_signup
 #. odoo-python
 #: code:addons/auth_signup/models/res_users.py:0
-msgid "A reset password link was send by email"
+msgid "A reset password link was sent by email"
 msgstr ""
 
 #. module: auth_signup
 #. odoo-python
 #: code:addons/auth_signup/models/res_users.py:0
-msgid "A signup link was send by email"
+msgid "A signup link was sent by email"
 msgstr ""
 
 #. module: auth_signup

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -232,10 +232,10 @@ class ResUsers(models.Model):
                     mail.send()
             if signup_type == 'reset':
                 _logger.info("Password reset email sent for user <%s> to <%s>", user.login, user.email)
-                message = _('A reset password link was send by email')
+                message = _('A reset password link was sent by email')
             else:
                 _logger.info("Signup email sent for user <%s> to <%s>", user.login, user.email)
-                message = _('A signup link was send by email')
+                message = _('A signup link was sent by email')
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',


### PR DESCRIPTION
**Before this commit:**
- The notifications for `Send an Invitation Email` and `Send Password Reset Instructions` contained grammatical mistakes.

**After this commit:**
- The grammatical mistakes have been corrected.

task-4975439

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
