### PR TITLE
[FIX] http_routing: use 404 instead of 403 for public users

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -560,8 +560,12 @@ class IrHttp(models.AbstractModel):
             if request.httprequest.method in ('GET', 'HEAD'):
                 try:
                     _, path = rule.build(args)
-                except odoo.exceptions.MissingError:
-                    raise werkzeug.exceptions.NotFound()
+                except exceptions.MissingError as exc:
+                    raise werkzeug.exceptions.NotFound() from exc
+                except exceptions.AccessError as exc:
+                    if request.env.user.is_public:
+                        raise werkzeug.exceptions.NotFound() from exc
+                    raise
                 assert path is not None
                 generated_path = werkzeug.urls.url_unquote_plus(path)
                 current_path = werkzeug.urls.url_unquote_plus(request.httprequest.path)

--- a/addons/test_website/tests/test_page.py
+++ b/addons/test_website/tests/test_page.py
@@ -51,7 +51,7 @@ class WithContext(HttpCase):
         website.homepage_url = f"/test_website/200/name-{rec_unpublished.id}"
         with mute_logger('odoo.http'):  # mute 403 warning
             r = self.url_open(website.homepage_url)
-        self.assertEqual(r.status_code, 403, "The website homepage_url should be a 403")
+        self.assertEqual(r.status_code, 404, "The website homepage_url should be a 404")
         r = self.url_open(home_url)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.history[0].status_code, 303)

--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -142,16 +142,16 @@ class TestRedirect(HttpCase):
             self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/name-{rec_unpublished.id}")
 
             resp = self.url_open(f"/test_website/308/name-{rec_unpublished.id}", allow_redirects=False)
-            self.assertEqual(resp.status_code, 403)
-            self.assertEqual(resp.text, "CUSTOM 403")
+            self.assertEqual(resp.status_code, 404)
+            self.assertEqual(resp.text, "CUSTOM 404")
 
             resp = self.url_open(f"/test_website/200/xx-{rec_unpublished.id}", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
             self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/xx-{rec_unpublished.id}")
 
             resp = self.url_open(f"/test_website/308/xx-{rec_unpublished.id}", allow_redirects=False)
-            self.assertEqual(resp.status_code, 403)
-            self.assertEqual(resp.text, "CUSTOM 403")
+            self.assertEqual(resp.status_code, 404)
+            self.assertEqual(resp.text, "CUSTOM 404")
 
             # with seo_name as slug
             rec_published.seo_name = "seo_name"
@@ -169,8 +169,8 @@ class TestRedirect(HttpCase):
             self.assertURLEqual(resp.headers.get('Location'), f"/test_website/308/xx-{rec_unpublished.id}")
 
             resp = self.url_open(f"/test_website/308/xx-{rec_unpublished.id}", allow_redirects=False)
-            self.assertEqual(resp.status_code, 403)
-            self.assertEqual(resp.text, "CUSTOM 403")
+            self.assertEqual(resp.status_code, 404)
+            self.assertEqual(resp.text, "CUSTOM 404")
 
             resp = self.url_open("/test_website/200/xx-100", allow_redirects=False)
             self.assertEqual(resp.status_code, 308)
@@ -205,10 +205,10 @@ class TestRedirect(HttpCase):
         r = self.url_open(url_rec1)
         self.assertEqual(r.status_code, 200)
 
-        # 2. Accessing unpublished record: expecting 403 by default
+        # 2. Accessing unpublished record: expecting 404 for public users
         rec1.is_published = False
         r = self.url_open(url_rec1)
-        self.assertEqual(r.status_code, 403)
+        self.assertEqual(r.status_code, 404)
 
         # 3. Accessing unpublished record with redirect to a 404: expecting 404
         redirect = self.env['website.rewrite'].create({

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -156,7 +156,7 @@ class TestWebsiteAccess(HttpCaseWithUserDemo, OnlineEventCase):
 
         unpublished_events = self.events.filtered(lambda event: not event.website_published)
         resp = self.url_open('/event/%i' % unpublished_events[0].id)
-        self.assertEqual(resp.status_code, 403, 'Public must not have access to unpublished event')
+        self.assertEqual(resp.status_code, 404, 'Public must not have access to unpublished event')
 
         resp = self.url_open('/event')
         self.assertTrue(published_events[0].name in resp.text, 'Public must see the published events.')


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have an unpublished product;
2. as admin, go to its `/shop` page;
3. copy URL;
4. open URL in private window.

Issue
-----
> ### 403: Forbidden
>
> Uh-oh! Looks like you have stumbled upon some top-secret records.
>
> Sorry, Public user (id=4) doesn't have 'read' access to:
    - Product (product.template)
>
> If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.

This is information should not be accessible to public users.

Cause
-----
Commit 06cc322e7e2f added a `_pre_dispatch` override which displays the product name in the URL for SEO purposes. However, when the user does not have access to the product record, it throws an `AccessError`, leading to the HTTP 403 response.

Solution
--------
If an `AccessError` is raised when building the URL for a public user, return a HTTP 404 response, as if the record doesn't exist.

opw-4936500