### PR TITLE
[IMP] website: remove not used flag

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -127,7 +127,6 @@ export class WebsiteBuilderClientAction extends Component {
         onMounted(() => {
             this.addListeners(document);
             this.addSystrayItems();
-            this.websiteService.useMysterious = true;
             const edition = !!(this.enableEditor || this.editTranslations);
             if (edition) {
                 this.onEditPage();


### PR DESCRIPTION
Previously, in the [html_builder refactoring] `useMysterious` tag was used to 
separate 2 instances of the website: the old and the new one. Now, we do not
need this flag anymore as the new website builder has already been merged 
and this flag isn't used anywhere anyway.
Related to task-4367641

[the html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb