### PR TITLE
[FIX] hr_recruitment: fix applicant interview meeting count

### DIFF
--- a/addons/hr_recruitment/models/calendar.py
+++ b/addons/hr_recruitment/models/calendar.py
@@ -11,6 +11,11 @@ class CalendarEvent(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        if not self.env.context.get('default_applicant_id'):
+            appointment_booker_id = vals_list[0].get('appointment_booker_id')
+            if appointment_booker_id:
+                applicant_id = self.env['hr.applicant'].search([('partner_id', '=', appointment_booker_id)], limit=1)
+                vals_list[0]['applicant_id'] = applicant_id.id
         events = super(CalendarEvent, self).create(vals_list)
         try:
             self.env['hr.applicant'].check_access_rights('read')


### PR DESCRIPTION
In this bug, the number of interview meeting of applicant is not shown correctly. The meetings which are scheduled by applicant in appointment app, are not take into account.

To reproduce:
1- Create a db with appointment and recruitment installed.
2- Create a new job position, with email template to let applicant schedule a meeting.
3- Move forward the applicant to interviewing stage, and use the link provided to the applicant to set an appointment.
4- Open applicant. As you see, the smart button is showing: `No Meeting`

This bug, is result of not setting `applicant_id` in the `calender.event` when the event is set by the applicant. When db user schedules the event, the context has a default value `default_applicant_id`, but this is missing for the case when applicant sets the interview themsevles resulting `applicant_id` to be empty.

opw-4784349
