### PR TITLE
[FIX] mail: disable copy link in portal chatter if no read access

### DIFF
--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -202,7 +202,8 @@ messageActionsRegistry
     .add("copy-link", {
         condition: (component) =>
             component.message.message_type &&
-            component.message.message_type !== "user_notification",
+            component.message.message_type !== "user_notification" &&
+            (!component.props.thread.access_token || component.props.thread.hasReadAccess),
         icon: "fa fa-link",
         title: _t("Copy Link"),
         onClick: (component) => component.message.copyLink(),


### PR DESCRIPTION
Before this commit, it was possible for a user to copy the link of messages in the chatter of a portal document accessed via share link with token.

This could lead to unintentionally leaking the access token of the document.

This commit fixes the issue by removing the possibility to copy links of messages inside portal documents for which a user has no read access.

discussed in task-4551910
