### PR TITLE
[FIX] account, l10n_es: remove user_groupby when using external engine

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -600,11 +600,13 @@ class AccountReportExpression(models.Model):
     @api.constrains('engine', 'report_line_id')
     def _validate_engine(self):
         for expression in self:
-            if expression.engine == 'aggregation' and (expression.report_line_id.groupby or expression.report_line_id.user_groupby):
+            if expression.engine in ('aggregation', 'external') and (expression.report_line_id.groupby or expression.report_line_id.user_groupby):
+                engine_description = dict(expression._fields['engine']._description_selection(self.env))
                 raise ValidationError(_(
-                    "Groupby feature isn't supported by aggregation engine. Please remove the groupby value on '%s'",
-                    expression.report_line_id.display_name,
-                ))
+                    "Groupby feature isn't supported by '%(engine)s' engine. Please remove the groupby value on '%(report_line)s'",
+                        engine=engine_description[expression.engine],
+                        report_line=expression.report_line_id.display_name
+                    ))
 
     def _get_auditable_engines(self):
         return {'tax_tags', 'domain', 'account_codes', 'external', 'aggregation'}

--- a/addons/l10n_es/data/mod111.xml
+++ b/addons/l10n_es/data/mod111.xml
@@ -31,6 +31,7 @@
                             <record id="mod_111_casilla_01" model="account.report.line">
                                 <field name="name">[01] Nº of recipients</field>
                                 <field name="code">aeat_mod_111_01</field>
+                                <field name="groupby" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_01_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -76,6 +77,7 @@
                             <record id="mod_111_casilla_04" model="account.report.line">
                                 <field name="name">[04] Nº of recipients</field>
                                 <field name="code">aeat_mod_111_04</field>
+                                <field name="groupby" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_04_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -128,6 +130,7 @@
                             <record id="mod_111_casilla_07" model="account.report.line">
                                 <field name="name">[07] Nº of recipients</field>
                                 <field name="code">aeat_mod_111_07</field>
+                                <field name="groupby" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_07_balance" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -173,6 +176,7 @@
                             <record id="mod_111_casilla_10" model="account.report.line">
                                 <field name="name">[10] Nº of recipients</field>
                                 <field name="code">aeat_mod_111_10</field>
+                                <field name="groupby" eval="False"/>
                                 <field name="expression_ids">
                                     <record id="mod_111_casilla_10_balance" model="account.report.expression">
                                         <field name="label">balance</field>


### PR DESCRIPTION
Commit https://github.com/odoo/odoo/commit/97fe24cea74241a7820841a470994d3ebf9d8d38 changed the engine for some report line of Modelo 111. The new engine used, `external`, is not compatible with having a grouping value defined by the user (field `user_groupby`). Except that value does not get removed from the report lines. As a result, a traceback pops up whenever we try to access the report.

Two previous commits aimed to sync that field with the `groupby` field (https://github.com/odoo/odoo/commit/a7d54c76aaee325449248fa698adb9e549c486ee), and update it if it was not compatible with the engine (https://github.com/odoo/odoo/commit/0d5bf820c3737ee3e4af54d1fb556b72d6c59c3d) but both only work with `aggregation` engine.

This commit makes `_validate_engine()` account for `external` engine, as it was only checking for `aggregation` engine when validating `groupby` related fields.

opw-4972212
opw-4971497
opw-4931269
opw-4949654
