### PR TITLE
[IMP] iot_drivers: colors in logs

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo.service
+++ b/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo.service
@@ -10,6 +10,7 @@ Group=odoo
 Environment="LIBCAMERA_LOG_LEVELS=3"
 Environment="XDG_RUNTIME_DIR=/run/odoo"
 Environment="XDG_CACHE_HOME=/run/odoo"
+Environment="ODOO_PY_COLORS=True"
 ExecStartPre=sudo /bin/mkdir -p /run/odoo
 ExecStartPre=sudo /bin/chown odoo:odoo /run/odoo
 ExecStartPre=sudo timedatectl set-ntp true


### PR DESCRIPTION
We now format logs with colors, same as odoo db's logs.

<img width="925" height="56" alt="image" src="https://github.com/user-attachments/assets/680212a0-6b14-49cf-950d-22e9ee98d156" />