### PR TITLE
[FIX] html_builder: prevent undo after partial save

### DIFF
--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -6,7 +6,7 @@ import { uniqueId } from "@web/core/utils/functions";
 
 export class SavePlugin extends Plugin {
     static id = "savePlugin";
-    static shared = ["save", "isAlreadySaved", "saveView"];
+    static shared = ["save", "saveView"];
     static dependencies = ["history"];
 
     resources = {
@@ -50,6 +50,8 @@ export class SavePlugin extends Plugin {
     }
 
     async save() {
+        this.dependencies.history.reset();
+
         // TODO: implement the "group by" feature for save
         const proms = [];
         for (const fn of this.getResource("before_save_handlers")) {
@@ -102,18 +104,10 @@ export class SavePlugin extends Plugin {
         // used to track dirty out of the editable scope, like header, footer or wrapwrap
         const willSaves = this.getResource("save_handlers").map((c) => c());
         await Promise.all(saveProms.concat(willSaves));
-        this.lastSavedStep = this.dependencies.history.getHistorySteps().at(-1);
     }
 
     groupElementHandler(model, field) {
         return model === "ir.ui.view" && field === "arch" ? uniqueId("view-part-to-save-") : "";
-    }
-
-    isAlreadySaved() {
-        return (
-            !this.dependencies.history.getHistorySteps().length ||
-            this.lastSavedStep === this.dependencies.history.getHistorySteps().at(-1)
-        );
     }
 
     /**


### PR DESCRIPTION
In case of error during the save, the website builder stays
open for the user to fix their changes, this was implemented in
9b7f06f53e71ea4a6db5168fd3e019406fc3a82f. Unfortunately, this enables
to user to undo changes that were saved. This is not well handled by the
builder, which may not save what the user see after undo (for example
if they undid the first change of a field, the `o_dirty` mark is removed
and the field won't be saved again)

Steps to reproduce:
- On `/blog`, open website builder
- Change the title of a blog post
- Change a date to something invalid
- Click on save
- Close the dialog about the failure to save because of the date
- Undo everything (the change to the date and the title)
- Click on save
- Bug: the change on the title is still present

To prevent this, the history is cleared on save, and a flag marking the
last save as failed is kept by the builder to prompt the user if they
want to discard unsaved changes.

Resetting the history on save makes the condition added by
30bbe413f1122bf243eb6e073be6fa19dddf984a redundant, therefore it is
removed

task-4367641
