### PR TITLE
[FIX] account: prevent traceback on partner bank removal

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -86,7 +86,9 @@ class ResPartnerBank(models.Model):
             ids=self.ids,
         )))
         for bank in self:
-            bank.duplicate_bank_partner_ids = self.env['res.partner'].browse(id2duplicates.get(bank._origin.id))
+            duplicate_record = id2duplicates.get(bank._origin.id) or []
+            duplicate_record = [x for x in duplicate_record if x]
+            bank.duplicate_bank_partner_ids = self.env['res.partner'].browse(duplicate_record) if duplicate_record else False
 
     @api.depends('partner_id.country_id', 'sanitized_acc_number', 'allow_out_payment', 'acc_type')
     def _compute_display_account_warning(self):


### PR DESCRIPTION
On removal of bank_ids from res_partner, When there was only one bank_id is left, when removing the last bank_ids from res_partner, a traceback appeared. `None` being passed to `duplicate_bank_partner_ids` and no null check was executed. We now avoid passing `None`

**Steps to recreate**:
1. Go to Vendor
2. Create a Contact
3. Go to Accounting Tab inside contact
4. Create bank account
5. Save contact 
6. Remove the bank account from that contact

Task [link](https://www.odoo.com/odoo/project/967/tasks/4976409)
task-4976409