### PR TITLE
[PERF] website, website_sale: speedup product search

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -159,7 +159,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             for srch in search.split(" "):
                 subdomains = [
                     Domain('name', 'ilike', srch),
-                    Domain('product_variant_ids.default_code', 'ilike', srch),
+                    Domain('variants_default_code', 'ilike', srch),
                 ]
                 if search_in_description:
                     subdomains.extend((


### PR DESCRIPTION
Improve the website fuzzy_search performances by changing the generated query. Currently the query looks like this
```sql
SELECT id, GREATEST(word_similarity(*), ..)
FROM table
ORDER by 2 desc
LIMIT 1000
```

The lack of WHERE conditions leads to postgresql always going for a Seq Scan, which quickly becomes slow when the number of records in the database increases. In ecommerce, having 50 000 products leads to a search > 1s.

To improve this, this commit introduces conditions using the `<%` operator that filters rows based on word_similarity
using `pg_trgm.word_similarity_threshold` as the threshold. Postgresql can then use GIST indexes (GIN indexes don't work here) to speed up table scanning. Those GIST indexes are added in this commit for product_template on website_sale module installation. We also add GIN indexes for website_description, description and description_sale to speedup the search_exact queries. The new GIST indexes are not hit in this case because the ORM only generates
jsonb_path_query_array type conditions when the field is set with index=trigram.

Another pain point when searching for products in ecommerce is the subquery on product_product to check `product_variant_ids.default_code`. This subquery is an optimization fence and forces postgresql to go for
a seq scan when doing an exact search on product.template. To improve that, this commit introduces a new computed stored field `variants_default_code` that is the concatenation of product_variant_ids.default_code with an delimiter char. This field is then indexed with a GIN indexe to speedup LIKE/ILIKE searches on it.

Same PR as this one: https://github.com/odoo/odoo/pull/200571
The branch's and PR's head got mismatched, hence this new one.

#### speedup

website benchmark searching for a product on ecommerce.

| Number of products | Before PR | After PR   |
|:------------------:|:---------:|:----------:|
|        1000        |    140ms  |    96ms    |
|        10000       |    401ms  |    200ms   |
|        50000       |    1.23s  |    263ms   |
|        200000      |    4s     |    545ms   |
|        694272      |    12.5s  |    1.78s   |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
