### PR TITLE
[IMP] *: support subsections in sections and notes

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -511,7 +511,7 @@ class AccountBankStatementLine(models.Model):
             state_domain = Domain.OR([state_domain, partnered_drafts_domain])
         return state_domain + [
             # Base domain.
-            ('display_type', 'not in', ('line_section', 'line_note')),
+            ('display_type', 'not in', ('line_section', 'line_subsection', 'line_note')),
             ('company_id', 'in', self.env['res.company'].search([('id', 'child_of', self.company_id.id)]).ids),  # allow to match invoices from same or children companies to be consistant with what's shown in the interface
             # Reconciliation domain.
             ('reconciled', '=', False),

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -1106,7 +1106,7 @@ class AccountJournal(models.Model):
         nb_lines, balance, amount_currency = self.env['account.move.line']._read_group(
             domain=([
                 ('account_id', 'in', tuple(self.default_account_id.ids)),
-                ('display_type', 'not in', ('line_section', 'line_note')),
+                ('display_type', 'not in', ('line_section', 'line_subsection', 'line_note')),
                 ('parent_state', '!=', 'cancel'),
             ] + (domain or [])),
             aggregates=('__count', 'balance:sum', 'amount_currency:sum'),

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -191,7 +191,7 @@ class AccountMove(models.Model):
         inverse_name='move_id',
         string='Journal Items',
         copy=False,
-        domain=[('display_type', 'not in', ('line_section', 'line_note'))],
+        domain=[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))],
     )
 
     # === Link to the partial that created this exchange move === #
@@ -353,7 +353,7 @@ class AccountMove(models.Model):
         'move_id',
         string='Invoice lines',
         copy=False,
-        domain=[('display_type', 'in', ('product', 'line_section', 'line_note'))],
+        domain=[('display_type', 'in', ('product', 'line_section', 'line_subsection', 'line_note'))],
     )
 
     # === Date fields === #
@@ -5130,7 +5130,7 @@ class AccountMove(models.Model):
         for move in self:
             if move.state in ['posted', 'cancel']:
                 validation_msgs.add(_('The entry %(name)s (id %(id)s) must be in draft.', name=move.name, id=move.id))
-            if not move.line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_note')):
+            if not move.line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_subsection', 'line_note')):
                 validation_msgs.add(_("Even magicians can't post nothing!"))
             if not soft and move.auto_post != 'no' and move.date > fields.Date.context_today(self):
                 date_msg = move.date.strftime(get_lang(self.env).date_format)
@@ -5181,7 +5181,7 @@ class AccountMove(models.Model):
             # partner on the lines to be the same as the one on the move, because that's the only one the user can see/edit.
             wrong_lines = invoice.is_invoice() and invoice.line_ids.filtered(lambda aml:
                 aml.partner_id != invoice.commercial_partner_id
-                and aml.display_type not in ('line_note', 'line_section')
+                and aml.display_type not in ('line_section', 'line_subsection', 'line_note')
             )
             if wrong_lines:
                 wrong_lines.write({'partner_id': invoice.commercial_partner_id.id})

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -10,10 +10,7 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
         show_label_warning: { type: Boolean, optional: true, default: false },
     };
 
