### PR TITLE
[FIX] website: fix traceback with s_carousel in hidden TOC navbar

### DIFF
--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -221,6 +221,8 @@ export class WysiwygAdapterComponent extends Wysiwyg {
                 $(el).empty();
             }
         }
+        // The jquery instance inside the iframe needs to be aware of the wysiwyg.
+        this.websiteService.contentWindow.$('#wrapwrap').data('wysiwyg', this);
         await super.startEdition();
 
         // Overriding the `filterMutationRecords` function so it can be used to
@@ -306,8 +308,6 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         if (this.props.beforeEditorActive) {
             await this.props.beforeEditorActive(this.$editable);
         }
-        // The jquery instance inside the iframe needs to be aware of the wysiwyg.
-        this.websiteService.contentWindow.$('#wrapwrap').data('wysiwyg', this);
         // grep: RESTART_WIDGETS_EDIT_MODE
         await new Promise((resolve, reject) => this._websiteRootEvent('widgets_start_request', {
             editableMode: true,


### PR DESCRIPTION
Problem:
When `s_carousel` is placed inside an `s_table_of_content` and the navbar of the TOC is hidden (visibility set to "Hide" on desktop), saving and reopening the editor results in a traceback.

Cause:
The traceback occurs due to the following sequence: In `WysiwygAdapterComponent.startEdition`, calling `await super.startEdition()` will invoke `createInvisibleElement()` if the navbar is hidden. This, in turn, activates the scroll spy by calling `_activateScrollSpy()` while starting the TOC snippet. That triggers `widgets_start_request`, which starts the `s_carousel` snippet.

However, at this point the `wysiwyg` instance has not yet been attached to the `wrapwrap` element. That happens later, at: https://github.com/odoo/odoo/blob/f12050f75ae9ae1125c0c01ec504a24bd401b1ea/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js#L318 and only after the `await super.startEdition()` call at: https://github.com/odoo/odoo/blob/f12050f75ae9ae1125c0c01ec504a24bd401b1ea/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js#L232

This delay causes a race condition when starting widgets like `s_carousel` that rely on the presence of the `wysiwyg` instance.

Solution:
Attach the `wysiwyg` instance to the DOM before
`await super.startEdition()` in
`WysiwygAdapterComponent.startEdition`.

Steps to reproduce:
- Add a Table of Content block
- Insert a Carousel inside the content
- Set the TOC navbar visibility to "Hide" on desktop
- Save the page
- Reopen the editor
- A traceback occurs

opw-4971409

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
