### PR TITLE
[ADD] l10n_ro_efactura_synchronize: A way to synchronize bills with ANAF

### DIFF
--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -4,9 +4,7 @@ from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 
-@tagged('post_install_l10n', 'post_install', '-at_install')
-class TestUBLRO(TestUBLCommon):
-
+class TestUBLROCommon(TestUBLCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref="ro"):
         super().setUpClass(chart_template_ref=chart_template_ref)
@@ -51,10 +49,6 @@ class TestUBLRO(TestUBLCommon):
             'country_id': cls.env.ref('base.ro').id,
         })
 
-    ####################################################
-    # Test export - import
-    ####################################################
-
     def create_move(self, move_type, send=True):
         return self._generate_move(
             self.env.company.partner_id,
@@ -74,6 +68,14 @@ class TestUBLRO(TestUBLCommon):
                 },
             ],
         )
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUBLRO(TestUBLROCommon):
+
+    ####################################################
+    # Test export - import
+    ####################################################
 
     def get_attachment(self, move):
         self.assertTrue(move.ubl_cii_xml_id)

--- a/addons/l10n_ro_efactura/models/ciusro_document.py
+++ b/addons/l10n_ro_efactura/models/ciusro_document.py
@@ -30,7 +30,7 @@ def make_efactura_request(session, company, endpoint, method, params, data=None)
 
     try:
         response = session.request(method=method, url=url, params=params, data=data, headers=headers, timeout=60)
-    except requests.HTTPError as e:
+    except (requests.ConnectionError, requests.TooManyRedirects) as e:
         return {'error': str(e)}
     if response.status_code == 204:
         return {'error': _('You reached the limit of requests. Please try again later.')}

--- a/addons/l10n_ro_efactura_synchronize/__init__.py
+++ b/addons/l10n_ro_efactura_synchronize/__init__.py
@@ -1,0 +1,3 @@
+from . import models
+from . import tests
+from . import wizard

--- a/addons/l10n_ro_efactura_synchronize/__manifest__.py
+++ b/addons/l10n_ro_efactura_synchronize/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'author': 'Odoo',
+    'name': "Romania - Synchronize E-Factura",
+    'version': '1.0',
+    'category': 'Accounting/Localizations/EDI',
+    'summary': "Additional module to synchronize bills with the SPV",
+    'countries': ['ro'],
+    'depends': ['l10n_ro_efactura'],
+    'data': [
+        'data/ir_cron.xml',
+        'views/account_move_views.xml',
+        'views/res_config_settings.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_ro_efactura_synchronize/static/src/components/*',
+        ],
+    },
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_ro_efactura_synchronize/data/ir_cron.xml
+++ b/addons/l10n_ro_efactura_synchronize/data/ir_cron.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_l10n_ro_edi_synchronize_invoices" model="ir.cron">
+            <field name="name">E-Factura: Synchronize with ANAF</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="state">code</field>
+            <field name="code">env['res.company']._cron_l10n_ro_edi_synchronize_invoices()</field>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="nextcall" eval="(DateTime.now() + timedelta(days=1)).strftime('%Y-%m-%d 22:00:00')"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_ro_efactura_synchronize/i18n/l10n_ro_efactura_synchronize.pot
+++ b/addons/l10n_ro_efactura_synchronize/i18n/l10n_ro_efactura_synchronize.pot
@@ -1,0 +1,110 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_efactura_synchronize
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-05 12:55+0000\n"
+"PO-Revision-Date: 2025-08-05 12:55+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_account_move_send
+msgid "Account Move Send"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_l10n_ro_edi_document
+msgid "Document object for tracking CIUS-RO XML sent to E-Factura"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_account_bank_statement_line__l10n_ro_edi_index
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_account_move__l10n_ro_edi_index
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_account_payment__l10n_ro_edi_index
+msgid "E-Factura Index"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.actions.server,name:l10n_ro_efactura_synchronize.ir_cron_l10n_ro_edi_synchronize_invoices_ir_actions_server
+msgid "E-Factura: Synchronize with ANAF"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#, python-format
+msgid "Error when trying to download the E-Factura data from the SPV: %s"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model_terms:ir.ui.view,arch_db:l10n_ro_efactura_synchronize.res_config_settings_form_inherit_l10n_ro_synchronize
+msgid "Import Vendor Bills in :"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_res_company__l10n_ro_edi_anaf_imported_inv_journal_id
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_res_config_settings__l10n_ro_edi_anaf_imported_inv_journal_id
+msgid "Select journal for SPV imported bills"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-javascript
+#: code:addons/l10n_ro_efactura_synchronize/static/src/components/fetch_invoice.xml:0
+#, python-format
+msgid "Synchronize with ANAF"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#, python-format
+msgid "Synchronized with SPV from message %s"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/ciusro_document.py:0
+#, python-format
+msgid "The SPV data could not be parsed."
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#, python-format
+msgid ""
+"The invoice has probably been refused by the SPV. We were unable to recover "
+"the reason of the refusal because the invoice had not received its index. "
+"Duplicate the invoice and attempt to send it again."
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#, python-format
+msgid "This invoice has been accepted by the SPV."
+msgstr ""

