### PR TITLE
[FIX] core: upgrade company-dependent override

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -419,6 +419,11 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
             cr.execute("SELECT model || '.' || name FROM ir_model_fields WHERE translate IS TRUE")
             registry._database_translated_fields = {row[0] for row in cr.fetchall()}
 
+            # determine the fields which are currently company dependent in the database
+            if odoo.tools.sql.column_exists(cr, 'ir_model_fields', 'company_dependent'):
+                cr.execute("SELECT model || '.' || name FROM ir_model_fields WHERE company_dependent IS TRUE")
+                registry._database_company_dependent_fields = {row[0] for row in cr.fetchall()}
+
         # processed_modules: for cleanup step after install
         # loaded_modules: to avoid double loading
         report = registry._assertion_report

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -153,6 +153,7 @@ class Registry(Mapping):
         self._sql_constraints = set()
         self._init = True
         self._database_translated_fields = ()  # names of translated fields in database
+        self._database_company_dependent_fields = ()  # names of company dependent fields in database
         if config['test_enable'] or config['test_file']:
             from odoo.tests.result import OdooTestResult  # noqa: PLC0415
             self._assertion_report = OdooTestResult()


### PR DESCRIPTION
before this commit:
if module_A has a field ``company_dependent=False`` and module_B override it to ``company_dependent=True`` When -u module_A, there would be an error since ORM tries to convert column type of the field from varchar/integer/boolean... to jsonb

This commit will add a patch to the field in the ORM registry if the field was company dependent before upgrade.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
