### PR TITLE
[FIX] html_editor: remove error throw in color plugin

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -231,7 +231,7 @@ export class ColorPlugin extends Plugin {
                 }
                 if (max === 0) {
                     someColorWasRemoved = false;
-                    throw new Error("Infinite Loop in removeAllColor().");
+                    // throw new Error("Infinite Loop in removeAllColor().");
                 }
             }
         }


### PR DESCRIPTION
Before this commit, it was not possible to set the color of a button to a theme color because an error would occur. A loop would try to remove all style while the color is applied through a class.

This temporary fix removes the error.
