### PR TITLE
[FIX] website: make timeline dots visible across all color presets

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -855,6 +855,7 @@ table.table_desc tr td {
     width: var(--o-timeline-dot-size, 24px);
     height: var(--o-timeline-dot-size, 24px);
     left: var(--o-dot-left);
+    color: $primary;
 
     &:before, &:after {
         position: absolute;
@@ -870,6 +871,12 @@ table.table_desc tr td {
 
     &:after {
         inset: 8px;
+    }
+}
+
+@for $index from 1 through 5 {
+    .o_cc#{$index} .o_dot {
+        color: var(--o-cc#{$index}-btn-primary);
     }
 }
 

--- a/addons/website/views/snippets/s_timeline.xml
+++ b/addons/website/views/snippets/s_timeline.xml
@@ -10,7 +10,7 @@
             <div class="position-relative pt-3">
                 <div class="s_timeline_row position-relative d-flex gap-md-5 flex-column flex-md-row pb-4" data-name="Milestone">
                     <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                     <div class="s_timeline_content w-100 ps-4 ps-md-0">
                         <div class="s_timeline_card s_card card my-0 ms-auto text-md-end" style="border-width: 0px !important;" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
                             <div class="card-body">
@@ -24,7 +24,7 @@
                 </div>
                 <div class="s_timeline_row position-relative d-flex gap-md-5 flex-column flex-md-row pb-4" data-name="Milestone">
                     <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                     <div class="s_timeline_content w-100 ps-4 ps-md-0">
                         <div class="s_timeline_card s_card card my-0 me-auto text-md-end" style="border-width: 0px !important;" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">
                             <div class="card-body">
@@ -46,7 +46,7 @@
                 </div>
                 <div class="s_timeline_row position-relative d-flex flex-column flex-md-row gap-md-5 pb-4" data-name="Milestone">
                     <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                     <div class="s_timeline_content w-0 w-md-100 h-0"/>
                     <div class="s_timeline_content w-100 ps-4 ps-md-0">
                         <div class="s_timeline_card s_card card my-0 ms-auto" style="border-width: 0px !important;" data-vxml="001" data-snippet="s_card" data-name="Milestone Event">

--- a/addons/website/views/snippets/s_timeline_images.xml
+++ b/addons/website/views/snippets/s_timeline_images.xml
@@ -9,7 +9,7 @@
             <div class="position-relative pt-3">
                 <div class="s_timeline_images_row position-relative d-flex flex-column" data-name="Milestone">
                     <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                     <div class="s_timeline_images_content w-100 ps-4">
                         <div class="row">
                             <div class="col-12 col-lg-4 pb16">
@@ -27,7 +27,7 @@
                 </div>
                 <div class="s_timeline_images_row position-relative d-flex flex-column" data-name="Milestone">
                     <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                    <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                     <div class="s_timeline_images_content w-100 ps-4">
                         <div class="row">
                             <div class="col-12 col-lg-4 pb16">

--- a/addons/website/views/snippets/s_timeline_list.xml
+++ b/addons/website/views/snippets/s_timeline_list.xml
@@ -11,37 +11,37 @@
                 <div>
                     <div class="s_timeline_list_row position-relative pb-4" data-name="Milestone">
                         <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                         <small class="text-muted">Feb 11, 2024</small>
                         <strong>Enhanced User Interface for Better Navigation</strong>
                     </div>
                     <div class="s_timeline_list_row position-relative pb-4" data-name="Milestone">
                         <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                         <small class="text-muted">Apr 03, 2024</small>
                         <strong>New Dashboard Features for Custom Reports</strong>
                     </div>
                     <div class="s_timeline_list_row position-relative pb-4" data-name="Milestone">
                         <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                         <small class="text-muted">Jun 15, 2024</small>
                         <strong>Integrated Multi-Language Support Added</strong>
                     </div>
                     <div class="s_timeline_list_row position-relative pb-4" data-name="Milestone">
                         <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                         <small class="text-muted">Aug 27, 2024</small>
                         <strong>Improved Security Protocols Implemented</strong>
                     </div>
                     <div class="s_timeline_list_row position-relative pb-4" data-name="Milestone">
                         <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                         <small class="text-muted">Oct 09, 2024</small>
                         <strong>Mobile App Compatibility Expanded</strong>
                     </div>
                     <div class="s_timeline_list_row position-relative pb-4" data-name="Milestone">
                         <div class="o_dot_line position-absolute top-0 bottom-0 w-0 mb-1 border-start pe-none"/>
-                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none text-o-color-1" contenteditable="false"/>
+                        <span class="o_dot o_not_editable position-absolute translate-middle-x rounded-circle pe-none" contenteditable="false"/>
                         <small class="text-muted">Dec 22, 2024</small>
                         <strong>Advanced Analytics Tools Introduced</strong>
                     </div>


### PR DESCRIPTION
Before this commit, the timeline (*) dots were invisible when using preset 4 because they shared the same color as the background (`text-o-color-1` on `o-color-1` background).

This fix implements a solution that ensures dots are always visible by using button primary colors for all presets.

*: s_timeline, s_timeline_list snippets

task-4922302

requires: https://github.com/odoo/design-themes/pull/1126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
