### PR TITLE
[16.0][IMP] account: Corrects amounts with currencies when foreign_currency_id equals to company_currency

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -474,6 +474,8 @@ class AccountBankStatementLine(models.Model):
             company_amount = journal_amount
         elif foreign_currency == company_currency:
             company_amount = transaction_amount
+            foreign_currency = journal_currency
+            transaction_amount = journal_amount
         else:
             company_amount = journal_currency._convert(journal_amount, company_currency,
                                                        self.journal_id.company_id, self.date)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR fixes an incorrect journal entry creation from a bank statement line under a specific multi-currency scenario. The issue occurs when the statement's journal is in a foreign currency (e.g., USD), while the statement line itself specifies an amount in the company's local currency (e.g., EUR).

Current behavior before PR:
Current logic misinterprets the provided amounts. It generates an unbalanced account.move that is then incorrectly balanced by posting the difference to the suspense account, requiring manual correction.

Desired behavior after PR is merged:
The logic is corrected to use the provided amount in the company's currency as the authoritative value for the journal entry. This results in a correctly balanced account.move from the start, without using the suspense account, ensuring data integrity.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
