### PR TITLE
[FIX] point_of_sale: correctly use existing Serial/Lot numbers

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/select_lot_popup/select_lot_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/select_lot_popup/select_lot_popup.js
@@ -79,7 +79,7 @@ export class SelectLotPopup extends Component {
                 sticky: false,
             });
         }
-        if (!lot.create || !this.props.customInput) {
+        if (!lot.create) {
             return this.notification.add(_t("The Lot/Serial number is not valid"), {
                 type: "warning",
                 sticky: false,
@@ -100,7 +100,8 @@ export class SelectLotPopup extends Component {
             return (
                 itemValue !== "" &&
                 !this.props.isLotNameUsed(itemValue) &&
-                (this.props.customInput || this.props.options.includes(itemValue))
+                (this.props.customInput ||
+                    this.props.options.map((o) => o.name).includes(itemValue))
             );
         });
         const filteredValues = this.props.uniqueValues

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -895,3 +895,18 @@ registry.category("web_tour.tours").add("test_load_pos_demo_data_by_pos_user", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_only_existing_lots", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Product with existing lots"),
+            ProductScreen.selectNthLotNumber(1),
+            ProductScreen.selectedOrderlineHas("Product with existing lots", "1.0"),
+            inLeftSide({
+                trigger: ".order-container .orderline .lot-number:contains('Lot Number 1001')",
+            }),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1723,6 +1723,32 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'LotTour', login="pos_user")
 
+    def test_only_existing_lots(self):
+        product = self.env['product.product'].create({
+            'name': 'Product with existing lots',
+            'is_storable': True,
+            'tracking': 'lot',
+            'available_in_pos': True,
+        })
+        self.env['stock.quant'].with_context(inventory_mode=True).create([{
+            'product_id': product.id,
+            'inventory_quantity': 1,
+            'location_id': self.env.user._get_default_warehouse_id().lot_stock_id.id,
+            'lot_id': self.env['stock.lot'].create({'name': '1001', 'product_id': product.id}).id,
+        }, {
+            'product_id': product.id,
+            'inventory_quantity': 1,
+            'location_id': self.env.user._get_default_warehouse_id().lot_stock_id.id,
+            'lot_id': self.env['stock.lot'].create({'name': '1002', 'product_id': product.id}).id,
+        }]).sudo().action_apply_inventory()
+
+        self.main_pos_config.picking_type_id.write({
+            "use_create_lots": False,
+            "use_existing_lots": True,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_only_existing_lots', login="pos_user")
 
     def test_product_search(self):
         """Verify that the product search works correctly"""


### PR DESCRIPTION
After commit https://github.com/odoo/odoo/commit/cb31a37508d32110731ad61b04d5d05dc7b31825, when the PoS picking type was configured to use existing lot numbers and not creating new ones, it was not possible to correctly add products with existing lot numbers.

opw-4974345

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