--- a/addons/l10n_ro_efactura_synchronize/i18n/ro.po
+++ b/addons/l10n_ro_efactura_synchronize/i18n/ro.po
@@ -1,0 +1,110 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_efactura_synchronize
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-05 12:55+0000\n"
+"PO-Revision-Date: 2025-08-05 12:55+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_account_move_send
+msgid "Account Move Send"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_l10n_ro_edi_document
+msgid "Document object for tracking CIUS-RO XML sent to E-Factura"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_account_bank_statement_line__l10n_ro_edi_index
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_account_move__l10n_ro_edi_index
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_account_payment__l10n_ro_edi_index
+msgid "E-Factura Index"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.actions.server,name:l10n_ro_efactura_synchronize.ir_cron_l10n_ro_edi_synchronize_invoices_ir_actions_server
+msgid "E-Factura: Synchronize with ANAF"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#, python-format
+msgid "Error when trying to download the E-Factura data from the SPV: %s"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model_terms:ir.ui.view,arch_db:l10n_ro_efactura_synchronize.res_config_settings_form_inherit_l10n_ro_synchronize
+msgid "Import Vendor Bills in :"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model,name:l10n_ro_efactura_synchronize.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_res_company__l10n_ro_edi_anaf_imported_inv_journal_id
+#: model:ir.model.fields,field_description:l10n_ro_efactura_synchronize.field_res_config_settings__l10n_ro_edi_anaf_imported_inv_journal_id
+msgid "Select journal for SPV imported bills"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-javascript
+#: code:addons/l10n_ro_efactura_synchronize/static/src/components/fetch_invoice.xml:0
+#, python-format
+msgid "Synchronize with ANAF"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#, python-format
+msgid "Synchronized with SPV from message %s"
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/ciusro_document.py:0
+#, python-format
+msgid "The SPV data could not be parsed."
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#, python-format
+msgid ""
+"The invoice has probably been refused by the SPV. We were unable to recover "
+"the reason of the refusal because the invoice had not received its index. "
+"Duplicate the invoice and attempt to send it again."
+msgstr ""
+
+#. module: l10n_ro_efactura_synchronize
+#. odoo-python
+#: code:addons/l10n_ro_efactura_synchronize/models/account_move.py:0
+#, python-format
+msgid "This invoice has been accepted by the SPV."
+msgstr ""

--- a/addons/l10n_ro_efactura_synchronize/models/__init__.py
+++ b/addons/l10n_ro_efactura_synchronize/models/__init__.py
@@ -1,0 +1,4 @@
+from . import account_move
+from . import ciusro_document
+from . import res_company
+from . import res_config_settings

