### PR TITLE
[FIX] website: fix non-deterministic runbot issue

### DIFF
--- a/addons/website/static/tests/tours/client_action_redirect.js
+++ b/addons/website/static/tests/tours/client_action_redirect.js
@@ -1,6 +1,7 @@
 /** @odoo-module */
 
 import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 const testUrl = '/test_client_action_redirect';
 
@@ -11,7 +12,9 @@ const goToBackendSteps = [{
         window.location.assign(`/@${testUrl}`);
     },
     expectUnloadPage: true,
-}, {
+},
+stepUtils.waitIframeIsReady(),
+{
     content: "Check we are in the backend",
     trigger: ".o_website_preview :iframe main:has(#test_contact_BE):has(#test_contact_FE)",
 }];


### PR DESCRIPTION
Previously, the tour step executed too quickly and did not wait for the
page iframe to fully load, causing intermittent failures.

This commit ensure the tour only proceeds after the iframe is
completely loaded.

runbot-230309