### PR TITLE
[FIX] hw_drivers: fix devices always being sent when unsupported

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -34,6 +34,7 @@ class Manager(Thread):
         self.token = helpers.get_token()
         self.version = helpers.get_version(detailed_version=True)
         self.previous_iot_devices = {}
+        self.previous_unsupported_devices = {}
 
     def _get_domain(self):
         """
@@ -53,8 +54,10 @@ class Manager(Thread):
         changed = False
 
         current_devices = set(iot_devices.keys()) | set(unsupported_devices.keys())
-        if current_devices != set(self.previous_iot_devices.keys()):
+        previous_devices = set(self.previous_iot_devices.keys()) | set(self.previous_unsupported_devices.keys())
+        if current_devices != previous_devices:
             self.previous_iot_devices = iot_devices.copy()
+            self.previous_unsupported_devices = unsupported_devices.copy()
             changed = True
 
         # Mac address can change if the user has multiple network interfaces
@@ -98,7 +101,7 @@ class Manager(Thread):
                 'connection': device.device_connection,
                 'subtype': device.device_subtype if device.device_type == 'printer' else '',
             }
-        devices_list.update(unsupported_devices)
+        devices_list.update(self.previous_unsupported_devices)
         devices_list_to_send = {
             key: value for key, value in devices_list.items() if key != 'distant_display'
         }  # Don't send distant_display to the db


### PR DESCRIPTION
In the forward port of odoo/odoo#218109, a bug was introduced where if an unsupported device is connected, the device list is always detected as being changed, so the IoT box sends devices to the database every 3 seconds. This doesn't cause any problems other than spamming the logs and the DB with requests, but should be fixed regardless.

After this commit, the unsupported devices are taken into account correctly when detecting device changes.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
