### PR TITLE
[IMP] stock_account: add sum of total value column

### DIFF
--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -94,7 +94,7 @@
                     }"/>
                     <field name="total_value" string="Total Value" optional="hide" options="{
                         'currency_field': 'company_currency_id',
-                    }"/>
+                    }" sum="Total Value"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
- added the `sum` of column `total_value` in `product_product_view_list_at_date`
  view which opens from `inventory at date`.
- helps user to view the total valuation with sum till specific date directly
  from the `inventory at date` without any manual calculation.

TaskId : 4910031