### PR TITLE
[FIX] html_editor: strikethrough option for checked list items

### DIFF
--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -67,7 +67,10 @@ export function isUnderline(node) {
 export function isStrikeThrough(node) {
     let parent = closestElement(node);
     while (parent) {
-        if (getComputedStyle(parent).textDecorationLine.includes("line-through")) {
+        if (
+            !parent.classList.contains("o_checked") &&
+            getComputedStyle(parent).textDecorationLine.includes("line-through")
+        ) {
             return true;
         }
         parent = parent.parentElement;

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1649,3 +1649,22 @@ test("toolbar update should be run only once", async () => {
     expect(getContent(el)).toBe("<p><strong>[test]</strong></p>");
     expect(counter).toBe(1);
 });
+
+test("toolbar strikethrough buttons should not be active when checked list is strikethrough using o_checked class", async () => {
+    const { el } = await setupEditor(
+        '<ul class="o_checklist"><li class="o_checked">[test]</li></ul>'
+    );
+    await expandToolbar();
+    expect(".o-we-toolbar .btn[name='strikethrough']").toHaveCount(1);
+    expect(".o-we-toolbar .btn[name='strikethrough']").not.toHaveClass("active");
+    await contains(".o-we-toolbar .btn[name='strikethrough']").click();
+    await waitFor(".btn[name='strikethrough'].active");
+    expect(getContent(el)).toBe(
+        '<ul class="o_checklist"><li class="o_checked"><s>[test]</s></li></ul>'
+    );
+    expect(".o-we-toolbar .btn[name='strikethrough']").toHaveClass("active");
+    await contains(".o-we-toolbar .btn[name='strikethrough']").click();
+    await waitFor(".btn[name='strikethrough']:not(.active)");
+    expect(getContent(el)).toBe('<ul class="o_checklist"><li class="o_checked">[test]</li></ul>');
+    expect(".o-we-toolbar .btn[name='strikethrough']").not.toHaveClass("active");
+});


### PR DESCRIPTION
Description of the issue this PR addresses:

This PR ensures that the strikethrough toolbar button is not shown as active when the selection is within a checked item of a checklist. However, if the text was already struck through before being added to the checklist, the button may still appear active in that case.

task-4949067

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
