### PR TITLE
[FIX] html_builder, website: allow to ask to deactivate the containers + [FIX] html_builder, website: review the calls to `updateContainers` 

### DIFF
--- a/addons/html_builder/static/src/core/clone_plugin.js
+++ b/addons/html_builder/static/src/core/clone_plugin.js
@@ -88,7 +88,7 @@ export class ClonePlugin extends Plugin {
 
         // Update the containers if required.
         if (activateClone) {
-            this.dependencies["builderOptions"].updateContainers(cloneEl);
+            this.dependencies.builderOptions.setNextTarget(cloneEl);
         }
 
         // Scroll to the clone if required and if it is not visible.

--- a/addons/html_builder/static/src/core/version_control_plugin.js
+++ b/addons/html_builder/static/src/core/version_control_plugin.js
@@ -37,6 +37,6 @@ export class VersionControlPlugin extends Plugin {
         const snippet = this.config.snippetModel.getOriginalSnippet(snippetKey);
         const cloneEl = snippet.content.cloneNode(true);
         el.replaceWith(cloneEl);
-        this.dependencies["builderOptions"].updateContainers(cloneEl);
+        this.dependencies.builderOptions.setNextTarget(cloneEl);
     }
 }

--- a/addons/html_builder/static/src/core/visibility_plugin.js
+++ b/addons/html_builder/static/src/core/visibility_plugin.js
@@ -103,7 +103,7 @@ export class VisibilityPlugin extends Plugin {
     onOptionVisibilityUpdate(editingEl, show) {
         const isShown = this.toggleVisibilityStatus({ editingEl, show });
         if (!isShown) {
-            this.dependencies["builderOptions"].deactivateContainers();
+            this.dependencies.builderOptions.setNextTarget(false);
         }
         this.config.updateInvisibleElementsPanel();
         this.dependencies.disableSnippets.disableUndroppableSnippets();

--- a/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/layout_column_option_plugin.js
@@ -34,7 +34,7 @@ class LayoutColumnOptionPlugin extends Plugin {
 
 export class ChangeColumnCountAction extends BuilderAction {
     static id = "changeColumnCount";
-    static dependencies = ["selection", "clone"];
+    static dependencies = ["selection", "clone", "builderOptions"];
     async apply({ editingElement, value: nbColumns }) {
         if (nbColumns === "custom") {
             return;
@@ -71,9 +71,7 @@ export class ChangeColumnCountAction extends BuilderAction {
         if (itemsDelta > 0) {
             for (let i = 0; i < itemsDelta; i++) {
                 const lastEl = rowEl.lastElementChild;
-                await this.dependencies.clone.cloneElement(lastEl, {
-                    activateClone: false,
-                });
+                await this.dependencies.clone.cloneElement(lastEl, { activateClone: false });
             }
         }
 
@@ -85,6 +83,10 @@ export class ChangeColumnCountAction extends BuilderAction {
             editingElement.append(...columnEl.children);
             rowEl.remove();
             cursors.restore();
+        } else if (prevNbColumns === 0) {
+            // Activate the first column options.
+            const firstColumnEl = editingElement.querySelector(".row > div");
+            this.dependencies.builderOptions.setNextTarget(firstColumnEl);
         }
     }
     isApplied({ editingElement, value }) {

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
@@ -41,11 +41,13 @@ export class FloatingBlocksRoundnessAction extends BuilderAction {
 }
 export class AddFloatingBlockCardAction extends BuilderAction {
     static id = "addFloatingBlockCard";
+    static dependencies = ["builderOptions"];
     apply({ editingElement: el }) {
         const newCardEl = renderToElement("website.s_floating_blocks.new_card");
         const wrapperEl = el.querySelector(".s_floating_blocks_wrapper");
         wrapperEl.appendChild(newCardEl);
         newCardEl.scrollIntoView({ behavior: "smooth", block: "center" });
+        this.dependencies.builderOptions.setNextTarget(newCardEl);
     }
 }
 

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -62,10 +62,8 @@ class ImageGalleryOption extends Plugin {
 
     restoreSelection(imageToSelect, isPreviewing) {
         if (imageToSelect && !isPreviewing) {
-            // We want to update the container to the equivalent cloned image.
-            // This has to be done in the new step so we manually add a step
-            this.dependencies.history.addStep();
-            this.dependencies["builderOptions"].updateContainers(imageToSelect);
+            // Activate the containers of the equivalent cloned image.
+            this.dependencies["builderOptions"].setNextTarget(imageToSelect);
         }
     }
 


### PR DESCRIPTION
[FIX] html_builder, website: allow to ask to deactivate the containers

Commit [1] made it so an option can ask to activate the containers of a
given element after adding its step. Logic was also added to properly
restore these containers on undo/redo.

This commit adds the logic to also ask to deactivate the containers, as
this behavior should also be restored on undo/redo (if an option asks to
deactivate the containers, then undo and redo, the containers should be
deactivated after replaying the option).

[1]: https://github.com/odoo/odoo/commit/203a7af2c2b27c02be7b201f5c707f46caa34573

task-4367641

---
[FIX] html_builder, website: review the calls to `updateContainers`

Since commit [1] (and the previous commit of this PR), when an operation
wants to activate another target, it should use `setNextTarget`. It
guarantees that the target is activated at the right time and that it
will correctly be restored on undo/redo.

Before these commits, this behavior was achieved by using a hack, by
calling `addStep` and then `updateContainers` in the `apply` of options
(so before calling the `addStep` post apply, which would then do nothing
as there is no mutation anymore).

This commit removes this hack use, as a follow-up of the mentionned
commits.

This commit also adds the missing calls to `setNextTarget` that were not
added back with the refactoring. This was done by looking where the
`activate_snippet` event of the old code was triggered. This ensures
that the behavior stays the same as before the refactoring.

[1]: https://github.com/odoo/odoo/commit/203a7af2c2b27c02be7b201f5c707f46caa34573

task-4367641