### PR TITLE
[IMP] hr: change contract type ordering

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -82,57 +82,62 @@
 
         <record id="contract_type_permanent" model="hr.contract.type">
             <field name="name">Permanent</field>
-            <field name="sequence">1</field>
+            <field name="sequence">1001</field>
         </record>
 
         <record id="contract_type_temporary" model="hr.contract.type">
             <field name="name">Temporary</field>
-            <field name="sequence">2</field>
+            <field name="sequence">1002</field>
+        </record>
+
+        <record id="contract_type_interim" model="hr.contract.type" forcecreate="1">
+            <field name="name">Interim</field>
+            <field name="sequence">1003</field>
         </record>
 
         <record id="contract_type_seasonal" model="hr.contract.type">
             <field name="name">Seasonal</field>
-            <field name="sequence">3</field>
+            <field name="sequence">1004</field>
         </record>
 
         <record id="contract_type_full_time" model="hr.contract.type">
             <field name="name">Full-Time</field>
-            <field name="sequence">4</field>
+            <field name="sequence">1005</field>
         </record>
 
         <record id="contract_type_part_time" model="hr.contract.type">
             <field name="name">Part-Time</field>
-            <field name="sequence">5</field>
+            <field name="sequence">1006</field>
         </record>
 
         <record id="contract_type_intern" model="hr.contract.type">
             <field name="name">Intern</field>
-            <field name="sequence">6</field>
+            <field name="sequence">1007</field>
         </record>
 
         <record id="contract_type_student" model="hr.contract.type">
             <field name="name">Student</field>
-            <field name="sequence">7</field>
+            <field name="sequence">1008</field>
         </record>
 
         <record id="contract_type_apprenticeship" model="hr.contract.type">
             <field name="name">Apprenticeship</field>
-            <field name="sequence">8</field>
+            <field name="sequence">1009</field>
         </record>
 
         <record id="contract_type_thesis" model="hr.contract.type">
             <field name="name">Thesis</field>
-            <field name="sequence">9</field>
+            <field name="sequence">1010</field>
         </record>
 
-        <record id="contract_type_statutaire" model="hr.contract.type">
+        <record id="contract_type_statutory" model="hr.contract.type">
             <field name="name">Statutory</field>
-            <field name="sequence">10</field>
+            <field name="sequence">1011</field>
         </record>
 
         <record id="contract_type_employee" model="hr.contract.type">
             <field name="name">Employee</field>
-            <field name="sequence">11</field>
+            <field name="sequence">1012</field>
         </record>
 
         <record id="home_work_location" model="hr.work.location">

--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -71,22 +71,7 @@
             <field name="color" eval="3"/>
         </record>
 
-        <!-- Contract Types -->
-        <record id="contract_type_permanent" model="hr.contract.type">
-            <field name="name">Permanent</field>
-            <field name="sequence">1</field>
-        </record>
-
-        <record id="contract_type_temporary" model="hr.contract.type">
-            <field name="name">Temporary</field>
-            <field name="sequence">2</field>
-        </record>
-
-        <record id="contract_type_interim" model="hr.contract.type">
-            <field name="name">Interim</field>
-            <field name="sequence">3</field>
-        </record>
-
+        <!-- Jobs -->
         <record id="job_cto" model="hr.job">
             <field name="name">Chief Technical Officer</field>
             <field name="department_id" ref="dep_rd"/>

--- a/addons/hr/data/scenarios/hr_scenario.xml
+++ b/addons/hr/data/scenarios/hr_scenario.xml
@@ -11,12 +11,6 @@
             <field name="color" eval="5"/>
         </record>
 
-        <!-- Contract Type -->
-        <record id="contract_type_interim" model="hr.contract.type" forcecreate="1">
-            <field name="name">Interim</field>
-            <field name="sequence">3</field>
-        </record>
-
         <!-- Job -->
         <record id="job_consultant" model="hr.job" forcecreate="1">
             <field name="name">Consultant</field>


### PR DESCRIPTION
When localizations are installed, the standard contract types are shown first. It should be the ones from the loca in first position then the standard ones.

Task: 4979947
