### PR TITLE
[IMP] website, html_editor: limit selection in current container

### DIFF
--- a/addons/html_builder/static/src/core/builder_container_editable_plugin.js
+++ b/addons/html_builder/static/src/core/builder_container_editable_plugin.js
@@ -1,0 +1,107 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { closestElement } from "@html_editor/utils/dom_traversal";
+
+export class BuilderContainerEditablePlugin extends Plugin {
+    static id = "builderContainerEditable";
+    static dependencies = ["history"];
+
+    resources = {
+        change_current_options_containers_listeners: this.restrictEditableArea.bind(this),
+        system_classes: ["o_restricted_editable_area"],
+        is_element_editable_predicates: this.isElementEditableRestricted.bind(this),
+        clean_for_save_handlers: this.cleanForSave.bind(this),
+    };
+
+    setup() {
+        this.restrictedElements = new Map();
+    }
+
+    destroy() {
+        super.destroy();
+        this.restoreRestrictedElements();
+    }
+
+    cleanForSave({ root }) {
+        [root, ...root.querySelectorAll(".o_restricted_editable_area")].forEach((el) => {
+            el.classList.remove("o_restricted_editable_area");
+        });
+    }
+
+    isElementEditableRestricted(element) {
+        const closestElementRestricted = closestElement(element, ".o_restricted_editable_area");
+        if (
+            element &&
+            (element.isContentEditable ||
+                (closestElementRestricted &&
+                    this.restrictedElements.get(closestElementRestricted)?.contenteditable !==
+                        false))
+        ) {
+            // if the element is contenteditable or was previously restricted, we consider it as editable
+            return true;
+        }
+        return false;
+    }
+
+    restoreRestrictedElements() {
+        // restore the previous state of previously restricted elements
+        this.dependencies.history.ignoreDOMMutations(() => {
+            this.restrictedElements.forEach((value, key) => {
+                if (value.contenteditable === null) {
+                    key.removeAttribute("contenteditable");
+                } else {
+                    key.setAttribute("contenteditable", value.contenteditable);
+                }
+                key.classList.remove("o_restricted_editable_area");
+            });
+        });
+
+        this.restrictedElements.clear();
+    }
+
+    restrictEditableArea(optionsContainer) {
+        this.restoreRestrictedElements();
+
+        // if there is only one or 0 option container, we do not restrict the selection
+        // as it is the only one option container in the editable area or a blank editable area
+        if (optionsContainer.length <= 1) {
+            return;
+        }
+
+        const mostInnerContainerParentEl = optionsContainer.at(-1).element?.parentElement;
+        const mostInnerContainerEl = optionsContainer.at(-1).element;
+
+        if (!mostInnerContainerParentEl) {
+            return;
+        }
+        // if the most inner container is not contenteditable, we do not restrict it
+        // as it is not editable by the user
+        if (mostInnerContainerEl && !mostInnerContainerEl.isContentEditable) {
+            return;
+        }
+
+        // store the current state
+        this.restrictedElements.set(mostInnerContainerParentEl, {
+            contenteditable: mostInnerContainerParentEl.getAttribute("contenteditable"),
+        });
+        this.restrictedElements.set(mostInnerContainerEl, {
+            contenteditable: mostInnerContainerEl.getAttribute("contenteditable"),
+        });
+
+        // Restrict the editable area to the most inner container
+        // set contenteditable to false on the parent element to block the selection
+        // inside the inner container element
+        this.dependencies.history.ignoreDOMMutations(() => {
+            mostInnerContainerParentEl.setAttribute("contenteditable", "false");
+            mostInnerContainerEl.setAttribute("contenteditable", "true");
+
+            // set temporary class to both manipulated elements
+            mostInnerContainerParentEl.classList.add("o_restricted_editable_area");
+            mostInnerContainerEl.classList.add("o_restricted_editable_area");
+        });
+    }
+}
+
+registry
+    .category("website-plugins")
+    .add(BuilderContainerEditablePlugin.id, BuilderContainerEditablePlugin);

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -767,9 +767,8 @@ export class LinkPlugin extends Plugin {
             }
         } else {
             const closestLinkElement = closestElement(selection.anchorNode, "A");
-            const isLinkEditable = this.delegateTo(
-                "is_link_editable_predicates",
-                closestLinkElement) || false;
+            const isLinkEditable =
+                this.delegateTo("is_link_editable_predicates", closestLinkElement) || false;
             if (closestLinkElement && closestLinkElement.isContentEditable) {
                 if (closestLinkElement !== this.linkInDocument || !this.currentOverlay.isOpen) {
                     this.openLinkTools(closestLinkElement);
@@ -817,7 +816,10 @@ export class LinkPlugin extends Plugin {
             return;
         }
         const cursors = this.dependencies.selection.preserveSelection();
-        if (link && link.isContentEditable) {
+        if (
+            link &&
+            (link.isContentEditable || this.delegateTo("is_element_editable_predicates", link))
+        ) {
             cursors.update(callbacksForCursorUpdate.unwrap(link));
             unwrapContents(link);
         }

--- a/addons/website/static/tests/builder/builder_selection_restrict.test.js
+++ b/addons/website/static/tests/builder/builder_selection_restrict.test.js
@@ -1,0 +1,60 @@
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { expect, test } from "@odoo/hoot";
+import { addOption, defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { xml } from "@odoo/owl";
+
+defineWebsiteModels();
+
+test("the selection should be restricted to the element bond to the most inner container", async () => {
+    addOption({
+        selector: ".parent-target",
+        template: xml`<BuilderRow label="'my label'">
+                <BuilderButton applyTo="'.child-target'" classAction="'test-parent'"/>
+            </BuilderRow>`,
+    });
+    addOption({
+        selector: ".child-target",
+        template: xml`<BuilderRow label="'my label'">
+                <BuilderButton applyTo="'.grandchild-target'" classAction="'test-child'"/>
+            </BuilderRow>`,
+    });
+
+    const { getEditableContent } = await setupWebsiteBuilder(
+        `<section class="parent-target o_colored_level"><div class="child-target"><p class="grandchild-target">b</p></div></section>`
+    );
+    const editableContent = getEditableContent();
+    await contains(":iframe .parent-target").click();
+    // the contenteditable should not be manipulated when there is only one option container
+    expect(editableContent).toHaveInnerHTML(
+        `<section class="parent-target o_colored_level"><div class="child-target"><p class="grandchild-target">b</p></div></section>`
+    );
+
+    await contains(":iframe .child-target").click();
+    // the contenteditable should be manipulated when there is more than one option container
+    expect(editableContent).toHaveInnerHTML(
+        `<section class="parent-target o_colored_level o_restricted_editable_area" contenteditable="false">
+            <div class="child-target o_restricted_editable_area" contenteditable="true"><p class="grandchild-target">b</p></div>
+        </section>`
+    );
+
+    const resultSave = [];
+    onRpc("ir.ui.view", "save", ({ args }) => {
+        resultSave.push(args[1]);
+        return true;
+    });
+
+    await contains("[data-class-action='test-child']").click();
+    expect(editableContent).toHaveInnerHTML(
+        `<section class="parent-target o_colored_level o_restricted_editable_area" contenteditable="false">
+            <div class="child-target o_restricted_editable_area" contenteditable="true"><p class="grandchild-target test-child">b</p></div>
+        </section>`
+    );
+    expect("[data-class-action='test-child']").toHaveClass("active");
+    expect("[data-class-action='test-child']").toHaveCount(1);
+
+    // after save the contenteditable manipulation should be removed
+    await contains(".o-snippets-top-actions button:contains(Save)").click();
+    expect(resultSave[0]).toBe(
+        `<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch"><section class="parent-target o_colored_level"><div class="child-target"><p class="grandchild-target test-child">b</p></div></section></div>`
+    );
+});


### PR DESCRIPTION
Reproduction:
1. drag and drop a column snippet in website
2. click on one of the column and press ctrl+A, everything is selected
3. similarly the selection with mouse also can cross the whole snippet

After this commit:
Selection is now restricted to the element bound by the current container. This is achieved by setting the target element’s `contenteditable` attribute to `true` and its parent’s to `false`. These changes are reverted whenever `change_current_options_containers_listeners` is dispatched, and also during destory, ensuring that the `contenteditable` manipulation only applies dynamically while editing in the website builder.

Special cases:
1. If the bound element is already `contenteditable="false"`, we do not modify the attribute to avoid unwanted changes.
2. If there is only one option container (e.g., the outermost container of a snippet), we do not alter the `contenteditable` attribute. This is because the outer section is naturally set as `contenteditable="false"`. Restriction is only needed when there are multiple option containers and an inner one is selected.

Predicate in addition to isContentEditable:
We introduce `is_element_editable_predicates` to determine if an element is editable, taking into account possible restrictions. Since the parent of the currently bound option container is set to `contenteditable="false"`, elements outside the bound element cannot be normalized. Using this predicate alongside `isContentEditable` ensures these elements are still considered editable when appropriate. This is a rare edge case, as typically only elements within the bound container are edited. See test change 1 for details.

Test changes:
1. Link normalization checks if the link element is not unremovable and stops normalization if it is. In the `website_media_iframe_video` tour, there is a case where the link to be normalized is outside the bound option container. The new predicate is used for proper normalization in this scenario.
2. The PR is designed to minimize test breakage. If tests involve only one option container, the new contenteditable manipulation logic does not affect them.
3. A new test for this contenteditable manipulation is added.

task-4901968


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
