### PR TITLE
[FIX] html_editor: allow deletion of empty nested div elements

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -136,6 +136,7 @@ export class Builder extends Component {
                 allowTargetBlank: true,
                 dropImageAsAttachment: true,
                 getAnimateTextConfig: () => ({ editor: this.editor, editorBus: this.editorBus }),
+                cleanEmptyStructuralContainers: false,
             },
             this.env.services
         );

--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -1,5 +1,9 @@
 import {
     containsAnyNonPhrasingContent,
+    getDeepestPosition,
+    isContentEditable,
+    isElement,
+    isEmpty,
     isMediaElement,
     isProtected,
     isProtecting,
@@ -14,10 +18,12 @@ import {
 } from "../utils/base_container";
 import { withSequence } from "@html_editor/utils/resource";
 import { selectElements } from "@html_editor/utils/dom_traversal";
+import { childNodeIndex } from "@html_editor/utils/position";
 
 export class BaseContainerPlugin extends Plugin {
     static id = "baseContainer";
     static shared = ["createBaseContainer", "getDefaultNodeName", "isCandidateForBaseContainer"];
+    static dependencies = ["selection"];
     /**
      * Register one of the predicates for `invalid_for_base_container_predicates`
      * as a property for optimization, see variants of `isCandidateForBaseContainer`.
@@ -37,6 +43,12 @@ export class BaseContainerPlugin extends Plugin {
         // because a `div` may only have the baseContainer identity if it does not
         // already have another incompatible identity given by another plugin.
         normalize_handlers: withSequence(Infinity, this.normalizeDivBaseContainers.bind(this)),
+        delete_handlers: () => {
+            if (this.config.cleanEmptyStructuralContainers === false) {
+                return;
+            }
+            this.cleanEmptyStructuralContainers();
+        },
         unsplittable_node_predicates: (node) => {
             if (node.nodeName !== "DIV") {
                 return false;
@@ -63,6 +75,46 @@ export class BaseContainerPlugin extends Plugin {
 
     getDefaultNodeName() {
         return this.config.baseContainer || "P";
+    }
+
+    cleanEmptyStructuralContainers() {
+        const node = this.document.getSelection().anchorNode;
+
+        if (!isElement(node) || !isEmpty(node)) {
+            return;
+        }
+
+        const closestEditable = (n) =>
+            isContentEditable(n.parentElement) ? closestEditable(n.parentElement) : n;
+
+        const isUnsplittable = this.isUnsplittablePredicate(node);
+        const isCandidateForBase = this.isCandidateForBaseContainerAllowUnsplittable(node);
+
+        if (isUnsplittable || !isCandidateForBase) {
+            return;
+        }
+
+        let anchorNode = node.parentElement;
+        if (
+            anchorNode === closestEditable(node) ||
+            !SUPPORTED_BASE_CONTAINER_NAMES.includes(anchorNode.nodeName) ||
+            this.getResource("unremovable_node_predicates").some((p) => p(anchorNode))
+        ) {
+            return;
+        }
+
+        if (isEmpty(anchorNode)) {
+            fillEmpty(anchorNode);
+        }
+
+        let anchorOffset = childNodeIndex(node);
+        node.remove();
+
+        [anchorNode, anchorOffset] = getDeepestPosition(anchorNode, anchorOffset);
+        this.dependencies.selection.setSelection({
+            anchorNode,
+            anchorOffset,
+        });
     }
 
     /**

--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -345,6 +345,11 @@ export const htmlField = {
         if ("baseContainer" in options) {
             editorConfig.baseContainer = options.baseContainer;
         }
+        if ("cleanEmptyStructuralContainers" in options) {
+            editorConfig.cleanEmptyStructuralContainers = Boolean(
+                options.cleanEmptyStructuralContainers
+            );
+        }
         return {
             editorConfig,
             isCollaborative: options.collaborative,

--- a/addons/html_editor/static/tests/delete/fix_base_container.test.js
+++ b/addons/html_editor/static/tests/delete/fix_base_container.test.js
@@ -1,0 +1,264 @@
+import { describe, test } from "@odoo/hoot";
+import { testEditor } from "../_helpers/editor";
+import { unformat } from "../_helpers/format";
+import { deleteBackward } from "../_helpers/user_actions";
+
+describe("Adjust base container on delete", () => {
+    test("should remove empty o-paragraph block", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div>
+                    <div class="o-paragraph">[]<br></div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
+            `),
+        });
+    });
+
+    test("should not remove empty o-paragraph block", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div>
+                    <div class="o-paragraph">[]<br></div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div>
+                    <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
+                </div>
+            `),
+            config: { cleanEmptyStructuralContainers: false },
+        });
+    });
+
+    test("should remove empty o-paragraph block after text", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div>
+                    abc<div class="o-paragraph">[]<br></div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div class="o-paragraph">abc[]</div>
+            `),
+        });
+    });
+
+    test("should remove div with selected text", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div>
+                    <div>[abc]</div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
+            `),
+        });
+    });
+
+    test("should remove empty nested paragraph", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div>
+                    <div>
+                        <p>[]<br></p>
+                    </div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div><div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div></div>
+            `),
+        });
+    });
+
+    test("should not remove standalone paragraph", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <p>[]<br></p>
+            `),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
+            `),
+        });
+    });
+
+    test("should not remove unremovable div with selected text", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                 <div class="oe_unremovable">
+                    [abc]
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div class="oe_unremovable">[]<br></div>
+            `),
+        });
+    });
+
+    test("should keep paragraph inside unremovable div", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div class="oe_unremovable">
+                    <p>[abc]</p>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div class="oe_unremovable">
+                    <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
+                </div>
+            `),
+        });
+    });
+
+    test("should keep block inside non-editable parent", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div contenteditable="false">
+                    <div contenteditable="true">[abc]</div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            // The P is added by the deletion, not by `cleanEmptyStructuralContainers`.
+            contentAfterEdit: unformat(`
+                <div contenteditable="false">
+                    <div contenteditable="true">
+                        <p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>
+                    </div>
+                </div>
+            `),
+        });
+    });
+
+    test("should keep o-paragraph inside non-editable parent", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div contenteditable="false">
+                    <div contenteditable="true">
+                        <div class="o-paragraph">[]<br></div>
+                    </div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div contenteditable="false">
+                    <div contenteditable="true">
+                        <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
+                    </div>
+                </div>
+            `),
+        });
+    });
+
+    test("should remove nested o-paragraph with inner paragraph", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div>
+                    <div class="o-paragraph">
+                        <p class="inner-paragraph">[]<br></p>
+                    </div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div>
+                    <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]</div>
+                </div>
+            `),
+        });
+    });
+
+    test("should remove first of multiple consecutive empty blocks", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div>
+                    <div>[]<br></div>
+                    <div><br></div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div>
+                    <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
+                </div>
+            `),
+        });
+    });
+
+    test("should not remove block with cursor at beginning of content", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div>
+                    <div>[]text</div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div>
+                    <div class="o-paragraph">[]text</div>
+                </div>
+            `),
+        });
+    });
+
+    test("should merge blocks when range spans multiple o-paragraphs", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div>
+                    <div class="o-paragraph">[abc</div>
+                    <div class="o-paragraph">def]</div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
+            `),
+        });
+    });
+
+    test("should remove o-paragraph inside nested non-editable structure", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <div contenteditable="false">
+                    <div contenteditable="true">
+                        <div class="o-paragraph">[]<br></div>
+                    </div>
+                </div>`),
+            stepFunction: async (editor) => {
+                deleteBackward(editor);
+            },
+            contentAfterEdit: unformat(`
+                <div contenteditable="false">
+                    <div contenteditable="true">
+                        <div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>
+                    </div>
+                </div>
+            `),
+        });
+    });
+});


### PR DESCRIPTION
Problem:
In some cases, content with nested `div` elements is added to the
editor. These `div`s can break certain editor features and cannot be
deleted through the UI.

Solution:
Add support to remove empty `div` elements when clearing content.

Steps to reproduce:
- Add `<div><div>abc</div></div>` to the editor
- Focus inside and remove all content
- The `div` elements remain and are not removed

opw-4805901

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
