### PR TITLE
[FIX] website: update ToC navbar items when translating headings

### DIFF
--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin_translate.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin_translate.js
@@ -1,0 +1,40 @@
+import { Plugin } from "@html_editor/plugin";
+import { applyFunDependOnSelectorAndExclude } from "../utils";
+
+export class TranslateTableOfContentOptionPlugin extends Plugin {
+    static id = "tableOfContentOption";
+
+    resources = {
+        normalize_handlers: this.normalize.bind(this),
+        force_not_editable_selector: [".s_table_of_content_navbar"],
+    };
+
+    normalize(root) {
+        applyFunDependOnSelectorAndExclude(this.updateTableOfContentNavbar.bind(this), root, {
+            selector: ".s_table_of_content_main",
+        });
+    }
+
+    updateTableOfContentNavbar(tableOfContentMain) {
+        const tableOfContent = tableOfContentMain.closest(".s_table_of_content");
+        const tableOfContentNavbar = tableOfContent.querySelector(".s_table_of_content_navbar");
+        const currentNavbarItems = [...tableOfContentNavbar.children].map((el) => el.firstChild);
+
+        const targetedElements = "h1, h2";
+        const currentHeadingItems = [
+            ...tableOfContentMain.querySelectorAll(targetedElements),
+        ].filter((el) => !el.closest(".o_snippet_desktop_invisible"));
+
+        currentNavbarItems.map((el, i) => {
+            const newText = currentHeadingItems[i]?.textContent || "";
+            if (el.textContent !== newText) {
+                el.textContent = newText;
+            }
+
+            const newHref = `#${currentHeadingItems[i]?.id}`;
+            if (newHref && el.parentElement.getAttribute("href") !== newHref) {
+                el.parentElement.setAttribute("href", newHref);
+            }
+        });
+    }
+}

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -24,6 +24,7 @@ import { BuilderActionsPlugin } from "@html_builder/core/builder_actions_plugin"
 import { CoreBuilderActionPlugin } from "@html_builder/core/core_builder_action_plugin";
 import { CarouselOptionTranslationPlugin } from "./plugins/carousel_option_translation_plugin";
 import { ThemeTab } from "./plugins/theme/theme_tab";
+import { TranslateTableOfContentOptionPlugin } from "./plugins/options/table_of_content_option_plugin_translate";
 import { BuilderContentEditablePlugin } from "@html_builder/core/builder_content_editable_plugin";
 
 const TRANSLATION_PLUGINS = [
@@ -44,6 +45,7 @@ const TRANSLATION_PLUGINS = [
     HighlightPlugin,
     OperationPlugin,
     EditInteractionPlugin,
+    TranslateTableOfContentOptionPlugin,
     BuilderContentEditablePlugin,
     CarouselOptionTranslationPlugin,
 ];

--- a/addons/website/static/src/snippets/s_table_of_content/table_of_content.js
+++ b/addons/website/static/src/snippets/s_table_of_content/table_of_content.js
@@ -62,7 +62,6 @@ export class TableOfContent extends Interaction {
         this.scrollHeight = 0;
         this.offset = 0;
 
-        this.stripNavbarStyles();
         this.scrollElement = closestScrollableY(this.el.closest(".s_table_of_content")) || this.el.ownerDocument.scrollingElement;
         this.scrollTarget = isScrollableY(this.scrollElement) ? this.scrollElement : this.scrollElement.ownerDocument.defaultView;
         this.tocElement = this.el.querySelector(".s_table_of_content_navbar");
@@ -80,18 +79,6 @@ export class TableOfContent extends Interaction {
     // Private
     //--------------------------------------------------------------------------
 
-    stripNavbarStyles() {
-        // This is needed for styles added on translations when the master text
-        // has no style.
-        for (let el of this.el.querySelectorAll(".s_table_of_content_navbar .table_of_content_link")) {
-            const translationEl = el.querySelector("span[data-oe-translation-state]");
-            if (translationEl) {
-                el = translationEl;
-            }
-            const text = el.textContent; // Get text from el.
-            el.textContent = text; // Replace all of el's content with that text.
-        }
-    }
     updateTableOfContentNavbarPosition() {
         if (!this.el.querySelector("a.table_of_content_link")) {
             // Do not start the scrollspy if the TOC is empty.


### PR DESCRIPTION
When we translate headings in the Table of Content snippet, the snippet's navbar items aren't responsive,
they stay connected to the original language headings.
Steps to reproduce the problem:
- Add a second language to your website
- Open Website and start editing
- Drop the table of content snippet
- Save, switch to your secondary language and start translating
- Modify the table's heading

=> Navbar headings aren't updated.
This commit also fixes the possibility of editing a navbar item directly, which shouldn't be the case.
This commit follows the [html_builder refactoring]. 
Related to task-4367641

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb