### PR TITLE
Saas 18.4 fix parallax in nested block bvr

### DIFF
--- a/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
@@ -100,6 +100,9 @@ export class BackgroundImageOptionPlugin extends Plugin {
         if (backgroundURL) {
             el.classList.add("oe_img_bg", "o_bg_img_center", "o_bg_img_origin_border_box");
         } else {
+            this.dependencies.builderActions.getAction("selectFilterColor").apply({
+                editingElement: el.classList.contains("s_parallax_bg") ? el.parentElement : el,
+            });
             el.classList.remove(
                 "oe_img_bg",
                 "o_bg_img_center",
@@ -183,7 +186,6 @@ export class ToggleBgImageAction extends BuilderAction {
         return !!getBgImageURLFromEl(editingElement);
     }
     clean({ editingElement }) {
-        editingElement.querySelector(".o_we_bg_filter")?.remove();
         this.dependencies.backgroundImageOption.applyReplaceBackgroundImage({
             editingElement: editingElement,
             loadResult: "",

--- a/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
@@ -45,7 +45,7 @@ class WebsiteParallaxPlugin extends Plugin {
         } else {
             delete editingElement.dataset.parallaxType;
         }
-        let parallaxEl = editingElement.querySelector(".s_parallax_bg");
+        let parallaxEl = editingElement.querySelector(":scope > .s_parallax_bg");
         if (isParallax) {
             if (!parallaxEl) {
                 parallaxEl = document.createElement("span");
@@ -68,7 +68,7 @@ class WebsiteParallaxPlugin extends Plugin {
         }
     }
     removeParallax(editingEl) {
-        const parallaxEl = editingEl.querySelector(".s_parallax_bg");
+        const parallaxEl = editingEl.querySelector(":scope > .s_parallax_bg");
         const bgImage = parallaxEl?.style.backgroundImage;
         if (
             !parallaxEl ||

--- a/addons/website/static/tests/builder/website_builder/background.test.js
+++ b/addons/website/static/tests/builder/website_builder/background.test.js
@@ -40,6 +40,26 @@ test("remove parallax changes editing element", async () => {
     expect(":iframe section").toHaveClass("o_bg_img_opt_repeat");
 });
 
+test("remove parallax from block containing an inner block with parallax", async () => {
+    const backgroundImageUrl = "url('/web/image/123/transparent.png')";
+    await setupWebsiteBuilder(`
+        <section id="section_a" style="background-image: ${backgroundImageUrl} !important;">
+            <section id="section_b">
+                <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
+            </section>
+        </section>`);
+    await contains(":iframe section#section_a").click();
+    await contains("[data-label='Scroll Effect'] button.o-dropdown").click();
+    await contains("[data-action-value='top']").click();
+    expect(":iframe section#section_a").toHaveClass("parallax");
+    expect(":iframe section#section_a > .s_parallax_bg").toHaveCount();
+    await contains("[data-label='Scroll Effect'] button.o-dropdown").click();
+    await contains("[data-action-value='none']").click();
+    expect(":iframe section#section_a > .s_parallax_bg").not.toHaveCount();
+    expect(":iframe section#section_b > .s_parallax_bg").toHaveCount();
+
+});
+
 async function setupWebsiteAndOpenParallaxOptions({ editingElClasses = "" } = {}) {
     const backgroundImageUrl = "url('/web/image/123/transparent.png')";
     const editingElClass = editingElClasses ? `class=${editingElClasses}` : "";

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -214,3 +214,15 @@ test("changing shape's background color doesn't hide the shape itself", async ()
     await contains(".o_colorpicker_section button[data-color='o-color-1']").click();
     expect(":iframe .o_we_shape").toHaveStyle({ backgroundImage: backgroundImageValue });
 });
+
+test("remove background image removes color filter", async () => {
+    const backgroundImageUrl = "url('/web/image/123/transparent.png')";
+    await setupWebsiteBuilder(`
+        <section>
+            <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
+            <div class="o_we_bg_filter bg-black-50 o-paragraph"><br></div>
+        </section>`);
+    await contains(":iframe section").click();
+    await contains("[data-action-id='toggleBgImage']").click();
+    expect(":iframe section .o_we_bg_filter").not.toHaveCount();
+});


### PR DESCRIPTION
**[FIX] website: remove background color filter when removing bg image**

Since the `html_builder`, when a block has a parallax background image
and the image is removed, any applied color filter remains applied.
This happens because the `editingElement` of the image toggle is the
parallax span instead of the actual section - and therefore the color
filter element is not properly located.

This commit finds out about that situation and removes the filter from
the right element.

Steps to reproduce:
- Drop a "Cover" block
- Remove its background image

=> Its color filter remained present in the DOM.

-------

**[FIX] website: fix parallax in nested block**

Steps to reproduce:

- In Website edit mode.
- Drag and drop a "Tabs" block.
- Drag and drop a "Cover" block inside the "Tabs".
- Add a background image to the "Tabs" block.
- Add a scroll effect (Parallax) to the "Tabs" block.
- Bug: The scroll effect is not applied.

This bug happened because the code checked for a parallax effect in the
whole block structure, not just on the block itself. It wrongly detected
a parallax because a child block had one, even if the parent didn’t.

task-4367641