### PR TITLE
[IMP] orm: add 'week_start' support to dates DSL

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -214,13 +214,13 @@
                 </xpath>
                 <filter name="month" position="inside">
                     <filter name="date_this_week" string="This Week" domain="[
-                        ('date', '&gt;=', '=monday'),
-                        ('date', '&lt;', '=monday +1w'),
+                        ('date', '&gt;=', '=week_start'),
+                        ('date', '&lt;', '=week_start +1w'),
                     ]"/>
                     <filter name="date_today" string="Today" domain="[('date', '&gt;=', 'today'), ('date', '&lt;', 'today +1d')]"/>
                     <filter name="date_last_week" string="Last Week" domain="[
-                        ('date', '&gt;=', '=monday -1w'),
-                        ('date', '&lt;', '=monday'),
+                        ('date', '&gt;=', '=week_start -1w'),
+                        ('date', '&lt;', '=week_start'),
                     ]"/>
                 </filter>
                 <xpath expr="//group[@name='groupby']" position="before">

--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
@@ -12,13 +12,13 @@
                     <separator/>
                     <filter name="month" string="Date" date="date">
                         <filter name="date_this_week" string="This Week" domain="[
-                            ('date', '&gt;=', '=monday'),
-                            ('date', '&lt;', '=monday +1w'),
+                            ('date', '&gt;=', '=week_start'),
+                            ('date', '&lt;', '=week_start +1w'),
                         ]"/>
                         <filter name="date_today" string="Today" domain="[('date', '&gt;=', 'today'), ('date', '&lt;', 'today +1d')]"/>
                         <filter name="date_last_week" string="Last Week" domain="[
-                            ('date', '&gt;=', '=monday -1w'),
-                            ('date', '&lt;', '=monday'),
+                            ('date', '&gt;=', '=week_start -1w'),
+                            ('date', '&lt;', '=week_start'),
                         ]"/>
                     </filter>
                     <filter name="group_by_user" string="Employee" context="{'group_by': 'employee_id'}"/>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -249,8 +249,8 @@
                 <filter string="This week" name="filter_date_deadline_week"
                         help="Show all records whose next action date is this week"
                         domain="[
-                            ('date_deadline', '&gt;=', '=monday'),
-                            ('date_deadline', '&lt;', '=monday +1w')
+                            ('date_deadline', '&gt;=', '=week_start'),
+                            ('date_deadline', '&lt;', '=week_start +1w')
                         ]"/>
                 <filter string="Future" name="filter_date_deadline_future"
                         domain="[('date_deadline', '&gt;', 'today')

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -293,8 +293,8 @@
                 <filter string="Deadline" name="date_deadline" date="date_deadline">
                     <filter name="deadline_future" string="Future" domain="[('date_deadline', '&gt;=', 'today +1d')]"/>
                     <filter name="deadline_this_week" string="This Week" domain="[
-                        ('date_deadline', '&gt;=', '=monday'),
-                        ('date_deadline', '&lt;', '=monday +1w'),
+                        ('date_deadline', '&gt;=', '=week_start'),
+                        ('date_deadline', '&lt;', '=week_start +1w'),
                     ]"/>
                     <filter name="deadline_today" string="Today" domain="[
                         ('date_deadline', '&gt;=', 'today'),

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -83,8 +83,8 @@
                     <filter string="Deadline" name="date_deadline" date="date_deadline">
                         <filter name="deadline_future" string="Future" domain="[('date_deadline', '&gt;=', 'today +1d')]"/>
                         <filter name="deadline_this_week" string="This Week" domain="[
-                            ('date_deadline', '&gt;=', '=monday'),
-                            ('date_deadline', '&lt;', '=monday +1w'),
+                            ('date_deadline', '&gt;=', '=week_start'),
+                            ('date_deadline', '&lt;', '=week_start +1w'),
                         ]"/>
                         <filter name="deadline_today" string="Today" domain="[
                             ('date_deadline', '&gt;=', 'today'),

--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -87,13 +87,13 @@ const smartDateUnits = {
     S: "seconds",
 };
 const smartWeekdays = {
-    monday: 0,
-    tuesday: 1,
-    wednesday: 2,
-    thursday: 3,
-    friday: 4,
-    saturday: 5,
-    sunday: 6,
+    monday: 1,
+    tuesday: 2,
+    wednesday: 3,
+    thursday: 4,
+    friday: 5,
+    saturday: 6,
+    sunday: 7,
 };
 
 /** @type {WeakMap<DateTime, string>} */
