### PR TITLE
[FIX] website: conditional visibility check on label rename

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -1104,7 +1104,7 @@ export class SetLabelTextAction extends BuilderAction {
                     const fieldData = await this.dependencies.websiteFormOption.loadFieldOptionData(
                         fieldWithConditionEl
                     );
-                    const names = fieldData.conditionInputs.map((entry) => CSS.escape(entry.name));
+                    const names = fieldData.conditionInputs.map((entry) => entry.name);
                     if (!names.includes(conditionFieldName)) {
                         deleteConditionalVisibility(fieldWithConditionEl);
                     }


### PR DESCRIPTION
Steps to reproduce:
- Drop a Form snippet
- Add a text field named "Field A"
- Add a text field named "Field B"
- Add a conditional visibility on "Field B" that relies on "Field A"
- Add a text field named "Field C"

This PR ensure renaming a field label won't broke conditional visibility logic due to incorrect name comparison. The code was escaping `entry.name` using `CSS.escape()` before comparing it with `conditionFieldName`, which is a raw string (e.g., comparing "Field\\ A" with "Field A").