--- a/addons/l10n_ro_efactura_synchronize/models/account_move.py
+++ b/addons/l10n_ro_efactura_synchronize/models/account_move.py
@@ -1,0 +1,275 @@
+import requests
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.osv import expression
+
+
+HOLDING_DAYS = 3  # Arbitrary
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    l10n_ro_edi_index = fields.Char(
+        string="E-Factura Index",
+        compute='_compute_l10n_ro_edi_index',
+        store=True,
+        copy=False,
+    )
+
+    @api.depends('l10n_ro_edi_document_ids')
+    def _compute_l10n_ro_edi_index(self):
+        for move in self:
+            documents = move.l10n_ro_edi_document_ids.filtered('key_loading').sorted()
+            move.l10n_ro_edi_index = documents[:1].key_loading
+
+    @api.depends('l10n_ro_edi_index')
+    def _compute_show_reset_to_draft_button(self):
+        # EXTENDS to remove the reset to draft button for invoices with an SPV
+        # index, i.e. they have already been sent and should not be modified
+        super()._compute_show_reset_to_draft_button()
+        for move in self:
+            if move.l10n_ro_edi_index:
+                move.show_reset_to_draft_button = True
+
+    @api.model
+    def _l10n_ro_edi_fetch_invoices(self):
+        """ Synchronize bills/invoices from SPV """
+        result = self.env['l10n_ro_edi.document']._request_ciusro_synchronize_invoices(
+            company=self.env.company,
+            session=requests.Session(),
+        )
+        if 'error' in result:
+            raise UserError(result['error'])
+
+        if result['sent_invoices_accepted_messages']:
+            self._l10n_ro_edi_process_invoice_accepted_messages(result['sent_invoices_accepted_messages'])
+
+        if result['sent_invoices_refused_messages']:
+            self._l10n_ro_edi_process_invoice_refused_messages(result['sent_invoices_refused_messages'])
+
+        if result['received_bills_messages']:
+            self._l10n_ro_edi_process_bill_messages(result['received_bills_messages'])
+
+        # Non-indexed moves that were not processed after some time have probably been refused by the SPV. Since
+        # there is no way to recover the index for refused invoices, we simply refuse them manually without proper reason.
+        domain = [
+            ('company_id', '=', self.env.company.id),
+            ('l10n_ro_edi_index', '=', False),
+            ('l10n_ro_edi_state', '=', 'invoice_sending'),
+        ]
+        non_indexed_invoices = self.env['account.move'].search(domain)
+
+        document_ids_to_delete = []
+        for invoice in non_indexed_invoices:
+            # At that point, only one sent document should exist on an invoice
+            sent_document = invoice.l10n_ro_edi_document_ids
+
+            if (fields.Datetime.now() - sent_document.create_date).days > HOLDING_DAYS:
+                # The last document sent to ANAF was live for longer than the holding period, refuse it
+                document_ids_to_delete += invoice.l10n_ro_edi_document_ids.ids
+
+                error_message = _(
+                    "The invoice has probably been refused by the SPV. We were unable to recover the reason of the refusal because "
+                    "the invoice had not received its index. Duplicate the invoice and attempt to send it again."
+                )
+                invoice._l10n_ro_edi_create_document_invoice_sending_failed(message=error_message)
+
+        self.env['l10n_ro_edi.document'].sudo().browse(document_ids_to_delete).unlink()
+
+        if self._can_commit():
+            self._cr.commit()
+
+    @api.model
+    def _l10n_ro_edi_process_invoice_accepted_messages(self, sent_invoices_accepted_messages):
+        """ Process the validation messages of invoices sent
+            It will also attempt to recover the original invoices, that are missing their index,
+            by matching the name returned by the server and the one in the database.
+            note: There is an edge case where 2 messages have the same invoice name but different indexes in
+            their data; this could be due to a resequencing of the invoice and/or re-sending of an invoice. In
+            that case coupled with name matching where none of the two invoices received an index, all signatures
+            are added to the invoice; the user will have to manually update/select the correct one.
+            For example: 2 invoices in the database
+                - 11 already sent and should have gotten index AA, but did not receive it
+                - 12 not sent
+            Resequence them: 11->12 and 12->11
+            Send new 11 that has not yet been sent, it should have gotten index AB but did not receive it.
+            => In the messages, 2 invoices with name 11 and both index AA and AB.
+        """
+        invoice_names = {message['answer']['invoice']['name'] for message in sent_invoices_accepted_messages if 'error' not in message}
+        invoice_indexes = [message['id_solicitare'] for message in sent_invoices_accepted_messages]
+        domain = expression.AND([
+            [('company_id', '=', self.env.company.id)],
+            [('move_type', 'in', self.get_sale_types())],
+            [('l10n_ro_edi_state', '=', 'invoice_sending')],
+            expression.OR([
+                [('l10n_ro_edi_index', 'in', invoice_indexes)],
+                expression.AND([
+                    [('name', 'in', list(invoice_names))],
+                    [('l10n_ro_edi_index', '=', False)],
+                ]),
+            ]),
+        ])
+        invoices = self.env['account.move'].search(domain)
+
+        document_ids_to_delete = []
+        index_to_move = {move.l10n_ro_edi_index: move for move in invoices}
+        name_to_move = {move.name: move for move in invoices}
+        for message in sent_invoices_accepted_messages:
+            invoice = index_to_move.get(message['id_solicitare'])
+
+            if not invoice:
+                # The move related to the message does not have an index
+                if 'error' in message or not name_to_move.get(message['answer']['invoice']['name']):
+                    continue
+
+                # An invoice with the same name has been found
+                invoice = name_to_move.get(message['answer']['invoice']['name'])
+
+                # Update the index of invoices succesfully sent but without SPV indexes due to server
+                # timeout for unknown reasons during the upload
+                invoice.l10n_ro_edi_index = message['id_solicitare']
+
+            if 'error' in message:
+                document_ids_to_delete += invoice._l10n_ro_edi_get_sending_and_failed_documents().ids
+                error_message = _(
+                    "Error when trying to download the E-Factura data from the SPV: %s",
+                    message['error'],
+                )
+                invoice._l10n_ro_edi_create_document_invoice_sending_failed(error_message)
+                continue
+
+            # Only delete invoice_sent documents and not all because one invoice can contain several signature due to
+            # the edge case where 2 messages have the same invoice name but different indexes in their data; this could
+            # be due to a resequencing of the invoice and/or re-sending of an invoice. In that case coupled with name
+            # matching where none of the two invoices received an index, all signatures are added to the invoice; the
+            # user will have to manually update/select the correct one.
+            document_ids_to_delete += invoice._l10n_ro_edi_get_sending_and_failed_documents().ids
+
+            invoice.message_post(body=_("This invoice has been accepted by the SPV."))
+            invoice._l10n_ro_edi_create_document_invoice_sent({
+                'key_loading': invoice.l10n_ro_edi_index,
+                'key_signature': message['answer']['signature']['key_signature'],
+                'key_certificate': message['answer']['signature']['key_certificate'],
+                'attachment_raw': message['answer']['signature']['attachment_raw'],
+            })
+
+        self.env['l10n_ro_edi.document'].sudo().browse(document_ids_to_delete).unlink()
+
+    @api.model
+    def _l10n_ro_edi_process_invoice_refused_messages(self, sent_invoices_refused_messages):
+        """ Process the refusal messages of invoices sent
+            For refused invoices, it is impossible to recover the original invoice from the message content like
+            in `_l10n_ro_edi_process_invoice_accepted_messages` since the message only contains the index and
+            error message (as relevant information).
+        """
+        refused_invoice_indexes = [message['id_solicitare'] for message in sent_invoices_refused_messages]
+        domain = [
+            ('company_id', '=', self.env.company.id),
+            ('move_type', 'in', self.get_sale_types()),
+            ('l10n_ro_edi_index', 'in', refused_invoice_indexes),
+            ('l10n_ro_edi_state', '=', 'invoice_sending'),
+        ]
+        invoices = self.env['account.move'].search(domain)
+        index_to_move = {move.l10n_ro_edi_index: move for move in invoices}
+
+        document_ids_to_delete = []
+        for message in sent_invoices_refused_messages:
+            invoice = index_to_move.get(message['id_solicitare'])
+            if not invoice:
+                continue
+
+            if 'error' in message:
+                document_ids_to_delete += invoice._l10n_ro_edi_get_sending_and_failed_documents().ids
+                error_message = _(
+                    "Error when trying to download the E-Factura data from the SPV: %s",
+                    message['error']
+                )
+                invoice._l10n_ro_edi_create_document_invoice_sending_failed(error_message)
+                continue
+
+            document_ids_to_delete += invoice.l10n_ro_edi_document_ids.ids
+
+            error_message = message['answer']['invoice']['error'].replace('\t', '')
+            invoice._l10n_ro_edi_create_document_invoice_sending_failed(error_message)
+
+        self.env['l10n_ro_edi.document'].sudo().browse(document_ids_to_delete).unlink()
+
+    @api.model
+    def _l10n_ro_edi_process_bill_messages(self, received_bills_messages):
+        """ Create bill received on the SPV, if it does not already exist.
+        """
+        # Search potential similar bills: similar bills either:
+        # - have an index that is present in the message data or,
+        # - the same amount and seller VAT, and optionally the same bill date
+        domain = expression.AND([
+            [('company_id', '=', self.env.company.id)],
+            [('move_type', 'in', self.get_purchase_types())],
+            expression.OR([
+                expression.AND([
+                    [('l10n_ro_edi_index', '=', False)],
+                    [('l10n_ro_edi_state', '=', False)],
+                    expression.OR([
+                        [
+                            ('amount_total', '=', message['answer']['invoice']['amount_total']),
+                            ('commercial_partner_id.vat', '=', message['answer']['invoice']['seller_vat']),
+                            ('invoice_date', 'in', [message['answer']['invoice']['date'], False])
+                        ]
+                        for message in received_bills_messages
+                        if 'error' not in message
+                    ]),
+                ]),
+                [('l10n_ro_edi_index', 'in', [message['id_solicitare'] for message in received_bills_messages])],
+            ]),
+        ])
+        similar_bills = self.env['account.move'].search(domain)
+
+        indexed_similar_bills = similar_bills.filtered('l10n_ro_edi_index').mapped('l10n_ro_edi_index')
+        non_indexed_similar_bills_dict = {
+            (bill.commercial_partner_id.vat, bill.amount_total, bill.invoice_date): bill
+            for bill in similar_bills
+            if not bill.l10n_ro_edi_index
+        }
+
+        for message in received_bills_messages:
+            if 'error' in message:
+                continue
+
+            if message['id_solicitare'] in indexed_similar_bills:
+                # A bill with the same SPV index was already imported, skip it as we don't want it twice.
+                continue
+
+            # Create new bills if they don't already exist, else update their content
+            bill = non_indexed_similar_bills_dict.get(
+                (message['answer']['invoice']['seller_vat'], float(message['answer']['invoice']['amount_total']), message['answer']['invoice']['date'])
+            )
+            if not bill:
+                bill = non_indexed_similar_bills_dict.get(
+                (message['answer']['invoice']['seller_vat'], float(message['answer']['invoice']['amount_total']), False)
+            )
+            if not bill:
+                bill = self.env['account.move'].create({
+                    'company_id': self.env.company.id,
+                    'move_type': 'in_invoice',
+                    'journal_id': self.env.company.l10n_ro_edi_anaf_imported_inv_journal_id.id,
+                })
+
+            bill._l10n_ro_edi_create_document_invoice_sent({
+                'key_loading': message['id_solicitare'],
+                'key_signature': message['answer']['signature']['key_signature'],
+                'key_certificate': message['answer']['signature']['key_certificate'],
+                'attachment_raw': message['answer']['signature']['attachment_raw'],
+            })
+            attachment_sudo = self.env['ir.attachment'].sudo().create(
+                bill._l10n_ro_edi_create_attachment_values(message['answer']['invoice']['attachment_raw'])
+            )
+            bill._extend_with_attachments(attachment_sudo)
+            bill.message_post(body=_("Synchronized with SPV from message %s", message['id']))
+
+    def action_l10n_ro_edi_fetch_invoices(self):
+        self._l10n_ro_edi_fetch_invoices()
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'reload',
+        }

