### PR TITLE
[FIX] pos*: wait before payment on discount

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -94,8 +94,8 @@
                 </t>
                 <button t-if="!currentOrder.isEmpty() and this.pos.numpadMode != 'table'"
                     t-on-click="() => pos.pay()" 
-                    class="button pay-order-button btn btn-lg w-50"
-                    t-attf-class="{{ this.highlightPay ? 'highlight btn-primary' : 'btn-secondary' }}" 
+                    class="button pay-order-button pay-order-button-restaurant btn btn-lg w-50"
+                    t-attf-class="{{ this.highlightPay ? 'highlight btn-primary' : 'btn-secondary' }}"
                 >
                     Payment
                 </button>

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
@@ -40,8 +40,9 @@
                 <t t-else="">
                     <button
                         class="btn-switchpane pay-button btn btn-lg flex-grow-1 lh-sm"
-                        t-attf-class="{{ currentOrder.isEmpty() ? 'btn-light disabled' : 'btn-primary' }}"
-                        t-on-click="() => this.pos.pay()">
+                        t-attf-class="{{ currentOrder.isEmpty() ? 'btn-light' : 'btn-primary' }}"
+                        t-on-click="() => this.pos.pay()"
+                        t-att-disabled="currentOrder.isEmpty()">
                         <span class="d-block">Pay</span>
                         <small><t t-esc="total" /></small>
                     </button>

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
@@ -39,18 +39,18 @@
                         </div>
 
                         <div class="pay-button" t-att-class="{'d-flex flex-row bg-view p-2 gap-2 rounded-3':this.ui.isSmall}">
-                            <button class="button btn btn-lg btn-primary py-3 py-lg-5"
+                            <button class="button btn btn-lg btn-primary py-3 py-lg-5 split-order-button"
                                 t-att-class="(this.ui.isSmall ? 'w-50' : 'w-100')"
                                 t-att-disabled="!this.getNumberOfProducts()"
                                 t-on-click="createSplittedOrder">
                                 Split Order
                             </button>
                             <div class="d-flex gap-2 w-100">
-                                <button class="btn btn-lg btn-secondary py-3 py-lg-5 w-100" t-att-class="(this.ui.isSmall ? '' : 'mt-2')"
+                                <button class="btn btn-lg btn-secondary py-3 py-lg-5 w-100 pay-split-order" t-att-class="(this.ui.isSmall ? '' : 'mt-2')"
                                     t-on-click="paySplittedOrder">
                                     Pay
                                 </button>
-                                <button class="btn btn-lg btn-secondary py-3 py-lg-5 w-100" t-att-class="(this.ui.isSmall ? '' : 'mt-2')"
+                                <button class="btn btn-lg btn-secondary py-3 py-lg-5 w-100 transfer-split-order" t-att-class="(this.ui.isSmall ? '' : 'mt-2')"
                                     t-on-click="transferSplittedOrder">
                                     Transfer
                                 </button>


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant

Before this commit, if a discount was applied with the blackbox, it was applied after communication with blackbox which could be slow. If the user was clicking payment before this disound was applied and had only one payment method, a payment line with the old amount was added which could lead to confusion and errors when this payment line was sent to a terminal.
This is fixed by waiting for the discount to be applied before being able to click on payment.

Enterprise PR: https://github.com/odoo/enterprise/pull/91256

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
