### PR TITLE
[FIX] mass_mailing: remove indeterminism from mass_mailing_code_view_…

### DIFF
--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_code_view.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_code_view.js
@@ -50,6 +50,7 @@ odoo.define('mass_mailing.mass_mailing_code_view_tour', function (require) {
     }, {
         trigger: '[name="body_arch"] iframe #email_designer_default_body [name="Title"] .ui-draggable-handle',
         content: 'Drag the "Title" snippet from the design panel and drop it in the editor',
+        extra_trigger: '[name="body_arch"] iframe body.editor_enable',
         run: function (actions) {
             actions.drag_and_drop('[name="body_arch"] iframe .o_editable', this.$anchor);
         }


### PR DESCRIPTION
…tour

Steps to reproduce
==================

Run the test `test_07_mass_mailing_code_view_tour` a bunch of times. It will eventually fail.

Cause of the issue
==================

It fails on the step
Drag the "Title" snippet from the design panel and drop it in the editor

When it does, the targetPosition.y is equal to 0

https://github.com/odoo/odoo/blob/b3c8320c5ee289136d645c2058656b622f92be7e/addons/web_tour/static/src/tour_service/tour_utils.js#L383-L386

=> the drag_and_drop does not move the pointer to the target position properly

Solution
========

We need to wait for the editor to be properly loaded

runbot-104287