### PR TITLE
[IMP] core: new cache level "default.short"

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -476,7 +476,7 @@ class IrModuleModule(models.Model):
             raise UserError(_('Connection to %s failed The list of industry modules cannot be fetched') % APPS_URL)
 
     @api.model
-    @ormcache('payload')
+    @ormcache('payload', cache='default.short')
     def _call_apps(self, payload):
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
         import requests  # noqa: PLC0415

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -380,6 +380,7 @@ class Website(models.Model):
     # This method is cached, must not return records! See also #8795
     @ormcache(
         'country_code', 'show_visible', 'current_pl_id', 'website_pricelist_ids', 'partner_pl_id',
+        cache='default.short'
     )
     def _get_pl_partner_order(
         self, country_code, show_visible, current_pl_id, website_pricelist_ids, partner_pl_id=False

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -689,7 +689,7 @@ class ResUsers(models.Model):
         return vals_list
 
     @api.model
-    @tools.ormcache('self.env.uid')
+    @tools.ormcache('self.env.uid', cache='default.short')
     def context_get(self):
         # use read() to not read other fields: this must work while modifying
         # the schema of models res.users or res.partner
@@ -719,7 +719,7 @@ class ResUsers(models.Model):
 
         return frozendict(context)
 
-    @tools.ormcache('self.id')
+    @tools.ormcache('self.id', cache='default.short')
     def _get_company_ids(self):
         # use search() instead of `self.company_ids` to avoid extra query for `active_test`
         domain = [('active', '=', True), ('user_ids', 'in', self.id)]
@@ -808,7 +808,7 @@ class ResUsers(models.Model):
         return auth_info
 
     @api.model
-    @tools.ormcache('uid', 'passwd')
+    @tools.ormcache('uid', 'passwd', cache='default.short')
     def _check_uid_passwd(self, uid, passwd):
         """Verifies that the given (uid, password) is authorized and
            raise an exception if it is not."""
@@ -845,7 +845,7 @@ class ResUsers(models.Model):
             "group_by": SQL("res_users.id"),
         }
 
-    @tools.ormcache('sid')
+    @tools.ormcache('sid', cache='default.short')
     def _compute_session_token(self, sid):
         """ Compute a session token given a session id and a user id """
         # retrieve the fields used to generate the session token
@@ -1084,7 +1084,7 @@ class ResUsers(models.Model):
         # for new record don't fill the ormcache
         return group_id in (self._get_group_ids() if self.id else self.all_group_ids._origin._ids)
 
-    @tools.ormcache('self.id')
+    @tools.ormcache('self.id', cache='default.short')
     def _get_group_ids(self):
         """ Return ``self``'s group ids (as a tuple)."""
         self.ensure_one()

--- a/odoo/addons/base/tests/test_ormcache.py
+++ b/odoo/addons/base/tests/test_ormcache.py
@@ -187,7 +187,7 @@ class TestOrmCache(TransactionCase):
             registry.check_signaling()
         self.assertEqual(
             logs.output,
-            ["INFO:odoo.registry:Invalidating caches after database signaling: ['assets', 'default', 'templates.cached_values']"],
+            ["INFO:odoo.registry:Invalidating caches after database signaling: ['assets', 'default', 'default.short', 'templates.cached_values']"],
         )
 
     def test_signaling_gc(self):

--- a/odoo/addons/base/tests/test_user_has_group.py
+++ b/odoo/addons/base/tests/test_user_has_group.py
@@ -316,16 +316,17 @@ class TestHasGroup(TransactionCase):
 
     def test_has_group_cleared_cache_on_write(self):
         self.env.registry.clear_cache()
-        self.assertFalse(self.registry._Registry__caches['default'], "Ensure ormcache is empty")
+        default_cache = self.registry._Registry__caches['default.short']
+        self.assertFalse(default_cache, "Ensure ormcache is empty")
 
         def populate_cache():
             self.test_user.has_group('test_user_has_group.group0')
-            self.assertTrue(self.registry._Registry__caches['default'], "user._has_group cache must be populated")
+            self.assertTrue(default_cache, "user._has_group cache must be populated")
 
         populate_cache()
 
         self.env.ref(self.group0).write({"share": True})
-        self.assertFalse(self.registry._Registry__caches['default'], "Writing on group must invalidate user._has_group cache")
+        self.assertFalse(default_cache, "Writing on group must invalidate user._has_group cache")
 
         populate_cache()
         # call_cache_clearing_methods is called in res.groups.write to invalidate
@@ -335,7 +336,7 @@ class TestHasGroup(TransactionCase):
         # the ormcache of method `user._has_group()`
         self.env['ir.model.access'].call_cache_clearing_methods()
         self.assertFalse(
-            self.registry._Registry__caches['default'],
+            default_cache,
             "call_cache_clearing_methods() must invalidate user._has_group cache"
         )
 

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -51,7 +51,8 @@ _schema = logging.getLogger('odoo.schema')
 
 
 _REGISTRY_CACHES = {
-    'default': 8192,
+    'default': 4096,
+    'default.short': 4096,
     'assets': 512, # arbitrary
     'templates': 1024, # arbitrary
     'routing': 1024,  # 2 entries per website
@@ -63,7 +64,7 @@ _REGISTRY_CACHES = {
 # cache invalidation dependencies, as follows:
 # { 'cache_key': ('cache_container_1', 'cache_container_3', ...) }
 _CACHES_BY_KEY = {
-    'default': ('default', 'templates.cached_values'),
+    'default': ('default', 'default.short', 'templates.cached_values'),
     'assets': ('assets', 'templates.cached_values'),
     'templates': ('templates', 'templates.cached_values'),
     'routing': ('routing', 'routing.rewrites', 'templates.cached_values'),

--- a/odoo/tools/cache.py
+++ b/odoo/tools/cache.py
@@ -68,9 +68,14 @@ class ormcache:
     """
     key: Callable[..., tuple]
 
-    def __init__(self, *args: str, cache: str = 'default', skiparg: int | None = None, **kwargs):
+    def __init__(self, *args: str, cache: str = '', skiparg: int | None = None, **kwargs):
         self.args = args
         self.skiparg = skiparg
+        if not cache:
+            if 'self.env.uid' in args:
+                cache = 'default.short'
+            else:
+                cache = 'default'
         self.cache_name = cache
         if skiparg is not None:
             warnings.warn("Deprecated since 19.0, ormcache(skiparg) will be removed", DeprecationWarning)


### PR DESCRIPTION
Split the default cache into 2 sections, the default one and one that rotates more quickly because keys are more unique.

By default, if the ormcache depends on "self.env.uid", we will use the short cache. For bigger servers with multiple workers and many users, this allows to avoid invalidating all objects in the default cache.

TODO needs timing analysis - is it worth it?

task-4978900



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
