### PR TITLE
[FIX] purchase_stock: ensure negative quantity test uses a consumable product

### DIFF
--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -697,6 +697,7 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         """
         Receive a negative quantity, the picking should be a delivery and the quantity received
         negative. """
+        self.product_id_2.type = 'consu'
         po_vals = {
             'partner_id': self.partner_a.id,
             'order_line': [Command.create({


### PR DESCRIPTION
The test `test_receive_negative_quantity` is failing when run with the `l10n_ke` module installed.

The failure occurs during the validation of the picking created from a negative-quantity purchase order. The test assumes the product is of type `consu`, which bypasses stock reservation. However, the following [XML default](https://github.com/odoo/enterprise/blob/17.0/l10n_ke_edi_oscu_stock/data/ir_default.xml#L5) in l10n_ke
forces the product type to `product` (stockable), triggering reservation logic.

Since the ordered quantity is negative, no reservation occurs, and the `_sanity_check()` fails with:

`You cannot validate a transfer if no quantities are reserved.`

We fix this by explicitly setting a product with the type `consu` in the test. This ensures that reservation is skipped regardless of which modules are installed or what defaults they apply.

runbot:[108147](https://runbot.odoo.com/odoo/error/108147)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
