### PR TITLE
[FIX] html_builder: show correct reorder arrows for popup snippet

### DIFF
--- a/addons/html_builder/static/src/core/move_plugin.js
+++ b/addons/html_builder/static/src/core/move_plugin.js
@@ -23,7 +23,9 @@ import { localization } from "@web/core/l10n/localization";
 export function getVisibleSibling(target, direction) {
     const siblingEls = [...target.parentNode.children];
     const visibleSiblingEls = siblingEls.filter(
-        (el) => window.getComputedStyle(el).display !== "none"
+        (el) =>
+            !el.classList.contains("o_we_no_overlay") &&
+            window.getComputedStyle(el).display !== "none"
     );
     const targetMobileOrder = target.style.order;
     // On mobile, if the target has a mobile order (which is independent

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -327,3 +327,26 @@ test("The overlay buttons should only appear for elements in editable areas, unl
     expect(".overlay .button-a").toHaveCount(1);
     expect(".overlay .button-b").toHaveCount(1);
 });
+
+test("Should hide 'move up' button when previous sibling is 'o_we_no_overlay'", async () => {
+    await setupWebsiteBuilder(`
+        <section class="o_we_no_overlay">
+            <h1>No overlay section</h1>
+        </section>
+        <section class="first">
+            <h1>First section</h1>
+        </section>
+        <section class="second">
+            <h1>Second section</h1>
+        </section>
+    `);
+
+    await contains(":iframe .first").click();
+    expect(".overlay .o_overlay_options").toHaveCount(1);
+
+    // Can't move up since the previous sibling is excluded
+    expect(".overlay .fa-angle-up").toHaveCount(0);
+
+    // Moving down is still valid
+    expect(".overlay .fa-angle-down").toHaveCount(1);
+});


### PR DESCRIPTION
**Issue:**
When editing a newsletter popup snippet, users could see
both up and down reorder arrows, even when only one
The direction made sense.
Clicking the move up arrow did nothing, and moving the block down
required clicking the move down arrow twice, which felt unresponsive.

**Steps to reproduce the issue:**
1. Drag and drop a newsletter popup snippet
2. Click on the blank region above the center text in the snippet
3. You will see both up and down reorder arrows;
   nothing will happen on clicking the up arrow
4. You need to click on the down arrow twice
   to move the block down.

**Fix:**
Now, only the valid reorder arrow (up or down) is shown based on
the block's position. Movement works as expected with a single click.

task-[5016731](https://www.odoo.com/odoo/project/974/tasks/5016731)