### PR TITLE
[FIX] website, html_builder: correct overlay size on snippet preview

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -15,7 +15,7 @@ function isResizable(el) {
 export class BuilderOverlayPlugin extends Plugin {
     static id = "builderOverlay";
     static dependencies = ["localOverlay", "history", "operation"];
-    static shared = ["showOverlayPreview", "hideOverlayPreview"];
+    static shared = ["showOverlayPreview", "hideOverlayPreview", "refreshOverlays"];
     resources = {
         step_added_handlers: this.refreshOverlays.bind(this),
         change_current_options_containers_listeners: this.openBuilderOverlays.bind(this),

--- a/addons/website/static/src/snippets/s_chart/chart.edit.js
+++ b/addons/website/static/src/snippets/s_chart/chart.edit.js
@@ -6,6 +6,12 @@ const ChartEdit = I => class extends I {
         super.setup();
         this.noAnimation = true;
     }
+
+    start() {
+        super.start();
+        this.websiteEditService = this.services.website_edit;
+        this.websiteEditService.callShared("builderOverlay", "refreshOverlays");
+    }
 };
 
 registry

--- a/addons/website/static/src/snippets/s_countdown/countdown.edit.js
+++ b/addons/website/static/src/snippets/s_countdown/countdown.edit.js
@@ -2,6 +2,11 @@ import { Countdown } from "./countdown";
 import { registry } from "@web/core/registry";
 
 const CountdownEdit = (I) => class extends I {
+    setup() {
+        super.setup();
+        this.websiteEditService = this.services.website_edit;
+        this.websiteEditService.callShared("builderOverlay", "refreshOverlays");
+    }
     get shouldHideCountdown() {
         return false;
     }


### PR DESCRIPTION
When previewing options of certain snippets in the website editor, the builder overlay (in blue) did not have the correct height. Concerned snippets: countdown and chart.

Steps to reproduce for the countdown snippet:
1. Open the website editor.
2. Add a countdown snippet.
3. Hover over any of the snippet options.
4. Observe that the blue overlay does not appear correctly around the countdown snippet.

The issue with the chart snippet can be reproduced similarly.