### PR TITLE
[FIX] html_builder: display a checkmark before active dropdown items

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.scss
@@ -1,6 +1,7 @@
 :not(.dropstart) > .dropdown-item {
     &.active, &.selected {
         &:not(.dropdown-item_active_noarrow)::before {
+            display: unset;
             top: 50%;
             transform: translate(-1.5em, -50%);
         }


### PR DESCRIPTION
In this [commit], `::before` was set to `display: none` for dropdown items. 
However, in the html builder, we need to show the checkmark when a 
dropdown item is selected (i.e., has the active class).
To reproduce the issue:
- Open website and start editing
- Click on the header
- Open any option with a dropdown, e.g. Font

=> Selected item doesn't have the checkmark

[commit]: https://github.com/odoo/odoo/commit/0923409082ead5ffdf2c28f3b063fbd91ebce553#diff-c5c3fcb1b90950ee741ff29a24f96016c40c258031887dcdd4ed8d09b51c5288
