### PR TITLE
[FIX] {test_,}website: avoid branding of ir.ui.view for restricted user

### DIFF
--- a/addons/test_website/static/tests/tours/restricted_editor.js
+++ b/addons/test_website/static/tests/tours/restricted_editor.js
@@ -122,3 +122,15 @@ wTourUtils.registerWebsitePreviewTour('test_restricted_editor_test_admin', {
     },
     ...wTourUtils.clickOnSave(),
 ]);
+
+wTourUtils.registerWebsitePreviewTour('test_restricted_editor_tester', {
+    test: true,
+    url: '/test_model/1',
+}, () => [
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    {
+        content: "Footer should not be be editable for restricted user",
+        trigger: "iframe :has(.o_editable) footer:not(.o_editable):not(:has(.o_editable))",
+    },
+    ...wTourUtils.clickOnSave(),
+]);

--- a/addons/test_website/tests/test_restricted_editor.py
+++ b/addons/test_website/tests/test_restricted_editor.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
+
+from odoo.tests.common import new_test_user
 from odoo.tools import mute_logger
 
 
@@ -51,3 +53,14 @@ class TestRestrictedEditor(odoo.tests.HttpCase):
             ])]
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_restricted_editor_test_admin', login='restricted')
+
+    @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
+    def test_03_restricted_editor_tester(self):
+        """
+        Tests that restricted users cannot edit ir.ui.view records despite being
+        on a page of a record (main_object) they can edit.
+        """
+        self.user_test = new_test_user(self.env, login='restricted', website_id=False)
+        self.user_test.groups_id |= self.env.ref('website.group_website_restricted_editor')
+        self.user_test.groups_id |= self.env.ref('test_website.group_test_website_tester')
+        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_restricted_editor_tester', login='restricted')

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -44,7 +44,7 @@ class IrQWeb(models.AbstractModel):
         irQweb = super()._prepare_frontend_environment(values)
 
         current_website = request.website
-        editable = irQweb.env.user.has_group('website.group_website_designer')
+        editable = has_group_designer = irQweb.env.user.has_group('website.group_website_designer')
         has_group_restricted_editor = irQweb.env.user.has_group('website.group_website_restricted_editor')
         if not editable and has_group_restricted_editor and 'main_object' in values:
             try:
@@ -90,7 +90,7 @@ class IrQWeb(models.AbstractModel):
 
         irQweb = irQweb.with_context(website_id=current_website.id)
         if 'inherit_branding' not in irQweb.env.context and not self.env.context.get('rendering_bundle'):
-            if editable:
+            if has_group_designer and editable:
                 # in edit mode add branding on ir.ui.view tag nodes
                 irQweb = irQweb.with_context(inherit_branding=True)
             elif has_group_restricted_editor:


### PR DESCRIPTION
Steps to reproduce:
- Install website_event, with demo data
- Change Marc Demo's website access to "Restricted Editor"
- Log into Marc Demo and visit an event's website page e.g."Live Music Festival"
- user is able to edits is footer contents,make a change
- try to save.  

Observation: 
A pop-up for access right appears

Cause:
after this fix odoo/odoo@11e94cb059901ffc3c521a431259d627beb69e1e , 
we allow website to be editable for restricted user if, user can modify other
models, which are editable from website,like event.
And, if website is editable, we brand the ir.ui.views nodes, 
https://github.com/odoo/odoo/blob/3ceb04bf2aa90442430f5bf321bac4a9d872752c/addons/website/models/ir_qweb.py#L93-L94
but restricted user do not have access to ir.ui.view model, causing access issue

Note: if a node is branded, that means it is editable

Fix:
Brand ir.ui.view nodes only if user has full access to website editor

opw-4659114


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
