### PR TITLE
[FIX] purchase: print PO instead of RFQ when order is confirmed

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -138,7 +138,8 @@
                     <button name="action_create_invoice" string="Create Bill" type="object" context="{'create_bill':True}" invisible="state not in ('purchase', 'done') or invoice_status not in ('no', 'invoiced') or not order_line" data-hotkey="w"/>
                     <button name="action_acknowledge" string="Acknowledge" type="object" invisible="acknowledged or state != 'purchase'"/>
                     <button name="button_draft" invisible="state != 'cancel'" string="Set to Draft" type="object" data-hotkey="o"/>
-                    <button name="print_quotation" string="Print" type="object" groups="base.group_user" data-hotkey="k"/>
+                    <button name="print_quotation" string="Print" type="object" groups="base.group_user" data-hotkey="k" invisible="state == 'purchase'"/>
+                    <button name="%(purchase.action_report_purchase_order)d" string="Print" type="action" groups="base.group_user" data-hotkey="k" invisible="state != 'purchase'"/>
                     <button name="button_cancel" invisible="state not in ('draft', 'to approve', 'sent', 'purchase')" string="Cancel" type="object" data-hotkey="x" />
                     <button name="button_done" type="object" string="Lock" invisible="state != 'purchase'" data-hotkey="l"/>
                     <button name="button_unlock" type="object" string="Unlock" invisible="state != 'done'" groups="purchase.group_purchase_manager" data-hotkey="l"/>


### PR DESCRIPTION
Before this commit:
-------------------------
- The 'Print' button in the Purchase Order form always triggered the RFQ report,
  regardless of the order state.
- This caused confusion for users expecting the Purchase Order report when the
  order was already confirmed.

Steps to reproduce:
-------------------------
1. Install 'purhcase' module.
2. Confirm a purchase order (move it to the 'Purchase Order' state).
3. Click on 'Print' button .
4. Notice that the RFQ report is printed instead of the PO report.

Cause of the issue
-------------------------
- The print button was hardcoded to always prints the RFQ report—even for
  confirmed purchase orders.

After this commit:
-----------------------
- The system now prints the Purchase Order report when the order is confirmed.
- The Print button behavior dynamically changes based on the order state
- This improves user experience by ensuring the correct document is printed
  according to the current state of the order.

Task Id: 4905350