### PR TITLE
[FIX] hr_holidays: fix overlapping styling issue in leave stats

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -13,6 +13,7 @@
                 color="employee_id"
                 event_open_popup="True"
                 js_class="time_off_calendar"
+                create="0"
                 show_unusual_days="True">
                 <field name="name"/>
                 <field name="employee_id" filters="1" invisible="1"/>

--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
@@ -16,7 +16,7 @@
                 </div>
             </div>
             <div class="d-flex flex-column mb-1">
-                <div t-foreach="state.leaves" t-as="leave" t-key="leave.id" class="d-flex mb-2">
+                <div t-foreach="state.leaves" t-as="leave" t-key="leave.id" class="d-flex mb-2 gap-1">
                     <span class="col-4 fw-bold" t-esc="leave.holiday_status_id[1]"/>
                     <div t-if="leave.leave_type_request_unit == 'hour'" class="d-flex gap-2 col-6">
                         <span t-esc="leave.date_from"/>
@@ -24,12 +24,12 @@
                         <i class="fa fa-long-arrow-right my-1" aria-label="Arrow icon" title="Arrow"/>
                         <span t-esc="leave.hour_to" class="fst-italic"/>
                     </div>
-                    <div t-else="" class="col-6 d-flex gap-2">
+                    <div t-else="" class="col-5 d-flex gap-2 flex-wrap">
                         <span t-esc="leave.date_from"/>
                         <i class="fa fa-long-arrow-right my-1" aria-label="Arrow icon" title="Arrow"/>
                         <span t-esc="leave.date_to"/>
                     </div>
-                    <div class="col-3">
+                    <div class="col-3 text-center">
                     (
                         <span t-if="leave.leave_type_request_unit == 'hour'"><t t-esc="leave.number_of_hours"/> hours</span>
                         <span t-else=""><t t-esc="leave.number_of_days"/> days</span>
@@ -48,7 +48,7 @@
             </div>
             <div class="d-flex flex-column mb-1">
                 <div t-foreach="state.departmentLeaves" t-as="leave" t-key="leave.id" class="d-flex flex-column mb-2">
-                    <div class=" d-flex my-1">
+                    <div class=" d-flex my-1 gap-1">
                         <div class="col-4 d-flex">
                             <KanbanMany2OneAvatarEmployeeField
                                 record="{'data' : {'employee_id': leave.employee_id}, 'fields': this.props.record.fields}"
@@ -62,12 +62,12 @@
                             <i class="fa fa-long-arrow-right my-1" aria-label="Arrow icon" title="Arrow"/>
                             <span t-esc="leave.hour_to" class="fst-italic"/>
                         </div>
-                        <div t-else="" class="col-6 d-flex gap-2">
+                        <div t-else="" class="col-5 d-flex gap-2 flex-wrap">
                             <span t-esc="leave.date_from"/>
                             <i class="fa fa-long-arrow-right my-1" aria-label="Arrow icon" title="Arrow"/>
                             <span t-esc="leave.date_to"/>
                         </div>
-                        <div class="col-3">
+                        <div class="col-3 text-center">
                             (
                             <span t-if="leave.leave_type_request_unit == 'hour'"><t t-esc="leave.number_of_hours"/> hours</span>
                             <span t-else=""><t t-esc="leave.number_of_days"/> days</span>

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
@@ -3,7 +3,7 @@
 
     <t t-name="hr_holidays.CalendarController" t-inherit="web.CalendarController" t-inherit-mode="primary">
         <xpath expr="//Layout" position="inside">
-            <t t-set-slot="control-panel-create-button">
+            <t t-if="props.archInfo.canCreate" t-set-slot="control-panel-create-button">
                 <span class="o_timeoff_buttons btn-group">
                     <div class="btn-group">
                         <button class="btn btn-primary btn-time-off " t-on-click="newTimeOffRequest" type="button">


### PR DESCRIPTION
This commit addresses an overlapping styling issue in the leave stats

task-4945729

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
