### PR TITLE
[IMP] point_of_sale, pos_restaurant: ui improvements

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -130,7 +130,9 @@ export class ControlButtons extends Component {
 
     get buttonClass() {
         return this.props.showRemainingButtons
-            ? "btn btn-secondary btn-lg py-5"
+            ? this.ui.isSmall
+                ? "btn bg-100 btn-md py-2 text-start"
+                : "btn btn-secondary btn-lg py-5"
             : "btn btn-secondary btn-lg lh-lg";
     }
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -22,12 +22,12 @@
                     label.translate="Customer Note"
                     class="buttonClass"
                     icon="'fa fa-sticky-note'"/>
-                <button t-if="this.pos.cashier._role != 'minimal'" class="o_pricelist_button btn btn-secondary btn-lg py-5" t-on-click="() => this.clickPricelist()">
+                <button t-if="this.pos.cashier._role != 'minimal'" class="o_pricelist_button" t-att-class="buttonClass" t-on-click="() => this.clickPricelist()">
                     <i class="fa fa-th-list me-2" role="img" aria-label="Price list" title="Price list" />
                     <t t-if="currentOrder?.pricelist_id" t-esc="currentOrder.pricelist_id.display_name" />
                     <t t-else="">Pricelist</t>
                 </button>
-                <button t-if="this.pos.cashier._role != 'minimal'" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.clickRefund()">
+                <button t-if="this.pos.cashier._role != 'minimal'" t-att-class="buttonClass" t-on-click="() => this.clickRefund()">
                     <i class="fa fa-undo me-1" role="img" aria-label="Refund" title="Refund" />
                     Refund
                 </button>
@@ -40,10 +40,10 @@
                     <t t-if="currentOrder?.fiscal_position_id" t-esc="currentOrder.fiscal_position_id.display_name" />
                     <t t-else="">Tax</t>
                 </button>
-                <button t-if="this.displayProductInfoBtn()" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onProductInfoClick(currentOrder.getSelectedOrderline().product_id.product_tmpl_id)">
+                <button t-if="this.displayProductInfoBtn()" t-att-class="buttonClass" t-on-click="() => this.pos.onProductInfoClick(currentOrder.getSelectedOrderline().product_id.product_tmpl_id)">
                     <i class="fa fa-info-circle me-1" role="img" aria-label="Product Info" title="Product Info" /> Info
                 </button>
-                <button t-if="this.pos.cashier._role != 'minimal'" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())">
+                <button t-if="this.pos.cashier._role != 'minimal'" t-att-class="buttonClass" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())">
                     <i class="fa fa-trash me-1" role="img" /> Cancel Order 
                 </button>
             </div>

--- a/addons/pos_restaurant/data/scenarios/restaurant_floor.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_floor.xml
@@ -4,7 +4,7 @@
         <!-- Floors: Main Floor -->
         <record id="floor_main" model="restaurant.floor">
             <field name="name">Main Floor</field>
-            <field name="background_color">rgb(255,255,255,0.75)</field>
+            <field name="background_color">white</field>
             <field name="floor_background_image" type="base64" file="pos_restaurant/static/img/floor_main.jpeg" />
         </record>
 
@@ -156,7 +156,7 @@
 
         <record id="floor_patio" model="restaurant.floor">
             <field name="name">Patio</field>
