### PR TITLE
[FIX] html_editor: disable link button when cells are selected

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -410,21 +410,15 @@ export class LinkPlugin extends Plugin {
         if (this.getResource("link_compatible_selection_predicates").some((p) => p())) {
             return true;
         }
-        const linksInSelection = this.dependencies.selection
-            .getTargetedNodes()
-            .filter((n) => n.tagName === "A");
         const targetedNodes = this.dependencies.selection.getTargetedNodes();
+        const targetedBlocks = targetedNodes.filter(isBlock);
+        const linksInSelection = targetedNodes.filter((n) => n.tagName === "A");
         return (
             linksInSelection.length < 2 &&
             // Prevent a link across sibling blocks:
-            !targetedNodes.some((node) => {
-                const next = node.nextSibling;
-                const previous = node.previousSibling;
-                return (
-                    (next && targetedNodes.includes(next) && isBlock(next)) ||
-                    (previous && targetedNodes.includes(previous) && isBlock(previous))
-                );
-            })
+            targetedBlocks.every((node) =>
+                targetedNodes.every((other) => node.contains(other) || other.contains(node))
+            )
         );
     }
 

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1009,12 +1009,13 @@ export class TablePlugin extends Plugin {
         const startTd = closestElement(selection.startContainer, "td");
         const endTd = closestElement(selection.endContainer, "td");
         if (startTd && startTd === endTd && !isProtected(startTd) && !isProtecting(startTd)) {
-            const targetedNodes = this.dependencies.selection.getTargetedNodes();
+            const selectedNodes = this.dependencies.selection
+                .getTargetedNodes()
+                .filter(this.dependencies.selection.areNodeContentsFullySelected);
             const cellContents = descendants(startTd);
-            /** @todo Test. Should probably use areNodeContentsFullySelected. */
             const areCellContentsFullySelected = cellContents
                 .filter((d) => !isBlock(d))
-                .every((child) => targetedNodes.includes(child));
+                .every((child) => selectedNodes.includes(child));
             if (areCellContentsFullySelected) {
                 const SENSITIVITY = 5;
                 if (!this._mouseMovePositionWhenAllContentsSelected) {

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1786,6 +1786,71 @@ describe("single cell selection", () => {
             </table>`
         );
     });
+
+    test("should not select single cell via mouse movement if content is not fully selected", async () => {
+        const content = unformat(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td>
+                            <p>abcd</p>
+                        </td>
+                        <td><p><br></p></td>
+                    </tr>
+                    <tr>
+                        <td><p><br></p></td>
+                        <td><p><br></p></td>
+                    </tr>
+                </tbody>
+            </table>
+        `);
+
+        const { el } = await setupEditor(content);
+
+        const firstTd = el.querySelector("td");
+        const firstP = firstTd.firstElementChild;
+        const textNode = firstP.firstChild;
+
+        // Get bounding rect of selection range at the end of text.
+        const range = document.createRange();
+        range.setStart(textNode, nodeSize(textNode));
+        range.setEnd(textNode, nodeSize(textNode));
+        const rangeRect = range.getBoundingClientRect();
+
+        // Simulate mousedown at the end of text.
+        await manuallyDispatchProgrammaticEvent(firstP, "mousedown", {
+            detail: 1,
+            clientX: rangeRect.right,
+            clientY: rangeRect.top,
+        });
+
+        // Put cursor at the end of text.
+        setSelection({
+            anchorNode: textNode,
+            anchorOffset: nodeSize(textNode),
+        });
+        await animationFrame();
+
+        // Simulate attempt to select single cell.
+        manuallyDispatchProgrammaticEvent(firstP, "mousemove", {
+            detail: 1,
+            clientX: rangeRect.right,
+            clientY: rangeRect.top,
+        });
+        manuallyDispatchProgrammaticEvent(firstP, "mousemove", {
+            detail: 1,
+            clientX: rangeRect.right + 15,
+            clientY: rangeRect.top,
+        });
+        manuallyDispatchProgrammaticEvent(firstP, "mouseup", {
+            detail: 1,
+            clientX: rangeRect.right + 15,
+            clientY: rangeRect.top,
+        });
+
+        await animationFrame();
+        expect(firstTd).not.toHaveClass("o_selected_td");
+    });
 });
 
 describe("deselecting table", () => {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -263,6 +263,25 @@ test("toolbar disable link button when selection cross blocks", async () => {
     expect(".btn[name='link']").toHaveClass("disabled");
 });
 
+test("toolbar disable link button when table cells are selected", async () => {
+    await setupEditor(`
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr>
+                    <td><p>[<br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td><p>]<br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+            </tbody>
+        </table>
+    `);
+    await waitFor(".o-we-toolbar");
+    expect(".btn[name='link']").toHaveClass("disabled");
+});
+
 test("toolbar enable link button when selection has only link", async () => {
     await setupEditor(`<p>[<a href="test.com">test.com</a>]</p>`);
 


### PR DESCRIPTION
**Current behaviour before PR:**

Steps to reproduce:

- Create a 3 x 3 table.
- Select first column.

The link button in toolbar is enabled and it should not. This happens because after merging this commit [1], `isLinkAllowedOnSelection` method returns true if selected cells are not adjacent.

**Desired behaviour after PR is merged:**

Now, selecting cells open toolbar with disabled link button.

[1]: https://github.com/odoo/odoo/commit/c0d07fdcf4cc139177524eb4ea22ab341b3da7fb

task-4965270




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
