### PR TITLE
[FIX] mail: bigger call view in chat window when there's video

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -13,6 +13,10 @@
         &.o-compact {
             height: 10%;
             min-height: #{"max(10%, 100px)"};
+            &.o-hasVideo.o-selfInCall {
+                width: 100%;
+                height: calc(100vw * 9 / 16);
+            }
         }
     }
 }

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -8,6 +8,8 @@
             'o-compact': props.compact and !isMobileOs,
             'o-minimized': minimized,
             'position-relative': !state.isFullscreen,
+            'o-hasVideo': props.thread.videoCount > 0,
+            'o-selfInCall': isActiveCall,
         }">
             <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-on-mouseleave="onMouseleaveMain">
                 <div


### PR DESCRIPTION
Before this commit, when in a discuss call in a chat window with at least 1 video, clicking on no main card had all cards sized for avatar, including the video stream.

This is a problem because the video stream are very small, barely visible, which is unfortunate because when there are video streams they are usually the most important thing that call participants want to see.

This commit fixes by adding a new CSS rule in chat window with call: when user in a call with at least 1 video stream, the size of call view matches the size of a 16:9 video stream when focused.

Part of task-4967123

Before / After
<img width="381" height="634" alt="Screenshot 2025-07-28 at 17 57 37" src="https://github.com/user-attachments/assets/878bae9f-01e5-4f81-9d61-b43180d4f809" /> <img width="385" height="637" alt="Screenshot 2025-07-28 at 17 57 17" src="https://github.com/user-attachments/assets/0261d716-e52c-4a72-ad6a-007c8d01a362" />

