### PR TITLE
[FIX] calendar: updated layout for overlapping divs

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -180,6 +180,10 @@
             background-color: rgba($gray-200, .5);
         }
 
+        .fc-daygrid-bg-harness {
+            z-index: -1;
+        }
+
         // ======  Specific agenda types ======
         // ====================================
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 

Related to this ticket [4879528](https://www.odoo.com/odoo/project.task/project.task/4879528)
When configured to have "everybody's calendar" selected, for day and weekly view, the "+x more" clickable link is overlapped by a "fc-daygrid-bg-harness" div, making it impossible for the user to select click this link. The fix serves to push the overlapping div back to ensure the user can click on the more link.

Note: This issue can be reproduced by using a weekend day, as it by default will have the overlapping div since it is a non business day.
    
  Steps to reproduce issue:
          - Select day / week view on calendar view
          - Create 6+ more events on a weekend day
          - Try and click the "+x more" button

Current behavior before PR:
The user could not click on the "+x more" link and instead the wizard to create a new calendar event appears.

Desired behavior after PR is merged:
The list of events appears when clicking the "+x more" link instead of the wizard.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
