### PR TITLE
[FIX] website: fix and clean "Add Element" grid option

### DIFF
--- a/addons/website/static/src/builder/plugins/layout_option/add_element_option.xml
+++ b/addons/website/static/src/builder/plugins/layout_option/add_element_option.xml
@@ -2,16 +2,11 @@
 <templates xml:space="preserve">
 
 <t t-name="website.AddElementOption">
-    <BuilderRow label.translate="Add Elements" level="props.level" preview="false" applyTo="props.applyTo">
-        <BuilderButton action="'addElText'" type="'success'">
-            Text
-        </BuilderButton>
-        <BuilderButton action="'addElImage'" type="'success'">
-            Image
-        </BuilderButton>
-        <BuilderButton action="'addElButton'" type="'success'">
-            Button
-        </BuilderButton>
+    <BuilderRow label.translate="Add Elements" level="props.level" preview="false"
+                action="'addGridElement'" applyTo="props.applyTo">
+        <BuilderButton actionParam="'image'" type="'success'">Image</BuilderButton>
+        <BuilderButton actionParam="'text'" type="'success'">Text</BuilderButton>
+        <BuilderButton actionParam="'button'" type="'success'">Button</BuilderButton>
     </BuilderRow>
 </t>
 </templates>

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -40,7 +40,7 @@ registerWebsitePreviewTour('website_replace_grid_image', {
     },
     {
         content: "Add new image column",
-        trigger: "[data-action-id='addElImage']",
+        trigger: "[data-action-id='addGridElement'][data-action-param='image']",
         run: "click",
     },
     {
@@ -73,7 +73,7 @@ registerWebsitePreviewTour("scroll_to_new_grid_item", {
     ...clickOnSnippet({id: "s_text_image", name: "Text - Image"}),
     changeOption("Text - Image", "setGridLayout"),
     // Add a new grid item.
-    changeOption("Text - Image", "addElImage"),
+    changeOption("Text - Image", "[data-action-id='addGridElement'][data-action-param='image']"),
     {
         content: "Select the new image in the media dialog",
         trigger: '.o_select_media_dialog img[title="s_banner_default_image.jpg"]',


### PR DESCRIPTION
This commit fixes several issues happening when using the "Add Element" grid mode option:

- When the new grid item was added, its options were not activated.
   => This commit fixes that by explicitely activating them (like it was done before the refactoring.

- When adding an image, the image was strangely shifted to the left, inside the column. This is because the image wrongly had the `row` and `o_grid_mode` classes, because the row was passed as the node to replace in the media dialog (the `node` parameter), and the row classes were therefore added on the image, causing their CSS rules to apply on it and shift it.
  => This commit removes the `node` parameter in the call to open the media dialog.

- When adding an image, the dialog which is supposed to only have the "Images" tab also had the "Documents" tab displayed. It happens because the `onlyImages` parameter only disables the "Icons" and "Videos" so, in order to disable the documents, `noDocuments` must also be specified.
  => This commit adds this parameter when opening the media dialog.

This commit also cleans the code, by adding back some missing comments, renaming the variables to follow the convention and give them more correct names, and adding/fixing some docstring.
A major change to note is that the three actions `AddElTextAction`, `AddElImageAction` and `AddElButtonAction`, were merged back into one single `AddGridElementAction`. Indeed, there was no need to define three of them, as only one is needed, with an `actionParam` telling in which case we are (like before the refactoring).

task-4367641