### PR TITLE
[FIX] website: fix image gallery navigation with unique IDs

### DIFF
--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -7,6 +7,7 @@ import { updateCarouselIndicators } from "../carousel_option_plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { withSequence } from "@html_editor/utils/resource";
 import { SNIPPET_SPECIFIC, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
+import { uniqueId } from "@web/core/utils/functions";
 
 class ImageGalleryOption extends Plugin {
     static id = "imageGalleryOption";
@@ -46,12 +47,28 @@ class ImageGalleryOption extends Plugin {
         on_snippet_dropped_handlers: ({ snippetEl }) => {
             const carousels = snippetEl.querySelectorAll(".s_image_gallery .carousel");
             this.addCarouselListener(carousels);
+            this.addUniqueIds(carousels);
+        },
+        on_cloned_handlers: ({ cloneEl }) => {
+            const carousels = cloneEl.querySelectorAll(".s_image_gallery .carousel");
+            this.addUniqueIds(carousels);
         },
     };
 
     setup() {
         const slideshowCarousels = this.document.querySelectorAll(".s_image_gallery .carousel");
         this.addCarouselListener(slideshowCarousels);
+    }
+
+    addUniqueIds(carousels) {
+        for (const carousel of carousels) {
+            const id = uniqueId("slideshow_");
+            carousel.id = id;
+            const controllerButtons = carousel.querySelectorAll(".o_carousel_controllers button");
+            for (const button of controllerButtons) {
+                button.setAttribute("data-bs-target", `#${id}`);
+            }
+        }
     }
 
     addCarouselListener(slideshowCarousels) {


### PR DESCRIPTION
After the website refactor [1], the image gallery snippet (carousel) no longer had unique IDs. As a result, when multiple image galleries were present on the page, navigating any carousel other than the first would incorrectly update only the first one.

This commit ensures that each image gallery snippet is assigned a unique ID, allowing all carousels to function independently and correctly.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

Related to task-4367641
