### PR TITLE
[FIX] project: allow portal users to read access_token and access_url

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -56,6 +56,8 @@ PROJECT_TASK_READABLE_FIELDS = {
     'display_follow_button',
     'is_template',
     'has_template_ancestor',
+    'access_token',
+    'access_url',
 }
 
 PROJECT_TASK_WRITABLE_FIELDS = {


### PR DESCRIPTION
To reproduce:
=============
- on a project task where a portal user is follower send a message
- the portal user should receive an email with a link to the task on the button "View Task" -> the link is not working

Problem:
========
starting from 18.3, a method to check field access was added to the project task model, `access_token` and `access_url` were not in set of readable fields for portal users, so the link was not working.

Solution:
=========
add `access_token` and `access_url` to the set of readable fields for portal users.

opw-4939913
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
