### PR TITLE
[FIX] purchase: inverse quantity on vendor credit note

### DIFF
--- a/addons/purchase/models/purchase_bill_line_match.py
+++ b/addons/purchase/models/purchase_bill_line_match.py
@@ -95,7 +95,7 @@ class PurchaseBillMatch(models.Model):
               FROM purchase_order_line pol
          LEFT JOIN purchase_order po ON pol.order_id = po.id
              WHERE pol.state in ('purchase', 'done')
-               AND pol.product_qty > pol.qty_invoiced
+               AND (pol.product_qty > pol.qty_invoiced OR pol.qty_to_invoice != 0)
                 OR ((pol.display_type = '' OR pol.display_type IS NULL) AND pol.is_downpayment AND pol.qty_invoiced > 0)
         """)
 

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -562,7 +562,7 @@ class PurchaseOrderLine(models.Model):
             'name': self.env['account.move.line']._get_journal_items_full_name(self.name, self.product_id.display_name),
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,
-            'quantity': self.qty_to_invoice,
+            'quantity': -self.qty_to_invoice if move and move.move_type == 'in_refund' else self.qty_to_invoice,
             'discount': self.discount,
             'price_unit': self.currency_id._convert(self.price_unit, aml_currency, self.company_id, date, round=False),
             'tax_ids': [(6, 0, self.taxes_id.ids)],


### PR DESCRIPTION
Steps to reproduce:-
- Create a Purchase Order with Product A(invoicing policy: received quantities)
  and Quantity 3.
- Create Vendor Bill with Product A and Quantity 3 and match it with the PO.
- Receive only 2 on PO.
- Now on PO, Quantity: 3, Received:2, Billed:3
- Create a Vendor Credit Note for that partner, add an empty line and save.
- Click on PO Matching at the top.
- Select line from Vendor Credit Note and line from PO, click match.

Problem: In Vendor Credit Note Quantity: -1 (which should be 1)

Before this commit: When credit note values are prepared from purchase
order, quantity to invoice on purchase order is set as quantity on credit note.

After this commit: When credit note values are prepared from purchase
order, inverse(-ve) of quantity to invoice on purchase order is set as quantity
on credit note.
***
Backport of https://github.com/odoo/odoo/commit/8bcc501a47bbd9df3f7d2a7d2bacd63b0127a087 
***
task-4975200