### PR TITLE
[FIX] website: restore navbar font class in submenu

### DIFF
--- a/addons/website/static/src/js/content/auto_hide_menu.js
+++ b/addons/website/static/src/js/content/auto_hide_menu.js
@@ -37,6 +37,7 @@ async function autoHideMenu(el, options) {
     }, options || {});
 
     const isUserNavbar = el.parentElement.classList.contains('o_main_navbar');
+    const isNavbar = el.parentElement.classList.contains('o_main_nav');
     const dropdownSubMenuClasses = ['show', 'border-0', 'position-static'];
     const dropdownToggleClasses = ['h-auto', 'py-2', 'text-secondary'];
     const autoMarginLeftRegex = /\bm[sx]?(?:-(?:sm|md|lg|xl|xxl))?-auto\b/; // grep: ms-auto mx-auto
@@ -92,7 +93,9 @@ async function autoHideMenu(el, options) {
                 const itemLink = item.querySelector('.dropdown-item');
                 if (itemLink) {
                     itemLink.classList.remove('dropdown-item');
-                    itemLink.classList.add('nav-link');
+                    if( !isNavbar ){
+                        itemLink.classList.add('nav-link');
+                    }
                 }
             } else {
                 item.classList.remove('dropdown-item');
@@ -174,7 +177,9 @@ async function autoHideMenu(el, options) {
                 const navLink = el.querySelector('.nav-link, a');
                 el.classList.remove('nav-item');
                 if (navLink) {
-                    navLink.classList.remove('nav-link');
+                    if( !isNavbar ){
+                        navLink.classList.remove('nav-link');
+                    }
                     navLink.classList.add('dropdown-item');
                 }
             } else {
@@ -296,6 +301,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
             });
             return img.matches && !img.matches(excludedImagesSelector);
+        });
+        // All menu items should be "nav-link" to allow correct font style.
+        header.querySelectorAll('[role="menuitem"]').forEach((el) => {
+            el.classList.add("nav-link")
         });
         autoHideMenu(topMenu, {
             unfoldable: unfoldable,


### PR DESCRIPTION
To reproduce:
=============
1- Go to website
2- Add a submenu to any menu item.
3- Choose a font for the navbar.
4- Change paragraph font.
→ Observe that the added submenu in the navbar also changes its font.

Problem:
=========
When creating submenu the class nav-link which contains the navbar font was removed by theses lines:
https://github.com/odoo/odoo/blob/6f5682b1cab3c2e043e1f1d4316093bab2752521/addons/website/static/src/js/content/auto_hide_menu.js#L173-L179
cause this one was false
https://github.com/odoo/odoo/blob/6f5682b1cab3c2e043e1f1d4316093bab2752521/addons/website/static/src/js/content/auto_hide_menu.js#L39-L39
but in the default template the navbar has another class name https://github.com/odoo/odoo/blob/6f5682b1cab3c2e043e1f1d4316093bab2752521/addons/website/views/website_templates.xml#L498-L498

Undesired Behavior:
===================
When you set a navbar font, the navbar and submenu both initially use it.
But if you change the paragraph font afterward,
the submenu text incorrectly switches to the paragraph font,
while the navbar still uses the correct navbar font.

Desired Behavior:
==================
Once a navbar font is set, it should be consistently applied to both the
navbar and submenu text, regardless of changes to the paragraph
font afterward.

Solution:
=========
If we are in the navbar we will keep the nav-link class.

Link for bug: https://drive.google.com/file/d/1OyWUUEvvtHw5MKITew5F_KOP_m6zgi9B/view

opw-4943240
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
