### PR TITLE
[REF] mail: remove _to_store of rtc session

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1093,7 +1093,13 @@ class DiscussChannel(models.Model):
             "member_count",
             "name",
             Store.One("parent_channel_id", predicate=is_channel_or_group),
-            Store.Many("rtc_session_ids", mode="ADD", extra=True, sudo=True),
+            # sudo: discuss.channel: reading sessions of accessible channel is acceptable
+            Store.Many(
+                "rtc_session_ids",
+                mode="ADD",
+                extra_fields=self.sudo().rtc_session_ids._get_store_extra_fields(),
+                sudo=True,
+            ),
             "uuid",
         ]
         if target.is_current_user(self.env):

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -460,7 +460,12 @@ class DiscussChannelMember(models.Model):
             member.rtc_inviting_session_id = self.rtc_session_ids.id
             Store(bus_channel=member._bus_channel()).add(
                 member.channel_id,
-                {"rtcInvitingSession": Store.One(member.rtc_inviting_session_id, extra=True)},
+                {
+                    "rtcInvitingSession": Store.One(
+                        member.rtc_inviting_session_id,
+                        extra_fields=member.rtc_inviting_session_id._get_store_extra_fields(),
+                    ),
+                },
             ).bus_send()
         if members:
             Store(bus_channel=self.channel_id).add(

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -109,7 +109,7 @@ class DiscussChannelRtcSession(models.Model):
         """
         valid_values = {'is_screen_sharing_on', 'is_camera_on', 'is_muted', 'is_deaf'}
         self.write({key: values[key] for key in valid_values if key in values})
-        store = Store().add(self, extra=True)
+        store = Store().add(self, extra_fields=self._get_store_extra_fields())
         self.channel_id._bus_send(
             "discuss.channel.rtc.session/update_and_broadcast",
             {"data": store.get_result(), "channelId": self.channel_id.id},
@@ -173,10 +173,8 @@ class DiscussChannelRtcSession(models.Model):
             ],
         )
 
-    def _to_store(self, store: Store, fields, *, extra=False):
-        if extra:
-            fields += ["is_camera_on", "is_deaf", "is_muted", "is_screen_sharing_on"]
-        store.add_records_fields(self, fields)
+    def _get_store_extra_fields(self):
+        return ["is_camera_on", "is_deaf", "is_muted", "is_screen_sharing_on"]
 
     @api.model
     def _inactive_rtc_session_domain(self):


### PR DESCRIPTION
The _to_store function was the original way to add data to store, but since then the Store class was added and it provides a better API, and _to_store was only kept for exceptions.

There are many different ways to provide extra fields in Store, there is no need for _to_store override for that.

task-4676464