### PR TITLE
[FIX] core: preserve translated values in cache

### DIFF
--- a/odoo/addons/base/tests/test_cache.py
+++ b/odoo/addons/base/tests/test_cache.py
@@ -128,3 +128,20 @@ class TestRecordCache(TransactionCaseWithUserDemo):
             mem_usage, MAX_MEMORY * 1024 * 1024,
             "Caching %s records must take less than %sMB of memory" % (NB_RECORDS, MAX_MEMORY),
         )
+
+    def test_multilang_persistence(self):
+        """ Check that the cache persists across multiple language reads and writes. """
+        self.env['res.lang']._activate_lang('en_US')
+        self.env['res.lang']._activate_lang('fr_FR')
+
+        model = self.env['ir.actions.actions']
+
+        # Ensure the value in env lang persists after reading the second lang value
+        record = model.new({'name': 'Test Action'})
+        _ = record.with_context(lang='fr_FR').name
+        self.assertTrue(record.name)
+
+        # Ensure the value in second lang persists after reading the env lang value
+        record = model.with_context(lang='fr_FR').new({'name': 'action de test'})
+        _ = record.with_context(lang='en_US').name
+        self.assertTrue(record.name)

--- a/odoo/addons/base/tests/test_cache.py
+++ b/odoo/addons/base/tests/test_cache.py
@@ -133,6 +133,7 @@ class TestRecordCache(TransactionCaseWithUserDemo):
         """ Check that the cache persists across multiple language reads and writes. """
         self.env['res.lang']._activate_lang('en_US')
         self.env['res.lang']._activate_lang('fr_FR')
+        self.env['res.lang']._activate_lang('nl_NL')
 
         model = self.env['ir.actions.actions']
 
@@ -143,5 +144,5 @@ class TestRecordCache(TransactionCaseWithUserDemo):
 
         # Ensure the value in second lang persists after reading the env lang value
         record = model.with_context(lang='fr_FR').new({'name': 'action de test'})
-        _ = record.with_context(lang='en_US').name
+        _ = record.with_context(lang='nl_NL').name
         self.assertTrue(record.name)

--- a/odoo/addons/base/tests/test_cache.py
+++ b/odoo/addons/base/tests/test_cache.py
@@ -146,3 +146,9 @@ class TestRecordCache(TransactionCaseWithUserDemo):
         record = model.with_context(lang='fr_FR').new({'name': 'action de test'})
         _ = record.with_context(lang='nl_NL').name
         self.assertTrue(record.name)
+
+        # Ensure field assignment does not nullify the values in other langs
+        record = model.new({'name': 'Another Test Action'})
+        record.with_context(lang='fr_FR').name = 'Autre action de test'
+        self.assertTrue(record.name)
+        self.assertTrue(record.with_context(lang='fr_FR').name)

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -1036,6 +1036,9 @@ class Cache(object):
             lang = record.env.lang or 'en_US'
             cache_value = field_cache.get(record._ids[0]) or {}
             cache_value[lang] = value
+            if not record._origin:
+                for code, _ in record.env['res.lang'].get_installed():
+                    cache_value.setdefault(code, None)
             value = cache_value
         field_cache[record._ids[0]] = value
 

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -1013,7 +1013,10 @@ class Cache(object):
             cache_value = field_cache[record._ids[0]]
             if field.translate and cache_value is not None:
                 lang = record.env.lang or 'en_US'
-                return cache_value[lang]
+                if lang == 'en_US' or (field.store and record._origin):
+                    return cache_value[lang]
+                # nothing to be found in database
+                return cache_value.get(lang) or cache_value['en_US']
             return cache_value
         except KeyError:
             if default is NOTHING:
@@ -1036,9 +1039,8 @@ class Cache(object):
             lang = record.env.lang or 'en_US'
             cache_value = field_cache.get(record._ids[0]) or {}
             cache_value[lang] = value
-            if not record._origin:
-                for code, _ in record.env['res.lang'].get_installed():
-                    cache_value.setdefault(code, None)
+            if not (field.store and record._origin) and 'en_US' not in cache_value:
+                cache_value['en_US'] = value
             value = cache_value
         field_cache[record._ids[0]] = value
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1793,7 +1793,7 @@ class _String(Field):
 
         # not dirty fields
         if not dirty:
-            cache.update_raw(records, self, [{lang: cache_value} for _id in records._ids], dirty=False)
+            cache.update(records, self, itertools.repeat(cache_value), dirty=False)
             return records
 
         # model translation


### PR DESCRIPTION
Steps to reproduce the issue:
1. Install a second language (eg, ar_001) and `product`
2. Start odoo shell
3. Run the following:

`(env := env(context=dict(env.context,lang='ar_001')))['product.template'].new({'name':'test'}).with_context(lang='en_US').name`

Current behavior before PR:
The `get` method of the cache will not find a value for the `en_US` 
language and set the value stored in the env language 
to a default (`None` in this case) after raising `CacheMiss`

Desired behavior after PR is merged:
We can read and write translatable fields in different 
languages on transient records without data loss.

opw-4943458
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr