### PR TITLE
[FIX] hr_fleet: adapt employee driver for multi company

### DIFF
--- a/addons/hr_fleet/tests/test_hr_fleet_driver.py
+++ b/addons/hr_fleet/tests/test_hr_fleet_driver.py
@@ -63,3 +63,23 @@ class TestHrFleetDriver(common.TransactionCase):
         })
         self.assertEqual(self.car2.future_driver_id.id, False)
         self.assertEqual(self.car2.driver_id.id, False)
+
+    def test_driver_employee_multi_company(self):
+        other_company = self.env['res.company'].create({
+            'name': 'Other Company'
+        })
+        test_employee2 = self.env['hr.employee'].with_company(other_company).create({
+            'name': 'Test Employee 2',
+            'work_contact_id': self.test_employee.work_contact_id.id
+        })
+        car = self.env['fleet.vehicle'].with_company(other_company).create({
+            'model_id': self.model.id,
+            'driver_id': test_employee2.work_contact_id.id
+        })
+        self.assertEqual(car.driver_employee_id, test_employee2)
+
+        assignation_log = self.env['fleet.vehicle.assignation.log'].search([
+            ('vehicle_id', '=', car.id)
+        ])
+        self.assertEqual(len(assignation_log), 1)
+        self.assertEqual(assignation_log.driver_employee_id, test_employee2)


### PR DESCRIPTION
There is a bug when multiple employees from different companies are linked to the same contact. Steps to reproduce:
- Create two employees, in two different companies that relate to the same contact (partner)
- In one of the two companies, create a vehicle and assign it to the partner created
- The field driver_employee_id in the vehicle and assignation log will be assigned to one of the two employees, without taking care of the company of the car

To fix this, the domain should also contain the company of the car, and must match the company of the employee.

task-4978443

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
