### PR TITLE
[FIX] event: remove hidden html sections and format external description

### DIFF
--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -636,6 +636,24 @@ class TestEventData(TestEventInternalsCommon):
         self.env['event.registration'].create(new_open_registration)
         reg_draft.write({'state': 'open'})
 
+    @users('user_eventmanager')
+    def test_event_external_description_with_hidden_value(self):
+        """Ensure `_get_external_description` works properly with hidden values in sections."""
+        event = self.event_0.with_user(self.env.user)
+        event.description = (
+            "<div class=\"oe_structure\">"
+            "<h5>Visible Title</h5>"
+            "<section class=\"s_countdown d-none\">"
+            "<h2>Hidden Content</h2>"
+            "</section>"
+            "<p>Visible End</p>"
+            "</div>"
+        )
+        external_description = event._get_external_description()
+        self.assertIn("Visible Title", external_description)
+        self.assertIn("Visible End", external_description)
+        self.assertNotIn("Hidden Content", external_description)
+
 
 @tagged('event_registration')
 class TestEventRegistrationData(TestEventInternalsCommon):


### PR DESCRIPTION
**Steps to reproduce:**
- Go to `Events` app
- Select any event
- Preview it on the website
- Options are available to add to external calendars
- Click on any of them
- Description will be added to the exported calendar event
- The description is an unformatted block of text
- When using editor widgets with hidden elements, those will also appear in the export.

**Issue:**
The method `html_to_inner_content` doesn't take the html formatting into account, which leads to the export of the 'hidden' elements.

**Fix:**
Format the description like it is done for `calendar_event` with `_get_customer_description` and remove non-visible blocks (using `d-none`class) if there are any in the html of the description.

opw-4923912

related : https://github.com/odoo/odoo/commit/96a76040f90c6faec6c2332c88af2e42af00663e

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