-    setup() {
-        super.setup();
-        this.descriptionColumn = "name";
-    }
+    static descriptionColumn = "name";
 
     get sectionAndNoteClasses() {
         return {

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -11,7 +11,6 @@
                     t-att-class="sectionAndNoteClasses"
                     t-att-readonly="sectionAndNoteIsReadonly"
                     t-att-value="label"
-                    t-on-change="(ev) => this.updateLabel(ev.target.value)"
                     t-ref="labelNodeRef"
                     t-key="props.readonly"
                 />
@@ -19,12 +18,11 @@
             <t t-elif="isSection()">
                 <input
                     type="text"
-                    class="o_input text-wrap border-0 fst-italic"
+                    class="o_input text-wrap border-0 fst-italic w-100"
                     placeholder="Enter a description"
                     t-att-class="sectionAndNoteClasses"
                     t-att-readonly="sectionAndNoteIsReadonly"
                     t-att-value="label"
-                    t-on-change="(ev) => this.updateLabel(ev.target.value)"
                     t-ref="labelNodeRef"
                     t-key="props.readonly"
                 />
@@ -50,7 +48,6 @@
                     t-att-class="{ ...sectionAndNoteClasses, 'd-none': !(columnIsProductAndLabel.value and (label or !props.readonly and labelVisibility.value)) }"
                     t-att-readonly="props.readonly and isProductClickable ? '1' : ''"
                     t-att-value="label"
-                    t-on-change="(ev) => this.updateLabel(ev.target.value)"
                     t-ref="labelNodeRef"
                     t-key="props.readonly"
                 />

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m.js
@@ -1,10 +1,10 @@
 import {
-    SectionAndNoteListRenderer,
+    SectionAndNoteFieldOne2Many,
     sectionAndNoteFieldOne2Many,
+    SectionAndNoteListRenderer,
 } from "@account/components/section_and_note_fields_backend/section_and_note_fields_backend";
-import { registry } from "@web/core/registry";
-import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { ProductNameAndDescriptionListRendererMixin } from "@product/product_name_and_description/product_name_and_description";
+import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
 
 export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRenderer {
@@ -47,17 +47,16 @@ export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRend
 
 patch(ProductLabelSectionAndNoteListRender.prototype, ProductNameAndDescriptionListRendererMixin);
 
-export class ProductLabelSectionAndNoteOne2Many extends X2ManyField {
+export class ProductLabelSectionAndNoteOne2Many extends SectionAndNoteFieldOne2Many {
     static components = {
-        ...X2ManyField.components,
+        ...super.components,
         ListRenderer: ProductLabelSectionAndNoteListRender,
     };
 }
 
 export const productLabelSectionAndNoteOne2Many = {
-    ...x2ManyField,
+    ...sectionAndNoteFieldOne2Many,
     component: ProductLabelSectionAndNoteOne2Many,
-    additionalClasses: sectionAndNoteFieldOne2Many.additionalClasses,
 };
 
 registry

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -7,7 +7,7 @@
     </t>
     <t t-name="account.SectionAndNoteListRenderer.RecordRow" t-inherit="web.ListRenderer.RecordRow">
         <xpath expr="//td[hasclass('o_list_record_remove')]" position="attributes">
-            <attribute name="t-if">!isSection(record) or props.list.count gt props.list.limit</attribute>
+            <attribute name="t-if">!isSection(record)</attribute>
         </xpath>
         <xpath expr="//td[hasclass('o_list_record_remove')]" position="after">
             <td t-else="" class="o_list_section_options w-print-0 p-print-0 text-center">
@@ -16,39 +16,49 @@
                         <i class="fa fa-ellipsis-v"/>
                     </button>
                     <t t-set-slot="content">
-                        <DropdownItem onSelected="() => this.addRowInSection(record, false)">
-                            <i class="me-1 fa fa-fw fa-plus"/><span>Add a product</span>
-                        </DropdownItem>
-                        <t t-if="this.isTopSection(record)">
-                            <DropdownItem onSelected="() => this.addRowAfterSection(record, false)">
-                                <i class="me-1 fa fa-fw fa-level-down"/><span>Add a section</span>
+                        <t t-if="this.isSectionInPage(record)">
+                            <DropdownItem onSelected="() => this.addRowInSection(record, false)">
+                                <i class="me-1 fa fa-fw fa-plus"/><span>Add a product</span>
                             </DropdownItem>
-                            <t t-if="this.canAddSubSection()">
-                                <DropdownItem onSelected="() => this.addRowInSection(record, true)">
+                            <t t-if="this.isTopSection(record)">
+                                <DropdownItem onSelected="() => this.addRowAfterSection(record, false)">
+                                    <i class="me-1 fa fa-fw fa-level-down"/><span>Add a section</span>
+                                </DropdownItem>
+                                <t t-if="this.canAddSubSection">
+                                    <DropdownItem onSelected="() => this.addRowInSection(record, true)">
+                                        <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
+                                    </DropdownItem>
+                                </t>
+                            </t>
+                            <t t-elif="this.canAddSubSection">
+                                <DropdownItem onSelected="() => this.addRowAfterSection(record, true)">
                                     <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
                                 </DropdownItem>
                             </t>
-                        </t>
-                        <t t-elif="this.canAddSubSection()">
-                            <DropdownItem onSelected="() => this.addRowAfterSection(record, true)">
-                                <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
+                            <DropdownItem onSelected="() => this.addNoteInSection(record)">
+                                <i class="me-1 fa fa-fw fa-sticky-note-o"/><span>Add a note</span>
                             </DropdownItem>
+                            <DropdownItem t-if="this.hasPreviousSection(record)" onSelected="() => this.moveSectionUp(record)">
+                                <i class="me-1 fa fa-fw fa-arrow-up"/><span>Move Up</span>
+                            </DropdownItem>
+                            <t t-set="nextSectionInPage" t-value="this.isNextSectionInPage(record)"/>
+                            <t t-set="moveDownItemAttrs" t-value="nextSectionInPage ? {} : { 'data-tooltip': this.disabledMoveDownItemTooltip }"/>
+                            <t t-set="moveDownItemDefaultProps" t-value="{ attrs: moveDownItemAttrs, class: { 'text-muted': !nextSectionInPage } }"/>
+                            <DropdownItem t-if="this.hasNextSection(record)" t-props="moveDownItemDefaultProps" onSelected="() => this.moveSectionDown(record)">
+                                <i class="me-1 fa fa-fw fa-arrow-down"/><span>Move Down</span>
+                            </DropdownItem>
+                            <DropdownItem onSelected="() => this.duplicateSection(record)">
+                                <i class="me-1 fa fa-fw fa-clone"/><span>Duplicate</span>
+                            </DropdownItem>
+                            <t t-if="hasDeleteButton">
+                                <DropdownItem onSelected="() => this.deleteSection(record)" class="'text-danger'">
+                                    <i class="me-1 fa fa-fw fa-trash"/><span>Delete</span>
+                                </DropdownItem>
+                            </t>
                         </t>
-                        <DropdownItem onSelected="() => this.addNoteInSection(record)">
-                            <i class="me-1 fa fa-fw fa-sticky-note-o"/><span>Add a note</span>
-                        </DropdownItem>
-                        <DropdownItem t-if="this.hasPreviousSection(record)" onSelected="() => this.moveSectionUp(record)">
-                            <i class="me-1 fa fa-fw fa-arrow-up"/><span>Move Up</span>
-                        </DropdownItem>
-                        <DropdownItem t-if="this.hasNextSection(record)" onSelected="() => this.moveSectionDown(record)">
-                            <i class="me-1 fa fa-fw fa-arrow-down"/><span>Move Down</span>
-                        </DropdownItem>
-                        <DropdownItem onSelected="() => this.duplicateSection(record)">
-                            <i class="me-1 fa fa-fw fa-clone"/><span>Duplicate</span>
-                        </DropdownItem>
-                        <t t-if="hasDeleteButton">
-                            <DropdownItem class="'text-danger'" onSelected="() => this.deleteSection(record)">
-                                <i class="me-1 fa fa-fw fa-trash"/><span>Delete</span>
+                        <t t-else="">
+                            <DropdownItem onSelected="() => this.expandPager()" attrs="{ 'data-tooltip': this.showAllItemsTooltip }">
+                                <i class="me-1 fa fa-fw fa-expand"/><span>Show all lines</span>
                             </DropdownItem>
                         </t>
                     </t>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -955,7 +955,7 @@
 
                         <div class="oe_title">
                             <span class="o_form_label">
-                                <field 
+                                <field
                                     name="move_type"
                                     invisible="move_type == 'entry'"
                                     widget="receipt_selector"
@@ -1160,7 +1160,7 @@
                                                groups="account.group_account_readonly"
                                                options="{'no_quick_create': True}"
                                                domain="[('company_ids', 'parent_of', company_id), ('account_type', 'not in', ('asset_receivable', 'liability_payable', 'off_balance'))]"
-                                               required="display_type not in ('line_note', 'line_section')"/>
+                                               required="display_type not in ('line_section', 'line_subsection', 'line_note')"/>
                                         <field name="analytic_distribution" widget="analytic_distribution"
                                                string="Analytic"
                                                groups="analytic.group_analytic_accounting"
@@ -1211,7 +1211,7 @@
                                         <templates>
                                             <t t-name="card">
                                                 <div t-attf-class="ps-0 pe-0 {{ record.display_type.raw_value ? 'o_is_' + record.display_type.raw_value : '' }}">
-                                                    <t t-if="!['line_note', 'line_section'].includes(record.display_type.raw_value)">
+                                                    <t t-if="!['line_note', 'line_section', 'line_subsection'].includes(record.display_type.raw_value)">
                                                         <div class="row g-0">
                                                             <div class="col-2 pe-3">
                                                                 <field name="product_id" widget="image" options="{'preview_image': 'image_128'}" class="w-100"/>
@@ -1242,8 +1242,14 @@
                                                             </div>
                                                         </div>
                                                     </t>
-                                                    <t t-if="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'">
-                                                        <field name="name"/>
+                                                    <t t-if="['line_section', 'line_subsection', 'line_note'].includes(record.display_type.raw_value)">
+                                                        <div t-att-class="{
+                                                            'fw-bolder': record.display_type.raw_value === 'line_section',
+                                                            'fw-bold': record.display_type.raw_value === 'line_subsection',
+                                                            'fst-italic': record.display_type.raw_value === 'line_note',
+                                                        }">
+                                                            <field name="name" />
+                                                        </div>
                                                     </t>
                                                 </div>
                                             </t>
@@ -1266,8 +1272,9 @@
                                             <field name="partner_id" invisible="1"/>
                                             <group>
                                                 <field name="product_id" widget="many2one_barcode"/>
-                                                <label for="name" string="Description" invisible="display_type in ('line_note', 'line_section')"/>
+                                                <label for="name" string="Description" invisible="display_type in ('line_section', 'line_subsection', 'line_note')"/>
                                                 <label for="name" string="Section" invisible="display_type != 'line_section'"/>
+                                                <label for="name" string="Subsection" invisible="display_type != 'line_subsection'"/>
                                                 <label for="name" string="Note" invisible="display_type != 'line_note'"/>
                                                 <field name="name" widget="text" nolabel="1"/>
                                                 <field name="quantity"/>
@@ -1366,11 +1373,11 @@
                                                readonly="tax_line_id or (parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and account_type in ('asset_receivable', 'liability_payable'))"/>
                                         <field name="debit"
                                                sum="Total Debit"
-                                               invisible="display_type in ('line_section', 'line_note')"
+                                               invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('product')"/>
                                         <field name="credit"
                                                sum="Total Credit"
-                                               invisible="display_type in ('line_section', 'line_note')"
+                                               invisible="display_type in ('line_section', 'line_subsection', 'line_note')"
                                                readonly="parent.move_type in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') and display_type in ('product')"/>
                                         <field name="balance" column_invisible="True"/>
                                         <field name="discount_date"
@@ -1785,7 +1792,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_move': 1, 'search_default_posted':1, 'create':0}</field>
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))]</field>
             <field name="view_id" ref="view_move_line_tree"/>
             <field name="view_mode">list,pivot,graph,kanban</field>
         </record>
