### PR TITLE
[IMP] purchase, sale, stock: update dates logic/UX

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -88,7 +88,7 @@ class PurchaseOrder(models.Model):
              "delivery order sent by your vendor.")
     date_order = fields.Datetime('Order Deadline', required=True, index=True, copy=False, default=fields.Datetime.now,
         help="Depicts the date within which the Quotation should be confirmed and converted into a purchase order.")
-    date_approve = fields.Datetime('Confirmation Date', readonly=True, index=True, copy=False)
+    date_approve = fields.Datetime('Order Date', readonly=True, index=True, copy=False)
     partner_id = fields.Many2one(
         'res.partner', string='Vendor', required=True, change_default=True,
         tracking=True, check_company=True, index=True,
@@ -132,7 +132,7 @@ class PurchaseOrder(models.Model):
     ], string='Billing Status', compute='_get_invoiced', store=True, readonly=True, copy=False, default='no')
     date_planned = fields.Datetime(
         string='Expected Arrival', index=True, copy=False, compute='_compute_date_planned', store=True, readonly=False,
-        help="Delivery date promised by vendor. This date is used to determine expected arrival of products.")
+        help="Expected delivery date of goods by the vendor based on the latest information")
     date_calendar_start = fields.Datetime(compute='_compute_date_calendar_start', readonly=True, store=True)
 
     amount_untaxed = fields.Monetary(string='Untaxed Amount', store=True, readonly=True, compute='_amount_all', tracking=True)

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -217,10 +217,6 @@
                         </group>
                         <group>
                             <field name="date_order" invisible="state  == 'purchase'" readonly="state in ['cancel', 'purchase']"/>
-                            <label for="date_approve" invisible="state != 'purchase'"/>
-                            <div name="date_approve" invisible="state != 'purchase'" class="o_row">
-                                <field name="date_approve"/>
-                            </div>
                             <label for="date_planned"/>
                             <div name="date_planned_div" class="o_row">
                                 <field name="date_planned" readonly="state not in ('draft', 'sent', 'to approve', 'purchase')"/>
@@ -230,7 +226,7 @@
                                 <field name="receipt_reminder_email"/>
                                 <span>Ask confirmation</span>
                                 <div class="o_row oe_inline" invisible="not receipt_reminder_email">
-                                    <field name="reminder_date_before_receipt" class="oe_inline" style="max-width: 30px;"/>
+                                    <field name="reminder_date_before_receipt" style="max-width: 30px;"/>
                                     day(s) before
                                     <widget name='toaster_button' button_name="send_reminder_preview" title="Preview the reminder email by sending it to yourself." invisible="not id"/>
                                 </div>
@@ -388,7 +384,7 @@
                                 <group>
                                     <field colspan="2" name="note" nolabel="1" placeholder="Define your terms and conditions ..."/>
                                 </group>
-                                <group class="oe_subtotal_footer">
+                                <group class="oe_subtotal_footer border-top-0">
                                     <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" readonly="1"/>
                                 </group>
                             </group>
@@ -401,6 +397,7 @@
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" readonly="state in ['cancel', 'purchase']"/>
                                 </group>
                                 <group name="billing_info" string="billing">
+                                    <field name="date_approve"/>
                                     <field name="invoice_status" invisible="state in ('draft', 'sent', 'to approve', 'cancel')"/>
                                     <field name="fiscal_position_id" options="{'no_create': True}" readonly="invoice_status == 'invoiced' or locked"/>
                                 </group>
@@ -659,7 +656,7 @@
                     <field name="amount_total_cc" sum="Total amount" widget="monetary" optional="hide"/>
                     <field name="company_currency_id" column_invisible="True"/>
                     <field name="invoice_status" widget="badge" decoration-success="invoice_status == 'invoiced'" decoration-info="invoice_status == 'to invoice'" optional="show"/>
-                    <field name="date_planned" column_invisible="context.get('quotation_only', False)" optional="show"/>
+                    <field name="date_planned" column_invisible="context.get('quotation_only', False)" optional="show" readonly="1"/>
                 </list>
             </field>
         </record>

--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -52,9 +52,9 @@ class ResPartner(models.Model):
             ('purchase_line_id', 'in', order_lines.ids),
             ('state', '=', 'done')])
         # Fetch fields from db and put them in cache.
-        order_lines.read(['date_planned', 'partner_id', 'product_uom_qty'], load='')
+        order_lines.read(['date_promised', 'partner_id', 'product_uom_qty'], load='')
         moves.read(['purchase_line_id', 'date'], load='')
-        moves = moves.filtered(lambda m: m.date.date() <= m.purchase_line_id.date_planned.date())
+        moves = moves.filtered(lambda m: m.date.date() <= m.purchase_line_id.date_promised.date())
         for move, quantity in zip(moves, moves.mapped('quantity')):
             lines_quantity[move.purchase_line_id.id] += quantity
         partner_dict = {}

