### PR TITLE
[FIX] html_builder: set initial mimetype on dropped block's images

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_format_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_format_option_plugin.js
@@ -7,6 +7,7 @@ import { Plugin } from "@html_editor/plugin";
 import { loadImage, loadImageInfo } from "@html_editor/utils/image_processing";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 
 class ImageFormatOptionPlugin extends Plugin {
     static id = "imageFormatOption";
@@ -15,6 +16,15 @@ class ImageFormatOptionPlugin extends Plugin {
         builder_actions: {
             SetImageFormatAction,
             SetImageQualityAction,
+        },
+        on_snippet_dropped_handlers: async ({ snippetEl }) => {
+            for (const imgEl of selectElements(
+                snippetEl,
+                "img:not([data-mimetype]), .oe_img_bg:not([data-mimetype])"
+            )) {
+                const info = await loadImageInfo(imgEl);
+                imgEl.dataset.mimetype = info.mimetypeBeforeConversion;
+            }
         },
     };
     /**


### PR DESCRIPTION
Since `html_builder`, when a block contains an image, its quality cannot be updated before another change is done.

This commit specifies the mimetype of the image before the first transformation so that the quality option can properly evaluate its visibility condition.

Steps to reproduce:
- Drop a block with an image (or several images, or a background image)
- Select the image (or the block with a background image)

=> The Quality option did not show up.

task-4367641
