### PR TITLE
[FIX] im_livechat: auto-close bot-only chats inactive for over 1 day

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -254,6 +254,18 @@ class DiscussChannel(models.Model):
         empty_channel_ids = [item['id'] for item in self.env.cr.dictfetchall()]
         self.browse(empty_channel_ids).unlink()
 
+    @api.autovacuum
+    def _gc_bot_only_ongoing_sessions(self):
+        """Garbage collect bot-only livechat sessions with no activity for over 1 day."""
+        limit_date = fields.Datetime.subtract(fields.Datetime.now(), days=1)
+        stale_sessions = self.search([
+            ("channel_type", "=", "livechat"),
+            ("livechat_active", "=", True),
+            ("last_interest_dt", "<=", limit_date),
+            ("livechat_agent_partner_ids", "=", False),
+        ])
+        stale_sessions.livechat_active = False
+
     def execute_command_history(self, **kwargs):
         self._bus_send(
             "im_livechat.history_command",

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -1,4 +1,7 @@
-from odoo import Command
+from datetime import timedelta
+from freezegun import freeze_time
+
+from odoo import Command, fields
 from odoo.tests import new_test_user, tagged
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 
@@ -100,3 +103,26 @@ class TestDiscussChannel(TestImLivechatCommon):
         channel.with_user(self.visitor_user).message_post(body="", attachment_ids=[attachment2.id])
         channel_history = channel._get_channel_history()
         self.assertEqual(channel_history, 'Operator Here<br/>Visitor Here<br/>')
+
+    def test_gc_bot_sessions_after_one_day_inactivity(self):
+        chatbot_script = self.env["chatbot.script"].create({"title": "Testing Bot"})
+        self.livechat_channel.rule_ids = [Command.create({"chatbot_script_id": chatbot_script.id})]
+        self.env["chatbot.script.step"].create({
+            "chatbot_script_id": chatbot_script.id,
+            "message": "Hello joey, how you doing?",
+            "step_type": "text",
+        })
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "Thomas",
+                "chatbot_script_id": chatbot_script.id,
+                "channel_id": self.livechat_channel.id,
+            },
+        )
+        channel = self.env["discuss.channel"].browse(data["channel_id"])
+        with freeze_time(fields.Datetime.to_string(fields.Datetime.now() + timedelta(hours=23))):
+            self.assertTrue(channel.livechat_active)
+        with freeze_time(fields.Datetime.to_string(fields.Datetime.now() + timedelta(days=1))):
+            channel._gc_bot_only_ongoing_sessions()
+        self.assertFalse(channel.livechat_active)


### PR DESCRIPTION
**Purpose of this PR:**

Garbage collect livechat sessions involving only bots if the last message was sent more than 1 day ago. This prevents indefinitely ongoing sessions from skewing livechat statistics.

task-4972170

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
