### PR TITLE
[FIX] pos_sale: correctly compute qty_delivered

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -194,17 +194,28 @@ class PosOrderLine(models.Model):
 
     @api.depends('order_id.state', 'order_id.picking_ids', 'order_id.picking_ids.state', 'order_id.picking_ids.move_ids.quantity')
     def _compute_qty_delivered(self):
+        product_qty_left_to_assign = {}
         for order_line in self:
             if order_line.order_id.state in ['paid', 'done', 'invoiced']:
                 outgoing_pickings = order_line.order_id.picking_ids.filtered(
                     lambda pick: pick.state == 'done' and pick.picking_type_code == 'outgoing'
                 )
 
-                if outgoing_pickings:
+                if outgoing_pickings and order_line.order_id.shipping_date:
                     moves = outgoing_pickings.move_ids.filtered(
                         lambda m: m.state == 'done' and m.product_id == order_line.product_id
                     )
-                    order_line.qty_delivered = sum(moves.mapped('quantity'))
+                    qty_left = product_qty_left_to_assign.get(order_line.product_id.id, False)
+                    if (qty_left):
+                        order_line.qty_delivered = min(order_line.qty, qty_left)
+                        product_qty_left_to_assign[order_line.product_id.id] -= order_line.qty_delivered
+                    else:
+                        order_line.qty_delivered = min(order_line.qty, sum(moves.mapped('quantity')))
+                        product_qty_left_to_assign[order_line.product_id.id] = sum(moves.mapped('quantity')) - order_line.qty_delivered
+
+                elif outgoing_pickings:
+                    # If the order is not delivered later, and in a "paid", "done" or "invoiced" state, it fully delivered
+                    order_line.qty_delivered = order_line.qty
                 else:
                     order_line.qty_delivered = 0
 

--- a/addons/pos_sale/tests/test_pos_sale_report.py
+++ b/addons/pos_sale/tests/test_pos_sale_report.py
@@ -132,7 +132,7 @@ class TestPoSSaleReport(TestPoSCommon):
 
         orders = []
 
-        orders.append(self.create_ui_order_data([(self.product0, 5)], self.partner_1))
+        orders.append(self.create_ui_order_data([(self.product0, 5, 100), (self.product0, 3)], self.partner_1))
         orders[0]['shipping_date'] = fields.Date.to_string(fields.Date.today())
 
         order = self.env['pos.order'].sync_from_ui(orders)
@@ -142,10 +142,10 @@ class TestPoSSaleReport(TestPoSCommon):
 
         report = self.env['sale.report'].sudo().search([('product_id', '=', self.product0.id)], order='id')
 
-        self.assertEqual(report.qty_to_deliver, 5)
-        self.assertEqual(report.qty_delivered, 0)
+        self.assertEqual(sum(report.mapped('qty_to_deliver')), 8)
+        self.assertEqual(sum(report.mapped('qty_delivered')), 0)
 
-        order.picking_ids.move_ids.quantity = 5.0
+        order.picking_ids.move_ids.quantity = 8.0
         order.picking_ids.button_validate()
         # flush computations and clear the cache before checking again the report
         self.env.flush_all()
@@ -153,5 +153,5 @@ class TestPoSSaleReport(TestPoSCommon):
 
         report = self.env['sale.report'].sudo().search([('product_id', '=', self.product0.id)], order='id')
 
-        self.assertEqual(report.qty_to_deliver, 0)
-        self.assertEqual(report.qty_delivered, 5)
+        self.assertEqual(sum(report.mapped('qty_to_deliver')), 0)
+        self.assertEqual(sum(report.mapped('qty_delivered')), 8)


### PR DESCRIPTION
If you made a sale with multiple lines having the same product, the qty_delivered was not correctly computed on the different lines.

Steps to reproduce:
-------------------
* Activate the ship later option in the PoS settings
* Open PoS
* Add any product with a quantity of 5
* Apply a discount of 20% to the line
* Click on the same product so that they are added as a second line
* Change the quantity of the second line to 3
* Validate the order and use the ship later option
* Validate the picking
* Go to the sale report and check the qty_delivered for the product
> Observation: The qty_delivered is doubled, 16 instead of 8.

Why the fix:
------------
The qty_delivered was computed by summing the quantities of all moves for the product, but it did not take into account that the same product could be present in multiple lines of the same order. We now make sure to dispatch the delivered quantity correctly across the different lines of the order, ensuring that the qty_delivered is accurate.

opw-4826487