### PR TITLE
[IMP] l10n_in_edi: handle IAP timeout as warning instead of error

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -175,7 +175,7 @@ class AccountEdiFormat(models.Model):
                 return {invoice: {
                     "success": False,
                     "error": error_message,
-                    "blocking_level": ("404" in error_codes) and "warning" or "error",
+                    "blocking_level": "warning" if {'404', 'timeout'} & set(error_codes) else "error",
                 }}
         if not response.get("error"):
             json_dump = json.dumps(response.get("data"))


### PR DESCRIPTION
Before this commit:
---
while requesting for E-invoice on MasterGST, If there was a ConnectionTimeout on the IAP server the response was treated as an error. This caused invoices to enter an error state and prevented them from being retried by cron.

In this commit:
---
Timeout errors are treated as warnings by setting blocking_level to "warning" for "timeout" error codes.
This allows cron jobs to automatically retry such invoices.

task-4970444
