### PR TITLE
[FIX] *: kit product invoiced then delivered

### DIFF
--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1271,6 +1271,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         components = self.env['product.product'].create([{
             'name': f'comp {i}',
             'type': 'product',
+            'purchase_method': 'purchase',
             'standard_price': 5,
             'list_price': 5,
         } for i in (1, 2)])
@@ -1286,10 +1287,16 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         ]})
         purchase_order = self.env['purchase.order'].create({
             'partner_id': self.partner_a.id,
-            'order_line': [Command.create({
-                'product_id': kit_product.id,
-                'product_qty': 1,
-            })],
+            'order_line': [
+                Command.create({
+                    'product_id': components[0].id,
+                    'product_qty': 1,
+                }),
+                Command.create({
+                    'product_id': kit_product.id,
+                    'product_qty': 1,
+                }),
+            ],
         })
         purchase_order.button_confirm()
         purchase_order.action_create_invoice()
@@ -1309,9 +1316,12 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         self.assertRecordValues(
             self.env['account.move.line'].search([], order='id asc'),
             [
+                {'account_id': stock_input_account.id,       'product_id': components[0].id,   'reconciled': True,    'debit': 5.0,    'credit':  0.0},
                 {'account_id': stock_input_account.id,       'product_id': kit_product.id,     'reconciled': True,    'debit': 10.0,   'credit':  0.0},
-                {'account_id': tax_paid_account.id,          'product_id': False,              'reconciled': False,   'debit':  1.5,   'credit':  0.0},
-                {'account_id': account_payable_account.id,   'product_id': False,              'reconciled': False,   'debit':  0.0,   'credit': 11.5},
+                {'account_id': tax_paid_account.id,          'product_id': False,              'reconciled': False,   'debit': 2.25,   'credit':  0.0},
+                {'account_id': account_payable_account.id,   'product_id': False,              'reconciled': False,   'debit':  0.0,   'credit':  17.25},
+                {'account_id': stock_input_account.id,       'product_id': components[0].id,   'reconciled': True,    'debit':  0.0,   'credit':  5.0},
+                {'account_id': stock_valuation_account.id,   'product_id': components[0].id,   'reconciled': False,   'debit':  5.0,   'credit':  0.0},
                 {'account_id': stock_input_account.id,       'product_id': components[0].id,   'reconciled': True,    'debit':  0.0,   'credit':  5.0},
                 {'account_id': stock_valuation_account.id,   'product_id': components[0].id,   'reconciled': False,   'debit':  5.0,   'credit':  0.0},
                 {'account_id': stock_input_account.id,       'product_id': components[1].id,   'reconciled': True,    'debit':  0.0,   'credit':  5.0},

--- a/addons/purchase_stock/models/stock_valuation_layer.py
+++ b/addons/purchase_stock/models/stock_valuation_layer.py
@@ -10,3 +10,7 @@ class StockValuationLayer(models.Model):
         :param layer: the layer the price unit is derived from
         """
         return self.value / self.quantity
+
+    def _get_related_product(self):
+        res = super()._get_related_product()
+        return self.stock_move_id.purchase_line_id.product_id if self.stock_move_id.purchase_line_id else res

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.fields import Command
 from odoo.tests import Form, tagged
 
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
@@ -625,3 +626,58 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
         cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
         self.assertAlmostEqual(cogs_aml.debit, 8.00, msg="Should include include the components from all subkits, with the price adapted for 1 Main kit")
         self.assertEqual(cogs_aml.credit, 0)
+
+    def test_sell_kit_invoice_before_delivery(self):
+        """ When a kit product is invoiced prior to delivery, we want to make sure to reconcile all
+        the AMLs from its explosion together, else we risk re-reconciliation attempts (which will
+        block certain actions from being performed altogether).
+        """
+        self.stock_account_product_categ.property_cost_method = 'average'
+
+        compo01 = self._create_product('Compo 01', 'product', 10)
+        compo02 = self._create_product('Compo 02', 'product', 20)
+        kit = self._create_product('Kit', 'product', 30)
+        warehouse = self.company_data['default_warehouse']
+        self.env['stock.quant']._update_available_quantity(compo01, warehouse.lot_stock_id, 1.0)
+        self.env['stock.quant']._update_available_quantity(compo02, warehouse.lot_stock_id, 2.0)
+        self.env['mrp.bom'].create({
+            'type': 'phantom',
+            'product_id': kit.id,
+            'product_tmpl_id': kit.product_tmpl_id.id,
+            'product_qty': 1,
+            'bom_line_ids': [
+                Command.create({'product_id': compo01.id, 'product_qty': 1}),
+                Command.create({'product_id': compo02.id, 'product_qty': 1}),
+            ],
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'product_id': kit.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 10,
+                }),
+                Command.create({
+                    'product_id': compo02.id,
+                    'product_uom_qty': 1,
+                    'price_unit': 5,
+                }),
+            ],
+        })
+        sale_order.action_confirm()
+        invoice = sale_order.with_context(default_journal_id=self.company_data['default_journal_sale'].id)._create_invoices()
+        invoice.action_post()
+        delivery = sale_order.picking_ids
+        # would fail due to attempted re-reconciliation prior to this commit
+        delivery.button_validate()
+        stock_output_amls = self.env['account.move.line'].search([('account_id', '=', self.company_data['default_account_stock_out'].id)], order='id asc')
+        self.assertRecordValues(stock_output_amls,
+            [
+                {'product_id': kit.id,       'reconciled': True,    'debit': 0.0,     'credit':  30.0},
+                {'product_id': compo02.id,   'reconciled': True,    'debit': 0.0,     'credit':  20.0},
+                {'product_id': compo01.id,   'reconciled': True,    'debit': 10.0,    'credit':  0.0},
+                {'product_id': compo02.id,   'reconciled': True,    'debit': 20.0,    'credit':  0.0},
+                {'product_id': compo02.id,   'reconciled': True,    'debit': 20.0,    'credit':  0.0},
+            ]
+        )

--- a/addons/sale_stock/models/__init__.py
+++ b/addons/sale_stock/models/__init__.py
@@ -9,3 +9,4 @@ from . import res_users
 from . import sale_order
 from . import sale_order_line
 from . import stock
+from . import stock_valuation_layer

--- a/addons/sale_stock/models/stock_valuation_layer.py
+++ b/addons/sale_stock/models/stock_valuation_layer.py
@@ -1,0 +1,9 @@
+from odoo import models
+
+
+class StockValuationLayer(models.Model):
+    _inherit = 'stock.valuation.layer'
+
+    def _get_related_product(self):
+        res = super()._get_related_product()
+        return self.stock_move_id.sale_line_id.product_id if self.stock_move_id.sale_line_id else res

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -70,6 +70,10 @@ class StockValuationLayer(models.Model):
         self.ensure_one()
         return tuple()
 
+    def _get_related_product(self):
+        self.ensure_one()
+        return self.product_id
+
     def _validate_accounting_entries(self):
         am_vals = []
         aml_to_reconcile = defaultdict(set)
@@ -85,7 +89,7 @@ class StockValuationLayer(models.Model):
         if am_vals:
             account_moves = self.env['account.move'].sudo().create(am_vals)
             account_moves._post()
-        products_svl = groupby(self, lambda svl: (svl.product_id, svl.company_id.anglo_saxon_accounting))
+        products_svl = groupby(self, lambda svl: (svl._get_related_product(), svl.company_id.anglo_saxon_accounting))
         for (product, anglo_saxon_accounting), svls in products_svl:
             svls = self.browse(svl.id for svl in svls)
             moves = svls.stock_move_id


### PR DESCRIPTION
#### *mrp_account, purchase_{stock, mrp}, sale_{stock, mrp}

### Steps to reporduced:

- In the settings enable: Automatic Accounting
- Create 3 storable product:
	- COMP1, cost 1 $
	- COMP2, cost 2 $
	- KIT with a kit bom using COMP1 and COMP2, cost 3 $
- Modify the product category of all three products to:
    - Costing Method: AVCO
    - Inventory Valuation: Automated
- Create and confirm a sale order with 2 lines:
    - 1 x KIT
    - 1 x COMP2
- Create and confirm the associated invoive
- Try to validate the delivery
#### > UserError: You are trying to reconcile some entries that are already reconciled.

### Cause of the issue:

Validating the delivery will create stock valuation layers related to the associated stock moves — one for COMP1 and two for COMP2 — and then attempt to validate the corresponding accounting entries: https://github.com/odoo/odoo/blob/596937dfef4d203b0cbf5431e71a97f60154d7cb/addons/stock_account/models/stock_move.py#L283-L291

However, during this call, the SVLs are grouped by product_id: https://github.com/odoo/odoo/blob/596937dfef4d203b0cbf5431e71a97f60154d7cb/addons/stock_account/models/stock_valuation_layer.py#L88-L93

As a result, the first time we enter the loop, the accounting entries related to COMP01 will not be reconciled by the
`_stock_account_anglo_saxon_reconcile_valuation` call. This is because we restrict this call using the product COMP01. Therefore, we will not find the invoice needed to reconcile the outgoing moves here: https://github.com/odoo/odoo/blob/596937dfef4d203b0cbf5431e71a97f60154d7cb/addons/stock_account/models/account_move.py#L217-L219 (This happens because the related line of the invoice actually refers to the kit product, as the AMLs were not exploded like the stock moves.)

Now, the issue is that, since the AMLs were not reconciled, they will be added to the pool of lines to be reconciled later: https://github.com/odoo/odoo/blob/596937dfef4d203b0cbf5431e71a97f60154d7cb/addons/stock_account/models/stock_valuation_layer.py#L92-L100

However, the second time we enter the loop — for COMP02 — since COMP02 was sold by itself, there will be an account move line referring to this product on the invoice. The `_stock_account_anglo_saxon_reconcile_valuation` call, now restricted to COMP02, will therefore reconcile the AMLs for both COMP02 and COMP01 related to the kits (as it successfully finds the invoice to reconcile all outgoing moves). This is problematic because the AML related to COMP01 has now been reconciled, despite already having been added to the set of moves to be reconciled. This will raise an error during the second reconciliation attempt: https://github.com/odoo/odoo/blob/596937dfef4d203b0cbf5431e71a97f60154d7cb/addons/account/models/account_move_line.py#L2379-L2380

### Fix:

In the case of kit products, the account move lines of the invoice refer to a different product than the stock valuation layers (because the stock move was exploded but not the AMLs). Therefore, it is important to refer to the kit product during the reconciliation process.

We achieve this by grouping the SVLs using the product of their associated SOL or POL. Unfortunately, we cannot rely on the product from the BoM related to the stock move of the SVL, as kits can be nested within one another. In such cases, the invoice related to the SO or the bill related to the PO would not refer to the intermediate kit we would found that way.

opw-4864925
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
