### PR TITLE
[FIX] l10n_vn: reorder QR code validation to avoid KeyError on payments

### DIFF
--- a/addons/l10n_vn/models/res_bank.py
+++ b/addons/l10n_vn/models/res_bank.py
@@ -28,24 +28,27 @@ class ResPartnerBank(models.Model):
         super(ResPartnerBank, self - bank_vn)._compute_display_qr_setting()
 
     def _get_merchant_account_info(self):
-        if self.country_code == 'VN':
-            proxy_type_mapping = {
-                'merchant_id': 'QRPUSH',
-                'payment_service': 'QRPUSH',
-                'atm_card': 'QRIBFTTC',
-                'bank_acc': 'QRIBFTTA',
-            }
-            payment_network = [
-                (0, self.bank_bic),
-                (1, self.proxy_value),
-            ]
-            vals = [
-                (0, 'A000000727'),
-                (1, ''.join([self._serialize(*val) for val in payment_network])),
-                (2, proxy_type_mapping[self.proxy_type]),
-            ]
-            return (38, ''.join([self._serialize(*val) for val in vals]))
-        return super()._get_merchant_account_info()
+
+        proxy_type_mapping = {
+            'merchant_id': 'QRPUSH',
+            'payment_service': 'QRPUSH',
+            'atm_card': 'QRIBFTTC',
+            'bank_acc': 'QRIBFTTA',
+        }
+
+        if self.country_code != 'VN' or self.proxy_type not in proxy_type_mapping:
+            return super()._get_merchant_account_info()
+
+        payment_network = [
+            (0, self.bank_bic),
+            (1, self.proxy_value),
+        ]
+        vals = [
+            (0, 'A000000727'),
+            (1, ''.join([self._serialize(*val) for val in payment_network])),
+            (2, proxy_type_mapping[self.proxy_type]),
+        ]
+        return (38, ''.join([self._serialize(*val) for val in vals]))
 
     def _get_additional_data_field(self, comment):
         if self.country_code == 'VN':
@@ -75,13 +78,13 @@ class ResPartnerBank(models.Model):
         if qr_method != 'emv_qr' or self.country_code != 'VN':
             return super()._check_for_qr_code_errors(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)
 
-        if not self._get_merchant_account_info():
-            return _("Missing Merchant Account Information.")
         if not (self.partner_id.city or self.partner_id.state_id):
             return _("Missing Merchant City or State.")
         if not self.proxy_type:
             return _("Missing Proxy Type.")
-        if not self.proxy_value:
-            return _("Missing Proxy Value.")
         if self.proxy_type not in ['merchant_id', 'payment_service', 'atm_card', 'bank_acc']:
             return _("The proxy type %s is not supported for Vietnamese partners. It must be either Merchant ID, ATM Card Number or Bank Account", self.proxy_type)
+        if not self.proxy_value:
+            return _("Missing Proxy Value.")
+        if not self._get_merchant_account_info():
+            return _("Missing Merchant Account Information.")

--- a/addons/l10n_vn/tests/test_l10n_vn_emv_qr.py
+++ b/addons/l10n_vn/tests/test_l10n_vn_emv_qr.py
@@ -46,6 +46,20 @@ class TestL10nVNEmvQrCode(AccountTestInvoicingCommon):
             'company_id': cls.company_data['company'].id,
             'invoice_line_ids': [Command.create({'quantity': 1, 'price_unit': 100})],
         })
+        cls.partner_with_bank_account_no_proxy = cls.env['res.partner'].create({
+            'name': 'Mr. Triboulet',
+            'company_id': cls.company_data['company'].id,
+            'country_id': cls.env.ref('base.vn').id,
+            'city': 'Vietnam',
+            'bank_ids': [
+                Command.create({
+                    'acc_number': '123456789012345670',
+                    'bank_id': cls.bank_vn.id,
+                    'currency_id': cls.env.ref('base.VND').id,
+                    'allow_out_payment': True
+                })
+            ]
+        })
 
     def test_emv_qr_code_generation(self):
         self.emv_qr_invoice.qr_code_method = 'emv_qr'
@@ -107,3 +121,12 @@ class TestL10nVNEmvQrCode(AccountTestInvoicingCommon):
 
         # Check the whole qr code string
         self.assertEqual(emv_qr_vals, '00020101021238590010A0000007270129000697042201156607040600001290208QRIBFTTA52040000530370454031005802VN5914aAeEoOiIuUyYdD6007Vietnam62150811INVTEST00026304E1C2')
+
+    def test_create_payment_with_no_proxy_in_client(self):
+        new_payment = self.env['account.payment'].create({
+            'partner_id': self.partner_with_bank_account_no_proxy.id,
+            'payment_type': 'outbound'
+        })
+        # The payment must be created but the qr_code will raise a silent error (False value)
+        self.assertTrue(new_payment.exists())
+        self.assertFalse(new_payment.qr_code)


### PR DESCRIPTION
### Issue:
When creating a vendor with a bank account and certain fields configured, trying to register a payment could raise a KeyError: 'none'.

This was due to the incorrect order of validations in _check_for_qr_code_errors, introduced in PR #219566. This commit reorders the checks to ensure proxy_type is validated before being used.

### Affected Versions:
17.0 and later

### To reproduce:
1. Install account_accountant, l10n_vn
2. Select VN Company
3. Go to Accounting > Vendors > Vendors
4. Create a partner with country set to Vietnam
5. In Accounting tab, add a bank account with:
   - Account Name
   - Bank
   - Currency
   - "Send money" set to True
6. Go to Accounting > Vendors > Payments
7. Try to create a payment for that partner

##### Expected: 
Payment is created successfully
##### Current: 
KeyError: 'none' is raised

OPW-4976541

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
