### PR TITLE
[FIX] website: switch the cookie navbar layout

### DIFF
--- a/addons/website/static/tests/builder/website_builder/cookies_bar_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/cookies_bar_option.test.js
@@ -1,5 +1,7 @@
-import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { waitFor } from "@odoo/hoot-dom";
+import { setSelection } from "@html_editor/../tests/_helpers/selection";
+import { insertText } from "@html_editor/../tests/_helpers/user_actions";
+import { describe, expect, test } from "@odoo/hoot";
+import { queryOne, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
 
@@ -33,21 +35,74 @@ const cookiesBarTemplate = `
     </div>`;
 
 describe("Cookies bar popup options", () => {
-    beforeEach(async () => {
+    test("Position option is not visible for discrete layout", async () => {
         await setupWebsiteBuilder(cookiesBarTemplate, {
             loadIframeBundles: true,
             loadAssetsFrontendJS: true,
         });
-    });
-    test("Position option is not visible for discrete layout", async () => {
         await contains(".o_we_invisible_el_panel .o_we_invisible_entry").click();
         await waitFor(".options-container");
         expect("[data-label='Position']").not.toHaveCount();
     });
     test("Position option is not visible for popup layout", async () => {
+        await setupWebsiteBuilder(cookiesBarTemplate, {
+            loadIframeBundles: true,
+            loadAssetsFrontendJS: true,
+        });
         await contains(".o_we_invisible_el_panel .o_we_invisible_entry").click();
         await contains(".dropdown-toggle:contains('Discrete')").click();
         await contains("[data-class-action=o_cookies_popup]").click();
         expect("[data-label='Position']").toBeVisible();
+    });
+
+    test("Switch between cookies bar layout should keep the edited cookies bar content", async () => {
+        const cookieBarContents = {
+            ".o_cookies_bar_text_button": "Allow all cookies",
+            ".o_cookies_bar_text_button_essential": "Only allow essential cookies",
+            ".o_cookies_bar_text_title": "Respecting your privacy is our priority.",
+            ".o_cookies_bar_text_primary":
+                "Allow the use of cookies from this website on this browser?",
+            ".o_cookies_bar_text_secondary":
+                "We use cookies to provide improved experience on this website. You can learn more about our cookies and how we use them in our Cookie Policy .",
+            ".o_cookies_bar_text_policy": "Cookie Policy",
+        };
+        function expectCookieBarContent() {
+            for (const selector in cookieBarContents) {
+                expect(`:iframe ${selector}`).toHaveText(cookieBarContents[selector]);
+            }
+        }
+
+        const { getEditor } = await setupWebsiteBuilder(cookiesBarTemplate, {
+            loadIframeBundles: true,
+            loadAssetsFrontendJS: true,
+        });
+        const editor = getEditor();
+        await contains(".o_we_invisible_el_panel .o_we_invisible_entry").click();
+        await contains("[data-label='Layout'] .dropdown-toggle").click();
+        await contains("[data-class-action=o_cookies_classic]").click();
+        expectCookieBarContent();
+
+        setSelection({
+            anchorNode: queryOne(":iframe .o_cookies_bar_text_secondary"),
+            anchorOffset: 0,
+        });
+        await insertText(editor, "Test:");
+        cookieBarContents[".o_cookies_bar_text_secondary"] =
+            "Test: We use cookies to provide improved experience on this website. You can learn more about our cookies and how we use them in our Cookie Policy .";
+        expectCookieBarContent();
+
+        await contains("[data-label='Layout'] .dropdown-toggle").click();
+        await contains("[data-class-action=o_cookies_discrete]").click();
+        await contains("[data-label='Layout'] .dropdown-toggle").click();
+        await contains("[data-class-action=o_cookies_classic]").click();
+        expectCookieBarContent();
+
+        await contains("[data-label='Layout'] .dropdown-toggle").click();
+        await contains("[data-class-action=o_cookies_popup]").click();
+        expectCookieBarContent();
+
+        await contains("[data-label='Layout'] .dropdown-toggle").click();
+        await contains("[data-class-action=o_cookies_classic]").click();
+        expectCookieBarContent();
     });
 });


### PR DESCRIPTION
Before this commit, switching from the classic cookie layout to popup caused the text contained in the cookie to be lost. It replaced part of it with [Object list].

Reason:
When switching from jQuery to native JS, some bugs were introduced into the code base.
- ReplaceChild does not accept lists as input.
- QuerySelectorAll does not return TextNodes.

How to reproduce:
- Go to edit mode on the website.
- Click on the cookie bar.
- Switch the layout to discreet.
- Switch the layout to popup.

Before this commit:
Part of the cookie navbar content is replaced by “[Object list]”.

After this commit:
The content is not modified.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
