### PR TITLE
[FIX] pos_restaurant: demo data loading

### DIFF
--- a/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
@@ -5,6 +5,39 @@
             <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
         </record>
 
+        <!-- Sides product attribute -->
+        <record id="pa_sides" model="product.attribute">
+            <field name="name">Sides</field>
+            <field name="create_variant">no_variant</field>
+            <field name="display_type">pills</field>
+            <field name="sequence">100</field>
+        </record>
+
+        <record id="pav_sides_fries" model="product.attribute.value">
+            <field name="name">Belgian fresh homemade fries</field>
+            <field name="attribute_id" ref="pa_sides"/>
+        </record>
+
+        <record id="pav_sides_sweet_potato" model="product.attribute.value">
+            <field name="name">Sweet potato fries</field>
+            <field name="attribute_id" ref="pa_sides"/>
+        </record>
+
+        <record id="pav_sides_smashed_sweet_potato" model="product.attribute.value">
+            <field name="name">Smashed sweet potatoes</field>
+            <field name="attribute_id" ref="pa_sides"/>
+        </record>
+
+        <record id="pav_sides_potato_thyme" model="product.attribute.value">
+            <field name="name">Potatoes with thyme</field>
+            <field name="attribute_id" ref="pa_sides"/>
+        </record>
+
+        <record id="pav_sides_grilled_vegetables" model="product.attribute.value">
+            <field name="name">Grilled vegetables</field>
+            <field name="attribute_id" ref="pa_sides"/>
+        </record>
+
         <!-- Food products -->
         <record model="product.product" id="pos_food_bacon">
             <field name="name">Bacon Burger</field>
@@ -30,15 +63,15 @@
 
         <record model="product.template.attribute.line" id="product_attribute_line_bacon_sides">
             <field name="product_tmpl_id" ref="pos_restaurant.product_bacon_burger_template"/>
-            <field name="attribute_id" ref="product.pa_sides"/>
+            <field name="attribute_id" ref="pa_sides"/>
             <field
                 name="value_ids"
                 eval="[Command.set([
-                    ref('product.pav_sides_fries'),
-                    ref('product.pav_sides_sweet_potato'),
-                    ref('product.pav_sides_smashed_sweet_potato'),
-                    ref('product.pav_sides_potato_thyme'),
-                    ref('product.pav_sides_grilled_vegetables'),
+                    ref('pos_restaurant.pav_sides_fries'),
+                    ref('pos_restaurant.pav_sides_sweet_potato'),
+                    ref('pos_restaurant.pav_sides_smashed_sweet_potato'),
+                    ref('pos_restaurant.pav_sides_potato_thyme'),
+                    ref('pos_restaurant.pav_sides_grilled_vegetables'),
             ])]" />
         </record>
 
@@ -66,15 +99,15 @@
 
         <record model="product.template.attribute.line" id="product_attribute_line_cheese_side">
             <field name="product_tmpl_id" ref="pos_restaurant.product_cheese_burger_template"/>
-            <field name="attribute_id" ref="product.pa_sides"/>
+            <field name="attribute_id" ref="pa_sides"/>
             <field
                 name="value_ids"
                 eval="[Command.set([
-                    ref('product.pav_sides_fries'),
-                    ref('product.pav_sides_sweet_potato'),
-                    ref('product.pav_sides_smashed_sweet_potato'),
-                    ref('product.pav_sides_potato_thyme'),
-                    ref('product.pav_sides_grilled_vegetables'),
+                    ref('pos_restaurant.pav_sides_fries'),
+                    ref('pos_restaurant.pav_sides_sweet_potato'),
+                    ref('pos_restaurant.pav_sides_smashed_sweet_potato'),
+                    ref('pos_restaurant.pav_sides_potato_thyme'),
+                    ref('pos_restaurant.pav_sides_grilled_vegetables'),
             ])]" />
         </record>
 

--- a/addons/product/data/product_attribute_demo.xml
+++ b/addons/product/data/product_attribute_demo.xml
@@ -535,39 +535,6 @@
         <field name="sequence">4</field>
     </record>
 
-    <!-- Sides -->
-    <record id="pa_sides" model="product.attribute">
-        <field name="name">Sides</field>
-        <field name="create_variant">no_variant</field>
-        <field name="display_type">pills</field>
-        <field name="sequence">100</field>
-    </record>
-
-    <record id="pav_sides_fries" model="product.attribute.value">
-        <field name="name">Belgian fresh homemade fries</field>
-        <field name="attribute_id" ref="pa_sides"/>
-    </record>
-
-    <record id="pav_sides_sweet_potato" model="product.attribute.value">
-        <field name="name">Sweet potato fries</field>
-        <field name="attribute_id" ref="pa_sides"/>
-    </record>
-
-    <record id="pav_sides_smashed_sweet_potato" model="product.attribute.value">
-        <field name="name">Smashed sweet potatoes</field>
-        <field name="attribute_id" ref="pa_sides"/>
-    </record>
-
-    <record id="pav_sides_potato_thyme" model="product.attribute.value">
-        <field name="name">Potatoes with thyme</field>
-        <field name="attribute_id" ref="pa_sides"/>
-    </record>
-
-    <record id="pav_sides_grilled_vegetables" model="product.attribute.value">
-        <field name="name">Grilled vegetables</field>
-        <field name="attribute_id" ref="pa_sides"/>
-    </record>
-
     <!-- Options -->
     <record id="pa_options" model="product.attribute">
         <field name="name">Options</field>


### PR DESCRIPTION
Finetuning of ffb976c3ed5fbcff2e5d06a3183bab2fbe0307ff to ensure that the product attributes demo data are loaded before loading the pos restaurant demo data




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
