### PR TITLE
[FIX] hr_timesheet: fix portal view-timesheet multi company access

### DIFF
--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -69,7 +69,7 @@ class TimesheetCustomerPortal(CustomerPortal):
 
     @http.route(['/my/timesheets', '/my/timesheets/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_timesheets(self, page=1, sortby=None, filterby=None, search=None, search_in='all', groupby='none', **kw):
-        Timesheet = request.env['account.analytic.line']
+        Timesheet = request.env['account.analytic.line'].with_context(allowed_company_ids=request.env.user.company_ids.ids)
         domain = Timesheet._timesheet_get_portal_domain()
         Timesheet_sudo = Timesheet.sudo()
 


### PR DESCRIPTION
**Steps to reproduce:**
1. Install hr_timesheet, Sales, Website > add BE company >
2. Go to website, configuration > website > update the website1 company to BE
3. Sales > create new SO > add product Junior Architect (Invoice on Timesheets)
4. Confirm > click to tasks smart-button > add timesheet > back to sales order
5. Create invoice > confirm
6. Preview > View Timesheet

**Issue:**
View timesheet button shows no timesheet records when accessing from different company website

**Cause:**
Portal timesheet domain is restricted to current website's company context. When user switches from San Francisco website to Belgium website, timesheets created under San Francisco company become invisible even though user has access to all companies.

**Solution:**
Add allowed_company_ids context to account.analytic.line model to include all user's accessible companies, allowing cross-company timesheet visibility.

**opw-4922212**
