### PR TITLE
[IMP] html_builder, website[_sale]: improve `/shop` previews

### DIFF
--- a/addons/html_builder/static/src/core/builder_action.js
+++ b/addons/html_builder/static/src/core/builder_action.js
@@ -11,12 +11,15 @@ export class BuilderAction {
         this.dispatchTo = plugin.dispatchTo.bind(plugin);
         this.delegateTo = plugin.delegateTo.bind(plugin);
 
-        this.preview = true;
-        this.withLoadingEffect = true;
-        this.loadOnClean = false;
-
         this.setup();
+
+        // Preview is enabled by default in non-reload actions,
+        // and disabled by default in reload actions.
+        this.preview ??= this.reload ? false : true;
+        this.withLoadingEffect ??= true;
+        this.loadOnClean ??= false;
     }
+
     /**
      * Called after dependencies and services are assigned.
      * Subclasses override this instead of the constructor.

--- a/addons/html_builder/static/src/core/building_blocks/builder_checkbox.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_checkbox.js
@@ -28,6 +28,8 @@ export class BuilderCheckbox extends Component {
                 isActive: isApplied(),
             };
         });
+        this.onPointerEnter = operation.preview;
+        this.onPointerLeave = operation.revert;
         this.onChange = operation.commit;
     }
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_checkbox.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_checkbox.xml
@@ -11,7 +11,9 @@
             t-att-data-style-action="info.styleAction"
             t-att-data-style-action-value="info.styleActionValue"
             t-att-data-attribute-action="info.attributeAction"
-            t-att-data-attribute-action-value="info.attributeActionValue">
+            t-att-data-attribute-action-value="info.attributeActionValue"
+            t-on-pointerenter="() => this.onPointerEnter(props.id)"
+            t-on-pointerleave="() => this.onPointerLeave(props.id)">
             <CheckBox className="getClassName()" onChange="onChange" value="state.isActive"/>
         </div>
     </BuilderComponent>

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -417,7 +417,6 @@ function useReloadAction(getAllActions) {
 
 export function useHasPreview(getAllActions) {
     const comp = useComponent();
-    const reload = useReloadAction(getAllActions).reload;
     const getAction = comp.env.editor.shared.builderActions.getAction;
 
     let hasPreview = true;
@@ -432,7 +431,6 @@ export function useHasPreview(getAllActions) {
 
     return (
         hasPreview &&
-        !reload &&
         (comp.props.preview === true ||
             (comp.props.preview === undefined && comp.env.weContext.preview !== false))
     );

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -157,6 +157,7 @@
         'website.website_builder_assets': [
             'website_sale/static/src/js/website_sale_form_editor.js',
             'website_sale/static/src/website_builder/**/*',
