### PR TITLE
[FIX] mail: no overlap on chat bubble im status and counter

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -45,7 +45,6 @@ export class ChatBubble extends Component {
             position: "left-middle",
             popoverClass:
                 "dropdown-menu bg-view border-0 p-0 overflow-visible o-rounded-bubble mx-1",
-            onClose: () => (this.state.showClose = false),
             ref: popoverRef,
         });
         this.env.bus.addEventListener("ChatBubble:preview-will-open", ({ detail }) => {
@@ -59,11 +58,10 @@ export class ChatBubble extends Component {
                 this.env.bus.trigger("ChatBubble:preview-will-open", this);
                 this.popover.open(this.rootRef.el, { chatWindow: this.props.chatWindow });
             },
-            onHovering: [100, () => (this.state.showClose = true)],
             onAway: () => this.popover.close(),
         });
         this.rootRef = useRef("root");
-        this.state = useState({ bouncing: false, showClose: true });
+        this.state = useState({ bouncing: false });
         useEffect(
             (importantCounter) => {
                 this.state.bouncing = Boolean(importantCounter);

--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -39,8 +39,8 @@
 }
 
 .o-mail-ChatBubble-close {
-    right: -5px;
-    top: -3px;
+    right: -3px;
+    top: -5px;
     z-index: 6;
     font-size: 11px;
     display: none;

--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -92,8 +92,8 @@
 
 .o-mail-ChatBubble-status {
     z-index: 6;
-    bottom: -2px;
-    right: -3px;
+    bottom: 0px;
+    right: -1px;
     background-color: transparent;
 }
 

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -4,7 +4,7 @@
         <div class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'o-active': popover.isOpen, 'o-mobile': isMobileOS }" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute text-400" t-att-class="{ 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
-            <button t-if="state.showClose and !env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
+            <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="thread?.correspondent?.im_status and thread?.correspondent?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute'" member="thread.correspondent">
                 <t t-set-slot="pre_icon">
                     <i style="font-size: 18px; right: -2px; bottom: -2px; z-index: -1;" t-att-class="{


### PR DESCRIPTION
Before this commit, when a chat bubble has important counter and chat bubble above shows IM status, the counter was overlapping on the IM status.

The problem comes from IM status being positioned too far from avatar, which both doesn't look elegant and lead to the overlap issue.

This commit fixes the issue by moving IM status closer to avatar, fixing the overlap issue but also aligning better the IM status icon with counters.

Before / After
<img width="57" height="201" alt="Screenshot 2025-08-01 at 11 28 22" src="https://github.com/user-attachments/assets/11e5a80a-9eff-4795-b36e-a07e8c06ed55" /> <img width="62" height="208" alt="Screenshot 2025-08-01 at 11 27 47" src="https://github.com/user-attachments/assets/ab43ec9a-6841-439e-8b4a-b35b91b8876c" />

Also better align close button with counter and IM status:

Before / After
<img width="50" height="233" alt="Screenshot 2025-08-01 at 11 42 29" src="https://github.com/user-attachments/assets/caee711a-a844-44d0-a871-f2a6bcaf6575" /> <img width="52" height="236" alt="Screenshot 2025-08-01 at 11 41 38" src="https://github.com/user-attachments/assets/bff4b6f3-565d-4359-b974-3ce21431486b" />
