### PR TITLE
[FIX] mail: fix recipient popover z-index to avoid alert overlap

### DIFF
--- a/addons/mail/static/src/core/web/recipients_input_tags_list_popover.scss
+++ b/addons/mail/static/src/core/web/recipients_input_tags_list_popover.scss
@@ -1,3 +1,3 @@
 .o-overlay-item:has(.o-mail-RecipientsInputTagsListPopover) {
-    z-index: $zindex-popover;
+    z-index: $zindex-modal;
 }


### PR DESCRIPTION
## Before this commit
When the user clicks the Send button and the partner does not have an email address, an alert message is raised. However, the recipient popover `(email input prompt)` appears above the alert, visually blocking it and breaking the expected `modal` behavior.

<img width="1844" height="873" alt="image" src="https://github.com/user-attachments/assets/31585785-27d6-48d4-b64c-c88b5f9426d6" />

## After this commit
The recipient popover's `z-index` is adjusted so that it no longer overlaps alert messages. This ensures that alerts remain visible and unobstructed, preserving clarity in the UI and respecting the intended visual hierarchy.

<img width="1736" height="764" alt="image" src="https://github.com/user-attachments/assets/9ff258b4-2072-4100-bcc4-b8420d5d1aa2" />
