### PR TITLE
[IMP] website_sale: introduce shop and categories options

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1774,6 +1774,18 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if write_vals:
             current_website.write(write_vals)
 
+    @route(['/shop/config/category'], type='jsonrpc', auth='user')
+    def _change_category_config(self, category_id, **options):
+        category = request.env['product.public.category'].browse(int(category_id))
+        if not category.exists():
+            raise NotFound()
+
+        # Restrict options we can write to.
+        targeted_options = {'show_category_title', 'show_category_description', 'align_category_content'}
+        modified_options = {option: value for option, value in options.items() if option in targeted_options}
+        if modified_options:
+            category.write(modified_options)
+
     def order_lines_2_google_api(self, order_lines):
         """ Transforms a list of order lines into a dict for google analytics """
         ret = []

--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -72,6 +72,24 @@ class ProductPublicCategory(models.Model):
         translate=html_translate,
     )
 
+    show_category_title = fields.Boolean(
+        string="Show Category Title",
+        default=False,
+        help="Display the category title on the shop page. Corresponds to the 'Show Title' editor option."
+    )
+
+    show_category_description = fields.Boolean(
+        string="Show Category Description",
+        default=True,
+        help="Display the category description on the shop page. Corresponds to the 'Show Description' editor option."
+    )
+
+    align_category_content = fields.Boolean(
+        string="Align Category Content",
+        default=False,
+        help="Align the category content on the shop page. Corresponds to the 'Center Content' editor option."
+    )
+
     # === COMPUTE METHODS === #
 
     @api.depends('parent_path')

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -82,10 +82,62 @@
         .o_pricelist_dropdown + .o_sortby_dropdown {
             margin-left: map-get($spacers, 2) * -1;
         }
-        // Hide empty category description in not-edition mode
-        @at-root body:not(.editor_enable) #category_header {
-            &:has(> br:first-child:last-child), &:empty {
-                display: none;
+
+        &.o_wsale_products_header_is_category {
+            &:where(:not(.o_wsale_products_header_show_category_title)) {
+                .o_wsale_category_title:where(:not(.o_wsale_category_title_is_search)) {
+                    display: none !important;
+                }
+            }
+
+            &:where(:not(.o_wsale_products_header_show_category_description)) {
+                .o_wsale_category_description {
+                    display: none !important;
+                }
+            }
+
+            &:where(.o_wsale_products_header_category_center_content) {
+                .o_wsale_category_title {
+                    align-self: center;
+                }
+
+                .o_wsale_category_description:where(:not(:has(section[class*="s_"]))) {
+                    align-self: center;
+                    text-align: center;
+                    max-width: 38rem;
+                }
+
+                #o_wsale_categories_filmstrip {
+                    justify-content: center;
+                }
+            }
+        }
+
+        &.o_wsale_products_header_is_shop {
+            &:where(:not(.o_wsale_products_header_show_shop_title)) {
+                .o_wsale_shop_title {
+                    display: none !important;
+                }
+            }
+
+            &:where(.o_wsale_products_header_shop_center_content) {
+                .o_wsale_shop_title {
+                    align-self: center;
+                }
+
+                #o_wsale_categories_filmstrip {
+                    justify-content: center;
+                }
+            }
+        }
+
+        // Hide empty dropzones when no dropzone are dragged.
+        @at-root body:where(:not(.oe_dropzone_active)) {
+            #category_header,
+            #oe_structure_products_header_shop {
+                &:has(> br:first-child:last-child), &:empty {
+                    display: none;
+                }
             }
         }
     }
