### PR TITLE
[FIX] l10n_latam_check: prevent duplicate third-party check payment methods per journal

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -339,7 +339,7 @@ class AccountPayment(models.Model):
         for rec in third_party_checks:
             dest_payment_method_code = 'in_third_party_checks' if rec.payment_type == 'outbound' else 'out_third_party_checks'
             dest_payment_method = rec.destination_journal_id.inbound_payment_method_line_ids.filtered(
-                lambda x: x.code == dest_payment_method_code)
+                lambda x: x.code == dest_payment_method_code)[:1]
             if dest_payment_method:
                 super(AccountPayment, rec.with_context(
                     default_payment_method_line_id=dest_payment_method.id,


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The same third-party check payment method (e.g., in_third_party_checks) can currently be assigned multiple times to the same journal, either as inbound or outbound. This misconfiguration leads to unexpected behavior and runtime errors when using the payment transfer wizard.

**Current behavior before PR:**

It is possible to assign a third-party check payment method more than once to a journal.

When transferring a third-party check via the wizard (l10n_latam_payment_mass_transfer), the system may raise:

pgsql
Copy
Edit
ValueError: Expected singleton
because more than one payment method line is returned.

Functionally, allowing duplicate third-party check payment methods in the same journal does not make sense, as each method should be clearly associated with a unique payment context.

**Desired behavior after PR is merged:**

The system raises a ValidationError if a restricted third-party check payment method is added more than once to a journal.

This ensures data consistency and prevents runtime errors when using the check transfer wizard.

If a different handling is needed for a third-party check method, a new journal should be created and configured accordingly.

**Video:**
https://drive.google.com/file/d/1arbsjfA3NPG4aO2_BKxVStSTw5y4cgnM/view

**Steps to reproduce the issue:**

1.Go to Accounting > Configuration > Journals.

2.Open a cash journal that will be used as the destination journal for third-party check transfers.

3.Add the same third-party check payment method multiple times in inbound_payment_method_line_ids.

4. Create the Third-Party Check.

5.Go to Accounting > Customer > Third-Party Checks and select a check to transfer.

6.Open the mass transfer wizard and select the journal from step 2 as the destination.

7.Click to confirm the transfer → the system will raise a ValueError: Expected singleton.


Note: This issue has been observed from Odoo v15 onwards

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
