### PR TITLE
[FIX] core: restore bin_size performance optimization

### DIFF
--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import io
 import os
+from unittest.mock import patch
 
 from PIL import Image
 
@@ -264,6 +265,21 @@ class TestIrAttachment(TransactionCaseWithUserDemo):
         a1 = self.Attachment.create({'name': 'a1', 'raw': unique_blob, 'mimetype': 'image/png'})
         self.assertEqual(a1.raw, unique_blob)
         self.assertEqual(a1.mimetype, 'image/png')
+
+    def test_15_read_bin_size_doesnt_read_datas(self):
+        self.env.invalidate_all()
+        IrAttachment = self.registry['ir.attachment']
+        main_partner = self.env.ref('base.main_partner')
+        with patch.object(
+            IrAttachment,
+            '_file_read',
+            side_effect=IrAttachment._file_read,
+            autospec=True,
+        ) as patch_file_read:
+            self.env['res.partner'].with_context(bin_size=True).search_read(
+                [('id', 'in', main_partner.ids)], ['image_128']
+            )
+            self.assertEqual(patch_file_read.call_count, 0)
 
 
 class TestPermissions(TransactionCaseWithUserDemo):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2576,6 +2576,11 @@ class Binary(Field):
             super().compute_value(records)
 
     def read(self, records):
+        def _encode(s: str | bool) -> bytes | bool:
+            if isinstance(s, str):
+                return s.encode("utf-8")
+            return s
+
         # values are stored in attachments, retrieve them
         assert self.attachment
         domain = [
@@ -2583,9 +2588,9 @@ class Binary(Field):
             ('res_field', '=', self.name),
             ('res_id', 'in', records.ids),
         ]
-        # Note: the 'bin_size' flag is handled by the field 'datas' itself
+        bin_size = records.env.context.get('bin_size')
         data = {
-            att.res_id: att.datas
+            att.res_id: _encode(human_size(att.file_size)) if bin_size else att.datas
             for att in records.env['ir.attachment'].sudo().search(domain)
         }
         records.env.cache.insert_missing(records, self, map(data.get, records._ids))


### PR DESCRIPTION
Since 7744886d6141ca7971d91807d0444c707e10fdf8, reading binary field with bin_size=True still reads the ir.attachment datas field, which is relatively slow with some storage backends.

In the products kanban view this can easily add 1 sec to web_search_read, if there is a 10ms latency when reading images.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
