### PR TITLE
[FIX] stock_account,mrp_subcontracting_dropshipping: create correct a…

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -121,8 +121,8 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
         amls = self.env['account.move.line'].search([('id', 'not in', all_amls_ids)])
         all_amls_ids += amls.ids
         self.assertRecordValues(amls, [
-            {'account_id': stock_valu_acc_id,   'product_id': self.product_a.id,    'debit': 0.0,   'credit': 110.0},
-            {'account_id': stock_in_acc_id,     'product_id': self.product_a.id,    'debit': 110.0, 'credit': 0.0},
+            {'account_id': stock_out_acc_id,      'product_id': self.product_a.id,    'debit': 0.0,   'credit': 110.0},
+            {'account_id': stock_valu_acc_id,     'product_id': self.product_a.id,    'debit': 110.0, 'credit': 0.0},
         ])
 
         # return to stock location

--- a/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
@@ -330,3 +330,68 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
         user_admin = self.env['res.users'].search([('login', '=', 'admin')])
         sol.with_user(user_admin).write({'product_uom_qty': 10})
         self.assertEqual(sol.purchase_line_ids.mapped('product_uom_qty'), [10, 10])
+
+    def test_dropship_standard_perpetual_anglosaxon_ordered_return_internal_aml(self):
+        """
+        test that, with sbc installed, the return to an internal location of a dropshipped move
+        (perpetual and anglosaxon) creates the correct account move (debitting stock valuation)
+        """
+        grp_multi_loc = self.env.ref('stock.group_stock_multi_locations')
+        self.env.user.write({'groups_id': [(4, grp_multi_loc.id)]})
+        self.env.company.anglo_saxon_accounting = True
+
+        product = self.env['product.product'].create({
+            'name': 'product',
+            'type': 'product',
+            'standard_price': 10,
+            'route_ids': [(6, 0, [self.dropship_route.id])],
+            'seller_ids': [(0, 0, {'partner_id': self.supplier.id})],
+        })
+        product.product_tmpl_id.categ_id.property_cost_method = 'standard'
+        product.product_tmpl_id.categ_id.property_valuation = 'real_time'
+        product.product_tmpl_id.invoice_policy = 'order'
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'picking_policy': 'direct',
+            'order_line': [
+                (0, 0, {'name': product.name, 'product_id': product.id, 'product_uom_qty': 1}),
+            ],
+        })
+        sale_order.action_confirm()
+        self.env['purchase.order'].search([], order='id desc', limit=1).button_confirm()
+        self.assertEqual(sale_order.order_line.qty_delivered, 0.0)
+        picking = sale_order.picking_ids
+        picking.button_validate()
+
+        stock_return_picking_form = Form(self.env['stock.return.picking']
+            .with_context(active_ids=sale_order.picking_ids.ids, active_id=sale_order.picking_ids.ids[0],
+            active_model='stock.picking'))
+        stock_return_picking_form.location_id = self.subcontractor_partner1.property_stock_subcontractor
+        stock_return_picking = stock_return_picking_form.save()
+        stock_return_picking_action = stock_return_picking.create_returns()
+        return_pick = self.env['stock.picking'].browse(stock_return_picking_action['res_id'])
+        return_pick.move_ids[0].move_line_ids[0].quantity = 1.0
+        return_pick.move_ids[0].picked = True
+        return_pick._action_done()
+        self.assertEqual(return_pick.move_ids._is_dropshipped_returned(), True)
+
+        stock_valuation_account = product.categ_id.property_stock_valuation_account_id
+        stock_interim_delivered = product.categ_id.property_stock_account_output_categ_id
+        stock_interim_received = product.categ_id.property_stock_account_input_categ_id
+        original_move_in_svl_amls = picking.move_ids.stock_valuation_layer_ids.filtered(lambda svl: svl.value >= 0).account_move_id.line_ids.sorted('debit')
+        original_move_out_svl_amls = picking.move_ids.stock_valuation_layer_ids.filtered(lambda svl: svl.value < 0).account_move_id.line_ids.sorted('debit')
+        return_move_amls = return_pick.move_ids.stock_valuation_layer_ids.account_move_id.line_ids.sorted('debit')
+
+        self.assertRecordValues(original_move_in_svl_amls, [
+            {'credit': 10, 'debit': 0, 'account_id': stock_interim_received.id},
+            {'credit': 0, 'debit': 10, 'account_id': stock_valuation_account.id},
+        ])
+        self.assertRecordValues(original_move_out_svl_amls, [
+            {'credit': 10, 'debit': 0, 'account_id': stock_valuation_account.id},
+            {'credit': 0, 'debit': 10, 'account_id': stock_interim_delivered.id},
+        ])
+        # it's a return to an internal location so it should even out the amls of the outgoing svl of the original move
+        self.assertRecordValues(return_move_amls, [
+            {'credit': 10, 'debit': 0, 'account_id': stock_interim_delivered.id},
+            {'credit': 0, 'debit': 10, 'account_id': stock_valuation_account.id},
+        ])

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -608,9 +608,7 @@ class StockMove(models.Model):
                 cost = -1 * cost
                 anglosaxon_am_vals = self.with_company(self.company_id)._prepare_account_move_vals(acc_valuation, acc_dest, journal_id, qty, description, svl_id, cost)
         elif self._is_dropshipped_returned():
