### PR TITLE
[FIX] html_editor: fix non-deterministic cropper test

### DIFF
--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -45,6 +45,7 @@ import { insertText } from "./_helpers/user_actions";
 import { expandToolbar } from "./_helpers/toolbar";
 import { nodeSize } from "@html_editor/utils/position";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { ImageCrop } from "@html_editor/main/media/image_crop";
 
 test.tags("desktop");
 test("toolbar is only visible when selection is not collapsed in desktop", async () => {
@@ -1167,6 +1168,18 @@ test("should not close image cropper while loading media", async () => {
     const base64Image =
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=";
 
+    // This promise is needed to ensure that the `show` method has completed
+    // before clicking on `Discard` button as it sets `isCropperActive` true
+    // at the end. In `closeCropper` method `isCropperActive` must be true
+    // to close the cropper.
+    const cropperReadyPromise = new Promise((resolve) => {
+        patchWithCleanup(ImageCrop.prototype, {
+            async show(...args) {
+                await super.show(...args);
+                resolve();
+            },
+        });
+    });
     // Mock backend image RPCs
     onRpc("/html_editor/get_image_info", async () => {
         await delay(50);
@@ -1190,8 +1203,7 @@ test("should not close image cropper while loading media", async () => {
     expect('.btn[title="Discard"]').toHaveCount(1);
 
     // Once the image loaded we should be able to close
-    await waitFor('img[src^="blob:"]', { timeout: 2000 });
-    await advanceTime(200);
+    await cropperReadyPromise;
     await click('.btn[title="Discard"]');
     await waitForNone('.btn[title="Discard"]', { timeout: 1500 });
 });


### PR DESCRIPTION
The cropper test fixed in [1] still fails non-diterministically on few runbot instances. This PR aims to fix the test.

[1]: https://github.com/odoo/odoo/commit/cd8d2e8e1e58a482e9b2bb151e9233b31ecac393
task-4982084



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