+            ('remove', 'website_sale/static/src/**/*.inside.scss'),
         ],
         'website.assets_wysiwyg': [
             'website_sale/static/src/scss/website_sale.editor.scss',
@@ -173,6 +174,9 @@
         ],
         'website.backend_assets_all_wysiwyg': [
             'website_sale/static/src/js/components/wysiwyg_adapter/wysiwyg_adapter.js',
+        ],
+        'website.inside_builder_style': [
+            'website_sale/static/src/website_builder/**/*.inside.scss',
         ],
         'web.assets_tests': [
             'website_sale/static/tests/tours/**/*',

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.inside.scss
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.inside.scss
@@ -1,0 +1,170 @@
+// Note: many lines in this file are disabled because variables such as
+// $o-we-handles-accent-color are not accessible from this bundle. The final
+// effect is that the colored outline around previews is not visible.
+// (TODO: make the variables accessible again?)
+
+// ==================
+// Edit-Mode Previews
+// ==================
+
+// body.editor_enable {
+//   // Outline the category description box
+//   #category_header {
+//     &:has(br:first-child:last-child), &:empty {
+//       outline: $border-width dashed fade-currentColor(25%);
+
+//       &:hover {
+//         outline: $border-width * 2 solid $o-we-handles-accent-color;
+//       }
+//     }
+//   }
+
+//   // Outline product description boxes
+//   .oe_subdescription {
+//     div:has(br:first-child:last-child):not(:hover), div:empty:not(:hover) {
+//       outline: $border-width dashed fade-currentColor(25%);
+//     }
+//   }
+// }
+
+
+// ==========================
+// Preview Components (/shop)
+// ==========================
+body.editor_enable:has(.o_wsale_edit_preview_enabled) {
+  // Hide default handles when other elements are highlighted
+  &:has(.o_wsale_previewing_sidebar),
+  &:has(.o_wsale_previewing_filmstrip),
+  &:has(.o_wsale_previewing_offcanvas),
+  &:has(.o_wsale_previewing_description),
+  &:has(.o_wsale_previewing_floating_bar) {
+    .o_handles {
+      visibility: hidden;
+    }
+  }
+
+  // @mixin _showcase {
+  //   z-index: $zindex-tooltip;
+  //   outline: $border-width * 2 solid $o-we-handles-accent-color;
+  // }
+
+  // Sidebar
+  .o_wsale_sidebar_preview {
+    padding: 0;
+    flex: 0 0 25%;
+    min-width: 0;
+    max-width: 0;
+    transform: translateX(-50%);
+    transition: all .2s;
+    opacity: 0;
+  }
+
+  .o_wsale_previewing_sidebar {
+    // #products_grid_before {
+    //   @include _showcase();
+    // }
+
+    .o_wsale_sidebar_preview:first-child {
+      // TODO: style error when including media-breakpoint-up
+      // @include media-breakpoint-up(lg) {
+      min-width: o-to-rem(240px);
+      max-width: var(--o-wsale-sidebar-maxwidth, 15rem);
+      opacity: 1;
+      transform: translateX(0);
+      // @include _showcase();
+      // }
+    }
+  }
+
+  // Categories Filmstrip (top)
+  .o_wsale_filmstrip_preview {
+    max-height: 0;
+    padding: 0;
+    transform: translateY(-50%);
+    opacity: 0;
+    transition: all .2s;
+  }
+
+  .o_wsale_previewing_filmstrip {
+    // .o_wsale_filmstip_container {
+    //   @include _showcase();
+    // }
+
+    .o_wsale_filmstrip_preview {
+      transform: translateY(0);
+      opacity: 1;
+      max-height: 100px;
+      // @include _showcase();
+      // outline-offset: 2px;
+    }
+  }
+
+  // Offcanvas
+  .o_wsale_previewing_offcanvas {
+    #o_wsale_offcanvas {
+      visibility: visible;
+      transform: none;
+      // box-shadow: $box-shadow-lg;
+      // @include _showcase();
+    }
+  }
+
+  // Descriptions
+  .o_wsale_description_preview {
+    opacity: 0;
+    transition: all .2s;
+
+    .placeholder {
+      transform: translateY(-50%);
+      min-height: 0em;
+      transition: all .2s;
+      opacity: .15;
+    }
+  }
+
+  .o_wsale_previewing_description {
+    // .oe_product_cart .oe_subdescription {
+    //   @include _showcase();
+    // }
+
+    .o_wsale_description_preview {
+      opacity: 1;
+      // outline: $border-width solid $o-we-handles-accent-color;
+      // outline-offset: 2px;
+
+      .placeholder {
+        transform: translateY(0);
+        min-height: .4em;
+      }
+    }
+  }
+
+  // Floating Bar
+  .o_wsale_floating_bar_preview {
+    transform: translateY(100%);
+    opacity: 0;
+    transition: all .2s;
+  }
+
+  .products_header {
+    max-height: 100px;
+    overflow: hidden;
+    transition: all .2s;
+  }
+
+  .o_wsale_previewing_floating_bar {
+    // #o_wsale_floating_bar {
+    //   @include _showcase();
+    // }
+
+    .products_header {
+      max-height: 0px;
+    }
+
+    .o_wsale_floating_bar_preview {
+      // @include _showcase();
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+}

--- a/addons/website_sale/static/src/website_builder/products_list_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option.xml
@@ -140,7 +140,15 @@
     </BuilderRow>
 
     <BuilderRow label.translate="Description" level="1">
-        <BuilderCheckbox action="'websiteConfig'" actionParam="{views: ['website_sale.products_description']}"/>
+        <BuilderCheckbox
+                action="'templatePreviewableWebsiteConfig'"
+                actionParam="{
+                    views: ['website_sale.products_description'],
+                    previewClass: 'o_wsale_previewing_description',
+                    templateId: 'website_sale.editor_preview.description',
+                    placeAfter: '.oe_product_cart:not(.oe_product_cart_has_description) .o_wsale_products_item_title',
+                }"
+        />
     </BuilderRow>
 
     <BuilderRow label.translate="Actions" level="1">
@@ -154,17 +162,29 @@
         <div class="flex-basis-100"/>
     </BuilderRow>
 
-    <BuilderRow label.translate="Categories" action="'websiteConfig'">
+    <BuilderRow label.translate="Categories" action="'templatePreviewableWebsiteConfig'">
         <BuilderButton
                 title.translate="Show into Sidebar"
                 id="'categories_opt'"
-                actionParam="{views: ['website_sale.products_categories']}"
+                actionParam="{
+                    views: ['website_sale.products_categories'],
+                    previewClass: 'o_wsale_previewing_sidebar o_wsale_has_sidebar',
+                    templateId: 'website_sale.editor_preview.sidebar',
+                    placeBefore: '#products_grid',
+                    placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_sidebar',
+                    }"
         >Sidebar</BuilderButton>
 
         <BuilderButton
                 title.translate="Show a filmstrip navigation at the Top"
                 id="'categories_opt_top'"
