### PR TITLE
[IMP] html_builder, *: refine social/share icon options

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -48,7 +48,8 @@ class ImageToolOptionPlugin extends Plugin {
             withSequence(ALIGNMENT_STYLE_PADDING, {
                 template: "html_builder.ImageAndFaOption",
                 selector: "span.fa, i.fa, img",
-                exclude: "[data-oe-type='image'] > img, [data-oe-xpath]",
+                exclude:
+                    "[data-oe-type='image'] > img, [data-oe-xpath], .s_social_media i.fa, .s_share i.fa",
                 name: "imageAndFaOption",
             }),
         ],

--- a/addons/website/static/src/builder/plugins/font_awesome_option.xml
+++ b/addons/website/static/src/builder/plugins/font_awesome_option.xml
@@ -6,11 +6,11 @@
         <BuilderColorPicker styleAction="'color'"/>
     </BuilderRow>
 
-    <BuilderRow label.translate="Background Color">
+    <BuilderRow label.translate="Background Color" t-if="state.showBackground">
         <BuilderColorPicker styleAction="'background-color'"/>
     </BuilderRow>
 
-    <BuilderRow label.translate="Size">
+    <BuilderRow label.translate="Size" t-if="state.showSize">
         <BuilderButtonGroup>
             <BuilderButton action="'faResize'" actionParam="''" title.translate="Size 1x">1x</BuilderButton>
             <BuilderButton action="'faResize'" actionParam="'fa-2x'" title.translate="Size 2x">2x</BuilderButton>
@@ -21,7 +21,7 @@
     </BuilderRow>
 
     <!-- TODO: check if that (should?) work in mass mailing -->
-    <BorderConfigurator label.translate="Border" withRoundCorner="false"/>
+    <BorderConfigurator label.translate="Border" withRoundCorner="false" t-if="state.showBorder"/>
 </t>
 
 </templates>

