### PR TITLE
[IMP] website: menu cache per website

### DIFF
--- a/addons/website/models/website_controller_page.py
+++ b/addons/website/models/website_controller_page.py
@@ -116,8 +116,9 @@ class WebsiteControllerPage(models.Model):
         self = self - views_to_delete.controller_page_ids
         views_to_delete.unlink()
 
-        # Make sure website._get_menu_ids() will be recomputed
-        self.env.registry.clear_cache()
+        # Make sure website.is_menu_cache_disabled() will be recomputed
+        if self:
+            self.env.registry.clear_cache('templates')
         return super().unlink()
 
     def open_website_url(self):

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -138,8 +138,9 @@ class WebsitePage(models.Model):
         self = self - views_to_delete.page_ids
         views_to_delete.unlink()
 
-        # Make sure website._get_menu_ids() will be recomputed
-        self.env.registry.clear_cache()
+        # Make sure website.is_menu_cache_disabled() will be recomputed
+        if self:
+            self.env.registry.clear_cache('templates')
         return super().unlink()
 
     def write(self, vals):


### PR DESCRIPTION
`_get_menu_ids` is always browsed and attributes are read, we can just do a `search_fetch` with the needed fields. Also fix the invalidated cache which does not match.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