--- a/addons/l10n_ro_efactura_synchronize/models/ciusro_document.py
+++ b/addons/l10n_ro_efactura_synchronize/models/ciusro_document.py
@@ -1,0 +1,128 @@
+import json
+from datetime import datetime
+
+import requests
+from lxml import etree
+
+from odoo import _, api, models
+from odoo.addons.l10n_ro_efactura.models.ciusro_document import (
+    make_efactura_request,
+)
+
+NS_DOWNLOAD = {
+    "cac": "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+    "cbc": "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+}
+
+
+class L10nRoEdiDocument(models.Model):
+    _inherit = 'l10n_ro_edi.document'
+
+    @api.model
+    def _request_ciusro_send_invoice(self, company, xml_data, move_type='out_invoice'):
+        # Override to catch Timeout exception and set a sent state on the document
+        # to avoid sending it several times; hoping that the synchronize will be able
+        # to recover the index
+        try:
+            return super()._request_ciusro_send_invoice(company, xml_data, move_type)
+        except requests.Timeout:
+            return {'key_loading': False}
+
+    @api.model
+    def _request_ciusro_fetch_status(self, company, key_loading, session):
+        # Override to process sent invoices with no ANAF index (due to timeout during
+        # the sending of the invoide)
+        if not key_loading:
+            return {}
+        return super()._request_ciusro_fetch_status(company, key_loading, session)
+
+    @api.model
+    def _request_ciusro_synchronize_invoices(self, company, session, nb_days=1):
+        result = make_efactura_request(
+            session=session,
+            company=company,
+            endpoint='listaMesajeFactura',
+            method='GET',
+            params={'zile': nb_days, 'cif': company.vat.replace('RO', '')},
+        )
+        if 'error' in result:
+            return {'error': result['error']}
+
+        try:
+            msg_content = json.loads(result['content'])
+        except ValueError:
+            return {'error': _("The SPV data could not be parsed.")}
+
+        if eroare := msg_content.get('eroare'):
+            return {'error': eroare}
+
+        received_bills_messages = []
+        sent_invoices_accepted_messages = []
+        sent_invoices_refused_messages = []
+        for message in msg_content.get('mesaje'):
+
+            # We need to call `_request_ciusro_download_answer` twice, once to recover
+            # the original invoice data or error message using status='nok' and the
+            # second one to get the signature using status=None
+            # This is removed in the refactor in saas~18.4
+
+            invoice_data = self.env['l10n_ro_edi.document']._request_ciusro_download_answer(
+                key_download=message['id'],
+                company=company,
+                session=session,
+                status='nok'
+            )
+            signature_data = self.env['l10n_ro_edi.document']._request_ciusro_download_answer(
+                key_download=message['id'],
+                company=company,
+                session=session,
+            )
+
+            answer = dict()
+
+            # If the signature data contains an error, this is a connection error
+            if signature_data['error']:
+                message['error'] = signature_data['error']
+            else:
+                answer['signature'] = {
+                    'attachment_raw': signature_data['attachment_raw'],
+                    'key_signature': signature_data['key_signature'],
+                    'key_certificate': signature_data['key_certificate'],
+                }
+
+            # If the invoice data contains an error and the invoice is not refused, this is either
+            # - a connection error
+            # - a refused invoice
+            if invoice_data['error']:
+                if message['tip'] != 'ERORI FACTURA':
+                    message['error'] = invoice_data['error']
+                else:
+                    answer['invoice'] = {
+                        'error': invoice_data['error'],
+                        'attachment_raw': invoice_data['attachment_raw'],
+                    }
+            else:
+                root = etree.fromstring(invoice_data['attachment_raw'])
+                answer['invoice'] = {
+                    'name': root.findtext('.//cbc:ID', namespaces=NS_DOWNLOAD),
+                    'amount_total': root.findtext('.//cbc:TaxInclusiveAmount', namespaces=NS_DOWNLOAD),
+                    'buyer_vat': root.findtext('.//cac:AccountingSupplierParty//cbc:CompanyID', namespaces=NS_DOWNLOAD),
+                    'seller_vat': root.findtext('.//cac:AccountingCustomerParty//cbc:CompanyID', namespaces=NS_DOWNLOAD),
+                    'date': datetime.strptime(root.findtext('.//cbc:IssueDate', namespaces=NS_DOWNLOAD), '%Y-%m-%d').date(),
+                    'attachment_raw': invoice_data['attachment_raw'],
+                }
+
+            message['answer'] = answer
+
+            if message['tip'] == 'FACTURA TRIMISA':
+                sent_invoices_accepted_messages.append(message)
+            elif message['tip'] == 'ERORI FACTURA':
+                sent_invoices_refused_messages.append(message)
+            elif message['tip'] == 'FACTURA PRIMITA':
+                received_bills_messages.append(message)
+
+        return {
+            'sent_invoices_accepted_messages': sent_invoices_accepted_messages,
+            'sent_invoices_refused_messages': sent_invoices_refused_messages,
+            'received_bills_messages': received_bills_messages,
+        }

