### PR TITLE
[FIX] base: ir.http._pre_dispatch preserve records' context

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -314,7 +314,10 @@ class IrHttp(models.AbstractModel):
                 continue
 
             # Replace uid and lang placeholder by the current request.env.uid and request.env.lang
-            args[key] = val.with_env(request.env)
+            # while preserving the context of the record.
+            args[key] = val.with_env(
+                request.env(context=dict(val.env.context, **request.env.context))
+            )
 
             try:
                 # explicitly crash now, instead of crashing later


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Preserve the context of the record found by a rule converter.

**Current behavior before PR:**

Prior to this change the whole env was completely overridden and ctx lost.

**Desired behavior after PR is merged:**

When a recordset is returned by rule converter, preserve its context to be able to have low level logic bound to ctx keys.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
