### PR TITLE
[FIX] point_of_sale: archive products instead of deleting in test

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2479,12 +2479,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         if loaded_demo_data(self.env):
             self.skipTest('Cannot test with demo data.')
 
-        # Unlink existing product records
-        self.env['product.product'].sudo().search([]).unlink()
+        # archive existing product records
+        archive_products(self.env)
 
         # cannot load by pos user
         self.start_pos_tour('test_load_pos_demo_data_by_pos_user', login='pos_user')
-        products = self.env['product.product'].search([])
+        products = self.env['product.template'].search_count([('available_in_pos', '=', True)])
         self.assertFalse(products, 'Demo data should not be loaded by user.')
 
         # pos admin group access
@@ -2493,7 +2493,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         # can load by pos admin
         self.start_pos_tour('test_load_pos_demo_data_by_pos_admin', login='pos_admin')
-        products = self.env['product.product'].search([])
+        products = self.env['product.template'].search_count([('available_in_pos', '=', True)])
         self.assertTrue(products, 'Demo data should be loaded by admin.')
 
 


### PR DESCRIPTION
### Before this commit:
- The `test_load_pos_demo_data` test case was deleting all products, including special ones like `Gift card`, `default_booking_product`, leading to errors due to constraints on deleting such records.

### After this commit:
- The test case now archives existing products instead of deleting them, avoiding these errors.

Runbot Errors: 229904 & 229903
Task: 4974081