--- a/addons/website/static/src/builder/plugins/font_awesome_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/font_awesome_option_plugin.js
@@ -3,13 +3,17 @@ import { registry } from "@web/core/registry";
 import { ClassAction } from "@html_builder/core/core_builder_action_plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { FONT_AWESOME } from "@html_builder/utils/option_sequence";
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
 
 class FontAwesomeOptionPlugin extends Plugin {
     static id = "fontAwesomeOptionPlugin";
     resources = {
         builder_options: [
             withSequence(FONT_AWESOME, {
-                template: "website.FontAwesomeOption",
+                // converted to option component to handle rendering of
+                // options based on the context(social media and share icons).
+                OptionComponent: FontAwesomeOptionComponent,
                 selector: "span.fa, i.fa",
                 exclude: "[data-oe-xpath]",
             }),
@@ -26,6 +30,22 @@ export class FaResizeAction extends ClassAction {
         const { editingElement } = context;
         editingElement.classList.remove("fa-1x", "fa-lg");
         super.apply(context);
+    }
+}
+export class FontAwesomeOptionComponent extends BaseOptionComponent {
+    static template = "website.FontAwesomeOption";
+    static components = { BorderConfigurator };
+    setup() {
+        super.setup();
+        this.state = useDomState((editingElement) => {
+            const hasRestrictedClass =
+                editingElement.closest(".s_social_media") || editingElement.closest(".s_share");
+            return {
+                showBackground: !hasRestrictedClass,
+                showBorder: !hasRestrictedClass,
+                showSize: !hasRestrictedClass,
+            };
+        });
     }
 }
 

--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -31,7 +31,7 @@ export class AnimateOptionPlugin extends Plugin {
                 OptionComponent: AnimateOption,
                 selector: ".o_animable, section .row > div, img, .fa, .btn",
                 exclude:
-                    "[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize",
+                    "[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, .s_social_media i.fa, .s_share i.fa",
                 props: this.animateOptionProps,
                 // todo: to implement
                 // textSelector: ".o_animated_text",

--- a/addons/website/static/src/builder/plugins/options/social_media_links.xml
+++ b/addons/website/static/src/builder/plugins/options/social_media_links.xml
@@ -33,10 +33,9 @@
                             action="'toggleRecordedSocialMediaLink'"
                             actionParam="item.domPosition ? { domPosition: item.domPosition } : { media: item.media, elementAfter: item.nextLink }"
                         />
-                        <div t-else="" style="margin: 0 3px">
+                        <div t-else="">
                             <BuilderButton
-                                type="'danger'"
-                                className="'fa fa-fw fa-minus'"
+                                className="'fa fa-fw fa-minus text-danger bg-transparent border-0'"
                                 title.translate="Remove link"
                                 action="'deleteSocialMediaLink'"
                                 applyTo="`a:nth-of-type(${item.domPosition})`"

--- a/addons/website/static/src/builder/plugins/options/social_media_option.xml
+++ b/addons/website/static/src/builder/plugins/options/social_media_option.xml
@@ -21,14 +21,26 @@
 
     <BuilderRow label.translate="Size">
         <BuilderSelect applyTo="'.fa'">
-            <BuilderSelectItem classAction="''">Small</BuilderSelectItem>
-            <BuilderSelectItem classAction="'fa-2x'">Medium</BuilderSelectItem>
-            <BuilderSelectItem classAction="'fa-3x'">Big</BuilderSelectItem>
+            <BuilderSelectItem classAction="'small_social_icon'">Small</BuilderSelectItem>
+            <BuilderSelectItem classAction="''">Medium</BuilderSelectItem>
+            <BuilderSelectItem classAction="'fa-2x'">Large</BuilderSelectItem>
+            <BuilderSelectItem classAction="'fa-3x'">Huge</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
 
-    <BuilderRow label.translate="Color">
+    <BuilderRow label.translate="Color" tooltip.translate="Keep the original icon color">
         <BuilderCheckbox classAction="'no_icon_color'" inverseAction="true"/>
+    </BuilderRow>
+    <BuilderRow label.translate="Link Style">
+        <BuilderSelect dataAttributeAction="'iconUnderline'">
+            <BuilderSelectItem dataAttributeActionValue="''">No Underline</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'hover'">Underline On Hover</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'always'">Always Underline</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+
+    <BuilderRow label.translate="Background Color">
+        <BuilderColorPicker applyTo="'.fa'" styleAction="'background-color'"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -3200,3 +3200,54 @@ input[value*="data-oe-translation-source-sha"] {
       width: 100%;
     }
 }
+
+.s_social_media, .s_share {
+    $-size: map-get($spacers, 5);
+    a {
+        text-decoration: none;
+        &:hover {
+            text-decoration: none;
+        }
+    }
+    &[data-icon-underline="hover"] a {
+        text-decoration: none;
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+    &[data-icon-underline="always"] a {
+        text-decoration: underline;
+    }
+    .small_social_icon {
+        width: $-size - 1rem;
+        height: $-size - 1rem;
+        font-size: 0.875em;
+    }
+    a {
+        .fa-stack{
+            /*
+            Ensures consistent size and padding around icons when the
+            layout is set to "none" and the size is "huge" or "large".
+            For "small", this is handled above, and for "medium",
+            it is handled in the respective SCSS files (@see
+            s_social_media/000.scss and s_share/000.scss).
+            */
+            @for $i from 2 through 3 {
+                &.fa-#{$i}x {
+                    width: $-size + $i;
+                    height: $-size + $i;
+                    line-height: $-size + $i;
+                }
+            }
+        }
+    }
+    /*
+    This rule makes social media icons inherit the text color of their parent
+    container when no explicit color is set.
+    */
+    &.no_icon_color {
+        a {
+            color: inherit !important;
+        }
+    }
+}

--- a/addons/website/static/src/snippets/s_share/000.scss
+++ b/addons/website/static/src/snippets/s_share/000.scss
@@ -1,6 +1,7 @@
 
 .s_share {
     user-select: none;
+    $-size: map-get($spacers, 5);
     > * {
         display: inline-block;
         vertical-align: middle;
@@ -13,6 +14,17 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            &[class*="o_cc"] {
+                background-color: var(--o-cc-bg);
+            }
+            &:not(.small_social_icon, .fa-2x, .fa-3x, .fa-4x, .fa-5x) {
+                &.rounded-circle,
+                &.rounded,
+                &.fa-stack {
+                    width: $-size - .5rem;
+                    height: $-size - .5rem;
+                }
+            }
         }
         margin: .2rem;
     }

--- a/addons/website/static/src/snippets/s_social_media/000.scss
+++ b/addons/website/static/src/snippets/s_social_media/000.scss
@@ -14,17 +14,20 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            &:not(.fa-2x, .fa-3x, .fa-4x, .fa-5x) {
+            &[class*="o_cc"] {
+                background-color: var(--o-cc-bg);
+            }
+            &:not(.small_social_icon, .fa-2x, .fa-3x, .fa-4x, .fa-5x) {
                 &.rounded-circle,
-                &.rounded {
+                &.rounded,
+                &.fa-stack {
                     width: $-size - .5rem;
                     height: $-size - .5rem;
                 }
             }
         }
-        &:has(i:not(.fa-stack)) {
-            margin: .2rem;
-        }
+        // Margin should be same for all layout options.
+        margin: .2rem;
     }
     &:not(.no_icon_color) {
         .s_social_media_facebook {

--- a/addons/website/static/tests/interactions/snippets/social_media_and_share.test.js
+++ b/addons/website/static/tests/interactions/snippets/social_media_and_share.test.js
@@ -1,0 +1,116 @@
+import { animationFrame, click, queryOne, waitFor } from "@odoo/hoot-dom";
+import { defineWebsiteModels, setupWebsiteBuilderWithSnippet } from "../../builder/website_helpers";
+import { expect, test } from "@odoo/hoot";
+import { onRpc } from "@web/../tests/web_test_helpers";
+
+defineWebsiteModels();
+
+async function setDropdownOption(
+    containerTitle,
+    optionLabel,
+    menuText,
+    snippetSelector,
+    verifySelector
+) {
+    await click(`[data-container-title='${containerTitle}'] [data-label='${optionLabel}'] button`);
+    await animationFrame();
+    await click(`.o_popover .o-dropdown-item:contains(${menuText})`);
+    await waitFor(`${snippetSelector}${verifySelector}`);
+}
+
+async function testSocialSnippetOptions(snippetName, containerTitle, iconName) {
+    const snippetSelector = `:iframe .${snippetName}`;
+    onRpc("website", "read", ({ args }) => {
+        expect(args[0]).toEqual([1]);
+        expect(args[1]).toInclude(`social_${iconName}`);
+        return [
+            {
+                id: 1,
+                social_github: `https://${iconName}.com/odoo`,
+            },
+        ];
+    });
+
+    const core = await setupWebsiteBuilderWithSnippet(snippetName, {
+        styleContent: `.${snippetName}.no_icon_color a {
+            color: inherit !important;
+        }`,
+    });
+
+    expect(snippetSelector).toHaveCount(1);
+    await click(`${snippetSelector} i:first-child`);
+    await animationFrame();
+    if (snippetName === "s_share") {
+        await click(
+            `[data-container-title='${containerTitle}'] [data-label='Color'] input[type='checkbox']`
+        );
+        await animationFrame();
+        // Here, .s_share selector can be removed but kept for specificity.
+        expect(":iframe .s_share.no_icon_color").toHaveCount(1);
+    }
+    const textColor = "rgb(255, 0, 0)";
+    core.getEditableContent().style.color = textColor;
+    const icon = await queryOne(`${snippetSelector} a .fa-${iconName}`);
+    if (icon) {
+        const iconColor = getComputedStyle(icon).color;
+        expect(iconColor).toBe(textColor);
+    }
+    const forbidden = ["Size", "Style", "Border", "Alignment", "Padding", "Animation"];
+    for (const label of forbidden) {
+        expect(`[data-container-title='Icon'] [data-label='${label}']`).toHaveCount(0);
+    }
+    const required = ["Animation", "Background Color"];
+    for (const label of required) {
+        expect(`[data-container-title='${containerTitle}'] [data-label='${label}']`).toHaveCount(1);
+    }
+    await setDropdownOption(
+        containerTitle,
+        "Link Style",
+        "Underline On Hover",
+        snippetSelector,
+        "[data-icon-underline='hover']"
+    );
+    await setDropdownOption(
+        containerTitle,
+        "Link Style",
+        "Always Underline",
+        snippetSelector,
+        "[data-icon-underline='always']"
+    );
+    await setDropdownOption(
+        containerTitle,
+        "Size",
+        "Small",
+        snippetSelector,
+        " i:first-child.small_social_icon"
+    );
+    await setDropdownOption(
+        containerTitle,
+        "Size",
+        "Medium",
+        snippetSelector,
+        " i:first-child:not(.small_social_icon):not(.fa-2x):not(.fa-3x)"
+    );
+    await setDropdownOption(
+        containerTitle,
+        "Size",
+        "Large",
+        snippetSelector,
+        " i:first-child.fa-2x"
+    );
+    await setDropdownOption(
+        containerTitle,
+        "Size",
+        "Huge",
+        snippetSelector,
+        " i:first-child.fa-3x"
+    );
+}
+
+test("Social Media snippet options are correct", async () => {
+    await testSocialSnippetOptions("s_social_media", "Social Media", "github");
+});
+
+test("Share snippet options are correct", async () => {
+    await testSocialSnippetOptions("s_share", "Block", "facebook");
+});

--- a/addons/website/views/snippets/s_share.xml
+++ b/addons/website/views/snippets/s_share.xml
@@ -5,22 +5,22 @@
     <div t-attf-class="s_share text-start o_no_link_popover #{_classes}">
         <h4 t-if="not _no_title" class="s_share_title d-none">Share</h4>
         <a t-if="not _exclude_share_links or not 'facebook' in _exclude_share_links" href="https://www.facebook.com/sharer/sharer.php?u={url}" t-attf-class="s_share_facebook #{_link_classes}" target="_blank" aria-label="Facebook">
-            <i t-attf-class="fa fa-facebook #{not _link_classes and 'rounded shadow-sm'}"/>
+            <i t-attf-class="fa fa-facebook #{not _link_classes and 'rounded shadow-sm'} small_social_icon"/>
         </a>
         <a t-if="not _exclude_share_links or not 'twitter' in _exclude_share_links" href="https://twitter.com/intent/tweet?text={title}&amp;url={url}" t-attf-class="s_share_twitter #{_link_classes}" target="_blank" aria-label="X">
-            <i t-attf-class="fa fa-twitter #{not _link_classes and 'rounded shadow-sm'}"/>
+            <i t-attf-class="fa fa-twitter #{not _link_classes and 'rounded shadow-sm'} small_social_icon"/>
         </a>
         <a t-if="not _exclude_share_links or not 'linkedin' in _exclude_share_links" href="https://www.linkedin.com/sharing/share-offsite/?url={url}" t-attf-class="s_share_linkedin #{_link_classes}" target="_blank" aria-label="LinkedIn">
-            <i t-attf-class="fa fa-linkedin #{not _link_classes and 'rounded shadow-sm'}"/>
+            <i t-attf-class="fa fa-linkedin #{not _link_classes and 'rounded shadow-sm'} small_social_icon"/>
         </a>
         <a t-if="not _exclude_share_links or not 'whatsapp' in _exclude_share_links" href="https://wa.me/?text={title}" t-attf-class="s_share_whatsapp #{_link_classes}" target="_blank" aria-label="WhatsApp">
-            <i t-attf-class="fa fa-whatsapp #{not _link_classes and 'rounded shadow-sm'}"/>
+            <i t-attf-class="fa fa-whatsapp #{not _link_classes and 'rounded shadow-sm'} small_social_icon"/>
         </a>
         <a t-if="not _exclude_share_links or not 'pinterest' in _exclude_share_links" href="https://pinterest.com/pin/create/button/?url={url}&amp;media={media}&amp;description={title}" t-attf-class="s_share_pinterest #{_link_classes}" target="_blank" aria-label="Pinterest">
-            <i t-attf-class="fa fa-pinterest #{not _link_classes and 'rounded shadow-sm'}"/>
+            <i t-attf-class="fa fa-pinterest #{not _link_classes and 'rounded shadow-sm'} small_social_icon"/>
         </a>
         <a t-if="not _exclude_share_links or not 'email' in _exclude_share_links" href="mailto:?body={url}&amp;subject={title}" t-attf-class="s_share_email #{_link_classes}" aria-label="Email">
-            <i t-attf-class="fa fa-envelope #{not _link_classes and 'rounded shadow-sm'}"/>
+            <i t-attf-class="fa fa-envelope #{not _link_classes and 'rounded shadow-sm'} small_social_icon"/>
         </a>
     </div>
 </template>

--- a/addons/website/views/snippets/s_social_media.xml
+++ b/addons/website/views/snippets/s_social_media.xml
@@ -9,28 +9,28 @@ title stay editable after a save (see SOCIAL_MEDIA_TITLE_CONTENTEDITABLE).
     <div class="s_social_media text-start o_not_editable" contenteditable="false">
         <h4 class="s_social_media_title d-none" contenteditable="true">Social Media</h4>
         <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
-            <i class="fa fa-facebook rounded shadow-sm o_editable_media"/>
+            <i class="fa fa-facebook rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
         <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank" aria-label="X">
-            <i class="fa fa-twitter rounded shadow-sm o_editable_media"/>
+            <i class="fa fa-twitter rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
         <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank" aria-label="LinkedIn">
-            <i class="fa fa-linkedin rounded shadow-sm o_editable_media"/>
+            <i class="fa fa-linkedin rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
         <a href="/website/social/youtube" class="s_social_media_youtube" target="_blank" aria-label="YouTube">
-            <i class="fa fa-youtube rounded shadow-sm o_editable_media"/>
+            <i class="fa fa-youtube rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
         <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank" aria-label="Instagram">
-            <i class="fa fa-instagram rounded shadow-sm o_editable_media"/>
+            <i class="fa fa-instagram rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
         <a href="/website/social/github" class="s_social_media_github" target="_blank" aria-label="GitHub">
-            <i class="fa fa-github rounded shadow-sm o_editable_media"/>
+            <i class="fa fa-github rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
         <a href="/website/social/tiktok" class="s_social_media_tiktok" target="_blank" aria-label="TikTok">
-            <i class="fa fa-tiktok rounded shadow-sm o_editable_media"/>
+            <i class="fa fa-tiktok rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
         <a href="/website/social/discord" class="s_social_media_discord" target="_blank" aria-label="Discord">
-            <i class="fa fa-discord rounded shadow-sm o_editable_media"/>
+            <i class="fa fa-discord rounded shadow-sm o_editable_media small_social_icon"/>
         </a>
     </div>
 </template>

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -306,12 +306,7 @@ Display a sidebar beside the post content.
                 <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Share this post</h6>
             </div>
 
-            <div class="o_wblog_social_links d-flex flex-wrap mx-n1 o_not_editable">
-                <t t-set="classes" t-translation="off">bg-100 border mx-1 mb-2 rounded-circle d-flex align-items-center justify-content-center text-decoration-none</t>
-                <a href="#" aria-label="Facebook" title="Share on Facebook" t-attf-class="o_facebook #{classes}"><i class="fa fa-facebook-square text-facebook"/></a>
-                <a href="#" aria-label="Twitter" title="Share on X" t-attf-class="o_twitter #{classes}"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
-                <a href="#" aria-label="LinkedIn" title="Share on LinkedIn" t-attf-class="o_linkedin #{classes}"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
-            </div>
+            <t t-snippet-call="website.s_share"/>
         </div>
 
         <div class="oe_structure" id="oe_structure_blog_post_sidebar_3"/>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -484,20 +484,11 @@
 <!-- Index - Sidebar - Follow us -->
 <template id="index_sidebar_follow_us" inherit_id="website_event.index_sidebar" active="False" name="Follow us" priority="30">
     <xpath expr="//div[@id='o_wevent_index_sidebar']" position="inside">
-        <div class="o_wevent_sidebar_block">
+        <div class="o_wevent_sidebar_block" t-ignore="true">
             <div>
                 <h6 class="o_wevent_sidebar_title">Follow Us</h6>
             </div>
-            <div class="o_wevent_sidebar_social mx-n1">
-                <a t-if="website.social_facebook" t-att-href="website.social_facebook" class="o_wevent_social_link"><i class="fa fa-facebook text-facebook" aria-label="Facebook" title="Facebook"/></a>
-                <a t-if="website.social_twitter" t-att-href="website.social_twitter" class="o_wevent_social_link"><i class="fa fa-twitter text-twitter" aria-label="X" title="X"/></a>
-                <a t-if="website.social_linkedin" t-att-href="website.social_linkedin" class="o_wevent_social_link"><i class="fa fa-linkedin text-linkedin" aria-label="LinkedIn" title="LinkedIn"/></a>
-                <a t-if="website.social_youtube" t-att-href="website.social_youtube" class="o_wevent_social_link"><i class="fa fa-youtube-play text-youtube" aria-label="Youtube" title="Youtube"/></a>
-                <a t-if="website.social_github" t-att-href="website.social_github" class="o_wevent_social_link"><i class="fa fa-github text-github" aria-label="Github" title="Github"/></a>
-                <a t-if="website.social_instagram" t-att-href="website.social_instagram" class="o_wevent_social_link"><i class="fa fa-instagram text-instagram" aria-label="Instagram" title="Instagram"/></a>
-                <a t-if="website.social_tiktok" t-att-href="website.social_tiktok" class="o_wevent_social_link"><i class="fa fa-tiktok text-tiktok" aria-label="TikTok" title="TikTok"/></a>
-                <a t-if="website.social_discord" t-att-href="website.social_discord" class="o_wevent_social_link"><i class="fa fa-discord text-discord" aria-label="Discord" title="Discord"/></a>
-            </div>
+            <t t-snippet-call="website.s_social_media"/>
         </div>
         <div id="oe_structure_website_event_follow_us_1" class="oe_structure"/>
     </xpath>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -1069,7 +1069,7 @@
 <!-- Right Side Bar -->
 <template id="job_right_side_bar" inherit_id="website_hr_recruitment.index" active="True" name="Right Side Bar">
     <xpath expr="//div[@id='jobs_grid']" position="after">
-        <div class="col-lg-4 oe_structure oe_empty" id="jobs_grid_right">
+        <div class="col-lg-4 oe_structure oe_empty" id="jobs_grid_right" t-ignore="true">
             <section class="">
                 <div class="container">
                     <div class="row">
@@ -1089,18 +1089,7 @@
                                     <li><i class="fa fa-phone fa-fw me-2"></i><span class="o_force_ltr"><a href="tel:+1 (650) 555-0187">+1 (650) 555-0187</a></span></li>
                                 </ul>
                                 <!-- Social media -->
-                                <div class="s_social_media text-start" data-name="Social Media" data-snippet="s_social_media">
-                                    <h5 class="s_social_media_title d-none">Follow us</h5>
-                                    <a href="/website/social/facebook" class="s_social_media_facebook text-decoration-none" target="_blank" aria-label="Facebook">
-                                        <i class="fa fa-facebook rounded-empty-circle btn btn-outline-primary shadow-sm"></i>
-                                    </a>
-                                    <a href="/website/social/twitter" class="s_social_media_twitter text-decoration-none" target="_blank" aria-label="X">
-                                        <i class="fa fa-twitter rounded-empty-circle btn btn-outline-primary shadow-sm"></i>
-                                    </a>
-                                    <a href="/website/social/linkedin" class="s_social_media_linkedin text-decoration-none" target="_blank" aria-label="LinkedIn">
-                                        <i class="fa fa-linkedin rounded-empty-circle btn btn-outline-primary shadow-sm"></i>
-                                    </a>
-                                </div>
+                                <t t-snippet-call="website.s_social_media"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
*=web, website, website_blog, website_event, website_hr_recruitment

1. In both the _Share_ and _Social Media_ snippets, conflicting options such as `Size`, `Style`, `Border`, `Rounded Corners`, `Alignment`, `Padding`, `Animation`, and `Background Color` have been removed from the icons. `Animation` and `Background Color` options were added only to the _Social Media_ snippet.

2. Added a `Link Style` option for _Social Media_ icons, similar to the links option in the _Theme_ tab.

3. In the _Social Media_ snippet, refactored and expanded the available icon sizes. Additionally, added a tooltip for the `Icon Color` option. If this option is disabled, the icons will automatically inherit the current text color of the snippet’s container. 

4. In the _Share_ snippet, the icon sizes are now aligned with those in the _Social Media_ snippet.

5. Replaced the large minus buttons in the _Social Media_ options with smaller ones, consistent with the **Form > Field > Selection** option.

6. Replaced the Social Media buttons with standard snippets on the following pages:
  -   Added _Share_ snippet on blog post page (`/blog/b-1/p-1`).
  -   Added _Social Media_ snippet on event list page (`/event`).
  -   Added _Share_ snippet on event page (`/event/evt-1/register`).
  -   Added **Social Media** snippet on job list page (`/jobs`).

task-4879376