### PR TITLE
[FIX] account: avoid translated terms in log errors

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1209,13 +1209,18 @@ class AccountChartTemplate(models.AbstractModel):
                     mapped_tag = tags.get(format_tag)
                     if not mapped_tag:
                         country = self.env['res.country'].browse(country_id)
-                        message = self.env._(
-                            'Error while loading the localization: missing tax tag %(tag_name)s for country %(country_name)s. You should probably update your localization app first.',
-                            tag_name=format_tag, country_name=country.name)
                         if not self._context.get('ignore_missing_tags'):
-                            raise UserError(message)
+                            raise UserError(self.env._(
+                                'Error while loading the localization: missing tax tag %(tag_name)s for country %(country_name)s.'
+                                ' You should probably update your localization app first.',
+                                tag_name=format_tag, country_name=country.name
+                            ))
                         else:
-                            _logger.error(message)
+                            _logger.error(
+                                'Error while loading the localization: missing tax tag %s for country %s.'
+                                ' You should probably update your localization app first.',
+                                format_tag, country.name
+                            )
                             continue
                     res.append(mapped_tag)
             return res


### PR DESCRIPTION
Currently, error messages in logs are translated, which can make it difficult to
debug issues — especially in multi-language environments or when analyzing logs programmatically.

This commit ensures logs use the original, untranslated message templates for
clarity and consistency, while keeping translations for user-facing errors.

sentry-6763108230

