### PR TITLE
[FIX] hr_holidays: display submit leave button if no warning message

### DIFF
--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
@@ -33,7 +33,7 @@ export class TimeOffDialogFormController extends FormController {
     }
 
     get hasNoWarning() {
-        return this.record.data.dashboard_warning_message == "";
+        return !this.record.data.dashboard_warning_message;
     }
 
     get canSave() {


### PR DESCRIPTION
**Steps to reproduce**
1. Install l10n_ch_hr_payroll_elm_transmission
2. Go to an employee's profile
3. Click on "Absences" smart button
4. Create a new Time Off request Issue: the form view dialog is missing a button to confirm the request.

Cause: the dashboard warning message is not part of the l10n_ch_hr_payroll_elm_transmission view.

Solution: display the "Submit Request" button if we don't have any dashboard warning message. There will still be a validation after the request is submitted.

opw-4972467