### PR TITLE
[FIX] web: Popover 'closeOnClickAway' callback

### DIFF
--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -35,7 +35,7 @@ function useClickAway(callback) {
     }
 
     function navigationHandler() {
-        callback();
+        callback(document.documentElement);
     }
 
     function pointerDownHandler(ev) {

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -372,6 +372,10 @@ test("popover closes when navigating", async () => {
     await mountWithCleanup(Popover, {
         props: {
             close: () => expect.step("close"),
+            closeOnClickAway: (target) => {
+                expect.step(target.tagName);
+                return true;
+            },
             target: getFixture(),
             component: Content,
         },
@@ -382,7 +386,7 @@ test("popover closes when navigating", async () => {
     history.back(); // Head back
     await animationFrame();
 
-    expect.verifySteps(["close"]);
+    expect.verifySteps(["HTML", "close"]);
 });
 
 test("arrow follows target and can get sucked", async () => {


### PR DESCRIPTION
The popover component's 'closeOnClickAway' prop is expected to receive an HTML element as first argument.

Before this commit, when navigating with an open popover, it tried to close by giving no argument to the callback, as it is expected to be an element on which the user clicked, that would cause the popover to close. The issue is that even though there was no click per se, the callback still expects an element and may crash when given none.

This commit arbitrarily gives the document element (<html>) to the callback when the window is the event target to prevent such crashes.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
