### PR TITLE
[FIX] stock: prevent traceback when returning products

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -100,6 +100,8 @@ class ReturnPicking(models.TransientModel):
     @api.depends('picking_id')
     def _compute_moves_locations(self):
         for wizard in self:
+            if not wizard.picking_id:
+                continue
             product_return_moves = [Command.clear()]
             if not wizard.picking_id._can_return():
                 raise UserError(_("You may only return Done pickings."))
@@ -115,10 +117,9 @@ class ReturnPicking(models.TransientModel):
                 product_return_moves_data = dict(product_return_moves_data_tmpl)
                 product_return_moves_data.update(wizard._prepare_stock_return_picking_line_vals_from_move(move))
                 product_return_moves.append(Command.create(product_return_moves_data))
-            if wizard.picking_id and not product_return_moves:
+            if not product_return_moves:
                 raise UserError(_("No products to return (only lines in Done state and not fully returned yet can be returned)."))
-            if wizard.picking_id:
-                wizard.product_return_moves = product_return_moves
+            wizard.product_return_moves = product_return_moves
 
     @api.model
     def _prepare_stock_return_picking_line_vals_from_move(self, stock_move):


### PR DESCRIPTION
step to reproduce :
create a sales order with a service and a consumable product deliver the consumable product
enable the 'returns' feature on your helpdesk team create a helpdesk ticket in this team
select the customer and the SOL you created
click on return
empty the delivery field => traceback

source of the issue :

Setting the delivery_id field to false triggers a compute, in which an ensure one is later call on the delivery_id. Since the delivery is empty, it triggers an error.

Solution :

When the compute is triggered, we can prevent the rest of the code execution when the picking is set to False.

task - 4935957
