### PR TITLE
[FIX] account: invoice_outstanding_credits_debits_widget badly computed

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -478,7 +478,7 @@ class AccountMove(models.Model):
     )
     invoice_has_outstanding = fields.Boolean(
         groups="account.group_account_invoice,account.group_account_readonly",
-        compute='_compute_payments_widget_to_reconcile_info',
+        compute='_compute_invoice_has_outstanding',
     )
     invoice_payments_widget = fields.Binary(
         groups="account.group_account_invoice,account.group_account_readonly",
@@ -1341,7 +1341,6 @@ class AccountMove(models.Model):
 
         for move in self:
             move.invoice_outstanding_credits_debits_widget = False
-            move.invoice_has_outstanding = False
 
             if move.state not in {'draft', 'posted'} \
                     or move.payment_state not in ('not_paid', 'partial') \
@@ -1396,7 +1395,11 @@ class AccountMove(models.Model):
 
             if payments_widget_vals['content']:
                 move.invoice_outstanding_credits_debits_widget = payments_widget_vals
-                move.invoice_has_outstanding = True
+
+    @api.depends('invoice_outstanding_credits_debits_widget')
+    def _compute_invoice_has_outstanding(self):
+        for move in self:
+            move.invoice_has_outstanding = bool(move.invoice_outstanding_credits_debits_widget)
 
     @api.depends('partner_id', 'company_id')
     def _compute_preferred_payment_method_line_id(self):


### PR DESCRIPTION
To reproduce:
- Install account_accountant (not reproducible on runbot with all modules installed)
- Create an invoice for partner_a
- Create a credit note for same partner
- Create a statement line for same partner
- Open the invoice

=> Traceback
The issue is that invoice_outstanding_credits_debits_widget is first put to False, then protected. So the real value is not put, while invoice_has_outstanding is changed. So in the override of the compute, it does not contain 'content' (=False), and so fails.

The issue is not easy to solve. Problem of cache protection etc,... The situation does not seem problematic per se. We separate the 2 fields in 2 compute, so invoice_outstanding_credits_debits_widget is not protected by the computation of invoice_has_outstanding




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
