### PR TITLE
[IMP] sale: simplify pricelist rule tooltip

### DIFF
--- a/addons/sale/views/product_pricelist_item_views.xml
+++ b/addons/sale/views/product_pricelist_item_views.xml
@@ -30,14 +30,13 @@
                             </div>
                         </div>
                         <div
-                            class="alert alert-danger"
+                            class="alert alert-info"
                             role="alert"
                             invisible="compute_price == 'percentage'"
                         >
                             <div id="formula_fixed_price_warning">
-                                When prices are calculated through formula or fixed, original price is NOT
-                                displayed in sale order lines. Calculated/fixed price is set as unit price
-                                with 0% discount.
+                                For formula or fixed pricing, the original price isn’t shown in
+                                sale orders.
                             </div>
                         </div>
                     </div>

--- a/addons/website_sale/views/product_pricelist_item_views.xml
+++ b/addons/website_sale/views/product_pricelist_item_views.xml
@@ -11,12 +11,8 @@
             </div>
             <div id="formula_fixed_price_warning" position="replace">
                 <div>
-                    When prices are calculated through a formula or fixed, the original price is
-                    generally not displayed in the sale order lines or checkout. However, for
-                    specific formula-based pricing rules, the discount can be shown on the shop
-                    page (e.g. product pages and configurators), but not in the cart or at checkout.
-                    In these cases, the calculated/fixed price is set as the unit price with 0% discount
-                    in the order.
+                    For formula or fixed pricing, the original price isn’t shown in
+                    sale orders or checkout.
                 </div>
             </div>
         </field>


### PR DESCRIPTION
Purpose of this commit to simplify pricelist rule tooltip about original price not showing in SO or checkout page directly and make it shorter and simpler to understand .

This commit update pricelist rule tooltip.

task-495361