--- a/addons/l10n_ro_efactura_synchronize/models/res_company.py
+++ b/addons/l10n_ro_efactura_synchronize/models/res_company.py
@@ -1,0 +1,43 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    l10n_ro_edi_anaf_imported_inv_journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        string="Select journal for SPV imported bills",
+        domain="[('type', '=', 'purchase')]",
+        compute="_compute_l10n_ro_edi_anaf_imported_inv_journal",
+        store=True,
+        readonly=False,
+    )
+
+    @api.depends('country_code')
+    def _compute_l10n_ro_edi_anaf_imported_inv_journal(self):
+        self.l10n_ro_edi_anaf_imported_inv_journal_id = False
+        for company in self:
+            if company.country_code == 'RO':
+                company.l10n_ro_edi_anaf_imported_inv_journal_id = self.env['account.journal'].search([
+                    ('type', '=', 'purchase'),
+                    *self.env['account.journal']._check_company_domain(company.id),
+                ], limit=1)
+
+    def _cron_l10n_ro_edi_synchronize_invoices(self):
+        """
+        This CRON method will be run every 24 hours to synchronize the invoices and the bills with the ANAF
+        """
+        ro_companies = self.env['res.company'].sudo().search([
+            ('l10n_ro_edi_refresh_token', '!=', False),
+            ('l10n_ro_edi_client_id', '!=', False),
+            ('l10n_ro_edi_client_secret', '!=', False),
+        ])
+        for company in ro_companies:
+            try:
+                self.env['account.move'].with_company(company)._l10n_ro_edi_fetch_invoices()
+            except UserError as e:
+                self._l10n_ro_edi_log_message(
+                    message=f'{company.id}\n{e}',
+                    func='_cron_l10n_ro_edi_synchronize_invoices',
+                )

--- a/addons/l10n_ro_efactura_synchronize/models/res_config_settings.py
+++ b/addons/l10n_ro_efactura_synchronize/models/res_config_settings.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    l10n_ro_edi_anaf_imported_inv_journal_id = fields.Many2one(related='company_id.l10n_ro_edi_anaf_imported_inv_journal_id', readonly=False)

--- a/addons/l10n_ro_efactura_synchronize/static/src/components/fetch_invoice.js
+++ b/addons/l10n_ro_efactura_synchronize/static/src/components/fetch_invoice.js
@@ -1,0 +1,46 @@
+/** @odoo-module **/
+
+import { Component } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { useService } from "@web/core/utils/hooks";
+
+
+export class FetchInvoicesCogMenu extends Component {
+    static template = "l10n_ro_edi.FetchInvoices";
+    static props = {};
+    static components = { DropdownItem };
+
+    setup() {
+        this.action = useService("action");
+        this.orm = useService("orm");
+    }
+
+    async fetchInvoices() {
+        const { context } = this.env.searchModel;
+        return this.action.doActionButton({
+            type: "object",
+            resModel: "account.move",
+            name: "action_l10n_ro_edi_fetch_invoices",
+            context: context,
+        });
+    }
+}
+
+export const CogMenuItem = {
+    Component: FetchInvoicesCogMenu,
+    groupNumber: 20,
+    isDisplayed: async ({ config, searchModel, services }) => {
+        if (
+            searchModel.resModel === "account.move" &&
+            ["kanban", "list"].includes(config.viewType) &&
+            config.actionType === "ir.actions.act_window"
+        ) {
+            const data = await services.orm.searchRead("res.company", [['id', '=', services.company.currentCompany.id]], ["country_code"]);
+            return data[0]?.country_code === 'RO';
+        }
+        return false;
+    },
+};
+
+registry.category("cogMenu").add("l10n_ro_edi-fetch-invoices", CogMenuItem, { sequence: 10 });

--- a/addons/l10n_ro_efactura_synchronize/static/src/components/fetch_invoice.xml
+++ b/addons/l10n_ro_efactura_synchronize/static/src/components/fetch_invoice.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="l10n_ro_edi.FetchInvoices" owl="1">
+         <DropdownItem class="'o_cog_menu'" onSelected.bind="fetchInvoices">
+             Synchronize with ANAF
+        </DropdownItem>
+    </t>
+</templates>

--- a/addons/l10n_ro_efactura_synchronize/tests/__init__.py
+++ b/addons/l10n_ro_efactura_synchronize/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_xml_ubl_ro

