### PR TITLE
[FIX] l10n_es_edi_verifactu{,_pos}: misc fixes

### DIFF
--- a/addons/l10n_es_edi_verifactu/i18n/es.po
+++ b/addons/l10n_es_edi_verifactu/i18n/es.po
@@ -71,6 +71,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
+msgid ""
+"A refund with Refund Reason %(refund_reason)s is not simplified (it needs a "
+"partner)."
+msgstr ""
+
+#. module: l10n_es_edi_verifactu
+#. odoo-python
+#: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
+#, python-format
 msgid "A tax with value '%(tax_type)s' as %(field)s is not supported."
 msgstr ""
 

--- a/addons/l10n_es_edi_verifactu/i18n/l10n_es_edi_verifactu.pot
+++ b/addons/l10n_es_edi_verifactu/i18n/l10n_es_edi_verifactu.pot
@@ -71,6 +71,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
+msgid ""
+"A refund with Refund Reason %(refund_reason)s is not simplified (it needs a "
+"partner)."
+msgstr ""
+
+#. module: l10n_es_edi_verifactu
+#. odoo-python
+#: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
+#, python-format
 msgid "A tax with value '%(tax_type)s' as %(field)s is not supported."
 msgstr ""
 

--- a/addons/l10n_es_edi_verifactu_pos/models/__init__.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/__init__.py
@@ -1,3 +1,4 @@
+from . import account_move
 from . import pos_config
 from . import pos_order
 from . import verifactu_document

--- a/addons/l10n_es_edi_verifactu_pos/models/account_move.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/account_move.py
@@ -1,0 +1,14 @@
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _l10n_es_edi_verifactu_get_record_values(self, cancellation=False):
+        self.ensure_one()
+        vals = super()._l10n_es_edi_verifactu_get_record_values(cancellation=cancellation)
+        # Case: We invoiced the refund but not the original order
+        refunded_order = None if self.reversed_entry_id else self.pos_order_ids.refunded_order_ids
+        if refunded_order:
+            vals['refunded_document'] = refunded_order.l10n_es_edi_verifactu_document_ids._get_last('submission')
+        return vals

--- a/addons/l10n_es_edi_verifactu_pos/models/verifactu_document.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/verifactu_document.py
@@ -21,7 +21,7 @@ class L10nEsEdiVerifactuDocument(models.Model):
             order = document.pos_order_id
             if order.l10n_es_edi_verifactu_state == 'cancelled' and order.state != 'cancel':
                 try:
-                    order.button_cancel()
+                    order.action_pos_order_cancel()
                 except UserError as error:
                     _logger.error("Error while canceling order %(name)s (id %(record_id)s) after Veri*Factu cancellation:\n%(error)s",
                                   record_id=order.id, name=order.name, error=error)

--- a/addons/l10n_es_edi_verifactu_pos/tests/test_pos_order.py
+++ b/addons/l10n_es_edi_verifactu_pos/tests/test_pos_order.py
@@ -181,6 +181,7 @@ class TestL10nEsEdiVerifactuPosOrder(TestL10nEsEdiVerifactuPosCommon):
                 order = self._create_order({
                     # Note: The total is not above the simplified invoice limit
                     'is_invoiced': True,
+                    'customer': self.partner_b,  # Spanish customer
                     'pos_order_lines_ui_args': [
                         (self.product, 1.0),
                     ],
@@ -192,18 +193,14 @@ class TestL10nEsEdiVerifactuPosOrder(TestL10nEsEdiVerifactuPosCommon):
                         'invoice_date': '2024-12-30',
                     }
                 })
-        # Check that we set the simplified partner on both the order and the invoice
-        # (even though we did not specify a customer).
+        # Check that the created invoice is not simplified
         invoice = order.account_move
         self.assertTrue(invoice)
-        simplified_partner = self.env.ref('l10n_es.partner_simplified')
-        self.assertTrue(invoice.partner_id == simplified_partner)
-
-        self.assertRecordValues(order, [{
-            'partner_id': simplified_partner.id,
-            'l10n_es_edi_verifactu_document_ids': [],
-            'l10n_es_edi_verifactu_qr_code': invoice.l10n_es_edi_verifactu_qr_code,
+        self.assertRecordValues(invoice, [{
+            'partner_id': self.partner_b.id,
+            'l10n_es_is_simplified': False,
         }])
+
         # The Veri*Factu document was created for the invoice and not the document
         self.assertRecordValues(invoice.l10n_es_edi_verifactu_document_ids, [{
             'pos_order_id': False,


### PR DESCRIPTION
- Use the right function instead of `button_cancel`.
- Fix "is_simplified" in case of refund. Only `R5` should be simplified.
  For R1 to R4 we need to set the partner info in the JSON / XML
  (`Destinatarios`)
- Fix refunding in PoS w.r.t. uninvoiced / invoiced combinations
  of refunding and refunded order.
  - We can invoice an uninvoiced order. Here we have to retrieve the
    refunded Veri*Factu document from the order when creating the
    record values for the refunding move.
  - We can refund w/o invoice an invoiced order. Here We have to retrieve the
    refunded Veri*Factu document from the invoice when creating the
    record values for the refunding order.
- Move the error checks s.t. the record values can be extended
  more easily.
- Invoices from PoS orders should not be simplified.
  (The PoS order would be could enough.)
  - We should not set the simplified partner automatically anymore
    (in case no partner is set). That way there will be an error
    when validating the order.
- We should use `sudo` when querying the number of spanish companies
  in the database. The results should be independent of access rights.

task-None