### PR TITLE
[FIX] web: fix popover raising traceback on state reload

### DIFF
--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -279,6 +279,9 @@ browser.addEventListener("popstate", (ev) => {
     // reloading the webclient's state when they manipulate history.
     if (!ev.state?.skipRouteChange && !router.skipLoad) {
         routerBus.trigger("ROUTE_CHANGE");
+        // a custom event to know if the popstate is sucessfully changing the state rather than
+        // replacing it
+        window.dispatchEvent(new CustomEvent("popstate:changed"));
     }
     router.skipLoad = false;
 });

--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -34,17 +34,20 @@ function useClickAway(callback) {
         }
     }
 
-    function navigationHandler() {
-        callback();
-    }
-
     function pointerDownHandler(ev) {
         callback(ev.composedPath()[0]);
     }
 
     useEarlyExternalListener(window, "pointerdown", pointerDownHandler, { capture: true });
     useEarlyExternalListener(window, "blur", blurHandler, { capture: true });
-    useEarlyExternalListener(window, "popstate", navigationHandler, { capture: true });
+}
+
+function useOnPageNavigation(callback) {
+    function navigationHandler(ev) {
+        // As navigation handler is used in `popstate` event which works on window level, it target is window
+        callback();
+    }
+    useEarlyExternalListener(window, "popstate:changed", navigationHandler, { capture: true });
 }
 
 const POPOVERS = new WeakMap();
@@ -135,6 +138,7 @@ export class Popover extends Component {
 
         if (this.props.target.isConnected) {
             useClickAway(this.onClickAway.bind(this));
+            useOnPageNavigation(this.onPageNavigation.bind(this));
 
             if (this.props.closeOnEscape) {
                 useHotkey("escape", () => this.props.close());
@@ -187,6 +191,10 @@ export class Popover extends Component {
         if (this.props.closeOnClickAway(target) && !this.isInside(target)) {
             this.props.close();
         }
+    }
+
+    onPageNavigation() {
+        this.props.close();
     }
 
     onPositioned({ direction, variant, variantOffset }) {

--- a/addons/web/static/tests/core/router.test.js
+++ b/addons/web/static/tests/core/router.test.js
@@ -1927,4 +1927,39 @@ describe("internal links", () => {
         expect(router.current).toEqual({});
         expect(defaultPrevented).toBe(false);
     });
+
+    test("clicking on a internal link to propagate event popstate:changed", async () => {
+        redirect("/");
+        on(window, "popstate:changed", () => expect.step("popstate:change detected"));
+        createRouter();
+
+        router.pushState({ k1: 1 });
+        await tick();
+
+        router.pushState({ k2: 2 });
+        await tick();
+
+        browser.history.back();
+        tick();
+        expect.verifySteps(["popstate:change detected"]);
+
+        browser.history.forward();
+        tick();
+        expect.verifySteps(["popstate:change detected"]);
+
+        const fixture = getFixture();
+        const link = document.createElement("a");
+        link.href = "/odoo/1/action-114/22";
+        fixture.appendChild(link);
+
+        browser.addEventListener("click", (ev) => {
+            expect.step("click");
+            ev.preventDefault();
+        });
+
+        await click("a");
+        tick();
+
+        expect.verifySteps(["click"]);
+    });
 });


### PR DESCRIPTION
Steps to reproduce:

- Open any popover that contains an anchor tag with href="#".
- The anchor should trigger another popover (like a drop-down).
- This causes a trace-back to appear.
- Currently reproducible with drop down components.

Issue:

- Clicking the anchor updates the browser’s history state, which triggers a popstate event.
- Popovers use a hook to automatically close themselves based on how events propagate.
- This hook relies on a callback, which can either be a simple `() => true` or something more complex that checks the event target.
- The same callback is being used for popstate events, but those events come from the window and don’t include a meaningful target.
- So when the callback tries to access the target, it crashes and raises a traceback.

Solution:

- One option could be to have a separate handler for navigation events that directly closes popovers, without relying on `onClickAway`.
- But since even href="#" causes a state change, handling it separately isn’t ideal.
- Fortunately, our router already detects when an anchor triggers a state change and avoids a full reload.
- So now, when we detect a genuine state change from a popstate, we emit a custom event.
- That event lets us close all open popovers safely, without depending on a missing or invalid event target.

Issue from commit: https://github.com/odoo/odoo/commit/51455ce7a2eda29c26070c57b1123de4e3a55372

task-4969369
