### PR TITLE
[FIX] html_editor: support changing odoo icon to fa icon

### DIFF
--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { MediaDialog } from "./media_dialog/media_dialog";
 import { ColorSelector } from "../font/color_selector";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
+import { ICON_SELECTOR, isElement } from "@html_editor/utils/dom_info";
 
 export class IconPlugin extends Plugin {
     static id = "icon";
@@ -142,7 +143,7 @@ export class IconPlugin extends Plugin {
 
     getTargetedIcon() {
         const targetedNodes = this.dependencies.selection.getTargetedNodes();
-        return targetedNodes.find((node) => node.classList?.contains?.("fa"));
+        return targetedNodes.find((node) => isElement(node) && node.matches(ICON_SELECTOR));
     }
 
     resizeIcon({ size }) {

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -6,6 +6,7 @@ import { ImageSelector } from "./image_selector";
 import { IconSelector } from "./icon_selector";
 
 import { Component, useState, useRef, useEffect } from "@odoo/owl";
+import { iconClasses } from "@html_editor/utils/dom_info";
 
 export const TABS = {
     IMAGES: {
@@ -153,15 +154,19 @@ export class MediaDialog extends Component {
                 TABS.ICONS.Component.tagNames.includes(this.props.media.tagName)
             ) {
                 const classes = this.props.media.className.split(/\s+/);
-                const mediaFont = fonts.find((font) => classes.includes(font.base));
-                if (mediaFont) {
-                    const selectedIcon = mediaFont.icons.find((icon) =>
+                const predefinedMediaFont = fonts.find((font) => classes.includes(font.base));
+                if (predefinedMediaFont) {
+                    const selectedIcon = predefinedMediaFont.icons.find((icon) =>
                         icon.names.some((name) => classes.includes(name))
                     );
                     if (selectedIcon) {
                         this.initialIconClasses.push(...selectedIcon.names);
                         this.selectMedia(selectedIcon, TABS.ICONS.id);
                     }
+                } else {
+                    const iconRegex = new RegExp(`\\b(?:${iconClasses.join("|")})(?:-\\S+)?\\b`);
+                    const fallbackIconClasses = classes.filter((cls) => iconRegex.test(cls));
+                    this.initialIconClasses.push(...fallbackIconClasses);
                 }
             }
         }

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -297,7 +297,7 @@ export const isNotEditableNode = (node) =>
 
 const iconTags = ["I", "SPAN"];
 // @todo @phoenix: move the specific part in a proper plugin.
-const iconClasses = ["fa", "fab", "fad", "far", "oi"];
+export const iconClasses = ["fa", "fab", "fad", "far", "oi"];
 
 export const ICON_SELECTOR = iconTags
     .map((tag) => iconClasses.map((cls) => `${tag}.${cls}`).join(", "))

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -6,6 +6,7 @@ import { getContent, setContent, setSelection } from "./_helpers/selection";
 import { undo } from "./_helpers/user_actions";
 import { contains } from "@web/../tests/web_test_helpers";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { execCommand } from "./_helpers/userCommands";
 
 test("icon toolbar is displayed", async () => {
     const { el } = await setupEditor(`<p><span class="fa fa-glass"></span></p>`);
@@ -267,6 +268,106 @@ test("Styles should be preserved when replacing icon", async () => {
     await contains("main.modal-body span.fa-search").click();
     await animationFrame();
     expect("span.fa-search.fa-3x").toHaveCount(1);
+});
+
+test("Can replace a odoo icon", async () => {
+    const { editor, el } = await setupEditor(`<p><span class="oi oi-plus"></span></p>`);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="oi oi-plus" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="oi oi-plus" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
+    execCommand(editor, "replaceIcon");
+    await animationFrame();
+    await contains("main.modal-body span.fa-search").click();
+    await animationFrame();
+    expect("span.fa.fa-search").toHaveCount(1);
+    expect("span.oi.oi-plus").toHaveCount(0);
+});
+
+test("Can replace a font awesome brand icon", async () => {
+    const { el, editor } = await setupEditor(`<p><span class="fab fa-opera"></span></p>`);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fab fa-opera" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fab fa-opera" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
+    execCommand(editor, "replaceIcon");
+    await animationFrame();
+    await contains("main.modal-body span.fa-search").click();
+    await animationFrame();
+    expect("span.fa.fa-search").toHaveCount(1);
+    expect("span.fab.fa-opera").toHaveCount(0);
+});
+
+test("Can replace a font awesome duotone icon", async () => {
+    const { el, editor } = await setupEditor(`<p><span class="fad fa-bus-alt"></span></p>`);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fad fa-bus-alt" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fad fa-bus-alt" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
+    execCommand(editor, "replaceIcon");
+    await animationFrame();
+    await contains("main.modal-body span.fa-search").click();
+    await animationFrame();
+    expect("span.fa.fa-search").toHaveCount(1);
+    expect("span.fad.fa-bus-alt").toHaveCount(0);
+});
+
+test("Can replace a font awesome regular icon", async () => {
+    const { el, editor } = await setupEditor(`<p><span class="far fa-money-bill-alt"></span></p>`);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="far fa-money-bill-alt" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="far fa-money-bill-alt" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
+    execCommand(editor, "replaceIcon");
+    await animationFrame();
+    await contains("main.modal-body span.fa-search").click();
+    await animationFrame();
+    expect("span.fa.fa-search").toHaveCount(1);
+    expect("span.far.fa-money-bill-alt").toHaveCount(0);
 });
 
 test("Should be able to undo after adding spin effect to an icon", async () => {


### PR DESCRIPTION
Description of the issue this PR addresses:

Before this PR, It wasn't possible to replace Odoo icon (oi) or Font Awesome duotone (fad), brand (fab), and regular (far) icons to a font awesome (fa) icon. This PR adds support replace such icons to fa icons.

task-4972193

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
