### PR TITLE
[FIX] web: hard reload after updating language

### DIFF
--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -90,3 +90,14 @@ async function softReload(env, action) {
 }
 
 registry.category("actions").add("soft_reload", softReload);
+
+/**
+ * Client action to refresh the session context (making sure
+ * HTTP requests will have the right one) then reload the
+ * whole interface.
+ */
+async function hardReload(env, action) {
+    await rpc("/web/session/get_session_info");
+    reload(env, action);
+}
+registry.category("actions").add("hard_reload", hardReload);

--- a/odoo/addons/base/wizard/base_language_install.py
+++ b/odoo/addons/base/wizard/base_language_install.py
@@ -73,5 +73,5 @@ class BaseLanguageInstall(models.TransientModel):
         self.env.user.lang = self.first_lang_id.code
         return {
             'type': 'ir.actions.client',
-            'tag': 'reload_context',
+            'tag': 'hard_reload',
         }


### PR DESCRIPTION
To reproduce:
=============
1- Install Arabic & switch to it

Problem:
=========
After updating the language from LTR to RTL
The page refreshes and the languages has changed
but you need to refresh again for the layout to be right-to-left This bug existed since this commit:
https://github.com/odoo/odoo/commit/f418f9ee6d359433159b39719695631a3cd43474

reload-context no longer refresh the whole interface.

Solution:
=========
Add hard reload and update the action for basic language install So it will refresh the whole interface after installing the language.

opw-4925941
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
