### PR TITLE
[FIX] mrp: prevent kit to be filtered as having 0 quantity on hand

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -366,6 +366,8 @@ class ProductProduct(models.Model):
         for product in kit_products:
             if OPERATORS[operator](product.qty_available, value):
                 product_ids.append(product.id)
+            elif product.id in product_ids:
+                product_ids.pop(product_ids.index(product.id))
         return list(set(product_ids))
 
     def action_archive(self):


### PR DESCRIPTION
#### Issue:
- When filtering products on "Quantity on hand", kits may appear when they shouldn't

#### Step to reproduce:
- with MRP
- create a new product
- create a BoM for this product as kit
- make sure you have product of the BoM on hand
- go to product
- add filters:
  - "Quantity on hand" > 1
  - "Quantity on hand" < *less_than_you_have*

#### Current behavior:
- kit appears

#### Expected behavior:
- kit doesn't show

#### Cause:
- kit were filtered has having both 0 quantity (as unstored product) and their quantity (computed from stock of BoM products). Therefore they were compliant with both filter.

#### Solution:
- remove kits from products compliant with the filter if they don't comply with the filter with their computed quantity

opw-4967763

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
