### PR TITLE
[IMP] mail: prettify message links

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -4,7 +4,6 @@ from werkzeug.exceptions import NotFound
 
 from odoo import http
 from odoo.http import request
-from odoo.tools.misc import OrderedSet
 from odoo.addons.mail.controllers.webclient import WebclientController
 from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
 
@@ -46,10 +45,6 @@ class DiscussChannelWebclientController(WebclientController):
         if name == "discuss.channel":
             channels = request.env["discuss.channel"].search([("id", "in", params)])
             request.update_context(channels=request.env.context["channels"] | channels)
-            if not_found_channels := request.env["discuss.channel"].browse(
-                OrderedSet(int(cid) for cid in params) - OrderedSet(channels.ids)
-            ):
-                store.delete(not_found_channels)
         if name == "/discuss/get_or_create_chat":
             channel = request.env["discuss.channel"]._get_or_create_chat(
                 params["partners_to"], params.get("pin", True)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4779,6 +4779,7 @@ class MailThread(models.AbstractModel):
             Store.Many("partner_ids", ["avatar_128", "name"]),
             "pinned_at",
             "write_date",
+            *message._get_store_linked_messages_fields(),
         ]
         if body is not None:
             # sudo: mail.message.translation - discarding translations of message after editing it

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -104,7 +104,7 @@ export class ChatHub extends Record {
         /** @param {import("models").Thread[]} threads */
         const insertChatWindows = (threads) =>
             threads
-                .filter((thread) => thread)
+                .filter((thread) => thread?.model === "discuss.channel")
                 .map((thread) => this.store.ChatWindow.insert({ thread }));
         const toFold = insertChatWindows(foldThreads);
         const toOpen = insertChatWindows(openThreads);

--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -2,7 +2,7 @@
     background-color: mix($white, $o-webclient-background-color, 15%) !important;
 }
 
-a.o_mail_redirect, a.o_channel_redirect {
+a.o_mail_redirect, a.o_channel_redirect, a.o_message_redirect_transformed {
     @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .2), rgba(lighten($o-action, 5%), .3), lighten($o-action, 10%));
 }
 

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -292,7 +292,7 @@ $o-mail-utilities: map-merge(
     }
 }
 
