### PR TITLE
[IMP] mail: more responsive Discuss search

### DIFF
--- a/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_command_palette_patch.js
@@ -13,6 +13,12 @@ commandCategoryRegistry
     .add(DISCUSS_RECENT, { namespace: "@", name: _t("Recent") }, { sequence: 20 });
 
 patch(DiscussCommandPalette.prototype, {
+    async fetch() {
+        await this.store.channels.fetch();
+        if (this.cleanedTerm) {
+            await this.store.searchConversations(this.cleanedTerm);
+        }
+    },
     buildResults() {
         const importantChannels = this.store.getSelfImportantChannels();
         const recentChannels = this.store.getSelfRecentChannels();

--- a/addons/mail/static/tests/discuss/core/web/command_palette.test.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette.test.js
@@ -120,17 +120,15 @@ test("only partners with dedicated users will be displayed in command palette", 
     const pyEnv = await startServer();
     const demoUid = pyEnv["res.users"].create({ name: "Demo" });
     pyEnv["res.partner"].create({ name: "Demo", user_ids: [demoUid] });
-    pyEnv["res.partner"].create({ name: "Portal" });
+    pyEnv["res.partner"].create({ name: "Demo (Portal)" });
     await start();
     triggerHotkey("control+k");
-    await insertText(".o_command_palette_search input", "@");
-    await contains(".o_command_name", { count: 5 });
+    await insertText(".o_command_palette_search input", "@demo");
+    await contains(".o_command_name", { count: 3 });
     await contains(".o_command_name", { text: "Demo" });
-    await contains(".o_command_name", { text: "OdooBot" });
-    await contains(".o_command_name", { text: "Mitchell Admin" }); // self-conversation
     await contains(".o_command_name", { text: "Create Channel" });
     await contains(".o_command_name", { text: "Create Chat" });
-    await contains(".o_command_name", { text: "Portal", count: 0 });
+    await contains(".o_command_name", { text: "Demo (Portal)", count: 0 });
 });
 
 test("hide conversations in recent if they have mentions", async () => {

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -49,7 +49,7 @@ test("can create a new channel", async () => {
     await contains(".o-mail-DiscussSidebar-item", { text: "abc", count: 0 });
     await click("input[placeholder='Find or start a conversation']");
     await insertText("input[placeholder='Search a conversation']", "abc");
-    await waitForSteps([`/discuss/search - {"term":""}`, `/discuss/search - {"term":"abc"}`]);
+    await waitForSteps([`/discuss/search - {"term":"abc"}`]);
     await click("a", { text: "Create Channel" });
     await contains(".o-mail-DiscussSidebar-item", { text: "abc" });
     await contains(".o-mail-Message", { count: 0 });
@@ -117,7 +117,7 @@ test("can make a DM chat", async () => {
                 fetch_params: { limit: 60, around: 0 },
             })}`,
         ],
-        stepsBefore: [`/discuss/search - {"term":""}`, `/discuss/search - {"term":"mario"}`],
+        stepsBefore: [`/discuss/search - {"term":"mario"}`],
     });
 });
 


### PR DESCRIPTION
This commit improves the responsiveness of the Discuss search command palette by skipping the search RPC when the search term is empty.

Since the palette triggers a search on open, with the default term being empty, skipping the unnecessary RPC call allows it to appear immediately.

This optimization is safe because when there's no search term (like upon opening), the palette instead displays a list of channels with mentions and recent interactions, which are not dependent on the search term.

task-4526176