@@ -1794,7 +1801,7 @@
             <field name="context">{'journal_type':'general', 'search_default_posted':1, 'expand':'1'}</field>
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))]</field>
             <field name="view_id" ref="view_move_line_tree"/>
             <field name="view_mode">list,pivot,graph,kanban</field>
         </record>
@@ -1803,7 +1810,7 @@
             <field name="context">{'journal_type':'sales', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_sales':1, 'expand': 1}</field>
             <field name="name">Sales</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_sales_purchases"/>
             <field name="view_mode">list,pivot,graph,kanban</field>
         </record>
@@ -1812,7 +1819,7 @@
             <field name="context">{'journal_type':'purchase', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_purchases':1, 'expand': 1}</field>
             <field name="name">Purchases</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_sales_purchases"/>
             <field name="view_mode">list,pivot,graph,kanban</field>
         </record>
@@ -1821,7 +1828,7 @@
             <field name="context">{'journal_type':'bank', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_bank':1, 'search_default_cash':1, 'expand': 1}</field>
             <field name="name">Bank and Cash</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_bank_cash"/>
             <field name="view_mode">list,pivot,graph,kanban</field>
         </record>
@@ -1830,7 +1837,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_move': 1, 'search_default_posted':1, 'search_default_misc_filter':1, 'expand': 1}</field>
             <field name="name">Miscellaneous</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_misc"/>
             <field name="view_mode">list,pivot,graph,kanban</field>
         </record>
@@ -1839,7 +1846,7 @@
             <field name="context">{'journal_type':'general', 'search_default_group_by_partner': 1, 'search_default_posted':1, 'search_default_trade_payable':1, 'search_default_trade_receivable':1, 'search_default_unreconciled':1}</field>
             <field name="name">Partner Ledger</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))]</field>
             <field name="view_id" ref="view_move_line_tree_grouped_partner"/>
             <field name="search_view_id" ref="view_account_move_line_filter"/>
             <field name="view_mode">list,pivot,graph</field>
@@ -1848,7 +1855,7 @@
         <record id="action_account_moves_all_tree" model="ir.actions.act_window">
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note'))]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note'))]</field>
             <field name="context">{'search_default_partner_id': [active_id], 'default_partner_id': active_id, 'search_default_posted':1}</field>
             <field name="view_id" ref="view_move_line_tree"/>
         </record>
@@ -1858,7 +1865,7 @@
             <field name="name">Journal Items</field>
             <field name="res_model">account.move.line</field>
             <field name="path">items</field>
-            <field name="domain">[('display_type', 'not in', ('line_section', 'line_note')), ('parent_state', '!=', 'cancel')]</field>
+            <field name="domain">[('display_type', 'not in', ('line_section', 'line_subsection', 'line_note')), ('parent_state', '!=', 'cancel')]</field>
             <field name="view_id" ref="view_move_line_tree"/>
             <field name="view_mode">list,pivot,graph,kanban</field>
         </record>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -173,7 +173,11 @@
                                     <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                                     <t t-set="current_total" t-value="current_total + line.price_total"/>
 
-                                    <tr t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
+                                    <tr t-att-class="{
+                                        'fw-bolder': line.display_type == 'line_section',
+                                        'fw-bold': line.display_type == 'line_subsection',
+                                        'fst-italic': line.display_type == 'line_note',
+                                    }" >
                                         <t t-if="line.display_type == 'product'" name="account_invoice_line_accountable">
                                             <td name="account_invoice_line_name">
                                                 <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
@@ -202,7 +206,7 @@
                                                 <span t-if="o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
                                             </td>
                                         </t>
-                                        <t t-elif="line.display_type == 'line_section'">
+                                        <t t-elif="line.display_type in ('line_section', 'line_subsection')">
                                             <td colspan="99">
                                                 <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
                                             </td>
@@ -215,8 +219,7 @@
                                             </td>
                                         </t>
                                     </tr>
-
-                                    <t t-if="current_section and (line_last or lines[line_index+1].display_type == 'line_section')">
+                                    <t t-if="current_section and (line_last or lines[line_index+1].display_type in ('line_section', 'line_subsection'))">
                                         <tr class="is-subtotal text-end">
                                             <td colspan="99">
                                                 <strong class="mr16">Subtotal</strong>