-            if cost > 0 and self.location_dest_id._should_be_valued():
-                anglosaxon_am_vals = self.with_company(self.company_id).with_context(is_returned=True)._prepare_account_move_vals(acc_valuation, acc_src, journal_id, qty, description, svl_id, cost)
-            elif cost > 0:
+            if cost > 0:
                 anglosaxon_am_vals = self.with_company(self.company_id).with_context(is_returned=True)._prepare_account_move_vals(acc_dest, acc_valuation, journal_id, qty, description, svl_id, cost)
             else:
                 cost = -1 * cost


### PR DESCRIPTION
…ml internal dropship return

**Problem:**
when the subcontracting setting is active, the return of a dropshipped product (not necessarily subcontracted) to the internal subcontracting location will create an account move that credits "stock valuation" instead of debitting it

**Steps to reproduce:**
- enable the "Anglo-Saxon Accounting","Multi-steps routes" and "Subcontracting" settings
- create a storable product with dropshipping route and a vendor
- in 'general information' write a non null cost
- make sure the product category's inventory valuation' is 'automated'
- create a new quotation for this product, confirm it and confirm the linked purchase order
- click on the dropship smart button and validate the picking
- click on return and select 'Physical Locations/Subcontracting Location' as the return location
- validate and click on the valuation smart button
- on the only stock valuation layer for this move, click on the book shaped widget

**Current behavior:**
the account move credits Stock Valuation and debits stock interim (received)

**Expected behavior:**
As we are returning the product to stock it should increase the value of the stock valuation account.
Therefore, it should debit stock valuation and credit stock interim (received)

**Cause of the issue:**
If the mrp_subcontracting_dropshipping module is active, and if we call _is_dropshipped_return on a stock move which is the return (to the subcontracting location) of a dropshipped move : the method will return true. https://github.com/odoo/odoo/blob/b34cebcf0c142d92affdb642525f066d431b7ca3/addons/mrp_subcontracting_dropshipping/models/stock_move.py#L29-L35 Therefore, inside _account_entry_move, _is_in will be false (contrary to if mrp_subcontracting_dropshipping is not installed or if the destination is another internal location)
https://github.com/odoo/odoo/blob/b34cebcf0c142d92affdb642525f066d431b7ca3/addons/stock_account/models/stock_move.py#L580 The aml vals will be computed inside _prepare_anglosaxon_account_move_vals https://github.com/odoo/odoo/blob/b34cebcf0c142d92affdb642525f066d431b7ca3/addons/stock_account/models/stock_move.py#L596 Here the fact the destination location is internal does not change the fact that it should debit the stock valuation account (meaning it should used acc_valuation as the second parameter of _prepare_account_move_vals) if the cost is positive. https://github.com/odoo/odoo/blob/b34cebcf0c142d92affdb642525f066d431b7ca3/addons/stock_account/models/stock_move.py#L610-L614

opw-4894755
