### PR TITLE
[FIX] mail: test audio sensitivity button

### DIFF
--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -12,6 +12,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { Deferred } from "@web/core/utils/concurrency";
 import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
+import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { monitorAudio } from "@mail/utils/common/media_monitoring";
 import { convertBrToLineBreak } from "./format";
@@ -351,10 +352,21 @@ export function useMicrophoneVolume() {
                 state.value = 0;
                 return;
             }
-            const audioStream = await browser.navigator.mediaDevices.getUserMedia({
-                audio: store.settings.audioConstraints,
-            });
-            const track = audioStream.getAudioTracks()[0];
+            let track;
+            try {
+                const audioStream = await browser.navigator.mediaDevices.getUserMedia({
+                    audio: store.settings.audioConstraints,
+                });
+                track = audioStream.getAudioTracks()[0];
+            } catch {
+                store.env.services.notification.add(
+                    _t('"%(hostname)s" requires microphone access', {
+                        hostname: browser.location.host,
+                    }),
+                    { type: "warning" }
+                );
+                return;
+            }
             if (isClosed) {
                 track.stop();
                 return;


### PR DESCRIPTION
**Before this PR:**

When you click on the `Test` Audio Sensitivity button in the voice & video configuration it would throw traceback if host doesn't have microphone permission which wasn't handled and was being displayed as an Uncaught Error.

**This PR** handles this traceback and displays a toast notification.

Task-4966597

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
