### PR TITLE
[FIX] crm, mail: only show active activities

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1106,8 +1106,7 @@
             <field name="res_model">crm.lead</field>
             <field name="view_mode">list,kanban,graph,pivot,calendar,form,activity</field>
             <field name="view_id" ref="crm_lead_view_list_activities"/>
-            <!-- Ensure that only records with at least one activity, "done" (archived) or not, are fetched. -->
-            <field name="domain">[("activity_ids.active", "in", [True, False])]</field>
+            <field name="domain">[("activity_ids.active", "=", True)]</field>
             <field name="search_view_id" ref="crm.view_crm_case_my_activities_filter"/>
             <field name="context">{'default_type': 'opportunity',
                     'search_default_assigned_to_me': 1}

--- a/addons/mail/static/src/core/web/activity_menu.js
+++ b/addons/mail/static/src/core/web/activity_menu.js
@@ -68,7 +68,7 @@ export class ActivityMenu extends Component {
             context["search_default_activities_upcoming_all"] = 1;
         }
 
-        let domain = [];
+        let domain = [["activity_ids.active", "=", true]];
         if (group.domain) {
             domain = Domain.and([domain, group.domain]).toList();
         }

--- a/addons/test_mail/static/tests/systray_activity_menu.test.js
+++ b/addons/test_mail/static/tests/systray_activity_menu.test.js
@@ -79,7 +79,7 @@ test("activity menu widget: activity menu with 2 models", async () => {
             search_default_activities_overdue: 1,
             search_default_activities_today: 1,
         },
-        domain: [],
+        domain: [["activity_ids.active", "=", true]],
     };
     mockService("action", {
         doAction(action) {


### PR DESCRIPTION
**Current Behavior:**

When users click on the activities icon, both active and archived activities are displayed. 
This can lead to confusion, as users expect to see only ongoing (i.e., pending or overdue) activities.

**To reproduce this issue:**
1) Install the Contacts module and create two partner records. 
2) Create a late activity for each of the two records. 
3) Mark one activity as Done by clicking the DONE button. 
4) Open the Late Activities for Contacts from the top-right corner.

**Issue:**
Even after marking one activity as done, both activities are shown. 
This results in two late activities appearing, instead of just one active one.

**Cause:**
When an activity is marked as Done, the `action_feedback` method is called via `markAsDone`.
https://github.com/odoo/odoo/blob/7fa14f9b8e2e886243d68d8e04b0798cd801615b/addons/mail/static/src/core/web/activity_model_patch.js#L44-L48
This method archives the corresponding `mail.activity` record.
https://github.com/odoo/odoo/blob/7fa14f9b8e2e886243d68d8e04b0798cd801615b/addons/mail/models/mail_activity.py#L556-L557

But because of the recent changes from the below-mentioned commit, 
we are now showing the archived records.
https://github.com/odoo/odoo/commit/f05c2f9c7942943140c98174f8c86917fc72fc9b#diff-cacfccf65b597df222b166a1c6d80d125bb75a1f2aeabf2eed2e88e189c144f0R59

However, this change was intended to display archived model records 
that still have active activities, not to show archived or completed activities themselves.

**Solution:**

Apply a domain filter to ensure that only active (non-archived) activity records are displayed.

opw-4946120
