### PR TITLE
[IMP] website: editor discard also discards theme changes

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -1012,6 +1012,27 @@ class Website(Home):
                 })
         return json.loads(metadata.raw)
 
+    @http.route(['/website/revert_changes'], type='jsonrpc', auth='user', website=True)
+    def revert_changes(self, theme_data=None, footer_data=None, scss_data=None):
+        """
+        In the website editor, editing some options cause changes to happen directly
+        in the backend; this function allows those changes to be reverted.
+
+        Every time an option that causes a backend change is modified the client
+        generates the required steps to revert that change and saves them in
+        localStorage. When the discard button is pressed, those steps are sent to the
+        backend and handled with this function.
+        """
+        if theme_data:
+            self.theme_customize_data(theme_data['is_view_data'], theme_data['enable'], theme_data['disable'])
+
+        if footer_data:
+            self.update_footer_template(footer_data['template_key'], footer_data['possible_values'])
+
+        if scss_data:
+            for value in scss_data:
+                self.env['website.assets'].make_scss_customization(value['url'], value['data'])
+
     def _get_customize_data(self, keys, is_view_data):
         model = 'ir.ui.view' if is_view_data else 'ir.asset'
         Model = request.env[model].with_context(active_test=False)

--- a/addons/website/models/assets.py
+++ b/addons/website/models/assets.py
@@ -307,6 +307,7 @@ class WebsiteAssets(models.AbstractModel):
             pattern = "'%s': %%s,\n" % name
             regex = re.compile(pattern % ".+")
             replacement = pattern % value
+
             if regex.search(updatedFileContent):
                 updatedFileContent = re.sub(regex, replacement, updatedFileContent)
             else:

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -78,6 +78,7 @@ export class CustomizeWebsitePlugin extends Plugin {
             }
         }),
         save_handlers: this.onSave.bind(this),
+        discard_handlers: this.onDiscard.bind(this),
     };
 
     async onSave() {
@@ -90,6 +91,26 @@ export class CustomizeWebsitePlugin extends Plugin {
             });
         }
     }
+
+    async onDiscard() {
+        const originalThemeData =
+            JSON.parse(localStorage.getItem("website-theme-data-rollback")) || null;
+        const originalFooterData = JSON.parse(
+            localStorage.getItem("website-footer-data-rollback") || "[]"
+        );
+        const originalScssData = JSON.parse(
+            localStorage.getItem("website-customization-rollback") || "[]"
+        );
+
+        if (originalThemeData || originalFooterData?.template_key || originalScssData.length) {
+            await rpc("/website/revert_changes", {
+                theme_data: originalThemeData,
+                footer_data: originalFooterData,
+                scss_data: originalScssData,
+            });
+        }
+    }
+
     cache = {};
     activeRecords = {};
     activeTemplateViews = {};
@@ -212,9 +233,34 @@ export class CustomizeWebsitePlugin extends Plugin {
         await this.makeSCSSCusto(url, colors, nullValue);
     }, 0);
     async makeSCSSCusto(url, values, defaultValue = "null") {
-        Object.keys(values).forEach((key) => {
+        const oldValues = {};
+        const style = getComputedStyle(this.document.documentElement);
+
+        for (const key of Object.keys(values)) {
             values[key] = values[key] || defaultValue;
-        });
+            oldValues[key] = getCSSVariableValue(key, style) || defaultValue;
+        }
+
+        // Each first overwritten value is stored to be reverted in case of a discard.
+        // Values are grouped by scss urls to minimize the amount of backend operations
+        // necessary.
+        const storageValue = localStorage.getItem("website-customization-rollback");
+        const websiteCustomizationRollback = storageValue ? JSON.parse(storageValue) : [];
+        for (const [key, value] of Object.entries(oldValues)) {
+            let entry = websiteCustomizationRollback.find((item) => item.url === url);
+            if (!entry) {
+                entry = { url: url, data: {} };
+                websiteCustomizationRollback.push(entry);
+            }
+            if (!(key in entry.data)) {
+                entry.data[key] = value;
+            }
+        }
+        localStorage.setItem(
+            "website-customization-rollback",
+            JSON.stringify(websiteCustomizationRollback)
+        );
+
         await this.services.orm.call("website.assets", "make_scss_customization", [url, values]);
     }
     reloadBundles = debounce(this._reloadBundles.bind(this), 0);