-            <field name="background_color">rgb(130, 233, 171)</field>
+            <field name="background_color">white</field>
         </record>
 
         <!-- Patio: Left table row -->

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -719,14 +719,12 @@ export class FloorScreen extends Component {
             title: _t("New Floor"),
             placeholder: _t("Floor name"),
             getPayload: async (newName) => {
-                const lightMode = cookie.get("pos_color_scheme") !== "dark";
-                const backgroundColor = lightMode ? "#E4E4E4" : "#1B1D26";
                 const floor = await this.pos.data.create(
                     "restaurant.floor",
                     [
                         {
                             name: newName,
-                            background_color: backgroundColor,
+                            background_color: "white",
                             pos_config_ids: [this.pos.config.id],
                         },
                     ],
@@ -898,7 +896,7 @@ export class FloorScreen extends Component {
     }
     _getColors() {
         const lightModeColors = {
-            white: [242, 245, 250],
+            white: [249, 250, 251],
             red: [220, 80, 90],
             green: [60, 160, 90],
             blue: [30, 130, 210],
@@ -911,7 +909,7 @@ export class FloorScreen extends Component {
         };
 
         const darkModeColors = {
-            white: [220, 220, 225],
+            white: [60, 62, 75],
             red: [200, 60, 75],
             green: [50, 130, 80],
             blue: [40, 90, 180],

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
@@ -137,7 +137,7 @@
                                     t-attf-style="
                                                 border: 3px solid {{table.color || 'var(--tableOccupied-bg-color, #35d374)'}};
                                                 border-radius: {{table.shape === 'round' ? 1000 : 6}}px;
-                                                background: {{isOccupied ? table.color || 'var(--tableOccupied-bg-color, #35d374)' : 'var(--table-bg-color, #00000030)'}};
+                                                background: {{isOccupied ? table.color || 'var(--tableOccupied-bg-color, #35d374)' : 'var(--table-bg-color, #ffffff65)'}};
                                                 color: {{isOccupied ? 'var(--tableOccupied-color, #000000)' : 'var(--table-color, #FFFFFF)'}};
                                                 opacity: {{state.potentialLink ? (isIntersecting or isIntersected ? 1 : 0.25) : 1}};
                                                 {{isKanban ?

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -12,6 +12,7 @@
         <xpath
             expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
             position="before">
+            <!-- All these buttons will only be displayed in a dialog -->
             <t t-if="pos.config.module_pos_restaurant">
                 <button t-if="pos.config.iface_printbill" t-att-class="buttonClass"
                     t-att-disabled="!pos.getOrder()?.getOrderlines()?.length"
@@ -19,28 +20,23 @@
                     <i class="fa fa-print me-1"></i>Bill
                 </button>
                 <button t-att-class="buttonClass" t-on-click="clickTableGuests">
-                    <span t-esc="currentOrder?.getCustomerCount() || 0" class="px-2 py-1 rounded-circle text-bg-dark fw-bolder small me-1"/>
+                    <span t-esc="currentOrder?.getCustomerCount() || 0" t-attf-class="rounded-circle text-bg-dark fw-bolder small me-1 {{ui.isSmall ? 'px-1' : 'px-2 py-1'}}"/>
                     <span>Guests</span>
                 </button>
             </t>
-        </xpath>
-        <xpath
-            expr="//t[@t-if='props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
-            position="before">
-            <!-- All these buttons will only be displayed in a dialog -->
             <t t-if="pos.config.module_pos_restaurant">
-                <button class="btn btn-secondary btn-lg py-5"
+                <button t-att-class="buttonClass"
                     t-att-disabled="pos.getOrder()?.getOrderlines()?.reduce((sum, line) => sum + line.qty, 0) lt 2"
                     t-on-click="openSplitPage">
                     <i class="fa fa-files-o me-1"/>Split
                 </button>
-                <button class="btn btn-secondary btn-lg py-5" t-on-click.stop="() => this.clickTransferOrder()">
+                <button t-att-class="buttonClass" t-on-click.stop="() => this.clickTransferOrder()">
                     <i class="oi oi-arrow-right me-1" />Transfer / Merge
                 </button>
-                   <button t-att-disabled="!this.showTransferCourse()" class="btn btn-secondary btn-lg py-5" t-on-click.stop="() => this.clickTransferCourse()">
+                   <button t-att-disabled="!this.showTransferCourse()" t-att-class="buttonClass" t-on-click.stop="() => this.clickTransferCourse()">
                     <i class="oi oi-arrow-down me-1" />Transfer course
                 </button>
-                <button t-if="!pos.getOrder()?.table_id" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.editFloatingOrderName(this.pos.getOrder())">
+                <button t-if="!pos.getOrder()?.table_id" t-att-class="buttonClass" t-on-click="() => this.pos.editFloatingOrderName(this.pos.getOrder())">
                     <i class="fa fa-pencil-square-o me-1" />Edit Order Name
                 </button>
             </t>


### PR DESCRIPTION
In this commit:
------------------
- Adjusted the control button size to be slightly smaller and aligned the text to the left for better consistency in small UI views.
- Updated the white color code to match the styling used in other views like Kanban, and also updated the Patio background to align with the overall design theme.
- Colors were being retrieved using color names using `getColors` but applied as RGBA values, now corrected to use consistent color formats creating the new floor.
- Since lightMode is already checked when retrieving colors, we removed unnecessary conditions during the floor creation process to simplify the logic

task: 4963071