### PR TITLE
[IMP] mail: move discuss sidebar search bar to sticky top

### DIFF
--- a/addons/im_livechat/static/tests/discuss_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_patch.test.js
@@ -142,7 +142,7 @@ test("sidebar search finds livechats", async () => {
     });
     await start();
     await openDiscuss();
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await click("a", { text: "Visitor 11" });
     await contains(".o-mail-Discuss-threadName[title='Visitor 11']");
 });

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -20,6 +20,7 @@ $o-mail-Message-sidebarWidth: 48px !default;
 $o-mail-NavigableList-zIndex: 21;
 $o-mail-Chatter-minWidth: 530px !default;
 $o-mail-Discuss-inspector: 300px !default; // same value as INSPECTOR_WIDTH
+$o-mail-DiscussSidebar-compactWidth: 60px !default; // same value as COMPACT_SIDEBAR_WIDTH
 
 $o-mail-CallMenu-bgColor-darker: #111827FF !default;
 $o-mail-CallMenu-bgColor: #1F2937FF !default;

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -6,6 +6,7 @@ export const DISCUSS_SIDEBAR_COMPACT_LS = "mail.user_setting.discuss_sidebar_com
 
 export class DiscussApp extends Record {
     INSPECTOR_WIDTH = 300;
+    COMPACT_SIDEBAR_WIDTH = 60;
     /** @type {'main'|'channel'|'chat'|'livechat'} */
     activeTab = "main";
     searchTerm = "";

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -1,20 +1,16 @@
 .o-mail-DiscussSidebar {
     box-shadow: 1px 0px 6px -3px rgba(50, 50, 50, 0.15);
-    width: 60px;
+    max-width: $o-mail-Discuss-inspector;
     --border-opacity: 0.25;
+}
 
-    &:not(.o-compact) {
-        width: $o-mail-Discuss-inspector;
-    }
+.o-mail-DiscussSidebar-resizablePanelContainer {
+    max-width: $o-mail-Discuss-inspector;
 }
 
 .o-mail-DiscussSidebar-optionsBtn {
     --border-opacity: 0.5;
     padding: map-get($spacers, 1) / 2;
-
-    &:not(.o-compact) {
-        right: map-get($spacers, 2) + map-get($spacers, 1);
-    }
 }
 
 .o-mail-DiscussSidebar-badge {
@@ -58,4 +54,23 @@
             box-shadow: $box-shadow !important;
         }
     }
+}
+
+.o-mail-DiscussSidebar-search {
+    --border-opacity: .5;
+
+    &, & input {
+        background-color: $o-view-background-color !important;
+    }
+
+    &:has(.o-mail-DiscussSidebar-searchClickable:hover) {
+        &, & input {
+            background-color: mix($gray-100, $gray-200) !important;
+        }
+    }
+}
+
+.o-mail-DiscussSidebar-searchBtn {
+    padding-top: map-get($spacers, 1) + map-get($spacers, 2) / 2; // so that button is square like other items
+    padding-bottom: map-get($spacers, 1) + map-get($spacers, 2) / 2; // so that button is square like other items
 }

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -1,22 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto o-scrollbar-thin flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor o-gap-0_5" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
-            <div class="o-mail-DiscussSidebar-top position-sticky justify-content-center top-0 z-2 o-mail-discussSidebarBgColor" t-att-class="{ 'pt-2 mt-1 pb-1': !store.inPublicPage, 'pt-1': store.inPublicPage }">
-                <div class="d-flex align-items-center justify-content-center" t-att-class="{ 'flex-column gap-2': store.discuss.isSidebarCompact }">
-                    <t name="options-btn">
-                        <Dropdown position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary px-0 py-1 mx-2 my-0 min-w-0 shadow-sm'">
-                            <button class="o-mail-DiscussSidebar-optionsBtn btn btn-light p-0 align-items-center justify-content-center smaller border border-dark rounded-circle opacity-25 opacity-100-hover" title="Options" t-att-class="{ 'ms-auto': !store.discuss.isSidebarCompact, 'position-absolute': !store.discuss.isSidebarCompact and !store.inPublicPage, 'o-compact': store.discuss.isSidebarCompact }"><i class="oi oi-ellipsis-h oi-fw align-text-top" style="font-size: 15px;"/></button>
+        <div class="o-mail-DiscussSidebar-resizablePanelContainer h-100 d-flex">
+            <ResizablePanel handleSide="'end'" initialWidth="store.discuss.isSidebarCompact ? store.discuss.COMPACT_SIDEBAR_WIDTH : store.discuss.INSPECTOR_WIDTH" minWidth="60" onResize.bind="onResize">
+                <div class="o-mail-DiscussSidebar d-flex d-print-none flex-column overflow-auto o-scrollbar-thin flex-shrink-0 h-100 border-end border-secondary z-1 o-mail-discussSidebarBgColor o-gap-0_5" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }">
+                    <div class="o-mail-DiscussSidebar-top position-sticky top-0 z-2 o-mail-discussSidebarBgColor d-flex align-items-center gap-1" t-att-class="{ 'py-2': !store.inPublicPage, 'pt-2 o-px-2_5': store.inPublicPage, 'flex-column': store.discuss.isSidebarCompact, 'o-ps-2_5 o-pe-1_5': !store.discuss.isSidebarCompact }" t-ref="top">
+                        <Dropdown t-if="store.discuss.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm o-rounded-bubble'" manual="true">
+                            <button class="o-mail-DiscussSidebar-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75 bg-transparent" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-fw fa-search"/></button>
                             <t t-set-slot="content">
