### PR TITLE
[IMP] core: @api.deprecated

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3431,6 +3431,7 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
 
     @api.model
+    @api.deprecated("Override of a deprecated method")
     def check_field_access_rights(self, operation, field_names):
         result = super().check_field_access_rights(operation, field_names)
         if not field_names:

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1416,6 +1416,7 @@ class AccountMoveLine(models.Model):
     # -------------------------------------------------------------------------
 
     @api.model
+    @api.deprecated("Override of a deprecated method")
     def check_field_access_rights(self, operation, field_names):
         result = super().check_field_access_rights(operation, field_names)
         if not field_names:

--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -292,7 +292,8 @@ def get_sorted_installed_modules(env):
 
 def is_public_method(model, name):
     try:
-        return get_public_method(model, name)
+        method = get_public_method(model, name)
+        return not hasattr(method, '__deprecated__')
     except (AttributeError, AccessError):
         return None
 

--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -4,7 +4,6 @@ import datetime
 import logging
 import re
 import traceback
-import warnings
 from collections import defaultdict
 from uuid import uuid4
 
@@ -1050,9 +1049,8 @@ class BaseAutomation(models.Model):
     def _get_calendar(self, automation, record):
         return automation.trg_date_calendar_id
 
-    @api.model
+    @api.deprecated("Since 19.0, use _cron_process_time_based_automations")
     def _check(self, automatic=False, use_new_cursor=False):
-        warnings.warn("Since 19.0, use _cron_process_time_based_automations", DeprecationWarning)
         if not automatic:
             raise RuntimeError("can run time-based automations only in automatic mode")
         self._cron_process_time_based_actions()

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -213,6 +213,7 @@ class HrEmployee(models.Model):
         return result
 
     @api.model
+    @api.deprecated("Override of a deprecated method")
     def check_field_access_rights(self, operation, field_names):
         # DISCLAIMER: Dirty hack to avoid having to create a bridge module to override only a
         # groups on a field which is not prefetched (because not stored) but would crash anyway

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import warnings
-
 import odoo
 from odoo import api, models, fields
 from odoo.http import request, DEFAULT_MAX_CONTENT_LENGTH
@@ -197,6 +195,6 @@ class IrHttp(models.AbstractModel):
             })
         return session_info
 
+    @api.deprecated("Deprecated since 19.0, use get_all_currencies on 'res.currency'")
     def get_currencies(self):
-        warnings.warn("Deprecated since 19.0, use get_all_currencies on 'res.currency'", DeprecationWarning)
         return self.env['res.currency'].get_all_currencies()

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -7,7 +7,6 @@ import os
 import psycopg2
 import psycopg2.errors
 import typing
-import warnings
 from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import relativedelta
 
@@ -752,6 +751,7 @@ class IrCron(models.Model):
         }])
         return self.with_context(ir_cron_progress_id=progress.id), progress
 
+    @api.deprecated("Since 19.0, use _commit_progress")
     def _notify_progress(self, *, done: int, remaining: int, deactivate: bool = False):
         """
         Log the progress of the cron job.
@@ -761,7 +761,6 @@ class IrCron(models.Model):
         :param int remaining: the number of tasks left to process
         :param bool deactivate: whether the cron will be deactivated
         """
-        warnings.warn("Since 19.0, use _commit_progress", DeprecationWarning)
         if not (progress_id := self.env.context.get('ir_cron_progress_id')):
             return
         if done < 0 or remaining < 0:

--- a/odoo/addons/test_rpc/models.py
+++ b/odoo/addons/test_rpc/models.py
@@ -11,11 +11,6 @@ class Test_RpcModel_A(models.Model):
     field_b1 = fields.Many2one("test_rpc.model_b", string="required field", required=True)
     field_b2 = fields.Many2one("test_rpc.model_b", string="restricted field", ondelete="restrict")
 
-    @api.model
-    @api.private
-    def read_group(self, *a, **kw):
-        return super().read_group(*a, **kw)
-
     @api.private
     def private_method(self):
         return "private"

