### PR TITLE
[FIX] tools: fix time_to_float method

### DIFF
--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -43,8 +43,8 @@ def time_to_float(duration: time | timedelta) -> float:
         return duration.total_seconds() / 3600
     if duration == time.max:
         return 24.0
-    seconds = time.microsecond / 1_000_000 + time.second + time.minute * 60
-    return seconds / 3600 + time.hour
+    seconds = duration.microsecond / 1_000_000 + duration.second + duration.minute * 60
+    return seconds / 3600 + duration.hour
 
 
 def localized(dt: datetime) -> datetime:


### PR DESCRIPTION
'time_to_float' method in the date utils is using 'time' to make
its computation but 'time' is actually the type of the parameter (datetime.time).
Using the actual duration parameter.

related PR: odoo/odoo#207882

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
