### PR TITLE
[FIX] l10n_in_ewaybill*: fix unused `t-name`

### DIFF
--- a/addons/l10n_in_ewaybill/report/ewaybill_report.xml
+++ b/addons/l10n_in_ewaybill/report/ewaybill_report.xml
@@ -23,9 +23,7 @@
                                              style="max-width: 8rem; height: auto;" alt="Company Logo"/>
                                     </td>
                                     <td id="ewaybill_header">
-                                        <t t-name="ewaybill_header">
-                                            <h4 style="margin-top: 1rem;">e-Way Bill</h4>
-                                        </t>
+                                        <h4 id="title" style="margin-top: 1rem;">e-Way Bill</h4>
                                     </td>
                                     <td t-if="doc.state in ewaybill_states">
                                         <img t-if="doc.name != False"

--- a/addons/l10n_in_ewaybill_stock/report/ewaybill_report_inherit.xml
+++ b/addons/l10n_in_ewaybill_stock/report/ewaybill_report_inherit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <template id="l10n_in_ewaybill_stock_inherit_report" inherit_id="l10n_in_ewaybill.report_ewaybill">
-        <xpath expr="//t[@t-name='ewaybill_header']" position="replace">
+        <xpath expr="//h4[@id='title']" position="replace">
             <h4 t-if="doc.state not in ewaybill_states and doc.picking_id"
                 style="margin-top: 1rem;">
                 Delivery Challan


### PR DESCRIPTION
When running the single app test on the runbot
nightly build with `l10n_in_ewaybill` and running the the following test `odoo.addons.base.tests.test_reports` it gives the following warning
```py
2025-07-31 23:33:13,259 26 WARNING 85955240-saas-18-2-all odoo.addons.base.models.ir_qweb: Unknown directives or unused attributes: {'t-name'} in l10n_in_ewaybill.report_ewaybill
```

In this commit, we resolve the above runbot issue and the warning is no longer visible

runbot-108326



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