-                actionParam="{views: ['website_sale.products_categories_top']}"
+                actionParam="{
+                    views: ['website_sale.products_categories_top'],
+                    previewClass: 'o_wsale_previewing_filmstrip',
+                    templateId: 'website_sale.editor_preview.filmstrip',
+                    placeAfter: '#o_wsale_products_header h1',
+                    placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_filmstrip',
+                }"
         >Top</BuilderButton>
     </BuilderRow>
 
@@ -242,7 +262,7 @@
     </BuilderRow>
 
     <BuilderRow label.translate="Filters">
-        <BuilderSelect action="'websiteConfig'">
+        <BuilderSelect action="'templatePreviewableWebsiteConfig'">
             <BuilderSelectItem
                     title.translate="Hide all filters"
                     id="'attributes_hide_opt'"
@@ -251,12 +271,21 @@
             <BuilderSelectItem
                     title.translate="Show filters into Sidebar"
                     id="'attributes_opt'"
-                    actionParam="{views: ['website_sale.products_attributes']}"
+                    actionParam="{
+                        views: ['website_sale.products_attributes'],
+                        previewClass: 'o_wsale_previewing_sidebar o_wsale_has_sidebar',
+                        templateId: 'website_sale.editor_preview.sidebar',
+                        placeBefore: '#products_grid',
+                        placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_sidebar',
+                    }"
             >Sidebar</BuilderSelectItem>
             <BuilderSelectItem
                     title.translate="Render a button to show the Off-screen Menu"
                     id="'attributes_opt_top'"
-                    actionParam="{views: ['website_sale.products_attributes_top']}"
+                    actionParam="{
+                        views: ['website_sale.products_attributes_top'],
+                        previewClass: 'o_wsale_previewing_offcanvas',
+                    }"
             >Off-screen Menu</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
@@ -296,9 +325,17 @@
             label.translate="Floating"
             tooltip.translate="Floating sticky Toolbar"
             level="1"
-            action="'websiteConfig'"
     >
-        <BuilderCheckbox actionParam="{views: ['website_sale.floating_bar']}"/>
+        <BuilderCheckbox
+                action="'templatePreviewableWebsiteConfig'"
+                actionParam="{
+                    views: ['website_sale.floating_bar'],
+                    previewClass: 'o_wsale_previewing_floating_bar',
+                    templateId: 'website_sale.editor_preview.floating_bar',
+                    placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_floating_bar',
+                    placeAfter: '.o_wsale_products_main_row',
+                }"
+        />
     </BuilderRow>
 
     <BuilderRow label.translate="Default Sort" level="1">

--- a/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_list_page_option_plugin.js
@@ -1,9 +1,9 @@
-import { ProductsListPageOption } from "@website_sale/website_builder/products_list_page_option";
+import { BuilderAction } from "@html_builder/core/builder_action";
 import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
-import { BuilderAction } from "@html_builder/core/builder_action";
+import { ProductsListPageOption } from "@website_sale/website_builder/products_list_page_option";
 
 class ProductsListPageOptionPlugin extends Plugin {
     static id = "productsListPageOptionPlugin";
@@ -38,7 +38,6 @@ class ProductsListPageOptionPlugin extends Plugin {
         }
     }
 }
-
 export class SetPpgAction extends BuilderAction {
     static id = "setPpg";
     setup() {

--- a/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
+++ b/addons/website_sale/static/src/xml/website_sale_editor_previews.xml
@@ -52,7 +52,7 @@
 
 <t t-name="website_sale.editor_preview.description">
     <div
-        class="o_wsale_description_preview position-relative d-flex flex-column gap-1 mb-2"
+        class="oe_subdescription o_wsale_description_preview position-relative d-flex flex-column gap-1 mb-2"
         data-wsale-injected-preview="website_sale.editor_preview.description"
     >
         <div class="d-block placeholder col-12"/>


### PR DESCRIPTION
This PR restores the preview system for `/shop` that was introduced by  [1]  and then lost during the transition to the new website builder.

task-4367641

[1]: https://github.com/odoo/odoo/pull/197320