### PR TITLE
[FIX] website: translate t-att- attributes

### DIFF
--- a/addons/html_builder/i18n/html_builder.pot
+++ b/addons/html_builder/i18n/html_builder.pot
@@ -533,6 +533,12 @@ msgstr ""
 
 #. module: html_builder
 #. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.js:0
+msgid "Delete %(snippetTitle)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
 #: code:addons/html_builder/static/src/core/building_blocks/builder_list.xml:0
 msgid "Delete item"
 msgstr ""
@@ -1304,6 +1310,12 @@ msgstr ""
 
 #. module: html_builder
 #. odoo-javascript
+#: code:addons/html_builder/static/src/sidebar/custom_inner_snippet.js:0
+msgid "Rename %(snippetTitle)s"
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
 #: code:addons/html_builder/static/src/snippets/snippet_viewer.js:0
 msgid "Rename the block"
 msgstr ""
@@ -2034,6 +2046,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/html_builder/static/src/sidebar/option_container.xml:0
 msgid "You can still access the block options but it might be ineffective."
+msgstr ""
+
+#. module: html_builder
+#. odoo-javascript
+#: code:addons/html_builder/static/src/core/building_blocks/builder_list.xml:0
+msgid "You don't have any record to add"
 msgstr ""
 
 #. module: html_builder

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -55,8 +55,9 @@
                 <Dropdown state="this.dropdown" menuClass="'o-hb-select-dropdown mt-1'">
                     <button class="bl-dropdown-toggle o-hb-select-toggle o-hb-btn btn btn-secondary text-start o-dropdown-caret w-100 mx-auto"
                         t-att-disabled="!this.availableRecords.length">
+                        <t t-set="noAvailableRecordLabel">You don't have any record to add</t>
                         <span class="w-100"
-                            t-att-title="!this.availableRecords.length ? `You don't have any record to add` : ''"
+                            t-att-title="!this.availableRecords.length ? noAvailableRecordLabel : ''"
                             t-att-style="!this.availableRecords.length ? 'pointer-events: auto; display: inline-block;' : ''">
                             <t t-out="props.addItemTitle" />
                         </span>

