### PR TITLE
[IMP] im_livechat: move forward agent logic to add members

### DIFF
--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -236,13 +236,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                     ),
                 },
             )
-            channel_data = Store().add(discuss_channel).get_result()
-            channel_data["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
-            channel_data_emp = Store().add(discuss_channel.with_user(self.user_employee)).get_result()
-            channel_data_emp["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
-            channel_data_emp["discuss.channel.member"][1]["message_unread_counter_bus_id"] = 0
-            channel_data = Store().add(discuss_channel).get_result()
-            channel_data["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
             return (
                 [
                     (self.cr.dbname, "discuss.channel", discuss_channel.id, "members"),
@@ -254,8 +247,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "res.partner", self.partner_employee.id),
-                    (self.cr.dbname, "res.partner", self.env.user.partner_id.id),
                 ],
                 [
                     {
@@ -377,8 +368,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                             ),
                         },
                     },
-                    {"type": "mail.record/insert", "payload": channel_data_emp},
-                    {"type": "mail.record/insert", "payload": channel_data},
                 ],
             )
 


### PR DESCRIPTION
This commit prepares the ground for the introduction of the AI livechat bridge. The chat bot already forwards customer to human agents, but this logic is encapsulated in the
`_process_step_forward_operator` method. AI bots also need to forward conversations to human operators.

When doing so, several steps need to be repeated such as creating the new member with the correct live chat member type, renaming the channel, updating the live chat failure state, pinning the chat on the operator side...

This commit introduces the `_foward_human_agent` on the discuss channel model so that it can be used by the AI livechat module.

part of task-4825509

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
