### PR TITLE
[IMP] im_livechat: remove company name for agent

### DIFF
--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -89,12 +89,14 @@ class ResPartner(models.Model):
             )
         self._bus_send_transient_message(channel, message_body)
 
-    @api.depends_context("im_livechat.hide_partner_company")
+    @api.depends_context("im_livechat_hide_partner_company")
     def _compute_display_name(self):
-        if not self.env.context.get("im_livechat.hide_partner_company"):
+        if not self.env.context.get("im_livechat_hide_partner_company"):
             super()._compute_display_name()
             return
-        for partner in self:
+        portal_partners = self.filtered("partner_share")
+        super(ResPartner, portal_partners)._compute_display_name()
+        for partner in self - portal_partners:
             partner.display_name = partner.name
 
     def action_view_livechat_sessions(self):

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -126,7 +126,7 @@
                     "search_default_filter_date_last_month": 1,
                     "pivot_measures": ["__count", "time_to_answer", "duration", "rating", "number_of_calls"],
                     "graph_measure": "__count__",
-                    "im_livechat.hide_partner_company": True,
+                    "im_livechat_hide_partner_company": True,
                 }
             </field>
             <field name="help" type="html">

--- a/addons/im_livechat/tests/test_session_views.py
+++ b/addons/im_livechat/tests/test_session_views.py
@@ -95,3 +95,13 @@ class TestImLivechatSessionViews(TestImLivechatCommon):
             "im_livechat.looking_for_help_kanban_real_time_update_tour",
             login="bob_looking_for_help",
         )
+
+    def test_partner_display_name(self):
+        user = new_test_user(self.env, login="agent", name="john")
+        company = self.env["res.partner"].create({"name": "TestCompany", "is_company": True})
+        user.partner_id.parent_id = company.id
+        self.assertEqual(
+            user.with_context(im_livechat_hide_partner_company=True).partner_id.display_name,
+            "john",
+        )
+        self.assertEqual(user.partner_id.display_name, "TestCompany, john")

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -163,7 +163,12 @@
             <field name="view_mode">kanban,list,pivot,graph,form</field>
             <field name="search_view_id" ref="im_livechat.discuss_channel_view_search"/>
             <field name="domain">[('livechat_channel_id', '!=', None)]</field>
-            <field name="context">{'search_default_filter_session_date': 'custom_rated_on_last_30_days'}</field>
+            <field name="context">
+                {
+                    "search_default_filter_session_date": "custom_rated_on_last_30_days",
+                    "im_livechat_hide_partner_company": True,
+                }
+            </field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
                     No data yet!
@@ -298,7 +303,12 @@
             <field name="res_model">discuss.channel</field>
             <field name="view_mode">list,kanban,form</field>
             <field name="domain">[("livechat_status", "=", "need_help")]</field>
-            <field name="context">{'search_default_filter_session_date': 'custom_created_on_last_30_days'}</field>
+            <field name="context">
+                {
+                    "search_default_filter_session_date": "custom_created_on_last_30_days",
+                    "im_livechat_hide_partner_company": True,
+                }
+            </field>
             <field name="search_view_id" ref="im_livechat.discuss_channel_looking_for_help_view_search"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">No conversations found</p>

--- a/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
@@ -132,7 +132,7 @@
                     "search_default_filter_date_last_month": 1,
                     "graph_measure": "__count__",
                     "pivot_measures": ["__count", "response_time_hour", "session_duration_hour", "rating", "call_count"],
-                    "im_livechat.hide_partner_company": True
+                    "im_livechat_hide_partner_company": True
                 }
             </field>
             <field name="search_view_id" ref="im_livechat_agent_history_view_search"/>

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -102,7 +102,7 @@
                                            mode="list,kanban"
                                            context="{'add_livechat_channel_ctx': True}">
                                         <list no_open="1">
-                                            <field name="partner_id" string="Agent" widget="many2one_avatar_user" width="175px" context="{'im_livechat.hide_partner_company': True}"/>
+                                            <field name="partner_id" string="Agent" widget="many2one_avatar_user" width="175px" context="{'im_livechat_hide_partner_company': True}"/>
                                             <field name="livechat_is_in_call" widget="boolean_phone" nolabel="1"/>
                                             <field string="Languages" name="livechat_lang_ids" widget="many2many_tags" optional="show"/>
                                             <field string="Expertise" name="livechat_expertise_ids" widget="many2many_tags" optional="show"/>


### PR DESCRIPTION
**Current behavior before PR:**

Display name for agent included company name

**Desired behavior after PR is merged:**

agent field will display only the agent name without the company name

task-4775840

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
