### PR TITLE
[REF] mail, *: enforce Store add() instead of constructor

### DIFF
--- a/addons/crm_livechat/models/crm_lead.py
+++ b/addons/crm_livechat/models/crm_lead.py
@@ -37,8 +37,7 @@ class CrmLead(models.Model):
         return super().write(vals)
 
     def action_open_livechat(self):
-        Store(
+        Store(bus_channel=self.env.user).add(
             self.origin_channel_id,
             extra_fields={"open_chat_window": True},
-            bus_channel=self.env.user,
         ).bus_send()

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -63,7 +63,7 @@ class TestOutOfOffice(TestHrHolidaysCommon):
             'channel_type': 'chat',
             'name': 'test'
         })
-        data = Store(channel).get_result()
+        data = Store().add(channel).get_result()
         partner_info = next(p for p in data["res.partner"] if p["id"] == partner.id)
         partner2_info = next(p for p in data["res.partner"] if p["id"] == partner2.id)
         user_info = next(u for u in data["res.users"] if u["id"] == partner_info["main_user_id"])

--- a/addons/hr_holidays/tests/test_res_partner.py
+++ b/addons/hr_holidays/tests/test_res_partner.py
@@ -59,13 +59,13 @@ class TestPartner(TransactionCase):
     def test_res_partner_to_store(self):
         self.leaves.write({'state': 'validate'})
         self.assertEqual(
-            Store(self.partner).get_result()["hr.employee"][0]["leave_date_to"],
+            Store().add(self.partner).get_result()["hr.employee"][0]["leave_date_to"],
             "2024-06-07",
             "Return date is the return date of the main user of the partner",
         )
         self.leaves[0].action_refuse()
         self.assertEqual(
-            Store(self.partner).get_result()["hr.employee"][0]["leave_date_to"],
+            Store().add(self.partner).get_result()["hr.employee"][0]["leave_date_to"],
             False,
             "Partner is not considered out of office if their main user is not on holiday",
         )
@@ -74,8 +74,9 @@ class TestPartner(TransactionCase):
     @users("user_no_hr_access")
     def test_res_partner_to_store_no_hr_access(self):
         self.leaves.write({"state": "validate"})
