### PR TITLE
[IMP] mass_mailing: added hacky ai service to qunit test

### DIFF
--- a/addons/mass_mailing/static/tests/mass_mailing_html_tests.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_tests.js
@@ -20,8 +20,15 @@ function makeFakeMailStoreService() {
     };
 }
 
+function makeFakeAILauncherService() {
+    return {
+        start: (env) => ({}),
+    };
+}
+
 function loadServices() {
     registry.category("services").add("mail.store", makeFakeMailStoreService());
+    registry.category("services").add("aiChatLauncher", makeFakeAILauncherService());
 }
 
 QUnit.module('mass_mailing', {}, function () {


### PR DESCRIPTION
Deleted and edited some legacy qunit tests in the web_editor and mass_mailing modules that were failing because of recent changes in the linked enterprise PR. 

Related Enterprise PR: https://github.com/odoo/enterprise/pull/91331
Related Upgrade PR: https://github.com/odoo/upgrade/pull/8143