### PR TITLE
[IMP] mail: add inbox tab with lazy loading to messaging menu

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -25,14 +25,15 @@
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'notification' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'notification'">Notifications</button>
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
-                        <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
-                        <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
+                        <button t-if="store.self.main_user_id?.notification_type === 'inbox'" class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'inbox' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'inbox'">Inbox</button>
+                        <button t-if="threads.length >= 20 and store.channels.status !== 'fetching' and !isInboxTabLoading" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
+                        <button t-if="store.channels.status === 'fetching' or isInboxTabLoading" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                     </t>
                 </t>
             </div>
         </xpath>
         <xpath expr="//*[@name='threads']" position="before">
-            <div t-if="store.channels.status !== 'fetching' and !hasPreviews and !store.discuss.searchTerm" class="d-flex justify-content-center py-4 px-2 text-muted">
+            <div t-if="store.channels.status !== 'fetching' and !hasPreviews and !store.discuss.searchTerm and !isInboxTabLoading" class="d-flex justify-content-center py-4 px-2 text-muted">
                 No conversation yet...
             </div>
             <div t-if="store.discuss.searchTerm and !threads.length" class="d-flex justify-content-center py-4 px-2 text-muted">
@@ -106,6 +107,17 @@
                     <t t-set="itemIndex" t-value="itemIndex + 1"/>
                 </t>
             </t>
+        </xpath>
+        <xpath expr="//*[@name='threads']" position="after">
+            <button t-ref="load-more" class="o-mail-MessagingMenu-loadMore btn btn-link opacity-0"
+                t-att-class="{ 'd-none': !(store.inbox.loadOlder or store.history.loadOlder) or store.discuss.activeTab !== 'inbox' or !!store.discuss.searchTerm or hasInboxTabLoadingFailed }"
+                t-on-click="loadMoreInboxTabData">Load More</button>
+            <t t-if="hasInboxTabLoadingFailed and store.discuss.activeTab === 'inbox' and !store.discuss.searchTerm" t-call="mail.MessagingMenu.loadingError"/>
+        </xpath>
+    </t>
+    <t t-name="mail.MessagingMenu.loadingError" t-inherit="mail.Thread.loadingError" t-inherit-mode="primary">
+        <xpath expr="//button" position="attributes">
+            <attribute name="t-on-click">loadMoreInboxTabData</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -301,10 +301,9 @@ export class ResPartner extends webModels.ResPartner {
                     }); // mock server simplification
                 }
                 if (partner.main_user_id && fields.includes("notification_type")) {
-                    store._add_record_fields(
-                        ResUsers.browse(partner.main_user_id),
-                        makeKwArgs({ fields: ["notification_type"] })
-                    );
+                    store._add_record_fields(ResUsers.browse(partner.main_user_id), [
+                        "notification_type",
+                    ]);
                 }
             }
             if (Object.keys(data).length) {


### PR DESCRIPTION
**Current behavior before PR:**
The messaging menu does not include a tab to view notifications that have already been read. Once read, these notifications disappear from the interface and are only accessible through the Discuss App.

**Desired behavior after PR is merged:**
A new Inbox tab is added to the messaging menu. This tab displays both unread and read notifications, provided the user’s notification preference is set to “Handle in Odoo.” The Inbox tab uses lazy loading to fetch messages in batches as the user scrolls.

task-[4458377](https://www.odoo.com/odoo/project/1519/tasks/4458377)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
