### PR TITLE
[IMP] mail: add device selection options in WelcomePage

### DIFF
--- a/addons/mail/static/src/discuss/call/common/device_select.xml
+++ b/addons/mail/static/src/discuss/call/common/device_select.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallDeviceSelect">
-        <select name="inputDevice" class="form-select d-flex w-auto shadow-sm" t-on-change="onChangeSelectAudioInput">
+        <select name="inputDevice" class="form-select d-flex shadow-sm" t-on-change="onChangeSelectAudioInput">
             <option value="">Browser default</option>
             <t t-foreach="state.userDevices" t-as="device" t-key="device_index">
                 <option t-if="device.kind === props.kind" t-att-selected="isSelected(device.deviceId)" t-att-value="device.deviceId">

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -2,33 +2,49 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.WelcomePage">
-    <div class="o-mail-WelcomePage h-100 w-100 d-flex flex-column justify-content-center align-items-center bg-light">
-        <h1 class="fw-light">
+    <div class="o-mail-WelcomePage w-100 d-flex flex-column justify-content-md-center align-items-center bg-light p-3" style="min-height: 100dvh;">
+        <h1 class="fw-light text-center">
             <span t-if="this.store.discuss.thread.default_display_mode === 'video_full_screen'">You've been invited to a meeting!</span>
             <span t-else="">You've been invited to a chat!</span>
         </h1>
-        <h2 class="m-5" t-esc="store.companyName"/>
-        <div class="d-flex justify-content-center gap-5" t-att-class="{'flex-column': ui.isSmall}">
-            <div t-if="this.store.discuss.thread.default_display_mode === 'video_full_screen'" class="position-relative d-flex justify-content-center" t-ref="root">
-                <video class="shadow rounded-3 bg-dark" t-attf-height="{{ui.isSmall ? 240 : 480}}" t-attf-width="{{ui.isSmall ? 320 : 640}}" autoplay="" t-ref="video"/>
-                <p t-if="hasRtcSupport and !state.videoStream" class="position-absolute bottom-50 text-light">
-                    Camera is off
-                </p>
-                <p t-if="!hasRtcSupport" class="position-absolute bottom-50 text-light">
-                    Your browser does not support videoconference
-                </p>
-                <div class="position-absolute bottom-0">
-                    <button class="btn fa-stack align-self-end p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ state.audioStream ? 'btn-dark' : 'btn-danger' }}" t-on-click="onClickMic">
-                        <i class="fa" t-attf-class="{{ state.audioStream ? 'fa-microphone' : 'fa-microphone-slash' }}"/>
-                    </button>
-                    <button class="btn fa-stack align-self-end p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ state.videoStream ? 'btn-dark' : 'btn-danger' }}" t-on-click="onClickVideo">
-                        <i class="fa fa-camera"/>
-                    </button>
-                    <button t-if="state.videoStream"  class="btn fa-stack p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ store.settings.useBlur ? 'btn-secondary' : 'btn-dark' }}" t-on-click="onClickBlur" t-att-title="blurButtonTitle">
-                        <i class="fa fa-photo" t-att-class="{ 'opacity-50': !store.settings.useBlur }"/>
-                    </button>
+        <h2 class="m-3 m-md-5" t-esc="store.companyName"/>
+        <div class="w-100 d-flex justify-content-center gap-5" t-att-class="{'flex-column': ui.isSmall}">
+            <div t-if="this.store.discuss.thread.default_display_mode === 'video_full_screen'" class="w-100 align-self-center" style="max-width: 640px;">
+                <div class="position-relative d-flex flex-column align-items-center" t-ref="root">
+                    <video class="shadow rounded-3 bg-dark object-fit-contain" t-attf-height="{{ui.isSmall ? 240 : 360}}" width="100%" autoplay="" t-ref="video"/>
+                    <p t-if="hasRtcSupport and !state.videoStream" class="position-absolute bottom-50 text-light">
+                        Camera is off
+                    </p>
+                    <p t-if="!hasRtcSupport" class="position-absolute bottom-50 text-light">
+                        Your browser does not support videoconference
+                    </p>
+                    <div class="position-absolute bottom-0">
+                        <button class="btn fa-stack align-self-end p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ state.audioStream ? 'btn-dark' : 'btn-danger' }}" t-on-click="onClickMic">
+                            <i class="fa" t-attf-class="{{ state.audioStream ? 'fa-microphone' : 'fa-microphone-slash' }}"/>
+                        </button>
+                        <button class="btn fa-stack align-self-end p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ state.videoStream ? 'btn-dark' : 'btn-danger' }}" t-on-click="onClickVideo">
+                            <i class="fa fa-camera"/>
+                        </button>
+                        <button t-if="state.videoStream"  class="btn fa-stack p-0 m-3 rounded-circle fs-1 shadow" t-attf-class="{{ store.settings.useBlur ? 'btn-secondary' : 'btn-dark' }}" t-on-click="onClickBlur" t-att-title="blurButtonTitle">
+                            <i class="fa fa-photo" t-att-class="{ 'opacity-50': !store.settings.useBlur }"/>
+                        </button>
+                    </div>
+                    <audio autoplay="" t-ref="audio"/>
                 </div>
