### PR TITLE
[FIX] website: prevent duplicate notification on non-translatable els

### DIFF
--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -282,7 +282,11 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
         };
         for (const translationEl of $editable) {
             if (translationEl.closest('.o_not_editable')) {
-                translationEl.addEventListener('click', showNotification);
+                translationEl.addEventListener('click', (ev) => {
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                    showNotification(ev);
+                });
             }
             if (translationEl.closest('.s_table_of_content_navbar_wrap')) {
                 // Make sure the same translation ids are used.


### PR DESCRIPTION
Since [1], when clicking a non-translatable element in translation mode, the notification was sometimes shown multiple times due to event bubbling.

This commit stops the click event from propagating, ensuring the notification is only triggered once.

[1]: https://github.com/odoo/odoo/commit/41e341177611cf69d1bd61e66a809510c22cc1b7