@@ -269,6 +269,7 @@ function isValidDate(date) {
  *   "+3M" will return now + 3 minutes
  *   "+3S" will return now + 3 seconds
  *   "today -1d" will return yesterday at midnight
+ *   "=week_start" will return the first day of the current week at midnight, according to the locale
  *
  * Difference with python version: a simple "+1" means "+1d" for the first term,
  * the unit is optional and defaults to "d".
@@ -300,9 +301,13 @@ function parseSmartDateInput(value) {
         }
 
         // Weekday
-        const weekdayNumber = smartWeekdays[term.slice(1)];
-        if (weekdayNumber != undefined) {
-            let weekdayOffset = weekdayNumber - now.weekday;
+        const dayname = term.slice(1);
+        if (Object.hasOwn(smartWeekdays, dayname) || dayname === "week_start") {
+            const { weekStart } = localization;
+            const weekdayNumber =
+                dayname === "week_start" ? weekStart : smartWeekdays[dayname];
+            let weekdayOffset =
+                ((weekdayNumber - weekStart + 7) % 7) - ((now.weekday - weekStart + 7) % 7);
             if (operator == "+" || operator == "-") {
                 if (weekdayOffset > 0 && operator == "-") {
                     weekdayOffset -= 7;

--- a/addons/web/static/tests/core/l10n/dates.test.js
+++ b/addons/web/static/tests/core/l10n/dates.test.js
@@ -228,6 +228,11 @@ test("parseDateTime with escaped characters (eg. Basque locale)", async () => {
 });
 
 test("parse smart date input", async () => {
+    patchWithCleanup(localization, {
+        dateFormat: "MM/dd/yyyy",
+        dateTimeFormat: "MM/dd/yyyy HH:mm:ss",
+        weekStart: 1, // Monday
+    });
     mockDate("2020-01-01 00:00:00", 0);
 
     const format = "yyyy-MM-dd HH:mm";
@@ -270,13 +275,30 @@ test("parse smart date input", async () => {
     expect(parseDateTime("today").toFormat(format)).toBe("2020-01-01 00:00");
     expect(parseDateTime("today +1w").toFormat(format)).toBe("2020-01-08 00:00");
 
-    expect(parseDateTime("=monday").toFormat(format)).toBe("2019-12-29 00:00");
-    expect(parseDateTime("=sunday").toFormat(format)).toBe("2020-01-04 00:00");
-    expect(parseDateTime("+monday").toFormat(format)).toBe("2020-01-05 00:01");
+    expect(parseDateTime("=monday").toFormat(format)).toBe("2019-12-30 00:00");
+    expect(parseDateTime("=sunday").toFormat(format)).toBe("2020-01-05 00:00");
+    expect(parseDateTime("+monday").toFormat(format)).toBe("2020-01-06 00:01");
 
     // reset after setting the day
     expect(parseDateTime("=3H =11d").toFormat(format)).toBe("2020-01-11 00:00");
-    expect(parseDateTime("=3H =sunday").toFormat(format)).toBe("2020-01-04 00:00");
+    expect(parseDateTime("=3H =sunday").toFormat(format)).toBe("2020-01-05 00:00");
+
+    expect(parseDateTime("=week_start").toFormat(format)).toBe("2019-12-30 00:00");
+    expect(parseDateTime("-week_start").toFormat(format)).toBe("2019-12-30 00:01");
+    expect(parseDateTime("+week_start").toFormat(format)).toBe("2020-01-06 00:01");
+
+    patchWithCleanup(localization, { weekStart: 7 }); // Sunday
+    expect(parseDateTime("=week_start").toFormat(format)).toBe("2019-12-29 00:00");
+    expect(parseDateTime("-week_start").toFormat(format)).toBe("2019-12-29 00:01");
+    expect(parseDateTime("+week_start").toFormat(format)).toBe("2020-01-05 00:01");
+    expect(parseDateTime("=sunday").toFormat(format)).toBe("2019-12-29 00:00");
+
+    patchWithCleanup(localization, { weekStart: 3 }); // Wednesday
+    expect(parseDateTime("=week_start").toFormat(format)).toBe("2020-01-01 00:00");
+    expect(parseDateTime("-week_start").toFormat(format)).toBe("2020-01-01 00:01");
+    expect(parseDateTime("+week_start").toFormat(format)).toBe("2020-01-01 00:01");
+    expect(parseDateTime("=tuesday").toFormat(format)).toBe("2020-01-07 00:00");
+    expect(parseDateTime("=wednesday").toFormat(format)).toBe("2020-01-01 00:00");
 });
 
 test("parseDateTime ISO8601 Format", async () => {

--- a/addons/web/static/tests/mock_server/mock_server.test.js
+++ b/addons/web/static/tests/mock_server/mock_server.test.js
@@ -5,7 +5,9 @@ import {
     makeMockServer,
     models,
     onRpc,
+    patchWithCleanup,
 } from "@web/../tests/web_test_helpers";
+import { localization } from "@web/core/l10n/localization";
 
 class Partner extends models.Model {
     _name = "res.partner";
@@ -392,6 +394,11 @@ test("performRPC: formatted_read_group, group by boolean", async () => {
 });
 
 test("performRPC: formatted_read_group, group by date", async () => {
+    patchWithCleanup(localization, {
+        dateFormat: "MM/dd/yyyy",
+        dateTimeFormat: "MM/dd/yyyy HH:mm:ss",
+        weekStart: 1,
+    });
     await makeMockServer();
     let result = await ormRequest({
         model: "bar",
@@ -624,6 +631,11 @@ test("performRPC: formatted_read_group, group by date with number granularity", 
 });
 
 test("performRPC: formatted_read_group, group by datetime", async () => {
+    patchWithCleanup(localization, {
+        dateFormat: "MM/dd/yyyy",
+        dateTimeFormat: "MM/dd/yyyy HH:mm:ss",
+        weekStart: 1,
+    });
     await makeMockServer();
 
     let result = await ormRequest({
@@ -1365,6 +1377,11 @@ test("performRPC: read_progress_bar grouped by boolean", async () => {
 });
 
 test("performRPC: read_progress_bar grouped by datetime", async () => {
+    patchWithCleanup(localization, {
+        dateFormat: "MM/dd/yyyy",
+        dateTimeFormat: "MM/dd/yyyy HH:mm:ss",
+        weekStart: 1,
+    });
     await makeMockServer();
 
     await expect(

--- a/odoo/addons/base/tests/test_date_utils.py
+++ b/odoo/addons/base/tests/test_date_utils.py
@@ -171,6 +171,7 @@ class TestDateUtils(TransactionCase):
 
     @freeze_time('2024-01-05 13:05:00')
     def test_parse_date_relative_utc(self):
+        self.env["res.lang"]._lang_get(self.env.user.lang).week_start = "1"
         env = self.env(context={'tz': 'UTC'})
         parse = partial(parse_date, env=env)
 
@@ -203,6 +204,26 @@ class TestDateUtils(TransactionCase):
         # next Sunday, previous Sunday
         self.assertEqual(parse('+sunday'), datetime(2024, 1, 7, 13, 5))
         self.assertEqual(parse('-sunday'), datetime(2023, 12, 31, 13, 5))
+
+        # week_start = 1 (Monday)
+        self.assertEqual(parse('=week_start'), datetime(2024, 1, 1))
+        self.assertEqual(parse('+week_start'), datetime(2024, 1, 8, 13, 5))
+        self.assertEqual(parse('-week_start'), datetime(2024, 1, 1, 13, 5))
+
+        # week_start = 6 (Saturday)
+        self.env["res.lang"]._lang_get(self.env.user.lang).week_start = "6"
+        self.assertEqual(parse('=week_start'), datetime(2023, 12, 30))
+        self.assertEqual(parse('+week_start'), datetime(2024, 1, 6, 13, 5))
+        self.assertEqual(parse('-week_start'), datetime(2023, 12, 30, 13, 5))
+        self.assertEqual(parse('=sunday'), datetime(2023, 12, 31))
+
+        # week_start = 5 (Friday)
+        self.env["res.lang"]._lang_get(self.env.user.lang).week_start = "5"
+        self.assertEqual(parse('=week_start'), datetime(2024, 1, 5))
+        self.assertEqual(parse('+week_start'), datetime(2024, 1, 5, 13, 5))
+        self.assertEqual(parse('-week_start'), datetime(2024, 1, 5, 13, 5))
+        self.assertEqual(parse('=thursday'), datetime(2024, 1, 11))
+        self.assertEqual(parse('=friday'), datetime(2024, 1, 5))
 
     @freeze_time('2024-01-05 13:05:00')
     def test_parse_date_relative_tz(self):


### PR DESCRIPTION
This PR introduces the "week_start" keyword in the dates DSL, to represent the first day of the week according to the current user's locale.
This enables building week-based domains (e.g.: "This Week") that adapt to the user's settings.
