### PR TITLE
[IMP] hr: Sync phone and email between employee and contact only if 1:1 link

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -215,8 +215,6 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="employee_admin" model="hr.employee">
             <field name="private_phone">+1 555-555-5555</field>
             <field name="private_email">admin@yourcompany.example.com</field>
-            <field name="work_phone">(555)-125-2389</field>
-            <field name="work_email">admin@yourcompany.example.com</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_3')])]"/>
             <field name="date_version" eval="time.strftime('%Y')+'-01-01'"/>
             <field name="contract_date_start" eval="time.strftime('%Y')+'-01-01'"/>
@@ -241,6 +239,7 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_ngh" model="res.partner">
             <field name="name">Jeffrey Kelly</field>
             <field name="email">jeffrey.kelly72@example.com</field>
+            <field name="phone">(555)-264-7362</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_ngh-image.jpg"/>
         </record>
 
@@ -252,7 +251,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_2')])]"/>
             <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
             <field name="work_location_id" ref="work_location_1"/>
-            <field name="work_phone">(555)-264-7362</field>
             <field name="work_contact_id" ref="hr.work_contact_ngh"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_ngh-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -268,7 +266,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="name">Marc Demo</field>
             <field name="user_id" ref="base.user_demo"/>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4')])]"/>
-            <field name="work_phone">+3281813700</field>
             <field name="work_contact_id" ref="base.partner_demo"/>
             <field name="date_version" eval="(DateTime.today() + relativedelta(years=-1, month=1, day=1))"/>
             <field name="contract_date_start" eval="(DateTime.today() + relativedelta(years=-1, month=1, day=1))"/>
@@ -294,13 +291,13 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_al" model="res.partner">
             <field name="name">Ronnie Hart</field>
             <field name="email">ronnie.hart87@example.com</field>
+            <field name="phone">(555)-310-7863</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_al-image.jpg"/>
         </record>
 
         <record id="employee_al" model="hr.employee">
             <field name="name">Ronnie Hart</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_3')])]"/>
-            <field name="work_phone">(555)-310-7863</field>
             <field name="work_contact_id" ref="hr.work_contact_al"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_al-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -321,13 +318,13 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_vad" model="res.partner">
             <field name="name">Tina Williamson</field>
             <field name="email">tina.williamson98@example.com</field>
+            <field name="phone">(555)-694-7266</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_vad-image.jpg"/>
         </record>
 
         <record id="employee_vad" model="hr.employee">
             <field name="name">Tina Williamson</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_7')])]"/>
-            <field name="work_phone">(555)-694-7266</field>
             <field name="work_contact_id" ref="hr.work_contact_vad"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_vad-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -349,6 +346,7 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_hne" model="res.partner">
             <field name="name">Abigail Peterson</field>
             <field name="email">abigail.peterson39@example.com</field>
+            <field name="phone">(555)-233-3393</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_hne-image.jpg"/>
         </record>
 
@@ -362,7 +360,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="private_email">abigail.peterson33@example.com</field>
             <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
             <field name="work_location_id" ref="work_location_1"/>
-            <field name="work_phone">(555)-233-3393</field>
             <field name="work_contact_id" ref="hr.work_contact_hne"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_hne-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -379,6 +376,7 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_fpi" model="res.partner">
             <field name="name">Audrey Peterson</field>
             <field name="email">audrey.peterson25@example.com</field>
+            <field name="phone">(555)-276-7903</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_fpi-image.jpg"/>
         </record>
 
@@ -387,7 +385,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_5')])]"/>
             <field name="private_country_id" ref="base.us"/>
             <field name="private_email">Audrey.peterson2020@example.com</field>
-            <field name="work_phone">(555)-276-7903</field>
             <field name="work_contact_id" ref="hr.work_contact_fpi"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_fpi-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -420,6 +417,7 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_lur" model="res.partner">
             <field name="name">Eli Lambert</field>
             <field name="email">eli.lambert22@example.com</field>
+            <field name="phone">(555)-169-1352</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_lur-image.jpg"/>
         </record>
 
@@ -431,7 +429,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_title">Marketing and Community Manager</field>
             <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
             <field name="work_location_id" ref="work_location_1"/>
-            <field name="work_phone">(555)-169-1352</field>
             <field name="work_contact_id" ref="hr.work_contact_lur"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_lur-image.jpg"/>
             <field name="date_version" eval="'2010-01-01'"/>
