### PR TITLE
[FIX] html_editor: avoid avatar overlapping toggle button in collab

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
-import { closestBlock } from "@html_editor/utils/blocks";
+import { closestBlock, isBlock } from "@html_editor/utils/blocks";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
@@ -79,7 +79,9 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
         if (!anchorNode || !focusNode || !anchorNode.isConnected || !focusNode.isConnected) {
             return;
         }
-        const anchorBlock = closestBlock(anchorNode);
+        const anchorBlock =
+            closestElement(anchorNode, (el) => isBlock(el) && el.parentElement === this.editable) ||
+            closestBlock(anchorNode);
         if (!anchorBlock) {
             return;
         }


### PR DESCRIPTION
Problem:
In collaboration mode, if another user's selection is on a toggle list, their avatar may overlap and hide the toggle button.

Solution:
When handling toggle lists, calculate the avatar position based on the toggle block itself rather than the nearest block.

Before:
<img width="743" height="368" alt="image" src="https://github.com/user-attachments/assets/72363e2b-184c-40ad-aff9-848b6c784783" />
After:
<img width="601" height="386" alt="image" src="https://github.com/user-attachments/assets/4eb5549e-cbf0-45c3-8b7a-c78b6dd6ce3c" />

Steps to reproduce:
- Add a toggle list
- Open the same document in a second tab
- In one tab, select content inside the toggle list
- In the other tab, observe the avatar position
- The avatar overlaps the toggle button

opw-4921845

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
