### PR TITLE
[FIX] website: move scripts from body to head

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -248,7 +248,7 @@
         <attribute name="t-if">not editable</attribute>
     </xpath>
 
-    <xpath expr="//div[@id='wrapwrap']" position="after">
+    <xpath expr="//head" position="inside">
         <t t-if="website.google_analytics_key and not editable">
             <script id="tracking_code" t-attf-src="https://www.googletagmanager.com/gtag/js?id={{ website.google_analytics_key }}" async="async"/>
             <script id="tracking_code_config">


### PR DESCRIPTION
Analytics scripts (Google Analytics and Plausible) were added in the `body` of the page instead of in its `head`. Both documentations ([1] and [2]) advise to put it in the head, to make sure metrics are as accurate as possible as it allows the script to run earlier.

Note that Google advises to put it "immediately after the opening `<head>`": we do not want that, as the first script that needs running is the `cookie_watcher` in case there is a cookie banner, in order to avoid sending tracking information as long as a user has not given their consent.

[1]: https://developers.google.com/tag-platform/gtagjs
[2]: https://plausible.io/docs/plausible-script

task-4816336