-                                <t t-set-slot="content">
-                                    <DiscussActions dropdown="true" group="[optionActions]"/>
-                                </t>
+                                <div class="p-2" t-ref="search-floating">
+                                    <span class="text-muted user-select-none">Search conversations</span>
+                                </div>
                             </t>
                         </Dropdown>
-                    </t>
+                        <div t-else="" class="o-mail-DiscussSidebar-search rounded border border-secondary shadow-sm position-relative d-flex align-items-center justify-content-center gap-1 flex-grow-1" t-on-click="onClickFindOrStartConversation">
+                            <div class="d-flex w-100 align-items-center ps-2 gap-2">
+                                <i class="oi oi-search o-opacity-35 smaller"/>
+                                <input class="form-control rounded border-0 bg-inherit ps-0" t-att-class="{ 'lh-1': !ui.isSmall }" disabled="true" placeholder="Search conversations" tabindex="0"/>
+                            </div>
+                            <div class="o-mail-DiscussSidebar-searchClickable position-absolute z-1 opacity-0 cursor-pointer w-100 h-100"/>
+                        </div>
+                    </div>
+                    <t t-foreach="discussSidebarItems" t-as="item" t-key="item_index" t-component="item"/>
                 </div>
-            </div>
-            <t t-foreach="discussSidebarItems" t-as="item" t-key="item_index" t-component="item"/>
+            </ResizablePanel>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.js
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.js
@@ -23,7 +23,7 @@ patch(DiscussSidebar.prototype, {
         });
         this.meetingFloating = useDropdownState();
     },
-    get startMeetingText() {
-        return _t("Start a meeting");
+    get newMeetingText() {
+        return _t("New Meeting");
     },
 });

--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussSidebar" t-inherit-mode="extension">
-        <xpath expr="//*[@name='options-btn']" position="after">
+        <xpath expr="//*[@t-ref='top']" position="inside">
             <Dropdown t-if="store.discuss.isSidebarCompact" state="meetingFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary p-2 mx-2 my-0 min-w-0 shadow-sm o-rounded-bubble'" manual="true">
                 <t t-call="mail.DiscussSidebar.startMeetingButton"/>
                 <t t-set-slot="content">
                     <div t-ref="meeting-floating">
-                        <span class="text-muted user-select-none" t-esc="startMeetingText"/>
+                        <span class="text-muted user-select-none" t-esc="newMeetingText"/>
                     </div>
                 </t>
             </Dropdown>
@@ -15,6 +15,6 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.startMeetingButton">
-        <button class="btn btn-primary rounded-3 d-flex align-items-center gap-1" t-att-class="{ 'o-px-1_5 py-2': store.discuss.isSidebarCompact, 'btn-sm mx-5': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
+        <button class="btn btn-primary rounded d-flex align-items-center gap-1 o-p-1_5" t-att-title="newMeetingText" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-user-plus opacity-75"/></button>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
@@ -2,3 +2,7 @@
     --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-200, $gray-300)};
     --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .15)};
 }
+
+.o-mail-DiscussSidebar-search {
+    --border-opacity: 0;
+}

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
@@ -14,7 +14,3 @@
 .o-mail-DiscussSidebarSubchannel {
     --mail-DiscussSidebarSubchannel-svgColor: #{mix($gray-300, $gray-400)};
 }