--- a/addons/purchase_stock/report/vendor_delay_report.py
+++ b/addons/purchase_stock/report/vendor_delay_report.py
@@ -30,7 +30,7 @@ SELECT pol.id                   AS id,
        pol.partner_id           AS partner_id,
        pol.product_uom_qty      AS qty_total,
        Sum(CASE
-             WHEN (m.state = 'done' and pol.date_planned::date >= m.date::date) THEN ((ml.quantity * ml_uom.factor) / pt_uom.factor)
+             WHEN (m.state = 'done' and pol.date_promised::date >= m.date::date) THEN ((ml.quantity * ml_uom.factor) / pt_uom.factor)
              ELSE 0
            END)                 AS qty_on_time
 FROM   stock_move m

--- a/addons/purchase_stock/tests/test_old_rules.py
+++ b/addons/purchase_stock/tests/test_old_rules.py
@@ -261,7 +261,7 @@ class TestPurchaseOldRules(PurchaseTestCommon):
         schedule_date = order_date + timedelta(days=self.product_1.seller_ids.delay + rule_delay)
         self.assertEqual(date_planned, schedule_date, 'Schedule date should be equal to: Order date of Purchase order + Delivery Lead Time(supplier and pull rules).')
 
-        # Check the picking crated or not
+        # Check if the picking is created
         self.assertTrue(purchase.picking_ids, "Picking should be created.")
 
         # Check scheduled date of Internal Type shipment
@@ -277,9 +277,10 @@ class TestPurchaseOldRules(PurchaseTestCommon):
         self.assertEqual(incoming_shipment2.date_deadline, incoming_shipment2_date)
         old_deadline2 = incoming_shipment2.date_deadline
 
-        # Modify the date_planned of the purchase -> propagate the deadline
+        # Modify the date_planned of the purchase -> propagate the scheduled date in a receipt, so the deadline remains unchanged
         purchase_form = Form(purchase)
         purchase_form.date_planned = purchase.date_planned + timedelta(days=1)
         purchase_form.save()
-        self.assertEqual(incoming_shipment2.date_deadline, old_deadline2 + timedelta(days=1), 'Deadline should be propagate')
-        self.assertEqual(incoming_shipment1.date_deadline, old_deadline1 + timedelta(days=1), 'Deadline should be propagate')
+        self.assertEqual(incoming_shipment2.date_deadline, old_deadline2, 'Deadline should remain unchanged')
+        self.assertEqual(incoming_shipment1.date_deadline, old_deadline1, 'Deadline should remain unchanged')
+        self.assertEqual(purchase.order_line.move_ids.picking_id.scheduled_date, purchase.date_planned, 'Scheduled Date should propagate')

--- a/addons/purchase_stock/tests/test_purchase_lead_time.py
+++ b/addons/purchase_stock/tests/test_purchase_lead_time.py
@@ -79,13 +79,12 @@ class TestPurchaseLeadTime(PurchaseTestCommon):
         picking_schedule_date = min(date_planned1, date_planned2)
         self.assertEqual(purchase2.picking_ids.scheduled_date, picking_schedule_date,
                          'Schedule date of In type shipment should be same as schedule date of purchase order.')
-
-        # Check deadline of pickings
+        # Check Scheduled date of pickings
         self.assertEqual(fields.Date.to_date(purchase2.picking_ids.date_deadline), fields.Date.to_date(purchase1.date_planned), "Deadline of pickings should be equals to the receipt date of purchase")
         purchase_form = Form(purchase2)
         purchase_form.date_planned = purchase2.date_planned + timedelta(days=2)
         purchase_form.save()