--- a/addons/l10n_ro_efactura_synchronize/tests/test_files/from_odoo/ciusro_in_invoice.xml
+++ b/addons/l10n_ro_efactura_synchronize/tests/test_files/from_odoo/ciusro_in_invoice.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:efactura.mfinante.ro:CIUS-RO:1.0.1</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2025/00006</cbc:ID>
+  <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+  <cbc:DueDate>2017-01-31</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>RON</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>RON</cbc:TaxCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>INV/2025/00006</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9947">8001011234567</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Romanian Coffee</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Roast Bean, 4</cbc:StreetName>
+        <cbc:CityName>SECTOR2</cbc:CityName>
+        <cbc:PostalZone>010101</cbc:PostalZone>
+        <cbc:CountrySubentity>RO-VS</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>RO</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>8001011234567</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Romanian Coffee</cbc:RegistrationName>
+        <cbc:CompanyID>8001011234567</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Romanian Coffee</cbc:Name>
+        <cbc:Telephone>+40 111 222 333</cbc:Telephone>
+        <cbc:ElectronicMail>RoastedB@company.roexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9947">RO1234567897</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Hudson Construction</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Strada Kunst, 3</cbc:StreetName>
+        <cbc:CityName>SECTOR1</cbc:CityName>
+        <cbc:PostalZone>010101</cbc:PostalZone>
+        <cbc:CountrySubentity>RO-VS</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>RO</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Hudson Construction</cbc:RegistrationName>
+        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Hudson Construction</cbc:Name>
+        <cbc:Telephone>+40 123 456 789</cbc:Telephone>
+        <cbc:ElectronicMail>HudsonC@company.roexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Strada Kunst, 3</cbc:StreetName>
+        <cbc:CityName>SECTOR1</cbc:CityName>
+        <cbc:PostalZone>010101</cbc:PostalZone>
+        <cbc:CountrySubentity>RO-VS</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>RO</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2025/00006</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>RO23PORL7165378476876732</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="RON">285</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="RON">1500.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="RON">285</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>19.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="RON">1500.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="RON">1500.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="RON">1785.0</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="RON">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="RON">1785.0</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">2.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="RON">1500.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>[DESK0005] Customizable Desk (Custom, White), 160x80cm, with large legs.</cbc:Description>
+      <cbc:Name>Customizable Desk</cbc:Name>
+      <cac:SellersItemIdentification>
+        <cbc:ID>DESK0005</cbc:ID>
+      </cac:SellersItemIdentification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>19.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="RON">750.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_ro_efactura_synchronize/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_efactura_synchronize/tests/test_xml_ubl_ro.py
@@ -1,0 +1,296 @@
+import datetime
+from unittest.mock import patch
+
+from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
+
+from odoo.tests import tagged
+from odoo.tools import file_open
+
+from odoo.addons.l10n_ro_edi.tests.test_xml_ubl_ro import TestUBLROCommon
+
+from odoo.addons.l10n_ro_efactura_synchronize.models.account_move import HOLDING_DAYS
+
+
+def _patch_request_ciusro_download_answer(company, key_download, session):
+    answer_data = {
+        '3029027561': {
+            'signature': {
+                'attachment_raw': b'__ignore__',
+                'key_signature': 'KEY_SIG_1',
+                'key_certificate': 'KEY_CERT_1',
+            },
+            'invoice': {
+                'name': 'INV/2017/00001',
+            },
+        },
+        '3029027562': {
+            'signature': {
+                'attachment_raw': b'__ignore__',
+                'key_signature': 'KEY_SIG_2',
+                'key_certificate': 'KEY_CERT_2',
+            },
+            'invoice': {
+                'name': 'INV/2017/00002',
+            },
+        },
+        '3030159318': {
+            'signature': {
+                'attachment_raw': b'__ignore__',
+                'key_signature': 'KEY_SIG_3',
+                'key_certificate': 'KEY_CERT_3',
+            },
+            'invoice': {
+                'error': 'There has been an error',
+            },
+        },
+        '3030439533': {
+            'signature': {
+                'attachment_raw': b'__ignore__',
+                'key_signature': 'KEY_SIG_4',
+                'key_certificate': 'KEY_CERT_4',
+            },
+            'invoice': {
+                'name': 'INV/2025/00006',
+                'amount_total': '1785.0',
+                'seller_vat': '8001011234567',
+                'date': datetime.date(2017, 1, 1),
+                'attachment_raw': file_open("l10n_ro_efactura_synchronize/tests/test_files/from_odoo/ciusro_in_invoice.xml").read(),
+            },
+        },
+    }
+    return answer_data.get(key_download, {})
+
+
+def _patch_request_ciusro_synchronize_invoices(self, company, session, nb_days=1):
+    sent_invoices_accepted_messages = [
+        {
+            'data_creare': '202503271639',
+            'cif': company.vat,
+            'id_solicitare': '5019882651',
+            'detalii': f"Factura cu id_incarcare=5019882651 emisa de cif_emitent={company.vat} pentru cif_beneficiar=RO1234567897",
+            'tip': 'FACTURA TRIMISA',
+            'id': '3029027561',
+            'answer': _patch_request_ciusro_download_answer(company, '3029027561', None),
+        },
+        {
+            'data_creare': '202503271639',
+            'cif': company.vat,
+            'id_solicitare': '5019882652',
+            'detalii': f"Factura cu id_incarcare=5019882652 emisa de cif_emitent={company.vat} pentru cif_beneficiar=RO1234567897",
+            'tip': 'FACTURA TRIMISA',
+            'id': '3029027562',
+            'answer': _patch_request_ciusro_download_answer(company, '3029027562', None),
+        },
+        {
+            'data_creare': '202503271639',
+            'cif': company.vat,
+            'id_solicitare': '5019882653',
+            'detalii': f"Factura cu id_incarcare=5019882653 emisa de cif_emitent={company.vat} pentru cif_beneficiar=RO1234567897",
+            'tip': 'FACTURA TRIMISA',
+            'id': '3029027562',
+            'answer': _patch_request_ciusro_download_answer(company, '3029027562', None),
+        },
+    ]
+    sent_invoices_refused_messages = [
+        {
+            'data_creare': '202504081504',
+            'cif': company.vat,
+            'id_solicitare': '5020592384',
+            'detalii': 'Erori de validare identificate la factura transmisa cu id_incarcare=5020592384',
+            'tip': 'ERORI FACTURA',
+            'id': '3030159318',
+            'answer': _patch_request_ciusro_download_answer(company, '3030159318', None),
+        },
+    ]
+    received_bills_messages = [
+        {
+            'data_creare': '202504011105',
+            'cif': company.vat,
+            'id_solicitare': '5020704741',
+            'detalii': f"Factura cu id_incarcare=5020704741 emisa de cif_emitent={company.vat} pentru cif_beneficiar=RO1234567897",
+            'tip': 'FACTURA PRIMITA',
+            'id': '3030439533',
+            'answer': _patch_request_ciusro_download_answer(company, '3030439533', None),
+        },
+    ]
+    return {
+        'sent_invoices_accepted_messages': sent_invoices_accepted_messages,
+        'sent_invoices_refused_messages': sent_invoices_refused_messages,
+        'received_bills_messages': received_bills_messages,
+    }
+
+
+@patch('odoo.addons.l10n_ro_efactura_synchronize.models.ciusro_document.L10nRoEdiDocument._request_ciusro_synchronize_invoices', new=_patch_request_ciusro_synchronize_invoices)
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUBLROSynchronize(TestUBLROCommon):
+
+    def test_ciusro_synchronize_invoices_bill_found(self):
+        """ Tests that if a bill with the same index is found, do nothing.
+        """
+        bill = self.create_move('in_invoice', send=False)
+        bill._l10n_ro_edi_create_document_invoice_sent({
+            'key_loading': '5020704741',
+            'key_signature': '__ignore__',
+            'key_certificate': '__ignore__',
+            'attachment_raw': b'__ignore__',
+        })
+
+        documents_before = bill.l10n_ro_edi_document_ids
+        messages_before = bill.message_ids
+        self.assertEqual(bill.l10n_ro_edi_state, 'invoice_sent')
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        self.assertEqual(bill.l10n_ro_edi_document_ids, documents_before)
+        self.assertEqual(bill.message_ids, messages_before)
+        self.assertEqual(bill.l10n_ro_edi_state, 'invoice_sent')
+
+    def test_ciusro_synchronize_invoices_bill_update_index(self):
+        """ Tests that if a bill with the same partner VAT, amount and date is found,
+            we update the index and validate the invoice.
+        """
+        # Need a bill without index and for which the partner VAT and amount match the data returned
+        bill = self.create_move('in_invoice', send=False)
+        self.partner_a.vat = '8001011234567'
+
+        self.assertEqual(bill.l10n_ro_edi_index, False)
+        self.assertEqual(bill.l10n_ro_edi_state, False)
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        self.assertEqual(bill.l10n_ro_edi_index, '5020704741')
+        self.assertEqual(bill.l10n_ro_edi_state, 'invoice_sent')
+
+    def test_ciusro_synchronize_invoices_bill_creation(self):
+        """ Tests that if no similar bills are found, we create one and fill it up with the XML content.
+        """
+        bills = self.env['account.move'].search([
+            ('move_type', 'in', self.env['account.move'].get_purchase_types()),
+            ('company_id', '=', self.env.company.id),
+        ])
+        self.assertEqual(len(bills), 0)
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        bills = self.env['account.move'].search([
+            ('move_type', 'in', self.env['account.move'].get_purchase_types()),
+            ('company_id', '=', self.env.company.id),
+        ])
+        self.assertEqual(len(bills), 1)
+        self.assertEqual(bills.state, 'draft')
+        self.assertEqual(bills.amount_total, 1785.0)
+        self.assertEqual(bills.commercial_partner_id.vat, '8001011234567')
+        self.assertEqual(bills.l10n_ro_edi_index, '5020704741')
+        self.assertEqual(bills.l10n_ro_edi_state, 'invoice_sent')
+
+    ####################################################
+    # Testing of the invoice synchronization with SPV
+    ####################################################
+
+    def test_ciusro_synchronize_invoices_validation(self):
+        """ Test that a sent invoice status is validated.
+        """
+        # Create an invoice that will match the success response returned by the server
+        invoice = self.create_move('out_invoice', send=False)
+        invoice._l10n_ro_edi_create_document_invoice_sending(
+            key_loading='5019882651',
+            attachment_raw=b"__ignore__"
+        )
+        self.assertEqual(invoice.l10n_ro_edi_index, '5019882651')
+        self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sending')
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sent')
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+
+    def test_ciusro_synchronize_invoices_validation_without_index(self):
+        """ Test that a sent invoice status is validated although the invoice did not receive its index.
+            The name of the invoice needs to match the name returned by SPV for the matching to work as intended.
+        """
+        invoice = self.create_move('out_invoice', send=False)
+        # Reset the invoice and remove its index to trigger the matching by name to the success response
+        invoice._l10n_ro_edi_create_document_invoice_sending(
+            key_loading=False,
+            attachment_raw=b"__ignore__"
+        )
+        invoice.name = 'INV/2017/00001'
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        self.assertEqual(invoice.l10n_ro_edi_index, '5019882651')
+        self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sent')
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+
+    def test_ciusro_synchronize_invoices_index_not_in_messages(self):
+        """ Test that a sent invoice status not present in the messages returned by SPV is not updated.
+        """
+        invoice = self.create_move('out_invoice', send=False)
+        invoice._l10n_ro_edi_create_document_invoice_sending(
+            key_loading='INDEX',
+            attachment_raw=b"__ignore__"
+        )
+        self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sending')
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sending')
+
+    def test_ciusro_synchronize_invoices_refusal(self):
+        """ Test that a sent invoice status is refused.
+        """
+        # Create an invoice to match the failure response returned by the server
+        invoice = self.create_move('out_invoice', send=False)
+        invoice._l10n_ro_edi_create_document_invoice_sending(
+            key_loading='5020592384',
+            attachment_raw=b"__ignore__"
+        )
+        self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sending')
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        self.assertEqual(invoice.l10n_ro_edi_state, False)
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+        self.assertEqual(invoice.l10n_ro_edi_document_ids.state, 'invoice_sending_failed')
+
+    def test_ciusro_synchronize_invoices_refusal_held_non_indexed(self):
+        """ Test that non-indexed invoices that have been held for too long get refused.
+        """
+        invoice = self.create_move('out_invoice', send=False)
+        invoice._l10n_ro_edi_create_document_invoice_sending(
+            key_loading=False,
+            attachment_raw=b"__ignore__"
+        )
+        invoice.name = 'INV/2017/00003'  # Skip 00001 and 00002 to avoid the validation due to similar invoice name
+        invoice.l10n_ro_edi_state = 'invoice_sending'
+
+        self.assertEqual(invoice.l10n_ro_edi_index, False)
+
+        with freeze_time(invoice.create_date + relativedelta(days=HOLDING_DAYS + 1)):
+            self.env['account.move']._l10n_ro_edi_fetch_invoices()
+        self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sending')
+
+        with freeze_time(invoice.create_date + relativedelta(days=HOLDING_DAYS + 2)):
+            self.env['account.move']._l10n_ro_edi_fetch_invoices()
+        self.assertEqual(invoice.l10n_ro_edi_state, False)
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 1)
+        self.assertEqual(invoice.l10n_ro_edi_document_ids.state, 'invoice_sending_failed')
+
+    def test_ciusro_synchronize_invoices_not_indexed_with_duplicate_name(self):
+        """ Test the edge case where 2 messages have the same invoice name but different indexes in
+            their data. This scenario coupled with name matching where none of the two invoices received an index,
+            we want all signatures added to the named invoices.
+        """
+        invoice = self.create_move('out_invoice', send=False)
+        invoice.name = 'INV/2017/00002'
+        invoice._l10n_ro_edi_create_document_invoice_sending(
+            key_loading=False,
+            attachment_raw=b"__ignore__"
+        )
+        invoice.l10n_ro_edi_state = 'invoice_sending'
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_sent')
+        self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 2)

