### PR TITLE
[IMP] mail: add auto-focus functionality for video calls

### DIFF
--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -229,6 +229,16 @@ export class Settings extends Record {
         );
     }
     /**
+     * @param {Boolean} active
+     */
+    setCameraAutoFocus(active) {
+        if (active) {
+            browser.localStorage.removeItem("mail_user_setting_disable_call_auto_focus");
+            return;
+        }
+        browser.localStorage.setItem("mail_user_setting_disable_call_auto_focus", "true");
+    }
+    /**
      * @param {string} value
      */
     setDelayValue(value) {
@@ -363,6 +373,9 @@ export class Settings extends Record {
         this.backgroundBlurAmount = backgroundBlurAmount ? parseInt(backgroundBlurAmount) : 10;
         const edgeBlurAmount = browser.localStorage.getItem("mail_user_setting_edge_blur_amount");
         this.edgeBlurAmount = edgeBlurAmount ? parseInt(edgeBlurAmount) : 10;
+        this.useCallAutoFocus = !browser.localStorage.getItem(
+            "mail_user_setting_disable_call_auto_focus"
+        );
     }
     /**
      * @private

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -18,15 +18,21 @@ const threadPatch = {
                 r.remove();
             },
         });
+        this.isDisplayedInDiscussAppDesktop = fields.Attr(undefined, {
+            /** @this {import("models").Thread} */
+            compute() {
+                if (this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
+                    return this.eq(this.store.discuss.thread);
+                }
+                return false;
+            },
+        });
     },
     get recipientsFullyLoaded() {
         return this.recipientsCount === this.recipients.length;
     },
     computeIsDisplayed() {
-        if (this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
-            return this.eq(this.store.discuss.thread);
-        }
-        return super.computeIsDisplayed();
+        return this.isDisplayedInDiscussAppDesktop || super.computeIsDisplayed();
     },
     async leave() {
         await this.closeChatWindow();

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -84,6 +84,20 @@ callActionsRegistry
         select: (component) => component.rtc.toggleVideo("screen", { env: component.env }),
         sequence: 40,
     })
+    .add("auto-focus", {
+        condition: (component) => component.rtc,
+        name: (component) =>
+            component.store.settings.useCallAutoFocus
+                ? _t("Disable speaker autofocus")
+                : _t("Autofocus speaker"),
+        isActive: (component) => component.store?.settings?.useCallAutoFocus,
+        inactiveIcon: "fa-eye",
+        icon: "fa-eye-slash",
+        select: (component) => {
+            component.store.settings.setCameraAutoFocus(!component.store.settings.useCallAutoFocus);
+        },
+        sequence: 50,
+    })
     .add("blur-background", {
         condition: (component) =>
             !isBrowserSafari() &&

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1255,13 +1255,6 @@ export class Rtc extends Record {
                 if (!session || !this.channel) {
                     return;
                 }
-                if (
-                    this.channel.activeRtcSession === session &&
-                    session.is_screen_sharing_on &&
-                    !info.isScreenSharingOn
-                ) {
-                    this.channel.activeRtcSession = undefined;
-                }
                 // `isRaisingHand` is turned into the Date `raisingHand`
                 this.setRemoteRaiseHand(session, info.isRaisingHand);
                 delete info.isRaisingHand;
@@ -1412,6 +1405,7 @@ export class Rtc extends Record {
                 event.preventDefault();
             })
         );
+        this.channel?.focusAvailableVideo();
     }
 
     newLogs() {

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -76,6 +76,7 @@ export class RtcSession extends Record {
             if (this.isTalking && !this.isMute) {
                 this.talkingTime = this.store.nextTalkingTime++;
             }
+            this.channel?.updateCallFocusStack(this);
         },
     });
     isActuallyTalking = fields.Attr(false, {


### PR DESCRIPTION
This commit introduces a new auto-focus feature for video calls.
When enabled, the main video in a call will automatically focus on the
participant who is currently speaking or sharing their screen.

* Screen sharing has the highest priority.
The participant who most recently started sharing their screen will
be focused.
* If no one is sharing their screen, the focus shifts to the participant
who most recently started talking.
* Manually clicking on a participant focuses it and turns the auto focus
off.
* The feature can be activated and disabled in the call actions.

task-4967123