### PR TITLE
[IMP] mail: minor style tweak messaging menu

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
@@ -21,7 +21,7 @@ patch(MessagingMenu.prototype, {
                 ),
                 id: "livechat",
                 icon: "fa fa-commenting-o",
-                label: _t("Livechat"),
+                label: _t("Live Chats"),
             });
         }
         return items;

--- a/addons/im_livechat/static/tests/messaging_menu_patch.test.js
+++ b/addons/im_livechat/static/tests/messaging_menu_patch.test.js
@@ -42,8 +42,8 @@ test('livechats should be in "livechat" tab in mobile', async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button", { text: "Livechat" });
+    await click("button", { text: "Live Chats" });
     await contains(".o-mail-NotificationItem", { text: "Visitor 11" });
-    await click("button", { text: "Chat" });
+    await click("button", { text: "Chats" });
     await contains(".o-mail-NotificationItem", { count: 0, text: "Visitor 11" });
 });

--- a/addons/im_livechat/static/tests/mobile_messaging_menu_patch.test.js
+++ b/addons/im_livechat/static/tests/mobile_messaging_menu_patch.test.js
@@ -39,5 +39,5 @@ test("Livechat button is present when there is at least one livechat thread", as
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu");
-    await contains(".o-mail-MessagingMenu-navbar", { text: "Livechat" });
+    await contains(".o-mail-MessagingMenu-navbar", { text: "Live Chats" });
 });

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -61,6 +61,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     }
 }
 
+.o-fw-600 {
+    font-weight: 600;
+}
+
 .o-min-height-0 {
     min-height: 0;
 }

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -128,7 +128,7 @@ export class MessagingMenu extends Component {
                 counter: this.store.getDiscussSidebarCategoryCounter(this.store.discuss.chats.id),
                 icon: "fa fa-user",
                 id: "chat",
-                label: _t("Chat"),
+                label: _t("Chats"),
             },
             {
                 channelHasUnread: Boolean(this.store.discuss.unreadChannels.length),
@@ -137,7 +137,7 @@ export class MessagingMenu extends Component {
                 ),
                 icon: "fa fa-users",
                 id: "channel",
-                label: _t("Channel"),
+                label: _t("Channels"),
             },
         ];
     }

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -18,24 +18,24 @@
             </div>
             <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto o-scrollbar-thin ps-1">
                 <div class="d-flex text-nowrap">
-                    <span class="o-mail-NotificationItem-name fw-bold" t-att-class="{ 'fw-bold': props.muted, 'fw-bolder': !props.muted }" t-att-style="props.nameMaxLine !== undefined ? webkitLineClamp(props.nameMaxLine) : ''">
+                    <span class="o-mail-NotificationItem-name" t-att-class="{ 'fw-bold': props.muted, 'o-fw-600': !props.muted, 'fs-5': ui.isSmall }" t-att-style="props.nameMaxLine !== undefined ? webkitLineClamp(props.nameMaxLine) : ''">
                         <t t-slot="name"/>
                     </span>
                     <span class="flex-grow-1"/>
