### PR TITLE
[IMP] mail: enable blur toggle and apply user preferences on welcome screen

### DIFF
--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -91,7 +91,19 @@ export class Settings extends Record {
     backgroundBlurAmount = 10;
     edgeBlurAmount = 10;
     showOnlyVideo = false;
-    useBlur = false;
+    useBlur = fields.Attr(false, {
+        compute() {
+            return browser.localStorage.getItem("mail_user_setting_use_blur") === "true";
+        },
+        /** @this {import("models").Settings} */
+        onUpdate() {
+            if (this.useBlur) {
+                browser.localStorage.setItem("mail_user_setting_use_blur", "true");
+            } else {
+                browser.localStorage.removeItem("mail_user_setting_use_blur");
+            }
+        },
+    });
     blurPerformanceWarning = fields.Attr(false, {
         compute() {
             const rtc = this.store.rtc;
@@ -370,7 +382,6 @@ export class Settings extends Record {
         );
         this.showOnlyVideo =
             browser.localStorage.getItem("mail_user_setting_show_only_video") === "true";
-        this.useBlur = browser.localStorage.getItem("mail_user_setting_use_blur") === "true";
         const backgroundBlurAmount = browser.localStorage.getItem(
             "mail_user_setting_background_blur_amount"
         );
@@ -417,6 +428,9 @@ export class Settings extends Record {
     onStorage(ev) {
         if (ev.key === MESSAGE_SOUND) {
             this.messageSound = ev.newValue !== "false";
+        }
+        if (ev.key === "mail_user_setting_use_blur") {
+            this.useBlur = ev.newValue === "true";
         }
     }
     /**

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -116,7 +116,6 @@ export class CallSettings extends Component {
 
     onChangeBlur(ev) {
         this.store.settings.useBlur = ev.target.checked;
-        browser.localStorage.setItem("mail_user_setting_use_blur", this.store.settings.useBlur);
     }
 
     onChangeShowOnlyVideo(ev) {

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -24,6 +24,9 @@
                     <button class="btn fa-stack align-self-end p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ state.videoStream ? 'btn-dark' : 'btn-danger' }}" t-on-click="onClickVideo">
                         <i class="fa fa-camera"/>
                     </button>
+                    <button t-if="state.videoStream"  class="btn fa-stack p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ store.settings.useBlur ? 'btn-secondary' : 'btn-dark' }}" t-on-click="onClickBlur" t-att-title="blurButtonTitle">
+                        <i class="fa fa-photo" t-att-class="{ 'opacity-50': !store.settings.useBlur }"/>
+                    </button>
                 </div>
                 <audio autoplay="" t-ref="audio"/>
             </div>

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -9,7 +9,7 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, test, expect } from "@odoo/hoot";
 import { advanceTime } from "@odoo/hoot-mock";
 import { asyncStep, patchWithCleanup, waitForSteps } from "@web/../tests/web_test_helpers";
 
@@ -120,9 +120,12 @@ test("local storage for call settings", async () => {
 
     // testing save to local storage
     await click("input[title='Show video participants only']");
-    await waitForSteps(["mail_user_setting_show_only_video: false"]);
+    await waitForSteps([
+        "mail_user_setting_use_blur: true",
+        "mail_user_setting_show_only_video: false",
+    ]);
     await click("input[title='Blur video background']");
-    await waitForSteps(["mail_user_setting_use_blur: false"]);
+    expect(localStorage.getItem("mail_user_setting_use_blur")).toBe(null);
     await editInput(document.body, ".o-Discuss-CallSettings-thresholdInput", 0.3);
     await advanceTime(2000); // threshold setting debounce timer
     await waitForSteps(["mail_user_setting_voice_threshold: 0.3"]);


### PR DESCRIPTION
**Purpose of this PR:** 

- Previously, users couldn't see the blur effect in `welcome screen` before joining a meeting, and there was no option to set or unset the blur beforehand. This could lead to confusion or an inconsistent visual experience once the meeting started.

- This PR introduces a toggle on the `welcome screen` that allows users to enable or disable the background blur effect before joining a meeting. It also ensures that the user’s previously saved blur preference is automatically applied when the screen loads, using `BlurManager`.

- With this change, the `welcome screen` now respects the user’s saved blur preference and applies it automatically on load. It also adds a toggle to allow users to set or unset the blur effect on their video before joining.

<hr/>

**Before Image:**
<img width="270" height="91" alt="image" src="https://github.com/user-attachments/assets/5232d52a-cd18-420d-88a6-854c01c829d4" />

**After Image:**
<img width="318" height="99" alt="image" src="https://github.com/user-attachments/assets/0fda6473-a7a3-4ca8-9363-0bdb47aa2843" />

Task- 4933841
