### PR TITLE
[FIX] l10n_es_edi_verifactu_pos: use simplified invoice limit field

### DIFF
--- a/addons/l10n_es_edi_verifactu_pos/i18n/es.po
+++ b/addons/l10n_es_edi_verifactu_pos/i18n/es.po
@@ -157,6 +157,12 @@ msgid "The order needs to be invoiced since its total amount is above 400€."
 msgstr ""
 
 #. module: l10n_es_edi_verifactu_pos
+#. odoo-python
+#: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
+msgid "The order needs to be invoiced since its total amount is above %s€."
+msgstr ""
+
+#. module: l10n_es_edi_verifactu_pos
 #. odoo-javascript
 #: code:addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/order_receipt/order_receipt.xml:0
 msgid "VERI*FACTU"

--- a/addons/l10n_es_edi_verifactu_pos/i18n/l10n_es_edi_verifactu_pos.pot
+++ b/addons/l10n_es_edi_verifactu_pos/i18n/l10n_es_edi_verifactu_pos.pot
@@ -157,6 +157,12 @@ msgid "The order needs to be invoiced since its total amount is above 400€."
 msgstr ""
 
 #. module: l10n_es_edi_verifactu_pos
+#. odoo-python
+#: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
+msgid "The order needs to be invoiced since its total amount is above %s€."
+msgstr ""
+
+#. module: l10n_es_edi_verifactu_pos
 #. odoo-javascript
 #: code:addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/order_receipt/order_receipt.xml:0
 msgid "VERI*FACTU"

--- a/addons/l10n_es_edi_verifactu_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/pos_order.py
@@ -231,8 +231,9 @@ class PosOrder(models.Model):
     def _process_saved_order(self, draft):
         self.ensure_one()
         if self.l10n_es_edi_verifactu_required:
-            if not self.to_invoice and self.amount_total > 400:
-                raise UserError(_("The order needs to be invoiced since its total amount is above 400€."))
+            if not self.to_invoice and self.amount_total > self.company_id.l10n_es_simplified_invoice_limit:
+                raise UserError(_("The order needs to be invoiced since its total amount is above %s€.",
+                                  self.company_id.l10n_es_simplified_invoice_limit))
             refunded_order = self.refunded_order_id
             if refunded_order:
                 if not self.l10n_es_edi_verifactu_refund_reason:

--- a/addons/l10n_es_edi_verifactu_pos/tests/test_pos_order.py
+++ b/addons/l10n_es_edi_verifactu_pos/tests/test_pos_order.py
@@ -110,7 +110,7 @@ class TestL10nEsEdiVerifactuPosOrder(TestL10nEsEdiVerifactuPosCommon):
 
     def test_error_above_simplified_limit(self):
         with self.with_pos_session():
-            with self.assertRaisesRegex(UserError, "The order needs to be invoiced since its total amount is above 400€."), \
+            with self.assertRaisesRegex(UserError, "The order needs to be invoiced since its total amount is above 400.0€."), \
                  mute_logger('odoo.addons.point_of_sale.models.pos_order'):
                 self._create_order({
                     'pos_order_lines_ui_args': [


### PR DESCRIPTION
In 18.0+ there is a field that determines the amount up to which an invoice can be simplified (`l10n_es_simplified_invoice_limit`).

After this commit we use that instead of the hardcoded limit of 400 € that was used in 17.0.

task-None