--- a/addons/account/wizard/account_merge_wizard.py
+++ b/addons/account/wizard/account_merge_wizard.py
@@ -234,6 +234,7 @@ class AccountMergeWizardLine(models.TransientModel):
     display_type = fields.Selection(
         selection=[
             ('line_section', "Section"),
+            ('line_subsection', "Subsection"),
             ('account', "Account"),
         ],
         required=True,

--- a/addons/account/wizard/account_merge_wizard_views.xml
+++ b/addons/account/wizard/account_merge_wizard_views.xml
@@ -13,7 +13,7 @@
                                nolabel="1"
                                widget="account_merge_wizard_lines_one2many">
                             <list editable="bottom" create="0" delete="0">
-                                <field name="is_selected" nolabel="1" invisible="display_type == 'line_section'"/>
+                                <field name="is_selected" nolabel="1" invisible="display_type == 'line_section' or display_type == 'line_subsection'"/>
                                 <field name="account_id" force_save="1"/>
                                 <field name="company_ids" widget="many2many_tags"/>
                                 <field name="info" decoration-danger="display_type == 'account'"/>

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -152,7 +152,7 @@ class AccountMoveReversal(models.TransientModel):
                 moves_vals_list = []
                 for move in moves.with_context(include_business_fields=True):
                     data = move.copy_data(self._modify_default_reverse_values(move))[0]
-                    data['line_ids'] = [line for line in data['line_ids'] if line[2]['display_type'] in ('product', 'line_section', 'line_note')]
+                    data['line_ids'] = [line for line in data['line_ids'] if line[2]['display_type'] in ('product', 'line_section', 'line_subsection', 'line_note')]
                     moves_vals_list.append(data)
                 new_moves = self.env['account.move'].create(moves_vals_list)
 

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -343,7 +343,7 @@ class AccountEdiCommon(models.AbstractModel):
 
     def _invoice_constraints_common(self, invoice):
         # check that there is a tax on each line
-        for line in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section') and x._check_edi_line_tax_required()):
+        for line in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_section', 'line_subsection', 'line_note') and x._check_edi_line_tax_required()):
             if not line.tax_ids:
                 return {'tax_on_line': _("Each invoice line should have at least one tax.")}
         return {}

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -333,7 +333,7 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
                 constraints.update({'cen_en16931_item_name': _("Each invoice line should have a product or a label.")})
                 break
 
-        for line in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section')):
+        for line in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_section', 'line_subsection', 'line_note')):
             if len(line.tax_ids.flatten_taxes_hierarchy().filtered(lambda t: t.amount_type != 'fixed')) != 1:
                 # [UBL-SR-48]-Invoice lines shall have one and only one classified tax category.
                 # /!\ exception: possible to have any number of ecotaxes (fixed tax) with a regular percentage tax

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -86,7 +86,7 @@ class AccountMove(models.Model):
     def _get_concept(self):
         """ Method to get the concept of the invoice considering the type of the products on the invoice """
         self.ensure_one()
-        invoice_lines = self.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section'))
+        invoice_lines = self.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_section', 'line_subsection', 'line_note'))
         product_types = set([x.product_id.type for x in invoice_lines if x.product_id])
         consumable = {'consu'}
         service = set(['service'])
@@ -133,7 +133,7 @@ class AccountMove(models.Model):
             # we require a single vat on each invoice line except from some purchase documents
             if inv.move_type in ['in_invoice', 'in_refund'] and inv.l10n_latam_document_type_id.purchase_aliquots == 'zero':
                 purchase_aliquots = 'zero'
-            for line in inv.mapped('invoice_line_ids').filtered(lambda x: x.display_type not in ('line_section', 'line_note')):
+            for line in inv.mapped('invoice_line_ids').filtered(lambda x: x.display_type not in ('line_section', 'line_subsection', 'line_note')):
                 vat_taxes = line.tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)
                 if len(vat_taxes) != 1:
                     raise UserError(_("There should be a single tax from the “VAT“ tax group per line, but this is not the case for line “%s”. Please add a tax to this line or check the tax configuration's advanced options for the corresponding field “Tax Group”.", line.name))

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -680,7 +680,7 @@ class TestAr(AccountTestInvoicingCommon):
             for line in data.get('lines', [{}]):
                 with invoice_form.invoice_line_ids.new() as invoice_line_form:
                     invoice_line_form.display_type = line.get('display_type', 'product')
-                    if line.get('display_type') in ('line_note', 'line_section'):
+                    if line.get('display_type') in ('line_section', 'line_subsection', 'line_note'):
                         invoice_line_form.name = line.get('name', 'not invoice line')
                     else:
                         invoice_line_form.product_id = line.get('product', self.product_iva_21)

--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -417,11 +417,11 @@ class AccountEdiFormat(models.Model):
             errors.append(_("Please add all the required fields in the branch details"))
         if not self._l10n_eg_validate_info_address(invoice.partner_id, invoice=invoice):
             errors.append(_("Please add all the required fields in the customer details"))
