### PR TITLE
[FIX] mrp: compute date_finished with production quantity factor

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -736,6 +736,8 @@ class MrpProduction(models.Model):
             if not production.date_start or production.is_planned or production.state == 'done':
                 continue
             days_delay = production.bom_id.produce_delay
+            factor = production.bom_id.product_qty and production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id, raise_if_failure=False) / production.bom_id.product_qty or 1
+            days_delay = factor * days_delay
             date_finished = production.date_start + relativedelta(days=days_delay)
             if production._should_postpone_date_finished(date_finished):
                 workorder_expected_duration = sum(production.workorder_ids.mapped('duration_expected'))


### PR DESCRIPTION
The date_finished calculation in manufacturing orders was not considering
the ratio between production quantity and BOM quantity, leading to incorrect finish dates when producing quantities different from the standard BOM quantity.

Previously, the system only used the BOM's produce_delay without accounting for the actual production quantity. This caused issues when:
- Producing 4 tables (BOM: 1 table) - finish date was too early
- Producing 0.5 tables (BOM: 1 table) - finish date was too late
- Using different UoMs between production and BOM

The fix introduces a factor calculation:
factor = production_qty / bom_qty
final_delay = factor * bom_produce_delay

This ensures that the finish date accurately reflects the actual production time based on the quantity being produced relative to the standard BOM quantity.

The change maintains backward compatibility and only affects the date_finished computation when a BOM is present and the production quantity differs from the BOM quantity.


https://github.com/user-attachments/assets/1c63a3ad-8859-4cd6-8605-812165ebbda1




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