--- a/addons/l10n_ro_efactura_synchronize/views/account_move_views.xml
+++ b/addons/l10n_ro_efactura_synchronize/views/account_move_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_move_form_inherit_l10n_ro_synchronize" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.l10n_ro_edi</field>
+        <field name="model">account.move</field>
+        <field name="priority">31</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='journal_div']" position="after">
+                <field name="l10n_ro_edi_index"
+                       invisible="not l10n_ro_edi_index or move_type in ('in_invoice', 'in_refund', 'out_receipt', 'in_receipt')"/>
+            </xpath>
+
+            <xpath expr="//button[@name='action_l10n_ro_edi_fetch_status']" position="attributes">
+                <attribute name="invisible">state != 'invoice_sending' or not key_loading</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ro_efactura_synchronize/views/res_config_settings.xml
+++ b/addons/l10n_ro_efactura_synchronize/views/res_config_settings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_form_inherit_l10n_ro_synchronize" model="ir.ui.view">
+        <field name="name">res.config.settings.form.inherit.l10n.ro.edi</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//block[@id='l10n_ro_edi_settings']" position="inside">
+                <div class="row">
+                    <label for="l10n_ro_edi_anaf_imported_inv_journal_id" class="col-lg-3 o_light_label" string="Import Vendor Bills in : "/>
+                    <field name="l10n_ro_edi_anaf_imported_inv_journal_id" domain="[('type', '=', 'purchase'), ('active', '=', True)]"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ro_efactura_synchronize/wizard/__init__.py
+++ b/addons/l10n_ro_efactura_synchronize/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_send