-        self.assertEqual(purchase2.picking_ids.date_deadline, purchase2.date_planned, "Deadline of pickings should be propagate")
+        self.assertEqual(purchase2.picking_ids.scheduled_date, purchase2.date_planned, "Scheduled Date of pickings should be propagated")
 
     def test_02_product_level_delay(self):
         """ To check schedule dates of multiple purchase order line of the same purchase order,

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -39,14 +39,14 @@
                     </button>
                 </div>
             </xpath>
+            <xpath expr="//field[@name='order_line']/list/field[@name='date_planned']" position="after">
+                <field name="date_promised" optional="hide" column_invisible="parent.state not in ('purchase', 'cancel')"/>
+            </xpath>
             <xpath expr="//label[@for='receipt_reminder_email']" position="attributes">
                 <attribute name="invisible">effective_date</attribute>
             </xpath>
             <xpath expr="//div[@name='reminder']" position="attributes">
                 <attribute name="invisible">effective_date</attribute>
-            </xpath>
-            <xpath expr="//div[@name='reminder']" position="after">
-                <field name="effective_date" invisible="not effective_date"/>
             </xpath>
             <xpath expr="//field[@name='order_line']/form//field[@name='invoice_lines']" position="after">
                 <field name="move_ids"/>
@@ -69,9 +69,25 @@
                 <field name="incoterm_id" readonly="locked"/>
                 <field name="incoterm_location"  readonly="locked"/>
             </xpath>
+            <xpath expr="//page[@name='purchase_delivery_invoice']/group/group[@name='billing_info']/field[@name='date_approve']" position="after">
+                <field name="date_promised" invisible="state not in ('purchase', 'cancel')"/>
+            </xpath>
             <xpath expr="//div[@name='reminder']" position="after">
                 <field name="picking_type_id" domain="[('code','=','incoming'), '|', ('warehouse_id', '=', False), ('warehouse_id.company_id', '=', company_id)]" options="{'no_create': True}" readonly="state in ['cancel', 'purchase']"/>
                 <field name="dest_address_id" invisible="default_location_dest_id_usage != 'customer'" readonly="locked" required="default_location_dest_id_usage == 'customer'"/>
+                <label for="receipt_status" invisible="state !='purchase'"/>
+                <div class="d-flex align-items-center"  invisible="state !='purchase'">
+                    <div class="me-3">
+                        <field name="receipt_status" widget="badge" invisible="state != 'purchase'"
+                               decoration-success="receipt_status == 'full'"
+                               decoration-info="receipt_status == 'partial'"
+                               decoration-danger="receipt_status == 'pending' and date_planned and date_planned &lt; context_today().strftime('%Y-%m-%d')"
+                               decoration-muted="receipt_status == 'pending' and date_planned and date_planned &gt;= context_today().strftime('%Y-%m-%d')"/>
+                    </div>
+                    <span class="text-muted" invisible="not effective_date">
+                        On <field name="effective_date" nolabel="1" class="text-muted oe_inline"/>
+                    </span>
+                </div>
             </xpath>
         </field>
     </record>
@@ -97,8 +113,9 @@
                 <field name="effective_date" column_invisible="True"/>
                 <field name="receipt_status" optional="hide" widget="badge"
                 decoration-success="receipt_status=='full'"
-                decoration-danger="date_planned and (date_planned &lt; effective_date or date_planned &lt; datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)).to_utc().strftime('%Y-%m-%d %H:%M:%S') and receipt_status!='full' and effective_date &lt;= date_planned)"
-                decoration-warning="date_planned and date_planned &gt;= datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)).to_utc().strftime('%Y-%m-%d %H:%M:%S') and date_planned &lt;= datetime.datetime.combine(datetime.date.today(), datetime.time(23,59,59)).to_utc().strftime('%Y-%m-%d %H:%M:%S') and receipt_status!='full'"/>
+                decoration-info="receipt_status == 'partial'"
+                decoration-danger="receipt_status == 'pending' and date_planned and date_planned &lt; context_today().strftime('%Y-%m-%d')"
+                decoration-muted="receipt_status == 'pending' and date_planned and date_planned &gt;= context_today().strftime('%Y-%m-%d')"/>
             </field>
             <xpath expr="//field[@name='date_planned']" position="attributes">
                 <attribute name="decoration-danger">date_planned and (date_planned &lt; effective_date or date_planned &lt; datetime.datetime.combine(datetime.date.today(), datetime.time(0,0,0)).to_utc().strftime('%Y-%m-%d %H:%M:%S') and receipt_status!='full' and effective_date &lt;= date_planned)</attribute>

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1156,7 +1156,7 @@ class SaleOrder(models.Model):
         self.write({'state': 'sent'})
 
     def action_confirm(self):
-        """ Confirm the given quotation(s) and set their confirmation date.
+        """ Confirm the given quotation(s) and set their confirmation and commitment dates.
 
         If the corresponding setting is enabled, also locks the Sale Order.
 
@@ -1165,6 +1165,8 @@ class SaleOrder(models.Model):
         :raise: UserError if trying to confirm cancelled SO's
         """
         for order in self:
+            if order.expected_date and not order.commitment_date:
+                order.commitment_date = order.expected_date
             error_msg = order._confirmation_error_message()
             if error_msg:
                 raise UserError(error_msg)

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -868,7 +868,7 @@
                             <group colspan="4" class="order-1 order-lg-0">
                                 <field  colspan="2" name="note" nolabel="1" placeholder="Terms and conditions..."/>
                             </group>
