### PR TITLE
[FIX] website, web_editor: make .btn-close color dynamic

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -615,6 +615,10 @@ pre {
                 }
             }
         }
+
+        .btn-close {
+            filter: unset;
+        }
     }
 }
 @for $index from 1 through length($o-color-combinations) {
@@ -718,6 +722,12 @@ pre {
                     background-color: $-btn-primary-color;
                     color: color-contrast($-btn-primary-color);
                     border-color: $-btn-primary-color;
+                }
+            }
+
+            .btn-close {
+                @if (lightness($-bg-color) < 50) {
+                    @include btn-close-white();
                 }
             }
         }

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -640,6 +640,14 @@ font[class*='bg-'] {
     }
 }
 
+.btn-close {
+    // Most components with an integrated .btn-close (o_notification, modals, offcanvas)
+    // use $body-bg by default, which is why we check it here.
+    @if (lightness($body-bg) < 50) {
+        @include btn-close-white();
+    }
+}
+
 // Badges
 .badge, .o_filter_tag {
     background: var(--background-color, var(--bg-light)) !important;


### PR DESCRIPTION
This commit makes `.btn-close` color dynamic based on the color palette
of the website.

Impacted components that are using `.btn-close`:

`.modal` (e.g.: `.o_sale_product_configurator_dialog`
`.offcanvas` (e.g.: `#o_wsale_offcanvas`)
`.o_notification`

task-4630175

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
