### PR TITLE
[FIX] account: correctly batch price-included taxes with mixed base-affecting flags

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -820,23 +820,41 @@ class AccountTax(models.Model):
         # Group them per batch.
         batch = self.env['account.tax']
         is_base_affected = False
+        include_base_amount = False
+        is_first_batch = True
         for tax in reversed(results['sorted_taxes']):
+            same_batch = False
             if batch:
                 same_batch = (
                     tax.amount_type == batch[0].amount_type
                     and (special_mode or tax.price_include == batch[0].price_include)
-                    and tax.include_base_amount == batch[0].include_base_amount
-                    and (
-                        (tax.include_base_amount and not is_base_affected)
-                        or not tax.include_base_amount
-                    )
                 )
+                if same_batch:
+                    same_batch = False
+                    if is_first_batch and tax.include_base_amount != include_base_amount:
+                        include_base_amount = tax.include_base_amount
+                    if not include_base_amount and not tax.include_base_amount:
+                        # No tax affecting another one.
+                        same_batch = True
+                    elif (
+                        include_base_amount
+                        and tax.include_base_amount
+                        and not is_base_affected
+                        and tax.is_base_affected
+                    ):
+                        # Tax affecting the following taxes but in batch using 'is_base_affected'.
+                        is_base_affected = tax.is_base_affected
+                        same_batch = True
+
                 if not same_batch:
                     for batch_tax in batch:
                         results['batch_per_tax'][batch_tax.id] = batch
                     batch = self.env['account.tax']
+                    is_first_batch = False
 
