### PR TITLE
[FIX] web_editor: fix non-deterministic list tests

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
@@ -5034,7 +5034,7 @@ describe('List', () => {
                 });
                 describe('Mixed', () => {
                     describe('Ordered to unordered', () => {
-                        it('should merge an ordered list into an unordered list', async () => {
+                        it('should merge an ordered list into an unordered list (1)', async () => {
                             await testEditor(BasicEditor, {
                                 contentBefore: '<ul><li>a</li></ul><ol><li>[]b</li></ol>',
                                 stepFunction: async editor => {
@@ -5043,6 +5043,8 @@ describe('List', () => {
                                 },
                                 contentAfter: '<ul><li>a[]b</li></ul>',
                             });
+                        });
+                        it('should merge an ordered list into an unordered list (2)', async () => {
                             await testEditor(BasicEditor, {
                                 contentBefore: '<ul><li>a</li></ul><ol><li><p>[]b</p></li></ol>',
                                 stepFunction: async editor => {
@@ -5051,6 +5053,8 @@ describe('List', () => {
                                 },
                                 contentAfter: '<ul><li>a[]b</li></ul>',
                             });
+                        });
+                        it("should merge an ordered list into an unordered list (3)", async () => {
                             await testEditor(BasicEditor, {
                                 contentBefore: '<ul><li><p>a</p></li></ul><ol><li>[]b</li></ol>',
                                 stepFunction: async editor => {
@@ -5059,6 +5063,8 @@ describe('List', () => {
                                 },
                                 contentAfter: '<ul><li>a[]b</li></ul>',
                             });
+                        });
+                        it("should merge an ordered list into an unordered list (4)", async () => {
                             await testEditor(BasicEditor, {
                                 contentBefore:
                                     '<ul><li><p>a</p></li></ul><ol><li><p>[]b</p></li></ol>',


### PR DESCRIPTION
Those tests were too long to be grouped in a single `it` as it would sometime hit the time limit when the runbot was too slow. Putting each of them in separate `it` significantly reduces the likelihood of the issue to occur.

runbot-230411
