### PR TITLE
[FIX] pos_self_order: prevent removing table number in display

### DIFF
--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -257,3 +257,19 @@ registry.category("web_tour.tours").add("test_add_multiple_serials_at_once", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_table_stand_number_exported", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            Chrome.clickMenuButton(),
+            ProductScreen.clickOrderMenu(),
+            ProductScreen.doubleClickOrder("12345678901234"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -529,3 +529,22 @@ export function checkTaxAmount(number) {
         },
     ]);
 }
+
+export function clickOrderMenu() {
+    return [
+        {
+            content: "Click Orders dropdown item",
+            trigger: '.dropdown-item.with-badge.py-2:contains("Orders")',
+        },
+    ];
+}
+
+export function doubleClickOrder(name) {
+    return [
+        {
+            content: `Select order`,
+            trigger: `.order-row:contains("${name}")`,
+            run: 'dblclick',
+        },
+    ];
+}

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -154,3 +154,9 @@ class PosOrder(models.Model):
         orders = super().export_for_ui_table_draft(table_ids)
         self_orders = self.get_standalone_self_order().export_for_ui()
         return orders + self_orders
+
+    def _export_for_ui(self, order):
+        order_for_ui = super()._export_for_ui(order)
+        if order_for_ui and order.table_stand_number:
+            order_for_ui['table_stand_number'] = order.table_stand_number
+        return order_for_ui

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -20,6 +20,19 @@ patch(Order.prototype, {
         }
     },
 
+    export_as_JSON() {
+        var json = super.export_as_JSON();
+        if (this.table_stand_number) {
+            json.table_stand_number = this.table_stand_number;
+        }
+        return json;
+    },
+
+    init_from_JSON(json) {
+        super.init_from_JSON(...arguments);
+        this.table_stand_number = json.table_stand_number;
+    },
+
     defaultTableNeeded(options) {
         return (
             super.defaultTableNeeded(...arguments) &&

--- a/addons/pos_self_order/tests/__init__.py
+++ b/addons/pos_self_order/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_self_order_attribute
 from . import test_self_order_combo
 from . import test_self_order_common
 from . import test_self_order_sequence
+from . import test_self_order_pos

--- a/addons/pos_self_order/tests/test_self_order_pos.py
+++ b/addons/pos_self_order/tests/test_self_order_pos.py
@@ -1,0 +1,40 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestSelfOrderPos(TestPointOfSaleHttpCommon):
+
+    def test_table_stand_number_exported(self):
+        """
+        Tests that even after being modified in the PoS, an
+        order's table_stand_number is not deleted or altered
+        """
+
+        self.main_pos_config.open_ui()
+
+        order = self.env['pos.order'].create({
+            'company_id': self.env.company.id,
+            'session_id': self.main_pos_config.current_session_id.id,
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': self.product_a.id,
+                'price_unit': 1000,
+                'discount': 0,
+                'qty': 1,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': 1000,
+                'price_subtotal_incl': 1000,
+            })],
+            'pricelist_id': self.main_pos_config.pricelist_id.id,
+            'amount_paid': 0.0,
+            'amount_total': 1000.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'table_stand_number': 9,
+            'pos_reference': 'POS/12345678901234',
+        })
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, "test_table_stand_number_exported", login="pos_user")
+        self.assertEqual(order.table_stand_number, '9')


### PR DESCRIPTION
**Problem:**
When making a purchase in the self order and put a table_stand_number, which is the table number you have to fill at the end of the order, it is displayed in the *pos_preparation_display*. But when loading this said order in the PoS, changing the order (like adding a note) and ordering it again, the table number is replaced by *IN*.

**Steps to reproduce:**
- Make a purchase in the kiosk
- Put a table number at the end of the order
- Go to the pos_preparation_display, it is displayed
- Go to the PoS session of the Kiosk and load the order
- Change the order by adding a note to it and order it again
- The table number is replaced by IN in the pos_preparation_display

**Why the fix:**
The field *table_stand_number* was not given to PoS in any case, which means that when reloading the order and saving it again, it saved it without the *table_stand_number*, as it was never loaded.
As it was never loaded, it went back to the fallback, which is writting *IN* if the table_stand_number was undefined. It is now loaded if the pos_self_order is installed, so that we can keep on showing the table number as it should be.

opw-4943404