@@ -344,7 +396,7 @@
         // <- End filmstrip design variations
 
         .o_wsale_filmstrip_wrapper {
-            margin-bottom: map-get($spacers, 2);
+            margin-bottom: map-get($spacers, 1);
             border-width: var(--o-wsale-filmstrip-wrapper-border-width, 0);
             border-style: solid;
             border-color: $border-color;
@@ -363,8 +415,7 @@
                 width: max-content;
 
                 li {
-                    flex: 0 0 var(--o-wsale-filmstrip-item-width, auto);
-                    min-width: 0;
+                    width: var(--o-wsale-filmstrip-item-width, auto);
                     aspect-ratio: var(--o-wsale-filmstrip-item-aspect-ratio, unset);
 
                     @include media-breakpoint-down (md) {
@@ -460,7 +511,7 @@
             }
 
             &:hover .o_wsale_filmstrip_wrapper {
-                margin-bottom: map-get($spacers, 1);
+                margin-bottom: 0;
 
                 &::-webkit-scrollbar {
                     height: 6px;

--- a/addons/website_sale/static/src/website_builder/product_header_category_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_header_category_option_plugin.js
@@ -1,0 +1,75 @@
+import { Plugin } from "@html_editor/plugin";
+import { rpc } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { _t } from "@web/core/l10n/translation";
+
+class ProductHeaderCategoryOptionPlugin extends Plugin {
+    static id = "ProductHeaderCategoryOptionPlugin";
+
+    resources = {
+        builder_options: {
+            template: "website_sale.ProductHeaderCategoryOption",
+            selector: "#products_grid:has(header.o_wsale_products_header_is_category)",
+            editableOnly: false,
+            reloadTarget: true,
+            title: _t((this.editable.querySelector("#o_wsale_products_header")?.dataset.categoryName || "Category") + ' Header'),
+            groups: ["website.group_website_restricted_editor"],
+        },
+
+        builder_actions: {
+            ToggleCategoryShowTitleAction,
+            ToggleCategoryShowDescriptionAction,
+            ToggleCategoryAlignContentAction,
+        },
+
+        save_handlers: this.onSave.bind(this),
+    };
+
+    async onSave() {
+        const headerEl = this.editable.querySelector("#o_wsale_products_header");
+        if (!headerEl) return;
+        const categoryId = headerEl.dataset.categoryId;
+
+        const showTitle = headerEl.classList.contains("o_wsale_products_header_show_category_title");
+        const showDescription = headerEl.classList.contains("o_wsale_products_header_show_category_description");
+        const alignCategoryContent = headerEl.classList.contains("o_wsale_products_header_category_center_content");
+
+        if (categoryId) {
+            return rpc("/shop/config/category", {
+                category_id: categoryId,
+                show_category_title: showTitle,
+                show_category_description: showDescription,
+                align_category_content: alignCategoryContent,
+            });
+        }
+    }
+}
+
+class BaseCategoryToggleAction extends BuilderAction {
+    isApplied({ editingElement: el, params }) {
+        return el.classList.contains(params.previewClass);
+    }
+
+    apply({ editingElement: el, params }) {
+        el.classList.add(params.previewClass);
+    }
+
+    clean({ editingElement: el, params }) {
+        el.classList.remove(params.previewClass);
+    }
+}
+
+export class ToggleCategoryShowTitleAction extends BaseCategoryToggleAction {
+    static id = "toggleCategoryShowTitle";
+}
+
+export class ToggleCategoryShowDescriptionAction extends BaseCategoryToggleAction {
+    static id = "toggleCategoryShowDescription";
+}
+
+export class ToggleCategoryAlignContentAction extends BaseCategoryToggleAction {
+    static id = "toggleCategoryAlignContent";
+}
+
+registry.category("website-plugins").add(ProductHeaderCategoryOptionPlugin.id, ProductHeaderCategoryOptionPlugin);

--- a/addons/website_sale/static/src/website_builder/product_header_category_options.xml
+++ b/addons/website_sale/static/src/website_builder/product_header_category_options.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website_sale.ProductHeaderCategoryOption">
+        <BuilderContext applyTo="'#o_wsale_products_header'">
+            <BuilderRow label.translate="Show Title">
+                <BuilderCheckbox
+                    action="'toggleCategoryShowTitle'"
+                    actionParam="{previewClass: 'o_wsale_products_header_show_category_title'}"
+                />
+            </BuilderRow>
+            <BuilderRow label.translate="Show Description">
+                <BuilderCheckbox
+                    action="'toggleCategoryShowDescription'"
+                    actionParam="{previewClass: 'o_wsale_products_header_show_category_description'}"
+                />
+            </BuilderRow>
+            <BuilderRow label.translate="Center Content">
+                <BuilderCheckbox
+                    action="'toggleCategoryAlignContent'"
+                    actionParam="{previewClass: 'o_wsale_products_header_category_center_content'}"
+                />
+            </BuilderRow>
+        </BuilderContext>
+    </t>
+</templates>

--- a/addons/website_sale/static/src/website_builder/product_header_shop_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_header_shop_option_plugin.js
@@ -1,0 +1,21 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+
+class ProductHeaderShopOptionPlugin extends Plugin {
+    static id = "ProductHeaderShopOptionPlugin";
+
+    resources = {
+        builder_options: {
+            template: "website_sale.ProductHeaderShopOption",
+            selector: "#products_grid:has(header.o_wsale_products_header_is_shop)",
+            editableOnly: false,
+            reloadTarget: true,
+            title: _t("Shop Header"),
+        },
+    };
+}
+
+registry
+    .category("website-plugins")
+    .add(ProductHeaderShopOptionPlugin.id, ProductHeaderShopOptionPlugin);

--- a/addons/website_sale/static/src/website_builder/product_header_shop_options.xml
+++ b/addons/website_sale/static/src/website_builder/product_header_shop_options.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website_sale.ProductHeaderShopOption">
+        <BuilderContext applyTo="'#o_wsale_products_header'">
+            <BuilderRow label.translate="Show Title">
+                <BuilderCheckbox
+                    action="'previewableWebsiteConfig'"
+                    actionParam="{views: ['website_sale.products_shop_title'], previewClass: 'o_wsale_products_header_show_shop_title'}"
+                />
+            </BuilderRow>
+            <BuilderRow label.translate="Center Content">
+                <BuilderCheckbox
+                    action="'previewableWebsiteConfig'"
+                    actionParam="{views: ['website_sale.products_shop_title_align'], previewClass: 'o_wsale_products_header_shop_center_content'}"
+                />
+            </BuilderRow>
+        </BuilderContext>
+    </t>
+</templates>

--- a/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
@@ -12,7 +12,7 @@ registerWebsitePreviewTour('category_page_and_products_snippet_edition', {
     },
     {
         content: "Wait for page to load",
-        trigger: ":iframe h1:contains('Test Category')",
+        trigger: ":iframe h1:contains('Test Category'):not(:visible)",
     },
     ...clickOnEditAndWaitEditMode(),
     {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -463,13 +463,22 @@
     <template id="products_breadcrumb" name="Products Breadcrumb">
         <ol t-if="category" t-attf-class="breadcrumb #{_classes}">
             <li class="breadcrumb-item">
-                <a t-att-href="keep(shop_path)">Products</a>
+                <a
+                    t-att-class="'d-none d-lg-inline' if len(category.parents_and_self) &gt; 1 else ''"
+                    t-att-href="keep(shop_path)"
+                >
+                    Products
+                </a>
+                <span t-if="len(category.parents_and_self) &gt; 1" class="d-lg-none">...</span>
             </li>
             <t t-foreach="category.parents_and_self" t-as="cat">
                 <li t-if="cat == category" class="breadcrumb-item">
                     <span class="d-inline-block" t-field="cat.name"/>
                 </li>
-                <li t-else="" class="breadcrumb-item">
+                <li
+                    t-else=""
+                    t-attf-class="breadcrumb-item {{cat_index &lt; cat_size - 2 and 'd-none d-lg-inline'}}"
+                >
                     <a
                         t-att-href="keep('%s/category/%s' % (shop_path, slug(cat)))"
                         t-field="cat.name"
@@ -617,22 +626,13 @@
                                 <t t-if="category and not search" t-call="website_sale.products_breadcrumb">
                                     <t
                                         t-set="_classes"
-                                        t-valuef="d-none d-lg-flex w-100 p-0 mb-0 small"
+                                        t-valuef="w-100 p-0 mb-0 small {{not opt_wsale_show_category_title and 'mb-2 mb-lg-0'}}"
                                     />
                                 </t>
                                 <h1
                                     t-if="category or search"
                                     t-attf-class="o_wsale_category_title d-flex gap-1 align-items-center mb-0 lh-lg {{search and bool(category) and 'mb-2'}} {{search and 'o_wsale_category_title_is_search base-fs font-sans-serif' or 'fs-3'}}"
                                 >
-                                    <a
-                                        t-if="(search and not category) or (not search and category)"
-                                        t-attf-class="btn ps-0 pe-2 {{not search and 'd-lg-none'}}"
-                                        t-att-href="keep('%s/category/%s' % (shop_path, slug(category.parent_id))) if category.parent_id else keep(shop_path, search=0)"
-                                        role="button"
-                                        t-attf-title="Back to {{category.parent_id and category.parent_id.name or 'Shop'}}"
-                                    >
-                                        <i class="oi oi-chevron-left" role="img"/>
-                                    </a>
                                     <t t-if="search and category">
                                         <span class="text-muted">Searching</span>
                                         <span class="badge text-bg-info fw-normal base-fs">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -502,6 +502,13 @@
             <t t-set="opt_wsale_attributes_top" t-value="is_view_active('website_sale.products_attributes_top')"/>
             <t t-set="opt_wsale_floating_bar" t-value="is_view_active('website_sale.floating_bar')"/>
 
+            <t t-set="opt_wsale_show_shop_title" t-value="is_view_active('website_sale.products_shop_title')"/>
+            <t t-set="opt_wsale_shop_title_align" t-value="is_view_active('website_sale.products_shop_title_align')"/>
+
+            <t t-set="opt_wsale_show_category_title" t-value="category and category.show_category_title"/>
+            <t t-set="opt_wsale_show_category_description" t-value="category and category.show_category_description"/>
+            <t t-set="opt_wsale_category_align" t-value="category and category.align_category_content"/>
+
             <t t-set="website_sale_pricelists" t-value="website.get_pricelist_available(show_visible=True)" />
             <t t-set="website_sale_sortable" t-value="website._get_product_sort_mapping()"/>
 
@@ -588,7 +595,7 @@
                                 <t t-call="website_sale.sidebar_dropzone_at_bottom"/>
                             </div>
                         </aside>
-                        <div id="products_grid" t-attf-class="col">
+                        <div id="products_grid" class="col">
                             <t
                                 t-set="_header_has_content"
                                 t-value="category or opt_wsale_categories_top or (not opt_wsale_floating_bar and (opt_wsale_attributes_top or is_view_active('website_sale.search') or is_view_active('website_sale.sort') or hasPricelistDropdown))"
@@ -596,8 +603,17 @@
 
                             <header
                                 id="o_wsale_products_header"
-                                t-attf-class="d-flex flex-column gap-2 {{_header_has_content and 'pt-4 pb-3' or (not _header_has_content and not opt_wsale_design_grid and 'py-3')}}"
-                                >
+                                t-att-data-category-id="category.id"
+                                t-att-data-category-name="category.name"
+                                t-attf-class="d-flex flex-column gap-2
+                                    {{_header_has_content and 'pt-4 pb-3' or opt_wsale_design_grid and 'py-3'}}
+                                    {{category and 'o_wsale_products_header_is_category' or 'o_wsale_products_header_is_shop'}}
+                                    {{opt_wsale_show_category_title and 'o_wsale_products_header_show_category_title'}}
+                                    {{opt_wsale_show_category_description and 'o_wsale_products_header_show_category_description'}}
+                                    {{opt_wsale_category_align and 'o_wsale_products_header_category_center_content'}}
+                                    {{opt_wsale_show_shop_title and 'o_wsale_products_header_show_shop_title'}}
+                                    {{opt_wsale_shop_title_align and 'o_wsale_products_header_shop_center_content'}}"
+                            >
                                 <t t-if="category and not search" t-call="website_sale.products_breadcrumb">
                                     <t
                                         t-set="_classes"
@@ -606,7 +622,7 @@
                                 </t>
                                 <h1
                                     t-if="category or search"
-                                    t-attf-class="d-flex gap-1 align-items-center mb-0 lh-lg {{search and 'base-fs font-sans-serif' or 'fs-3'}} {{search and bool(category) and 'mb-2'}}"
+                                    t-attf-class="o_wsale_category_title d-flex gap-1 align-items-center mb-0 lh-lg {{search and bool(category) and 'mb-2'}} {{search and 'o_wsale_category_title_is_search base-fs font-sans-serif' or 'fs-3'}}"
                                 >
                                     <a
                                         t-if="(search and not category) or (not search and category)"
@@ -643,9 +659,14 @@
                                     <span t-elif="search">
                                         <span class="text-muted">Search results for </span>'<strong t-out="search"/>' <small t-if="search_count" class="text-muted"> (<t t-out="search_count"/>)</small>
                                     </span>
-                                    <t t-elif="category" t-out="category.name"/>
+                                    <t t-elif="category">
+                                        <span t-field="category.name"/>
+                                    </t>
                                 </h1>
-                                <h1 class="h4-fs" t-if="not category and not search">
+                                <h1
+                                    class="o_wsale_shop_title h4-fs"
+                                    t-if="not category and not search"
+                                >
                                     All products
                                 </h1>
                                 <t t-if="category">
@@ -655,8 +676,19 @@
                                     </t>
                                     <div
                                         id="category_header"
+                                        class="o_wsale_category_description"
                                         t-att-data-editor-message="editor_msg"
                                         t-field="category.website_description"
+                                    />
+                                </t>
+                                <t t-else="">
+                                    <t t-set="editor_msg">
+                                        Drag building blocks here to customize the header for the shop page.
+                                    </t>
+                                    <div
+                                        id="oe_structure_products_header_shop"
+                                        class="oe_structure oe_empty"
+                                        t-att-data-editor-message="editor_msg"
                                     />
                                 </t>
                                 <t t-if="opt_wsale_categories_top"
@@ -928,6 +960,9 @@
     <template id="website_sale.products_categories" active="False" name="Categories in Left Side "/>
     <template id="website_sale.products_categories_top" active="True" name="Categories in top-nav"/>
     <template id="website_sale.products_attributes_top" active="False" name="Attributes in top-nav"/>
+
+    <template id="website_sale.products_shop_title" active="True" name="Show Shop Title"/>
+    <template id="website_sale.products_shop_title_align" active="False" name="Align Shop Title"/>
 
     <template id="website_sale.filter_color_attributes" name="Color attributes in Filter">
         <t t-foreach="a.value_ids" t-as="v">
@@ -1345,7 +1380,7 @@
             class="o_wsale_filmstrip_container o_wsale_filmstrip_default d-flex align-items-stretch overflow-hidden"
             role="navigation"
         >
-            <div class="o_wsale_filmstrip_wrapper position-relative w-100 overflow-auto z-1">
+            <div class="o_wsale_filmstrip_wrapper position-relative overflow-auto z-1">
                 <ul
                     class="o_wsale_filmstrip d-flex align-items-stretch mb-0 list-unstyled overflow-visible"
                     role="menu"


### PR DESCRIPTION
This PR introduces options for the categories and /shop page.

Feature:
- Create category specific options
- Opt. Show/Hide title on categories and /shop
- Opt. Center Content (title, desc, filmstrip) on categories & /shop
- Opt. Show/Hide description on categories

Note: since we now have an option to center the filmstrip, `w-100` is
not viable to solve the rendering on safari. This bug was due to a
miscalculation of the `flex-basis`, we now use a width instead.

[task-4711722](https://www.odoo.com/web#id=4711722&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
