### PR TITLE
[FIX] html_builder: adapt sublevel line

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -2,9 +2,9 @@
     position: absolute;
     border: $o-we-border-width solid var(--o-hb-row-sublevel-color, #{mix($o-we-bg-lighter, $o-we-fg-light)});
     border-width: 0 0 $o-we-border-width $o-we-border-width;
-    height: 100%;
+    height: calc(100% + #{$o-hb-row-spacing * 3});
     pointer-events: none;
-    transform: translate($_level-left - $o-we-border-width, ($o-hb-row-min-height * -0.5) - $o-we-border-width);
+    transform: translate($_level-left - $o-we-border-width, ($o-hb-row-min-height * -0.65) - $o-we-border-width);
     content: "";
 }
 
@@ -103,7 +103,7 @@
     }
 
     // ==== Sublevels
-    &.hb-row-sublevel:after {
+    &.hb-row-sublevel > .hb-row-label::after {
         @include sublevel-line;
     }
 
@@ -114,7 +114,7 @@
         $_level-left: $_level-padding - $_level-width - $o-we-border-width;
 
         &.hb-row-sublevel-#{$_level} {
-            .hb-row-label, &:after {
+            .hb-row-label, & > .hb-row-label::after {
                 z-index: $_z-index - $_level;
             }
 
@@ -122,13 +122,13 @@
                 padding-left: $_level-padding;
             }
 
-            &:after {
+            & > .hb-row-label::after {
                 width: $_level-width;
                 left: $_level-left;
             }
         }
 
-        &[data-label=" "]:not(.hb-row-sublevel):has(+ .hb-row-sublevel-#{$_level}):after {
+        &[data-label=" "]:not(.hb-row-sublevel):has(+ .hb-row-sublevel-#{$_level})::after {
             @include sublevel-line($_level-left);
             z-index: $_z-index - $_level;
         }


### PR DESCRIPTION
When a `BuilderRow`'s content is bigger than its label (e.g.: a
`BuilderSelect` with an image vs. a one-word label), the sublevel
decoration line in front of it is too big.
This is because the line is set as a pseudo-element on the `.hb-row`
instead of it's label, with a 100% height. Adapting it to the
`.hb-row-label` fixes it.