### PR TITLE
[FIX] point_of_sale: sync idb on order line change

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -432,6 +432,11 @@ export class PosData extends Reactive {
             this.debouncedSynchronizeLocalDataInIndexedDB.bind(this)
         );
 
+        this.models["pos.order.line"].addEventListener(
+            "update",
+            this.debouncedSynchronizeLocalDataInIndexedDB.bind(this)
+        );
+
         const ignore = Object.keys(this.opts.databaseTable);
         for (const model of Object.keys(this.relations)) {
             if (ignore.includes(model)) {

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -32,6 +32,18 @@ describe("pos_store.js", () => {
         expect(order.lines.length).toBe(3); // 2 original lines + 1 tip line
     });
 
+    test("syncToIndexedDbCalledPoSOrderLine", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store); // Should have 2 lines
+        let syncCount = 0;
+        store.data.debouncedSynchronizeLocalDataInIndexedDB = () => {
+            syncCount += 1;
+        };
+        store.data.initListeners();
+        order.lines[0].setQuantity(5, true);
+        expect(syncCount).toBe(1);
+    });
+
     describe("syncAllOrders", () => {
         test("simple sync", async () => {
             const store = await setupPosEnv();


### PR DESCRIPTION
If you modified the quantity of a pos order line with the numpad, then refreshed the page the new quantity would be lost.

Steps to reproduce:
-------------------
* Open PoS
* Add any product to the cart
* Modify the quantity using the numpad
* Direclty refresh the page
> Observation: The quantity of the product is back to 1

Why the fix:
------------
When modifying a pos order line it was not synched with the indexed local database. We now make sure that when a pos order line is modified it is synched correctly.

opw-4801613