### PR TITLE
[FIX] l10n_es_pos: fix blank screen when processing POS orders

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_es_pos/static/src/overrides/models/pos_store.js
@@ -5,7 +5,7 @@ patch(PosStore.prototype, {
     getReceiptHeaderData(order) {
         const result = super.getReceiptHeaderData(...arguments);
         result.is_spanish = this.config.is_spanish;
-        result.simplified_partner_id = this.config.simplified_partner_id.id;
+        result.simplified_partner_id = this.config.simplified_partner_id?.id;
         if (order) {
             result.is_l10n_es_simplified_invoice = order.is_l10n_es_simplified_invoice;
             result.partner = order.get_partner();

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -90,3 +90,16 @@ registry.category("web_tour.tours").add("test_simplified_invoice_not_override_se
             ReceiptScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_simplified_partner_inactive_case", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Desk Pad", "1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -153,3 +153,8 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_simplified_invoice_not_override_set_pricelist', login="pos_user")
         order = self.env['pos.order'].search([('partner_id', '=', self.main_pos_config.simplified_partner_id.id)])
         self.assertNotEqual(order.pricelist_id, self.main_pos_config.simplified_partner_id.property_product_pricelist)
+
+    def test_simplified_partner_inactive_case(self):
+        self.main_pos_config.simplified_partner_id.active = False
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id,
+                        'test_simplified_partner_inactive_case', login="pos_user")


### PR DESCRIPTION
Steps to Reproduce:
--------------------
- Install the l10n_es_pos module in version 18.0.
- Navigate to Contacts.
- Search for Simplified Invoice Partner (ES) and archive the record.
- Open the Point of Sale (POS) and proceed to place an order.
- Select a product.
- Proceed to the payment screen.
- Choose a payment method and click Validate.

Issue:
---------------------
In version 18.0, when the user proceeds with placing an order, a blank screen appears without any error message,
leading to confusion for the customer.

This issue occurs because during the [pos_load_data](https://github.com/odoo/odoo/blob/cd4c1d599ea9403ce3791e239ad765d946446a47/addons/point_of_sale/models/pos_session.py#L181) process,  while preparing the pos.config, the `simplified_partner_id` is fetched. However, the corresponding `res.partner` record is not included during the preparation of the `res.partner` model data, as the record is archived. As a result, when the system attempts to link the related partner record to `pos.config.simplified_partner_id` on the [JavaScript side](https://github.com/odoo/odoo/blob/cd4c1d599ea9403ce3791e239ad765d946446a47/addons/point_of_sale/static/src/app/models/related_models.js#L1063-L1131 ), [ref](https://github.com/odoo/odoo/blob/cd4c1d599ea9403ce3791e239ad765d946446a47/addons/point_of_sale/static/src/app/models/related_models.js#L1114)
 the simplified_partner_id remains undefined. This eventually leads to an error when attempting to access [simplified_partner_id.id](https://github.com/odoo/odoo/blob/cd4c1d599ea9403ce3791e239ad765d946446a47/addons/l10n_es_pos/static/src/overrides/models/pos_store.js#L8)  and will lead to the blanck screen

video ref: https://drive.google.com/file/d/1oG6bBIWxhlvnJAgj22hEVtlW0hr8_1eU/view?usp=sharing
```text
Other Approaches:
- We can override the _load_pos_data method and append the simplified partner to ensure it's included during the data loading process.
- Instead of showing a blank screen, we can display an alert message informing the customer to unarchive the simplified partner and proceed with the flow.
`I’m open to any suggestions or alternative approaches that would be the best way to handle this.`
```

OPW: 4953896

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
