### PR TITLE
[FIX] website_event_track: order priority desc

### DIFF
--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -31,7 +31,7 @@ YAHOO_CALENDAR_URL = 'https://calendar.yahoo.com/?v=60&view=d&type=20&'
 class EventTrack(models.Model):
     _name = 'event.track'
     _description = 'Event Track'
-    _order = 'priority, date'
+    _order = 'priority desc, date'
     _inherit = [
         'mail.thread',
         'mail.activity.mixin',


### PR DESCRIPTION
Priority ordering should show high priority first

Current behavior
<img width="329" height="410" alt="image" src="https://github.com/user-attachments/assets/7c4fb8ed-4a4a-4af1-b128-3ddf46b949d3" />