@@ -712,6 +758,24 @@ export class WebsiteConfigAction extends BuilderAction {
                 defs.map((def) => def.resolve());
                 return;
             } else {
+                // Compose an object that contains the necessary information for a rollback
+                // Views that were enabled and are being disabled should be reenabled in rollback
+                // The opposite is true for disabled views
+                const enable = [...aggregatedToDisable].filter((view) =>
+                    this.dependencies.customizeWebsite.getConfigKey(view)
+                );
+                const disable = [...aggregatedToDisable.union(aggregatedToEnable)].filter(
+                    (view) => !enable.includes(view)
+                );
+                handleThemeDataRollback(
+                    {
+                        is_view_data: isViewData,
+                        enable: enable,
+                        disable: disable,
+                    },
+                    "website-theme-data-rollback"
+                );
+
                 rpc("/website/theme_customize_data", {
                     is_view_data: isViewData,
                     enable: [...aggregatedToEnable],
@@ -724,6 +788,33 @@ export class WebsiteConfigAction extends BuilderAction {
         }, 0);
         return def;
     }
+}
+
+function handleThemeDataRollback(data, localStorageItem) {
+    let originalThemeData = JSON.parse(localStorage.getItem(localStorageItem)) || null;
+    // Collapses all the rollback steps into a single one
+    // Example:
+    // I have A enabled
+    // To enable B I have to disable A and enable B
+    // To then enable C I have to disable B and enable C
+    // And to enable D I have to disable C and enable D
+    // If I wanto to roll back to the original status, I just need to disable D and
+    // enable A, I can skip all the intermediate steps
+    // If A -> B and B -> C, then A -> C
+    if (originalThemeData) {
+        const valsToDisable = originalThemeData.disable;
+        valsToDisable.forEach((val) => {
+            if (data.enable.includes(val)) {
+                originalThemeData.disable = originalThemeData.disable.filter((data) => data != val);
+                data.enable = data.enable.filter((data) => data != val);
+            }
+        });
+        originalThemeData.enable = [...new Set(originalThemeData.enable.concat(data.enable))];
+        originalThemeData.disable = [...new Set(originalThemeData.disable.concat(data.disable))];
+    } else {
+        originalThemeData = data;
+    }
+    localStorage.setItem(localStorageItem, JSON.stringify(originalThemeData));
 }
 
 export class PreviewableWebsiteConfigAction extends BuilderAction {

--- a/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
@@ -201,12 +201,25 @@ export class WebsiteConfigFooterAction extends BuilderAction {
     }
     async apply({ params: { vars, view }, selectableContext }) {
         const possibleValues = new Set();
+        let oldValue = null;
         for (const item of selectableContext.items) {
             for (const a of item.getActions()) {
                 if (a.actionId === "websiteConfigFooter") {
                     possibleValues.add(a.actionParam.view);
+                    if (item.isApplied()) {
+                        oldValue = a.actionParam.view;
+                    }
                 }
             }
+        }
+        if (oldValue && localStorage.getItem("website-footer-data-rollback") === "[]") {
+            localStorage.setItem(
+                "website-footer-data-rollback",
+                JSON.stringify({
+                    template_key: oldValue,
+                    possible_values: [...possibleValues],
+                })
+            );
         }
         await Promise.all([
             this.dependencies.customizeWebsite.makeSCSSCusto(

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -104,7 +104,16 @@ export class WebsiteBuilder extends Component {
         });
     }
 
-    discard() {
+    async discard() {
+        const dispatchDiscardAndCloseEditor = async () => {
+            if (this.editor) {
+                for (const handler of this.editor.getResource("discard_handlers") || []) {
+                    await handler();
+                }
+            }
+            this.props.builderProps.closeEditor();
+        };
+
         if (this.editor.shared.history.canUndo()) {
             this.dialog.add(ConfirmationDialog, {
                 title: _t("Discard all changes?"),
@@ -113,11 +122,11 @@ export class WebsiteBuilder extends Component {
                 ),
                 confirmLabel: _t("Discard changes"),
                 cancelLabel: _t("Keep editing"),
-                confirm: () => this.props.builderProps.closeEditor(),
+                confirm: async () => await dispatchDiscardAndCloseEditor(),
                 cancel: () => {},
             });
         } else {
-            this.props.builderProps.closeEditor();
+            await dispatchDiscardAndCloseEditor();
         }
     }
 

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -286,6 +286,9 @@ export class WebsiteBuilderClientAction extends Component {
                 },
             })
         );
+        localStorage.removeItem("website-theme-data-rollback");
+        localStorage.removeItem("website-footer-data-rollback");
+        localStorage.removeItem("website-customization-rollback");
         this.unblockIframe();
         this.state.isEditing = true;
     }


### PR DESCRIPTION
This PR contains two commits:

The first commit adds a dispatch on pressing the discard button in
the editor, so that other elements can react to the editor discarding.

The second commit allows the discard button to also revert backend
changes, meaning that theme/header/footer changes that go throught
the backend directly get properly reverted when the discard button
is pressed.

task-4257306