-                <audio autoplay="" t-ref="audio"/>
+                <div class="d-flex flex-column flex-md-row gap-2 text-muted mt-3">
+                    <div class="w-100 text-uppercase">
+                        <i class="fa fa-microphone"></i> Microphone
+                        <DeviceSelect kind="'audioinput'"/>
+                    </div>
+                    <div class="w-100 text-uppercase">
+                        <i class="fa fa-volume-up"></i> Output
+                        <DeviceSelect kind="'audiooutput'"/>
+                    </div>
+                    <div class="w-100 text-uppercase">
+                        <i class="fa fa-camera"></i> Camera
+                        <DeviceSelect kind="'videoinput'"/>
+                    </div>
+                </div>
             </div>
             <div class="d-flex flex-column justify-content-center">
                 <t t-if="store.self_guest">

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -19,22 +19,20 @@ describe.current.tags("desktop");
 defineMailModels();
 
 test("Renders the call settings", async () => {
-    patchWithCleanup(browser.navigator, {
-        mediaDevices: {
-            enumerateDevices: () =>
-                Promise.resolve([
-                    {
-                        deviceId: "mockAudioDeviceId",
-                        kind: "audioinput",
-                        label: "mockAudioDeviceLabel",
-                    },
-                    {
-                        deviceId: "mockVideoDeviceId",
-                        kind: "videoinput",
-                        label: "mockVideoDeviceLabel",
-                    },
-                ]),
-        },
+    patchWithCleanup(browser.navigator.mediaDevices, {
+        enumerateDevices: () =>
+            Promise.resolve([
+                {
+                    deviceId: "mockAudioDeviceId",
+                    kind: "audioinput",
+                    label: "mockAudioDeviceLabel",
+                },
+                {
+                    deviceId: "mockVideoDeviceId",
+                    kind: "videoinput",
+                    label: "mockVideoDeviceLabel",
+                },
+            ]),
     });
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });


### PR DESCRIPTION
**Before this PR,** 
the `DeviceSelect` dropdown did not update when a new device was added or when
camera/microphone permissions changed, leading to an outdated device list.

the `WelcomePage` shown when joining a call through a link only displayed 
a preview of the user’s camera and microphone but did not provide any way 
to change devices.

**This PR,** 
improves the `DeviceSelect` component by adding event listeners for `devicechange`
and permission change events, ensuring the dropdown is automatically refreshed
with the latest available devices.

enhances the `WelcomePage` by adding dropdowns below the video 
preview, allowing users to select their preferred microphone, camera, and audio 
output device before joining the call.

Before / After:
<img width="1920" height="854" alt="image" src="https://github.com/user-attachments/assets/8750fa87-0f04-4498-b238-692f187a713a" />
<img width="1920" height="854" alt="image" src="https://github.com/user-attachments/assets/ed62e012-f7e8-40e8-a006-9f7b0beb6f1a" />

<img width="350" height="1103" alt="image" src="https://github.com/user-attachments/assets/fb68de96-212d-4fc7-92e4-1f9edb33c9a6" />
<img width="350" height="1103" alt="image" src="https://github.com/user-attachments/assets/897ef62e-f71b-4049-a124-8e7888fe4a68" />


task-[4967129](https://www.odoo.com/odoo/project/1519/tasks/4967129)