-a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention {
+a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention, a.o_message_redirect_transformed {
     border-radius: $btn-border-radius-sm;
     padding: 0rem 0.1875rem;
     border: 1px solid;
@@ -300,7 +300,7 @@ a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention {
     display: inline-block;
 }
 
-a.o_mail_redirect, a.o_channel_redirect {
+a.o_mail_redirect, a.o_channel_redirect, a.o_message_redirect_transformed {
     @include o-mention-variant(rgba($primary, .15), rgba($primary, .25), darken($primary, 10%), rgba($primary, .2), rgba($primary, .5), darken($primary, 15%));
 }
 

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -34,7 +34,7 @@ import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
 import { createElementWithContent } from "@web/core/utils/html";
-import { url } from "@web/core/utils/urls";
+import { getOrigin, url } from "@web/core/utils/urls";
 import { useMessageActions } from "./message_actions";
 import { cookie } from "@web/core/browser/cookie";
 import { rpc } from "@web/core/network/rpc";
@@ -402,8 +402,7 @@ export class Message extends Component {
         }
         const editedEl = bodyEl.querySelector(".o-mail-Message-edited");
         editedEl?.replaceChildren(renderToElement("mail.Message.edited"));
-        const linkEls = bodyEl.querySelectorAll(".o_channel_redirect");
-        for (const linkEl of linkEls) {
+        for (const linkEl of bodyEl.querySelectorAll(".o_channel_redirect")) {
             const text = linkEl.textContent.substring(1); // remove '#' prefix
             const icon = linkEl.classList.contains("o_channel_redirect_asThread")
                 ? "fa fa-comments-o"
@@ -411,6 +410,16 @@ export class Message extends Component {
             const iconEl = renderToElement("mail.Message.mentionedChannelIcon", { icon });
             linkEl.replaceChildren(iconEl);
             linkEl.insertAdjacentText("beforeend", ` ${text}`);
+        }
+        for (const el of bodyEl.querySelectorAll(".o_message_redirect")) {
+            // only transform links targetting the same database
+            if (el.getAttribute("href")?.startsWith(getOrigin())) {
+                const message = this.store["mail.message"].get(el.dataset.oeId);
+                if (message?.thread?.displayName) {
+                    el.classList.add("o_message_redirect_transformed");
+                    el.replaceChildren(renderToElement("mail.Message.messageLink", { message }));
+                }
+            }
         }
     }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -256,4 +256,12 @@
     </small>
 </t>
 
+    <t t-name="mail.Message.messageLink">
+        <span>
+            <span class="me-1" t-out="message.thread.displayName"/>
+            <span class="fa fa-angle-right me-1" aria-hidden="true"/>
+            <span class="fa fa-comment" aria-hidden="true"/>
+        </span>
+    </t>
+
 </templates>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -438,6 +438,11 @@ export class Thread extends Record {
         return {};
     }
 
+    async checkReadAccess() {
+        await this.store.Thread.getOrFetch(this, ["hasReadAccess"]);
+        return this.hasReadAccess;
+    }
+
     executeCommand(command, body = "") {
         return this.store.env.services.orm.call(
             "discuss.channel",
@@ -729,8 +734,13 @@ export class Thread extends Record {
     /** @param {import("models").Message} message */
     onNewSelfMessage(message) {}
 
-    /** @param {Object} [options] */
-    open(options) {}
+    /**
+     * @param {Object} [options]
+     * @return {boolean} true if the thread was opened, false otherwise
+     */
+    open(options) {
+        return false;
+    }
 
     async openChatWindow({ focus = false, fromMessagingMenu, bypassCompact } = {}) {
         const thread = await this.store.Thread.getOrFetch(this);

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -32,7 +32,7 @@
                             className="'o-mail-Discuss-threadName fw-bolder flex-shrink-1 text-dark py-0 fs-4'"
                             enabled="thread.is_editable or thread.channel_type === 'chat'"
                             onValidate.bind="renameThread"
-                            value="thread.displayName"
+                            value="thread.displayName || ''"
                         />
                         <t t-if="thread.allowDescription and (thread.is_editable or (!thread.is_editable and thread.description))">
                             <div class="flex-shrink-0 mx-1 py-2 border-start"/>

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -37,7 +37,8 @@ export class MessagingMenu extends Component {
 
     onClickThread(isMarkAsRead, thread) {
         if (!isMarkAsRead) {
-            this.openDiscussion(thread);
+            thread.open({ focus: true, fromMessagingMenu: true, bypassCompact: true });
+            this.dropdown.close();
             return;
         }
         this.markAsRead(thread);
@@ -140,11 +141,6 @@ export class MessagingMenu extends Component {
                 label: _t("Channels"),
             },
         ];
-    }
-
-    openDiscussion(thread) {
-        thread.open({ focus: true, fromMessagingMenu: true, bypassCompact: true });
-        this.dropdown.close();
     }
 
     onClickNavTab(tabId) {

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -91,13 +91,6 @@ patch(Thread.prototype, {
             this.store.env.services.action.currentController.action.context.active_id = activeId;
         }
     },
-    open(options) {
-        if (this.store.env.services.ui.isSmall) {
-            this.openChatWindow(options);
-            return;
-        }
-        this.setAsDiscussThread();
-    },
     async unpin() {
         this.isLocallyPinned = false;
         if (this.eq(this.store.discuss.thread)) {

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -121,20 +121,7 @@ patch(MessagingMenu.prototype, {
         }
     },
     async openThread(thread) {
-        if (this.store.discuss.isActive) {
-            this.action.doAction({
-                type: "ir.actions.act_window",
-                res_model: thread.model,
-                views: [[false, "form"]],
-                res_id: thread.id,
-            });
-            await this.store.chatHub.initPromise;
-            // Close the related chat window as having both the form view
-            // and the chat window does not look good.
-            this.store.ChatWindow.get({ thread })?.close();
-        } else {
-            thread.open({ focus: true, fromMessagingMenu: true });
-        }
+        thread.open({ focus: true, fromMessagingMenu: true });
         this.dropdown.close();
     },
     openFailureView(failure) {

--- a/addons/mail/static/src/core/web/thread_actions.js
+++ b/addons/mail/static/src/core/web/thread_actions.js
@@ -34,31 +34,4 @@ threadActionsRegistry
             component.store = useService("mail.store");
         },
         text: _t("Unstar all"),
-    })
-    .add("expand-form", {
-        condition(component) {
-            return (
-                component.thread &&
-                !["mail.box", "discuss.channel"].includes(component.thread.model) &&
-                component.props.chatWindow?.isOpen
-            );
-        },
-        setup() {
-            const component = useComponent();
-            component.actionService = useService("action");
-        },
-        icon: "fa fa-fw fa-expand",
-        iconLarge: "fa fa-lg fa-fw fa-expand",
-        name: _t("Open Form View"),
-        open(component) {
-            component.actionService.doAction({
-                type: "ir.actions.act_window",
-                res_id: component.thread.id,
-                res_model: component.thread.model,
-                views: [[false, "form"]],
-            });
-            component.props.chatWindow.close();
-        },
-        sequence: 40,
-        sequenceGroup: 20,
     });

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -48,28 +48,19 @@ const threadPatch = {
         );
         this.store.insert(data);
     },
+    /** @override */
     open(options) {
-        if (this.model === "discuss.channel" && !this.selfMember) {
-            this.store.env.services["bus_service"].addChannel(this.busChannel);
+        const res = super.open(...arguments);
+        if (res) {
+            return res;
         }
-        if (!this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
-            this.openChatWindow(options);
-            return;
-        }
-        if (this.store.env.services.ui.isSmall && this.model === "discuss.channel") {
-            this.openChatWindow(options);
-            return;
-        }
-        if (this.model !== "discuss.channel") {
-            this.store.env.services.action.doAction({
-                type: "ir.actions.act_window",
-                res_id: this.id,
-                res_model: this.model,
-                views: [[false, "form"]],
-            });
-            return;
-        }
-        super.open(...arguments);
+        this.store.env.services.action.doAction({
+            type: "ir.actions.act_window",
+            res_id: this.id,
+            res_model: this.model,
+            views: [[false, "form"]],
+        });
+        return true;
     },
     async unpin() {
         await this.store.chatHub.initPromise;
@@ -84,6 +75,6 @@ const threadPatch = {
             partner_ids: [this.store.self.id],
         });
         this.store.insert(data);
-    }
+    },
 };
 patch(Thread.prototype, threadPatch);

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -17,6 +17,7 @@ declare module "models" {
         channelMembers: ChannelMember[];
     }
     export interface Store {
+        channelIdsFetchingDeferred: Map<number, Deferred>;
         channel_types_with_seen_infos: string[];
         createGroupChat: (param0: { default_display_mode: string, partners_to: number[], name: string }) => Promise<Thread>;
         "discuss.channel.member": StaticMailRecord<ChannelMember, typeof ChannelMemberClass>;

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -9,6 +9,8 @@ const storeServicePatch = {
     /** @override */
     setup() {
         super.setup();
+        /** @type {Map<number, Deferred>} */
+        this.channelIdsFetchingDeferred = new Map();
         /**
          * Defines channel types that have the message seen indicator/info feature.
          * @see `discuss.channel`._types_allowing_seen_infos()

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -54,7 +54,7 @@ export class DiscussSidebarSubchannel extends Component {
     /** @param {MouseEvent} ev */
     openThread(ev, thread) {
         markEventHandled(ev, "sidebar.openThread");
-        thread.setAsDiscussThread();
+        thread.open();
     }
 }
 
@@ -102,7 +102,9 @@ export class DiscussSidebarChannel extends Component {
         return {
             "bg-inherit": this.thread.notEq(this.store.discuss.thread),
             "o-active": this.thread.eq(this.store.discuss.thread),
-            "o-unread": this.thread.selfMember?.message_unread_counter > 0 && !this.thread.selfMember?.mute_until_dt,
+            "o-unread":
+                this.thread.selfMember?.message_unread_counter > 0 &&
+                !this.thread.selfMember?.mute_until_dt,
             "border-bottom-0 rounded-bottom-0": this.bordered,
             "opacity-50": this.thread.selfMember?.mute_until_dt,
             "position-relative justify-content-center o-compact mt-0 p-1":
@@ -132,9 +134,11 @@ export class DiscussSidebarChannel extends Component {
     get itemNameAttClass() {
         return {
             "o-unread fw-bolder":
-                this.thread.selfMember?.message_unread_counter > 0 && !this.thread.selfMember?.mute_until_dt,
+                this.thread.selfMember?.message_unread_counter > 0 &&
+                !this.thread.selfMember?.mute_until_dt,
             "text-muted":
-                this.thread.selfMember?.message_unread_counter === 0 || this.thread.selfMember?.mute_until_dt,
+                this.thread.selfMember?.message_unread_counter === 0 ||
+                this.thread.selfMember?.mute_until_dt,
         };
     }
 
@@ -161,7 +165,10 @@ export class DiscussSidebarChannel extends Component {
         if (!this.thread.selfMember?.mute_until_dt || sub.selfMember?.message_unread_counter > 0) {
             return true;
         }
-        return this.isSelfOrThreadActive && !(this.thread.selfMember?.mute_until_dt && sub.selfMember?.mute_until_dt);
+        return (
+            this.isSelfOrThreadActive &&
+            !(this.thread.selfMember?.mute_until_dt && sub.selfMember?.mute_until_dt)
+        );
     }
 
     get isSelfOrThreadActive() {
@@ -174,7 +181,7 @@ export class DiscussSidebarChannel extends Component {
     /** @param {MouseEvent} ev */
     openThread(ev, thread) {
         markEventHandled(ev, "sidebar.openThread");
-        thread.setAsDiscussThread();
+        thread.open();
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -130,6 +130,14 @@ const threadPatch = {
             this.sub_channel_ids.forEach((c) => (c.isLocallyPinned = false));
         }
     },
+    /** @override */
+    openChannel() {
+        if (this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
+            this.setAsDiscussThread();
+            return true;
+        }
+        return super.openChannel();
+    },
     setAsDiscussThread() {
         super.setAsDiscussThread(...arguments);
         if (!this.displayToSelf && this.model === "discuss.channel") {

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -184,12 +184,12 @@ test("Hover on chat bubble shows chat name + last message preview", async () => 
 
 test("Chat bubble preview works on author as email address", async () => {
     const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
+    const partnerId = pyEnv["discuss.channel"].create({ name: "test channel" });
     const messageId = pyEnv["mail.message"].create({
         author_id: null,
         body: "Some email message",
         email_from: "md@oilcompany.fr",
-        model: "res.partner",
+        model: "discuss.channel",
         needaction: true,
         res_id: partnerId,
     });

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -77,76 +77,6 @@ test('chat window: post message on channel with "CTRL-Enter" keyboard shortcut f
     await contains(".o-mail-Message");
 });
 
-test("Message post in chat window of chatter should log a note", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
-    const messageId = pyEnv["mail.message"].create({
-        model: "res.partner",
-        body: "A needaction message to have it in messaging menu",
-        author_id: serverState.odoobotId,
-        needaction: true,
-        res_id: partnerId,
-    });
-    pyEnv["mail.notification"].create({
-        mail_message_id: messageId,
-        notification_status: "sent",
-        notification_type: "inbox",
-        res_partner_id: serverState.partnerId,
-    });
-    await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-Message", {
-        text: "A needaction message to have it in messaging menu",
-        contains: [".o-mail-Message-bubble"], // bubble = "Send message" mode
-    });
-    await contains(".o-mail-Composer [placeholder='Log an internal note…']");
-    await insertText(".o-mail-ChatWindow .o-mail-Composer-input", "Test");
-    triggerHotkey("control+Enter");
-    await contains(".o-mail-Message", {
-        text: "Test",
-        contains: [".o-mail-Message-bubble", { count: 0 }], // no bubble = "Log note" mode
-    });
-});
-
-test("Chatter in chat window should scroll to most recent message", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
-    // Fill both channels with random messages in order for the scrollbar to
-    // appear.
-    pyEnv["mail.message"].create(
-        Array(50)
-            .fill(0)
-            .map((_, index) => ({
-                model: "res.partner",
-                body: "Non Empty Body ".repeat(25),
-                author_id: serverState.odoobotId,
-                needaction: true,
-                res_id: partnerId,
-            }))
-    );
-    const lastMessageId = pyEnv["mail.message"].create({
-        model: "res.partner",
-        body: "A needaction message to have it in messaging menu",
-        author_id: serverState.odoobotId,
-        needaction: true,
-        res_id: partnerId,
-    });
-    pyEnv["mail.notification"].create({
-        mail_message_id: lastMessageId,
-        notification_status: "sent",
-        notification_type: "inbox",
-        res_partner_id: serverState.partnerId,
-    });
-    await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-Message", { count: 30 });
-    await contains(".o-mail-Thread", { scroll: "bottom" });
-});
-
 test("load messages from opening chat window from messaging menu", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
@@ -1076,31 +1006,31 @@ test("Ctrl+k opens the @ command palette", async () => {
 
 test("Do not squash logged notes", async () => {
     const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
+    const partnerId = pyEnv["discuss.channel"].create({ name: "test channel" });
     const messageId = pyEnv["mail.message"].create([
         {
-            model: "res.partner",
+            model: "discuss.channel",
             body: "Test Message",
             author_id: partnerId,
             needaction: true,
             res_id: partnerId,
         },
         {
-            model: "res.partner",
+            model: "discuss.channel",
             body: "Message",
             author_id: serverState.partnerId,
             needaction: true,
             res_id: partnerId,
         },
         {
-            model: "res.partner",
+            model: "discuss.channel",
             body: "Message Squashed",
             author_id: serverState.partnerId,
             needaction: true,
             res_id: partnerId,
         },
         {
-            model: "res.partner",
+            model: "discuss.channel",
             body: "Hello",
             author_id: serverState.partnerId,
             needaction: true,
@@ -1110,7 +1040,7 @@ test("Do not squash logged notes", async () => {
             ])[0],
         },
         {
-            model: "res.partner",
+            model: "discuss.channel",
             body: "World!",
             author_id: serverState.partnerId,
             needaction: true,

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1976,7 +1976,9 @@ test("Copy Message Link", async () => {
     await waitForSteps([url(`/mail/message/${messageId_2}`)]);
     await press(["ctrl", "v"]);
     await press("Enter");
-    await contains(".o-mail-Message", { text: url(`/mail/message/${messageId_2}`) });
+    await contains(`.o-mail-Message a[href='${url(`/mail/message/${messageId_2}`)}']`, {
+        text: "channel1",
+    });
 });
 
 test("deleted message should not have translate feature", async () => {
@@ -2057,4 +2059,28 @@ test("Pause GIF when thread is not focused", async () => {
     await contains(".o-mail-AttachmentImage[data-paused]");
     await focus(".o-mail-Thread");
     await contains(".o-mail-AttachmentImage:not([data-paused])");
+});
+
+test("Prettify message links", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "channel1" });
+    const partnerId = pyEnv["res.partner"].create({
+        email: "testpartner@odoo.com",
+        name: "TestPartner",
+    });
+    const messageId_1 = pyEnv["mail.message"].create({
+        body: "Message on partner",
+        res_id: partnerId,
+        model: "res.partner",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(
+        ".o-mail-Composer-input",
+        `${url(`/mail/message/${messageId_1}`)} ${url(`/mail/message/100`)}`
+    );
+    await press("Enter");
+    await contains(".o-mail-Message", { text: "TestPartner" });
+    await contains(".o-mail-Message .fa.fa-comment");
+    await contains(".o-mail-Message", { text: url(`/mail/message/100`) });
 });

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -328,12 +328,12 @@ test("grouped notifications by document", async () => {
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-ChatWindow", { count: 0 });
+    await contains(".o-mail-Chatter", { count: 0 });
     await click(".o-mail-NotificationItem", {
         text: "Email Failure: Contact",
         contains: [".badge", { text: "2" }],
     });
-    await contains(".o-mail-ChatWindow");
+    await contains(".o-mail-Chatter");
 });
 
 test("grouped notifications by document model", async () => {
@@ -853,47 +853,11 @@ test("click on preview should mark as read and open the thread", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", { text: "Frodo Baggins" });
-    await contains(".o-mail-ChatWindow", { count: 0 });
+    await contains(".o-mail-Chatter", { count: 0 });
     await click(".o-mail-NotificationItem", { text: "Frodo Baggins" });
-    await contains(".o-mail-ChatWindow");
+    await contains(".o-mail-Chatter");
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", { count: 0, text: "Frodo Baggins" });
-});
-
-test("click on expand from chat window should close the chat window and open the form view", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "Frodo Baggins" });
-    const messageId = pyEnv["mail.message"].create({
-        model: "res.partner",
-        body: "not empty",
-        author_id: serverState.odoobotId,
-        needaction: true,
-        res_id: partnerId,
-    });
-    pyEnv["mail.notification"].create({
-        mail_message_id: messageId,
-        notification_status: "sent",
-        notification_type: "inbox",
-        res_partner_id: serverState.partnerId,
-    });
-    mockService("action", {
-        doAction(action) {
-            asyncStep("do_action");
-            expect(action.res_id).toBe(partnerId);
-            expect(action.res_model).toBe("res.partner");
-        },
-    });
-    await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem", { text: "Frodo Baggins" });
-    // dropdown requires an extra delay before click (because handler is registered in useEffect)
-    await contains("[title='Open Actions Menu']");
-    await click("[title='Open Actions Menu']");
-    await click(".o-dropdown-item", { text: "Open Form View" });
-    await contains(".o-mail-ChatWindow", { count: 0 });
-    await waitForSteps(["do_action"], {
-        message: "should have done an action to open the form view",
-    });
 });
 
 test("preview should display last needaction message preview even if there is a more recent message that is not needaction in the thread", async () => {

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -1,5 +1,4 @@
 import {
-    assertChatHub,
     click,
     contains,
     defineMailModels,
@@ -695,39 +694,6 @@ test("chat window header should not have unread counter for non-channel thread",
     await contains(".o-mail-ChatWindow-counter", { count: 0, text: "1" });
 });
 
-test("non-channel chat window are saved", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "test" });
-    const messageId = pyEnv["mail.message"].create({
-        author_id: partnerId,
-        body: "not empty",
-        model: "res.partner",
-        needaction: true,
-        res_id: partnerId,
-    });
-    pyEnv["mail.notification"].create({
-        mail_message_id: messageId,
-        notification_status: "sent",
-        notification_type: "inbox",
-        res_partner_id: serverState.partnerId,
-    });
-    await start();
-    await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow", { count: 0 });
-    await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow");
-    assertChatHub({ opened: [{ id: partnerId, model: "res.partner" }] });
-});
-
-test("non-channel chat window are restored", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "test partner" });
-    setupChatHub({ opened: [{ id: partnerId, model: "res.partner" }] });
-    await start();
-    await contains(".o-mail-ChatWindow:contains('test partner')");
-});
-
 test("Thread messages are only loaded once", async () => {
     const pyEnv = await startServer();
     const channelIds = pyEnv["discuss.channel"].create([{ name: "General" }, { name: "Sales" }]);
@@ -933,7 +899,7 @@ test("Update unread counter when receiving new message", async () => {
         channel_member_ids: [
             Command.create({
                 message_unread_counter: 1,
-                partner_id: serverState.partnerId
+                partner_id: serverState.partnerId,
             }),
             Command.create({ partner_id: partnerId }),
         ],


### PR DESCRIPTION
PURPOSE:

Currently, internal links that redirect to messages are displayed as raw URLs, which makes them hard to read and understand. This commit aims to enhance the user experience by improving the display of these message links.

SPECIFICATION:

Message links should be presented in a more user-friendly format, displaying the `Thread name > {Comment Icon}`, similar to how other platforms like Discord handle message links.

Thread.open code is refactored to properly work in all cases, as the method is used internally when opening a message link from many different places. Non-channel documents now always open in form view rather than sometimes in chat window.

task-4095268
task-4681025

Taken from https://github.com/odoo/odoo/pull/179522

https://github.com/odoo/enterprise/pull/91424