### PR TITLE
[FIX] hr{_contract} : display unavailability in gantt view

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -290,3 +290,13 @@ class HrEmployeeBase(models.AbstractModel):
                     # The employees should be working now according to their work schedule
                     working_now += res_employee_ids.ids
         return working_now
+
+    def _get_calendar_periods(self, start, stop):
+        # This method can be overridden in other modules where it's possible
+        # to have different resource calendars for an employee depending on the
+        # date.
+        calendar_periods_by_employee = {}
+        for employee in self:
+            calendar = employee.resource_calendar_id or employee.company_id.resource_calendar_id
+            calendar_periods_by_employee[employee] = [(start, stop, calendar)]
+        return calendar_periods_by_employee


### PR DESCRIPTION
### Steps to reproduce:
	- Install hr_attendance_gantt module
	- Go to the Attendance > Overview > Gantt view

### Current behavior before PR:
Weekend days are not shown in grey cells in gantt view as it should. This is happening because we are not considering unavailability when loading the gantt view.

### Desired behavior after PR is merged:
We are now using fetching unavailability for each employee according to his working hours.

Back-port of https://github.com/odoo/odoo/pull/163945/commits/c9af1d131fbad25a3e0721864a2f8cbda8bd8905#diff-666b8ffb3891abbbb22bfbe2e3bb16fcc142369edc8fd551e642edcbf9b5cf25

opw-4203233