### PR TITLE
[FIX] point_of_sale: Fix existing multiple refunded orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -376,7 +376,7 @@ class PosOrder(models.Model):
     def _compute_refund_related_fields(self):
         for order in self:
             order.refund_orders_count = len(order.mapped('lines.refund_orderline_ids.order_id'))
-            order.refunded_order_id = order.lines.refunded_orderline_id.order_id
+            order.refunded_order_id = next(iter(order.lines.refunded_orderline_id.order_id), False)
 
     @api.depends('lines.refunded_qty', 'lines.qty')
     def _compute_has_refundable_lines(self):


### PR DESCRIPTION
In saas~17.1, the field `refunded_order_id` was changed from a Many2Many to a Many2One, as refunding lines from different orders with the same order was no longer possible.

The problem is that there were no changes applied to the existing data to account for this, so databases with those kind of refunds will trigger an error when the field is computed:
```
ValueError: Wrong value for pos.order.refunded_order_id
```

This behaviour can also break upgrades if the error happens during the mock crawl test after the upgrade.

To reproduce:
	- In 17, create an order refunding products from different orders.
	- Upgrade to 18.
	- Try to view the refunding order.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
