### PR TITLE
[FIX] stock: prevent incorrect quants for sbc products

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1143,7 +1143,7 @@ class StockQuant(models.Model):
         }
         for product, location, lot, package, owner, reserved_quantity, quants in reserved_quants:
             ml_reserved_qty = reserved_move_lines.get((product, location, lot, package, owner), 0)
-            if location.should_bypass_reservation():
+            if location.should_bypass_reservation() or (product.tracking in ('lot', 'serial') and not lot):
                 quants._update_reserved_quantity(product, location, -reserved_quantity, lot_id=lot, package_id=package, owner_id=owner)
             elif float_compare(reserved_quantity, ml_reserved_qty, precision_rounding=product.uom_id.rounding) != 0:
                 quants._update_reserved_quantity(product, location, ml_reserved_qty - reserved_quantity, lot_id=lot, package_id=package, owner_id=owner)
@@ -1151,7 +1151,7 @@ class StockQuant(models.Model):
                 del reserved_move_lines[(product, location, lot, package, owner)]
 
         for (product, location, lot, package, owner), reserved_quantity in reserved_move_lines.items():
-            if location.should_bypass_reservation():
+            if location.should_bypass_reservation() or (product.tracking in ('lot', 'serial') and not lot):
                 continue
             else:
                 self.env['stock.quant']._update_reserved_quantity(product, location, reserved_quantity, lot_id=lot, package_id=package, owner_id=owner)


### PR DESCRIPTION
Problem:
When a purchase order for a subcontracted product tracked by lots/serials is confirmed, the "Procurement: run scheduler" action creates a stock reservation in the subcontracting location. This reservation is created without a lot or serial number.

When the finished product is later received with its lot/serial, the system tries to use the untracked reservation to define a source for the move, but will still create a new quant line because of the destination. This results in two quants, leading to incorrect inventory levels:
- A positive quant for the product with the correct lot/serial.
- A negative quant for the same product without a lot/serial, with a hanging reservation.

Solution:
The reservation mechanism in _clean_reservations() is now bypassed for stock moves that should have a lot or serial number, but do not. This ensures that when the tracked product is received, no redundant quants are created.

Steps to reproduce on Runbot (tested on 18.3 and 18.0):

1. Create a new product and track by lots
2. Add a BOM for this product, setting type to Subcontracting
3. Create a PO for the product and confirm it
4. With debug enabled, go to Inventory > Operations > Procurement: run scheduler To see the issue:
5. Go to Inventory > Reporting > Locations
6. Search for the product, note the quant line at the subcontractor location with no lot number
7. Return to the PO and recieve, specifying lot number
8. Go to Inventory > Reporting > Locations
9. Search for the product again, note that there are now 2 quant lines at the subcontractor location when the quantity on hand should have zeroed out

opw-4935822

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
