### PR TITLE
[IMP] purchase*: enhance UX of 'Other Info' tab layout in PO

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -209,6 +209,7 @@
                              readonly="state in ['cancel', 'purchase']"/>
                             <field name="partner_ref"/>
                             <field name="currency_id" groups="base.group_multi_currency" force_save="1" readonly="state in ['cancel', 'purchase']"/>
+                            <field name="payment_term_id" readonly="invoice_status == 'invoiced' or locked" options="{'no_create': True}"/>
                             <field name="id" invisible="1"/>
                             <field name="company_id" invisible="1" readonly="state in ['cancel', 'purchase']"/>
                             <field name="currency_id" invisible="1" readonly="state in ['cancel', 'purchase']" groups="!base.group_multi_currency"/>
@@ -393,17 +394,18 @@
                             </group>
                             <div class="clearfix"/>
                         </page>
-                        <page string="Other Information" name="purchase_delivery_invoice">
+                        <page string="Other Info" name="purchase_delivery_invoice">
                             <group>
-                                <group name="other_info">
+                                <group name="purchase_info" string="purchase">
                                     <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" readonly="state in ['cancel', 'purchase']"/>
-                                    <field name="origin"/>
                                 </group>
-                                <group name="invoice_info">
+                                <group name="billing_info" string="billing">
                                     <field name="invoice_status" invisible="state in ('draft', 'sent', 'to approve', 'cancel')"/>
-                                    <field name="payment_term_id" readonly="invoice_status == 'invoiced' or locked" options="{'no_create': True}"/>
                                     <field name="fiscal_position_id" options="{'no_create': True}" readonly="invoice_status == 'invoiced' or locked"/>
+                                </group>
+                                <group name="tracking_info" string="tracking">
+                                    <field name="origin"/>
                                 </group>
                             </group>
                         </page>

--- a/addons/purchase_product_matrix/models/purchase.py
+++ b/addons/purchase_product_matrix/models/purchase.py
@@ -8,8 +8,6 @@ from odoo.exceptions import ValidationError
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
-    report_grids = fields.Boolean(string="Print Variant Grids", default=True, help="If set, the matrix of configurable products will be shown on the report of this order.")
-
     """ Matrix loading and update: fields and methods :
 
     NOTE: The matrix functionality was done in python, server side, to avoid js
@@ -141,19 +139,18 @@ class PurchaseOrder(models.Model):
     def get_report_matrixes(self):
         """Reporting method."""
         matrixes = []
-        if self.report_grids:
-            grid_configured_templates = self.order_line.filtered('is_configurable_product').product_template_id
-            # TODO is configurable product and product_variant_count > 1
-            # configurable products are only configured through the matrix in purchase, so no need to check product_add_mode.
-            for template in grid_configured_templates:
-                if len(self.order_line.filtered(lambda line: line.product_template_id == template)) > 1:
-                    matrix = self._get_matrix(template)
-                    matrix_data = []
-                    for row in matrix['matrix']:
-                        if any(column['qty'] != 0 for column in row[1:]):
-                            matrix_data.append(row)
-                    matrix['matrix'] = matrix_data
-                    matrixes.append(matrix)
+        grid_configured_templates = self.order_line.filtered('is_configurable_product').product_template_id
+        # TODO is configurable product and product_variant_count > 1
+        # configurable products are only configured through the matrix in purchase, so no need to check product_add_mode.
+        for template in grid_configured_templates:
+            if len(self.order_line.filtered(lambda line: line.product_template_id == template)) > 1:
+                matrix = self._get_matrix(template)
+                matrix_data = []
+                for row in matrix['matrix']:
+                    if any(column['qty'] != 0 for column in row[1:]):
+                        matrix_data.append(row)
+                matrix['matrix'] = matrix_data
+                matrixes.append(matrix)
         return matrixes
 
 

--- a/addons/purchase_product_matrix/views/purchase_views.xml
+++ b/addons/purchase_product_matrix/views/purchase_views.xml
@@ -28,9 +28,6 @@
                 <field name="grid_product_tmpl_id" invisible="1"/>
                 <field name="grid_update" invisible="1"/>
             </field>
-            <group name="other_info" position="inside">
-                <field name="report_grids" groups="base.group_no_one"/>
-            </group>
         </field>
     </record>
 

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -51,7 +51,7 @@
             <xpath expr="//field[@name='order_line']/form//field[@name='invoice_lines']" position="after">
                 <field name="move_ids"/>
             </xpath>
-            <field name="invoice_status" position="before">
+            <field name="origin" position="after">
                 <field name="receipt_status" invisible="state != 'purchase'"/>
             </field>
             <xpath expr="//field[@name='order_line']/form//field[@name='analytic_distribution']" position="before">
@@ -64,7 +64,7 @@
                 <attribute name="column_invisible">parent.state != 'purchase'</attribute>
                 <attribute name="readonly">product_type == 'consu'</attribute>
             </xpath>
-            <xpath expr="//page[@name='purchase_delivery_invoice']/group/group" position="inside">
+            <xpath expr="//field[@name='fiscal_position_id']" position="after">
                 <field name="default_location_dest_id_usage" invisible="1"/>
                 <field name="incoterm_id" readonly="locked"/>
                 <field name="incoterm_location"  readonly="locked"/>


### PR DESCRIPTION
- Renamed the 'Other Information' tab to 'Other Info' for better readability
  and simplified navigation.
- Introduced three sections within the 'Other Info' tab — Purchase, Billing
  and Tracking — to better organize fields based on their purpose and
  improve the overall layout. which made easy to deal with all the fields.
- Rearranged fields in the tab according to their functional relevance and
  moved them to appropriate  sections to enhance user experience.
- Payment Terms field has been moved to the main form view for better
  visibility and quicker access.
- Removed the 'Print Variant Grid' boolean from the view. This option was
  previously invisible in debug mode. Users who do not require the grid can
  now manage this via the report, ensuring cleaner code and simplified user
  control.
- These changes collectively deliver a clearer and more simplified view for
  users, improving efficiency and usability.

Task Id: 4778630