### PR TITLE
[IMP] resource,hr{*,_holidays}: work intervals for flex resources

### DIFF
--- a/addons/hr/tests/__init__.py
+++ b/addons/hr/tests/__init__.py
@@ -16,3 +16,4 @@ from . import test_scenario
 from . import test_hr_department
 from . import test_hr_version
 from . import test_hr_contract_versions
+from . import test_flexible_resource_calendar

--- a/addons/hr/tests/test_flexible_resource_calendar.py
+++ b/addons/hr/tests/test_flexible_resource_calendar.py
@@ -1,0 +1,123 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import pytz
+from datetime import datetime, date
+
+from odoo.tests.common import TransactionCase
+
+UTC = pytz.timezone('UTC')
+
+
+class TestFlexibleResourceCalendar(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.calendar_40h_flex = cls.env['resource.calendar'].create({
+            'name': 'Flexible 40h/week',
+            'tz': 'UTC',
+            'hours_per_day': 8.0,
+            'flexible_hours': True,
+        })
+        cls.flex_resource, cls.fully_flex_resource = cls.env['resource.resource'].create([{
+            'name': 'Flex',
+            'tz': 'UTC',
+            'calendar_id': cls.calendar_40h_flex.id,
+        }, {
+            'name': 'fully flex',
+            'tz': 'UTC',
+            'calendar_id': False,
+        }])
+
+    def test_flexible_resource_work_intervals_with_contracts(self):
+        flex_employee, fully_flex_employee = self.env['hr.employee'].create([{
+            'name': "flex employee",
+            'date_version': date(2025, 1, 1),
+            'contract_date_start': date(2025, 1, 1),
+            'contract_date_end': date(2025, 7, 29),
+            'wage': 10,
+            'resource_calendar_id': self.calendar_40h_flex.id,
+            'resource_id': self.flex_resource.id,
+        }, {
+            'name': "fully flex employee",
+            'date_version': date(2025, 1, 1),
+            'contract_date_start': date(2025, 1, 1),
+            'contract_date_end': date(2025, 7, 29),
+            'wage': 10,
+            'resource_calendar_id': False,
+            'resource_id': self.fully_flex_resource.id,
+        }])
+        flex_employee.create_version({
+            'date_version': date(2025, 8, 2),
+            'contract_date_start': date(2025, 8, 2),
+            'wage': 10,
+            'resource_calendar_id': self.calendar_40h_flex.id,
+        })
+
+        fully_flex_employee.create_version({
+            'date_version': date(2025, 8, 2),
+            'contract_date_start': date(2025, 8, 2),
+            'wage': 10,
+            'resource_calendar_id': False,
+        })
+
+        start_dt = datetime(2025, 7, 28).astimezone(UTC)
+        end_dt = datetime(2025, 8, 3, 17).astimezone(UTC)
+
+        resources = self.flex_resource | self.fully_flex_resource
+        work_intervals, hours_per_day, hours_per_week = resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+        self.maxDiff = None
+        for resource in resources:
+            self.assertEqual(work_intervals[resource.id]._items, [
+                (datetime(2025, 7, 28, 0, 0, tzinfo=UTC), datetime(2025, 7, 28, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 7, 29, 0, 0, tzinfo=UTC), datetime(2025, 7, 29, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 8, 2, 0, 0, tzinfo=UTC), datetime(2025, 8, 2, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 8, 3, 0, 0, tzinfo=UTC), datetime(2025, 8, 3, 17, 0, tzinfo=UTC), self.env['resource.calendar.attendance']),
+            ], "work intervals should be inside contract 1 and 2 periods, no contracts on 30, 31, 1")
+
+        self.assertDictEqual(hours_per_day[self.flex_resource.id], {
+            date(2025, 7, 28): 8.0,
+            date(2025, 7, 29): 8.0,
+            date(2025, 8, 2): 8.0,
+            date(2025, 8, 3): 8.0,
+        })
+
+        self.assertDictEqual(hours_per_week[self.flex_resource.id], {
+            (2025, 31): 32.0,
+            (2025, 32): 40.0,
+        }, "working day 27, 28, 29 and 02 on week 31, having a valid contract on week 32")
+
+        self.assertTrue(self.fully_flex_resource.id not in hours_per_day, "no date hours limit for fully flexible employees")
+
+    def test_flexible_resource_work_intervals_without_contracts(self):
+        start_dt = datetime(2025, 7, 28).astimezone(UTC)
+        end_dt = datetime(2025, 8, 3, 17).astimezone(UTC)
+
+        resources = self.flex_resource | self.fully_flex_resource
+        work_intervals, hours_per_day, hours_per_week = resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+        self.maxDiff = None
+        for resource in resources:
+            self.assertEqual(work_intervals[resource.id]._items, [
+                (datetime(2025, 7, 28, 0, 0, tzinfo=UTC), datetime(2025, 7, 28, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 7, 29, 0, 0, tzinfo=UTC), datetime(2025, 7, 29, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 7, 30, 0, 0, tzinfo=UTC), datetime(2025, 7, 30, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 7, 31, 0, 0, tzinfo=UTC), datetime(2025, 7, 31, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 8, 1, 0, 0, tzinfo=UTC), datetime(2025, 8, 1, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 8, 2, 0, 0, tzinfo=UTC), datetime(2025, 8, 2, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 8, 3, 0, 0, tzinfo=UTC), datetime(2025, 8, 3, 17, 0, tzinfo=UTC), self.env['resource.calendar.attendance']),
+            ], "when no contracts at all, we get the full period")
+
+        self.assertDictEqual(hours_per_day[self.flex_resource.id], {
+            date(2025, 7, 28): 8.0,
+            date(2025, 7, 29): 8.0,
+            date(2025, 7, 30): 8.0,
+            date(2025, 7, 31): 8.0,
+            date(2025, 8, 1): 8.0,
+            date(2025, 8, 2): 8.0,
+            date(2025, 8, 3): 8.0,
+        }, "when no contracts at all, we get the full period")
+        self.assertTrue(self.fully_flex_resource.id not in hours_per_day, "no date hours limit for fully flexible employees")
+
+        self.assertDictEqual(hours_per_week[self.flex_resource.id], {
+            (2025, 31): 40.0,
+            (2025, 32): 40.0,
+        })

--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -3,8 +3,10 @@
 from odoo import fields, models, api, _
 from odoo.exceptions import ValidationError
 from odoo.fields import Domain
+from odoo.tools import babel_locale_parse
+from odoo.tools.date_utils import weeknumber
 import pytz
-from datetime import datetime
+from datetime import datetime, time
 
 
 class ResourceCalendarLeaves(models.Model):
@@ -180,3 +182,38 @@ class ResourceResource(models.Model):
     _inherit = "resource.resource"
 
     leave_date_to = fields.Date(related="user_id.leave_date_to")
+
+    def _format_leave(self, leave, resource_hours_per_day, resource_hours_per_week, ranges_to_remove, start_day, end_day, locale):
+        leave_start = leave[0]
+        leave_record = leave[2]
+        holiday_id = leave_record.holiday_id
+        tz = pytz.timezone(self.tz or self.env.user.tz)
+
+        if holiday_id.request_unit_half:
+            # Half day leaves are limited to half a day within a single day
+            leave_day = leave_start.date()
+            half_start_datetime = tz.localize(datetime.combine(leave_day, datetime.min.time() if holiday_id.request_date_from_period == "am" else time(12)))
+            half_end_datetime = tz.localize(datetime.combine(leave_day, time(12) if holiday_id.request_date_from_period == "am" else datetime.max.time()))
+            ranges_to_remove.append((half_start_datetime, half_end_datetime, self.env['resource.calendar.attendance']))
+
+            if not self._is_fully_flexible():
+                # only days inside the original period
+                if leave_day >= start_day and leave_day <= end_day:
+                    resource_hours_per_day[self.id][leave_day] -= holiday_id.number_of_hours
+                week = weeknumber(babel_locale_parse(locale), leave_day)
+                resource_hours_per_week[self.id][week] -= holiday_id.number_of_hours
+        elif holiday_id.request_unit_hours:
+            # Custom leaves are limited to a specific number of hours within a single day
+            leave_day = leave_start.date()
+            range_start_datetime = pytz.utc.localize(leave_record.date_from).replace(tzinfo=None).astimezone(tz)
+            range_end_datetime = pytz.utc.localize(leave_record.date_to).replace(tzinfo=None).astimezone(tz)
+            ranges_to_remove.append((range_start_datetime, range_end_datetime, self.env['resource.calendar.attendance']))
+
+            if not self._is_fully_flexible():
+                # only days inside the original period
+                if leave_day >= start_day and leave_day <= end_day:
+                    resource_hours_per_day[self.id][leave_day] -= holiday_id.number_of_hours
+                week = weeknumber(babel_locale_parse(locale), leave_day)
+                resource_hours_per_week[self.id][week] -= holiday_id.number_of_hours
+        else:
+            super()._format_leave(leave, resource_hours_per_day, resource_hours_per_week, ranges_to_remove, start_day, end_day, locale)

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -32,3 +32,4 @@ from . import test_hr_leave_type_tour
 from . import test_time_off_graph_view_tour
 from . import test_leave_type_data
 from . import test_multi_contract
+from . import test_flexible_resource_calendar

--- a/addons/hr_holidays/tests/test_flexible_resource_calendar.py
+++ b/addons/hr_holidays/tests/test_flexible_resource_calendar.py
@@ -1,0 +1,150 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import pytz
+from datetime import datetime, date
+
+from odoo.tests.common import TransactionCase
+
+UTC = pytz.timezone('UTC')
+
+
+class TestFlexibleResourceCalendar(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.calendar_40h_flex = cls.env['resource.calendar'].create({
+            'name': 'Flexible 40h/week',
+            'tz': 'UTC',
+            'hours_per_day': 8.0,
+            'flexible_hours': True,
+        })
+        cls.flex_resource, cls.fully_flex_resource = cls.env['resource.resource'].create([{
+            'name': 'Flex',
+            'tz': 'UTC',
+            'calendar_id': cls.calendar_40h_flex.id,
+        }, {
+            'name': 'fully flex',
+            'tz': 'UTC',
+            'calendar_id': False,
+        }])
+
+        cls.flex_employee, cls.fully_flex_employee = cls.env['hr.employee'].create([{
+            'name': "flexible employee",
+            'date_version': date(2025, 1, 1),
+            'contract_date_start': date(2025, 1, 1),
+            'wage': 10,
+            'resource_calendar_id': cls.calendar_40h_flex.id,
+            'resource_id': cls.flex_resource.id,
+        }, {
+            'name': "fully flexible employee",
+            'date_version': date(2025, 1, 1),
+            'contract_date_start': date(2025, 1, 1),
+            'wage': 10,
+            'resource_calendar_id': False,
+            'resource_id': cls.fully_flex_resource.id,
+        }])
+
+    def test_flexible_resource_work_intervals_with_leaves(self):
+        self.env['resource.calendar.leaves'].create([{
+            'resource_id': self.flex_resource.id,
+            'date_from': datetime(2025, 7, 31, 8),
+            'date_to': datetime(2025, 8, 1, 17),
+        }, {
+            'resource_id': self.fully_flex_resource.id,
+            'date_from': datetime(2025, 7, 31, 8),
+            'date_to': datetime(2025, 8, 1, 17),
+        }])
+
+        custom_leave, half_day_leave = self.env['hr.leave.type'].create([{
+            'name': 'Custom Leave',
+            'requires_allocation': False,
+            'request_unit': 'hour',
+        }, {
+            'name': 'Half day',
+            'requires_allocation': False,
+            'request_unit': 'half_day',
+        }])
+
+        self.env['hr.leave'].with_context(mail_create_nolog=True, mail_notrack=True).create([{
+            'name': 'Half 1',
+            'holiday_status_id': half_day_leave.id,
+            'employee_id': self.flex_employee.id,
+            'request_date_from': date(2025, 7, 28),
+            'request_date_to': date(2025, 7, 28),
+            'request_date_from_period': 'am',
+            'request_date_to_period': 'am',
+        }, {
+            'name': 'Half 2',
+            'holiday_status_id': half_day_leave.id,
+            'employee_id': self.flex_employee.id,
+            'request_date_from': date(2025, 7, 30),
+            'request_date_to': date(2025, 7, 30),
+            'request_date_from_period': 'pm',
+            'request_date_to_period': 'pm',
+        }, {
+            'name': 'Custom',
+            'holiday_status_id': custom_leave.id,
+            'employee_id': self.flex_employee.id,
+            'request_date_from': date(2025, 7, 29),
+            'request_date_to': date(2025, 7, 29),
+            'request_hour_from': 11.0,
+            'request_hour_to': 16.0,
+        }, {
+            'name': 'Half 1',
+            'holiday_status_id': half_day_leave.id,
+            'employee_id': self.fully_flex_employee.id,
+            'request_date_from': date(2025, 7, 28),
+            'request_date_to': date(2025, 7, 28),
+            'request_date_from_period': 'am',
+            'request_date_to_period': 'am',
+        }, {
+            'name': 'Half 2',
+            'holiday_status_id': half_day_leave.id,
+            'employee_id': self.fully_flex_employee.id,
+            'request_date_from': date(2025, 7, 30),
+            'request_date_to': date(2025, 7, 30),
+            'request_date_from_period': 'pm',
+            'request_date_to_period': 'pm',
+        }, {
+            'name': 'Custom',
+            'holiday_status_id': custom_leave.id,
+            'employee_id': self.fully_flex_employee.id,
+            'request_date_from': date(2025, 7, 29),
+            'request_date_to': date(2025, 7, 29),
+            'request_hour_from': 11.0,
+            'request_hour_to': 16.0,
+        }]).action_approve()
+
+        start_dt = datetime(2025, 7, 28).astimezone(UTC)
+        end_dt = datetime(2025, 8, 3, 17).astimezone(UTC)
+
+        resources = self.flex_resource | self.fully_flex_resource
+        work_intervals, hours_per_day, hours_per_week = resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+
+        self.maxDiff = None
+        for resource in resources:
+            self.assertEqual(work_intervals[resource.id]._items, [
+                (datetime(2025, 7, 28, 12, 0, tzinfo=UTC), datetime(2025, 7, 28, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 7, 29, 0, 0, tzinfo=UTC), datetime(2025, 7, 29, 11, 0, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 7, 29, 16, 0, tzinfo=UTC), datetime(2025, 7, 29, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 7, 30, 0, 0, tzinfo=UTC), datetime(2025, 7, 30, 12, 0, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 8, 2, 0, 0, tzinfo=UTC), datetime(2025, 8, 2, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 8, 3, 0, 0, tzinfo=UTC), datetime(2025, 8, 3, 17, 0, tzinfo=UTC), self.env['resource.calendar.attendance']),
+            ], "resource not available on 29, 31, 01, 28 morning and 30 afternoon. for other days, resource can do his hours at any moment of the day (from 00:00:00 to 23:59:59)")
+
+        self.assertDictEqual(hours_per_day[self.flex_resource.id], {
+            date(2025, 7, 28): 4.0,
+            date(2025, 7, 29): 3.0,
+            date(2025, 7, 30): 4.0,
+            date(2025, 7, 31): 0.0,
+            date(2025, 8, 1): 0.0,
+            date(2025, 8, 2): 8.0,
+            date(2025, 8, 3): 8.0,
+        }, "hours_per_day/2 for half days off, and hours_per_day - number_of_hoursfor custom time off")
+        self.assertTrue(self.fully_flex_resource.id not in hours_per_day)
+
+        self.assertDictEqual(hours_per_week[self.flex_resource.id], {
+            (2025, 31): 11.0,
+            (2025, 32): 40.0,
+        }, "week 31 (27/07 -> 02/08): 2 days off 31 & 01 (-16 hours), half day on 28 and 30 (-8 hours), 5 hours off on day 29 / hours = 40-(16+8+5) = 11 hours, no timeoff on week 32")
+        self.assertTrue(self.fully_flex_resource.id not in hours_per_week)

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -468,12 +468,11 @@ class ResourceCalendar(models.Model):
             start_dt, end_dt, resources=resource, domain=domain, tz=tz,
         )[resource.id]
 
-    def _leave_intervals_batch(self, start_dt, end_dt, resources=None, domain=None, tz=None, any_calendar=False):
+    def _leave_intervals_batch(self, start_dt, end_dt, resources=None, domain=None, tz=None):
         """ Return the leave intervals in the given datetime range.
             The returned intervals are expressed in specified tz or in the calendar's timezone.
         """
         assert start_dt.tzinfo and end_dt.tzinfo
-        self.ensure_one()
 
         if not resources:
             resources = self.env['resource.resource']
@@ -482,8 +481,9 @@ class ResourceCalendar(models.Model):
             resources_list = list(resources) + [self.env['resource.resource']]
         if domain is None:
             domain = [('time_type', '=', 'leave')]
-        if not any_calendar:
-            domain = domain + [('calendar_id', 'in', [False, self.id])]
+        if self:
+            domain = domain + [('calendar_id', 'in', [False] + self.ids)]
+
         # for the computation, express all datetimes in UTC
         # Public leave don't have a resource_id
         domain = domain + [

--- a/addons/resource/tests/__init__.py
+++ b/addons/resource/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_utils
 from . import test_resource_calendar
+from . import test_flexible_resource_calendar

--- a/addons/resource/tests/test_flexible_resource_calendar.py
+++ b/addons/resource/tests/test_flexible_resource_calendar.py
@@ -1,0 +1,103 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import pytz
+from datetime import datetime, date
+
+from odoo.tests.common import TransactionCase
+
+UTC = pytz.timezone('UTC')
+
+
+class TestFlexibleResourceCalendar(TransactionCase):
+
+    def test_flexible_resource_work_intervals(self):
+        flex_calendar = self.env['resource.calendar'].create({
+            'name': 'Flexible 40h/week',
+            'tz': 'UTC',
+            'hours_per_day': 8.0,
+            'flexible_hours': True,
+        })
+
+        fully_flex_resource, flex_resource = self.env['resource.resource'].create([{
+            'name': 'Wade Wilson',
+            'calendar_id': False,
+            'tz': 'UTC',
+        }, {
+            'name': 'Wade Wilson',
+            'calendar_id': flex_calendar.id,
+            'tz': 'UTC',
+        }])
+
+        self.env['resource.calendar.leaves'].create([
+            {
+                'resource_id': flex_resource.id,
+                'date_from': datetime(2025, 7, 29, 8),
+                'date_to': datetime(2025, 7, 29, 17),
+            },
+            {
+                'resource_id': flex_resource.id,
+                'date_from': datetime(2025, 7, 31, 8),
+                'date_to': datetime(2025, 8, 1, 17),
+            },
+            {
+                'resource_id': fully_flex_resource.id,
+                'date_from': datetime(2025, 7, 29, 8),
+                'date_to': datetime(2025, 7, 29, 17),
+            },
+            {
+                'resource_id': fully_flex_resource.id,
+                'date_from': datetime(2025, 7, 31, 8),
+                'date_to': datetime(2025, 8, 1, 17),
+            },
+            {
+                'calendar_id': flex_calendar.id,
+                'date_from': datetime(2025, 8, 4, 8),
+                'date_to': datetime(2025, 8, 4, 17),
+            },
+            {
+                'calendar_id': False,
+                'date_from': datetime(2025, 8, 5, 8),
+                'date_to': datetime(2025, 8, 5, 17),
+            },
+        ])
+
+        start_dt = datetime(2025, 7, 28).astimezone(UTC)
+        end_dt = datetime(2025, 8, 3, 17, 0).astimezone(UTC)
+
+        resources = flex_resource | fully_flex_resource
+        work_intervals, hours_per_day, hours_per_week = resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+
+        self.maxDiff = None
+        for resource in resources:
+            self.assertEqual(work_intervals[resource.id]._items, [
+                (datetime(2025, 7, 28, 0, 0, tzinfo=UTC), datetime(2025, 7, 28, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 7, 30, 0, 0, tzinfo=UTC), datetime(2025, 7, 30, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 8, 2, 0, 0, tzinfo=UTC), datetime(2025, 8, 2, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+                (datetime(2025, 8, 3, 0, 0, tzinfo=UTC), datetime(2025, 8, 3, 17, tzinfo=UTC), self.env['resource.calendar.attendance']),
+            ], "resource not available on 29, 31 and 01, for other days, resource can do his hours at any moment of the day (from 00:00:00 to 23:59:59)")
+
+        self.assertDictEqual(hours_per_day[flex_resource.id], {
+            date(2025, 7, 28): 8.0,
+            date(2025, 7, 29): 0.0,
+            date(2025, 7, 30): 8.0,
+            date(2025, 7, 31): 0.0,
+            date(2025, 8, 1): 0.0,
+            date(2025, 8, 2): 8.0,
+            date(2025, 8, 3): 8.0,
+        }, "0 hours when the resource is not available, hours_per_day from the calendar for working days")
+        self.assertDictEqual(hours_per_week[flex_resource.id], {
+            (2025, 31): 16.0,
+            (2025, 32): 24.0,
+        }, "3 days off (24 hours), remaining 16h, 2 days off (16 hours) for second week")
+
+        self.assertTrue(fully_flex_resource.id not in hours_per_day and fully_flex_resource not in hours_per_week, "no daily and weekly limit")
+
+        start_dt = datetime(2025, 8, 4).astimezone(UTC)
+        end_dt = datetime(2025, 8, 5, 17, 0).astimezone(UTC)
+
+        work_intervals, hours_per_day, hours_per_week = resources._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+
+        self.assertEqual(work_intervals[flex_resource.id]._items, [], "flex calendar have a public holidays on day 4, and there's a public holiday on day 5 for all calendars")
+
+        self.assertEqual(work_intervals[fully_flex_resource.id]._items, [
+            (datetime(2025, 8, 4, 0, 0, tzinfo=UTC), datetime(2025, 8, 4, 23, 59, 59, 999999, tzinfo=UTC), self.env['resource.calendar.attendance']),
+        ], "fully flex resource doesn't have a calendar, he should not follow the flex calendar public holiday, he follows holidays without a calendar")

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -463,3 +463,31 @@ def weeknumber(locale: babel.Locale, date: date) -> tuple[int, int]:
     doy = (date - fdow).days
 
     return date.year, (doy // 7 + 1)
+
+
+def weekstart(locale: babel.Locale, date: date):
+    """
+    Return the first weekday of the week containing `day`
+
+    If `day` is already that weekday, it is returned unchanged.
+    Otherwise, it is shifted back to the most recent such weekday.
+
+    Examples: week starts Sunday
+        - weekstart of Sat 30 Aug -> Sun 24 Aug
+        - weekstart of Sat 23 Aug -> Sun 17 Aug
+    """
+    return date + relativedelta(weekday=weekdays[locale.first_week_day](-1))
+
+
+def weekend(locale: babel.Locale, date: date):
+    """
+    Return the last weekday of the week containing `day`
+
+    If `day` is already that weekday, it is returned unchanged.
+    Otherwise, it is shifted forward to the next such weekday.
+
+    Examples: week starts Sunday (so week ends Saturday)
+        - weekend of Sun 24 Aug -> Sat 30 Aug
+        - weekend of Sat 30 Aug -> Sat 30 Aug
+    """
+    return weekstart(locale, date) + relativedelta(days=6)


### PR DESCRIPTION
[IMP] resource,hr{*,_holidays}: work intervals for flex resources
Before this commit:

- auto plan, for planning and project, considers flex resources
as regular resources working with a regular calendar from 8 to 17.
for fully flexible resources, they are considered working the full
range, without checking leaves, and the overload on the day itself,
there is no daily limit in the calendar, but the day is limited to 24
hours.

After this commit:

- new methods to get flex resources work intervals were added to be used
only in services apps (planning and project), the resource should not
follow a regular calendar as flex calendars doesn't have attendances,
they can work at any moment of the day without exceeding a number of hours
per day and a number of hours per week (configured in the flex calendar).
The auto plan plans shifts/tasks without exceeding daily/week rate
and without following a regular calendar, a flex employee is considered
working from 00:00 to 23:59 to cover more use-cases, such as restaurants,
hospitals, firefighters.

Same for fully flexible employees, the auto plan makes sure no overload
on a range of time, example: it's not possible to do a shift/task of 4 hours
between 8 and 10 (only 2 working hours available)

related Prs:
Enterprise: https://github.com/odoo/enterprise/pull/90948

task-4822880