### PR TITLE
[FIX] point_of_sale: synchro when losing connection

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -59,6 +59,8 @@ export class PosData extends Reactive {
 
     async checkConnectivity() {
         try {
+            clearTimeout(this.checkConnectivityTimeout);
+            this.checkConnectivityTimeout = null;
             // Runbot tests will soon be run in dockers with no access to the outside world,
             // so all their interfaces will be disconnected. The problem is that the browser
             // considers itself offline when no interface is connected. However, in this case,
@@ -73,9 +75,17 @@ export class PosData extends Reactive {
 
             this.network.offline = false;
             this.network.warningTriggered = false;
+
+            window.dispatchEvent(new CustomEvent("pos-network-online"));
         } catch (error) {
             if (error instanceof ConnectionLostError) {
                 this.network.offline = true;
+                if (navigator.onLine) {
+                    this.checkConnectivityTimeout = setTimeout(
+                        () => this.checkConnectivity(),
+                        2000
+                    );
+                }
             }
         }
     }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -149,7 +149,7 @@ export class PosStore extends WithLazyGetterTrap {
         this.closeOtherTabs();
         this.syncAllOrdersDebounced = debounce(this.syncAllOrders, 100);
         this._searchTriggered = false;
-        window.addEventListener("online", () => {
+        window.addEventListener("pos-network-online", () => {
             // Sync should be done before websocket connection when going online
             this.syncAllOrdersDebounced();
         });


### PR DESCRIPTION
Steps to reproduce:
- open a pos on a runbot from saas-18.2
- turn off the wifi on your device until you see the disconnected sign
- turn back on the wifi
- the pos stays in "offline" mode

Issue:
The ping rpc call is made before the connection is really reestablished. The rpc call fails and the network.offline attribute stays true. This prevent the data from being sent to the backend.

Fix:
Set a timeout to perform the ping rpc call and sent an envent to notify the pos_store to syncAllOrders when back online.

Task-id: 4978122

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