--- a/odoo/api/__init__.py
+++ b/odoo/api/__init__.py
@@ -7,6 +7,7 @@ from odoo.orm.decorators import (
     constrains,
     depends,
     depends_context,
+    deprecated,
     model,
     model_create_multi,
     onchange,

--- a/odoo/orm/decorators.py
+++ b/odoo/orm/decorators.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import typing
+import warnings
 from collections.abc import Mapping
 from functools import wraps
 
@@ -13,6 +14,41 @@ try:
     from decorator import decoratorx as decorator
 except ImportError:
     from decorator import decorator
+
+try:
+    # available since python 3.13
+    from warnings import deprecated
+except ImportError:
+    # simplified version
+    class deprecated:
+        def __init__(
+            self,
+            message: str,
+            /,
+            *,
+            category: type[Warning] | None = DeprecationWarning,
+            stacklevel: int = 1,
+        ) -> None:
+            self.message = message
+            self.category = category
+            self.stacklevel = stacklevel
+
+        def __call__(self, obj, /):
+            message = self.message
+            category = self.category
+            stacklevel = self.stacklevel
+            if category is None:
+                obj.__deprecated__ = message
+                return obj
+            if callable(obj):
+                @wraps(obj)
+                def wrapper(*args, **kwargs):
+                    warnings.warn(message, category=category, stacklevel=stacklevel + 1)
+                    return obj(*args, **kwargs)
+
+                obj.__deprecated__ = wrapper.__deprecated__ = message
+                return wrapper
+            raise TypeError(f"@deprecated decorator cannot be applied to {obj!r}")
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Collection

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -2654,6 +2654,7 @@ class BaseModel(metaclass=MetaModel):
 
     @api.model
     @api.readonly
+    @api.deprecated("Since 19.0, read_group is deprecated. Please use _read_group in the backend code or formatted_read_group for a complete formatted result")
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
         """Deprecated - Get the list of records in list view grouped by the given ``groupby`` fields.
 
@@ -2693,10 +2694,6 @@ class BaseModel(metaclass=MetaModel):
         :rtype: [{'field_name_1': value, ...}, ...]
         :raise AccessError: if user is not allowed to access requested information
         """
-        warnings.warn(
-            "Since 19.0, read_group is deprecated. Please use _read_group in the backend code or formatted_read_group for a complete formatted result",
-            DeprecationWarning,
-        )
         groupby = [groupby] if isinstance(groupby, str) else groupby
         lazy_groupby = groupby[:1] if lazy else groupby
 
@@ -3338,6 +3335,10 @@ class BaseModel(metaclass=MetaModel):
         raise AccessError(error_msg)
 
     @api.model
+    @api.deprecated(
+        "Deprecated since 19.0, use `_check_field_access` on models."
+        " To get the list of allowed fields, use `fields_get`.",
+    )
     def check_field_access_rights(self, operation: str, field_names: list[str] | None) -> list[str]:
         """Check the user access rights on the given fields.
 
@@ -3352,11 +3353,6 @@ class BaseModel(metaclass=MetaModel):
         :raise AccessError: if the user is not allowed to access
           the provided fields.
         """
-        warnings.warn(
-            "Deprecated since 19.0, use `_check_field_access` on models."
-            " To get the list of allowed fields, use `fields_get`.",
-            DeprecationWarning,
-        )
         if self.env.su:
             return field_names or list(self._fields)
 
@@ -4054,6 +4050,7 @@ class BaseModel(metaclass=MetaModel):
         return None
 
     @api.model
+    @api.deprecated("check_access_rights() is deprecated since 18.0; use check_access() instead.")
     def check_access_rights(self, operation, raise_exception=True):
         """ Verify that the given operation is allowed for the current user accord to ir.model.access.
 
@@ -4063,14 +4060,11 @@ class BaseModel(metaclass=MetaModel):
         :rtype: bool
         :raise AccessError: if the operation is forbidden and raise_exception is True
         """
-        warnings.warn(
-            "check_access_rights() is deprecated since 18.0; use check_access() instead.",
-            DeprecationWarning, stacklevel=2,
-        )
         if raise_exception:
             return self.browse().check_access(operation)
         return self.browse().has_access(operation)
 
+    @api.deprecated("check_access_rule() is deprecated since 18.0; use check_access() instead.")
     def check_access_rule(self, operation):
         """ Verify that the given operation is allowed for the current user according to ir.rules.
 
@@ -4078,25 +4072,15 @@ class BaseModel(metaclass=MetaModel):
         :return: None if the operation is allowed
         :raise UserError: if current ``ir.rules`` do not permit this operation.
         """
-        warnings.warn(
-            "check_access_rule() is deprecated since 18.0; use check_access() instead.",
-            DeprecationWarning, stacklevel=2,
-        )
         self.check_access(operation)
 
+    @api.deprecated("_filter_access_rules() is deprecated since 18.0; use _filtered_access() instead.")
     def _filter_access_rules(self, operation):
         """ Return the subset of ``self`` for which ``operation`` is allowed. """
-        warnings.warn(
-            "_filter_access_rules() is deprecated since 18.0; use _filtered_access() instead.",
-            DeprecationWarning, stacklevel=2,
-        )
         return self._filtered_access(operation)
 
+    @api.deprecated("_filter_access_rules_python() is deprecated since 18.0; use _filtered_access() instead.")
     def _filter_access_rules_python(self, operation):
-        warnings.warn(
-            "_filter_access_rules_python() is deprecated since 18.0; use _filtered_access() instead.",
-            DeprecationWarning, stacklevel=2,
-        )
         return self._filtered_access(operation)
 
     def unlink(self) -> typing.Literal[True]:
@@ -5597,12 +5581,12 @@ class BaseModel(metaclass=MetaModel):
         ))
         return bool(cr.fetchone())
 
