### PR TITLE
[FIX] website: prevent ecommerce installation with events page

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -474,7 +474,7 @@
         <field name="description">Publish on-site and online events</field>
         <field name="sequence">10</field>
         <field name="website_config_preselection">event</field>
-        <field name="module_id" ref="base.module_website_event_sale"/>
+        <field name="module_id" ref="base.module_website_event"/>
         <field name="icon">fa-ticket</field>
         <field name="menu_sequence">20</field>
         <field name="feature_url">/event</field>


### PR DESCRIPTION
Steps to reproduce:
1. Install website module
2. Select events in configurator
3. Build website.

=> Ecommerce is installed, which should not as it does not make sense
   with only the events.

After this commit:
- Ecommerce will no longer be installed when the events is configured.

task-4922600