### PR TITLE
[FIX] website: fix image alignment issue in gallery with links

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2979,3 +2979,21 @@ input[value*="data-oe-translation-source-sha"] {
     border-radius: $btn-border-radius;
     padding: $btn-padding-y $btn-padding-x;
 }
+
+// Image links
+
+// For links inside a flex parent; adjusts margins when wrapping an image.
+// A single 'width: 100%' rule isn't used to keep link size matching image.
+// The 'where:'s prevents overriding custom rules in stable.
+// TODO: remove the 'where:'s in master.
+.carousel-item, .d-flex {
+    & > :where(a:has(> .img:only-child.mh-100)) {
+        max-height: 100%;
+    }
+    & > :where(a:has(> .img:only-child.me-auto, > .img:only-child.mx-auto)) {
+        margin-right: auto;
+    }
+    & > :where(a:has(> .img:only-child.ms-auto, > .img:only-child.mx-auto)) {
+        margin-left: auto;
+    }
+}


### PR DESCRIPTION
Problem:
When adding a link to an image in an image gallery, the image becomes left-aligned instead of centered. This issue is most noticeable with images that have a small width.

Cause:
The image is centered using the `mx-auto` class. However, when the image is wrapped in an anchor (`<a>`), the anchor does not take up the full width of the container. As a result, the image is no longer centered and shifts to the left.

Before:
<img width="836" height="586" alt="image" src="https://github.com/user-attachments/assets/f51fed85-727d-4391-a186-8a966f71657a" />
After:
<img width="747" height="583" alt="image" src="https://github.com/user-attachments/assets/6a3bd724-5b9c-4160-b0a4-73e8d7fdd1ec" />

Steps to reproduce:
- Add an image gallery block.
- Replace an image with one that has a small width.
- Add a link to the image.
- The image is no longer centered and aligns to the left.

The issue occurs because the direct parent of the link-image uses `display: flex`.

In this commit, a CSS rule was added so that links wrapping an image with Bootstrap margin classes (`mx-auto`, etc.) applied by the image alignment option also get the same margins.

This is only done when the direct parent of the link uses `display: flex` which is the case for elements like `carousel-item`.

We also targeted parents with the `d-flex` class to fix a similar issue in the `Blockquote` snippet, where the "avatar" image has a `d-flex` parent and becomes misaligned when wrapped in a link.

A JavaScript fix was initially considered, by detecting in the image alignment or link application options whether the link’s parent used `display: flex`. That approach would have been more precise to detect a `display: flex` parent, but it wouldn’t cover manually added/moved images. The CSS solution covers all known cases, can still be improved, and has the advantage of working reliably in all situations.

opw-4985504

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
