### PR TITLE
[FIX] auth_signup: fix links on email templates

### DIFF
--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -314,12 +314,10 @@
                 <tr><td valign="middle" align="left" style="opacity: 0.7;">
                     <t t-out="object.company_id.phone or ''">+1 650-123-4567</t>
                     <t t-if="object.company_id.email">
-                        | <a t-attf-href="'mailto:%s' % {{ object.company_id.email }}" style="text-decoration:none; color: #454748;"><t t-out="object.company_id.email or ''">info@yourcompany.com</t></a>
+                        | <a t-attf-href="mailto:{{object.company_id.email}}" style="text-decoration:none; color: #454748;" t-out="object.company_id.email or ''">info@yourcompany.com</a>
                     </t>
                     <t t-if="object.company_id.website">
-                        | <a t-attf-href="'%s' % {{ object.company_id.website }}" style="text-decoration:none; color: #454748;">
-                            <t t-out="object.company_id.website or ''">http://www.example.com</t>
-                        </a>
+                        | <a t-att-href="object.company_id.website" style="text-decoration:none; color: #454748;" t-out="object.company_id.website or ''">http://www.example.com</a>
                     </t>
                 </td></tr>
             </table>


### PR DESCRIPTION
Website and email links were malformed on the New User Invite email template. Later versions also have this issue on the other templates will change those in forward ports.

Renderer was treating the string formatting as a string itself when using the double curly braces on variables. Removed the curly braces so the variable was properly evaluated and inserted into the string.

opw-4977756
