### PR TITLE
[IMP] base: remove time from domain context 

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -447,8 +447,8 @@
                     <separator/>
                     <filter string="Invoice Date" name="invoice_date" date="invoice_date"/>
                     <filter string="Next Payment Date" name="payment_date" date="payment_date"/>
-                    <filter string="Overdue" name="late" domain="[('date_maturity', '&lt;', time.strftime('%Y-%m-%d'))]" help="Overdue payments, due date passed"/>
-                    <filter string="Early Discount" name="early_discount" domain="[('discount_date', '!=', False), ('discount_date', '&gt;', time.strftime('%Y-%m-%d'))]"/>
+                    <filter string="Overdue" name="late" domain="[('date_maturity', '&lt;', 'today')]" help="Overdue payments, due date passed"/>
+                    <filter string="Early Discount" name="early_discount" domain="[('discount_date', '!=', False), ('discount_date', '&gt;', 'today')]"/>
                     <separator/>
                     <filter string="Report Dates" name="date_between" domain="[('date', '&gt;=', context.get('date_from')), ('date', '&lt;=', context.get('date_to'))]" invisible="1"/>
                     <filter string="Report Dates" name="date_before" domain="[('date', '&lt;=', context.get('date_to'))]" invisible="1"/>
@@ -1676,7 +1676,7 @@
                     <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->
                     <filter name="late" string="Overdue" domain="[
-                        ('invoice_date_due', '&lt;', time.strftime('%Y-%m-%d')),
+                        ('invoice_date_due', '&lt;', 'today'),
                         ('state', '=', 'posted'),
                         ('payment_state', 'in', ('not_paid', 'partial'))
                     ]" help="Overdue invoices, maturity date passed"/>

--- a/addons/hr_holidays_attendance/views/hr_leave_attendance_report_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_leave_attendance_report_views.xml
@@ -95,7 +95,7 @@
                 <separator/>
                 <filter name="date" string="Date" date="date"/>
                 <filter string="Last 2 Months" name="last_two_months" invisible="1"
-                    domain="[('date', '>', (context_today() - relativedelta(months=2) + relativedelta(day=1)))]"/>
+                    domain="[('date', '&gt;', '-2m =1d')]"/>
                 <separator/>
                 <filter string="Archived Employees" name="archived_employees"
                     domain="[('active', '=', False)]"/>

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -269,10 +269,10 @@
                     <filter name="filter_my_expertise" string="My Expertise" domain="[('livechat_matches_self_expertise', '=', True)]"/>
                     <separator />
                     <filter name="filter_session_date" date="create_date" string="Session Date">
-                        <filter name="created_on_last_24_hours" string="Last 24 Hours" domain="[('create_date', '&gt;', (datetime.datetime.now() - datetime.timedelta(hours=24)).to_utc())]"/>
-                        <filter name="created_on_last_7_days" string="Last 7 Days" domain="[('create_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=7), datetime.time(23, 59, 59)).to_utc())]"/>
-                        <filter name="created_on_last_30_days" string="Last 30 Days" domain="[('create_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=30), datetime.time(23, 59, 59)).to_utc())]"/>
-                        <filter name="created_on_last_365_days" string="Last 365 Days" domain="[('create_date', '&gt;', datetime.datetime.combine(context_today() - datetime.timedelta(days=365), datetime.time(23, 59, 59)).to_utc())]"/>
+                        <filter name="created_on_last_24_hours" string="Last 24 Hours" domain="[('create_date', '&gt;', '-24H')]"/>
+                        <filter name="created_on_last_7_days" string="Last 7 Days" domain="[('create_date', '&gt;=', 'today -7d +1d')]"/>
+                        <filter name="created_on_last_30_days" string="Last 30 Days" domain="[('create_date', '&gt;=', 'today -30d +1d')]"/>
+                        <filter name="created_on_last_365_days" string="Last 365 Days" domain="[('create_date', '&gt;=', 'today -365d +1d')]"/>
                     </filter>
                     <separator/>
                     <group>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -13,7 +13,7 @@
                 <filter string="Blocked" name="blocked" domain="[('state','=','blocked')]"/>
                 <filter string="In Progress" name="progress" domain="[('state','=','progress')]"/>
                 <filter string="Done" name="done" domain="[('state','=', 'done')]"/>
-                <filter string="Late" name="late" domain="[('date_start','&lt;=',time.strftime('%Y-%m-%d'))]"/>
+                <filter string="Late" name="late" domain="[('date_start', '&lt;=', 'today')]"/>
                 <separator/>
                 <filter string="Start Date" name="date_start_filter" date="date_start"/>
                 <group>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -383,7 +383,7 @@
         <field name="res_model">pos.order.line</field>
         <field name="view_mode">list</field>
         <field name="view_id" ref="view_pos_order_line"/>
-        <field name="domain">[('create_date', '&gt;=', time.strftime('%Y-%m-%d 00:00:00')),('create_date', '&lt;=', time.strftime('%Y-%m-%d 23:59:59'))]</field>
+        <field name="domain">[('create_date', '&gt;=', 'today'), ('create_date', '&lt;', 'today +1d')]</field>
     </record>
 
     <record id="view_pos_order_tree_all_sales_lines" model="ir.ui.view">

--- a/addons/product_expiry/views/production_lot_views.xml
+++ b/addons/product_expiry/views/production_lot_views.xml
@@ -35,7 +35,7 @@
         <field name="inherit_id" ref="stock.search_product_lot_filter"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_id']" position="after">
-                <filter string="Expiration Alerts" name="expiration_alerts" domain="[('alert_date', '&lt;=', time.strftime('%Y-%m-%d %H:%M:%S'))]"/>
+                <filter string="Expiration Alerts" name="expiration_alerts" domain="[('alert_date', '&lt;=', 'now')]"/>
             </xpath>
         </field>
      </record>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -1222,7 +1222,7 @@
             <field name="name">Overpassed Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">list,form,calendar,graph,kanban</field>
-            <field name="domain">[('is_closed', '=', False), ('date_deadline','&lt;',time.strftime('%Y-%m-%d')), ('project_id', '!=', False), ('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('is_closed', '=', False), ('date_deadline', '&lt;', 'today'), ('project_id', '!=', False), ('has_template_ancestor', '=', False)]</field>
             <field name="filter" eval="True"/>
             <field name="search_view_id" ref="view_task_search_form"/>
         </record>

--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import ast
 
 from odoo import api, fields, models
-from odoo.tools.safe_eval import safe_eval, datetime
 
 
 class IrFilters(models.Model):
@@ -64,11 +63,10 @@ class IrFilters(models.Model):
         return new_filter
 
     def _get_eval_domain(self):
-        self.ensure_one()
-        return safe_eval(self.domain, {
-            'datetime': datetime,
-            'context_today': datetime.datetime.now,
-        })
+        try:
+            return ast.literal_eval(self.domain)
+        except ValueError as e:
+            raise ValueError("Invalid domain: {self.domain}") from e
 
     @api.model
     def _get_action_domain(self, action_id=None, embedded_action_id=None, embedded_parent_res_id=None):

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -46,7 +46,6 @@ class IrRule(models.Model):
         # independent from the context
         return {
             'user': self.env.user.with_context({}),
-            'time': time,
             'company_ids': self.env.companies.ids,
             'company_id': self.env.company.id,
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Remove remaining dynamic dates and remove dates from the eval context of filters. They now become simple literals.

task-4868324
odoo/enterprise#91421

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
