### PR TITLE
[FIX] website: ecommerce install with events page

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -446,7 +446,7 @@
         <field name="description">Publish on-site and online events</field>
         <field name="sequence">10</field>
         <field name="website_config_preselection">event</field>
-        <field name="module_id" ref="base.module_website_event_sale"/>
+        <field name="module_id" ref="base.module_website_event"/>
         <field name="icon">fa-ticket</field>
         <field name="menu_sequence">20</field>
         <field name="feature_url">/event</field>


### PR DESCRIPTION
Steps to reproduce:
- Fresh master
- Install website
- Follow the configurator flow
- Check "Events" only when in the features screen
- See that shop was installed

Issue:
- This is annoying if you're not planning on selling online, as your
  website now includes a "Shop" page.
- Unless you voluntarily install eCommerce, it shouldn't be added to
  your DB.

After this commit:
- Events configurator will no longer install eCommerce and add `shop`,
  unless you manually do.

task-4922600