### PR TITLE
[FIX] website_livechat: fix error when accessing the website

### DIFF
--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -109,9 +109,9 @@ class WebsiteVisitor(models.Model):
         if upsert == 'inserted':
             visitor_sudo = self.sudo().browse(visitor_id)
             if guest := self.env["mail.guest"]._get_guest_from_context():
-                guest_livechats = guest.channel_ids.filtered(lambda c: c.channel_type == "livechat")
-                guest_livechats.channel_ids.livechat_visitor_id = visitor_sudo.id
-                guest_livechats.channel_ids.anonymous_name = (
+                guest_livechats = guest.sudo().channel_ids.filtered(lambda c: c.channel_type == "livechat")
+                guest_livechats.livechat_visitor_id = visitor_sudo.id
+                guest_livechats.anonymous_name = (
                     "Visitor #%d (%s)" % (visitor_sudo.id, visitor_sudo.country_id.name)
                     if visitor_sudo.country_id
                     else f"Visitor #{visitor_sudo.id}"


### PR DESCRIPTION
When user tries to open the website,
A traceback will appear.

Steps to reproduce the error:
- Install ``website_livechat`` with demo data
- Sign in as ``Mitchell admin`` on one browser window
- Create a new ``User A`` > Set login and password for User A
- In Incognito tab, Go to Sign in Page > click on the livechat button > Send any message > End the conversation >
  Sign in as ``Marc Demo`` > Open Website > Sign out
- User will face Access Error
- In Same Incognito Tab > Go to ``/web/login`` > click on the livechat button > Send any message > End the conversation >
  Sign in as ``User A`` > Open the Website

Traceback:
```
AttributeError: 'discuss.channel' object has no attribute 'channel_ids'
```

https://github.com/odoo/odoo/blob/d9c63a85955c2321bae1a705cc09b2554155f826/addons/website_livechat/models/website_visitor.py#L113
Here, The ``guest_livechats`` variable contains records of the ``discuss.channel`` model.
However, the ``discuss.channel`` model does not have a ``channel_ids`` field.
So, It will lead to the above traceback.

When the Marc Demo user logs out, the following line will raise an access error:
because now the user is considered as a guest, and guest users do not have the necessary access rights to update the ``livechat_visitor_id`` field.
To resolve this, ``sudo()`` is used to bypass access rights at the following line: https://github.com/odoo/odoo/blob/254d66e1e3d646c9c82fbb3561a40aba7790c3b5/addons/website_livechat/models/website_visitor.py#L112-L114

sentry-6670622453

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
