### PR TITLE
[FIX] iot_drivers: ensure websocket event for printers

### DIFF
--- a/addons/iot_drivers/controllers/driver.py
+++ b/addons/iot_drivers/controllers/driver.py
@@ -40,8 +40,6 @@ class DriverController(http.Controller):
             _logger.warning("IoT Device with identifier %s not found", device_identifier)
             return False
 
-        iot_device.data['owner'] = session_id
-
         _logger.debug("Calling action %s for device %s", data.get('action', ''), device_identifier)
         iot_device.action(data)
         return True

--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -47,7 +47,9 @@ class Driver(Thread):
         :param dict data: the action method name and the parameters to be passed to it
         :return: the result of the action method
         """
+        self.data['owner'] = data.get('session_id')
         action = data.get('action', '')
+
         try:
             response = {'status': 'success', 'result': self._actions[action](data), 'action_args': {**data}}
         except Exception as e:

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -86,7 +86,7 @@ class PrinterDriverBase(Driver, ABC):
         """
         self.data['status'] = status
         self.data['message'] = message
-        event_manager.device_changed(self)
+        event_manager.device_changed(self, {'session_id': self.data.get('owner')})
 
     def print_receipt(self, data):
         _logger.debug("print_receipt called for printer %s", self.device_name)


### PR DESCRIPTION
We now provide the session_id to printer drivers to ensure we create an event when the printers notifies it job completion.

Enterprise PR: https://github.com/odoo/enterprise/pull/91356