### PR TITLE
[FIX] website: correct event target in cookie consent

### DIFF
--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -448,7 +448,7 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
      * @param ev
      */
     _onAcceptClick(ev) {
-        const isFullConsent = ev.target.id === "cookies-consent-all";
+        const isFullConsent = ev.currentTarget.id === "cookies-consent-all";
         this.cookieValue = `{"required": true, "optional": ${isFullConsent}}`;
         if (isFullConsent) {
             document.dispatchEvent(new Event("optionalCookiesAccepted"));


### PR DESCRIPTION
Steps to reproduce:
1. Enable the cookie bar on a website page.
2. Modify the "Accept all cookies" button to a structure like:
```html
<a id="cookies-consent-all">
    <span>Accept all cookies</span>
</a>
```
3. Click the button.
4. Cookies are not fully accepted because the event target reference points to the child element <span> instead of the <a>.

This fix ensures the handler correctly identifies clicks on the "Accept all cookies" button.

opw-4946989
