### PR TITLE
[FIX] hr: hide module_hr_contract from settings

### DIFF
--- a/addons/hr/models/res_config_settings.py
+++ b/addons/hr/models/res_config_settings.py
@@ -9,7 +9,7 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.resource_calendar_id', readonly=False)
     module_hr_presence = fields.Boolean(string="Advanced Presence Control")
     module_hr_skills = fields.Boolean(string="Skills Management")
-    module_hr_contract = fields.Boolean(string="Contracts Management")
+    module_hr_contract = fields.Boolean(string="Contracts Management", readonly=True, default=True)
     hr_presence_control_login = fields.Boolean(related='company_id.hr_presence_control_login', readonly=False)
     hr_presence_control_email = fields.Boolean(related='company_id.hr_presence_control_email', readonly=False)
     hr_presence_control_ip = fields.Boolean(related='company_id.hr_presence_control_ip', readonly=False)

--- a/addons/hr/views/res_config_settings_views.xml
+++ b/addons/hr/views/res_config_settings_views.xml
@@ -55,7 +55,7 @@
                         <setting help="Enrich employee profiles with skills and resumes" id="enrich_employee_setting">
                             <field name="module_hr_skills"/>
                         </setting>
-                        <setting help="Manage the contracts of your employees or create contract templates" id="manage_contracts_setting">
+                        <setting help="Manage the contracts of your employees or create contract templates" id="manage_contracts_setting" invisible="1">
                             <field name="module_hr_contract"/>
                         </setting>
                     </block>


### PR DESCRIPTION
When `hr_contract` was merged into `hr` we forgot to remove the field from `res.config.settings`. To be stable-friendly we hide the field in the view, and make it readonly and such that it always shows as True.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
