### PR TITLE
FIX: fix issue with _set_inventory_quantity function clearing context

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -233,7 +233,7 @@ class StockQuant(models.Model):
                 continue
             quant.inventory_quantity = quant.inventory_quantity_auto_apply
             quant_to_inventory |= quant
-        quant_to_inventory.with_context({'set_inventory_quantity_auto_apply': True}).action_apply_inventory()
+        quant_to_inventory.with_context(set_inventory_quantity_auto_apply=True).action_apply_inventory()
 
     def _search_on_hand(self, operator, value):
         """Handle the "on_hand" filter, indirectly calling `_get_domain_locations`."""


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On stock.quant inside the _set_inventory_quantity function there is a line that is calling the action_apply_inventory function.
with_context is being used to add context before making this call, however with_context has been used by setting args instead of kwargs, causing it to clear the context at this point.

Current behavior before PR:
Context is not carried through to the action_apply_inventory function

Desired behavior after PR is merged:
maintain the context while adding to it.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
