### PR TITLE
[FIX] l10n_es_edi_tbai: fix sign of unit price for credit notes

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -381,8 +381,8 @@ class AccountEdiFormat(models.Model):
                 total = abs(line.balance) * -refund_sign * (-1 if line_price_total < 0 else 1)
             invoice_lines.append({
                 'line': line,
-                'discount': discount * refund_sign,
-                'unit_price': (line.balance + discount) / line.quantity * refund_sign if line.quantity else 0.0,
+                'discount': -discount,
+                'unit_price': -(line.balance + discount) / line.quantity if line.quantity else 0.0,
                 'total': total,
                 'description': regex_sub(r'[^0-9a-zA-Z ]', '', line.name or '')[:250]
             })

--- a/addons/l10n_es_edi_tbai/tests/common.py
+++ b/addons/l10n_es_edi_tbai/tests/common.py
@@ -372,3 +372,100 @@ class TestEsEdiTbaiCommon(AccountEdiTestCommon):
         </FacturasRecibidas>
     </lrpjframp:LROEPJ240FacturasRecibidasAltaModifPeticion>
     """
+
+    L10N_ES_TBAI_CREDIT_NOTE_XML_POST = """<?xml version='1.0'?>
+<T:TicketBai xmlns:etsi="http://uri.etsi.org/01903/v1.3.2#" xmlns:T="urn:ticketbai:emision" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <Cabecera>
+    <IDVersionTBAI>1.2</IDVersionTBAI>
+  </Cabecera>
+  <Sujetos>
+    <Emisor>
+      <NIF>___ignore___</NIF>
+      <ApellidosNombreRazonSocial>EUS Company</ApellidosNombreRazonSocial>
+    </Emisor>
+    <Destinatarios>
+      <IDDestinatario>
+        <IDOtro>
+          <IDType>02</IDType>
+          <ID>BE0477472701</ID>
+        </IDOtro>
+        <ApellidosNombreRazonSocial>&amp;@&#224;&#193;$&#163;&#8364;&#232;&#234;&#200;&#202;&#246;&#212;&#199;&#231;&#161;&#8539;&#8482;&#179;</ApellidosNombreRazonSocial>
+        <CodigoPostal>___ignore___</CodigoPostal>
+        <Direccion>___ignore___</Direccion>
+      </IDDestinatario>
+    </Destinatarios>
+    <VariosDestinatarios>N</VariosDestinatarios>
+    <EmitidaPorTercerosODestinatario>N</EmitidaPorTercerosODestinatario>
+  </Sujetos>
+  <Factura>
+    <CabeceraFactura>
+      <SerieFactura>___ignore___</SerieFactura>
+      <NumFactura>00001</NumFactura>
+      <FechaExpedicionFactura>01-01-2025</FechaExpedicionFactura>
+      <HoraExpedicionFactura>___ignore___</HoraExpedicionFactura>
+      <FacturaSimplificada>N</FacturaSimplificada>
+      <FacturaEmitidaSustitucionSimplificada>N</FacturaEmitidaSustitucionSimplificada>
+      <FacturaRectificativa>
+        <Codigo>R1</Codigo>
+        <Tipo>I</Tipo>
+      </FacturaRectificativa>
+      <FacturasRectificadasSustituidas>
+        <IDFacturaRectificadaSustituida>
+          <SerieFactura>INVTEST</SerieFactura>
+          <NumFactura>01</NumFactura>
+          <FechaExpedicionFactura>___ignore___</FechaExpedicionFactura>
+        </IDFacturaRectificadaSustituida>
+      </FacturasRectificadasSustituidas>
+    </CabeceraFactura>
+    <DatosFactura>
+      <DescripcionFactura>manual</DescripcionFactura>
+      <DetallesFactura>
+        <IDDetalleFactura>
+          <DescripcionDetalle>producta</DescripcionDetalle>
+          <Cantidad>5.00</Cantidad>
+          <ImporteUnitario>-1000.00</ImporteUnitario>
+          <Descuento>-1000.00</Descuento>
+          <ImporteTotal>-4840.00</ImporteTotal>
+        </IDDetalleFactura>
+      </DetallesFactura>
+      <ImporteTotalFactura>-4840.00</ImporteTotalFactura>
+      <Claves>
+        <IDClave>
+          <ClaveRegimenIvaOpTrascendencia>01</ClaveRegimenIvaOpTrascendencia>
+        </IDClave>
+      </Claves>
+    </DatosFactura>
+    <TipoDesglose>
+      <DesgloseTipoOperacion>
+        <Entrega>
+          <Sujeta>
+            <NoExenta>
+              <DetalleNoExenta>
+                <TipoNoExenta>S1</TipoNoExenta>
+                <DesgloseIVA>
+                  <DetalleIVA>
+                    <BaseImponible>-4000.00</BaseImponible>
+                    <TipoImpositivo>21.00</TipoImpositivo>
+                    <CuotaImpuesto>-840.00</CuotaImpuesto>
+                  </DetalleIVA>
+                </DesgloseIVA>
+              </DetalleNoExenta>
+            </NoExenta>
+          </Sujeta>
+        </Entrega>
+      </DesgloseTipoOperacion>
+    </TipoDesglose>
+  </Factura>
+  <HuellaTBAI>
+    <Software>
+      <LicenciaTBAI>___ignore___</LicenciaTBAI>
+      <EntidadDesarrolladora>
+        <NIF>___ignore___</NIF>
+      </EntidadDesarrolladora>
+      <Nombre>___ignore___</Nombre>
+      <Version>___ignore___</Version>
+    </Software>
+    <NumSerieDispositivo>___ignore___</NumSerieDispositivo>
+  </HuellaTBAI>
+</T:TicketBai>
+"""

--- a/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
@@ -219,3 +219,25 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
         xml_doc.remove(xml_doc.find("Signature", namespaces=NS_MAP))
         xml_expected = etree.fromstring(super().L10N_ES_TBAI_SAMPLE_XML_CANCEL)
         self.assertXmlTreeEqual(xml_doc, xml_expected)
+
+    def test_xml_tree_credit_note_post(self):
+        """Test of Customer Credit Note XML"""
+        self.out_invoice.action_post()
+        move_reversal = self.env['account.move.reversal'].with_context(
+            active_model="account.move",
+            active_ids=self.out_invoice.ids
+        ).create({
+            'date': str(self.out_invoice.invoice_date),
+            'reason': 'no reason',
+            'l10n_es_tbai_refund_reason': 'R1',
+            'refund_method': 'cancel',
+            'journal_id': self.out_invoice.journal_id.id,
+        })
+        reversal = move_reversal.reverse_moves()
+        reverse_move = self.env['account.move'].browse(reversal['res_id'])
+
+        with freeze_time(self.frozen_today):
+            xml_doc = self.edi_format._get_l10n_es_tbai_invoice_xml(reverse_move, cancel=False)[reverse_move]['xml_file']
+            xml_doc.remove(xml_doc.find("Signature", namespaces=NS_MAP))
+            xml_expected = etree.fromstring(super().L10N_ES_TBAI_CREDIT_NOTE_XML_POST)
+            self.assertXmlTreeEqual(xml_doc, xml_expected)


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_es_edi_tbai

- Switch to a Spanish company (e.g. ES Company)
- Go to Accounting settings
- Select "Hacienda Foral de Araba" as Tax Agency

- Create an invoice:
  * Customer: [a Spanish customer]
  * Invoice Lines: [a line with a tax]
- Confirm the invoice
- Process the invoice by TicketBAI (ES)
- Add a credit note:
  * Credit Method: Full Refund
  * Reason: [anything]
  * Invoice Refund Reason Code (TicketBai): R1
- Process the credit note by TicketBAI (ES)

**Issue:**
A validation error is returned by TicketBAI:
"010: 78-AVISO: Error validación de negocio [Sumatorio detalle no coincide con el sumatorio desglose]"

**Cause:**
In the XML, "ImporteTotal" (i.e. Total amount) is negative, which is correct for a credit note.
However, "ImporteUnitario" (i.e. Price unit) is positive, which is incorrect because the total amount doesn't correspond to "Price unit" * "Quantity.
"ImporteTotal" should be equal to "ImporteUnitario" * "Cantidad".
There is a similar issue for "Descuento" (i.e. Discount).

**Solution:**
Inverse the sign of "ImporteUnitario" and "Descuento" for credit notes.


opw-4593240



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