+    @api.deprecated("Deprecated since 18.0, use _has_cycle() instead")
     def _check_recursion(self, parent=None):
-        warnings.warn("Deprecated since 18.0, use _has_cycle() instead", DeprecationWarning, stacklevel=2)
         return not self._has_cycle(parent)
 
+    @api.deprecated("Deprecated since 18.0, use _has_cycle() instead")
     def _check_m2m_recursion(self, field_name):
-        warnings.warn("Deprecated since 18.0, use _has_cycle() instead", DeprecationWarning, stacklevel=2)
         return not self._has_cycle(field_name)
 
     def _get_external_ids(self) -> dict[IdType, list[str]]:
@@ -5699,9 +5683,9 @@ class BaseModel(metaclass=MetaModel):
 
         return records._read_format(fnames=fields, **read_kwargs)
 
+    @api.deprecated("Deprecated since 19.0, use action_archive or action_unarchive")
     def toggle_active(self):
         "Inverses the value of :attr:`active` on the records in ``self``."
-        warnings.warn("Deprecated since 19.0, use action_archive or action_unarchive", DeprecationWarning)
         assert self._active_name, f"No 'active' field on model {self._name}"
         active_recs = self.filtered(self._active_name)
         active_recs.action_archive()
@@ -5822,18 +5806,18 @@ class BaseModel(metaclass=MetaModel):
         return list(OriginIds(self._ids))
 
     @property
+    @api.deprecated("Deprecated since 19.0, use self.env.cr directly")
     def _cr(self):
-        warnings.warn("Deprecated since 19.0, use self.env.cr directly", DeprecationWarning)
         return self.env.cr
 
     @property
+    @api.deprecated("Deprecated since 19.0, use self.env.uid directly")
     def _uid(self):
-        warnings.warn("Deprecated since 19.0, use self.env.uid directly", DeprecationWarning)
         return self.env.uid
 
     @property
+    @api.deprecated("Deprecated since 19.0, use self.env.context directly")
     def _context(self):
-        warnings.warn("Deprecated since 19.0, use self.env.context directly", DeprecationWarning)
         return self.env.context
 
     #


### PR DESCRIPTION
Like `warnings.deprecated` but available before python 3.13. The simplified version is implemented only for callables and does not work for classes.

The decorator adds a `__deprecated__` attribute on the caller containing the message. This can be used for documentation purposes.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