-
-.o-mail-DiscussSidebarCategories-search {
-    --border-opacity: 0;
-}

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -249,21 +249,6 @@ export class DiscussSidebarCategories extends Component {
         this.store = useService("mail.store");
         this.discusscorePublicWebService = useService("discuss.core.public.web");
         this.orm = useService("orm");
-        this.ui = useService("ui");
-        this.command = useService("command");
-        this.searchHover = useHover(["search-btn", "search-floating"], {
-            onHover: () => {
-                if (this.store.discuss.isSidebarCompact) {
-                    this.searchFloating.isOpen = true;
-                }
-            },
-            onAway: () => {
-                if (this.store.discuss.isSidebarCompact) {
-                    this.searchFloating.isOpen = false;
-                }
-            },
-        });
-        this.searchFloating = useDropdownState();
         useSubEnv({
             filteredThreads: (threads) => this.filteredThreads(threads),
         });
@@ -271,10 +256,6 @@ export class DiscussSidebarCategories extends Component {
 
     filteredThreads(threads) {
         return threads.filter((thread) => thread.displayInSidebar);
-    }
-
-    onClickFindOrStartConversation() {
-        this.command.openMainPalette({ searchValue: "@" });
     }
 }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -90,25 +90,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
     }
 }
 
-.o-mail-DiscussSidebarCategories-searchBtn {
-    padding-top: map-get($spacers, 1) + map-get($spacers, 2) / 2; // so that button is square like other items
-    padding-bottom: map-get($spacers, 1) + map-get($spacers, 2) / 2; // so that button is square like other items
-}
-
-.o-mail-DiscussSidebarCategories-search {
-    --border-opacity: .5;
-
-    &, & input {
-        background-color: $o-view-background-color !important;
-    }
-
-    &:has(.o-mail-DiscussSidebarCategories-searchClickable:hover) {
-        &, & input {
-            background-color: mix($gray-100, $gray-200) !important;
-        }
-    }
-}
-
 .o-mail-DiscussSidebarSubchannel svg {
     color: var(--mail-DiscussSidebarSubchannel-svgColor, mix($gray-300, $gray-400, 75%));
     left: 22px;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarCategories">
-        <Dropdown t-if="store.discuss.isSidebarCompact" state="searchFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary mx-2 my-0 min-w-0 p-0 shadow-sm o-rounded-bubble'" manual="true">
-            <button class="o-mail-DiscussSidebarCategories-searchBtn btn btn-light d-flex align-items-center justify-content-center border-0 px-1 mx-2 opacity-75 bg-transparent" t-on-click="onClickFindOrStartConversation" t-ref="search-btn"><i class="fa fa-fw fa-search"/></button>
-            <t t-set-slot="content">
-                <div class="p-2" t-ref="search-floating">
-                    <span class="text-muted user-select-none">Find or start a conversation</span>
-                </div>
-            </t>
-        </Dropdown>
-        <div t-else="" class="o-mail-DiscussSidebarCategories-search rounded-3 mx-3 my-2 border border-secondary shadow-sm position-relative d-flex align-items-center justify-content-center gap-1" t-on-click="onClickFindOrStartConversation">
-            <input class="form-control rounded-3 border-0 bg-inherit" t-att-class="{ 'lh-1': !ui.isSmall }" disabled="true" placeholder="Find or start a conversation" tabindex="0"/>
-            <div class="o-mail-DiscussSidebarCategories-searchClickable position-absolute z-1 opacity-0 cursor-pointer w-100 h-100"/>
-        </div>
         <t t-foreach="store.discuss.allCategories" t-as="cat" t-key="cat.id">
             <t t-if="cat.isVisible" t-call="mail.DiscussSidebarCategories.category">
                 <t t-set="category" t-value="cat"/>

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
@@ -9,7 +9,7 @@
             <t t-if="ui.isSmall">
                 <t t-if="store.discuss.activeTab !== 'main' or !env.inDiscussApp">
                     <button name="startMeetingButton" class="w-50 m-1 me-0 btn btn-primary" t-on-click.stop="onClickStartMeeting">
-                        <i class="fa fa-users"/> Start a meeting
+                        <i class="fa fa-user-plus"/> New Meeting
                     </button>
                     <button t-att-class="ui.isSmall ? 'w-50 p-2 btn btn-secondary m-1' : 'btn btn-link p-2'" t-on-click.stop="onClickNewMessage">
                         <i class="fa fa-pencil"/> Start a conversation

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -15,7 +15,7 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: "click",
         },
         {
-            trigger: ".o-mail-DiscussSidebarCategories-search",
+            trigger: ".o-mail-DiscussSidebar-search",
             content: markup(
                 _t(
                     "<p>Channels make it easy to organize information across different topics and groups.</p> <p>Try to <b>create your first channel</b> (e.g. sales, marketing, product XYZ, after work party, etc).</p>"
@@ -70,7 +70,7 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: "click",
         },
         {
-            trigger: ".o-mail-DiscussSidebarCategories-search",
+            trigger: ".o-mail-DiscussSidebar-search",
             content: markup(
                 _t(
                     "<p><b>Chat with coworkers</b> in real-time using direct messages.</p><p><i>You might need to invite users from the Settings app first.</i></p>"

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -252,7 +252,7 @@ test("Camera video stream stays in focus when on/off", async () => {
 test("Create a direct message channel when clicking on start a meeting", async () => {
     await start();
     await openDiscuss();
-    await click("button", { text: "Start a meeting" });
+    await click("button[title='New Meeting']");
     await contains(".o-mail-DiscussSidebarChannel", { text: "Mitchell Admin" });
     await contains(".o-discuss-Call");
     await contains(".o-discuss-ChannelInvitation");
@@ -312,7 +312,7 @@ test("join/leave sounds are only played on main tab", async () => {
     await waitForSteps(["tab1 - play - call-leave"]);
 });
 
-test("'Start a meeting' in mobile", async () => {
+test("'New Meeting' in mobile", async () => {
     patchUiSize({ size: SIZES.SM });
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Partner 2" });
@@ -322,7 +322,7 @@ test("'Start a meeting' in mobile", async () => {
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
     await click("button", { text: "Chats" });
-    await click("button", { text: "Start a meeting" });
+    await click("button", { text: "New Meeting" });
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Partner 2" });
     await click("button:not([disabled])", { text: "Invite to Group Chat" });
     await contains(".o-discuss-Call");

--- a/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
+++ b/addons/mail/static/tests/discuss/call/ptt_ad_banner.test.js
@@ -33,7 +33,7 @@ test("display banner when ptt extension is not enabled", async () => {
     await click(".o-dropdown-item", { text: "Call Settings" });
     await click("button", { text: "Push to Talk" });
     await click("[title*='Close Chat Window']");
-    await click("button", { text: "Start a meeting" });
+    await click("button", { text: "New Meeting" });
     await click("button[title='Close panel']"); // invitation panel automatically open
     await contains(".o-discuss-PttAdBanner");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)

--- a/addons/mail/static/tests/discuss/call/web/call.test.js
+++ b/addons/mail/static/tests/discuss/call/web/call.test.js
@@ -22,7 +22,7 @@ test("no auto-call on joining chat", async () => {
     pyEnv["res.users"].create({ partner_id: partnerId });
     await start();
     await openDiscuss();
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await insertText("input[placeholder='Search a conversation']", "mario");
     await click("a", { text: "mario" });
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario" });
@@ -40,7 +40,7 @@ test("no auto-call on joining group chat", async () => {
     pyEnv["res.users"].create([{ partner_id: partnerId_1 }, { partner_id: partnerId_2 }]);
     await start();
     await openDiscuss();
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await click("a", { text: "Create Chat" });
     await click("li", { text: "Mario" });
     await click("li", { text: "Luigi" });

--- a/addons/mail/static/tests/discuss/core/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss.test.js
@@ -66,7 +66,7 @@ test("bus subscription is refreshed when channel is joined", async () => {
     await waitForSteps(["subscribe"]);
     await openDiscuss();
     await waitForSteps([]);
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await insertText("input[placeholder='Search a conversation']", "new channel");
     await waitForSteps(["subscribe"]);
 });

--- a/addons/mail/static/tests/discuss/core/web/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/web/crosstab.test.js
@@ -23,7 +23,7 @@ test("Channel subscription is renewed when channel is manually added", async () 
         },
     });
     await openDiscuss();
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await insertText("input[placeholder='Search a conversation']", "General");
     await click("a", { text: "General" });
     await contains(".o-mail-DiscussSidebar-item", { text: "General" });

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -47,7 +47,7 @@ test("can create a new channel", async () => {
     );
     await contains(".o-mail-Discuss");
     await contains(".o-mail-DiscussSidebar-item", { text: "abc", count: 0 });
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await insertText("input[placeholder='Search a conversation']", "abc");
     await waitForSteps([`/discuss/search - {"term":""}`, `/discuss/search - {"term":"abc"}`]);
     await click("a", { text: "Create Channel" });
@@ -104,7 +104,7 @@ test("can make a DM chat", async () => {
     });
     await contains(".o-mail-Discuss");
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario", count: 0 });
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await insertText("input[placeholder='Search a conversation']", "mario");
     await click("a", { text: "Mario" });
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario" });
@@ -130,7 +130,7 @@ test("can create a group chat conversation", async () => {
     pyEnv["res.users"].create([{ partner_id: partnerId_1 }, { partner_id: partnerId_2 }]);
     await start();
     await openDiscuss();
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await click("a", { text: "Create Chat" });
     await click("li", { text: "Mario" });
     await click("li", { text: "Luigi" });
@@ -156,7 +156,7 @@ test("Chat is pinned on other tabs when joined", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(undefined, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
-    await click("input[placeholder='Find or start a conversation']", { target: env1 });
+    await click("input[placeholder='Search conversations']", { target: env1 });
     await insertText("input[placeholder='Search a conversation']", "Jer", { target: env1 });
     await click("a", { text: "Jerry Golay", target: env1 });
     await contains(".o-mail-DiscussSidebar-item", { target: env1, text: "Jerry Golay" });
@@ -207,7 +207,7 @@ test("can access portal partner profile from avatar popover", async () => {
 test("Preserve letter case and accents when creating channel from sidebar", async () => {
     await start();
     await openDiscuss();
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await insertText("input[placeholder='Search a conversation']", "Crème brûlée Fan Club");
     await click("a", { text: "Create Channel" });
     await contains(".o-mail-Discuss-threadName", { value: "Crème brûlée Fan Club" });
@@ -216,7 +216,7 @@ test("Preserve letter case and accents when creating channel from sidebar", asyn
 test("Create channel must have a name", async () => {
     await start();
     await openDiscuss();
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await click("a", { text: "Create Channel" });
     await click("input[placeholder='Channel name']");
     await triggerHotkey("Enter");

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2252,7 +2252,7 @@ test("Newly created chat is at the top of the DM list", async () => {
     });
     await start();
     await openDiscuss();
-    await click("input[placeholder='Find or start a conversation']");
+    await click("input[placeholder='Search conversations']");
     await insertText("input[placeholder='Search a conversation']", "Jer");
     await click(".o_command_name", { text: "Jerry Golay" });
     await contains(".o-mail-DiscussSidebar-item", {

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -14,7 +14,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { DISCUSS_SIDEBAR_COMPACT_LS } from "@mail/core/public_web/discuss_app_model";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, press, queryFirst } from "@odoo/hoot-dom";
+import { animationFrame, drag, press, queryFirst } from "@odoo/hoot-dom";
 import { Deferred, mockDate } from "@odoo/hoot-mock";
 import {
     asyncStep,
@@ -1214,8 +1214,11 @@ test("Can make sidebar smaller", async () => {
     await openDiscuss();
     await contains(".o-mail-DiscussSidebar");
     const normalWidth = queryFirst(".o-mail-DiscussSidebar").getBoundingClientRect().width;
-    await click(".o-mail-DiscussSidebar [title='Options']");
-    await click(".dropdown-item", { text: "Collapse panel" });
+    await (
+        await drag(".o-mail-DiscussSidebar-resizablePanelContainer .o_resizable_panel_handle")
+    ).drop(".o-mail-DiscussSidebar-resizablePanelContainer .o_resizable_panel_handle", {
+        position: { x: 0 },
+    });
     await contains(".o-mail-DiscussSidebar.o-compact");
     const compactWidth = queryFirst(".o-mail-DiscussSidebar").getBoundingClientRect().width;
     expect(normalWidth).toBeGreaterThan(compactWidth);
@@ -1229,12 +1232,18 @@ test("Sidebar compact is locally persistent (saved in local storage)", async () 
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebar.o-compact");
-    await click(".o-mail-DiscussSidebar [title='Options']");
-    await click(".dropdown-item", { text: "Expand panel" });
+    await (
+        await drag(".o-mail-DiscussSidebar-resizablePanelContainer .o_resizable_panel_handle")
+    ).drop(".o-mail-DiscussSidebar-resizablePanelContainer .o_resizable_panel_handle", {
+        position: { x: 1000 },
+    });
     await contains(".o-mail-DiscussSidebar:not(.o-compact)");
     expect(browser.localStorage.getItem(DISCUSS_SIDEBAR_COMPACT_LS)).toBe(null);
-    await click(".o-mail-DiscussSidebar [title='Options']");
-    await click(".dropdown-item", { text: "Collapse panel" });
+    await (
+        await drag(".o-mail-DiscussSidebar-resizablePanelContainer .o_resizable_panel_handle")
+    ).drop(".o-mail-DiscussSidebar-resizablePanelContainer .o_resizable_panel_handle", {
+        position: { x: 0 },
+    });
     await contains(".o-mail-DiscussSidebar.o-compact");
     expect(browser.localStorage.getItem(DISCUSS_SIDEBAR_COMPACT_LS)).toBe("true");
 });
@@ -1251,8 +1260,18 @@ test("Sidebar compact is crosstab synced", async () => {
     await openDiscuss(channelId, { target: env2 });
     await contains(".o-mail-DiscussSidebar:not(.o-compact)", { target: env1 });
     await contains(".o-mail-DiscussSidebar:not(.o-compact)", { target: env2 });
-    await click(".o-mail-DiscussSidebar [title='Options']", { target: env1 });
-    await click(".dropdown-item:contains('Collapse panel')", { target: env1 });
+    await (
+        await drag(
+            `.o-mail-Discuss-asTabContainer[data-as-tab-id='${env1.discussAsTabId}']
+            .o-mail-DiscussSidebar-resizablePanelContainer
+            .o_resizable_panel_handle`
+        )
+    ).drop(
+        `.o-mail-Discuss-asTabContainer[data-as-tab-id='${env1.discussAsTabId}']
+        .o-mail-DiscussSidebar-resizablePanelContainer
+        .o_resizable_panel_handle`,
+        { position: { x: 0 } }
+    );
     await contains(".o-mail-DiscussSidebar.o-compact", { target: env1 });
     await contains(".o-mail-DiscussSidebar.o-compact", { target: env2 });
 });

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -297,6 +297,8 @@ async function addSwitchTabDropdownItem(rootTarget, tabTarget) {
     dropdownDiv.querySelector(".dropdown-menu").appendChild(li);
 }
 
+let discussAsTabId = 0;
+
 /**
  * @param {{
  *  asTab?: boolean;
@@ -340,13 +342,15 @@ export async function start(options) {
     }
     let env;
     if (options?.asTab) {
+        discussAsTabId++;
         restoreRegistry(registry);
         const rootTarget = target;
         target = document.createElement("div");
         target.classList.add("o-mail-Discuss-asTabContainer");
+        target.dataset.asTabId = discussAsTabId;
         rootTarget.appendChild(target);
         addSwitchTabDropdownItem(rootTarget, target);
-        env = await makeMockEnv({}, { makeNew: true });
+        env = await makeMockEnv({ discussAsTabId }, { makeNew: true });
     } else {
         env = getMockEnv() || (await makeMockEnv({}));
     }


### PR DESCRIPTION
Before this commit, discuss sidebar search feature was shown in-between mailboxes (Inbox, history) and the 1st channel category.

For improved visibility of the feature, this is moved to the sticky top part of the discuss sidebar.

This commit also makes the following changes to discuss sidebar:

1. The "start a meeting" button has been changed to an inline button next to the search bar. Due to space constraint, the label was removed and replaced by title, and the icon was changed to `.fa-user-plus` to give a better idea this is to make a new conversation with intend to invite new users. Label was also renamed to "New Meeting"

2. compact mode of discuss sidebar is now triggered by manual drag on the discuss sidebar end, rather than a dedicated button "...".

Part of task-4967071

Before / After
<img width="299" height="414" alt="Screenshot 2025-08-01 at 15 01 08" src="https://github.com/user-attachments/assets/5ad8bce1-90a9-4cea-8f2a-ea7aa6252004" /> <img width="298" height="429" alt="Screenshot 2025-08-01 at 14 54 26" src="https://github.com/user-attachments/assets/d6b24373-f25e-42cd-839e-181592ae09e2" />
