### PR TITLE
[FIX] website_sale: align sidebar dropzone

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -578,6 +578,16 @@ $input-border-color: $gray-400;
             height: 32px;
             width: 32px;
         }
+
+        & #oe_structure_website_sale_sidebar_top {
+            &:where(:not(:has(div.oe_dropzone))) .s_text_block p:only-child {
+                margin-bottom: 0;
+            }
+
+            &:where(:has(.s_text_block p:not(:only-child))) {
+                padding-top: map-get($spacers, 3);
+            }
+        }
     }
 }
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -680,10 +680,10 @@
                         <aside
                             t-if="hasLeftColumn"
                             id="products_grid_before"
-                            class="d-none d-lg-block position-sticky align-self-start col clearfix"
+                            class="d-none d-lg-block position-sticky align-self-start col clearfix pt-2"
                         >
                             <t t-call="website_sale.sidebar_dropzone_at_top"/>
-                            <div class="o_wsale_products_grid_before_rail vh-100 ms-n2 pt-2 px-lg-2 ps-2 overflow-y-scroll">
+                            <div class="o_wsale_products_grid_before_rail vh-100 ms-n2 px-lg-2 ps-2 overflow-y-scroll">
                                 <t
                                     t-set="is_sidebar_collapsible"
                                     t-value="is_view_active('website_sale.products_categories_list_collapsible')"
@@ -715,7 +715,7 @@
                                     </a>
                                 </div>
                                 <div
-                                    t-attf-class="products_attributes_filters d-empty-none {{opt_wsale_categories and 'border-top'}}"
+                                    t-attf-class="products_attributes_filters d-empty-none {{opt_wsale_categories and 'border-top'}} {{'pt-3' if not is_sidebar_collapsible else ''}}"
                                 />
                                 <t
                                     t-if="show_price_filter"
@@ -726,8 +726,8 @@
                                         t-valuef="{{is_sidebar_collapsible and 'accordion accordion-flush'}} {{is_sidebar_collapsible and (opt_wsale_categories or len(attributes) > 0) and 'border-top'}}"
                                     />
                                 </t>
+                                <t t-call="website_sale.sidebar_dropzone_at_bottom"/>
                             </div>
-                            <t t-call="website_sale.sidebar_dropzone_at_bottom"/>
                         </aside>
                         <div id="products_grid" t-attf-class="col">
                             <t


### PR DESCRIPTION
In commit[1] dropzones were introduced in the sidebar to be able to drop
inner snippet inside. However due to the `<p>`'s margin it misalign the
sidebar content from the /shop page title.

This PR adds a css rule to:
- Remove the p's margin when no snippet are yet dropped inside (p:only-child)
- Let the `<p>` margin exist if the dropzone is visible to avoid dropzone overlapping eachother when editing)
- Add a top padding if a snippet exists inside to align the content of the snippet to the title (p is not only-child)
- Add a pt-3 for not collapsable sidebar (fixes alignment for non-collapsable sidebar + bonus fix a bug with the product attribute border when categories are in the sidebar).

[task-4979001](https://www.odoo.com/web#id=4979001&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)

[1]: odoo/odoo@85254e3da69b78c586f8e21be80015426ddcaeed

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
