### PR TITLE
[FIX] web: show more event not clickable

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -390,7 +390,6 @@ export class CalendarCommonRenderer extends Component {
     wrapMoreLink({ el }) {
         const wrapper = document.createElement("div");
         wrapper.classList.add("fc-more-cell");
-        el.classList.remove("fc-daygrid-more-link");
         el.parentNode.insertBefore(wrapper, el);
         wrapper.appendChild(el);
     }

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -184,6 +184,20 @@
             background-color: rgba($gray-200, .5);
         }
 
+        .fc-daygrid-day-bottom {
+            display: flex;
+            justify-content: center;
+
+            .fc-more-link {
+                color: $link-color;
+                cursor: pointer;
+
+                &:hover {
+                    background: none;
+                }
+            }
+        }
+
         // ======  Specific agenda types ======
         // ====================================
 
@@ -478,15 +492,6 @@
 
             .fc-bg .fc-day-today:not(.o_calendar_disabled) {
                 background: none;
-            }
-
-            .fc-more-cell {
-                text-align: center;
-
-                .fc-more-link {
-                    color: $link-color;
-                    cursor: pointer;
-                }
             }
 
             .fc-event {


### PR DESCRIPTION
**PROBLEM**
If you add a lot of daily event on a off-day, the "show more" link to show all events is not clickable. Clicking bring the event creation popover.

**REPRO STEPS**
1. install calendar and hr.
2. on a off day (grey background) in the week or day view, add events until the "show more" link shows up.
3. click on it, and notice the event creation popover pops up instead of the event list popover.

**CAUSE**
FullCalendar css class fc-non-business have a zindex of 1, a div with this class is "above" the link.

**FIX**
Removing a line that removed the css class fc-daygrid-more-link to the "more-link" element.
Modifying css to keep the style consistent even with this new class.

opw-4844719