### PR TITLE
[IMP] mail, im_livechat: hide chatbot's IM status in website

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chat_bubble_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_bubble_patch.js
@@ -1,0 +1,12 @@
+import { ChatBubble } from "@mail/core/common/chat_bubble";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(ChatBubble.prototype, {
+    get showImStatus() {
+        return (
+            super.showImStatus &&
+            !(this.thread?.correspondent?.livechat_member_type === "bot" && this.env.embedLivechat)
+        );
+    },
+});

--- a/addons/im_livechat/static/tests/embed/chat_bubble.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_bubble.test.js
@@ -1,0 +1,35 @@
+import {
+    defineLivechatModels,
+    loadDefaultEmbedConfig,
+} from "@im_livechat/../tests/livechat_test_helpers";
+import { contains, setupChatHub, start, startServer } from "@mail/../tests/mail_test_helpers";
+import { describe, test } from "@odoo/hoot";
+import { Command, makeMockEnv } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineLivechatModels();
+
+test("Do not show bot IM status", async () => {
+    const pyEnv = await startServer();
+    await loadDefaultEmbedConfig();
+    await makeMockEnv({ embedLivechat: true });
+    const partnerId1 = pyEnv["res.partner"].create({ name: "Mitchell", im_status: "online" });
+    pyEnv["res.users"].create({ partner_id: partnerId1 });
+    const channelId1 = pyEnv["discuss.channel"].create({
+        channel_member_ids: [Command.create({ partner_id: partnerId1 })],
+        channel_type: "chat",
+    });
+    const partnerId2 = pyEnv["res.partner"].create({ name: "Dummy" });
+    const channelId2 = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: partnerId2, livechat_member_type: "bot" }),
+        ],
+        channel_type: "livechat",
+        livechat_operator_id: partnerId2,
+    });
+    setupChatHub({ folded: [channelId1, channelId2] });
+    await start({ authenticateAs: false });
+    await contains(".o-mail-ChatBubble[name='Mitchell'] .o-mail-ImStatus");
+    await contains(".o-mail-ChatBubble[name='Dummy']");
+    await contains(".o-mail-ChatBubble[name='Dummy'] .o-mail-ImStatus", { count: 0 });
+});

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -75,4 +75,11 @@ export class ChatBubble extends Component {
     get thread() {
         return this.props.chatWindow.thread;
     }
+
+    get showImStatus() {
+        return (
+            this.thread?.correspondent?.im_status &&
+            this.thread.correspondent.im_status !== "offline"
+        );
+    }
 }

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -5,7 +5,7 @@
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute text-400" t-att-class="{ 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
-            <ImStatus t-if="thread?.correspondent?.im_status and thread?.correspondent?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute'" member="thread.correspondent">
+            <ImStatus t-if="showImStatus" className="'o-mail-ChatBubble-status position-absolute'" member="thread.correspondent">
                 <t t-set-slot="pre_icon">
                     <i style="font-size: 18px; right: -2px; bottom: -2px; z-index: -1;" t-att-class="{
                         'bg-success rounded-pill position-absolute': thread?.correspondent?.isTyping,


### PR DESCRIPTION
**Description of the issue this PR addresses:**

Chatbot's IM Status shouldn't be visible on the website

**Current behavior before PR:**

Before this PR, the chatbot's IM status was shown
on the website during live chat.

**Desired behavior after PR is merged:**

This PR hides the IM status for chatbot
when embedded in the website, while keeping it visible elsewhere.


task-[4930194](https://www.odoo.com/odoo/project/1519/tasks/4930194)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
