### PR TITLE
[IMP] service: simplify check ormcache

### DIFF
--- a/odoo/service/security.py
+++ b/odoo/service/security.py
@@ -1,12 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.modules.registry import Registry
 from odoo.tools.misc import consteq
-
-
-def check(db, uid, passwd):
-    res_users = Registry(db)['res.users']
-    return res_users.check(db, uid, passwd)
 
 
 def compute_session_token(session, env):


### PR DESCRIPTION
Simplify the authorization flow for `dispatch`.
The `check` method on res.users has a very generic name and is a class method with an `ormcache`: an odd beast. We refactor that method into a cached model method and adapt the calls so that a cursor is opened only once for the call.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
