### PR TITLE
[IMP] hr_work_entry/holiday: Hong Kong entry updates

### DIFF
--- a/addons/account/tests/test_account_all_l10n.py
+++ b/addons/account/tests/test_account_all_l10n.py
@@ -38,7 +38,6 @@ def test_all_l10n(env):
     l10n_mods = env['ir.module.module'].search([
         ('name', '=like', 'l10n_%'),
         ('state', '=', 'uninstalled'),
-        '!', ('name', '=like', 'l10n_hk_hr%'),  #failling for obscure reason
     ])
     with patch.object(AccountChartTemplate, 'try_loading', try_loading_patch),\
             patch.object(TranslationImporter, 'load_file', _load_file):

--- a/addons/hr_holidays/data/hr_leave_type_data.xml
+++ b/addons/hr_holidays/data/hr_leave_type_data.xml
@@ -430,6 +430,13 @@
         <field name="country_id" ref="base.hk"/>
     </record>
 
+    <record id="l10n_hk_leave_type_paternity_leave_80" model="hr.leave.type">
+        <field name="name">HK Paternity Leaves 80%</field>
+        <field name="requires_allocation">False</field>
+        <field name="company_id" eval="False" />
+        <field name="country_id" ref="base.hk"/>
+    </record>
+
     <record id="l10n_hk_leave_type_compassionate_leave" model="hr.leave.type">
         <field name="name">HK Compassionate Leaves</field>
         <field name="requires_allocation">False</field>

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -627,6 +627,7 @@
         <field name="color">6</field>
         <field name="country_id" ref="base.hk"/>
         <field name="is_leave" eval="True"/>
+        <field name="amount_rate">0.8</field>
     </record>
 
     <record id="l10n_hk_work_entry_type_compassionate_leave" model="hr.work.entry.type">
@@ -667,6 +668,7 @@
         <field name="color">6</field>
         <field name="country_id" ref="base.hk"/>
         <field name="is_leave" eval="True"/>
+        <field name="amount_rate">0.8</field>
     </record>
 
     <record id="l10n_hk_work_entry_type_paternity_leave" model="hr.work.entry.type">

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -679,6 +679,15 @@
         <field name="is_leave" eval="True"/>
     </record>
 
+    <record id="l10n_hk_work_entry_type_paternity_leave_80" model="hr.work.entry.type">
+        <field name="name">Paternity Leave 80%</field>
+        <field name="code">HKLEAVE221</field>
+        <field name="color">6</field>
+        <field name="country_id" ref="base.hk"/>
+        <field name="is_leave" eval="True"/>
+        <field name="amount_rate">0.8</field>
+    </record>
+
     <record id="l10n_hk_work_entry_type_statutory_holiday" model="hr.work.entry.type">
         <field name="name">Statutory Holiday</field>
         <field name="code">HKLEAVE500</field>

--- a/addons/hr_work_entry_holidays/data/hr_leave_type_data.xml
+++ b/addons/hr_work_entry_holidays/data/hr_leave_type_data.xml
@@ -152,6 +152,10 @@
         <field name="work_entry_type_id" ref="hr_work_entry.l10n_hk_work_entry_type_paternity_leave"/>
     </record>
 
+    <record id="hr_holidays.l10n_hk_leave_type_paternity_leave_80" model="hr.leave.type">
+        <field name="work_entry_type_id" ref="hr_work_entry.l10n_hk_work_entry_type_paternity_leave_80"/>
+    </record>
+
     <record id="hr_holidays.l10n_hk_leave_type_compassionate_leave" model="hr.leave.type">
         <field name="work_entry_type_id" ref="hr_work_entry.l10n_hk_work_entry_type_compassionate_leave"/>
     </record>


### PR DESCRIPTION
To better cover the Hong Kong payroll needs, we add an 80% paid paternity leave.
We also remove the l10n_hk_non_full_pay field, which can be easily replaced by the new amount_rate field.

task-5004835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
