### PR TITLE
[FIX] sale_project: Fill company and taxes fields on a sales project

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -46,7 +46,7 @@ class SaleOrderLine(models.Model):
                 sale_order = None
                 so_create_values = {
                     'partner_id': partner_id,
-                    'company_id': self.env.context.get('default_company_id') or self.env.company.id,
+                    'company_id': self.env.context.get('company_id') or self.env.company.id,
                 }
                 if project_id:
                     try:

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -174,7 +174,7 @@
                         'with_remaining_hours': True,
                         'form_view_ref': 'sale_project.sale_order_line_view_form_editable',
                         'default_partner_id': partner_id,
-                        'default_company_id': company_id,
+                        'company_id': company_id,
                     }</attribute>
                 </xpath>
             </field>


### PR DESCRIPTION

## Short functional explanation of the error
When clicking on "create and edit" on a Sales Order Item field in a task, the company field is left blank. As a result, the taxes linked to the product don't appear.

## Reproduction Steps
1. Install the modules sales, timesheet and project.
2. Make sure that you have at least 2 different companies in the settings.
2. Click on the project app and create a new project. Check the Billable and Timesheets boxes.
3. Create a task and click on it. Set a customer: the field "Sales Order Item" should appear.
4. Click on the "Sales Order Item" field. Type random letters and click on "create and edit".
5. Select a product that has at least one tax.

### Expected behavior
The company field should be filled as soon as we click on the create and edit button, and the taxes field should be filled with the taxes of the
 product as soon as we select said product.

### Unexpected behavior
The company and taxes field remain empty.

## Origin of the issue
Some fields were set at "default_."

__
opw-4904861

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
