### PR TITLE
[IMP] hw_posbox_homepage: update no certificate warning message

### DIFF
--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -96,10 +96,11 @@ export class Homepage extends Component {
             </div>
             <div t-if="!this.store.advanced and !state.data.is_certificate_ok" class="alert alert-warning" role="alert">
                 <p class="m-0 fw-bold">
-                    No subscription linked to your IoT Box.
+                    This IoT Box doesn't have a valid certificate.
                 </p>
                 <small>
-                    Please contact your account manager to take advantage of your IoT Box's full potential.
+                    The IoT Box should get a certificate automatically when paired with a database. If it doesn't, 
+                    try to restart it.
                 </small>
             </div>
             <div t-if="this.store.advanced" t-att-class="'alert ' + (state.data.is_certificate_ok === true ? 'alert-info' : 'alert-warning')" role="alert">


### PR DESCRIPTION
When the IoT Box doesn't have a valid ssl certificate, we used to display a warning telling that there is no valid subscription. As users don't need a subscription anymore to get a valid certificate, we now only tell that the certificate is invalid.

Task: 4978644