-        if not all(aml.product_uom_id.l10n_eg_unit_code_id.code for aml in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section'))):
+        if not all(aml.product_uom_id.l10n_eg_unit_code_id.code for aml in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_section', 'line_subsection', 'line_note'))):
             errors.append(_("Please make sure the invoice lines UoM codes are all set up correctly"))
-        if not all(tax.l10n_eg_eta_code for tax in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section')).tax_ids):
+        if not all(tax.l10n_eg_eta_code for tax in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_section', 'line_subsection', 'line_note')).tax_ids):
             errors.append(_("Please make sure the invoice lines taxes all have the correct ETA tax code"))
-        if not all(aml.product_id.l10n_eg_eta_code or aml.product_id.barcode for aml in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section'))):
+        if not all(aml.product_id.l10n_eg_eta_code or aml.product_id.barcode for aml in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_section', 'line_subsection', 'line_note'))):
             errors.append(_("Please make sure the EGS/GS1 Barcode is set correctly on all products"))
         return errors
 

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -621,7 +621,7 @@ class AccountEdiFormat(models.Model):
         if not move.company_id.vat:
             res.append(_("VAT number is missing on company %s", move.company_id.display_name))
         total_taxes = self.env['account.tax']
-        for line in move.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section')):
+        for line in move.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_subsection', 'line_note')):
             taxes = line.tax_ids.flatten_taxes_hierarchy()
             total_taxes |= taxes
             recargo_count = taxes.mapped('l10n_es_type').count('recargo')

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -255,8 +255,12 @@
                             <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                             <t t-set="current_total" t-value="current_subtotal + line.price_total" t-if="o.tax_calculation_rounding_method == 'round_per_line'"/>
 
-                            <tr t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
-                                <t t-if="line.display_type not in ('line_note', 'line_section')" name="account_invoice_line_accountable">
+                            <tr t-att-class="{
+                                'fw-bolder': line.display_type == 'line_section',
+                                'fw-bold': line.display_type == 'line_subsection',
+                                'fst-italic': line.display_type == 'line_note',
+                            }" >
+                                <t t-if="line.display_type not in ('line_section', 'line_subsection', 'line_note')" name="account_invoice_line_accountable">
                                     <td class="text-end o_price_total">
                                         <span class="text-nowrap" t-field="line.price_total"/>
                                     </td>
@@ -293,7 +297,7 @@
                                     </td>
 
                                 </t>
-                                <t t-if="line.display_type == 'line_section'">
+                                <t t-if="line.display_type in ('line_section', 'line_subsection')">
                                     <td colspan="99">
                                         <span t-field="line.name" t-options="{'widget': 'text'}"/>
                                     </td>
@@ -306,8 +310,7 @@
                                     </td>
                                 </t>
                             </tr>
-
-                            <t t-if="current_section and (line_last or lines[line_index+1].display_type == 'line_section')">
+                            <t t-if="current_section and (line_last or lines[line_index+1].display_type in ('line_section', 'line_subsection'))">
                                 <tr class="is-subtotal text-end">
                                     <td colspan="99">
                                         <strong class="mr16" style="display: inline-block">Subtotal/الإجمالي الفرعي</strong>
@@ -560,7 +563,7 @@
                         </div>
                     </div>
                 </p>
-                
+
                 <p name="incoterm" t-if="0"></p>
                 <div class="row" t-if="o.invoice_incoterm_id" name="incoterm">
                     <div class="col-2 offset-6">

--- a/addons/l10n_gr_edi/models/account_move.py
+++ b/addons/l10n_gr_edi/models/account_move.py
@@ -649,7 +649,7 @@ class AccountMove(models.Model):
         move_disallow_classification = self.is_purchase_document(include_receipts=True) and self.l10n_gr_edi_inv_type in TYPES_WITH_FORBIDDEN_CLASSIFICATION
 
         for line_no, line in enumerate(self.invoice_line_ids, start=1):
-            if line.display_type in ('line_section', 'line_note'):
+            if line.display_type in ('line_section', 'line_subsection', 'line_note'):
                 continue
             if move_disallow_classification and line.l10n_gr_edi_cls_category:
                 errors[f'l10n_gr_edi_{line_no}_forbidden_classification'] = {

--- a/addons/l10n_it_edi/data/invoice_it_simplified_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_simplified_template.xml
@@ -95,7 +95,7 @@
                             <ElementiRettificati t-out="format_alphanumeric(record.ref, 1000)"/>
                         </DatiFatturaRettificata>
                     </DatiGenerali>
-                    <t t-foreach="record.invoice_line_ids.filtered(lambda l: l.display_type not in ('line_note', 'line_section'))" t-as="line">
+                    <t t-foreach="record.invoice_line_ids.filtered(lambda l: l.display_type not in ('line_section', 'line_subsection', 'line_note'))" t-as="line">
                         <t t-call="l10n_it_edi.account_invoice_line_it_simplified_FatturaPA"/>
                     </t>
                     <Allegati t-if="pdf">

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -771,7 +771,7 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
         scopes = []
-        for line in self.invoice_line_ids.filtered(lambda l: l.display_type not in ('line_note', 'line_section')):
+        for line in self.invoice_line_ids.filtered(lambda l: l.display_type not in ('line_section', 'line_subsection', 'line_note')):
             tax_ids_with_tax_scope = line.tax_ids.filtered(lambda x: x.tax_scope)
             if tax_ids_with_tax_scope:
                 scopes += tax_ids_with_tax_scope.mapped('tax_scope')
@@ -833,7 +833,7 @@ class AccountMove(models.Model):
         return any(
             professional_fee_tag.id in line.account_id.tag_ids.ids
             for line in self.invoice_line_ids
-            if line.display_type not in ('line_note', 'line_section')
+            if line.display_type not in ('line_section', 'line_subsection', 'line_note')
         )
 
     def _l10n_it_edi_features_for_document_type_selection(self):

--- a/addons/l10n_it_stock_ddt/models/account_invoice.py
+++ b/addons/l10n_it_stock_ddt/models/account_invoice.py
@@ -45,7 +45,7 @@ class AccountMove(models.Model):
             return {}
         line_count = 0
         invoice_line_pickings = {}
-        for line in self.invoice_line_ids.filtered(lambda l: l.display_type not in ('line_note', 'line_section')):
+        for line in self.invoice_line_ids.filtered(lambda l: l.display_type not in ('line_section', 'line_subsection', 'line_note')):
             line_count += 1
             done_moves_related = line.sale_line_ids.mapped('move_ids').filtered(
                 lambda m: m.state == 'done' and m.location_dest_id.usage == 'customer' and m.picking_type_id.code == 'outgoing')

--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -367,7 +367,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
 
         refund_move = line.move_id
         invoice_move = refund_move.reversed_entry_id
-        invoice_lines = invoice_move.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section'))
+        invoice_lines = invoice_move.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_subsection', 'line_note'))
         n = len(invoice_lines)
 
         line_id = -1

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -285,13 +285,13 @@ class AccountMove(models.Model):
                 error_msgs.append(_('Please make sure the "Customer Reference" contains the reason for the return'))
 
         if any(
-            line.display_type not in ('line_note', 'line_section')
+            line.display_type not in ('line_section', 'line_subsection', 'line_note')
             and (line.quantity < 0 or line.price_unit < 0)
             for line in self.invoice_line_ids
         ):
             error_msgs.append(_("JoFotara portal cannot process negative quantity nor negative price on invoice lines"))
 
-        for line in self.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section')):
+        for line in self.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_subsection', 'line_note')):
             if self.company_id.l10n_jo_edi_taxpayer_type == 'income' and len(line.tax_ids) != 0:
                 error_msgs.append(_("No taxes are allowed on invoice lines for taxpayers unregistered in the sales tax"))
             elif self.company_id.l10n_jo_edi_taxpayer_type == 'sales' and len(line.tax_ids) != 1:

--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -364,7 +364,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             if partner.commercial_partner_id.sst_registration_number and len(partner.commercial_partner_id.sst_registration_number.split(';')) > 2:
                 self._l10n_my_edi_make_validation_error(constraints, 'too_many_sst', partner_type, partner.commercial_partner_id.display_name)
 
-        for line in invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section')):
+        for line in invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_subsection', 'line_note')):
             if (not line.product_id or not line.product_id.product_tmpl_id.l10n_my_edi_classification_code) and not line.l10n_my_edi_classification_code:
                 self._l10n_my_edi_make_validation_error(constraints, 'class_code_required', line.id, line.display_name)
             if not line.tax_ids:

--- a/addons/product/static/src/product_name_and_description/product_name_and_description.js
+++ b/addons/product/static/src/product_name_and_description/product_name_and_description.js
@@ -6,6 +6,7 @@ import { Component, onMounted, onPatched, onWillUnmount, useEffect, useRef, useS
 import { Many2OneField } from "@web/views/fields/many2one/many2one_field";
 import { useProductAndLabelAutoresize } from "./product_and_label_autoresize";
 import { computeM2OProps, Many2One } from "@web/views/fields/many2one/many2one";
+import { useInputField } from "@web/views/fields/input_field_hook";
 
 export const ProductNameAndDescriptionListRendererMixin = {
     getCellTitle(column, record) {
@@ -42,6 +43,8 @@ export class ProductNameAndDescriptionField extends Component {
     static props = { ...Many2OneField.props };
     static template = Many2One.template;
 
+    static descriptionColumn = "";
+
     setup() {
         this.isPrintMode = useState({ value: false });
         this.labelVisibility = useState({ value: false });
@@ -51,6 +54,14 @@ export class ProductNameAndDescriptionField extends Component {
         useProductAndLabelAutoresize(this.labelNode, { targetParentName: this.props.name });
         this.productNode = useRef("productNodeRef");
         useProductAndLabelAutoresize(this.productNode, { targetParentName: this.props.name });
+
+        this.descriptionColumn = this.constructor.descriptionColumn;
+        useInputField({
+            ref: this.labelNode,
+            fieldName: this.descriptionColumn,
+            getValue: () => this.label,
+            parse: (v) => this.parseLabel(v),
+        });
 
         useEffect(
             () => {
@@ -128,10 +139,8 @@ export class ProductNameAndDescriptionField extends Component {
         this.switchToLabel = true;
     }
 
-    updateLabel(value) {
-        this.props.record.update({
-            [this.descriptionColumn]: value || this.productName,
-        });
+    parseLabel(value) {
+        return value || this.productName;
     }
 
     /**

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -52,7 +52,7 @@ class AccountMove(models.Model):
 
         # Copy data from PO
         invoice_vals = self.purchase_id.with_company(self.purchase_id.company_id)._prepare_invoice()
-        has_invoice_lines = bool(self.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section')))
+        has_invoice_lines = bool(self.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_section', 'line_subsection', 'line_note')))
         new_currency_id = self.currency_id if has_invoice_lines else invoice_vals.get('currency_id')
         del invoice_vals['company_id']  # avoid recomputing the currency
         if self.move_type == invoice_vals['move_type']:

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -733,7 +733,7 @@ class PurchaseOrder(models.Model):
             invoice_vals = order._prepare_invoice()
             # Invoice line values (keep only necessary sections).
             for line in order.order_line:
-                if line.display_type == 'line_section':
+                if line.display_type in ('line_section', 'line_subsection'):
                     pending_section = line
                     continue
                 if pending_section:
@@ -822,7 +822,7 @@ class PurchaseOrder(models.Model):
                 # Merge RFQs into the oldest purchase order
                 rfqs -= oldest_rfq
                 for rfq_line in rfqs.order_line:
-                    existing_line = oldest_rfq.order_line.filtered(lambda l: l.display_type not in ['line_note', 'line_section'] and
+                    existing_line = oldest_rfq.order_line.filtered(lambda l: l.display_type not in ['line_section', 'line_subsection', 'line_note'] and
                                                                                 l.product_id == rfq_line.product_id and
                                                                                 l.product_uom_id == rfq_line.product_uom_id and
                                                                                 l.analytic_distribution == rfq_line.analytic_distribution and

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -71,6 +71,7 @@ class PurchaseOrderLine(models.Model):
         string='Tax calculation rounding method', readonly=True)
     display_type = fields.Selection([
         ('line_section', "Section"),
+        ('line_subsection', "Subsection"),
         ('line_note', "Note")], default=False, help="Technical field for UX purpose.")
     is_downpayment = fields.Boolean()
     selected_seller_id = fields.Many2one('product.supplierinfo', compute='_compute_selected_seller_id', help='Technical field to get the vendor pricelist used to generate this line')
@@ -240,7 +241,7 @@ class PurchaseOrderLine(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_except_purchase(self):
         for line in self:
-            if line.order_id.state == 'purchase' and line.display_type not in ['line_note', 'line_section']:
+            if line.order_id.state == 'purchase' and line.display_type not in ['line_section', 'line_subsection', 'line_note']:
                 state_description = {state_desc[0]: state_desc[1] for state_desc in self._fields['state']._description_selection(self.env)}
                 raise UserError(_('Cannot delete a purchase order line which is in state “%s”.', state_description.get(line.state)))
 

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -69,7 +69,11 @@
                     <t t-foreach="o.order_line.filtered(lambda l: l.display_type or l.product_qty != 0)" t-as="line">
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
 
-                        <tr t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
+                        <tr t-att-class="{
+                            'fw-bolder': line.display_type == 'line_section',
+                            'fw-bold': line.display_type == 'line_subsection',
+                            'fst-italic': line.display_type == 'line_note',
+                        }" >
                             <t t-if="not line.display_type">
                                 <td id="product" class="text-start">
                                     <span t-field="line.name"/>
@@ -96,7 +100,7 @@
                                         t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                 </td>
                             </t>
-                            <t t-if="line.display_type == 'line_section'">
+                            <t t-if="line.display_type in ('line_section', 'line_subsection')">
                                 <td colspan="99" id="section">
                                     <span t-field="line.name"/>
                                 </td>
@@ -109,7 +113,7 @@
                                 </td>
                             </t>
                         </tr>
-                        <t t-if="current_section and (line_last or o.order_line[line_index+1].display_type == 'line_section')">
+                        <t t-if="current_section and (line_last or o.order_line[line_index+1].display_type in ('line_section', 'line_subsection'))">
                             <tr class="is-subtotal text-end">
                                 <td colspan="99" id="subtotal">
                                     <strong class="mr16">Subtotal</strong>

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -35,7 +35,11 @@
                 </thead>
                 <tbody>
                     <t t-foreach="o.order_line.filtered(lambda l: l.display_type or l.product_qty != 0)" t-as="order_line">
-                        <tr t-att-class="'fw-bold o_line_section' if order_line.display_type == 'line_section' else 'fst-italic o_line_note' if order_line.display_type == 'line_note' else ''">
+                        <tr t-att-class="{
+                            'fw-bolder o_line_section': order_line.display_type == 'line_section',
+                            'fw-bold o_line_subsection': order_line.display_type == 'line_subsection',
+                            'fst-italic o_line_note': order_line.display_type == 'line_note',
+                        }">
                             <t t-if="not order_line.display_type">
                                 <td id="product">
                                     <span t-field="order_line.name"/>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -304,7 +304,11 @@
 
                               <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
 
-                            <tr t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic text-break' if line.display_type == 'line_note' else ''">
+                            <tr t-att-class="{
+                                'fw-bolder o_line_section': line.display_type == 'line_section',
+                                'fw-bold o_line_subsection': line.display_type == 'line_subsection',
+                                'fst-italic o_line_note': line.display_type == 'line_note',
+                            }">
                                 <t t-if="not line.display_type">
                                     <td id="product_name" class="d-flex">
                                         <img t-att-src="image_data_uri(resize_to_48(line.product_id.image_1024))" alt="Product" class="d-none d-lg-inline"/>
@@ -347,7 +351,7 @@
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
                                     </td>
                                 </t>
-                                <t t-if="line.display_type == 'line_section'">
+                                <t t-if="line.display_type in ('line_section', 'line_subsection')">
                                     <td colspan="99">
                                         <span t-field="line.name"/>
                                     </td>
@@ -360,8 +364,7 @@
                                     </td>
                                 </t>
                             </tr>
-
-                            <t t-if="current_section and (line_last or order.order_line[line_index+1].display_type == 'line_section') and order.state == 'purchase'">
+                            <t t-if="current_section and (line_last or order.order_line[line_index+1].display_type in ('line_section', 'line_subsection')) and order.state == 'purchase'">
                                 <tr class="is-subtotal text-end">
                                     <td colspan="99">
                                         <strong class="mr16">Subtotal</strong>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -333,6 +333,7 @@
                                             </group>
                                         </group>
                                         <label for="name" string="Section Name (eg. Products, Services)" invisible="display_type != 'line_section'"/>
+                                        <label for="name" string="Subsection Name" invisible="display_type != 'line_subsection'"/>
                                         <label for="name" string="Note" invisible="display_type != 'line_note'"/>
                                         <field name="name" nolabel="1"  invisible="not display_type"/>
                                 </form>
@@ -366,8 +367,12 @@
                                                     Discount: <field name="discount" />%
                                                 </span>
                                             </t>
-                                            <div t-elif="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'">
-                                                <div t-attf-class="{{record.display_type.raw_value === 'line_section' ? 'fw-bold' : 'fst-italic' }}">
+                                            <div t-elif="['line_section', 'line_subsection', 'line_note'].includes(record.display_type.raw_value)">
+                                                <div t-att-class="{
+                                                    'fw-bolder': record.display_type.raw_value === 'line_section',
+                                                    'fw-bold': record.display_type.raw_value === 'line_subsection',
+                                                    'fst-italic': record.display_type.raw_value === 'line_note',
+                                                }">
                                                     <field name="name" />
                                                 </div>
                                             </div>

--- a/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
@@ -96,5 +96,5 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
             'product_uom_id': order_line.product_uom_id.id,
             'display_type': order_line.display_type,
             'analytic_distribution': order_line.analytic_distribution,
-            **({'name': order_line.name} if order_line.display_type in ('line_section', 'line_note') or not has_product_description else {}),
+            **({'name': order_line.name} if order_line.display_type in ('line_section', 'line_subsection', 'line_note') or not has_product_description else {}),
         }

--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -23,7 +23,7 @@
         <br/>
         <t t-set="documents" t-value="object._get_product_documents()"/>
         <t t-if="documents">
-            <br/> 
+            <br/>
             <t t-if="len(documents)>1">
                 Here are some additional documents that may interest you:
             </t>
@@ -111,7 +111,7 @@
         <br/>
         <t t-set="documents" t-value="object._get_product_documents()"/>
         <t t-if="documents">
-            <br/> 
+            <br/>
             <t t-if="len(documents)>1">
                 Here are some additional documents that may interest you:
             </t>
@@ -166,7 +166,7 @@
             <t t-set="current_subtotal" t-value="current_subtotal + line_subtotal"/>
             <t
                 t-if="(not hasattr(line, 'is_delivery') or not line.is_delivery) and (
-                    line.display_type in ['line_section', 'line_note']
+                    line.display_type in ['line_section', 'line_subsection', 'line_note']
                     or line.product_type == 'combo'
                 )"
             >
@@ -175,8 +175,8 @@
                     <tr t-att-style="'background-color: #f2f2f2' if loop_cycle_number % 2 == 0 else 'background-color: #ffffff'">
                         <t t-set="loop_cycle_number" t-value="loop_cycle_number + 1" />
                         <td colspan="4">
-                            <t t-if="line.display_type == 'line_section' or line.product_type == 'combo'">
-                                <span style="font-weight:bold;" t-out="line.name or ''">Taking care of Trees Course</span>
+                            <t t-if="line.display_type in ('line_section', 'line_subsection') or line.product_type == 'combo'">
+                                <span t-att-style="'font-weight:bold;' if line.display_type == 'line_subsection' else 'font-weight:bolder;'" t-out="line.name or ''">Taking care of Trees Course</span>
                                 <t t-set="current_section" t-value="line"/>
                                 <t t-set="current_subtotal" t-value="0"/>
                             </t>
@@ -211,7 +211,7 @@
             <t
                 t-if="current_section and (
                     line_last
-                    or object.order_line[line_index+1].display_type == 'line_section'
+                    or object.order_line[line_index+1].display_type in ('line_section', 'line_subsection')
                     or object.order_line[line_index+1].product_type == 'combo'
                     or (
                         line.combo_item_id

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -932,8 +932,8 @@ class SaleOrder(models.Model):
                 # come first.
                 update_commands = [Command.update(
                     order_line.id,
-                    {'sequence': line.sequence + len(selected_combo_items) + line_index - index},
-                ) for line_index, order_line in enumerate(self.order_line) if line_index > index]
+                    {'sequence': order_line.sequence + len(selected_combo_items)},
+                ) for order_line in self.order_line if order_line.sequence > line.sequence]
 
                 # Clear `selected_combo_items` to avoid applying the same changes multiple times.
                 line.selected_combo_items = False
@@ -1437,7 +1437,7 @@ class SaleOrder(models.Model):
         precision = self.env['decimal.precision'].precision_get('Product Unit')
 
         for line in self.order_line:
-            if line.display_type == 'line_section':
+            if line.display_type in ('line_section', 'line_subsection'):
                 section_line_ids = [line.id]  # Start a new section.
                 continue
             if line.display_type != 'line_note' and float_is_zero(line.qty_to_invoice, precision_digits=precision):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -66,6 +66,7 @@ class SaleOrderLine(models.Model):
     display_type = fields.Selection(
         selection=[
             ('line_section', "Section"),
+            ('line_subsection', "Subsection"),
             ('line_note', "Note"),
         ],
         default=False)

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -98,14 +98,12 @@
                     <t t-foreach="lines_to_report" t-as="line">
 
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
-
                         <tr
-                            t-att-class="'fw-bold o_line_section' if (
-                                line.display_type == 'line_section'
-                                or line.product_type == 'combo'
-                            )
-                            else 'fst-italic o_line_note' if line.display_type == 'line_note'
-                            else ''"
+                            t-att-class="{
+                                'fw-bolder o_line_section': line.display_type == 'line_section' or line.product_type == 'combo',
+                                'fw-bold o_line_subsection': line.display_type == 'line_subsection',
+                                'fst-italic o_line_note': line.display_type == 'line_note',
+                            }"
                         >
                             <t t-if="not line.display_type and line.product_type != 'combo'">
                                 <td name="td_name"><span t-field="line.name">Bacon Burger</span></td>
@@ -131,7 +129,7 @@
                                     <span t-field="line.price_subtotal">27.00</span>
                                 </td>
                             </t>
-                            <t t-elif="line.display_type == 'line_section' or line.product_type == 'combo'">
+                            <t t-elif="line.display_type in ('line_section', 'line_subsection') or line.product_type == 'combo'">
                                 <td name="td_section_line" colspan="99">
                                     <span t-field="line.name">A section title</span>
                                 </td>
@@ -144,7 +142,6 @@
                                 </td>
                             </t>
                         </tr>
-
                         <t
                             t-if="current_section and (
                                 line_last

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -87,6 +87,10 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
     isComboItem(record) {
         return !!record.data.combo_item_id;
     }
+
+    shouldDuplicateSectionItem(record) {
+        return !this.isCombo(record) && !this.isComboItem(record);
+    }
 }
 
 export class SaleOrderLineOne2Many extends ProductLabelSectionAndNoteOne2Many {

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -154,16 +154,11 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         return this.props.record.data.translated_product_name;
     }
 
-    updateLabel(value) {
+    parseLabel(value) {
         if (!this.translatedProductName) {
-            return super.updateLabel(value);
+            return super.parseLabel(value);
         }
-        this.props.record.update({
-            name: (
-                value && this.translatedProductName.concat("\n", value)
-                || this.translatedProductName
-            ),
-        });
+        return value && this.translatedProductName.concat("\n", value) || this.translatedProductName;
     }
 
     get m2oProps() {

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -498,7 +498,9 @@
                             name="order_line"
                             widget="sol_o2m"
                             mode="list,kanban"
-                            readonly="state == 'cancel' or locked">
+                            readonly="state == 'cancel' or locked"
+                            aggregated_fields="price_subtotal,price_total"
+                        >
                             <form>
                                 <field name="technical_price_unit" invisible="1"/>
                                 <!--
@@ -570,6 +572,7 @@
                                 </group>
                                 <label for="name" string="Description" invisible="display_type"/>
                                 <label for="name" string="Section Name (eg. Products, Services)" invisible="display_type != 'line_section'"/>
+                                <label for="name" string="Subsection Name" invisible="display_type != 'line_subsection'"/>
                                 <label for="name" string="Note" invisible="display_type != 'line_note'"/>
                                 <field name="name"/>
                                 <div name="invoice_lines" groups="base.group_no_one" invisible="display_type">
@@ -783,9 +786,13 @@
                                                 </t>
                                             </main>
                                         </t>
-                                        <t t-if="record.display_type.raw_value === 'line_section' || record.display_type.raw_value === 'line_note'">
-                                            <div t-attf-class="{{record.display_type.raw_value === 'line_section' ? 'fw-bold' : 'fst-italic' }}">
-                                                <field name="name"/>
+                                        <t t-if="['line_section', 'line_subsection', 'line_note'].includes(record.display_type.raw_value)">
+                                            <div t-att-class="{
+                                                'fw-bolder': record.display_type.raw_value === 'line_section',
+                                                'fw-bold': record.display_type.raw_value === 'line_subsection',
+                                                'fst-italic': record.display_type.raw_value === 'line_note',
+                                            }">
+                                                <field name="name" />
                                             </div>
                                         </t>
                                     </t>
@@ -897,7 +904,7 @@
                 <field name="team_id" string="Sales Team"/>
                 <field name="order_line" string="Product" filter_domain="[('order_line.product_id', 'ilike', self)]"/>
                 <field name="activity_user_id" string="Activities of"/>
-                <field name="activity_type_id" string="Activity type"/> 
+                <field name="activity_type_id" string="Activity type"/>
                 <!-- We only allow to search on the following sale order line fields (product, name) because the other fields, such as price, quantity, ...
                     will not be searched as often, and if they need to be searched it's usually in the context of products
                     and then they can be searched from the page listing the sale order lines related to a product (from the product itself).

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -725,12 +725,11 @@
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                                 <t t-set="is_note" t-value="line.display_type == 'line_note'"/>
                                 <tr
-                                    t-att-class="'fw-bold o_line_section' if (
-                                        line.display_type == 'line_section'
-                                        or line.product_type == 'combo'
-                                    )
-                                    else 'fst-italic o_line_note' if is_note
-                                    else ''"
+                                    t-att-class="{
+                                        'fw-bolder o_line_section': line.display_type == 'line_section' or line.product_type == 'combo',
+                                        'fw-bold o_line_subsection': line.display_type == 'line_subsection',
+                                        'fst-italic o_line_note': line.display_type == 'line_note',
+                                    }"
                                 >
                                     <t
                                         name="product_line_row"
@@ -768,7 +767,7 @@
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
                                         </td>
                                     </t>
-                                    <t t-if="line.display_type == 'line_section' or line.product_type == 'combo'">
+                                    <t t-if="line.display_type in ('line_section', 'line_subsection') or line.product_type == 'combo'">
                                         <td colspan="99">
                                             <span t-field="line.name"/>
                                         </td>
@@ -784,7 +783,7 @@
                                 <tr
                                     t-if="current_section and (
                                         line_last
-                                        or lines_to_report[line_index+1].display_type == 'line_section'
+                                        or lines_to_report[line_index+1].display_type in ('line_section', 'line_subsection')
                                         or lines_to_report[line_index+1].product_type == 'combo'
                                         or (
                                             line.combo_item_id

--- a/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
+++ b/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
@@ -200,7 +200,7 @@ class SaleEdiXmlUbl_Bis3(models.AbstractModel):
         return allowance_charge_vals
 
     def _get_order_line_vals(self, order_lines, customer, supplier):
-        filtered_order_lines = order_lines.filtered(lambda l: l.display_type not in ['line_note', 'line_section'])
+        filtered_order_lines = order_lines.filtered(lambda l: l.display_type not in ['line_section', 'line_subsection', 'line_note'])
         order_lines_to_process = []
         for line_id, line in enumerate(filtered_order_lines, 1):
             order_lines_to_process.append({

--- a/addons/sale_management/models/sale_order_template_line.py
+++ b/addons/sale_management/models/sale_order_template_line.py
@@ -56,6 +56,7 @@ class SaleOrderTemplateLine(models.Model):
 
     display_type = fields.Selection([
         ('line_section', "Section"),
+        ('line_subsection', "Subsection"),
         ('line_note', "Note")], default=False)
 
     #=== COMPUTE METHODS ===#

--- a/addons/stock/static/src/views/picking_form/stock_move_product_label.js
+++ b/addons/stock/static/src/views/picking_form/stock_move_product_label.js
@@ -4,11 +4,7 @@ import { many2OneField } from "@web/views/fields/many2one/many2one_field";
 
 export class MoveProductLabelField extends ProductNameAndDescriptionField {
     static template = "stock.MoveProductLabelField";
-
-    setup() {
-        super.setup();
-        this.descriptionColumn = "description_picking";
-    }
+    static descriptionColumn = "description_picking";
 
     get label() {
         const record = this.props.record.data;
@@ -19,10 +15,8 @@ export class MoveProductLabelField extends ProductNameAndDescriptionField {
         }
         return label.trim();
     }
-    updateLabel(value) {
-        this.props.record.update({
-          [this.descriptionColumn]: value,
-        });
+    parseLabel(value) {
+        return value;
     }
 }
 

--- a/addons/stock/static/src/views/picking_form/stock_move_product_label.xml
+++ b/addons/stock/static/src/views/picking_form/stock_move_product_label.xml
@@ -21,7 +21,6 @@
             t-att-class="{ 'd-none': !(columnIsProductAndLabel.value and (label or !props.readonly and labelVisibility.value)) }"
             t-att-readonly="props.readonly and isProductClickable ? '1' : ''"
             t-att-value="label"
-            t-on-change="(ev) => this.updateLabel(ev.target.value)"
             t-ref="labelNodeRef"
         />
     </t>

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -216,7 +216,7 @@ class StockLandedCost(models.Model):
                     accounts = product.product_tmpl_id.get_product_accounts()
                     input_account = accounts['stock_input']
                     all_amls.filtered(lambda aml: aml.account_id == input_account and not aml.reconciled\
-                         and not aml.display_type in ('line_section', 'line_note')).reconcile()
+                         and not aml.display_type in ('line_section', 'line_subsection', 'line_note')).reconcile()
 
     def get_valuation_lines(self):
         self.ensure_one()

--- a/addons/web/static/src/views/fields/input_field_hook.js
+++ b/addons/web/static/src/views/fields/input_field_hook.js
@@ -93,7 +93,11 @@ export function useInputField(params) {
     }
     function onKeydown(ev) {
         const hotkey = getActiveHotkey(ev);
-        if (["enter", "tab", "shift+tab"].includes(hotkey)) {
+        const keys = ["tab", "shift+tab"];
+        if (ev.target.tagName.toLowerCase() !== "textarea") {
+            keys.push("enter");
+        }
+        if (keys.includes(hotkey)) {
             commitChanges(false);
         }
         if (params.preventLineBreaks && ["enter", "shift+enter"].includes(hotkey)) {


### PR DESCRIPTION
This commit introduces a new line_subsection value to the display_type
field on models such as account.move.line, purchase.order.line, and
sale.order.line. This addition enables the actual use of subsections in
views that use the section_and_note_one2many widget.

All relevant logic in Accounting, Sales, and Purchase related apps has
been adapted to support this new display type.

This commit also fixes a few issues with section and note inputs.

task-4920305

Co-authored-by: Michaël Mattiello <mcm@odoo.com>
Co-authored-by: Julien Carion <juca@odoo.com>