### PR TITLE
[FIX] account: bypass audit log check when unloading chart template

### DIFF
--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -145,7 +145,7 @@ class Message(models.Model):
             raise UserError(self.env._('Operation not supported'))
         return [('model', '=', model)] + res_id_domain
 
-    @api.ondelete(at_uninstall=True)
+    @api.ondelete(at_uninstall=False)
     def _except_audit_log(self):
         if self.env.context.get('bypass_audit') is bypass_token:
             return


### PR DESCRIPTION
When installing the Accounting app on a new database created with Germany as country and with demo data loaded, the demo loader invokes in `account/demo/account_demo.xml` the `<function name="try_loading">` call which does a wholesale `records.with_context({MODULE_UNINSTALL_FLAG: True}).unlink()`. This cascades into deleting mail.message records, but the audit‑trail hook in only bypasses its check when the `bypass_audit` token is present not when `MODULE_UNINSTALL_FLAG is set causing a “You cannot remove parts of the audit trail” UserError.

Steps to reproduce:
- Created new database, with Germany as country
- Install l10n_de
- Download demo data
- Attempt to install Accounting application ! Receive error message
OPW- 4712364


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
