### PR TITLE
[FIX] purchase_stock: credit note cogs lines balance in standard cost

### DIFF
--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -76,9 +76,9 @@ class AccountMove(models.Model):
                         'quantity': relevant_qty,
                         'price_unit': price_unit_val_dif,
                         'price_subtotal': relevant_qty * price_unit_val_dif,
-                        'amount_currency': relevant_qty * price_unit_val_dif * line.move_id.direction_sign,
+                        'amount_currency': relevant_qty * price_unit_val_dif,
                         'balance': line.currency_id._convert(
-                            relevant_qty * price_unit_val_dif * line.move_id.direction_sign,
+                            relevant_qty * price_unit_val_dif,
                             line.company_currency_id,
                             line.company_id, fields.Date.today(),
                         ),
@@ -99,9 +99,9 @@ class AccountMove(models.Model):
                         'quantity': relevant_qty,
                         'price_unit': -price_unit_val_dif,
                         'price_subtotal': relevant_qty * -price_unit_val_dif,
-                        'amount_currency': relevant_qty * -price_unit_val_dif * line.move_id.direction_sign,
+                        'amount_currency': relevant_qty * -price_unit_val_dif,
                         'balance': line.currency_id._convert(
-                            relevant_qty * -price_unit_val_dif * line.move_id.direction_sign,
+                            relevant_qty * -price_unit_val_dif,
                             line.company_currency_id,
                             line.company_id, fields.Date.today(),
                         ),


### PR DESCRIPTION
When users refund a real-time/standard cost product purchase, cogs lines are not reversed

**Steps to reproduce**

1. Create a product category [CATEG]:
    - Costing Method: Standard
    - Inventory Valuation: Automated
    - Price Difference Account: 101403 Outstanding Payments (any account will do)
2. Create a product [PROD]
    - Type: Storable
    - Category: [CATEG]
3. Create and confirm a PO with [PROD]
4. Process the receipt
5. Create the bill
6. Issue the return and process it
7. Create the refund

**Issue**

The credit note cogs lines (price difference account and stock interim) have the same balance of the bill
However the credit note should mirror the original BILL with the opposite accounting entries.

This seems to occur because, when generating cogs lines, we take into account that the current move is a refund but then we use the move direction sign to alter the balance sign

opw-4845342