### PR TITLE
[FIX] website: adapt test TestImageUploadProgress

### DIFF
--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -230,7 +230,7 @@ registerWebsitePreviewTour('test_image_upload_progress_unsplash', {
         run: "click",
     }, {
         content: "unsplash image (mocked to logo) should have been used",
-        trigger: ":iframe #wrap .s_image_gallery img[src^='/unsplash/HQqIOc8oYro/fox']",
+        trigger: ":iframe #wrap .s_image_gallery img[data-original-src^='/unsplash/HQqIOc8oYro/fox']",
         run() {
             unpatchMediaDialog();
         },

--- a/addons/test_website/tests/test_image_upload_progress.py
+++ b/addons/test_website/tests/test_image_upload_progress.py
@@ -7,11 +7,8 @@ from odoo.addons.web_unsplash.controllers.main import Web_Unsplash
 import odoo.tests
 
 from odoo import http
-import unittest
 
 
-# TODO master-mysterious-egg fix error
-@unittest.skip("prepare mysterious-egg for merging")
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestImageUploadProgress(odoo.tests.HttpCase):
 


### PR DESCRIPTION
TestImageUploadProgress test was previously broken due to DOM structure changes introduced by the new website builder and was consequently disabled.

This commit updates the tour steps to align with the new DOM and re-enables the associated test.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