--- a/addons/l10n_ro_efactura_synchronize/wizard/account_move_send.py
+++ b/addons/l10n_ro_efactura_synchronize/wizard/account_move_send.py
@@ -1,0 +1,16 @@
+from odoo import api, models
+
+
+class AccountMoveSend(models.TransientModel):
+    _inherit = 'account.move.send'
+
+    @api.depends('move_ids.l10n_ro_edi_state', 'enable_ubl_cii_xml')
+    def _compute_l10n_ro_edi_send_enable(self):
+        # Override to enable the sending to SPV if the invoice does not have an index,
+        # i.e, it has not yet been sent
+        super()._compute_l10n_ro_edi_send_enable()
+        for wizard in self:
+            wizard.l10n_ro_edi_send_enable &= not any(
+                move.l10n_ro_edi_index
+                for move in wizard.move_ids
+            )


### PR DESCRIPTION
Backport of the odoo/odoo#208082, adding the possibility to synchronize invoice and bill status at once.

The endpoint `ListaMesajeFactura` returns a list of messages to process.
Those messages can:
- Return an invoice status update with a success or an error;
- Return a new bill from another vendor already validated by the
authority.

The messages contain a message ID to recover and download the official data from the ANAF server: the invoice/bill XML and the signature.

(documentation)[https://mfinante.gov.ro/static/10/eFactura/prezentare%20api%20efactura.pdf]

When synchronizing, we retrieve the new messages from the last 24 hours and update the database content accordingly:
- in case of invoice status update, update the relevant invoice/bill status and download the signature in case of success (note that this was already done before, we only call the relevant methods to do so);
- in case of a new vendor bill, we download the bill XML and signature, create a new in_invoice move and fill it up with the XML content. In case a bill with the same index is already in the database, we do nothing to avoid duplicate. If a similar bill (same date and amount) is found but not yet validated, we only validate it.

The synchronization can be triggered manually through the option in the list view and it is automatically triggered every 4 hours with a CRON.

Lastly, the created bill journal can be set up in the Accounting settings so that users can specify their favorite journals for automated ANAF bills.

task-4891081

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
