### PR TITLE
[FIX] website_sale: add missing `this.waitFor` in checkout interaction

### DIFF
--- a/addons/website_sale/static/src/interactions/checkout.js
+++ b/addons/website_sale/static/src/interactions/checkout.js
@@ -29,7 +29,7 @@ export class Checkout extends Interaction {
     }
 
     async willStart() {
-        await this._prepareDeliveryMethods();
+        await this.waitFor(this._prepareDeliveryMethods());
     }
 
     /**


### PR DESCRIPTION
After recent refactor of public widget to interaction in https://github.com/odoo/odoo/commit/1eb449ae71197ce92071dca04260d1df3fb0c14c `this.waitFor` was missing in `willStart` of checkout interaction.

Because of that a tour of loyalty was randomly failing on runbot.

error-229963

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
