### PR TITLE
[IMP] website_sale: prevent repeated clicks on add to cart button

### DIFF
--- a/addons/website_sale/static/src/interactions/add_to_cart.js
+++ b/addons/website_sale/static/src/interactions/add_to_cart.js
@@ -5,7 +5,7 @@ import wSaleUtils from '@website_sale/js/website_sale_utils';
 export class AddToCart extends Interaction {
     static selector = '#add_to_cart, .o_we_buy_now, #products_grid .o_wsale_product_btn .a-submit';
     dynamicContent = {
-        _root: { 't-on-click.prevent': this.addToCart },
+        _root: { "t-on-click.prevent": this.locked(this.addToCart, true) },
     };
 
     /**

--- a/addons/website_sale/static/src/interactions/cart_suggestion.js
+++ b/addons/website_sale/static/src/interactions/cart_suggestion.js
@@ -4,15 +4,17 @@ import { registry } from '@web/core/registry';
 export class CartSuggestion extends Interaction {
     static selector = '[name="suggested_product"]';
     dynamicContent = {
-        'button.js_add_suggested_products': { 't-on-click': this.addSuggestedProduct },
+        "button.js_add_suggested_products": {
+            "t-on-click": this.locked(this.addSuggestedProduct, true),
+        },
     };
 
     /**
      * @param {Event} ev
      */
-    addSuggestedProduct(ev) {
+    async addSuggestedProduct(ev) {
         const dataset = ev.currentTarget.dataset;
-        this.services['cart'].add({
+        await this.services["cart"].add({
             productTemplateId: parseInt(dataset.productTemplateId),
             productId: parseInt(dataset.productId),
             isCombo: dataset.productType === 'combo',

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -22,6 +22,10 @@ export function addToCart({
         trigger: "#add_to_cart",
         run: "click",
     });
+    steps.push({
+        content: "Check if the button is disabled",
+        trigger: "#add_to_cart.pe-none",
+    });
     if (productHasVariants) {
         steps.push(clickOnElement('Continue Shopping', 'button:contains("Continue Shopping")'));
     }

--- a/addons/website_sale/static/src/snippets/s_add_to_cart/add_to_cart_snippet.js
+++ b/addons/website_sale/static/src/snippets/s_add_to_cart/add_to_cart_snippet.js
@@ -6,7 +6,7 @@ import { rpc } from '@web/core/network/rpc';
 export class AddToCartSnippet extends Interaction {
     static selector = '.s_add_to_cart_btn';
     dynamicContent = {
-        _root: { 't-on-click': this.onClickAddToCartButton },
+        _root: { "t-on-click": this.locked(this.onClickAddToCartButton, true) },
     };
 
     async onClickAddToCartButton(ev) {
@@ -31,7 +31,7 @@ export class AddToCartSnippet extends Interaction {
             }
         }
 
-        this.services['cart'].add({
+        await this.services["cart"].add({
             productTemplateId: productTemplateId,
             productId: productId,
             isCombo: isCombo,

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/carousel_product_card.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/carousel_product_card.js
@@ -5,7 +5,7 @@ import { rpc } from '@web/core/network/rpc';
 export class CarouselProductCard extends Interaction {
     static selector = '.o_carousel_product_card';
     dynamicContent = {
-        '.js_add_cart': { 't-on-click': this.onClickAddToCart },
+        ".js_add_cart": { "t-on-click": this.locked(this.onClickAddToCart, true) },
         '.js_remove': { 't-on-click': this.onRemoveFromRecentlyViewed },
     };
 
@@ -26,7 +26,7 @@ export class CarouselProductCard extends Interaction {
         const isCombo = dataset.productType === 'combo';
         const showQuantity = Boolean(dataset.showQuantity);
 
-        await this.waitFor(this.services['cart'].add({
+        await this.waitFor(this.services["cart"].add({
             productTemplateId: productTemplateId,
             productId: productId,
             isCombo: isCombo,

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -24,6 +24,13 @@ function checkQuanityInCart(quantity) {
     };
 }
 
+function checkButtonIsDisabled() {
+    return {
+        content: "Check if the button is disabled",
+        trigger: ":iframe .s_add_to_cart_btn.pe-none",
+    };
+}
+
 registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         url: '/',
         edition: true,
@@ -36,6 +43,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...changeOptionInPopover("Add to Cart Button", "Product", "Product No Variant", true),
         ...clickOnSave(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
+        checkButtonIsDisabled(),
         checkQuanityInCart("1"),
 
         // Product with 2 variants with visitor choice (will open modal)
@@ -43,6 +51,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...changeOptionInPopover("Add to Cart Button", "Product", "Product Yes Variant 1", true),
         ...clickOnSave(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
+        checkButtonIsDisabled(),
         clickOnElement("add to cart", ":iframe .modal button:contains(Add to Cart)"),
         checkQuanityInCart("2"),
 
@@ -56,6 +65,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...changeOptionInPopover("Add to Cart Button", "Variant", "Product Yes Variant 2 (Pink)"),
         ...clickOnSave(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
+        checkButtonIsDisabled(),
         // Since 18.2, even if a specific variant is selected, the product configuration modal is displayed
         // The variant set on the modal used the default variants attributes (so will not correspond to the selected variant)
         // TODO: fix this misbahvior by setting the variant attributes based on the chosen variant 
@@ -87,6 +97,7 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         // At this point the "Add to cart" button was changed to a "Buy Now" button
         ...clickOnSave(),
         clickOnElement('"Buy Now" button', ':iframe .s_add_to_cart_btn'),
+        checkButtonIsDisabled(),
         checkQuanityInCart("4"),
         {
             // wait for the page to load, as the next check was sometimes too fast

--- a/addons/website_sale_comparison/static/src/interactions/comparison_page.js
+++ b/addons/website_sale_comparison/static/src/interactions/comparison_page.js
@@ -16,7 +16,9 @@ export class ComparisonPage extends Interaction {
     };
 
     dynamicContent = {
-        'button[name="comparison_add_to_cart"]': { 't-on-click': this.addToCart },
+        "button[name='comparison_add_to_cart']": {
+            "t-on-click": this.locked(this.addToCart, true),
+        },
         '.o_comparelist_remove': { 't-on-click': this.removeProduct },
         _backButton: { 't-on-click': () => redirect('/shop') },
         _clearAllButton: { 't-on-click': this.clearAllProducts },
@@ -131,13 +133,13 @@ export class ComparisonPage extends Interaction {
      *
      * @param {Event} ev
      */
-    addToCart(ev) {
+    async addToCart(ev) {
         const button = ev.currentTarget;
         const productId = parseInt(button.dataset.productProductId);
         const productTemplateId = parseInt(button.dataset.productTemplateId);
         const showQuantity = Boolean(button.dataset.showQuantity);
 
-        this.services['cart'].add({
+        await this.services["cart"].add({
             productTemplateId: productTemplateId,
             productId: productId,
         }, {

--- a/addons/website_sale_wishlist/static/src/interactions/product_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/interactions/product_wishlist.js
@@ -8,7 +8,7 @@ export class ProductWishlist extends Interaction {
     static selector = '.wishlist-section';
     dynamicContent = {
         '.o_wish_rm': { 't-on-click': this.removeProduct },
-        '.o_wish_add': { 't-on-click': this.addToCart },
+        ".o_wish_add": { "t-on-click": this.locked(this.addToCart, true) },
     };
 
     /**


### PR DESCRIPTION
Issue:
Users with slow connections were able to click Add to Cart button
repeatedly, which resulted in multiple duplicate items being added to
the cart.

This commit updates all usages of the Add to Cart button to prevent
users from clicking it multiple times while the request is still
processing. The button is disabled and given a loading effect until the
operation is complete.

Updated in:
- Website shop -> product page
- Checkout page (`cart suggestion`)
- `Add to Cart` snippet
- `s_dynamic_snippet_products` carousel
- Comparison page
- Product wishlist page

task-[4979205](https://www.odoo.com/odoo/project/974/tasks/4979205)