+        data = Store().add(self.partner.with_user(self.user_no_hr_access)).get_result()
         self.assertEqual(
-            Store(self.partner.with_user(self.user_no_hr_access)).get_result()["hr.employee"][0]["leave_date_to"],
+            data["hr.employee"][0]["leave_date_to"],
             "2024-06-07",
             "Return date is the return date of the main user of the partner, "
             "even if the user has no access to the company",

--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -17,7 +17,7 @@ class LivechatChatbotScriptController(http.Controller):
         message = discuss_channel.with_context(lang=chatbot_language)._chatbot_restart(chatbot)
         return {
             "message_id": message.id,
-            "store_data": Store(message).get_result(),
+            "store_data": Store().add(message).get_result(),
         }
 
     @http.route("/chatbot/answer/save", type="jsonrpc", auth="public")
@@ -74,7 +74,7 @@ class LivechatChatbotScriptController(http.Controller):
         # sudo: discuss.channel - updating current step on the channel is allowed
         discuss_channel.sudo().chatbot_current_step_id = next_step.id
         posted_message = next_step._process_step(discuss_channel)
-        store = Store(posted_message)
+        store = Store().add(posted_message)
         store.add(next_step)
         store.add_model_values(
             "ChatbotStep",
@@ -126,5 +126,5 @@ class LivechatChatbotScriptController(http.Controller):
         if last_user_message:
             result = chatbot._validate_email(last_user_message.body, discuss_channel)
             if posted_message := result.pop("posted_message"):
-                result["data"] = Store(posted_message).get_result()
+                result["data"] = Store().add(posted_message).get_result()
         return result

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -422,7 +422,7 @@ class DiscussChannel(models.Model):
                 member.sudo()._rtc_leave_call()
             # sudo: discuss.channel - visitor left the conversation, state must be updated
             self.sudo().livechat_end_dt = fields.Datetime.now()
-            Store(self, "livechat_end_dt", bus_channel=self).bus_send()
+            Store(bus_channel=self).add(self, "livechat_end_dt").bus_send()
             # avoid useless notification if the channel is empty
             if not self.message_ids:
                 return
@@ -670,4 +670,4 @@ class DiscussChannel(models.Model):
         ):
             # sudo: discuss.channel - last operator left the conversation, state must be updated.
             channel_sudo.livechat_end_dt = fields.Datetime.now()
-            Store(channel_sudo, "livechat_end_dt", bus_channel=self).bus_send()
+            Store(bus_channel=self).add(channel_sudo, "livechat_end_dt").bus_send()

--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -138,14 +138,13 @@ class DiscussChannelMember(models.Model):
         sessions_to_be_unpinned.write({'unpin_dt': fields.Datetime.now()})
         sessions_to_be_unpinned.channel_id.livechat_end_dt = fields.Datetime.now()
         for member in sessions_to_be_unpinned:
-            Store(
+            Store(bus_channel=member._bus_channel()).add(
                 member.channel_id,
                 {
                     "close_chat_window": True,
                     "is_pinned": False,
                     "livechat_end_dt": fields.Datetime.now(),
                 },
-                bus_channel=member._bus_channel(),
             ).bus_send()
 
     def _to_store_defaults(self, target):

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -228,13 +228,13 @@ class Im_LivechatChannel(models.Model):
             raise AccessError(_("Only Live Chat operators can join Live Chat channels"))
         # sudo: im_livechat.channel - operators can join channels
         self.sudo().user_ids = [Command.link(self.env.user.id)]
-        Store(self, ["are_you_inside", "name"], bus_channel=self.env.user).bus_send()
+        Store(bus_channel=self.env.user).add(self, ["are_you_inside", "name"]).bus_send()
 
     def action_quit(self):
         self.ensure_one()
         # sudo: im_livechat.channel - users can leave channels
         self.sudo().user_ids = [Command.unlink(self.env.user.id)]
-        Store(self.sudo(), ["are_you_inside", "name"], bus_channel=self.env.user).bus_send()
+        Store(bus_channel=self.env.user).add(self.sudo(), ["are_you_inside", "name"]).bus_send()
 
     def action_view_rating(self):
         """ Action to display the rating relative to the channel, so all rating of the

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -170,7 +170,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
         def get_forward_op_bus_params():
             messages = self.env["mail.message"].search([], order="id desc", limit=3)
             # only data relevant to the test are asserted for simplicity
-            transfer_message_data = Store(messages[1], bus_channel=discuss_channel).get_result()
+            transfer_message_data = Store(bus_channel=discuss_channel).add(messages[1]).get_result()
             transfer_message_data["mail.message"][0].update(
                 {
                     "author_id": self.chatbot_script.operator_partner_id.id,
@@ -181,7 +181,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                 }
             )
             transfer_message_data["mail.thread"][0]["display_name"] = "Testing Bot"
-            joined_message_data = Store(messages[0], bus_channel=discuss_channel).get_result()
+            joined_message_data = Store(bus_channel=discuss_channel).add(messages[0]).get_result()
             joined_message_data["mail.message"][0].update(
                 {
                     "author_id": self.chatbot_script.operator_partner_id.id,
@@ -202,10 +202,9 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                 lambda m: m.partner_id == self.partner_employee
             )
             # data in-between join and leave
-            channel_data_join = Store(
-                discuss_channel,
-                bus_channel=member_emp._bus_channel(),
-            ).get_result()
+            channel_data_join = (
+                Store(bus_channel=member_emp._bus_channel()).add(discuss_channel).get_result()
+            )
             channel_data_join["discuss.channel"][0]["invited_member_ids"] = [["ADD", []]]
             channel_data_join["discuss.channel"][0]["rtc_session_ids"] = [["ADD", []]]
             channel_data_join["discuss.channel"][0]["livechat_outcome"] = "no_agent"
@@ -237,12 +236,12 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                     ),
                 },
             )
-            channel_data = Store(discuss_channel).get_result()
+            channel_data = Store().add(discuss_channel).get_result()
             channel_data["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
-            channel_data_emp = Store(discuss_channel.with_user(self.user_employee)).get_result()
+            channel_data_emp = Store().add(discuss_channel.with_user(self.user_employee)).get_result()
             channel_data_emp["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
             channel_data_emp["discuss.channel.member"][1]["message_unread_counter_bus_id"] = 0
-            channel_data = Store(discuss_channel).get_result()
+            channel_data = Store().add(discuss_channel).get_result()
             channel_data["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
             return (
                 [

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -74,7 +74,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
         )
         chatbot_message = discuss_channel.chatbot_message_ids.mail_message_id[:1]
         self.assertEqual(
-            Store(chatbot_message).get_result()["mail.message"],
+            Store().add(chatbot_message).get_result()["mail.message"],
             [
                 {
                     "attachment_ids": [],
@@ -149,7 +149,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
             rating_id=record_rating.id,
         )
         self.assertEqual(
-            Store(message).get_result(),
+            Store().add(message).get_result(),
             {
                 "mail.message": self._filter_messages_fields(
                     {

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -69,7 +69,7 @@ class AttachmentController(ThreadController):
             attachment = request.env["ir.attachment"].sudo().create(vals)
             attachment._post_add_create(**kwargs)
             res = {
-                "data": Store(
+                "data": Store().add(
                     attachment,
                     extra_fields=request.env["ir.attachment"]._get_store_ownership_fields(),
                 ).get_result()

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -78,7 +78,7 @@ class ChannelController(http.Controller):
             domain=[("id", "not in", known_member_ids), ("channel_id", "=", channel.id)],
             limit=100,
         )
-        store = Store(channel, "member_count").add(unknown_members)
+        store = Store().add(channel, "member_count").add(unknown_members)
         return store.get_result()
 
     @http.route("/discuss/channel/update_avatar", methods=["POST"], type="jsonrpc")
@@ -105,7 +105,7 @@ class ChannelController(http.Controller):
             messages.set_message_done()
         return {
             **res,
-            "data": Store(messages).get_result(),
+            "data": Store().add(messages).get_result(),
             "messages": messages.ids,
         }
 
@@ -116,7 +116,7 @@ class ChannelController(http.Controller):
         if not channel:
             raise NotFound()
         messages = channel.pinned_message_ids.sorted(key="pinned_at", reverse=True)
-        return Store(messages).get_result()
+        return Store().add(messages).get_result()
 
     @http.route("/discuss/channel/mark_as_read", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
@@ -180,7 +180,7 @@ class ChannelController(http.Controller):
             domain.append(["id", "<", before])
         # sudo: ir.attachment - reading attachments of a channel that the current user can access
         attachments = request.env["ir.attachment"].sudo().search(domain, limit=limit, order="id DESC")
-        return Store(attachments).get_result()
+        return Store().add(attachments).get_result()
 
     @http.route("/discuss/channel/join", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
@@ -189,7 +189,7 @@ class ChannelController(http.Controller):
         if not channel:
             raise NotFound()
         channel._find_or_create_member_for_self()
-        return Store(channel).get_result()
+        return Store().add(channel).get_result()
 
     @http.route("/discuss/channel/sub_channel/create", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_sub_channel_create(self, parent_channel_id, from_message_id=None, name=None):
@@ -197,7 +197,7 @@ class ChannelController(http.Controller):
         if not channel:
             raise NotFound()
         sub_channel = channel._create_sub_channel(from_message_id, name)
-        return {"data": Store(sub_channel).get_result(), "sub_channel": sub_channel.id}
+        return {"data": Store().add(sub_channel).get_result(), "sub_channel": sub_channel.id}
 
     @http.route("/discuss/channel/sub_channel/fetch", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
@@ -211,4 +211,4 @@ class ChannelController(http.Controller):
         if search_term:
             domain.append(("name", "ilike", search_term))
         sub_channels = request.env["discuss.channel"].search(domain, order="id desc", limit=limit)
-        return Store(sub_channels).add(sub_channels._get_last_messages()).get_result()
+        return Store().add(sub_channels).add(sub_channels._get_last_messages()).get_result()

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -139,7 +139,7 @@ class RtcController(http.Controller):
             ]
             channel_member_sudo.channel_id.rtc_session_ids.filtered_domain(domain).write({})  # update write_date
         current_rtc_sessions, outdated_rtc_sessions = channel_member_sudo._rtc_sync_sessions(check_rtc_session_ids)
-        return Store(
+        return Store().add(
             member.channel_id,
             [
                 {"rtc_session_ids": Store.Many(current_rtc_sessions, mode="ADD")},

--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -13,7 +13,7 @@ class MailboxController(http.Controller):
         messages = res.pop("messages")
         return {
             **res,
-            "data": Store(messages, add_followers=True).get_result(),
+            "data": Store().add(messages, add_followers=True).get_result(),
             "messages": messages.ids,
         }
 
@@ -24,7 +24,7 @@ class MailboxController(http.Controller):
         messages = res.pop("messages")
         return {
             **res,
-            "data": Store(messages).get_result(),
+            "data": Store().add(messages).get_result(),
             "messages": messages.ids,
         }
 
@@ -35,6 +35,6 @@ class MailboxController(http.Controller):
         messages = res.pop("messages")
         return {
             **res,
-            "data": Store(messages).get_result(),
+            "data": Store().add(messages).get_result(),
             "messages": messages.ids,
         }

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -70,7 +70,7 @@ class ThreadController(http.Controller):
             messages.set_message_done()
         return {
             **res,
-            "data": Store(messages).get_result(),
+            "data": Store().add(messages).get_result(),
             "messages": messages.ids,
         }
 
@@ -137,7 +137,7 @@ class ThreadController(http.Controller):
         record.check_access("read")
         # find current model subtypes, add them to a dictionary
         subtypes = record._mail_get_message_subtypes()
-        store = Store(subtypes, ["name"]).add(follower, ["subtype_ids"])
+        store = Store().add(subtypes, ["name"]).add(follower, ["subtype_ids"])
         return {
             "store_data": store.get_result(),
             "subtype_ids": subtypes.sorted(
@@ -245,7 +245,7 @@ class ThreadController(http.Controller):
                 if key in thread._get_allowed_message_update_params()
             }
         )
-        return Store(message).get_result()
+        return Store().add(message).get_result()
 
     # side check for access
     # ------------------------------------------------------------
@@ -258,7 +258,7 @@ class ThreadController(http.Controller):
     def mail_thread_unsubscribe(self, res_model, res_id, partner_ids):
         thread = self.env[res_model].browse(res_id)
         thread.message_unsubscribe(partner_ids)
-        return Store(
+        return Store().add(
             thread, [], as_thread=True, request_list=["followers", "suggestedRecipients"]
         ).get_result()
 
@@ -266,6 +266,6 @@ class ThreadController(http.Controller):
     def mail_thread_subscribe(self, res_model, res_id, partner_ids):
         thread = self.env[res_model].browse(res_id)
         thread.message_subscribe(partner_ids)
-        return Store(
+        return Store().add(
             thread, [], as_thread=True, request_list=["followers", "suggestedRecipients"]
         ).get_result()

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -91,8 +91,8 @@ class MailGuest(models.Model):
         if len(name) > 512:
             raise UserError(_("Guest's name is too long."))
         self.name = name
-        Store(self, ["avatar_128", "name"], bus_channel=self.channel_ids).bus_send()
-        Store(self, ["avatar_128", "name"], bus_channel=self).bus_send()
+        Store(bus_channel=self.channel_ids).add(self, ["avatar_128", "name"]).bus_send()
+        Store(bus_channel=self).add(self, ["avatar_128", "name"]).bus_send()
 
     def _update_timezone(self, timezone):
         query = """

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -93,7 +93,7 @@ class ResPartner(models.Model):
             Store.One("channel_id", [], as_thread=True),
             *self.env["discuss.channel.member"]._to_store_persona([]),
         ]
-        store = Store(members, member_fields).add(partners)
+        store = Store().add(members, member_fields).add(partners)
         store.add(channel, "group_public_id")
         if allowed_group:
             for p in partners:

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -601,7 +601,7 @@ class MailActivity(models.Model):
 
     @api.readonly
     def activity_format(self):
-        return Store(self).get_result()
+        return Store().add(self).get_result()
 
     def _to_store_defaults(self, target):
         return [

--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -97,7 +97,9 @@ class MailLinkPreview(models.Model):
             ]
         )
         (message.sudo().message_link_preview_ids - message_link_previews_ok)._unlink_and_notify()
