### PR TITLE
[FIX] html_builder, web: fix dark theme compatibility with builder

### DIFF
--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -13,6 +13,8 @@ export const COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES = [
     "info",
     "warning",
     "danger",
+    "black",
+    "white",
 ];
 
 /**

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -72,7 +72,7 @@
                 t-on-focusout="onColorFocusout">
                 <div class="o_colorpicker_section">
                     <t t-foreach="DEFAULT_THEME_COLOR_VARS" t-as="color" t-key="color">
-                        <button t-att-data-color="color" t-att-class="{'selected': color === defaultColorSet}" 
+                        <button t-att-data-color="color" t-att-class="{'selected': color === defaultColorSet}"
                             t-att-style="`background-color: var(--${props.themeColorPrefix + color})` + (color_index === 3 ? '; grid-column: 5' : '')" class="btn p-0 o_color_button"/>
                     </t>
                 </div>
@@ -97,7 +97,7 @@
                 <t t-foreach="Object.values(this.grayscales)" t-as="grayscaleColors" t-key="grayscaleColors">
                     <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                         <t t-foreach="grayscaleColors" t-as="color" t-key="color">
-                            <button t-att-data-color="color" class="o_color_button btn p-0" t-att-class="{'selected': color === defaultColorSet}" t-attf-style="background-color: var(--{{color}})" />
+                            <button t-att-data-color="color" class="o_color_button btn p-0" t-att-class="{'selected': color === defaultColorSet}" t-attf-style="background-color: var(--{{props.themeColorPrefix}}{{color}})" />
                         </t>
                     </div>
                 </t>


### PR DESCRIPTION
In the html builder, colorpickers belong to the global window (backend), while the elements they target belong to an inner iframe (frontend). When the dark theme is toggled on in the backend, it doesn't affect the frontend. However, given how it works, until this commit, custom black to white color tints were switched visually, but still applied the opposite color (i.e. clicking on the black tint applied white).

This commit makes sure that, in such an environment where the colorpicker and the targeted element are not in the same DOM, the color swatches are properly displayed.