-            is_base_affected = tax.is_base_affected
+            if not same_batch:
+                is_base_affected = tax.is_base_affected
+                include_base_amount = tax.include_base_amount
             batch |= tax
 
         if batch:

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -66,26 +66,51 @@ export const accountTaxHelpers = {
         // Group them per batch.
         let batch = [];
         let is_base_affected = false;
+        let include_base_amount = false;
+        let is_first_batch = true;
         for (const tax of results.sorted_taxes.toReversed()) {
-            if (batch.length > 0) {
-                const same_batch =
+            let same_batch = false;
+            if (batch.length) {
+                same_batch =
                     tax.amount_type === batch[0].amount_type &&
-                    (special_mode || tax.price_include === batch[0].price_include) &&
-                    tax.include_base_amount === batch[0].include_base_amount &&
-                    ((tax.include_base_amount && !is_base_affected) || !tax.include_base_amount);
+                    (special_mode || tax.price_include === batch[0].price_include);
+                if (same_batch) {
+                    same_batch = false;
+                    if (is_first_batch && tax.include_base_amount !== include_base_amount) {
+                        include_base_amount = tax.include_base_amount;
+                    }
+                    if (!include_base_amount && !tax.include_base_amount) {
+                        // No tax affecting another one.
+                        same_batch = true;
+                    } else if (
+                        include_base_amount &&
+                        tax.include_base_amount &&
+                        !is_base_affected &&
+                        tax.is_base_affected
+                    ) {
+                        // Tax affecting the following taxes but in batch using 'is_base_affected'.
+                        is_base_affected = tax.is_base_affected;
+                        same_batch = true;
+                    }
+                }
+
                 if (!same_batch) {
-                    for (const batch_tax of batch) {
+                    for (let batch_tax of batch) {
                         results.batch_per_tax[batch_tax.id] = batch;
                     }
                     batch = [];
+                    is_first_batch = false;
                 }
             }
 
-            is_base_affected = tax.is_base_affected;
+            if (!same_batch) {
+                is_base_affected = tax.is_base_affected;
+                include_base_amount = tax.include_base_amount;
+            }
             batch.push(tax);
         }
 
-        if (batch.length !== 0) {
+        if (batch.length) {
             for (const batch_tax of batch) {
                 results.batch_per_tax[batch_tax.id] = batch;
             }

--- a/addons/account/tests/test_taxes_computation.py
+++ b/addons/account/tests/test_taxes_computation.py
@@ -490,6 +490,79 @@ class TestTaxesComputation(TestTaxCommon):
         )
         self._run_js_tests()
 
+    def test_batch_for_taxes_computation(self):
+        tax_percent_5 = self.percent_tax(5.0)
+        tax_percent_10 = self.percent_tax(10.0)
+        tax_percent_15 = self.percent_tax(15.0)
+        taxes = tax_percent_5 + tax_percent_10 + tax_percent_15
+
+        # No tax affecting another one.
+        # tax               price_incl      incl_base_amount    is_base_affected
+        # -----------------------------------------------------------------------
+        # tax_percent_5                                         T
+        # tax_percent_10                                        T
+        # tax_percent_15                                        T
+        self.assert_taxes_computation(
+            taxes,
+            100.0,
+            {
+                'total_included': 130.0,
+                'total_excluded': 100.0,
+                'taxes_data': (
+                    (100.0, 5.0),
+                    (100.0, 10.0),
+                    (100.0, 15.0),
+                ),
+            },
+        )
+
+        # Tax affecting the following taxes but in batch using 'is_base_affected'.
+        # We expect 2 batches here: (tax_percent_5, tax_percent_10) & tax_percent_15
+        # tax               price_incl      incl_base_amount    is_base_affected
+        # -----------------------------------------------------------------------
+        # tax_percent_5                     T                   T
+        # tax_percent_10                    T
+        # tax_percent_15                    T                   T
+        taxes.include_base_amount = True
+        tax_percent_10.is_base_affected = False
+        self.assert_taxes_computation(
+            taxes,
+            100.0,
+            {
+                'total_included': 132.25,
+                'total_excluded': 100.0,
+                'taxes_data': (
+                    (100.0, 5.0),
+                    (100.0, 10.0),
+                    (115.0, 17.25),
+                ),
+            },
+        )
+
+        # Tax affecting the following taxes but there is no following tax.
+        # tax               price_incl      incl_base_amount    is_base_affected
+        # -----------------------------------------------------------------------
+        # tax_percent_5     T                                   T
+        # tax_percent_10    T                                   T
+        # tax_percent_15    T               T                   T
+        taxes.is_base_affected = True
+        taxes.price_include_override = 'tax_included'
+        (tax_percent_5 + tax_percent_10).include_base_amount = False
+        self.assert_taxes_computation(
+            taxes,
+            100.0,
+            {
+                'total_included': 100.0,
+                'total_excluded': 76.92,
+                'taxes_data': (
+                    (76.92, 3.85),
+                    (76.92, 7.69),
+                    (76.92, 11.54),
+                ),
+            },
+        )
+        self._run_js_tests()
+
     def test_fixed_tax_price_included_affect_base_on_0(self):
         tax = self.fixed_tax(0.05, price_include_override='tax_included', include_base_amount=True)
         self.assert_taxes_computation(

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -983,7 +983,7 @@ class TestLoyalty(TestSaleCouponCommon):
         order._update_programs_and_rewards()
         self._claim_reward(order, loyalty_program)
         msg = "Discountable should take child tax amount into account"
-        self.assertEqual(order.amount_total, 10, msg=msg)
+        self.assertEqual(order.amount_to_invoice, 10, msg=msg)
 
     def test_ewallet_program_without_trigger_product(self):
         self.ewallet_program.trigger_product_ids = [Command.clear()]


### PR DESCRIPTION
**Issue**
When creating an invoice with two price-included taxes, one that affects the base of subsequent taxes (`include_base_amount=True`) and another that does not, the tax computation is incorrect. This leads to inconsistent base amounts and triggers a warning in the tax report, particularly visible in the Tax Return Report.

**Steps to Reproduce**
1. Create two taxes with `price_include=True`: Tax1 with "Affect Base of Subsequent Taxes" disabled Tax2 with it enabled
2. Add both taxes to the same invoice line and confirm the invoice
3. Open the Tax Report and filter by the invoice date
4. The report shows an inconsistency because the computed base is wrong

**Root Cause**
The batching logic separates taxes into groups when their properties differ. In this case, because the two taxes have different `include_base_amount` values, they are split into different batches. Since batching drives how price-included taxes are reversed to compute the base, splitting the batch leads to misinterpreted base amounts and incorrect tax calculations.

**Fix**
Adjusting batching conditions to allow taxes to be grouped together even if their `include_base_amount` flags differ. This ensures that price-included taxes are handled consistently and the base is computed correctly across all taxes in the group.

Opw-4863100
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
