### PR TITLE
[IMP] l10n_ee:  Update standard VAT rate in Estonia from 22% to 24%

### DIFF
--- a/addons/l10n_ee/__manifest__.py
+++ b/addons/l10n_ee/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Estonia - Accounting',
-    'version': '1.2',
+    'version': '1.3',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 This is the base module to manage the accounting chart for Estonia in Odoo.

--- a/addons/l10n_ee/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_ee/data/account_fiscal_position_template_data.xml
@@ -174,14 +174,14 @@
     <record id="afptt_eu_ic_9" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_20_g"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_24"/>
     </record>
 
     <!-- Purchase of Goods 22% -> Purchase of Goods in EU 0% IC -->
     <record id="afptt_eu_ic_19" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_22_g"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_24"/>
     </record>
 
     <!-- Purchase of Goods 24% -> Purchase of Goods in EU 0% IC -->
@@ -191,19 +191,18 @@
         <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_24"/>
     </record>
 
-
     <!-- Purchase of Services 20% -> Purchase of Services in EU 0% IC -->
     <record id="afptt_eu_ic_10" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_20_s"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_24"/>
     </record>
 
     <!-- Purchase of Services 22% -> Purchase of Services in EU 0% IC -->
     <record id="afptt_eu_ic_10_22" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_22_s"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_24"/>
     </record>
 
     <!-- Purchase of Services 24% -> Purchase of Services in EU 0% IC -->
@@ -217,49 +216,49 @@
     <record id="afptt_eu_ic_18" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_13_s"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_24"/>
     </record>
 
     <!-- Purchase of Goods 9% -> Purchase of Goods in EU 0% IC -->
     <record id="afptt_eu_ic_11" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_9_g"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_24"/>
     </record>
 
     <!-- Purchase of Services 9% -> Purchase of Services in EU 0% IC -->
     <record id="afptt_eu_ic_12" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_9_s"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_24"/>
     </record>
 
     <!-- Purchase of Goods 5% -> Purchase of Goods in EU 0% IC -->
     <record id="afptt_eu_ic_13" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_5_g"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_24"/>
     </record>
 
     <!-- Purchase of Services 5% -> Purchase of Services in EU 0% IC -->
     <record id="afptt_eu_ic_14" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_5_s"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_24"/>
     </record>
 
     <!-- Purchase of Goods 0% -> Purchase of Goods in EU 0% IC -->
     <record id="afptt_eu_ic_15" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_0_g"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_g_24"/>
     </record>
 
     <!-- Purchase of Services 0% -> Purchase of Services in EU 0% IC -->
     <record id="afptt_eu_ic_16" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="afpt_eu_ic"/>
         <field name="tax_src_id" ref="l10n_ee_vat_in_0_s"/>
-        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_22"/>
+        <field name="tax_dest_id" ref="l10n_ee_vat_in_0_eu_s_24"/>
     </record>
 
     <!-- IMPORT/EXPORT -->

--- a/addons/l10n_ee/data/account_tax_report_data.xml
+++ b/addons/l10n_ee/data/account_tax_report_data.xml
@@ -13,9 +13,12 @@
             </record>
         </field>
         <field name="line_ids">
+            <!-- Valid until 2025-06-31 -->
             <record id="tax_report_line_1" model="account.report.line">
                 <field name="name">1 - Acts and transactions subject to tax at a rate of 22%</field>
                 <field name="code">l10n_ee_vat_1</field>
+                <field name="sequence" eval="1"/>
+                <field name="hide_if_zero" eval="True"/>
                 <field name="expression_ids">
                     <record id="tax_report_line_1_tag" model="account.report.expression">
                         <field name="label">balance</field>
@@ -24,14 +27,43 @@
                     </record>
                 </field>
             </record>
