### PR TITLE
[FIX] web: Keep context when expanding form view dialog

### DIFF
--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -115,6 +115,9 @@ export class FormViewDialog extends Component {
                 res_model: this.props.resModel,
                 res_id: this.currentResId,
                 views: [[false, "form"]],
+                context: {
+                    ...this.props.context,
+                },
             });
         }
     }

--- a/addons/web/static/tests/views/view_dialogs/form_view_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/form_view_dialog.test.js
@@ -428,6 +428,7 @@ test("existing record has an expand button", async () => {
                 actionRequest.res_model,
                 actionRequest.type,
                 actionRequest.views,
+                actionRequest.context,
             ]);
         },
     });
@@ -435,6 +436,7 @@ test("existing record has an expand button", async () => {
     getService("dialog").add(FormViewDialog, {
         resModel: "partner",
         resId: 1,
+        context: {key: "val"}
     });
     await animationFrame();
     expect(".o_dialog .o_form_view").toHaveCount(1);
@@ -442,7 +444,18 @@ test("existing record has an expand button", async () => {
     await fieldInput("foo").edit("hola");
     await click(".o_dialog .modal-header .o_expand_button");
     await animationFrame();
-    expect.verifySteps(["save", [1, "partner", "ir.actions.act_window", [[false, "form"]]]]);
+    expect.verifySteps([
+        "save",
+        [
+            1,
+            "partner",
+            "ir.actions.act_window",
+            [[false, "form"]],
+            {
+                key: "val",
+            },
+        ],
+    ]);
 });
 
 test("expand button with save and new", async () => {


### PR DESCRIPTION
### Steps to reproduce:
	- Go to any task in project module
	- Create a new meeting activity
	- Open Calendar and drag to create a slot
	- Notice the name of the meeting in the pop-up is the same as the task
	- Click on the expand button top-right of the dialog
	- Notice the calendar.event form opened but without a name

### Cause:
When expanding the view using 'More options' button we are keeping the context in the new request.

https://github.com/odoo/odoo/blob/d9c63a85955c2321bae1a705cc09b2554155f826/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js#L45-L49

But when doing the same through the expand button we don't pass the current context so it will be lost.

https://github.com/odoo/odoo/blob/3dde420665257c63885e891f1ec366568df5007b/addons/web/static/src/views/view_dialogs/form_view_dialog.js#L106-L116

### Fix:
Backporting the commit https://github.com/odoo/odoo/commit/4f71fbbd26b428e57943d974e8441bef295cdef1
to pass the context while expanding the form view

opw-4966486