### PR TITLE
[FIX] point_of_sale: prevent rounding error with combos

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -21,13 +21,16 @@ export const computeComboItems = (
 
     let remainingTotal = parentLstPrice;
     const ProductPrice = currency_id || decimalPrecision.find((dp) => dp.name === "Product Price");
+    if (childLineConf[childLineConf.length - 1]?.qty > 1) {
+        childLineConf[childLineConf.length - 1].qty -= 1;
+        childLineConf.push({ ...childLineConf[childLineConf.length - 1], qty: 1 });
+    }
     for (const conf of childLineConf) {
         const comboItem = conf.combo_item_id;
         const combo = comboItem.combo_id;
         let priceUnit = ProductPrice.round((combo.base_price * parentLstPrice) / originalTotal);
         remainingTotal -= priceUnit * conf.qty;
-
-        if (comboItem.id == childLineConf[childLineConf.length - 1].combo_item_id.id) {
+        if (conf === childLineConf[childLineConf.length - 1]) {
             priceUnit += remainingTotal;
         }
         const attribute_value_ids = conf.configuration?.attribute_value_ids?.map(

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -201,9 +201,9 @@ registry.category("web_tour.tours").add("ProductComboMaxFreeQtyTour", {
 
             Dialog.confirm(),
             inLeftSide([
-                ...ProductScreen.selectedOrderlineHasDirect("Office Combo", "1", "151.97"),
+                ...ProductScreen.selectedOrderlineHasDirect("Office Combo", "1", "151.96"),
             ]),
-            ProductScreen.totalAmountIs("151.97"),
+            ProductScreen.totalAmountIs("151.96"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -150,6 +150,81 @@ test("getTotalDiscount", async () => {
     expect(taxTotalsWDiscount.tax_amount_currency).toBe(1.83);
 });
 
+test("preventRoundingErrorsCombo", async () => {
+    const store = await setupPosEnv();
+    store.models["product.product"].get(7).taxes_id = [1];
+    store.models["product.product"].get(7).lst_price = 50;
+    store.models["product.product"].get(8).taxes_id = [1];
+    store.models["product.product"].get(9).taxes_id = [1];
+    store.models["pos.preset"].get(1).pricelist_id = false;
+    store.models["product.combo"].get(1).qty_free = 3;
+    store.models["product.combo"].get(1).base_price = 10;
+    const comboProduct1 = store.models["product.combo.item"].get(1);
+    const comboProduct2 = store.models["product.combo.item"].get(2);
+    comboProduct2.extra_price = 0;
+    const template = store.models["product.template"].get(7);
+    const order = store.addNewOrder();
+    const order2 = store.addNewOrder();
+    const order3 = store.addNewOrder();
+
+    // 3 of the same product
+    await store.addLineToOrder(
+        {
+            product_tmpl_id: template,
+            payload: [[{ combo_item_id: comboProduct1, qty: 3 }]],
+            qty: 1,
+        },
+        order
+    );
+    expect(order.amount_total).toBe(57.5);
+    expect(order.lines[1].qty).toBe(2);
+    expect(order.lines[1].price_unit).toBe(16.67);
+    expect(order.lines[2].qty).toBe(1);
+    expect(Math.round(order.lines[2].price_unit * 100) / 100).toBe(16.66);
+
+    // 2 different products
+    await store.addLineToOrder(
+        {
+            product_tmpl_id: template,
+            payload: [
+                [
+                    { combo_item_id: comboProduct1, qty: 1 },
+                    { combo_item_id: comboProduct2, qty: 2 },
+                ],
+            ],
+            qty: 1,
+        },
+        order2
+    );
+    expect(order2.amount_total).toBe(57.5);
+    expect(order2.lines[1].price_unit).toBe(16.67);
+    expect(order2.lines[1].qty).toBe(1);
+    expect(order2.lines[2].price_unit).toBe(16.67);
+    expect(order2.lines[2].qty).toBe(1);
+    expect(Math.round(order2.lines[3].price_unit * 100) / 100).toBe(16.66);
+    expect(order2.lines[3].qty).toBe(1);
+
+    // 3 of the same product and 3 of the same extra items
+    await store.addLineToOrder(
+        {
+            product_tmpl_id: template,
+            payload: [
+                [{ combo_item_id: comboProduct1, qty: 3 }],
+                [{ combo_item_id: comboProduct1, qty: 3 }],
+            ],
+            qty: 1,
+        },
+        order3
+    );
+    expect(order3.amount_total).toBe(92);
+    expect(order3.lines[1].qty).toBe(2);
+    expect(order3.lines[1].price_unit).toBe(16.67);
+    expect(Math.round(order3.lines[2].price_unit * 100) / 100).toBe(16.66);
+    expect(order3.lines[2].qty).toBe(1);
+    expect(order3.lines[3].qty).toBe(3);
+    expect(order3.lines[3].price_unit).toBe(10);
+});
+
 test("customer requirements", async () => {
     const store = await setupPosEnv();
     const preset = store.models["pos.preset"].get(3); // Address Required Preset


### PR DESCRIPTION
**Steps to reproduce:**
- Create a combo, set the free and max to 3
- Create the product combo and set it's price to 50
- Go to PoS, order said combo and chose the same product 3 times
- The price is 49.98 instead of 50

**Problem:**
When ordering a combo and taking the same product multiple times, the method to adjust the price does not work as it should. In this case, the method would subtract too much from the total, leading it to be only 49.98 instead of 50.

**Why the fix:**
This happens because when ordering a combo, each line will get it's price_unit from the combo's price divided by the number of lines.
In the case where we have 3 different products, hence 3 different lines, the first two would have a unit_price of 16.67 and the last line will be adjusted as to make it equal to the combo's price, so the last line would be 16.66, making the sum 50. But in the case where there is only one line, the last line is still adjusted, making all the lines 16.66, introducing this error. 

The solution would be to take the line's qty into account when computing how much we should subtract.
Unfortunalty, doing so will, in some cases, introduce a rounding error. If the new unit_price does not round up well (like in this case where it is 16.666668 before rounding and 16.67 after), the rounding will cause a difference between what's shown in the frontend and what's written on the lines in the backend, as the lines are rounded up again before being saved to the backend.

The introduced solution is to split the lines, and each have a quantity of 1. With this solution, we can have a different price_unit for each line, which resolves our problem, as the first two lines will have 16.67 and the last one will have 16.66 as price_unit. 
This is how it was done up until version 18.0, showing every line with a quantity of 1 instead of grouping them.
As the grouped lines are now single, some rounding with taxes might differ from what it was before, which is why a test was altered.

opw-4931215