### PR TITLE
[FIX] mrp: Skip the state change for Work Orders

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1774,7 +1774,7 @@ class MrpProduction(models.Model):
             for workorder in order.workorder_ids:
                 if workorder.state not in ('done', 'cancel'):
                     workorder.duration_expected = workorder._get_duration_expected()
-                if workorder.duration == 0.0:
+                if workorder.duration == 0.0 and workorder.state != 'cancel':
                     workorder.duration = workorder.duration_expected
                     workorder.duration_unit = round(workorder.duration / max(workorder.qty_produced, 1), 2)
             order._cal_price(moves_to_do_by_order[order.id])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

-The first step is to produce all but one unit from an MRP production order to enable a split. As the example images show, the first line of the "Work Orders" has both quantities completed, while the second line only has one of the two quantities completed.

<img width="1522" height="681" alt="image" src="https://github.com/user-attachments/assets/fb44e688-b851-45bb-9d86-0f5b03f9141d" />

<img width="1524" height="744" alt="image" src="https://github.com/user-attachments/assets/85ce3838-3b53-48ef-ad2f-c99308b5fb2d" />


-After performing the split, the "-002" segment should resemble what's depicted in the screenshots, with one line being canceled and the other remaining in the "Ready" status.

<img width="1529" height="805" alt="image" src="https://github.com/user-attachments/assets/a66c3414-a73b-4810-9fca-ac18c235704b" />

<img width="1532" height="856" alt="image" src="https://github.com/user-attachments/assets/46480229-0380-47f3-8552-c92f7c4282a6" />


-Now for the actual issue: once you produce everything in the second split, the line that was canceled goes back to "in process," which is incorrect. It should remain canceled because its full quantity was already completed in the first split. I've included screenshots showing how the "Work Order" lines appear after everything is produced.

<img width="1525" height="787" alt="image" src="https://github.com/user-attachments/assets/596cd97c-3f9a-4b1d-b51d-43b76fd083ce" />



My change prevents canceled or completed work orders from reverting to the “in progress” status. This is because when a change is made to the duration of a work order, the status is automatically updated. Therefore, I have added a status check to the condition to prevent this unwanted status change.


The issue occurs because a change in duration triggers a call to the "inverse" method of the "duration" field. This "inverse" method is responsible for updating the state of the "Work Orders," leading to the observed problem.

I've included both a screenshot of the code that changes the status and a link for easier access and review.

<img width="864" height="448" alt="image" src="https://github.com/user-attachments/assets/daafd66d-fe23-4d7c-a609-677c8fc29487" />

https://github.com/odoo/odoo/blob/18.0/addons/mrp/models/mrp_workorder.py#L349

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
