### PR TITLE
[FIX] account_peppol: prevert a singleton error

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -61,10 +61,11 @@ class ResPartner(models.Model):
     def _compute_available_peppol_eas(self):
         # EXTENDS 'account_edi_ubl_cii'
         super()._compute_available_peppol_eas()
-        eas_codes = set(self.available_peppol_eas)
-        if self.env.company._get_peppol_edi_mode() != 'demo' and 'odemo' in eas_codes:
-            eas_codes.remove('odemo')
-            self.available_peppol_eas = list(eas_codes)
+        for partner in self:
+            eas_codes = set(partner.available_peppol_eas)
+            if partner.env.company._get_peppol_edi_mode() != 'demo' and 'odemo' in eas_codes:
+                eas_codes.remove('odemo')
+                partner.available_peppol_eas = list(eas_codes)
 
     # -------------------------------------------------------------------------
     # HELPERS


### PR DESCRIPTION
An error occurs when the system tries to access single values `(of available_peppol_eas)` from multiple records at [1] during a studio export.

Link [1]: https://github.com/odoo/odoo/blob/1ff538bfefb9b5342335b37e5de163d97f270258/addons/account_peppol/models/res_partner.py#L64

`ValueError: Expected singleton: res.partner(15, 27, 34, 28, 10, 36, 19)`

To resolve this issue, use an iteration(for loop) to iterate records one by one.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