-                    <div class="d-flex align-items-center">
-                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter shadow-sm"><t t-esc="props.counter"/></span>
-                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 rounded-3 fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer shadow-sm" title="Mark As Read" t-ref="markAsRead"/>
-                    </div>
+                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 me-1 flex-shrink-0 align-self-end" t-att-class="{ 'opacity-75': props.muted, 'o-fw-600': !props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
+                        <t t-esc="dateText"/>
+                    </small>
                 </div>
                 <div class="d-flex">
-                    <div class="o-mail-NotificationItem-text opacity-75" t-att-class="{ 'fw-bold': !props.muted, 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate  }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
+                    <div class="o-mail-NotificationItem-text opacity-75" t-att-class="{ 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate  }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
                         <t t-slot="body-icon"/>
                         <t t-if="props.slots?.body" name="notificationBody" t-slot="body"/>
                     </div>
                     <div class="flex-grow-1"/>
-                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 me-1 opacity-75 flex-shrink-0 align-self-end" t-att-class="{ 'fw-bold': !props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
-                        <t t-esc="dateText"/>
-                    </small>
+                    <div class="d-flex align-items-start">
+                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter shadow-sm"><t t-esc="props.counter"/></span>
+                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 rounded-3 fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer shadow-sm" title="Mark As Read" t-ref="markAsRead"/>
+                    </div>
                 </div>
             </div>
             <t t-if="props.slots and props.slots.sideContent">

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -322,7 +322,7 @@ test("Show send button in mobile", async () => {
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
-    await click("button", { text: "Channel" });
+    await click("button", { text: "Channels" });
     await click(".o-mail-NotificationItem", { text: "minecraft-wii-u" });
     await contains(".o-mail-Composer button[title='Send']");
     await contains(".o-mail-Composer button[title='Send'] i.fa-paper-plane-o");

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -322,7 +322,7 @@ test("'Start a meeting' in mobile", async () => {
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
-    await click("button", { text: "Chat" });
+    await click("button", { text: "Chats" });
     await click("button", { text: "Start a meeting" });
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Partner 2" });
     await click("button:not([disabled])", { text: "Invite to Group Chat" });

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -144,7 +144,7 @@ test("mobile chat search should allow to create group chat", async () => {
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
-    await click("button", { text: "Chat" });
+    await click("button", { text: "Chats" });
     await contains("button", { text: "Start a conversation" });
 });
 

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -28,7 +28,7 @@ test("can make DM chat in mobile", async () => {
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
-    await click("button", { text: "Chat" });
+    await click("button", { text: "Chats" });
     await click("button", { text: "Start a conversation" });
     await insertText("input[placeholder='Search a conversation']", "Gandalf");
     await click(".o_command_name", { text: "Gandalf" });
@@ -42,7 +42,7 @@ test("can search channel in mobile", async () => {
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
-    await click("button", { text: "Channel" });
+    await click("button", { text: "Channels" });
     await click("button", { text: "Start a conversation" });
     await insertText("input[placeholder='Search a conversation']", "Gryff");
     await click("a", { text: "Gryffindors" });
@@ -54,7 +54,7 @@ test("can make new channel in mobile", async () => {
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
-    await click("button", { text: "Channel" });
+    await click("button", { text: "Channels" });
     await click("button", { text: "Start a conversation" });
     await insertText("input[placeholder='Search a conversation']", "slytherins");
     await click("a", { text: "Create Channel" });

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -580,8 +580,8 @@ test("mobile: active icon is highlighted", async () => {
     patchUiSize({ size: SIZES.SM });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-MessagingMenu-tab", { text: "Chat" });
-    await contains(".o-mail-MessagingMenu-tab.fw-bold", { text: "Chat" });
+    await click(".o-mail-MessagingMenu-tab", { text: "Chats" });
+    await contains(".o-mail-MessagingMenu-tab.fw-bold", { text: "Chats" });
 });
 
 test("open chat window from preview", async () => {

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -27,7 +27,7 @@ test("auto-select 'Inbox' when discuss had channel as active thread", async () =
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-ChatWindow [title*='Close Chat Window']");
-    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bold", { text: "Channel" });
+    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bold", { text: "Channels" });
     await click("button", { text: "Mailboxes" });
     await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bold", { text: "Mailboxes" });
     await contains("button.active", { text: "Inbox" });

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -237,7 +237,7 @@ test("mobile: mark as read when opening chat", async () => {
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
-    await click("button:has(.badge:contains('1'))", { text: "Chat" });
+    await click("button:has(.badge:contains('1'))", { text: "Chats" });
     await contains(".o-mail-NotificationItem:has(.badge:contains(1))", { text: "bob" });
     await click(".o-mail-NotificationItem", { text: "bob" });
     await contains(".o-mail-Message");


### PR DESCRIPTION
This commit makes the following improvements to messaging menu:
- datetime of notification is now above counter, was previously counter above datetime
- datetime is bolder when notification is important
- bold weight of important message is slightly lower, to look less harsh while still looking bold
- text part of important item has font weight reduced, for improved readability
- name of notification is slightly bigger in mobile
- mobile navbar items have their name slightly changed: chats, channels, live chats

Part of task-4967066

Before / After
<img width="295" height="639" alt="mobile-before" src="https://github.com/user-attachments/assets/234c7491-d0e9-4818-b2c6-4ec349a0efc8" /> <img width="295" height="639" alt="mobile-after" src="https://github.com/user-attachments/assets/4ba973d1-6b9e-41ef-a058-adee25c4226e" />


Before / After
<img width="481" height="551" alt="desktop-before" src="https://github.com/user-attachments/assets/a8774c9f-5d47-434e-b468-214d44cab7ef" /> <img width="482" height="554" alt="desktop-after" src="https://github.com/user-attachments/assets/5c23929e-d52a-40b8-ad1d-b6d6f899e875" />

