### PR TITLE
[FIX] website_hr_recruitment: fix url_encode import

### DIFF
--- a/addons/website_hr_recruitment/models/hr_recruitment_source.py
+++ b/addons/website_hr_recruitment/models/hr_recruitment_source.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from werkzeug.urls import url_encode
 
 from odoo import api, fields, models
 from odoo.tools import urls
@@ -15,9 +16,9 @@ class HrRecruitmentSource(models.Model):
         for source in self:
             source.url = urls.urljoin(source.job_id.get_base_url(), "%s?%s" % (
                 source.job_id.website_url,
-                urls.url_encode({
+                url_encode({
                     'utm_campaign': self.env.ref('hr_recruitment.utm_campaign_job').name,
                     'utm_medium': source.medium_id.name or self.env['utm.medium']._fetch_or_create_utm_medium('website').name,
                     'utm_source': source.source_id.name or None
-                })
+                }),
             ))


### PR DESCRIPTION
Follow up of commit 977e62d that changed the import for url_join. This commit mistakenly changed the import for 'url_encode', causing the code to crash.

Reproduce the issue:
- go to recruitment
- click on "configure" for any job position