### PR TITLE
[IMP] core: cache stats per transaction (and fixes)

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -2850,10 +2850,15 @@ def render(template_name, values, load, **options):
         def _get_asset_nodes(self, *args):
             raise NotImplementedError("Assets are not allowed in this rendering mode. Please use \"env['ir.qweb']._render\" method")
 
+    class MockCr:
+        def __init__(self):
+            self.cache = {}
+
     class MockEnv(dict):
         def __init__(self):
             super().__init__()
             self.context = {}
+            self.cr = MockCr()
 
         def __call__(self, cr=None, user=None, context=None, su=None):
             """ Return an mocked environment based and update the sent context.

--- a/odoo/addons/base/tests/test_ormcache.py
+++ b/odoo/addons/base/tests/test_ormcache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests.common import TransactionCase, tagged
@@ -32,6 +31,8 @@ class TestOrmCache(TransactionCase):
         cache, key, counter = get_cache_key_counter(IMD._xmlid_lookup, XMLID)
         hit = counter.hit
         miss = counter.miss
+        tx_hit = counter.tx_hit
+        tx_miss = counter.tx_miss
 
         # clear the caches of ir.model.data, retrieve its key and
         self.env.registry.clear_cache()
@@ -41,18 +42,24 @@ class TestOrmCache(TransactionCase):
         self.env.ref(XMLID)
         self.assertEqual(counter.hit, hit)
         self.assertEqual(counter.miss, miss + 1)
+        self.assertEqual(counter.tx_hit, tx_hit)
+        self.assertEqual(counter.tx_miss, tx_miss + 1)
         self.assertIn(key, cache)
 
         # lookup again
         self.env.ref(XMLID)
         self.assertEqual(counter.hit, hit + 1)
         self.assertEqual(counter.miss, miss + 1)
+        self.assertEqual(counter.tx_hit, tx_hit)
+        self.assertEqual(counter.tx_miss, tx_miss + 1)
         self.assertIn(key, cache)
 
         # lookup again
         self.env.ref(XMLID)
         self.assertEqual(counter.hit, hit + 2)
         self.assertEqual(counter.miss, miss + 1)
+        self.assertEqual(counter.tx_hit, tx_hit)
+        self.assertEqual(counter.tx_miss, tx_miss + 1)
         self.assertIn(key, cache)
 
     def test_invalidation(self):

--- a/odoo/orm/decorators.py
+++ b/odoo/orm/decorators.py
@@ -29,7 +29,6 @@ _logger = logging.getLogger('odoo.api')
 #  - method._constrains: set by @constrains, specifies constraint dependencies
 #  - method._depends: set by @depends, specifies compute dependencies
 #  - method._onchange: set by @onchange, specifies onchange fields
-#  - method.clear_cache: set by @ormcache, used to clear the cache
 #  - method._ondelete: set by @ondelete, used to raise errors for unlink operations
 #
 # On wrapping method only:

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -57,7 +57,7 @@ _REGISTRY_CACHES = {
     'routing': 1024,  # 2 entries per website
     'routing.rewrites': 8192,  # url_rewrite entries
     'templates.cached_values': 2048, # arbitrary
-    'groups': 1,  # contains all res.groups
+    'groups': 8,  # see res.groups
 }
 
 # cache invalidation dependencies, as follows:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The main change is to add logging for the first call for a given cursor and key. We are logging TX hits and misses in addition to normal counters. This allows to check whether caches are reused between RPC calls. The current hit ratio measures all calls which can result in a high number is a single call uses the cache a lot and other do it only sparsely.
- TX Calls = TX Hit + TX Miss
- TX Hit Ratio = TX Hit / TX Calls

Small changes:
- Refactor the cache logging mechanism.
- Log only one line per `ormcache` and registry. The goal is to see the effectiveness of the cache (not for a particular value/model).
- Display a summary per cache.
- Fix the computed size for mangled attribute names.
- There are 2 functions using 'groups' cache with no arguments.

Current behavior before PR:
```
Database odoo:
               Cache Name,  Entry,  Memory SUM [Bytes],  Memory MAX [Bytes],   Hit,  Miss,   Err,  Gen Time [s],  Hit Ratio,   Model.Method
                   assets,      6,    1205197 ( 74.5%),              428097,     0,     6,     0,         0.137,       0.0%,   ir.asset._get_asset_paths
                templates,      7,     162028 ( 10.0%),               49913,     1,     7,     0,         0.030,      12.5%,   ir.qweb._generate_code_cached
                  default,      2,     146928 (  9.1%),              133199,     1,     2,     0,         0.007,      33.3%,   ir.model.fields._get_fields_cached
...
                   groups,      1,         40 (  0.0%),                  40,    17,     1,     0,         0.004,      94.4%,   res.groups._get_group_definitions
```

Desired behavior after PR is merged:
```
Database odoo:
 * default: 36/8192 (112160 bytes)
 * assets: 0/5120
 * templates: 4/1024 (26079 bytes)
 * routing: 1/1024 (3157 bytes)
 * routing.rewrites: 0/81920
 * templates.cached_values: 0/20480
 * groups: 1/2 (14062 bytes)
Details:
               Cache Name,  Entry,  Memory %,  Memory SUM,  Memory MAX,   Hit,  Miss,   Err, Gen Time [s], Hit Ratio, TX Hit Ratio,TX Calls,  Method
                  default,      4,     31.3%,       48609,       14391,    50,     4,     0,        0.007,     92.6%,        33.3%,       6,  IrModelAccess._get_allowed_models
                templates,      4,     16.8%,       26079,       10332,     0,     4,     0,        0.019,      0.0%,         0.0%,       4,  Base._get_view_cache
                  default,      3,     16.5%,       25697,       16871,    51,     3,     0,        0.007,     94.4%,        25.0%,       4,  IrModelFields._get_fields_cached
                   groups,      1,      9.0%,       14062,       14062,    26,     1,     0,        0.003,     96.3%,        50.0%,       2,  ResGroups._get_group_definitions
```




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
