### PR TITLE
[FIX] *: preserve manually set header background over theme gradient

### DIFF
--- a/addons/html_builder/static/src/scss/builder.variables.scss
+++ b/addons/html_builder/static/src/scss/builder.variables.scss
@@ -220,7 +220,13 @@ $o-we-sidebar-content-field-toggle-control-bg: $o-we-fg-lighter !default;
         @extend .o_cc;
         @extend .o_cc#{$-related-color};
     } @else {
-        @include o-bg-color(o-color($-related-color), $with-extras: $with-extras, $background: $background, $important: false);
+        $-color: o-color($-related-color);
+        @if $-color {
+            // Remove the background image so manually set backgrounds (color or
+            // gradient) take precedence over a theme preset with a gradient.
+            background-image: none;
+        }
+        @include o-bg-color($-color, $with-extras: $with-extras, $background: $background, $important: false);
     }
 }
 

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -232,6 +232,15 @@ body {
     }
 }
 
+// The position of this rule is important: it ensures that manually set
+// background gradients on elements take precedence over the color preset
+// gradients.
+@for $index from 1 through 5 {
+    .o_cc#{$index} {
+        @include o-add-gradient('o-cc#{$index}-bg-gradient')
+    }
+}
+
 #wrapwrap {
     @if o-website-value('body-image') {
         @include body-image-bg-style();
@@ -572,12 +581,6 @@ $-header-nav-link-height: $nav-link-height;
         @include o-apply-colors('copyright', $background: $-footer-color);
         @include o-apply-colors('copyright-custom', $background: $-footer-color);
         @include o-add-gradient('copyright-gradient');
-    }
-}
-
-@for $index from 1 through 5 {
-    .o_cc#{$index} {
-        @include o-add-gradient('o-cc#{$index}-bg-gradient')
     }
 }
 

--- a/addons/website/static/tests/tours/background_color_gradient_precedence.js
+++ b/addons/website/static/tests/tours/background_color_gradient_precedence.js
@@ -1,0 +1,53 @@
+import {
+    changeBackgroundColor,
+    clickOnSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "background_color_gradient_precedence",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        {
+            content: "Verify that the correct gradient has been applied",
+            trigger: ":iframe .o_header_standard nav",
+            run() {
+                const bg = getComputedStyle(this.anchor)["background-image"];
+                if (!bg.includes("linear-gradient(rgb(2, 2, 2), rgb(3, 3, 3))")) {
+                    throw new Error("Gradient was NOT applied!");
+                }
+            },
+        },
+        ...clickOnSnippet({ id: "o_header_standard", name: "Header" }),
+        changeBackgroundColor(),
+        {
+            content: "Switch to custom colors pane",
+            trigger: ".o-hb-colorpicker .custom-tab",
+            run: "click",
+        },
+        {
+            content: "Select custom color background",
+            trigger: ".o_color_picker_button[data-color='black']",
+            run: "click",
+        },
+        {
+            content: "Verify custom color is selected in picker",
+            trigger: ".o_we_color_preview[style='background-color: #000000']",
+        },
+        {
+            content: "Verify custom color is applied to Header",
+            trigger: ":iframe .o_header_standard nav",
+            run() {
+                if (
+                    getComputedStyle(this.anchor)["background-image"] ===
+                    "linear-gradient(rgb(0, 0, 0), rgb(1, 1, 1))"
+                ) {
+                    throw new Error("Custom color was NOT applied!");
+                }
+            },
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -745,3 +745,17 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_anchor_on_accordion_item(self):
         self.start_tour("/", "anchor_behaviour_on_accordion_same_tab", login="admin")
         self.start_tour("/#What-services-does-your-company-offer-%3F", "anchor_behaviour_on_accordion_new_tab", login="admin")
+
+    def test_background_color_gradient_precedence(self):
+        # Configure CC1 with a gradient and apply it to the header, then set a
+        # different gradient directly on the header background.
+        self.env['website.assets'].with_context(website_id=1).make_scss_customization(
+            '/website/static/src/scss/options/user_values.scss',
+            {
+                'o-cc1-bg-gradient': 'linear-gradient(rgb(0, 0, 0), rgb(1, 1, 1))',
+                'o-cc1-bg': 'null',
+                'menu': '1',
+                'menu-gradient': 'linear-gradient(rgb(2, 2, 2), rgb(3, 3, 3))',
+            },
+        )
+        self.start_tour('/', 'background_color_gradient_precedence', login='admin')


### PR DESCRIPTION
>\* = `html_builder`, `website`

Issue:
-------
When a user manually sets a background (color or gradient) on the 
header, footer, or page breadcrumb (elements whose background values are
stored in the database, it gets overridden when a theme gradient is
applied via the active colour preset.

Steps to reproduce:
------
1. Edit a website page > Select Header/Footer/Breadcrumb > Set a
   background color (Custom color or Gradient).
2. Go to Theme > Select the active color preset of the
   header/footer/breadcrumb > Set any gradient as background for this
   preset.
3. Header/Footer/Breadcrumb background gets replaced by the selected
   theme gradient.

Desired behaviour:
-------
Manually set backgrounds (color or gradient) on the header, footer, or
breadcrumb persists, even when the theme preset is updated with a
gradient.

task-[4916455](https://www.odoo.com/odoo/project/974/tasks/4916455)