### PR TITLE
[FIX] l10n_fr_pos_cert: backport enable self-service invoicing for french companies

### DIFF
--- a/addons/l10n_fr_pos_cert/__manifest__.py
+++ b/addons/l10n_fr_pos_cert/__manifest__.py
@@ -39,6 +39,9 @@ The module adds following features:
         'point_of_sale._assets_pos': [
             'l10n_fr_pos_cert/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'l10n_fr_pos_cert/static/tests/**/*',
+        ],
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/l10n_fr_pos_cert/static/src/js/order_receipt.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/order_receipt.js
@@ -3,9 +3,6 @@ import { patch } from "@web/core/utils/patch";
 
 patch(OrderReceipt.prototype, {
     get qrCode() {
-        if (this.order.is_french_country()) {
-            return false;
-        }
         return super.qrCode;
     },
 });

--- a/addons/l10n_fr_pos_cert/static/tests/tours/l10n_fr_pos_cert_tour.js
+++ b/addons/l10n_fr_pos_cert/static/tests/tours/l10n_fr_pos_cert_tour.js
@@ -1,0 +1,23 @@
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("l10nFrPosCertSelfInvoicingTour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            {
+                trigger: ".pos-receipt #posqrcode",
+                content: "QR code is visible on the receipt",
+            },
+        ].flat(),
+});

--- a/addons/l10n_fr_pos_cert/tests/__init__.py
+++ b/addons/l10n_fr_pos_cert/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_string_to_hash
+from . import test_frontend

--- a/addons/l10n_fr_pos_cert/tests/test_frontend.py
+++ b/addons/l10n_fr_pos_cert/tests/test_frontend.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+class Testl10nFrPosCert(TestPointOfSaleHttpCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        company = cls.main_pos_config.company_id
+        company.country_id = cls.env.ref("base.fr")
+        company.point_of_sale_use_ticket_qr_code = True
+        company.point_of_sale_ticket_portal_url_display_mode = 'qr_code_and_url'
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestUi(Testl10nFrPosCert):
+    def test_pos_use_ticket_qr_code_for_fr(self):
+        company = self.main_pos_config.company_id
+        self.assertEqual(company.country_id.code, "FR", "Company should be set to France (FR)")
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("l10nFrPosCertSelfInvoicingTour", login="pos_user")


### PR DESCRIPTION
This commit backports parts of https://github.com/odoo/odoo/commit/4fd28add5c22614a4e5a386a440617edefed6d67,
which originally was only merged into master, since it's unstable.

Here however, we only backport the bare minimum to make the invoice QR
code visible on the receipt, while keeping the changes stable. We also
backport the test.

opw-4981573
