### PR TITLE
[FIX] google_calendar: avoid company access error in multi-company sync

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -148,11 +148,16 @@ class GoogleSync(models.AbstractModel):
         if self.env.user._get_google_sync_status() != "sync_paused":
             for record in cancelled_records:
                 if record.google_id and record.need_sync:
-                    record.with_user(record._get_event_user())._google_delete(google_service, record.google_id)
+                    user = record._get_event_user()
+                    record.with_user(user).with_company(user.company_id)._google_delete(google_service, record.google_id)
+
             for record in new_records:
-                record.with_user(record._get_event_user())._google_insert(google_service, record._google_values())
+                user = record._get_event_user()
+                record.with_user(user).with_company(user.company_id)._google_insert(google_service, record._google_values())
+
             for record in updated_records:
-                record.with_user(record._get_event_user())._google_patch(google_service, record.google_id, record._google_values())
+                user = record._get_event_user()
+                record.with_user(user).with_company(user.company_id)._google_patch(google_service, record.google_id, record._google_values())
 
     def _cancel(self):
         self.with_context(dont_notify=True).write({'google_id': False})


### PR DESCRIPTION
**Description**
When syncing a calendar event to Google, the system impersonates the event organizer in a multi-company context, this causes an access error
if the current context includes companies the organizer does not have access to.

---

**Steps to Reproduce**
- Create Company B and organizer user (Company A access only)
- Set current user to have access to both companies
- Login as the organizer user
- Go to Calendar app
- Create a new event with Google sync enabled
- Login as multi-company user
- Select both companies in company switcher
- Navigate to the event created by organizer
- Trigger Google Calendar sync (accept/decline event)

---
**Before**
  ` Access to unauthorized or invalid companies`

**Root cause:**
   - The sync switches to the organizer's identity but keeps the original multi-company context
   - This creates a mismatch where the organizer doesn't have access to all companies in the context
   - Results in access violation when trying to sync

**After:**
   - Properly scope the company context to match the organizer's company when switching user identity
   - This ensures the sync operation runs within the correct company boundaries

opw-4911040