### PR TITLE
[FIX] web: editor avatars shouldn't overlap with statusbar when scroll

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -438,7 +438,9 @@ export class FormCompiler extends ViewCompiler {
      * @returns {Element}
      */
     compileHeader(el, params) {
-        const statusBar = createElement("div");
+        const statusBar = createElement("div", {
+            "t-att-class": "{ 'shadow-sm': __comp__.state.isStatusbarStickyPinned }",
+        });
         statusBar.className = "o_form_statusbar d-flex justify-content-between py-2";
         const buttons = [];
         const others = [];
@@ -644,7 +646,9 @@ export class FormCompiler extends ViewCompiler {
      * @returns {Element}
      */
     compileSheet(el, params) {
-        const sheetBG = createElement("div");
+        const sheetBG = createElement("div", {
+            "t-on-scroll": "__comp__.onScrollThrottled",
+        });
         sheetBG.className = "o_form_sheet_bg";
 
         const sheetFG = createElement("div");

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -301,6 +301,8 @@
     .o_form_statusbar {
         position: relative;
         z-index: 0;
+        margin-inline: calc(-1 * var(--formView-sheetBg-padding-x));
+        padding-inline: var(--formView-sheetBg-padding-x);
 
         @include media-breakpoint-up(md) {
             position: sticky;
@@ -309,7 +311,6 @@
 
             &:not(.modal .o_form_statusbar) {
                 background-color: $body-bg;
-                box-shadow: 0 0.3rem 0.25rem -0.25rem rgba(0, 0, 0, 0.075);
             }
         }
 

--- a/addons/web/static/src/views/form/form_renderer.js
+++ b/addons/web/static/src/views/form/form_renderer.js
@@ -5,7 +5,7 @@ import { Field } from "@web/views/fields/field";
 import { browser } from "@web/core/browser/browser";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { useService } from "@web/core/utils/hooks";
-import { useDebounced } from "@web/core/utils/timing";
+import { useDebounced, useThrottleForAnimation } from "@web/core/utils/timing";
 import { ButtonBox } from "@web/views/form/button_box/button_box";
 import { InnerGroup, OuterGroup } from "@web/views/form/form_group/form_group";
 import { ViewButton } from "@web/views/view_button/view_button";
@@ -68,6 +68,7 @@ export class FormRenderer extends Component {
         useSubEnv({ model: record.model });
         this.uiService = useService("ui");
         this.onResize = useDebounced(this.render, 200);
+        this.onScrollThrottled = useThrottleForAnimation(this.onScroll);
         onMounted(() => browser.addEventListener("resize", this.onResize));
         onWillUnmount(() => browser.removeEventListener("resize", this.onResize));
 
@@ -137,5 +138,10 @@ export class FormRenderer extends Component {
 
     get shouldAutoFocus() {
         return !hasTouch() && !this.props.archInfo.disableAutofocus;
+    }
+
+    onScroll(ev) {
+        this.state.isStatusbarStickyPinned =
+            !this.env.inDialog && !this.env.isSmall && ev.target.scrollTop !== 0;
     }
 }

--- a/addons/web/static/tests/views/form/form_compiler.test.js
+++ b/addons/web/static/tests/views/form/form_compiler.test.js
@@ -173,7 +173,7 @@ test("properly compile no sheet", () => {
     const expected = /*xml*/ `
         <t t-translation="off">
             <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
-                <div class="o_form_statusbar d-flex justify-content-between py-2">
+                <div t-att-class="{ 'shadow-sm': __comp__.state.isStatusbarStickyPinned }" class="o_form_statusbar d-flex justify-content-between py-2">
                     <StatusBarButtons/>
                 </div>
                 <div>someDiv</div>
@@ -197,8 +197,8 @@ test("properly compile sheet", () => {
     const expected = /*xml*/ `
         <t t-translation="off">
             <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
-                <div class="o_form_sheet_bg">
-                    <div class="o_form_statusbar d-flex justify-content-between py-2"><StatusBarButtons/></div>
+                <div t-on-scroll="__comp__.onScrollThrottled" class="o_form_sheet_bg">
+                    <div t-att-class="{ 'shadow-sm': __comp__.state.isStatusbarStickyPinned }" class="o_form_statusbar d-flex justify-content-between py-2"><StatusBarButtons/></div>
                     <div>someDiv</div>
                     <div class="o_form_sheet position-relative">
                         <div>inside sheet</div>
@@ -227,7 +227,7 @@ test("properly compile buttonBox invisible in sheet", () => {
                  t-att-class="__comp__.props.class"
                  t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}"
                  t-ref="compiled_view_root">
-                <div class="o_form_sheet_bg">
+                <div t-on-scroll="__comp__.onScrollThrottled" class="o_form_sheet_bg">
                     <div class="o_form_sheet position-relative">
                     </div>
                 </div>
@@ -292,7 +292,7 @@ test("properly compile status bar with content", () => {
     const expected = /*xml*/ `
         <t t-translation="off">
             <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
-                <div class="o_form_statusbar d-flex justify-content-between py-2">
+                <div t-att-class="{ 'shadow-sm': __comp__.state.isStatusbarStickyPinned }" class="o_form_statusbar d-flex justify-content-between py-2">
                     <StatusBarButtons>
                         <t t-set-slot="button_0" isVisible="true">
                             <div>someDiv</div>
@@ -314,7 +314,7 @@ test("properly compile status bar without content", () => {
     const expected = /*xml*/ `
         <t t-translation="off">
             <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
-                <div class="o_form_statusbar d-flex justify-content-between py-2">
+                <div t-att-class="{ 'shadow-sm': __comp__.state.isStatusbarStickyPinned }" class="o_form_statusbar d-flex justify-content-between py-2">
                     <StatusBarButtons/>
                 </div>
             </div>
@@ -374,7 +374,7 @@ test("properly compile empty ButtonBox", () => {
     const expected = /*xml*/ `
         <t t-translation="off">
             <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
-                <div class="o_form_sheet_bg">
+                <div t-on-scroll="__comp__.onScrollThrottled" class="o_form_sheet_bg">
                     <div class="o_form_sheet position-relative">
                         <div class="oe_button_box" name="button_box">
                         </div>


### PR DESCRIPTION
User avatars displayed in collaborative mode overlap with buttons when scrolling.

This commit extends the statusbar to take the full width, independently of the sheet's one. Also, to avoid an ugly shadow when not scrolling, it only adds it when the scroll is actually performed.

Steps to reproduce:
- open a task with two users
- write in the description in collaborative mode -> user avatars should be displayed
- make sure the description is long enough for the sheet to scroll
- scroll for one of the avatars to reach the sticky statusbar => overlap between the avatar and the statusbar

task-4907797

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
