### PR TITLE
[FIX] l10n_be: prevent error on demo data loading if the related tag is deleted

### DIFF
--- a/addons/l10n_be/demo/account_demo.py
+++ b/addons/l10n_be/demo/account_demo.py
@@ -6,16 +6,24 @@ class AccountChartTemplate(models.AbstractModel):
 
     @api.model
     def _get_demo_data(self, company=False):
+        def link_tag(tag_xml_id):
+            tag = self.env.ref(tag_xml_id, raise_if_not_found=False)
+            return [Command.link(tag.id)] if tag else []
+
         demo_data = super()._get_demo_data(company)
         if company.chart_template.startswith('be'):
             cid = company.id
             account_data = demo_data.setdefault('account.account', {})
+            account_tag_map = {
+                'a100': 'account.demo_capital_account',
+                'a300': 'account.demo_stock_account',
+                'a7600': 'account.demo_sale_of_land_account',
+                'a6201': 'account.demo_ceo_wages_account',
+                'a240000': 'account.demo_office_furniture_account',
+            }
             account_data.update({
-                f"account.{cid}_a100": {'tag_ids': [Command.link(self.env.ref('account.demo_capital_account').id)]},
-                f"account.{cid}_a300": {'tag_ids': [Command.link(self.env.ref('account.demo_stock_account').id)]},
-                f"account.{cid}_a7600": {'tag_ids': [Command.link(self.env.ref('account.demo_sale_of_land_account').id)]},
-                f"account.{cid}_a6201": {'tag_ids': [Command.link(self.env.ref('account.demo_ceo_wages_account').id)]},
-                f"account.{cid}_a240000": {'tag_ids': [Command.link(self.env.ref('account.demo_office_furniture_account').id)]},
+                f"account.{cid}_{account}": {'tag_ids': link_tag(tag)}
+                for account, tag in account_tag_map.items()
             })
 
         return demo_data


### PR DESCRIPTION
Currently, installing the Belgium Accounting localization fails with an error, if the user has deleted referenced demo account tags.

**Steps to reproduce:**
- Install the Accounting app.
- Delete the "Demo Capital Account" account tag.
- Install the Belgium Accounting localization (`l10n_be`).

**Error:**
`ValueError - External ID not found in the system: account.demo_capital_account`

At [1], if the `account.demo_capital_account` is not found, it raises an error if the external ID is missing.

This commit prevents the error by explicitly passing `raise_if_not_found=False` and skipping the tag if not found.

[1] -  https://github.com/odoo/odoo/blob/71d1c9a4bef1c29485e3b0390713a9301ad6db4f/addons/l10n_be/demo/account_demo.py#L13-L19

sentry-6776341713