### PR TITLE
[FIX] survey: Update subject from template in surveys

### DIFF
--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -154,7 +154,7 @@ class SurveyInvite(models.TransientModel):
 
     @api.depends('template_id', 'partner_ids')
     def _compute_subject(self):
-        for invite in self.filtered(lambda inv: not inv.subject):
+        for invite in self:
             if invite.template_id and invite.template_id.subject:
                 invite.subject = invite.template_id.subject
             else:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fixed [previous commit] where the subject doesn't update when the template was updated. This was due to a filter in place preventing this from happening. 

Steps to reproduce on runbot:
1. Go to mail templates and search for Survey
2. Open the Survey: Invite template
3. Update the subject on this template
4. Open the Surveys app and select any survey
5. Click on Share and then enable send by email
6. Change the template being used
6. The subject will stay the same

[previous commit]: https://github.com/odoo/odoo/commit/16a2c28c9aec307f7ce9dbed0a660b512db31f3a

opw-4654411

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
