### PR TITLE
[FIX] l10n_it_pos: make sure order is passed around in printReceipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -372,7 +372,7 @@ export class PaymentScreen extends Component {
                 : true;
 
             if (invoiced_finalized) {
-                this.pos.printReceipt(this.currentOrder);
+                this.pos.printReceipt({ order: this.currentOrder });
 
                 if (this.pos.config.iface_print_skip_screen) {
                     this.currentOrder.set_screen_data({ name: "" });


### PR DESCRIPTION
Before this commit, the printReceipt logic in the module l10n_it_pos would not pass the order to be printed.
This can become a problem upon context changes, where pos.get_order does not return the completed order, but a newly created one. This can for example happen when skipping the receipt screen with the option to "print automatically" (iface_print_auto).

After this commit, we keep order as an argument, so we always print the last completed order and not a newly created one.

opw-4882480