### PR TITLE
[FIX] crm: Adapt `Lead/Opportunities` action domain props type

### DIFF
--- a/addons/crm/static/src/activity_menu_patch.js
+++ b/addons/crm/static/src/activity_menu_patch.js
@@ -39,7 +39,7 @@ patch(ActivityMenu.prototype, {
                 action.domain = Domain.and([
                     action.domain || [],
                     [["active", "in", [true, false]]],
-                ]);
+                ]).toList();
                 this.action.doAction(action, {
                     additionalContext: context,
                     clearBreadcrumbs: true,


### PR DESCRIPTION
Steps:
- Install `crm`
- Enable dev mode
- Dashboard -> Activities icon -> Lead/Opportunitiess
- Traceback

This is simply due to the fact that the withsearch props indicate that they want to receive an array of strings or arrays, whereas the crm patch overrides the action domain by keeping the “Domain” type, which is an object and not an array.

One solution is to use `.toList()` on the domain to convert it into a 2d array.

linked pr: https://github.com/odoo/enterprise/pull/91521
opw-4979173