### PR TITLE
[FIX] pos_self_order: correct price calculation in self order

### DIFF
--- a/addons/pos_self_order/static/src/app/services/card_utils.js
+++ b/addons/pos_self_order/static/src/app/services/card_utils.js
@@ -188,7 +188,9 @@ export function getOrderLineValues(
         const price = values.product_id.getPrice(
             currentOrder.pricelist_id,
             values.qty,
-            values.price_extra
+            values.price_extra,
+            false,
+            values.product_id
         );
 
         values.price_unit = price;

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -92,3 +92,27 @@ registry.category("web_tour.tours").add("self_order_product_info", {
         },
     ],
 });
+
+registry.category("web_tour.tours").add("test_self_order_multi_check_attribute_with_extra_price", {
+    steps: () =>
+        [
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Desk Organizer"),
+            ProductPage.setupAttribute(
+                [
+                    { name: "Fabric", value: "Leather" },
+                    { name: "Size", value: "M" },
+                    { name: "Add-ons", value: "Pen Holder" },
+                    { name: "Add-ons", value: "Mini Drawer" },
+                    { name: "Colour", value: "Blue" },
+                ],
+                false
+            ),
+            Utils.clickBtn("Add to Cart"),
+            Utils.clickBtn("Checkout"),
+            CartPage.checkProduct("Desk Organizer", "11.62", "1"),
+            Utils.clickBtn("Order"),
+            Utils.clickBtn("Ok"),
+            Utils.clickBtn("My Order"),
+        ].flat(),
+});


### PR DESCRIPTION
Currently, there is inconsistent behavior in price calculation 
when a user places a self order for a product containing attributes.

**Pre-requisites:**
- POS module installed and configured.
- Variant enabled in settings.
- Self-ordering is enabled in the POS configuration.
- Two product attributes created in the settings/attributes:
   - One of type radio with variant creation set to Instantly.
   - Another of type multi-checkbox with variant creation set to Never.
- Create attribute lines for both attributes with default extra prices.

**Steps to reproduce:**
1) Create a product template linking the above attributes 
2) Ensure the product is available in POS and self ordering 
3) Open a POS session in one browser tab and the self-ordering in another. 
4) Select the product in the self-ordering interface, first choosing
   an option for the radio attribute, then selecting one or more options
   for the multi-checkbox attribute.

**Error:**

You will see the difference between the expected price and the displayed price

**Example for Clarity:**

Consider a product called Pizza with 2 attributes. The base price of the pizza is $10.

| Attribute                           | Option           | Extra Price           |
| ----------------------------------- | ---------------- | --------------------- |
| **Size** (radio)                    | Small (S)        | \$0 (no extra charge) |
|                                     | Medium (M)       | \$5                   |
|                                     | Large (L)        | \$10                  |
| **Extra Toppings** (multi-checkbox) | Veggies          | \$3                   |
|                                     | Extra Cheese     | \$3                   |
|                                     | Veggies & Cheese | \$5                   |

If the user selects a medium-sized pizza with veggie toppings, 
The expected price is: 
```
$10 (base) + $5 (Medium size) + $3 (Veggies) = $18. However, the price shown is only $13.
```

**Root Cause:**
For attributes of the multi-checkbox type, variant creation is set to Never by default. 
This means no product variants are generated for such attributes.

Because of this, when calculating the price, the extra price associated with the 
multi-checkbox attribute is added directly to the base price of the product template
instead of the price of the selected variant. 

This happens because the variant information is not properly passed to the price calculation method:
https://github.com/odoo/odoo/blob/9df334c0aca8a57dcbed4c87b43b18403f3a7c6e/addons/pos_self_order/static/src/app/services/card_utils.js#L187-L196 https://github.com/odoo/odoo/blob/9df334c0aca8a57dcbed4c87b43b18403f3a7c6e/addons/point_of_sale/static/src/app/models/product_template.js#L185-L189

As a result, the extra price for the multi-checkbox attribute is incorrectly added 
to the product template’s base price rather than the variant’s price.

**Solution:**

Pass the product_variant derived from the selected product.product to the price calculation method. 
This ensures that if a variant exists based on the user’s selection, 
the extra price is added to the variant’s price rather than the base product template price, 
resulting in the correct total price.

opw-4963537