-                            <group class="oe_subtotal_footer d-flex order-0 order-lg-1 flex-column gap-0 gap-sm-3" colspan="2" name="sale_total">
+                            <group class="oe_subtotal_footer border-top-0 d-flex order-0 order-lg-1 flex-column gap-0 gap-sm-3" colspan="2" name="sale_total">
                                 <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" readonly="1"/>
                             </group>
                         </group>
@@ -919,10 +919,10 @@
                                 <field name="invoice_status" invisible="1" groups="!base.group_no_one"/>
                             </group>
                             <group name="sale_shipping" string="Shipping">
-                                <label for="commitment_date" string="Delivery Date"/>
+                                <label for="commitment_date" string="Delivery Date" invisible="state != 'draft'"/>
+                                <label for="commitment_date" string="Promised Delivery" invisible="state =='draft'"/>
                                 <div name="commitment_date_div" class="o_row">
                                     <field name="commitment_date" readonly="state == 'cancel' or locked"/>
-                                    <span name="expected_date_span" invisible="not expected_date" class="text-muted">Expected: <field name="expected_date" class="oe_inline"/></span>
                                 </div>
                             </group>
                             <group name="sale_reporting" string="Tracking">

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -28,18 +28,15 @@
                 <field name="incoterm_location"/>
                 <field name="picking_policy" required="True" readonly="state not in ['draft', 'sent']"/>
             </label>
-            <span name="expected_date_span" position="attributes">
-                <attribute name="invisible">effective_date and commitment_date</attribute>
-            </span>
             <div name="commitment_date_div" position="replace">
                 <div class="o_row">
-                    <field name="commitment_date"/>
-                    <span class="text-muted" invisible="not expected_date or (effective_date and commitment_date)">Expected: <field name="expected_date" class="oe_inline"/></span>
+                    <field name="expected_date" invisible="1"/>  <!-- Needed for the placeholder widget -->
+                    <field name="commitment_date" options="{'placeholder_field': 'expected_date'}"/>
                 </div>
                 <field name="effective_date" invisible="not effective_date"/>
                 <field name="delivery_status" invisible="state != 'sale'"/>
             </div>
-            <xpath expr="//page[@name='other_information']//field[@name='expected_date']" position="after">
+            <xpath expr="//page[@name='other_information']//field[@name='commitment_date']" position="after">
                 <field string=" " name="json_popover" widget="stock_rescheduling_popover" invisible="not show_json_popover"/>
             </xpath>
             <xpath expr="//field[@name='order_line']//form//field[@name='analytic_distribution']" position="before">

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -576,7 +576,7 @@ Please change the quantity done or the rounding precision in your settings.""",
         self = self.with_context(date_deadline_propagate_ids=already_propagate_ids)
         for move in self:
             moves_to_update = (move.move_dest_ids | move.move_orig_ids)
-            if move.date_deadline:
+            if move.date_deadline and new_deadline:
                 delta = move.date_deadline - fields.Datetime.to_datetime(new_deadline)
             else:
                 delta = 0

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -79,7 +79,7 @@
                     <field name="partner_id" optional="show" readonly="state in ['cancel', 'done']"/>
                     <field name="is_signed" string="Signed" optional="hide" groups="stock.group_stock_sign_delivery"/>
                     <field name="user_id" optional="hide" widget="many2one_avatar_user" readonly="state in ['cancel', 'done']"/>
-                    <field name="scheduled_date" optional="show" widget="remaining_days" invisible="state in ('done', 'cancel')" readonly="state in ['cancel', 'done']"/>
+                    <field name="scheduled_date" optional="show" widget="remaining_days" invisible="state in ('done', 'cancel')" readonly="1"/>
                     <field name="picking_type_code" column_invisible="True"/>
                     <field name="products_availability_state" column_invisible="True" options='{"lazy": true}'/>
                     <field name="products_availability" options='{"lazy": true}'


### PR DESCRIPTION
To avoid confusion after confirming an RFQ:
- New field has been added 'Promised Date' in Purchase Order and Purchase Order Line.
- 'Promised Date' updates the deadline on a receipt.
- 'Promised Date' only shows after confirming an RFQ, taking the place of 'Confirmation Date'.
- Confirmation Date was moved to 'Other information' section.
- Updating "Expected Arrival" on PO or PO line updates the date scheduled on a receipt and no longer updates the deadline.
- Updated "Expected Arrival" help message to adapt to the change.
- Dates in Receipts and POs are linked, changing POL expected arrival should propagate
to stock move scheduled date (and the other way around), and promised date propagates to deadlines.

In Sales Order:
- 'Delivery Date' now uses a dynamic placeholder giving it a cleaner look.
- On Confirmation, if no date is set it will be assigned to the placeholder's value and 'Delivery Date' label is changed to 'Promised Delivery'.
- Some UI Changes.

Task: 4687135




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
