### PR TITLE
[FIX] hr_holidays: allow time off within same-schedule overlapping versions

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -20,6 +20,7 @@ from odoo.tools.float_utils import float_round, float_compare
 from odoo.tools.misc import format_date
 from odoo.tools.translate import _
 from odoo.osv import expression
+from odoo.fields import Domain
 
 _logger = logging.getLogger(__name__)
 
@@ -367,14 +368,16 @@ class HrLeave(models.Model):
 
     def _get_overlapping_contracts(self):
         self.ensure_one()
-        domain = [
-            ('employee_id', '=', self.employee_id.id),
-            ('contract_date_start', '<=', self.date_to),
-            '|',
-                ('contract_date_end', '>=', self.date_from),
-                ('contract_date_end', '=', False),
-        ]
-        return self.env['hr.version'].sudo().search(domain)
+        domain = Domain.AND([
+            Domain('employee_id', '=', self.employee_id.id),
+            Domain('contract_date_start', '<=', self.date_to),
+            Domain.OR([
+                Domain('contract_date_end', '>=', self.date_from),
+                Domain('contract_date_end', '=', False),
+            ])
+        ])
+        versions = self.env['hr.version'].sudo().search(domain)
+        return versions.filtered(lambda v: v._is_overlapping_period(self.date_from.date(), self.date_to.date()))
 
     @api.constrains('date_from', 'date_to')
     def _check_contracts(self):
@@ -385,25 +388,25 @@ class HrLeave(models.Model):
             contracts are later modifed/created in the middle of the leave.
         """
         for holiday in self.filtered('employee_id'):
-            contracts = holiday._get_overlapping_contracts()
-            if len(contracts.resource_calendar_id) > 1:
+            versions = holiday._get_overlapping_contracts()
+            if len(versions.resource_calendar_id) > 1:
                 raise ValidationError(
-                    _("""A leave cannot be set across multiple contracts with different working schedules.
+                    self.env._("""A leave cannot be set across multiple versions with different working schedules.
 
-Please create one time off for each contract.
+Please create one time off for each version period.
 
 Time off:
 %(time_off)s
 
-Contracts:
-%(contracts)s""",
+Versions:
+%(versions)s""",
                       time_off=holiday.display_name,
-                      contracts='\n'.join(_(
-                          "Contract %(contract)s from %(start_date)s to %(end_date)s",
-                          contract=contract.name or contract.employee_id.name,
-                          start_date=format_date(self.env, contract.date_start),
-                          end_date=format_date(self.env, contract.date_end) if contract.date_end else _("undefined"),
-                      ) for contract in contracts)))
+                      versions='\n'.join(_(
+                          "- '%(version)s' from %(start_date)s to %(end_date)s",
+                          version=version.name or version.employee_id.name,
+                          start_date=format_date(self.env, version.date_start),
+                          end_date=format_date(self.env, version.date_end) if version.date_end else self.env._("undefined"),
+                      ) for version in versions)))
 
     @api.depends('request_date_from_period', 'request_hour_from', 'request_hour_to', 'request_date_from', 'request_date_to',
                  'request_unit_half', 'request_unit_hours', 'employee_id')

--- a/addons/hr_holidays/tests/test_multi_contract.py
+++ b/addons/hr_holidays/tests/test_multi_contract.py
@@ -101,6 +101,26 @@ class TestHolidaysMultiContract(TestHolidayContract):
             'wage': 5000.0,
         })
 
+    def test_leave_same_contract_multiple_versions_with_different_schedules(self):
+        self.contract_cdi.contract_date_end = date(2022, 7, 30)
+        self.jules_emp.create_version({
+            'date_version': date(2022, 6, 10),
+            'contract_date_start': self.contract_cdi.contract_date_start,
+            'contract_date_end': self.contract_cdi.contract_date_end,
+            'name': 'New Version with a different schedule for Jules',
+            'resource_calendar_id': self.calendar_40h.id,
+            'wage': 5000.0,
+        })
+        with self.assertRaises(ValidationError):
+            leave = self.create_leave(datetime(2022, 6, 1, 7, 0, 0), datetime(2022, 6, 30, 18, 0, 0), name="Doctor Appointment", employee_id=self.jules_emp.id)
+            leave.action_approve()
+
+        leave = self.create_leave(datetime(2022, 5, 1, 7, 0, 0), datetime(2022, 5, 10, 18, 0, 0), name="Doctor Appointment", employee_id=self.jules_emp.id)
+        leave.action_approve()
+
+        leave = self.create_leave(datetime(2022, 6, 15, 7, 0, 0), datetime(2022, 7, 20, 18, 0, 0), name="Doctor Appointment", employee_id=self.jules_emp.id)
+        leave.action_approve()
+
     def test_leave_multi_contracts_split(self):
         # Check that setting a contract as running correctly
         # splits the existing time off for this employee that


### PR DESCRIPTION
When an employee has multiple versions with the same contract start and end dates but different working schedules, the system incorrectly blocks time off requests, even if the time off period lies entirely within a single schedule or even a single version.

This fix adjusts the significant constraint logic to filter the versions with overlapping contracts to those only overlapping with the leave period.

Task-4981318