-        Store(message, "message_link_preview_ids", bus_channel=message._bus_channel()).bus_send()
+        Store(
+            bus_channel=message._bus_channel(),
+        ).add(message, "message_link_preview_ids").bus_send()
 
     @api.model
     def _is_link_preview_enabled(self):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -870,7 +870,7 @@ class MailMessage(models.Model):
         self.env.user._bus_send(
             "mail.message/toggle_star", {"message_ids": [self.id], "starred": starred}
         )
-        return Store(self, {"starred": self.starred}).get_result()
+        return Store().add(self, {"starred": self.starred}).get_result()
 
     @api.model
     def _message_fetch(self, domain, search_term=None, before=None, after=None, around=None, limit=30):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3319,9 +3319,8 @@ class MailThread(models.AbstractModel):
                 ]
             )
             for user in users:
-                Store(
+                Store(bus_channel=user).add(
                     message.with_user(user).with_context(allowed_company_ids=[]),
-                    bus_channel=user,
                     msg_vals=msg_vals,
                     add_followers=True,
                     followers=followers,
@@ -4785,7 +4784,7 @@ class MailThread(models.AbstractModel):
             # sudo: mail.message.translation - discarding translations of message after editing it
             self.env["mail.message.translation"].sudo().search([("message_id", "=", message.id)]).unlink()
             res.append({"translationValue": False})
-        Store(message, res, bus_channel=message._bus_channel()).bus_send()
+        Store(bus_channel=message._bus_channel()).add(message, res).bus_send()
 
     # ------------------------------------------------------
     # STORE

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -279,7 +279,7 @@ class ResPartner(models.Model):
         """
         domain = self._get_mention_suggestions_domain(search)
         partners = self._search_mention_suggestions(domain, limit)
-        store = Store(partners)
+        store = Store().add(partners)
         try:
             roles = self.env["res.role"].search([("name", "ilike", search)], limit=8)
             store.add(roles, "name")

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -178,7 +178,7 @@ class ResUsers(models.Model):
                 )
         if "notification_type" in vals:
             for user in user_notification_type_modified:
-                Store(user, "notification_type", bus_channel=user).bus_send()
+                Store(bus_channel=user).add(user, "notification_type").bus_send()
 
         return write_res
 

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -315,7 +315,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     def test_channel_info_get(self):
         # `channel_get` should return a new channel the first time a partner is given
         channel = self.env["discuss.channel"]._get_or_create_chat(partners_to=self.test_partner.ids)
-        init_data = Store(channel).get_result()
+        init_data = Store().add(channel).get_result()
         initial_channel_info = init_data["discuss.channel"][0]
         self.assertEqual(
             {persona["id"] for persona in init_data["res.partner"]},
@@ -324,20 +324,20 @@ class TestChannelInternals(MailCommon, HttpCase):
 
         # `channel_get` should return the existing channel every time the same partner is given
         same_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=self.test_partner.ids)
-        same_channel_info = Store(same_channel).get_result()["discuss.channel"][0]
+        same_channel_info = Store().add(same_channel).get_result()["discuss.channel"][0]
         self.assertEqual(same_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return the existing channel when the current partner is given together with the other partner
         together_pids = (self.partner_employee_nomail + self.test_partner).ids
         together_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=together_pids)
-        together_channel_info = Store(together_channel).get_result()["discuss.channel"][0]
+        together_channel_info = Store().add(together_channel).get_result()["discuss.channel"][0]
         self.assertEqual(together_channel_info['id'], initial_channel_info['id'])
 
         # `channel_get` should return a new channel the first time just the current partner is given,
         # even if a channel containing the current partner together with other partners already exists
         solo_pids = self.partner_employee_nomail.ids
         solo_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=solo_pids)
-        solo_channel_data = Store(solo_channel).get_result()
+        solo_channel_data = Store().add(solo_channel).get_result()
         solo_channel_info = solo_channel_data["discuss.channel"][0]
         self.assertNotEqual(solo_channel_info['id'], initial_channel_info['id'])
         self.assertEqual(
@@ -348,7 +348,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         # `channel_get` should return the existing channel every time the current partner is given
         same_solo_pids = self.partner_employee_nomail.ids
         same_solo_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=same_solo_pids)
-        same_solo_channel_info = Store(same_solo_channel).get_result()["discuss.channel"][0]
+        same_solo_channel_info = Store().add(same_solo_channel).get_result()["discuss.channel"][0]
         self.assertEqual(same_solo_channel_info['id'], solo_channel_info['id'])
 
     # `channel_get` will pin the channel by default and thus last interest will be updated.
@@ -380,7 +380,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         msg_2 = self._add_messages(chat, 'Body2', author=self.user_employee.partner_id)
         self_member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
         self_member._mark_as_read(msg_2.id)
-        init_data = Store(chat).get_result()
+        init_data = Store().add(chat).get_result()
         self_member_info = next(
             filter(lambda d: d["id"] == self_member.id, init_data["discuss.channel.member"])
         )
@@ -390,7 +390,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             "Last message id should have been updated",
         )
         self_member._mark_as_read(msg_1.id)
-        final_data = Store(chat).get_result()
+        final_data = Store().add(chat).get_result()
         self_member_info = next(
             filter(lambda d: d["id"] == self_member.id, final_data["discuss.channel.member"])
         )

--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -63,11 +63,13 @@ class TestDiscussTools(TransactionCase):
     def test_075_store_same_related_field_twice(self):
         """Test adding the same related field twice combines their data"""
         user = mail_new_test_user(self.env, login="test_user", name="Test User")
-        res = Store(
-            user, [Store.One("partner_id", "name"), Store.One("partner_id", "country_id")],
-        ).get_result()
         self.assertEqual(
-            res,
+            Store()
+            .add(
+                user,
+                [Store.One("partner_id", "name"), Store.One("partner_id", "country_id")],
+            )
+            .get_result(),
             {
                 "res.partner": [
                     {

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -80,21 +80,10 @@ class Store:
     The keys of data are the name of models as defined in mail JS code, and the values are any
     format supported by store.insert() method (single dict or list of dict for each model name)."""
 
-    def __init__(
-        self,
-        records=None,
-        fields=None,
-        extra_fields=None,
-        as_thread=False,
-        bus_channel=None,
-        bus_subchannel=None,
-        **kwargs,
-    ):
+    def __init__(self, bus_channel=None, bus_subchannel=None):
         self.data = {}
         self.data_id = None
         self.target = Store.Target(bus_channel, bus_subchannel)
-        if records:
-            self.add(records, fields, extra_fields=extra_fields, as_thread=as_thread, **kwargs)
 
     def add(self, records, fields=None, extra_fields=None, as_thread=False, **kwargs):
         """Add records to the store. Data is coming from _to_store() method of the model if it is

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -109,13 +109,13 @@ class TestMessageValues(MailCommon):
         # message _to_store.
         self.env.flush_all()
         self.env.invalidate_all()
-        res = Store(message.with_user(self.user_employee)).get_result()
+        res = Store().add(message.with_user(self.user_employee)).get_result()
         self.assertEqual(res["mail.message"][0].get("record_name"), "Test1")
 
         record1.write({"name": "Test2"})
         self.env.flush_all()
         self.env.invalidate_all()
-        res = Store(message.with_user(self.user_employee)).get_result()
+        res = Store().add(message.with_user(self.user_employee)).get_result()
         self.assertEqual(res["mail.message"][0].get('record_name'), 'Test2')
 
         # check model not inheriting from mail.thread -> should not crash
@@ -124,7 +124,7 @@ class TestMessageValues(MailCommon):
             'model': record_nothread._name,
             'res_id': record_nothread.id,
         })
-        formatted = Store(message).get_result()["mail.message"][0]
+        formatted = Store().add(message).get_result()["mail.message"][0]
         self.assertEqual(formatted['record_name'], record_nothread.name)
 
     def test_records_by_message(self):

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1374,13 +1374,13 @@ class TestNoThread(MailCommon, TestRecipients):
             'model': test_record._name,
             'res_id': test_record.id,
         })
-        formatted = Store(message).get_result()["mail.message"][0]
+        formatted = Store().add(message).get_result()["mail.message"][0]
         self.assertEqual(formatted['default_subject'], test_record.name)
         self.assertEqual(formatted['record_name'], test_record.name)
 
         test_record.write({'name': 'Just Test'})
         message.invalidate_recordset(['record_name'])
-        formatted = Store(message).get_result()["mail.message"][0]
+        formatted = Store().add(message).get_result()["mail.message"][0]
         self.assertEqual(formatted['default_subject'], 'Just Test')
         self.assertEqual(formatted['record_name'], 'Just Test')
 

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -101,14 +101,14 @@ class TestTracking(MailCommon):
             )
         # first record: tracking value should be hidden
         message_0 = records[0].message_ids[0]
-        formatted = Store(message_0).get_result()["mail.message"][0]
+        formatted = Store().add(message_0).get_result()["mail.message"][0]
         self.assertEqual(formatted['trackingValues'], [], 'Hidden values should not be formatted')
         mail_render = records[0]._notify_by_email_prepare_rendering_context(message_0, {})
         self.assertEqual(mail_render['tracking_values'], [])
 
         # second record: all values displayed
         message_1 = records[1].message_ids[0]
-        formatted = Store(message_1).get_result()["mail.message"][0]
+        formatted = Store().add(message_1).get_result()["mail.message"][0]
         self.assertEqual(len(formatted['trackingValues']), 1)
         self.assertDictEqual(
             formatted['trackingValues'][0],
@@ -768,9 +768,9 @@ class TestTrackingInternals(MailCommon):
         self.record.sudo().write({'email_from': 'X'})
         self.flush_tracking()
 
-        msg_emp = Store(self.record.message_ids).get_result()
-        msg_admin = Store(self.record.with_user(self.user_admin).message_ids).get_result()
-        msg_sudo = Store(self.record.sudo().message_ids).get_result()
+        msg_emp = Store().add(self.record.message_ids).get_result()
+        msg_admin = Store().add(self.record.with_user(self.user_admin).message_ids).get_result()
+        msg_sudo = Store().add(self.record.sudo().message_ids).get_result()
 
         tracking_values = self.env['mail.tracking.value'].search([('mail_message_id', '=', self.record.message_ids[0].id)])
         formatted_tracking_values = [{

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1435,7 +1435,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         messages_all = self.messages_all.with_env(self.env)
 
         with self.assertQueryCount(employee=23):  # tm 22
-            res = Store(messages_all).get_result()
+            res = Store().add(messages_all).get_result()
 
         self.assertEqual(len(res["mail.message"]), 2 * 2)
         for message in res["mail.message"]:
@@ -1448,7 +1448,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         message = self.messages_all[0].with_env(self.env)
 
         with self.assertQueryCount(employee=23):  # tm 22
-            res = Store(message).get_result()
+            res = Store().add(message).get_result()
 
         self.assertEqual(len(res["mail.message"]), 1)
         self.assertEqual(len(res["mail.message"][0]["attachment_ids"]), 2)
@@ -1469,14 +1469,14 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         } for record in records])
 
         with self.assertQueryCount(employee=4):
-            res = Store(messages).get_result()
+            res = Store().add(messages).get_result()
             self.assertEqual(len(res["mail.message"]), 6)
 
         self.env.flush_all()
         self.env.invalidate_all()
 
         with self.assertQueryCount(employee=14):  # tm: 13
-            res = Store(messages).get_result()
+            res = Store().add(messages).get_result()
             self.assertEqual(len(res["mail.message"]), 6)
 
     @warmup

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -92,10 +92,9 @@ class WebsiteVisitor(models.Model):
                 )
                 channel._add_members(guests=guest, post_joined_message=False)
         # Open empty channel to allow the operator to start chatting with the visitor
-        Store(
+        Store(bus_channel=self.env.user).add(
             discuss_channels,
             extra_fields={"open_chat_window": True},
-            bus_channel=self.env.user,
         ).bus_send()
 
     def _merge_visitor(self, target):

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -190,7 +190,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         operator_member = channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
         guest_member = channel.channel_member_ids.filtered(lambda m: m.guest_id == guest)
         self.assertEqual(
-            Store(channel).get_result(),
+            Store().add(channel).get_result(),
             {
                 "discuss.channel": [
                     {
@@ -304,7 +304,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             channel.channel_member_ids.filtered(lambda m: m.partner_id == self.operator.partner_id)
         )
         self.assertEqual(
-            Store(
+            Store().add(
                 channel.with_user(self.user_public).with_context(guest=guest),
             ).get_result()["discuss.channel"],
             [


### PR DESCRIPTION
With the introduction of bus_channel in Store, which is only allowed to be set in constructor, it becomes confusing as to what are constructor parameters and what are add() parameters.

And even before bus_channel, having 2 ways to add data to Store was unnecessarily confusing as the shortcut only saved very few characters.

https://github.com/odoo/enterprise/pull/91363