### PR TITLE
[FIX] account_update_tax_tags: fix invisible setting

### DIFF
--- a/addons/account_update_tax_tags/views/res_config_settings_views.xml
+++ b/addons/account_update_tax_tags/views/res_config_settings_views.xml
@@ -14,9 +14,8 @@
             <field name="inherit_id" ref="account.res_config_settings_view_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//block[@name='default_taxes_setting_container']" position="inside">
-                    <setting id="update_tax_tags">
+                    <setting id="update_tax_tags" groups="base.group_no_one">
                         <button name="%(account_update_tax_tags.action_open_wizard)d" icon="fa-refresh" type="action" class="btn-link"
-                                groups="base.group_no_one"
                                 string="Update tax tags on existing Journal Entries"/>
                     </setting>
                 </xpath>


### PR DESCRIPTION
On the res config settings view, a group was applied on a button, but if the group is not respected, the button is invisible but not the setting div, leading to an empty div in the settings.

Move the groups attribute from the button to the setting element, so we won't have any empty space anymore.

Linked: https://github.com/odoo/enterprise/pull/84533

no-task