@@ -441,6 +438,7 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_jod" model="res.partner">
             <field name="name">Rachel Perry</field>
             <field name="email">jod@odoo.com</field>
+            <field name="phone">(555)-267-3735</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jod-image.jpg"/>
         </record>
 
@@ -452,7 +450,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_title">Marketing and Community Manager</field>
             <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
             <field name="work_location_id" ref="work_location_1"/>
-            <field name="work_phone">(555)-267-3735</field>
             <field name="work_contact_id" ref="hr.work_contact_jod"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jod-image.jpg"/>
             <field name="date_version" eval="'2010-01-01'"/>
@@ -462,13 +459,13 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_fme" model="res.partner">
             <field name="name">Keith Byrd</field>
             <field name="email">keith.byrd52@example.com</field>
+            <field name="phone">(555)-505-5146</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_fme-image.jpg"/>
         </record>
 
         <record id="employee_fme" model="hr.employee">
             <field name="name">Keith Byrd</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4')])]"/>
-            <field name="work_phone">(555)-505-5146</field>
             <field name="work_contact_id" ref="hr.work_contact_fme"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_fme-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -490,6 +487,7 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_jep" model="res.partner">
             <field name="name">Doris Cole</field>
             <field name="email">doris.cole31@example.com</field>
+            <field name="phone">(555)-331-5378</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jep-image.jpg"/>
         </record>
 
@@ -503,7 +501,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="private_email">Doris.cole.LoveSong@example.com</field>
             <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
             <field name="work_location_id" ref="work_location_1"/>
-            <field name="work_phone">(555)-331-5378</field>
             <field name="work_contact_id" ref="hr.work_contact_jep"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jep-image.jpg"/>
             <field name="date_version" eval="'2010-01-01'"/>
@@ -514,6 +511,7 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_jgo" model="res.partner">
             <field name="name">Ernest Reed</field>
             <field name="email">ernest.reed47@example.com</field>
+            <field name="phone">(555)-518-8232</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jgo-image.jpg"/>
         </record>
 
@@ -525,7 +523,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_title">Consultant</field>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
-            <field name="work_phone">(555)-518-8232</field>
             <field name="work_contact_id" ref="hr.work_contact_jgo"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jgo-image.jpg"/>
             <field name="date_version" eval="'2010-01-01'"/>
@@ -535,13 +532,13 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_jth" model="res.partner">
             <field name="name">Toni Jimenez</field>
             <field name="email">toni.jimenez23@example.com</field>
+            <field name="phone">(555)-707-8451</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jth-image.jpg"/>
         </record>
 
         <record id="employee_jth" model="hr.employee">
             <field name="name">Toni Jimenez</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_5'), ref('employee_category_6')])]"/>
-            <field name="work_phone">(555)-707-8451</field>
             <field name="work_contact_id" ref="hr.work_contact_jth"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jth-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -564,13 +561,13 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="name">Anita Oliver</field>
             <field name="phone">(555)-672-3185</field>
             <field name="email">anita.oliver32@example.com</field>
+            <field name="phone">(555)-497-4804</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_mit-image.jpg"/>
         </record>
 
         <record id="employee_mit" model="hr.employee">
             <field name="name">Anita Oliver</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4')])]"/>
-            <field name="work_phone">(555)-497-4804</field>
             <field name="work_contact_id" ref="hr.work_contact_mit"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_mit-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -594,13 +591,13 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_niv" model="res.partner">
             <field name="name">Sharlene Rhodes</field>
             <field name="email">sharlene.rhodes49@example.com</field>
+            <field name="phone">(555)-719-4182</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_niv-image.jpg"/>
         </record>
 
         <record id="employee_niv" model="hr.employee">
             <field name="name">Sharlene Rhodes</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_7')])]"/>
-            <field name="work_phone">(555)-719-4182</field>
             <field name="work_contact_id" ref="hr.work_contact_niv"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_niv-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -622,13 +619,13 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_stw" model="res.partner">
             <field name="name">Randall Lewis</field>
             <field name="email">randall.lewis74@example.com</field>
+            <field name="phone">(555)-775-6660</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_stw-image.jpg"/>
         </record>
 
         <record id="employee_stw" model="hr.employee">
             <field name="name">Randall Lewis</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4')])]"/>
