### PR TITLE
[FIX] hw_drivers: stale token used in send_all_devices

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -38,7 +38,6 @@ class Manager(Thread):
         self.hostname = helpers.get_hostname()
         self.mac_address = helpers.get_mac_address()
         self.domain = self._get_domain()
-        self.token = helpers.get_token()
         self.version = helpers.get_version(detailed_version=True)
         self.previous_iot_devices = {}
 
@@ -90,7 +89,7 @@ class Manager(Thread):
                 'name': self.hostname,
                 'identifier': self.mac_address,
                 'ip': self.domain,
-                'token': self.token,
+                'token': helpers.get_token(),
                 'version': self.version,
             }
             devices_list = {}


### PR DESCRIPTION
Since the PR odoo/odoo#218109, the send_all_devices logic was refactored to always send whenever something changes. However, there was a bug introduced due to the fact the token is saved at start-up and never updated. This caused the devices to not get sent correctly immediately after pairing with a DB (in the time before checking out and restarting).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