+            <!-- Valid from 2025-07-01 -->
+            <record id="tax_report_line_1_24" model="account.report.line">
+                <field name="name">1 - Acts and transactions subject to tax at a rate of 24%</field>
+                <field name="code">l10n_ee_vat_1_24</field>
+                <field name="sequence" eval="2"/>
+                <field name="hide_if_zero" eval="True"/>
+                <field name="expression_ids">
+                    <record id="tax_report_line_1_24_tag" model="account.report.expression">
+                        <field name="label">balance</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">1_24</field>
+                    </record>
+                </field>
+            </record>
             <record id="tax_report_line_1_1" model="account.report.line">
                 <field name="name">1¹ - Acts and transactions subject to tax at a rate of 20%</field>
                 <field name="code">l10n_ee_vat_1_1</field>
+                <field name="sequence" eval="3"/>
                 <field name="expression_ids">
                     <record id="tax_report_line_1_1_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
                         <field name="formula">1_1</field>
+                    </record>
+                </field>
+            </record>
+            <!-- Valid from 2025-07-01 -->
+            <record id="tax_report_line_1_2" model="account.report.line">
+                <field name="name">1² - Acts and transactions subject to tax at a rate of 22%</field>
+                <field name="code">l10n_ee_vat_1_2</field>
+                <field name="sequence" eval="4"/>
+                <field name="hide_if_zero" eval="True"/>
+                <field name="expression_ids">
+                    <record id="tax_report_line_1_2_tag" model="account.report.expression">
+                        <field name="label">balance</field>
+                        <field name="engine">tax_tags</field>
+                        <field name="formula">1_2</field>
                     </record>
                 </field>
             </record>
@@ -168,7 +200,7 @@
                     <record id="tax_report_line_4_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">aggregation</field>
-                        <field name="formula">l10n_ee_vat_1.balance * 0.22 + l10n_ee_vat_1_1.balance * 0.2 + l10n_ee_vat_2.balance * 0.09 + l10n_ee_vat_2_1.balance * 0.05 + l10n_ee_vat_2_2.balance * 0.13</field>
+                        <field name="formula">l10n_ee_vat_1_24.balance * 0.24 + l10n_ee_vat_1.balance * 0.22 + l10n_ee_vat_1_2.balance * 0.22 + l10n_ee_vat_1_1.balance * 0.2 + l10n_ee_vat_2.balance * 0.09 + l10n_ee_vat_2_1.balance * 0.05 + l10n_ee_vat_2_2.balance * 0.13</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_ee/data/account_tax_template_data.xml
+++ b/addons/l10n_ee/data/account_tax_template_data.xml
@@ -48,7 +48,7 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'plus_report_expression_ids': [ref('tax_report_line_1_tag')],
+                'plus_report_expression_ids': [ref('tax_report_line_1_2_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -58,7 +58,7 @@
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'minus_report_expression_ids': [ref('tax_report_line_1_tag')],
+                'minus_report_expression_ids': [ref('tax_report_line_1_2_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -80,7 +80,7 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'plus_report_expression_ids': [ref('tax_report_line_1_tag')],
+                'plus_report_expression_ids': [ref('tax_report_line_1_24_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -90,7 +90,7 @@
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'minus_report_expression_ids': [ref('tax_report_line_1_tag')],
+                'minus_report_expression_ids': [ref('tax_report_line_1_24_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -145,7 +145,7 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'plus_report_expression_ids': [ref('tax_report_line_1_tag')],
+                'plus_report_expression_ids': [ref('tax_report_line_1_2_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -155,7 +155,7 @@
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'minus_report_expression_ids': [ref('tax_report_line_1_tag')],
+                'minus_report_expression_ids': [ref('tax_report_line_1_2_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -177,7 +177,7 @@
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'plus_report_expression_ids': [ref('tax_report_line_1_tag')],
+                'plus_report_expression_ids': [ref('tax_report_line_1_24_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -187,7 +187,7 @@
         <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, {
                 'repartition_type': 'base',
-                'minus_report_expression_ids': [ref('tax_report_line_1_tag')],
+                'minus_report_expression_ids': [ref('tax_report_line_1_24_tag')],
             }),
             (0,0, {
                 'repartition_type': 'tax',
@@ -707,6 +707,52 @@
         ]"/>
     </record>
 
+    <!-- Sales 0% under KMS §41¹ 24% Special-->
+    <record id="l10n_ee_vat_out_0_kms_41_3" model="account.tax.template">
+        <field name="sequence">162</field>
+        <field name="name">0% KMS §41¹</field>
+        <field name="type_tax_use">sale</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">24% Special</field>
+        <field name="active" eval="False"/>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
+        <field name="l10n_ee_kmd_inf_code">2</field>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_expression_ids': [ref('tax_report_line_9_tag')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [ref('tax_report_line_9_tag')],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+    </record>
+
     <!-- ========== PURCHASE TAXES ========== -->
 
     <!-- Purchase of Goods 20% -->
@@ -1130,7 +1176,7 @@
             (0,0, {
                 'repartition_type': 'base',
                 'plus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_2_tag'),
                     ref('tax_report_line_6_1_tag'),
                 ],
             }),
@@ -1150,7 +1196,7 @@
             (0,0, {
                 'repartition_type': 'base',
                 'minus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_2_tag'),
                     ref('tax_report_line_6_1_tag'),
                 ],
             }),
@@ -1182,7 +1228,7 @@
             (0,0, {
                 'repartition_type': 'base',
                 'plus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_24_tag'),
                     ref('tax_report_line_6_1_tag'),
                 ],
             }),
@@ -1202,7 +1248,7 @@
             (0,0, {
                 'repartition_type': 'base',
                 'minus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_24_tag'),
                     ref('tax_report_line_6_1_tag'),
                 ],
             }),
@@ -1287,7 +1333,7 @@
             (0,0, {
                 'repartition_type': 'base',
                 'plus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_2_tag'),
                     ref('tax_report_line_6_tag'),
                 ],
             }),
@@ -1307,7 +1353,7 @@
             (0,0, {
                 'repartition_type': 'base',
                 'minus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_2_tag'),
                     ref('tax_report_line_6_tag'),
                 ],
             }),
@@ -1339,7 +1385,7 @@
             (0,0, {
                 'repartition_type': 'base',
                 'plus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_24_tag'),
                     ref('tax_report_line_6_tag'),
                 ],
             }),
