### PR TITLE
[FIX] website_blog: fix update of author's avatar on author change

### DIFF
--- a/addons/website_blog/static/src/website_builder/author_avatar_many2one_plugin.js
+++ b/addons/website_blog/static/src/website_builder/author_avatar_many2one_plugin.js
@@ -1,32 +1,28 @@
 import { patch } from "@web/core/utils/patch";
-import { Many2OneOptionPlugin } from "@website/builder/plugins/options/many2one_option_plugin";
+import { Many2OneAction } from "@website/builder/plugins/options/many2one_option_plugin";
 
-patch(Many2OneOptionPlugin, {
-    dependencies: [...Many2OneOptionPlugin.dependencies, "history"],
+patch(Many2OneAction, {
+    dependencies: [...Many2OneAction.dependencies, "history"],
 });
 
-patch(Many2OneOptionPlugin.prototype, {
-    getActions() {
-        const actions = super.getActions();
-        const newApply = (args) => {
-            actions.many2One.apply(args);
-            const { editingElement, value } = args;
-            const { id } = JSON.parse(value);
-            const { oeId, oeField } = editingElement.dataset;
+patch(Many2OneAction.prototype, {
+    apply(args) {
+        super.apply(args);
+        const { editingElement, value } = args;
+        const { id } = JSON.parse(value);
+        const { oeId, oeField } = editingElement.dataset;
 
-            if (oeField === "author_id") {
-                for (const node of this.editable.querySelectorAll(
-                    `[data-oe-model="blog.post"][data-oe-id="${oeId}"][data-oe-field="author_avatar"]`
-                )) {
-                    node.querySelector("img").src = `/web/image/res.partner/${id}/avatar_1024`;
-                    // We do not want to save it to the server
-                    // TODO: a more general approach for editing records that are used at different parts of the page
-                    this.dependencies.history.ignoreDOMMutations(() => {
-                        node.classList.remove("o_dirty");
-                    });
-                }
+        if (oeField === "author_id") {
+            for (const node of this.editable.querySelectorAll(
+                `[data-oe-model="blog.post"][data-oe-id="${oeId}"][data-oe-field="author_avatar"]`
+            )) {
+                node.querySelector("img").src = `/web/image/res.partner/${id}/avatar_1024`;
+                // We do not want to save it to the server
+                // TODO: a more general approach for editing records that are used at different parts of the page
+                this.dependencies.history.ignoreDOMMutations(() => {
+                    node.classList.remove("o_dirty");
+                });
             }
-        };
-        return { ...actions, many2One: { ...actions.many2One, apply: newApply } };
+        }
     },
 });

--- a/addons/website_blog/static/tests/website_builder/many2one_option.test.js
+++ b/addons/website_blog/static/tests/website_builder/many2one_option.test.js
@@ -7,7 +7,7 @@ import {
 
 defineWebsiteModels();
 
-test.skip("Change contact oe-many2one-id of a blog author changes other instance of same contact and avatar", async () => {
+test("Change contact oe-many2one-id of a blog author changes other instance of same contact and avatar", async () => {
     onRpc(
         "ir.qweb.field.contact",
         "get_record_to_html",


### PR DESCRIPTION
The test that check avatar update on author's changes has been skipped during the merge of the initial website builder refactor, and was not re-enabled. During this time, the change to use classes for actions has been merged but broke the patch in `website_blog`.

This commit adapts the patch to apply to the action instead of the plugin

Actions to classes: b4b215325db61fbbe9793545293c8b6fbc99f310
Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
