### PR TITLE
[IMP] mail: remove displayName from mail_guest_model

### DIFF
--- a/addons/mail/static/src/core/common/mail_guest_model.js
+++ b/addons/mail/static/src/core/common/mail_guest_model.js
@@ -35,11 +35,6 @@ export class MailGuest extends Record {
     /** @type {number} */
     id;
     debouncedSetImStatus;
-    displayName = fields.Attr(undefined, {
-        compute() {
-            return this._computeDisplayName();
-        },
-    });
     monitorPresence = fields.Attr(false, {
         compute() {
             return this.store.env.services.bus_service.isActive && this.id > 0;
@@ -90,10 +85,6 @@ export class MailGuest extends Record {
         },
     });
     write_date = fields.Datetime();
-
-    _computeDisplayName() {
-        return this.name;
-    }
 
     get avatarUrl() {
         const accessTokenParam = {};

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -330,6 +330,10 @@ export class Thread extends Record {
      * @param {import("models").Persona} persona
      */
     getPersonaName(persona) {
+        // Guest do not implement `displayName` and can safely use `name`.
+        if (persona.type === "guest") {
+            return persona.name;
+        }
         return persona.displayName;
     }
 


### PR DESCRIPTION
This code is dead code from the split of persona_model. Guest don't use displayName, just name.

task-4965928