--- a/addons/html_builder/static/src/sidebar/custom_inner_snippet.js
+++ b/addons/html_builder/static/src/sidebar/custom_inner_snippet.js
@@ -1,5 +1,6 @@
 import { Img } from "@html_builder/core/img";
 import { Component, useState, useRef } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 import { useAutofocus } from "@web/core/utils/hooks";
 
 export class CustomInnerSnippet extends Component {
@@ -17,6 +18,13 @@ export class CustomInnerSnippet extends Component {
         useAutofocus({ refName: "rename-input" });
 
         this.state = useState({ isRenaming: false });
+
+        this.renameButtonTooltip = _t("Rename %(snippetTitle)s", {
+            snippetTitle: this.snippet.title,
+        });
+        this.deleteButtonTooltip = _t("Delete %(snippetTitle)s", {
+            snippetTitle: this.snippet.title,
+        });
     }
 
     get snippet() {

--- a/addons/html_builder/static/src/sidebar/custom_inner_snippet.xml
+++ b/addons/html_builder/static/src/sidebar/custom_inner_snippet.xml
@@ -29,10 +29,10 @@
         </div>
         <div t-if="!state.isRenaming" class="rename-delete-buttons float-end z-1">
             <button class="fa fa-pencil btn o_we_hover_success btn-outline-info border-0"
-                    t-attf-data-tooltip="Rename {{snippet.title}}"
+                    t-att-data-tooltip="renameButtonTooltip"
                     t-on-click.stop="toggleRenamingState"/>
             <button class="fa fa-trash btn o_we_hover_danger btn-outline-danger border-0"
-                    t-attf-data-tooltip="Delete {{snippet.title}}"
+                    t-att-data-tooltip="deleteButtonTooltip"
                     t-on-click="() => this.props.snippetModel.deleteCustomSnippet(snippet)"/>
         </div>
     </div>

--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -59,6 +59,36 @@ msgid "\"%(company)s form submission\" <%(email)s>"
 msgstr ""
 
 #. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.js:0
+msgid "\"%(keyword)s\" is used in page content"
+msgstr ""
+
+#. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.js:0
+msgid "\"%(keyword)s\" is used in page description"
+msgstr ""
+
+#. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.js:0
+msgid "\"%(keyword)s\" is used in page first level heading"
+msgstr ""
+
+#. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.js:0
+msgid "\"%(keyword)s\" is used in page second level heading"
+msgstr ""
+
+#. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.js:0
+msgid "\"%(keyword)s\" is used in page title"
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_reviews_wall
 msgid ""
 "\"Engaging with this team was effortless from start to end. Their "
@@ -2816,6 +2846,12 @@ msgid "Add"
 msgstr ""
 
 #. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.js:0
+msgid "Add \"%(suggestion)s\""
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.view_edit_third_party_domains
 msgid ""
 "Add 3rd-party service domains <em>(\"www.example.com\" or "
@@ -3098,6 +3134,20 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/website/static/src/components/dialog/seo.xml:0
 msgid "Add up to 10 relevant keywords"
+msgstr ""
+
+#. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.xml:0
+msgid "Add your keyword"
+msgstr ""
+
+#. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.js:0
+msgid ""
+"Add your own title or leave empty to use \"%(defaultTitle)s\". Your page "
+"title should contain max 65 characters."
 msgstr ""
 
 #. module: website
@@ -9045,6 +9095,12 @@ msgid "Google key, or Enable to access first reply"
 msgstr ""
 
 #. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/builder/plugins/theme/theme_advanced_option.js:0
+msgid "Gray %(grayCode)s"
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.snippet_options
 msgid "Gray {{0}}"
 msgstr ""
@@ -14604,6 +14660,12 @@ msgstr ""
 
 #. module: website
 #. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.js:0
+msgid "Remove \"%(keyword)s\""
+msgstr ""
+
+#. module: website
+#. odoo-javascript
 #: code:addons/website/static/src/builder/plugins/options/chart_option.xml:0
 msgid "Remove Column"
 msgstr ""
@@ -14640,6 +14702,12 @@ msgstr ""
 #: code:addons/website/static/src/builder/plugins/options/navtabs_header_buttons.xml:0
 #: model_terms:ir.ui.view,arch_db:website.snippet_options_tabs
 msgid "Remove Tab"
+msgstr ""
+
+#. module: website
+#. odoo-javascript
+#: code:addons/website/static/src/components/dialog/seo.xml:0
+msgid "Remove a keyword first"
 msgstr ""
 
 #. module: website

--- a/addons/website/static/src/builder/plugins/theme/theme_advanced_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_advanced_option.js
@@ -1,8 +1,13 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { _t } from "@web/core/l10n/translation";
 
 export class ThemeAdvancedOption extends BaseOptionComponent {
     static template = "website.ThemeAdvancedOption";
     static props = {
         grays: Object,
     };
+
+    getGrayTitle(grayCode) {
+        return _t("Gray %(grayCode)s", { grayCode });
+    }
 }

--- a/addons/website/static/src/builder/plugins/theme/theme_advanced_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_advanced_option.xml
@@ -46,7 +46,7 @@
             <div class="o_we_gray_preview d-flex w-100">
 	            <t t-foreach="[0,1,2,3,4,5,6,7,8]" t-as="i" t-key="i">
 	                <t t-set="grayCode" t-value="(9 - i) * 100"/>
-	                <span t-attf-title="Gray #{grayCode}"
+	                <span t-att-title="getGrayTitle(grayCode)"
 	                      t-attf-variable="#{grayCode}"
 	                      t-attf-class="o_we_user_value_widget o_we_gray_preview bg-#{grayCode}"
 	                      t-attf-style="background-color: {{props.grays[grayCode]}} !important"

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -263,6 +263,26 @@ class Keyword extends Component {
             suggestions: [],
         });
 
+        this.translatedStrings = {
+            usedInH1: _t('"%(keyword)s" is used in page first level heading', {
+                keyword: this.props.keyword,
+            }),
+            usedInH2: _t('"%(keyword)s" is used in page second level heading', {
+                keyword: this.props.keyword,
+            }),
+            usedInTitle: _t('"%(keyword)s" is used in page title', {
+                keyword: this.props.keyword,
+            }),
+            usedInDescription: _t('"%(keyword)s" is used in page description', {
+                keyword: this.props.keyword,
+            }),
+            usedInContent: _t('"%(keyword)s" is used in page content', {
+                keyword: this.props.keyword,
+            }),
+            suggestionTag: (suggestion) => _t('Add "%(suggestion)s"', { suggestion }),
+            removeBtn: _t('Remove "%(keyword)s"', { keyword: this.props.keyword }),
+        };
+
         onMounted(async () => {
             const suggestions = await rpc('/website/seo_suggest', {
                 lang: jsToPyLocale(this.props.language),
@@ -480,6 +500,11 @@ class TitleDescription extends Component {
 
         this.maxRecommendedDescriptionSize = 160;
         this.minRecommendedDescriptionSize = 50;
+
+        this.titleTooltip = _t(
+            'Add your own title or leave empty to use "%(defaultTitle)s". Your page title should contain max 65 characters.',
+            { defaultTitle: this.props.defaultTitle }
+        );
 
         // Update the title when its input value changes
         useEffect(() => {

--- a/addons/website/static/src/components/dialog/seo.xml
+++ b/addons/website/static/src/components/dialog/seo.xml
@@ -24,21 +24,51 @@
 <t t-name="website.Keyword">
     <tr class="o_seo_keyword_row">
         <td><span t-out="props.keyword"></span></td>
-        <td class="text-center o_seo_mentioned_keyword"><i t-if="usedInH1" class="fa fa-check text-success" t-att-title="'&quot;' + props.keyword + '&quot; is used in page first level heading'"/></td>
-        <td class="text-center o_seo_mentioned_keyword"><i t-if="usedInH2" class="fa fa-check text-success" t-att-title="'&quot;' + props.keyword + '&quot; is used in page second level heading'"/></td>
-        <td class="text-center o_seo_mentioned_keyword"><i t-if="usedInTitle" class="fa fa-check text-success" t-att-title="'&quot;' + props.keyword + '&quot; is used in page title'"/></td>
-        <td class="text-center o_seo_mentioned_keyword"><i t-if="usedInDescription" class="fa fa-check text-success" t-att-title="'&quot;' + props.keyword + '&quot; is used in page description'"/></td>
-        <td class="text-center o_seo_mentioned_keyword"><i t-if="usedInContent" class="fa fa-check text-success" t-att-title="'&quot;' + props.keyword + '&quot; is used in page content'"/></td>
+        <td class="text-center o_seo_mentioned_keyword">
+            <div t-if="usedInH1">
+                <span class="visually-hidden" t-out="translatedStrings.usedInH1"/>
+                <i aria-hidden="true" class="fa fa-check text-success" t-att-title="translatedStrings.usedInH1"/>
+            </div>
+        </td>
+        <td class="text-center o_seo_mentioned_keyword">
+            <div t-if="usedInH2">
+                <span class="visually-hidden" t-out="translatedStrings.usedInH2"/>
+                <i aria-hidden="true" class="fa fa-check text-success" t-att-title="translatedStrings.usedInH2"/>
+            </div>
+        </td>
+        <td class="text-center o_seo_mentioned_keyword">
+            <div t-if="usedInTitle">
+                <span class="visually-hidden" t-out="translatedStrings.usedInTitle"/>
+                <i aria-hidden="true" class="fa fa-check text-success" t-att-title="translatedStrings.usedInTitle"/>
+            </div>
+        </td>
+        <td class="text-center o_seo_mentioned_keyword">
+            <div t-if="usedInDescription">
+                <span class="visually-hidden" t-out="translatedStrings.usedInDescription"/>
+                <i aria-hidden="true" class="fa fa-check text-success" t-att-title="translatedStrings.usedInDescription"/>
+            </div>
+        </td>
+        <td class="text-center o_seo_mentioned_keyword">
+            <div t-if="usedInContent">
+                <span class="visually-hidden" t-out="translatedStrings.usedInContent"/>
+                <i aria-hidden="true" class="fa fa-check text-success" t-att-title="translatedStrings.usedInContent"/>
+            </div>
+        </td>
         <td class="o_seo_keyword_suggestion">
             <ul class="list-inline mb0">
                 <t t-foreach="state.suggestions" t-as="suggestion" t-key="suggestion">
                     <li class="list-inline-item me-1 mb-1" t-on-click="() => props.addKeyword(suggestion)">
-                        <span class="o_seo_suggestion badge rounded py-1 text-bg-info" t-att-title="'Add &quot;' + suggestion + '&quot;'" t-esc="suggestion"/>
+                        <span class="o_seo_suggestion badge rounded py-1 text-bg-info" t-att-title="translatedStrings.suggestionTag(suggestion)" t-esc="suggestion"/>
                     </li>
                 </t>
             </ul>
         </td>
-        <td class="text-center" t-on-click="() => props.removeKeyword(props.keyword)"><a href="#" class="oe_remove text-danger" t-att-title="'Remove &quot;' + props.keyword + '&quot;'"><i class="fa fa-trash"/></a></td>
+        <td class="text-center" t-on-click="() => props.removeKeyword(props.keyword)">
+            <button class="o_btn_reset oe_remove text-danger">
+                <span class="visually-hidden" t-out="translatedStrings.removeBtn"/>
+                <i class="fa fa-trash" aria-hidden="true"/>
+            </button>
+        </td>
     </tr>
 </t>
 
@@ -148,7 +178,9 @@
             </table>
         </div>
         <div role="form" class="input-group w-50">
-            <input t-model="state.keyword" type="text" class="form-control" t-att-placeholder="isFull ? 'Remove a keyword first' : 'Add your keyword'" t-att-readonly="isFull" maxlength="30" t-on-keyup="onKeyup"/>
+            <t t-set="placeholderRemove">Remove a keyword first</t>
+            <t t-set="placeholderAdd">Add your keyword</t>
+            <input t-model="state.keyword" type="text" class="form-control" t-att-placeholder="isFull ? placeholderRemove : placeholderAdd" t-att-readonly="isFull" maxlength="30" t-on-keyup="onKeyup"/>
             <select t-if="languages.length > 1" title="The language of the keyword and related keywords."
                     t-model="state.language" class="btn btn-outline-primary pe-5 form-select">
                 <t t-foreach="languages" t-as="lang" t-key="lang[0]">
@@ -212,8 +244,7 @@
             <div class="col-lg-6">
                 <div class="mb-3">
                     <label for="website_meta_title">
-                        Title <i class="fa fa-question-circle text-primary" data-tooltip-position="right"
-                            t-att-data-tooltip="'Add your own title or leave empty to use &quot;' + props.defaultTitle + '&quot;. Your page title should contain max 65 characters.'"/>
+                        Title <i class="fa fa-question-circle text-primary" data-tooltip-position="right" t-att-data-tooltip="titleTooltip"/>
                     </label>
                     <input type="text" t-model="seoContext.title" t-att-disabled="!props.canEditTitle" class="form-control" t-att-placeholder="props.defaultTitle" maxlength="70" size="70" t-ref="autofocus"/>
                 </div>


### PR DESCRIPTION
In OWL templates, translatable attributes (like `title` or `placeholder`) are not exported if set with `t-att-`. In such cases, we need to use a translatable string in JS.
