### PR TITLE
[FIX] website, html_editor: clean content editable after the rest

### DIFF
--- a/addons/html_editor/static/src/core/content_editable_plugin.js
+++ b/addons/html_editor/static/src/core/content_editable_plugin.js
@@ -15,7 +15,7 @@ export class ContentEditablePlugin extends Plugin {
     static id = "contentEditablePlugin";
     resources = {
         normalize_handlers: withSequence(5, this.normalize.bind(this)),
-        clean_for_save_handlers: this.cleanForSave.bind(this),
+        clean_for_save_handlers: withSequence(Infinity, this.cleanForSave.bind(this)),
         filter_contenteditable_handlers: this.filterContentEditable.bind(this),
     };
 


### PR DESCRIPTION
The commit b455ea85853dfc19ed01e33986ad270cf80ee5d6 changed which plugin cleans the `contenteditable` attribute. This changed the order in which `contenteditable` is removed compared to the others cleanups

The feff plugin depends on the `contenteditable` to clean the correct feffs. With that change of order, it did not cleaned the feff on website anymore.

This commit fixes that by explicitely setting the sequence order on the clean up of `contenteditable` so that it is run rather late.

Steps to reproduce:
- Open website editor
- Edit a something that is in the same savable element as a link
- Save
- Bug: the public website now has feff around the label of the links

task-4367641
