### PR TITLE
[IMP] account, base, base_vat, l10n_ar, portal: Tax ID on child contacts

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -279,6 +279,12 @@
                            groups="account.group_account_invoice,account.group_account_readonly"
                     />
                 </group>
+                <xpath expr="//page[@name='contact_addresses']//form//group//field[@name='vat']" position="before">
+                    <field name="partner_vat_placeholder" invisible="1"/> <!-- Needed for the placeholder widget -->
+                </xpath>
+                <xpath expr="//page[@name='contact_addresses']//form//group//field[@name='vat']" position="attributes">
+                    <attribute name="options">{'placeholder_field': 'partner_vat_placeholder'}</attribute>
+                </xpath>
             </field>
         </record>
 

--- a/addons/l10n_ar/models/account_fiscal_position.py
+++ b/addons/l10n_ar/models/account_fiscal_position.py
@@ -10,10 +10,10 @@ class AccountFiscalPosition(models.Model):
         string='ARCA Responsibility Types', help='List of ARCA responsibilities where this fiscal position '
         'should be auto-detected')
 
-    def _get_fpos_validation_functions(self, partner):
-        functions = super()._get_fpos_validation_functions(partner)
+    def _get_fpos_validation_functions(self, delivery_partner, vat_partner):
+        functions = super()._get_fpos_validation_functions(delivery_partner, vat_partner)
         if self.env.company.country_id.code != "AR":
             return functions
         return [
-            lambda fpos: partner.l10n_ar_afip_responsibility_type_id in fpos.l10n_ar_afip_responsibility_type_ids,
+            lambda fpos: delivery_partner.l10n_ar_afip_responsibility_type_id in fpos.l10n_ar_afip_responsibility_type_ids,
         ] + functions

--- a/addons/portal/tests/test_addresses.py
+++ b/addons/portal/tests/test_addresses.py
@@ -250,6 +250,30 @@ class TestPortalAddresses(BaseCommon, HttpCase):
             [self.default_address_values],
         )
 
+    def test_update_vat_on_child_delivery_addresses(self):
+        """
+        Check that the VAT can be updated on a child delivery address, without updating the parent's VAT.
+        """
+        self.authenticate(self.portal_user.login, self.portal_user.login)
+        csrf_token = Request.csrf_token(self)
+
+        res = self._submit_address_values({
+            **self.default_address_values,
+            'csrf_token': csrf_token,
+            'address_type': 'delivery',
+            'vat': 'BE0926372368',
+        })
+        self.assertEqual(res, {'redirectUrl': '/my/addresses'})
+        delivery_address = self.portal_user.partner_id.child_ids
+        self.assertRecordValues(
+            delivery_address,
+            [{**self.default_address_values, 'vat': 'BE0926372368'}],
+        )
+        self.assertRecordValues(
+            self.portal_user.partner_id,
+            [{'vat': False}],
+        )
+
     def test_delivery_use_as_billing_address_creation(self):
         self.authenticate(self.portal_user.login, self.portal_user.login)
         csrf_token = Request.csrf_token(self)

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -881,6 +881,13 @@ class TestPartnerAddressCompany(TransactionCase):
         for partner in company_2 + contact + contact_dlr + contact_ct + contact2:
             self.assertEqual(partner.vat, contactvat, 'Commercial sync works upstream, therefore also for siblings')
 
+        # change vat of delivery contact - shouldn't be propagated upstream
+        deliveryvat = 'BE0729163846'
+        contact_dlr.write({'vat': deliveryvat})
+        self.assertEqual(contact_dlr.vat, deliveryvat, 'VAT changed for delivery contact')
+        for partner in company_2 + contact + contact_ct + contact2:
+            self.assertEqual(partner.vat, contactvat, 'VAT not propagated upstream')
+
     def test_commercial_field_sync_reset(self):
         """ Test voiding fields propagation. We would like to allow forcing void
         values from parent, but limiting upstream reset from children. """

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -274,6 +274,7 @@
                                             </group>
                                         </group>
                                         <group>
+                                            <field name="vat" placeholder="e.g. BE0477472701" invisible="type != 'delivery'"/>
                                             <field name="company_id" invisible="1"/>    <!-- Need to save value from parented record, cf onchange -->
                                             <label for="comment"/>
                                             <field name="comment" options="{'height': 100}" placeholder="Internal notes..." nolabel="1"/>


### PR DESCRIPTION
This PR:
1. Enables distinct Tax IDs on child contacts, so that updating a child's Tax ID does not affect the parent partner's Tax ID.
2. Update the fiscal position detection function, so it only uses the Tax ID from a delivery address if that address is a registered child contact. Otherwise, the billing partner's Tax ID is used. Furthermore, if a delivery address exists, it is always used in the FP computation (while before, if the billing partner's tax id was from the same EU country as the company, the delivery address was ignored).

More details available on the respective commit messages.

task-4955193

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