-            <field name="work_phone">(555)-775-6660</field>
             <field name="work_contact_id" ref="hr.work_contact_stw"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_stw-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -650,13 +647,13 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_chs" model="res.partner">
             <field name="name">Jennie Fletcher</field>
             <field name="email">jennie.fletcher76@example.com</field>
+            <field name="phone">(555)-363-8229</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_chs-image.jpg"/>
         </record>
 
         <record id="employee_chs" model="hr.employee">
             <field name="name">Jennie Fletcher</field>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_7')])]"/>
-            <field name="work_phone">(555)-363-8229</field>
             <field name="work_contact_id" ref="hr.work_contact_chs"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_chs-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -678,12 +675,12 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_jve" model="res.partner">
             <field name="name">Paul Williams</field>
             <field name="email">paul.williams59@example.com</field>
+            <field name="phone">(555)-262-1607</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jve-image.jpg"/>
         </record>
 
         <record id="employee_jve" model="hr.employee">
             <field name="name">Paul Williams</field>
-            <field name="work_phone">(555)-262-1607</field>
             <field name="work_contact_id" ref="hr.work_contact_jve"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jve-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -705,12 +702,12 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_han" model="res.partner">
             <field name="name">Walter Horton</field>
             <field name="email">walter.horton80@example.com</field>
+            <field name="phone">(555)-912-1201</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_han-image.jpg"/>
         </record>
 
         <record id="employee_han" model="hr.employee">
             <field name="name">Walter Horton</field>
-            <field name="work_phone">(555)-912-1201</field>
             <field name="work_contact_id" ref="hr.work_contact_han"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_han-image.jpg"/>
             <field name="create_date">2010-01-01 00:00:00</field>
@@ -731,6 +728,7 @@ If you have development competencies, we can propose you specific traineeships</
         <record id="work_contact_jog" model="res.partner">
             <field name="name">Beth Evans</field>
             <field name="email">beth.evans77@example.com</field>
+            <field name="phone">(555)-532-3841</field>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jog-image.jpg"/>
         </record>
 
@@ -744,7 +742,6 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="private_email">beth.evans@example.com</field>
             <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
             <field name="work_location_id" ref="work_location_1"/>
-            <field name="work_phone">(555)-532-3841</field>
             <field name="work_contact_id" ref="hr.work_contact_jog"/>
             <field name="image_1920" type="base64" file="hr/static/img/employee_jog-image.jpg"/>
             <field name="date_version" eval="'2010-01-01'"/>
@@ -754,12 +751,12 @@ If you have development competencies, we can propose you specific traineeships</
 
         <record id="work_contact_barty_mcbly" model="res.partner">
             <field name="name">Barty McBly</field>
+            <field name="phone">(555)-234-3424</field>
             <field name="email">barty.mcbly@example.com</field>
         </record>
 
         <record id="employee_barty_mcbly" model="hr.employee">
             <field name="name">Barty McBly</field>
-            <field name="work_phone">(555)-234-3424</field>
             <field name="work_contact_id" ref="hr.work_contact_barty_mcbly"/>
             <field name="date_version">1885-09-02</field>
             <field name="contract_date_start">1885-09-02</field>

--- a/addons/test_discuss_full/static/tests/tours/avatar_card_tour.js
+++ b/addons/test_discuss_full/static/tests/tours/avatar_card_tour.js
@@ -16,7 +16,7 @@ const steps = [
     },
     {
         content: "Check that the employee's work phone is displayed",
-        trigger: ".o_avatar_card:contains(987654321)",
+        trigger: ".o_avatar_card:contains(123456789)",
     },
     {
         content: "Check that the employee's holiday status is displayed",

--- a/addons/test_discuss_full/tests/test_avatar_card_tour.py
+++ b/addons/test_discuss_full/tests/test_avatar_card_tour.py
@@ -49,6 +49,7 @@ class TestAvatarCardTour(MailCommon, HttpCase):
                 "job_id": job.id,
                 "address_id": other_partner.id,
                 "work_email": "test_employee@test.com",
+                "work_phone": "123456789",
             })
         )
         cls.test_employee = test_employee


### PR DESCRIPTION
When a res.partner is linked to exactly one employee, phone (work_phone for employee)  changes on either side (employee or contact) are synchronized to the other.
If the partner is linked to multiple employees (e.g. across companies), no sync is performed to avoid conflicts.
Related task: 4979640.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
