### PR TITLE
[FIX] hr_attendance: use full time hours for OT

### DIFF
--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -570,8 +570,8 @@ class TestHrAttendanceOvertime(TransactionCase):
 
         self.env['hr.attendance'].create({
             'employee_id': self.flexible_employee.id,
-            'check_in': datetime(2024, 2, 1, 8, 0),
-            'check_out': datetime(2024, 2, 1, 16, 0)
+            'check_in': datetime(2024, 3, 1, 8, 0),
+            'check_out': datetime(2024, 3, 1, 16, 0)
         })
 
         self.assertAlmostEqual(self.employee.total_overtime, 0, 2)


### PR DESCRIPTION
Before this change, computing overtime hours for flexible employees was based on the idea that they would work their set hours starting from the monday for the amount of average hours every day. If you filled out an attendance for any day that falls outside of those hours, then it would automatically be considered overtime.

For example, if you have a flexible working schedule with an average 8 hour day and 40 hours full time requirement, creating any attendance on the weekend would cause the entirety of the worked hours to be considered overtime.

This change changes the behavior such that only worked time over the required full time hours is considered overtime for flexible employees. This means that flexible employees can now work on any day of the week without counting it as overtime.

opw-4972232