### PR TITLE
[FIX] base, test_mimetypes: fix tests when magic is installed

### DIFF
--- a/odoo/addons/base/tests/test_mimetypes.py
+++ b/odoo/addons/base/tests/test_mimetypes.py
@@ -111,8 +111,9 @@ class test_guess_mimetype(BaseCase):
         self.assertEqual(mimetype, 'application/zip')
 
     def test_mimetype_xml(self):
+        expected_mimetype = 'application/xml' if magic is None else 'text/xml'
         mimetype = guess_mimetype(XML, default='test')
-        self.assertEqual(mimetype, 'application/xml')
+        self.assertEqual(mimetype, expected_mimetype)
 
     def test_mimetype_get_extension(self):
         self.assertEqual(get_extension('filename.Abc'), '.abc')

--- a/odoo/addons/test_mimetypes/tests/test_guess_mimetypes.py
+++ b/odoo/addons/test_mimetypes/tests/test_guess_mimetypes.py
@@ -2,7 +2,7 @@
 import os.path
 
 from odoo.tests.common import BaseCase
-from odoo.tools.mimetypes import guess_mimetype
+from odoo.tools.mimetypes import guess_mimetype, magic
 
 def contents(extension):
     with open(os.path.join(
@@ -15,14 +15,16 @@ def contents(extension):
 
 class TestMimeGuessing(BaseCase):
     def test_doc(self):
-        self.assertEqual(
+        expected_mimetypes = ['application/msword'] if magic is None else ['application/x-ole-storage', 'application/CDFV2']
+        self.assertIn(
             guess_mimetype(contents('doc')),
-            'application/msword'
+            expected_mimetypes
         )
     def test_xls(self):
-        self.assertEqual(
+        expected_mimetypes = ['application/vnd.ms-excel'] if magic is None else ['application/x-ole-storage', 'application/CDFV2']
+        self.assertIn(
             guess_mimetype(contents('xls')),
-            'application/vnd.ms-excel'
+            expected_mimetypes
         )
     def test_docx(self):
         self.assertEqual(
@@ -63,7 +65,8 @@ class TestMimeGuessing(BaseCase):
         )
 
     def test_unknown(self):
+        expected_mimetype = 'application/octet-stream' if magic is None else 'text/csv'
         self.assertEqual(
             guess_mimetype(contents('csv')),
-            'application/octet-stream'
+            expected_mimetype
         )


### PR DESCRIPTION
Those tests are failing when python-magic is installed. Since 26f9c82b99 Odoo > saas-18.4 has this lib as a requirement and comes with appropriate fixes.

This commit adapts some test for versions prior to saas-18.4 to also work when the python-magic lib is installed.

