### PR TITLE
[IMP] bus: add prefix to websocket worker message

### DIFF
--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -19,23 +19,23 @@ export class OutdatedPageWatcherService {
         this.closeNotificationFn;
         let wasBusAlreadyConnected;
         bus_service.addEventListener(
-            "worker_state_updated",
+            "BUS:WORKER_STATE_UPDATED",
             ({ detail: state }) => {
                 wasBusAlreadyConnected = state !== "IDLE";
             },
             { once: true }
         );
         bus_service.addEventListener(
-            "disconnect",
+            "BUS:DISCONNECT",
             () => (this.lastNotificationId = multi_tab.getSharedValue("last_notification_id"))
         );
-        bus_service.addEventListener("connect", async () => {
+        bus_service.addEventListener("BUS:CONNECT", async () => {
             if (wasBusAlreadyConnected) {
                 this.checkHasMissedNotifications();
             }
             wasBusAlreadyConnected = true;
         });
-        bus_service.addEventListener("reconnect", () => this.checkHasMissedNotifications());
+        bus_service.addEventListener("BUS:RECONNECT", () => this.checkHasMissedNotifications());
         multi_tab.bus.addEventListener("shared_value_updated", ({ detail: { key } }) => {
             if (key === "bus.has_missed_notifications") {
                 this.showOutdatedPageNotification();

--- a/addons/bus/static/src/services/bus_monitoring_service.js
+++ b/addons/bus/static/src/services/bus_monitoring_service.js
@@ -21,7 +21,7 @@ export class BusMonitoringService {
      * @param {Partial<import("services").Services>} services
      */
     setup(env, { bus_service }) {
-        bus_service.addEventListener("worker_state_updated", ({ detail }) =>
+        bus_service.addEventListener("BUS:WORKER_STATE_UPDATED", ({ detail }) =>
             this.workerStateOnChange(detail)
         );
         browser.addEventListener("offline", () => (this.isReconnecting = false));

--- a/addons/bus/static/tests/bus_monitoring_service.test.js
+++ b/addons/bus/static/tests/bus_monitoring_service.test.js
@@ -36,14 +36,14 @@ function stepConnectionStateChanges() {
 test("connection considered as lost after failed reconnect attempt", async () => {
     stepConnectionStateChanges();
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]
     );
     await makeMockEnv();
-    await waitForSteps(["isConnectionLost - false", "connect"]);
+    await waitForSteps(["isConnectionLost - false", "BUS:CONNECT"]);
     const unlockWebsocket = lockWebsocketConnect();
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     await runAllTimers();
     await waitForSteps(["isConnectionLost - true"]);
     unlockWebsocket();
@@ -54,35 +54,35 @@ test("connection considered as lost after failed reconnect attempt", async () =>
 test("brief disconect not considered lost", async () => {
     stepConnectionStateChanges();
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")],
-        ["reconnect", () => asyncStep("reconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")],
+        ["BUS:RECONNECT", () => asyncStep("BUS:RECONNECT")]
     );
     await makeMockEnv();
-    await waitForSteps(["isConnectionLost - false", "connect"]);
+    await waitForSteps(["isConnectionLost - false", "BUS:CONNECT"]);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.SESSION_EXPIRED);
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     await runAllTimers();
-    await waitForSteps(["reconnect"]); // Only reconnect step, which means the monitoring state didn't change.
+    await waitForSteps(["BUS:RECONNECT"]); // Only reconnect step, which means the monitoring state didn't change.
 });
 
 test("computer sleep doesn't mark connection as lost", async () => {
     stepConnectionStateChanges();
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")],
-        ["reconnect", () => asyncStep("reconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")],
+        ["BUS:RECONNECT", () => asyncStep("BUS:RECONNECT")]
     );
     await makeMockEnv();
-    await waitForSteps(["isConnectionLost - false", "connect"]);
+    await waitForSteps(["isConnectionLost - false", "BUS:CONNECT"]);
     const unlockWebsocket = lockWebsocketConnect();
     patchWithCleanup(navigator, { onLine: false });
     await manuallyDispatchProgrammaticEvent(window, "offline"); // Offline event is triggered when the computer goes to sleep.
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     patchWithCleanup(navigator, { onLine: true });
     await manuallyDispatchProgrammaticEvent(window, "online"); // Online event is triggered when the computer wakes up.
     unlockWebsocket();
     await runAllTimers();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     expect(getService("bus.monitoring_service").isConnectionLost).toBe(false);
 });

--- a/addons/bus/static/tests/bus_service.test.js
+++ b/addons/bus/static/tests/bus_service.test.js
@@ -40,7 +40,7 @@ describe.current.tags("desktop");
 
 test("notifications not received after stoping the service", async () => {
     const firstTabEnv = await makeMockEnv();
-    stepWorkerActions("leave");
+    stepWorkerActions("BUS:LEAVE");
     restoreRegistry(registry);
     const secondTabEnv = await makeMockEnv(null, { makeNew: true });
     startBusService(firstTabEnv);
@@ -53,7 +53,7 @@ test("notifications not received after stoping the service", async () => {
         [secondTabEnv, "notifType", "beta"]
     );
     secondTabEnv.services.bus_service.stop();
-    await waitForSteps(["leave"]);
+    await waitForSteps(["BUS:LEAVE"]);
     MockServer.env["bus.bus"]._sendone("lambda", "notifType", "epsilon");
     await waitNotifications(
         [firstTabEnv, "notifType", "epsilon"],
@@ -63,8 +63,8 @@ test("notifications not received after stoping the service", async () => {
 
 test("notifications still received after disconnect/reconnect", async () => {
     addBusServiceListeners(
-        ["disconnect", () => asyncStep("disconnect")],
-        ["reconnect", () => asyncStep("reconnect")]
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")],
+        ["BUS:RECONNECT", () => asyncStep("BUS:RECONNECT")]
     );
     await makeMockEnv();
     getService("bus_service").addChannel("lambda");
@@ -72,9 +72,9 @@ test("notifications still received after disconnect/reconnect", async () => {
     MockServer.env["bus.bus"]._sendone("lambda", "notifType", "beta");
     await waitNotifications(["notifType", "beta"]);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     await runAllTimers();
-    await waitForSteps(["reconnect"]);
+    await waitForSteps(["BUS:RECONNECT"]);
     MockServer.env["bus.bus"]._sendone("lambda", "notifType", "gamma");
     await waitNotifications(["notifType", "gamma"]);
 });
@@ -95,7 +95,7 @@ test("notifications are received by each tab", async () => {
 
 test("second tab still receives notifications after main pagehide", async () => {
     const mainEnv = await makeMockEnv();
-    stepWorkerActions("leave");
+    stepWorkerActions("BUS:LEAVE");
     mainEnv.services.bus_service.addChannel("lambda");
     // Prevent second tab from receiving pagehide event.
     patchWithCleanup(browser, {
@@ -122,7 +122,7 @@ test("second tab still receives notifications after main pagehide", async () => 
     await waitNotifications([mainEnv, "notifType", "beta"], [secondEnv, "notifType", "beta"]);
     // simulate unloading main
     await manuallyDispatchProgrammaticEvent(window, "pagehide");
-    await waitForSteps(["leave"]);
+    await waitForSteps(["BUS:LEAVE"]);
     MockServer.env["bus.bus"]._sendone("lambda", "notifType", "gamma");
     await waitNotifications(
         [mainEnv, "notifType", "gamma", { received: false }],
@@ -170,19 +170,19 @@ test("channel management from multiple tabs", async () => {
 
 test("re-subscribe on reconnect", async () => {
     onWebsocketEvent("subscribe", (data) => asyncStep(`subscribe - [${data.channels.toString()}]`));
-    addBusServiceListeners(["reconnect", () => asyncStep("reconnect")]);
+    addBusServiceListeners(["BUS:RECONNECT", () => asyncStep("BUS:RECONNECT")]);
     await makeMockEnv();
     startBusService();
     await waitForSteps(["subscribe - []"]);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT);
     await runAllTimers();
-    await waitForSteps(["reconnect", "subscribe - []"]);
+    await waitForSteps(["BUS:RECONNECT", "subscribe - []"]);
 });
 
 test("pass last notification id on initialization", async () => {
     patchWithCleanup(WebsocketWorker.prototype, {
         _onClientMessage(_client, { action, data }) {
-            if (action === "initialize_connection") {
+            if (action === "BUS:INITIALIZE_CONNECTION") {
                 asyncStep(`${action} - ${data["lastNotificationId"]}`);
             }
             return super._onClientMessage(...arguments);
@@ -190,7 +190,7 @@ test("pass last notification id on initialization", async () => {
     });
     const firstEnv = await makeMockEnv();
     startBusService(firstEnv);
-    await waitForSteps(["initialize_connection - 0"]);
+    await waitForSteps(["BUS:INITIALIZE_CONNECTION - 0"]);
     firstEnv.services.bus_service.addChannel("lambda");
     await waitForChannels(["lambda"]);
     MockServer.env["bus.bus"]._sendone("lambda", "notifType", "beta");
@@ -198,41 +198,41 @@ test("pass last notification id on initialization", async () => {
     restoreRegistry(registry);
     const secondEnv = await makeMockEnv(null, { makeNew: true });
     startBusService(secondEnv);
-    await waitForSteps([`initialize_connection - 1`]);
+    await waitForSteps([`BUS:INITIALIZE_CONNECTION - 1`]);
 });
 
 test("websocket disconnects when user logs out", async () => {
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]
     );
     patchWithCleanup(session, { user_id: null });
     patchWithCleanup(user, { userId: 1 });
     const firstTabEnv = await makeMockEnv();
     startBusService(firstTabEnv);
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     patchWithCleanup(user, { userId: null });
     restoreRegistry(registry);
     const env2 = await makeMockEnv(null, { makeNew: true });
     startBusService(env2);
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
 });
 
 test("websocket reconnects upon user log in", async () => {
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]
     );
     patchWithCleanup(session, { user_id: null });
     patchWithCleanup(user, { userId: false });
     await makeMockEnv();
     startBusService();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     patchWithCleanup(user, { userId: 1 });
     restoreRegistry(registry);
     const secondTabEnv = await makeMockEnv(null, { makeNew: true });
     startBusService(secondTabEnv);
-    await waitForSteps(["disconnect", "connect"]);
+    await waitForSteps(["BUS:DISCONNECT", "BUS:CONNECT"]);
 });
 
 test("websocket connects with URL corresponding to given serverURL", async () => {
@@ -249,26 +249,26 @@ test("websocket connects with URL corresponding to given serverURL", async () =>
 test("disconnect on offline, re-connect on online", async () => {
     browser.addEventListener("online", () => asyncStep("online"));
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]
     );
     await makeMockEnv();
     startBusService();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     manuallyDispatchProgrammaticEvent(window, "offline");
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     manuallyDispatchProgrammaticEvent(window, "online");
     await waitForSteps(["online"]);
     await runAllTimers();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
 });
 
 test("no disconnect on offline/online when bus is inactive", async () => {
     browser.addEventListener("online", () => asyncStep("online"));
     browser.addEventListener("offline", () => asyncStep("offline"));
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]
     );
     mockService("bus_service", {
         addChannel() {},
@@ -284,15 +284,15 @@ test("no disconnect on offline/online when bus is inactive", async () => {
 test("can reconnect after late close event", async () => {
     browser.addEventListener("online", () => asyncStep("online"));
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")],
-        ["reconnect", () => asyncStep("reconnect")],
-        ["reconnecting", () => asyncStep("reconnecting")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")],
+        ["BUS:RECONNECT", () => asyncStep("BUS:RECONNECT")],
+        ["BUS:RECONNECTING", () => asyncStep("BUS:RECONNECTING")]
     );
     const closeDeferred = new Deferred();
     await makeMockEnv();
     startBusService();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     patchWithCleanup(getWebSocketWorker().websocket, {
         async close(code = WEBSOCKET_CLOSE_CODES.CLEAN, reason) {
             this._readyState = 2; // WebSocket.CLOSING
@@ -313,18 +313,18 @@ test("can reconnect after late close event", async () => {
     manuallyDispatchProgrammaticEvent(window, "online");
     await waitForSteps(["online"]);
     await runAllTimers();
-    await waitForSteps(["disconnect", "connect"]);
+    await waitForSteps(["BUS:DISCONNECT", "BUS:CONNECT"]);
     // Trigger the close event, it shouldn't have any effect since it is
     // related to an old connection that is no longer in use.
     closeDeferred.resolve();
     await waitForSteps([]);
     // Server closes the connection, the worker should reconnect.
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT);
-    await waitForSteps(["disconnect", "reconnecting", "reconnect"]);
+    await waitForSteps(["BUS:DISCONNECT", "BUS:RECONNECTING", "BUS:RECONNECT"]);
 });
 
 test("fallback on simple worker when shared worker failed to initialize", async () => {
-    addBusServiceListeners(["connect", () => asyncStep("connect")]);
+    addBusServiceListeners(["BUS:CONNECT", () => asyncStep("BUS:CONNECT")]);
     // Starting the server first, the following patch would be overwritten otherwise.
     await makeMockServer();
     patchWithCleanup(browser, {
@@ -353,7 +353,7 @@ test("fallback on simple worker when shared worker failed to initialize", async 
         "shared-worker-creation",
         'Error while loading "bus_service" SharedWorker, fallback on Worker.',
         "worker-creation",
-        "connect",
+        "BUS:CONNECT",
     ]);
 });
 
@@ -371,32 +371,32 @@ test("subscribe to single notification", async () => {
 
 test("do not reconnect when worker version is outdated", async () => {
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")],
-        ["reconnect", () => asyncStep("reconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")],
+        ["BUS:RECONNECT", () => asyncStep("BUS:RECONNECT")]
     );
     await makeMockEnv();
     startBusService();
     await runAllTimers();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     const worker = getWebSocketWorker();
     expect(worker.state).toBe(WORKER_STATE.CONNECTED);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     await runAllTimers();
-    await waitForSteps(["reconnect"]);
+    await waitForSteps(["BUS:RECONNECT"]);
     expect(worker.state).toBe(WORKER_STATE.CONNECTED);
     patchWithCleanup(console, { warn: (message) => asyncStep(message) });
     MockServer.env["bus.bus"]._simulateDisconnection(
         WEBSOCKET_CLOSE_CODES.CLEAN,
         "OUTDATED_VERSION"
     );
-    await waitForSteps(["Worker deactivated due to an outdated version.", "disconnect"]);
+    await waitForSteps(["Worker deactivated due to an outdated version.", "BUS:DISCONNECT"]);
     await runAllTimers();
-    stepWorkerActions("start");
+    stepWorkerActions("BUS:START");
     startBusService();
     await runAllTimers();
-    await waitForSteps(["start"]);
+    await waitForSteps(["BUS:START"]);
     // Verify the worker state instead of the steps as the connect event is
     // asynchronous and may not be fired at this point.
     expect(worker.state).toBe(WORKER_STATE.DISCONNECTED);
@@ -404,29 +404,29 @@ test("do not reconnect when worker version is outdated", async () => {
 
 test("reconnect on demande after clean close code", async () => {
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")],
-        ["reconnect", () => asyncStep("reconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")],
+        ["BUS:RECONNECT", () => asyncStep("BUS:RECONNECT")]
     );
     await makeMockEnv();
     startBusService();
     await runAllTimers();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     await runAllTimers();
-    await waitForSteps(["reconnect"]);
+    await waitForSteps(["BUS:RECONNECT"]);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.CLEAN);
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     await runAllTimers();
     startBusService();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
 });
 
 test("remove from main tab candidates when version is outdated", async () => {
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]
     );
     await makeMockEnv();
     patchWithCleanup(getService("multi_tab"), { isOnMainTab: () => true });
@@ -435,7 +435,7 @@ test("remove from main tab candidates when version is outdated", async () => {
         asyncStep("no_longer_main_tab")
     );
     startBusService();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     expect(getService("multi_tab").isOnMainTab()).toBe(true);
     MockServer.env["bus.bus"]._simulateDisconnection(
         WEBSOCKET_CLOSE_CODES.CLEAN,
@@ -443,7 +443,7 @@ test("remove from main tab candidates when version is outdated", async () => {
     );
     await waitForSteps([
         "Worker deactivated due to an outdated version.",
-        "disconnect",
+        "BUS:DISCONNECT",
         "no_longer_main_tab",
     ]);
 });
@@ -451,17 +451,17 @@ test("remove from main tab candidates when version is outdated", async () => {
 test("show notification when version is outdated", async () => {
     browser.location.addEventListener("reload", () => asyncStep("reload"));
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]
     );
     patchWithCleanup(console, { warn: (message) => asyncStep(message) });
     await mountWithCleanup(WebClient);
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     MockServer.env["bus.bus"]._simulateDisconnection(
         WEBSOCKET_CLOSE_CODES.CLEAN,
         "OUTDATED_VERSION"
     );
-    await waitForSteps(["Worker deactivated due to an outdated version.", "disconnect"]);
+    await waitForSteps(["Worker deactivated due to an outdated version.", "BUS:DISCONNECT"]);
     await runAllTimers();
     await waitFor(".o_notification", {
         text: "Save your work and refresh to get the latest updates and avoid potential issues.",
@@ -471,7 +471,7 @@ test("show notification when version is outdated", async () => {
 });
 
 test("subscribe message is sent first", async () => {
-    addBusServiceListeners(["disconnect", () => asyncStep("disconnect")]);
+    addBusServiceListeners(["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]);
     // Starting the server first, the following patch would be overwritten otherwise.
     await makeMockServer();
     const ogSocket = window.WebSocket;
@@ -494,7 +494,7 @@ test("subscribe message is sent first", async () => {
     getService("bus_service").send("some_event");
     await waitForSteps(["some_event"]);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.CLEAN);
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     getService("bus_service").send("some_event");
     getService("bus_service").send("some_other_event");
     getService("bus_service").addChannel("channel_1");
@@ -507,18 +507,18 @@ test("subscribe message is sent first", async () => {
 
 test("worker state is available from the bus service", async () => {
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]
     );
     await makeMockEnv();
     startBusService();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     expect(getService("bus_service").workerState).toBe(WORKER_STATE.CONNECTED);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.CLEAN);
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     await runAllTimers();
     expect(getService("bus_service").workerState).toBe(WORKER_STATE.DISCONNECTED);
     startBusService();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     expect(getService("bus_service").workerState).toBe(WORKER_STATE.CONNECTED);
 });

--- a/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
+++ b/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
@@ -51,7 +51,7 @@ export class BusBus extends models.Model {
                 message: { payload: JSON.parse(JSON.stringify(payload)), type },
             });
         }
-        getWebSocketWorker().broadcast("notification", values);
+        getWebSocketWorker().broadcast("BUS:NOTIFICATION", values);
     }
 
     /**

--- a/addons/bus/static/tests/outdated_page_watcher.test.js
+++ b/addons/bus/static/tests/outdated_page_watcher.test.js
@@ -20,21 +20,21 @@ describe.current.tags("desktop");
 test("disconnect during vacuum should ask for reload", async () => {
     browser.location.addEventListener("reload", () => asyncStep("reload"));
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")],
-        ["reconnecting", () => asyncStep("reconnecting")],
-        ["reconnect", () => asyncStep("reconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")],
+        ["BUS:RECONNECTING", () => asyncStep("BUS:RECONNECTING")],
+        ["BUS:RECONNECT", () => asyncStep("BUS:RECONNECT")]
     );
     onRpc("/bus/has_missed_notifications", () => true);
     await mountWithCleanup(WebClient);
     getService("multi_tab").setSharedValue("last_notification_id", 1);
     startBusService();
     await runAllTimers();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
-    await waitForSteps(["disconnect", "reconnecting"]);
+    await waitForSteps(["BUS:DISCONNECT", "BUS:RECONNECTING"]);
     await runAllTimers();
-    await waitForSteps(["reconnect"]);
+    await waitForSteps(["BUS:RECONNECT"]);
     await waitFor(".o_notification");
     expect(".o_notification_content:first").toHaveText(
         "Save your work and refresh to get the latest updates and avoid potential issues."
@@ -45,20 +45,20 @@ test("disconnect during vacuum should ask for reload", async () => {
 
 test("reconnect after going offline after bus gc should ask for reload", async () => {
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["disconnect", () => asyncStep("disconnect")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:DISCONNECT", () => asyncStep("BUS:DISCONNECT")]
     );
     onRpc("/bus/has_missed_notifications", () => true);
     await mountWithCleanup(WebClient);
     getService("multi_tab").setSharedValue("last_notification_id", 1);
     startBusService();
     await runAllTimers();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     browser.dispatchEvent(new Event("offline"));
-    await waitForSteps(["disconnect"]);
+    await waitForSteps(["BUS:DISCONNECT"]);
     browser.dispatchEvent(new Event("online"));
     await runAllTimers();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     await waitFor(".o_notification");
     expect(".o_notification_content:first").toHaveText(
         "Save your work and refresh to get the latest updates and avoid potential issues."

--- a/addons/bus/static/tests/websocket_worker.test.js
+++ b/addons/bus/static/tests/websocket_worker.test.js
@@ -35,36 +35,36 @@ const startWebSocketWorker = async (onBroadcast) => {
 
 test("connect event is broadcasted after calling start", async () => {
     await startWebSocketWorker((type) => {
-        if (type !== "worker_state_updated") {
+        if (type !== "BUS:WORKER_STATE_UPDATED") {
             asyncStep(`broadcast ${type}`);
         }
     });
-    await waitForSteps(["broadcast connect"]);
+    await waitForSteps(["broadcast BUS:CONNECT"]);
 });
 
 test("disconnect event is broadcasted", async () => {
     const worker = await startWebSocketWorker((type) => {
-        if (type !== "worker_state_updated") {
+        if (type !== "BUS:WORKER_STATE_UPDATED") {
             asyncStep(`broadcast ${type}`);
         }
     });
-    await waitForSteps(["broadcast connect"]);
+    await waitForSteps(["broadcast BUS:CONNECT"]);
     worker.websocket.close(WEBSOCKET_CLOSE_CODES.CLEAN);
     await runAllTimers();
-    await waitForSteps(["broadcast disconnect"]);
+    await waitForSteps(["broadcast BUS:DISCONNECT"]);
 });
 
 test("reconnecting/reconnect event is broadcasted", async () => {
     const worker = await startWebSocketWorker((type) => {
-        if (type !== "worker_state_updated") {
+        if (type !== "BUS:WORKER_STATE_UPDATED") {
             asyncStep(`broadcast ${type}`);
         }
     });
-    await waitForSteps(["broadcast connect"]);
+    await waitForSteps(["broadcast BUS:CONNECT"]);
     worker.websocket.close(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
-    await waitForSteps(["broadcast disconnect", "broadcast reconnecting"]);
+    await waitForSteps(["broadcast BUS:DISCONNECT", "broadcast BUS:RECONNECTING"]);
     await runAllTimers();
-    await waitForSteps(["broadcast reconnect"]);
+    await waitForSteps(["broadcast BUS:RECONNECT"]);
 });
 
 test("notification event is broadcasted", async () => {
@@ -80,28 +80,28 @@ test("notification event is broadcasted", async () => {
         },
     ];
     await startWebSocketWorker((type, message) => {
-        if (type === "notification") {
+        if (type === "BUS:NOTIFICATION") {
             expect(message).toEqual(notifications);
         }
-        if (["connect", "notification"].includes(type)) {
+        if (["BUS:CONNECT", "BUS:NOTIFICATION"].includes(type)) {
             asyncStep(`broadcast ${type}`);
         }
     });
-    await waitForSteps(["broadcast connect"]);
+    await waitForSteps(["broadcast BUS:CONNECT"]);
     for (const serverWs of MockServer.current._websockets) {
         serverWs.send(JSON.stringify(notifications));
     }
-    await waitForSteps(["broadcast notification"]);
+    await waitForSteps(["broadcast BUS:NOTIFICATION"]);
 });
 
 test("disconnect event is sent when stopping the worker", async () => {
     const worker = await startWebSocketWorker((type) => {
-        if (type !== "worker_state_updated") {
+        if (type !== "BUS:WORKER_STATE_UPDATED") {
             expect.step(`broadcast ${type}`);
         }
     });
-    await expect.waitForSteps(["broadcast connect"]);
+    await expect.waitForSteps(["broadcast BUS:CONNECT"]);
     worker._stop();
     await runAllTimers();
-    await expect.waitForSteps(["broadcast disconnect"]);
+    await expect.waitForSteps(["broadcast BUS:DISCONNECT"]);
 });

--- a/addons/mail/static/src/core/common/im_status_service.js
+++ b/addons/mail/static/src/core/common/im_status_service.js
@@ -37,7 +37,7 @@ export const imStatusService = {
                 becomeAwayTimeout = browser.setTimeout(() => updateBusPresence(), awayTime);
             }
         };
-        bus_service.addEventListener("connect", () => updateBusPresence(), { once: true });
+        bus_service.addEventListener("BUS:CONNECT", () => updateBusPresence(), { once: true });
         bus_service.subscribe(
             "bus.bus/im_status_updated",
             async ({ presence_status, im_status, partner_id, guest_id, debounce = true }) => {

--- a/addons/mail/static/tests/discuss_app/bus_connection_alert.test.js
+++ b/addons/mail/static/tests/discuss_app/bus_connection_alert.test.js
@@ -37,16 +37,16 @@ test("show warning when bus connection encounters issues", async () => {
         );
     }
     addBusServiceListeners(
-        ["connect", () => asyncStep("connect")],
-        ["reconnect", () => asyncStep("reconnect")],
-        ["reconnecting", () => asyncStep("reconnecting")]
+        ["BUS:CONNECT", () => asyncStep("BUS:CONNECT")],
+        ["BUS:RECONNECT", () => asyncStep("BUS:RECONNECT")],
+        ["BUS:RECONNECTING", () => asyncStep("BUS:RECONNECTING")]
     );
     await start();
     await openDiscuss();
-    await waitForSteps(["connect"]);
+    await waitForSteps(["BUS:CONNECT"]);
     const unlockWebsocket = lockWebsocketConnect();
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
-    await waitForSteps(["reconnecting"]);
+    await waitForSteps(["BUS:RECONNECTING"]);
     expect(await waitFor(".o-bus-ConnectionAlert", { timeout: 2500 })).toHaveText(
         "Real-time connection lost..."
     );
@@ -55,6 +55,6 @@ test("show warning when bus connection encounters issues", async () => {
     expect(".o-bus-ConnectionAlert").toHaveText("Real-time connection lost...");
     unlockWebsocket();
     await runAllTimers();
-    await waitForSteps(["reconnect"]);
+    await waitForSteps(["BUS:RECONNECT"]);
     await waitForNone(".o-bus-ConnectionAlert");
 });

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -54,7 +54,7 @@ export class PosData extends Reactive {
 
         browser.addEventListener("online", () => this.checkConnectivity());
         browser.addEventListener("offline", () => this.checkConnectivity());
-        this.bus.addEventListener("connect", this.reconnectWebSocket.bind(this));
+        this.bus.addEventListener("BUS:CONNECT", this.reconnectWebSocket.bind(this));
     }
 
     async checkConnectivity() {

--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -12,7 +12,7 @@ function logout() {
                 await animationFrame();
                 await new Promise((resolve) => {
                     const bus = odoo.__WOWL_DEBUG__.root.env.services.bus_service;
-                    bus.addEventListener("connect", resolve, { once: true });
+                    bus.addEventListener("BUS:CONNECT", resolve, { once: true });
                     if (bus.workerState === WORKER_STATE.CONNECTED) {
                         resolve();
                     }


### PR DESCRIPTION
Add the prefix `BUS:` to all websocket worker actions/events. This is a preparation for reuse bus shared worker for other purpose other than websocket.



enterprise:  https://github.com/odoo/enterprise/pull/91144