@@ -1359,7 +1405,7 @@
             (0,0, {
                 'repartition_type': 'base',
                 'minus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_24_tag'),
                     ref('tax_report_line_6_tag'),
                 ],
             }),
@@ -2105,7 +2151,7 @@
             (0,0, {
                 'repartition_type': 'base',
                 'plus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_2_tag'),
                     ref('tax_report_line_7_1_tag'),
                 ],
             }),
@@ -2125,7 +2171,61 @@
             (0,0, {
                 'repartition_type': 'base',
                 'minus_report_expression_ids': [
-                    ref('tax_report_line_1_tag'),
+                    ref('tax_report_line_1_2_tag'),
+                    ref('tax_report_line_7_1_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'minus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+    </record>
+
+    <!-- Purchase 0% under KMS §41¹ -->
+    <record id="l10n_ee_vat_in_0_kms_41_3" model="account.tax.template">
+        <field name="sequence">371</field>
+        <field name="name">0% KMS §41¹</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="amount">24</field>
+        <field name="amount_type">percent</field>
+        <field name="description">0%</field>
+        <field name="active" eval="False"/>
+        <field name="tax_group_id" ref="tax_group_vat_24"/>
+        <field name="l10n_ee_kmd_inf_code">12</field>
+        <field name="chart_template_id" ref="l10nee_chart_template"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_expression_ids': [
+                    ref('tax_report_line_1_24_tag'),
+                    ref('tax_report_line_7_1_tag'),
+                ],
+            }),
+            (0,0, {
+                'factor_percent': 100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201201'),
+                'plus_report_expression_ids': [ref('tax_report_line_5_tag')],
+            }),
+            (0,0, {
+                'factor_percent': -100,
+                'repartition_type': 'tax',
+                'account_id': ref('l10n_ee_201204'),
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [
+                    ref('tax_report_line_1_24_tag'),
                     ref('tax_report_line_7_1_tag'),
                 ],
             }),

--- a/addons/l10n_ee/i18n/et.po
+++ b/addons/l10n_ee/i18n/et.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.5alpha1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-27 09:46+0000\n"
-"PO-Revision-Date: 2023-03-27 11:54+0200\n"
+"POT-Creation-Date: 2025-07-29 12:26+0000\n"
+"PO-Revision-Date: 2025-07-29 12:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: et\n"
@@ -190,6 +190,11 @@ msgid "1 - Acts and transactions subject to tax at a rate of 22%"
 msgstr "1 - 22% määraga maksustatavad toimingud ja tehingud"
 
 #. module: l10n_ee
+#: model:account.report.line,name:l10n_ee.tax_report_line_1_24
+msgid "1 - Acts and transactions subject to tax at a rate of 24%"
+msgstr "1 - 24% määraga maksustatavad toimingud ja tehingud"
+
+#. module: l10n_ee
 #: model:account.report.line,name:l10n_ee.tax_report_line_10
 msgid "10 - Adjustments (+)"
 msgstr "10 - Täpsustused (+)"
@@ -208,6 +213,11 @@ msgstr "12 - Tasumisele kuuluv käibemaks"
 #: model:account.report.line,name:l10n_ee.tax_report_line_13
 msgid "13 - Overpaid value added tax"
 msgstr "13 - Enammakstud käibemaks"
+
+#. module: l10n_ee
+#: model:account.report.line,name:l10n_ee.tax_report_line_1_2
+msgid "1² - Acts and transactions subject to tax at a rate of 22%"
+msgstr "1² - 22% määraga maksustatavad toimingud ja tehingud"
 
 #. module: l10n_ee
 #: model:account.report.line,name:l10n_ee.tax_report_line_1_1

--- a/addons/l10n_ee/i18n/l10n_ee.pot
+++ b/addons/l10n_ee/i18n/l10n_ee.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-27 09:46+0000\n"
-"PO-Revision-Date: 2023-03-27 09:46+0000\n"
+"POT-Creation-Date: 2025-07-29 11:38+0000\n"
+"PO-Revision-Date: 2025-07-29 11:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -188,6 +188,11 @@ msgid "1 - Acts and transactions subject to tax at a rate of 22%"
 msgstr ""
 
 #. module: l10n_ee
+#: model:account.report.line,name:l10n_ee.tax_report_line_1_24
+msgid "1 - Acts and transactions subject to tax at a rate of 24%"
+msgstr ""
+
+#. module: l10n_ee
 #: model:account.report.line,name:l10n_ee.tax_report_line_10
 msgid "10 - Adjustments (+)"
 msgstr ""
@@ -205,6 +210,11 @@ msgstr ""
 #. module: l10n_ee
 #: model:account.report.line,name:l10n_ee.tax_report_line_13
 msgid "13 - Overpaid value added tax"
+msgstr ""
+
+#. module: l10n_ee
+#: model:account.report.line,name:l10n_ee.tax_report_line_1_2
+msgid "1² - Acts and transactions subject to tax at a rate of 22%"
 msgstr ""
 
 #. module: l10n_ee

--- a/addons/l10n_ee/migrations/1.3/post-migrate_update_data.py
+++ b/addons/l10n_ee/migrations/1.3/post-migrate_update_data.py
@@ -1,0 +1,5 @@
+from odoo.addons.account.models.chart_template import update_taxes_from_templates
+
+
+def migrate(cr, version):
+    update_taxes_from_templates(cr, 'l10n_ee.l10nee_chart_template')


### PR DESCRIPTION
- Changed tax grids for the 22% and 24% VAT rate effective from 1 July 2025.
- Updated account.tax.report to include a new line for the 24% VAT rate (Line 1_24) to ensure backward compatibility with reports generated before 1 July 2025.
- Updated account.tax.report to include a new line for the 22% VAT rate (Line 1_2).
- Ensured automatic change of the tax grid during module upgrade.
- Adjusted related tax report data and views reflect the updated VAT rate.
- Maintained compatibility with existing data and reports by preserving the 22% VAT rate for historical records.

For technical info, please see:
https://www.emta.ee/en/business-client/e-services-training-courses/how-use-e-services/technical-information-services#value-added-tax-return

Backport of this PR: https://github.com/odoo/odoo/pull/207751

Enterprise PR: https://github.com/odoo/enterprise/pull/91364

Task: [4951230](https://www.odoo.com/odoo/project/967/tasks/4951230)