### PR TITLE
[IMP] html_builder, website: enhance sidebar UI

### DIFF
--- a/addons/html_builder/static/src/builder.scss
+++ b/addons/html_builder/static/src/builder.scss
@@ -32,9 +32,9 @@
         --border-color: #{$o-we-color-accent};
         --bg-color: #{rgba($o-we-color-accent, .15)};
 
-        width: CALC(#{percentage(1/3)} - var(--gap));
+        width: percentage(1/3);
         transition: all .5s, transform .25s;
-        border: $o-we-border-width solid var(--border-color);
+        border-bottom: #{$o-we-sidebar-tabs-active-border-width} solid var(--border-color);
         background-color: var(--bg-color);
         transform: translateX(var(--x));
 
@@ -63,30 +63,48 @@
         }
     }
 
-    .o-hb-btn {
-        --btn-bg: transparent;
-        --btn-color: #{$o-we-fg-light};
-        --btn-hover-bg: transparent;
-        --btn-hover-color: #{$o-we-fg-lighter};
-        --btn-active-bg: transparent;
-        --btn-active-color: #{$o-we-fg-lighter};
+    .nav-underline {
+        --nav-underline-gap: 0;
+        --nav-link-color: #{$o-we-fg-light};
+        --nav-link-hover-color: #{$o-we-fg-lighter};
+        --nav-underline-link-active-color: #{$o-we-fg-light};
 
-        &[data-name="blocks"] {
+        .nav-item {
+            width:  percentage(1/3);
+        }
+
+        .nav-link {
+            transition: none;
+        }
+
+        .nav-link[data-name="blocks"]{
             --o-snippets-tabs-accent-color: #{$o-we-color-success};
+            --o-snippets-tabs-border-color-hover: #{rgba($o-we-color-success, .5)};
         }
-        &[data-name="customize"] {
+
+        .nav-link[data-name="customize"] {
             --o-snippets-tabs-accent-color: #{$o-we-color-accent};
+            --o-snippets-tabs-border-color-hover: #{rgba($o-we-color-accent, .5)};
         }
-        &[data-name="theme"] {
+
+        .nav-link[data-name="theme"] {
             --o-snippets-tabs-accent-color: #{$o-we-color-global};
+            --o-snippets-tabs-border-color-hover: #{rgba($o-we-color-global, .5)};
         }
 
-        & i {
+        .nav-link.active, .nav-link:hover, & .show > .nav-link {
+            border-bottom-color: var(--o-snippets-tabs-border-color-hover);
+        }
+
+        .nav-link:focus-visible {
+            box-shadow: none;
+            outline: 1px solid var(--o-snippets-tabs-accent-color);
+            outline-offset: -1px;
+            border-bottom-color: transparent;
+        }
+
+        & .fa {
             color: var(--o-snippets-tabs-accent-color);
-        }
-
-        &:focus-visible, &:active {
-            box-shadow: 0 0 0 #{$o-we-border-width} var(--o-snippets-tabs-accent-color);
         }
     }
 }

--- a/addons/html_builder/static/src/builder.variables.scss
+++ b/addons/html_builder/static/src/builder.variables.scss
@@ -140,6 +140,7 @@ $o-we-sidebar-tabs-color: $o-we-sidebar-color !default;
 $o-we-sidebar-tabs-disabled-color: $o-we-fg-darker !default;
 $o-we-sidebar-tabs-active-border-width: 2px !default;
 $o-we-sidebar-tabs-active-border-color: $o-we-color-accent !default;
+$o-we-sidebar-tabs-active-background-color: rgba($o-we-color-accent, .15) !default;
 $o-we-sidebar-tabs-active-color: $o-we-fg-lighter !default;
 
 $o-we-sidebar-blocks-content-bg: $o-we-bg-dark !default;

--- a/addons/html_builder/static/src/builder.xml
+++ b/addons/html_builder/static/src/builder.xml
@@ -14,23 +14,31 @@
                 <button type="button" t-on-click="save" class="o-hb-btn btn btn-success px-3" data-action="save" accesskey="s">Save</button>
             </div>
         </div>
-        <div class="o-snippets-tabs position-relative grid px-2 my-2" style="--columns: 3; --gap: 0.25rem">
+        <div class="o-snippets-tabs position-relative">
             <div
-                class="o-snippets-tabs-highlighter position-absolute start-50 h-100 rounded pe-none"
+                class="o-snippets-tabs-highlighter position-absolute start-50 h-100 pe-none"
                 t-att-class="{
                     'o-highlight-blocks': state.activeTab === 'blocks',
                     'o-highlight-theme': state.activeTab === 'theme',
                 }"
             />
-            <button data-name="blocks" data-hotkey="1" class="o-hb-btn position-relative btn" t-att-class="{'active cursor-default': state.activeTab === 'blocks'}" t-on-click="() => this.onTabClick('blocks')" t-att-disabled="displayOnlyCustomizeTab">
-                <i class="oi oi-plus me-1" role="img"/>Add
-            </button>
-            <button data-name="customize" class="o-hb-btn position-relative btn" t-att-class="{'active cursor-default': state.activeTab === 'customize'}" t-on-click="() => this.onTabClick('customize')">
-                <i class="oi oi-settings-adjust me-1" role="img"/>Edit
-            </button>
-            <button data-name="theme" data-hotkey="2" t-if="ThemeTab" class="o-hb-btn position-relative btn" t-att-class="{'active cursor-default': state.activeTab === 'theme'}" t-on-click="() => this.onTabClick('theme')" t-att-disabled="displayOnlyCustomizeTab">
-                <i class="fa fa-cog me-1" role="img"/>Theme
-            </button>
+            <ul class="nav nav-underline" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button id="blocks-tab" data-name="blocks" data-hotkey="1" class="o-hb-tab nav-link position-relative w-100" t-att-class="{'active cursor-default': state.activeTab === 'blocks'}" t-on-click="() => this.onTabClick('blocks')" t-att-disabled="displayOnlyCustomizeTab" role="tab" t-att-aria-selected="state.activeTab === 'blocks' ? 'true' : 'false'">
+                        <i class="fa fa-th-large me-2" role="none"/>Blocks
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button id="customize-tab" data-name="customize" class="o-hb-tab nav-link position-relative w-100" t-att-class="{'active cursor-default': state.activeTab === 'customize'}" t-on-click="() => this.onTabClick('customize')" role="tab" t-att-aria-selected="state.activeTab === 'customize' ? 'true' : 'false'">
+                        <i class="fa fa-paint-brush me-2" role="none"/>Style
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button id="theme-tab" data-name="theme" data-hotkey="2" t-if="ThemeTab" class="o-hb-tab nav-link position-relative w-100" t-att-class="{'active cursor-default': state.activeTab === 'theme'}" t-on-click="() => this.onTabClick('theme')" t-att-disabled="displayOnlyCustomizeTab" role="tab" t-att-aria-selected="state.activeTab === 'theme' ? 'true' : 'false'">
+                        <i class="fa fa-cog me-2" role="none"/>Theme
+                    </button>
+                </li>
+            </ul>
         </div>
         <div class="o-tab-content overflow-y-auto overflow-x-hidden flex-grow-1">
             <t t-if="state.activeTab === 'blocks'">

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.scss
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.scss
@@ -4,6 +4,11 @@
     font-size: $o-we-sidebar-font-size * 1.4;
 }
 
+.o-hb-select-pager-tab-container {
+    border-top: $o-we-border-width solid $o-we-bg-lighter;
+    border-bottom: $o-we-border-width solid $o-we-bg-lighter;
+}
+
 .o-hb-select-pager-tab {
     display: inline-flex;
     flex: 1 1 auto;
@@ -11,16 +16,24 @@
     min-width: 0;
     border: none;
     background-color: transparent;
-    color: inherit;
+    color: $o-we-fg-light;
     font-weight: normal;
 
     > span {
         $-r: $o-we-sidebar-tabs-size-ratio;
+        border-bottom: $o-we-sidebar-tabs-active-border-width solid transparent;
         padding: (0.6em * $-r) (0.4em * $-r) (0.5em * $-r);
     }
+
+    &:hover > span {
+        color: $o-we-fg-lighter;
+        border-bottom-color: #{rgba($o-we-sidebar-tabs-active-border-color, .5)};
+    }
+
     &.active > span {
+        background-color: $o-we-sidebar-tabs-active-background-color;
         color: $o-we-sidebar-content-field-colorpicker-dropdown-active-color;
-        box-shadow: inset 0 ($o-we-sidebar-tabs-active-border-width * -1) 0 $o-we-sidebar-tabs-active-border-color;
+        border-bottom-color: $o-we-sidebar-tabs-active-border-color;
     }
 }
 

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.xml
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.shapeSelector">
     <header class="o_pager_nav d-flex flex-column flex-wrap flex-shrink-0 mh-100">
-        <div class="d-flex align-items-center mt-2 p-2">
+        <div class="d-flex align-items-center p-2">
             <button class="o_pager_nav_angle btn btn-secondary bg-transparent border-0"
                     t-on-click="this.props.onClose">
                     <i class="fa fa-angle-left" aria-hidden="true"/>
@@ -11,9 +11,9 @@
                     <span class="ps-2 text-white" t-out="props.selectorTitle"/>
             </button>
         </div>
-        <div class="d-flex" t-ref="tabs">
+        <div class="o-hb-select-pager-tab-container d-flex" t-ref="tabs">
             <t t-foreach="Object.entries(this.props.shapeGroups)" t-as="group" t-key="group_index">
-                <button type="button" class="o-hb-select-pager-tab btn p-0 text-uppercase" t-att-class="{ 'active': state.activeGroup === group[0] }" t-on-click="() => this.scrollToShapes(group[0])" t-att-data-group-id="group[0]">
+                <button type="button" class="o-hb-select-pager-tab p-0 text-uppercase" t-att-class="{ 'active': state.activeGroup === group[0] }" t-on-click="() => this.scrollToShapes(group[0])" t-att-data-group-id="group[0]">
                     <span class="w-100" t-out="group[1].label"/>
                 </button>
             </t>

--- a/addons/html_builder/static/src/sidebar/block_tab.scss
+++ b/addons/html_builder/static/src/sidebar/block_tab.scss
@@ -21,10 +21,10 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
 
         .o_snippet_thumbnail_img {
             width: 100%;
-            padding-top: 75%;
+            padding-top: 65%;
             background-repeat: no-repeat;
-            background-size: contain;
-            background-position: top center;
+            background-size: cover;
+            background-position: center;
             overflow: hidden;
         }
     }
@@ -41,7 +41,7 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
 
 .o_block_tab {
     background-color: $o-we-sidebar-blocks-content-bg;
-    padding-left: map-get($spacers, 2) ;
+    padding: map-get($spacers, 2);
     height: 100%; // give enough space for tips pointing at snippets after a snippet search
     z-index: 1;
 
@@ -54,7 +54,7 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
         position: sticky;
         top: 0;
         background-color: $o-we-sidebar-blocks-content-bg;
-        padding-top: $o-we-sidebar-blocks-content-spacing * .5;
+        padding-top: $o-we-sidebar-blocks-content-spacing;
         z-index: 1;
     }
 
@@ -64,6 +64,17 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
         margin-left: -$o-we-sidebar-blocks-content-snippet-spacing;
         z-index: 0;
         position: relative;
+
+        &.o_snippets_container_body_row_cols_2 {
+            .o_snippet {
+                width: 50%;
+            }
+            .o_snippet_thumbnail_img {
+                padding-top: 45%;
+                background-size: contain;
+                background-position: center top;
+            }
+        }
 
         .o_snippet {
             flex: 0 0 auto;

--- a/addons/html_builder/static/src/sidebar/block_tab.xml
+++ b/addons/html_builder/static/src/sidebar/block_tab.xml
@@ -6,10 +6,11 @@
     <t t-set="disabledBlockTooltip">This block cannot be dropped anywhere on this page.</t>
     <div class="o_block_tab"
          t-att-class="{'o_we_ongoing_insertion': this.state.ongoingInsertion}"
-         t-ref="block-tab">
+         t-ref="block-tab"
+         role="tabpanel"
+         aria-labelledby="blocks-tab">
         <div class="o_snippets_container" id="snippet_groups">
-            <div class="o_snippets_container_header"><span>Categories</span></div>
-            <div class="o_snippets_container_body">
+            <div class="o_snippets_container_body o_snippets_container_body_row_cols_2">
                 <t t-foreach="this.snippetModel.snippetGroups" t-as="snippet" t-key="snippet.id">
                     <Snippet snippet="snippet"
                              snippetModel="this.snippetModel"

--- a/addons/html_builder/static/src/sidebar/customize_tab.xml
+++ b/addons/html_builder/static/src/sidebar/customize_tab.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.CustomizeTab">
-    <div class="o_customize_tab h-100">
+    <div class="o_customize_tab h-100" role="tabpanel" aria-labelledby="customize-tab">
         <t t-set="currentOptionsContainers" t-value="this.getCurrentOptionsContainers()"/>
         <t t-if="!currentOptionsContainers.length || !this.state.hasContent">
             <div class="text-center pt-5">

--- a/addons/html_builder/static/tests/block_tab/snippet_content.test.js
+++ b/addons/html_builder/static/tests/block_tab/snippet_content.test.js
@@ -193,5 +193,5 @@ test("click just after drop is redispatched in next operation", async () => {
     await animationFrame();
     expect.verifySteps(["onClick", "next", "updateContainers"]); // On click redispatched
     await animationFrame();
-    expect(".o-snippets-tabs .o-hb-btn.active").toHaveText("Edit");
+    expect(".o-snippets-tabs .o-hb-tab.active").toHaveText("Style");
 });

--- a/addons/website/static/src/builder/plugins/theme/theme_tab.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.ThemeTab">
-    <div class="o_theme_tab h-100">
+    <div class="o_theme_tab h-100" role="tabpanel" aria-labelledby="theme-tab">
         <div t-ref="content" class="d-flex flex-column h-100">
             <t t-foreach="optionsContainers" t-as="optionsContainer" t-key="optionsContainer.id">
                 <!-- TODO Define a more basic kind of options container -->

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
@@ -6,6 +6,7 @@
     &.o_builder_sidebar_open {
         width: $o-we-sidebar-width;
         transition-delay: 200ms;
+        box-sizing: content-box;
 
         .o_website_fullscreen & {
             width: 0;

--- a/addons/website/static/src/img/snippets_thumbs/s_blog_posts.svg
+++ b/addons/website/static/src/img/snippets_thumbs/s_blog_posts.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="60" viewBox="0 0 82 60">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="60" viewBox="0 0 140 60">
   <defs>
-    <rect id="path-1" width="82" height="55" x="0" y="0"/>
+    <rect id="path-1" width="140" height="60" x="0" y="0"/>
     <linearGradient id="linearGradient-3" x1="72.875%" x2="40.332%" y1="46.753%" y2="35.353%">
       <stop offset="0%" stop-color="#008374"/>
       <stop offset="100%" stop-color="#006A59"/>
@@ -15,7 +15,7 @@
       <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
       <feColorMatrix in="shadowOffsetOuter1" values="0 0 0 0 1   0 0 0 0 1   0 0 0 0 1  0 0 0 0.4 0"/>
     </filter>
-    <path id="path-7" d="M24 31v1H14v-1h10zm9-3v1H14v-1h19z"/>
+    <path id="path-7" d="M24 31v1H14v-1h10zm9-3v1H14v-1h19z" transform="translate(20px, 0)"/>
     <filter id="filter-8" width="105.3%" height="150%" x="-2.6%" y="-12.5%" filterUnits="objectBoundingBox">
       <feOffset dy="1" in="SourceAlpha" result="shadowOffsetOuter1"/>
       <feComposite in="shadowOffsetOuter1" in2="SourceAlpha" operator="out" result="shadowOffsetOuter1"/>
@@ -38,23 +38,23 @@
               <use xlink:href="#path-1"/>
             </mask>
             <use fill="#79D1F2" class="mask" xlink:href="#path-1"/>
-            <circle cx="65.5" cy="11.5" r="7.5" fill="#F3EC60" class="oval" mask="url(#mask-2)"/>
-            <ellipse cx="63" cy="55.5" fill="url(#linearGradient-3)" class="oval" mask="url(#mask-2)" rx="28" ry="16.5"/>
-            <ellipse cx="6.5" cy="52.5" fill="url(#linearGradient-4)" class="oval" mask="url(#mask-2)" rx="42.5" ry="22.5"/>
+            <circle xmlns="http://www.w3.org/2000/svg" cx="90.5" cy="11.5" r="7.5" fill="#F3EC60" class="oval" mask="url(#mask-2)" style="transform: scale(1.3);"/>
+            <ellipse xmlns="http://www.w3.org/2000/svg" cx="75" cy="38.5" fill="url(#linearGradient-3)" class="oval" mask="url(#mask-2)" rx="28" ry="16.5" style="transform: scale(1.5);"/>
+            <ellipse cx="12.5" cy="42.5" fill="url(#linearGradient-4)" class="oval" mask="url(#mask-2)" rx="42.5" ry="22.5" style="transform: scale(1.5);"/>
           </g>
         </g>
-        <g class="rectangle">
+        <g class="rectangle" style="transform: translate(19px, -4px) scale(1.2)">
           <use fill="#000" filter="url(#filter-6)" xlink:href="#path-5"/>
           <use fill="#FFF" fill-opacity=".95" xlink:href="#path-5"/>
         </g>
-        <g class="combined_shape">
+        <g class="combined_shape" style="transform: translate(18px, -7px) scale(1.3)">
           <use fill="#000" filter="url(#filter-8)" xlink:href="#path-7"/>
           <use fill="#FFF" fill-opacity=".8" xlink:href="#path-7"/>
         </g>
         <mask id="mask-10" fill="#fff">
           <use xlink:href="#path-9"/>
         </mask>
-        <g class="rss">
+        <g class="rss" style="transform: translate(20px, -2px) scale(1.1)">
           <use fill="#000" filter="url(#filter-11)" xlink:href="#path-9"/>
           <use fill="#FFF" fill-opacity=".95" xlink:href="#path-9"/>
         </g>

--- a/addons/website/static/src/img/snippets_thumbs/s_cover.svg
+++ b/addons/website/static/src/img/snippets_thumbs/s_cover.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="82" height="60" viewBox="0 0 82 60">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="140" height="60" viewBox="0 0 140 60">
   <defs>
     <linearGradient id="linearGradient-1" x1="0%" x2="100%" y1="23.23%" y2="76.77%">
       <stop offset="0%" stop-color="#00A09D"/>
@@ -19,19 +19,19 @@
   </defs>
   <g fill="none" fill-rule="evenodd" class="snippets_thumbs">
     <g class="s_cover">
-      <rect width="82" height="60" class="bg"/>
+      <rect width="140" height="60" class="bg"/>
       <g fill="url(#linearGradient-1)" class="group" opacity=".4">
         <g class="image_1">
-          <rect width="82" height="60" class="rectangle"/>
+          <rect width="140" height="60" class="rectangle"/>
         </g>
       </g>
-      <g class="center_group" transform="translate(31 26)">
+      <g class="center_group" transform="translate(52 21) scale(1.7)">
         <g class="rectangle">
-          <use fill="#000" filter="url(#filter-3)" xlink:href="#path-2"/>
+          <use fill="#FFF" xlink:href="#path-2"/>
           <use fill="#FFF" fill-opacity=".95" xlink:href="#path-2"/>
         </g>
         <g class="combined_shape">
-          <use fill="#000" filter="url(#filter-5)" xlink:href="#path-4"/>
+          <use fill="#FFF" xlink:href="#path-4"/>
           <use fill="#FFF" fill-opacity=".95" xlink:href="#path-4"/>
         </g>
       </g>

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -164,7 +164,7 @@ test("Use the sidebar 'save snippet' buttons", async () => {
     expect(".o_notification_manager .o_notification_content").toHaveCount(1);
 
     // Check that the custom sections appeared.
-    await contains(".o-website-builder_sidebar .o-snippets-tabs button:contains(Add)").click();
+    await contains(".o-website-builder_sidebar .o-snippets-tabs button:contains(Blocks)").click();
     expect(
         ".o-snippets-menu div:contains('Custom Inner Content') div[name='Custom Button']"
     ).toHaveCount(1);

--- a/addons/website/static/tests/builder/custom_tab/invisibily_options.test.js
+++ b/addons/website/static/tests/builder/custom_tab/invisibily_options.test.js
@@ -106,7 +106,7 @@ test("click on 'Show/hide on mobile' in mobile view", async () => {
     await contains("button[data-action='mobile']").click();
 
     await contains("button[data-action-id='toggleDeviceVisibility']:last").click();
-    expect(".o-snippets-tabs button:contains('Add')").toHaveClass("active");
+    expect(".o-snippets-tabs button:contains('Blocks')").toHaveClass("active");
     expect(":iframe .col-lg-3[data-invisible='1']").toHaveClass("o_snippet_mobile_invisible");
 });
 

--- a/addons/website/static/tests/builder/custom_tab/misc.test.js
+++ b/addons/website/static/tests/builder/custom_tab/misc.test.js
@@ -281,7 +281,7 @@ test("hide empty OptionContainer and display OptionContainer with content (with 
 test("fallback on the 'Blocks' tab if no option match the selected element", async () => {
     await setupWebsiteBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     await contains(":iframe .parent-target > div").click();
-    expect(".o-snippets-tabs button:contains('Add')").toHaveClass("active");
+    expect(".o-snippets-tabs button:contains('Blocks')").toHaveClass("active");
 });
 
 test("display empty message if no option container is visible", async () => {

--- a/addons/website/static/tests/builder/invisible_elements.test.js
+++ b/addons/website/static/tests/builder/invisible_elements.test.js
@@ -42,9 +42,9 @@ test("click on invisible elements in the invisible elements tab (check sidebar t
         '<div class="s_test d-lg-none o_snippet_desktop_invisible" data-invisible="1">a</div>'
     );
     await contains(".o_we_invisible_el_panel .o_we_invisible_entry").click();
-    expect("button:contains('Edit')").toHaveClass("active");
+    expect("button:contains('Style')").toHaveClass("active");
     await contains(".o_we_invisible_el_panel .o_we_invisible_entry").click();
-    expect("button:contains('Add')").toHaveClass("active");
+    expect("button:contains('Blocks')").toHaveClass("active");
 });
 
 test("Add an element on the invisible elements tab", async () => {

--- a/addons/website/static/tests/builder/snippets_menu.test.js
+++ b/addons/website/static/tests/builder/snippets_menu.test.js
@@ -39,11 +39,11 @@ test("navigate between builder tab don't fetch snippet description again", async
     });
     await setupWebsiteBuilder(`<h1> Homepage </h1>`);
     expect(queryAllTexts(".o-website-builder_sidebar .o-snippets-tabs button")).toEqual([
-        "Add",
-        "Edit",
+        "Blocks",
+        "Style",
         "Theme",
     ]);
-    expect(queryOne(".o-website-builder_sidebar .o-snippets-tabs button.active")).toHaveText("Add");
+    expect(queryOne(".o-website-builder_sidebar .o-snippets-tabs button.active")).toHaveText("Blocks");
     expect.verifySteps(["render_public_asset"]);
 
     await contains(".o-website-builder_sidebar .o-snippets-tabs button:contains(Theme)").click();
@@ -52,8 +52,8 @@ test("navigate between builder tab don't fetch snippet description again", async
         "Theme"
     );
 
-    await contains(".o-website-builder_sidebar .o-snippets-tabs button:contains(Add)").click();
-    expect(queryOne(".o-website-builder_sidebar .o-snippets-tabs button.active")).toHaveText("Add");
+    await contains(".o-website-builder_sidebar .o-snippets-tabs button:contains(Blocks)").click();
+    expect(queryOne(".o-website-builder_sidebar .o-snippets-tabs button.active")).toHaveText("Blocks");
     expect.verifySteps([]);
 });
 
@@ -89,38 +89,38 @@ test("undo and redo buttons", async () => {
 
 test("activate customize tab without any selection", async () => {
     await setupWebsiteBuilder("<h1> Homepage </h1>");
-    expect(queryOne(".o-website-builder_sidebar .o-snippets-tabs button.active")).toHaveText("Add");
-    await contains(".o-website-builder_sidebar .o-snippets-tabs button:contains(Edit)").click();
+    expect(queryOne(".o-website-builder_sidebar .o-snippets-tabs button.active")).toHaveText("Blocks");
+    await contains(".o-website-builder_sidebar .o-snippets-tabs button:contains(Style)").click();
     expect(queryOne(".o-website-builder_sidebar .o-snippets-tabs button.active")).toHaveText(
-        "Edit"
+        "Style"
     );
 });
 
-test("Clicking on the 'Add' or 'Theme' tab should deactivate the options", async () => {
+test("Clicking on the 'Blocks' or 'Theme' tab should deactivate the options", async () => {
     await setupWebsiteBuilderWithSnippet("s_banner");
 
     await contains(":iframe .s_banner").click();
     await animationFrame();
     expect(".oe_overlay").toHaveCount(1);
-    expect(".o-snippets-tabs button:contains('Edit')").toHaveClass("active");
+    expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
     expect(".o_customize_tab .options-container").toHaveCount(1);
 
-    await contains(".o-snippets-tabs button:contains('Add')").click();
+    await contains(".o-snippets-tabs button:contains('Blocks')").click();
     expect(".oe_overlay").toHaveCount(0);
-    await contains(".o-snippets-tabs button:contains('Edit')").click();
-    expect(".o-snippets-tabs button:contains('Edit')").toHaveClass("active");
+    await contains(".o-snippets-tabs button:contains('Style')").click();
+    expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
     expect(".o_customize_tab .options-container").toHaveCount(0);
 
     await contains(":iframe .s_banner").click();
     await waitFor(".o_customize_tab .options-container");
     expect(".oe_overlay").toHaveCount(1);
-    expect(".o-snippets-tabs button:contains('Edit')").toHaveClass("active");
+    expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
     expect(".o_customize_tab .options-container").toHaveCount(1);
 
     await contains(".o-snippets-tabs button:contains('Theme')").click();
     expect(".oe_overlay").toHaveCount(0);
-    await contains(".o-snippets-tabs button:contains('Edit')").click();
-    expect(".o-snippets-tabs button:contains('Edit')").toHaveClass("active");
+    await contains(".o-snippets-tabs button:contains('Style')").click();
+    expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
     expect(".o_customize_tab .options-container").toHaveCount(0);
 });
 

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -61,10 +61,10 @@ test("systray in translate mode", async () => {
 
 test("snippets menu in translate mode", async () => {
     await setupSidebarBuilderForTranslation({ websiteContent: `<h1> Homepage </h1>` });
-    expect(".o-snippets-tabs button:contains('Add')").toHaveAttribute("disabled");
+    expect(".o-snippets-tabs button:contains('Blocks')").toHaveAttribute("disabled");
     expect(".o-snippets-tabs button:contains('THEME')").toHaveAttribute("disabled");
-    expect(".o-snippets-tabs button:contains('Edit')").toHaveClass("active");
-    expect(".o-snippets-tabs button:contains('Edit')").not.toHaveAttribute("disabled");
+    expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
+    expect(".o-snippets-tabs button:contains('Style')").not.toHaveAttribute("disabled");
 });
 
 test("invisible elements in translate mode", async () => {


### PR DESCRIPTION
This PR updates the sidebar navigation by replacing buttons with tabs and revising some labels and icons.
It also highlights the distinction between sections by changing the size of the snippet thumbnails.

| Before | After |
|--------|--------|
| <img width="307" height="557" alt="website-sidebar-before" src="https://github.com/user-attachments/assets/d7cfe040-788c-41bc-bb06-eb787900d762" /> | <img width="306" height="751" alt="Screenshot 2025-07-31 at 16 12 49" src="https://github.com/user-attachments/assets/ff2593e7-e5c0-4085-bd85-58f161644bb3" /> |

task-4948949

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
