### PR TITLE
[FIX] sale: use _should_be_locked to filter SOs to lock

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1164,10 +1164,8 @@ class SaleOrder(models.Model):
         context.pop('default_user_id', None)
 
         self.with_context(context)._action_confirm()
-        user = self[:1].create_uid
-        if user and user.sudo().has_group('sale.group_auto_done_setting'):
-            # Public user can confirm SO, so we check the group on any record creator.
-            self.action_lock()
+
+        self.filtered(lambda so: so._should_be_locked()).action_lock()
 
         if self.env.context.get('send_email'):
             self._send_order_confirmation_mail()


### PR DESCRIPTION
The diff from this commit was introduced in the past up until saas-17.1, to prevent locking of subscription sales orders.
https://github.com/odoo/odoo/pull/159863

However, the forward porting commits after saas-17.2 are missing this diff.
https://github.com/odoo/odoo/pull/159993/files

Few months after the commits were merged, someone mentioned about this diff being missing, but no actions were taken afterwards.

This commit applies the missing diff.

---

In another [bugfix](https://github.com/odoo/enterprise/pull/91339), which is dependent on this , we decided to not lock SOs from FSM tasks, taking similar approaches as how Subscription Orders process it, utilizing the `_should_be_locked()` function. 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
