### PR TITLE
[FIX] sale_project: align customer field in create wizard

### DIFF
--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -10,7 +10,7 @@
                 <field name="company_id" invisible="1"/>
                 <setting class="col-lg-12" help="Invoice your time and material to customers" invisible="context.get('hide_allow_billable', False)">
                     <field name="allow_billable"/>
-                    <div invisible="not allow_billable">
+                    <div invisible="not allow_billable" class="d-flex flex-column flex-sm-row align-items-baseline">
                         <label for="partner_id"/>
                         <field name="partner_id" class="ms-1" widget="res_partner_many2one" context="{'res_partner_search_mode': 'customer'}"
                             options="{'no_create_edit': True, 'no_open': True}" placeholder="Select who to bill..."/>


### PR DESCRIPTION
**Steps to Reproduce:**
- Go to the Projects app
- Click "Create" to open the wizard
- Enable the "Billable" option
- Observe the alignment of the "Customer" field that appears

**Issue:**

The "Customer" label and input field are stacked vertically, with the input's
underline (green line) positioned below the label, leading to uneven spacing and
misalignment compared to other fields.

**Current behaviour:**
- The "Customer" field is visually misaligned , its label and input are not
horizontally aligned, causing UI inconsistency.

**Expected behaviour:**
- The "Customer" label and input field should align horizontally on a single
line, with the input's underline matching the label's baseline.

**Fix:**

The layout is updated using proper flexbox classes to ensure the "Customer"
label and input field appear on the same line with proper vertical alignment.

Task-4949146
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
