### PR TITLE
[FIX] website: remove iframe's flickering after page style change

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -521,11 +521,26 @@ export class WebsitePreview extends Component {
         // If the iframe is currently displaying an XML file, the body does not
         // exist, so we do not replace the iframefallback content.
         // The iframefallback is hidden in test mode
-        if (!this.websiteContext.edition && this.iframe.el.contentDocument.body && this.iframefallback.el) {
-            this.iframefallback.el.contentDocument.body.replaceWith(this.iframe.el.contentDocument.body.cloneNode(true));
-            this.iframefallback.el.classList.remove('d-none');
-            getScrollingElement(this.iframefallback.el.contentDocument).scrollTop = getScrollingElement(this.iframe.el.contentDocument).scrollTop;
-            this._cleanIframeFallback();
+        const websiteDoc = this.iframe.el?.contentDocument;
+        const fallbackDoc = this.iframefallback.el?.contentDocument;
+        if (!this.websiteContext.edition && websiteDoc && fallbackDoc) {
+            if (websiteDoc.head) {
+                fallbackDoc.head
+                    .querySelectorAll("link[rel='stylesheet'], style")
+                    .forEach((el) => el.remove());
+                for (const el of websiteDoc.head.querySelectorAll(
+                    "link[rel='stylesheet'], style"
+                )) {
+                    fallbackDoc.head.appendChild(el.cloneNode(true));
+                }
+            }
+            if (websiteDoc.body) {
+                fallbackDoc.body.replaceWith(websiteDoc.body.cloneNode(true));
+                this.iframefallback.el.classList.remove("d-none");
+                getScrollingElement(fallbackDoc).scrollTop =
+                    getScrollingElement(websiteDoc).scrollTop;
+                this._cleanIframeFallback();
+            }
         }
     }
     _onPageHide() {


### PR DESCRIPTION
In this [commit], fallback iframe was added to avoid flickering between iframe reloads. But the flicker still happens if we change page's style, since we do not apply the new styles to the fallback iframe. To reproduce the issue:
- Open Website and start editing
- Move to the 'Theme' tab
- Change page layout to 'Boxed'
- Set background color to a non-transparent color, e.g. red
- Save, and do any action to reload the iframe, e.g. go to /contactus

=> The iframe flickers from the previous color to red, which shouldn't be the case.
Task-4985472

[commit]: https://github.com/odoo/odoo/commit/7b19831e1c624b483008feb526ba773ec8b23009