### PR TITLE
[CLA] Sign Odoo Individual Contributor License Agreement

### DIFF
--- a/doc/cla/individual/shawkialaddin.md
+++ b/doc/cla/individual/shawkialaddin.md
@@ -1,0 +1,11 @@
+Egypt, 2025
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Shawki Aladdin bolshuq@gmail.com https://github.com/shawkialaddin


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Sign the Odoo Individual Contributor License Agreement (CLA) for GitHub user shawkialaddin.
Current behavior before PR:
CLA not signed.
Desired behavior after PR is merged:
CLA signed and recorded in doc/cla/individual/ under shawkialaddin.md.
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
