### PR TITLE
Fix restricted editor snippet click

### DIFF
--- a/addons/html_builder/static/src/sidebar/snippet.xml
+++ b/addons/html_builder/static/src/sidebar/snippet.xml
@@ -11,7 +11,7 @@
          t-on-mouseover="onInstallableHover"
          t-on-mouseout="onInstallableHover">
         <div class="o_snippet_thumbnail" t-att-data-snippet="snippet.name">
-            <button t-if="!snippet.isInstallable" class="o_snippet_thumbnail_area" t-on-click="props.onClickHandler" title="Insert snippet"/>
+            <button t-if="!snippet.isInstallable and !snippet.isDisabled" class="o_snippet_thumbnail_area" t-on-click="props.onClickHandler" title="Insert snippet"/>
             <Img t-if="snippet.isDisabled" src="'/html_builder/static/img/snippet_disabled.svg'" class="'o_snippet_undroppable'"/>
             <div class="o_snippet_thumbnail_img" t-attf-style="background-image: url({{snippet.thumbnailSrc}});"/>
             <span class="o_snippet_thumbnail_title" t-esc="snippet.title"/>

--- a/addons/test_website/static/tests/tours/restricted_editor.js
+++ b/addons/test_website/static/tests/tours/restricted_editor.js
@@ -64,6 +64,13 @@ registerWebsitePreviewTour('test_restricted_editor_only', {
     {
         content: "Check icons cannot be dragged",
         trigger: "#snippet_groups .o_snippet[name='Intro'].o_disabled",
+        run: function () {
+            if (document.querySelector("button.o_snippet_thumbnail_area")) {
+                    console.error(
+                        "The button to open the add snippet dialog should not be display for restricted editor."
+                    );
+            }
+        },
     },
     ...clickOnSave(),
     ...switchTo('fr'),
@@ -80,6 +87,13 @@ registerWebsitePreviewTour('test_restricted_editor_only', {
     {
         content: "Check icons cannot be dragged",
         trigger: "#snippet_groups .o_snippet[name='Intro'].o_disabled",
+        run: function () {
+            if (document.querySelector("button.o_snippet_thumbnail_area")) {
+                    console.error(
+                        "The button to open the add snippet dialog should not be display for restricted editor."
+                    );
+            }
+        },
     },
     ...clickOnSave(),
     ...switchTo('fr'),


### PR DESCRIPTION
[FIX] html_builder: fix restricted editor snippet click

Previously, when a user entered the website’s edit mode, they could
still open the snippet selection popup. This led to errors, as
restricted users don’t have permission to add new snippets.
This commit fixes the issue by ensuring the button that opens the
snippet popup is not rendered when snippet functionality is disabled
for the user.
