### PR TITLE
[FIX] hr_timesheet: avoid double counting sub-task allocated hours in portal

### DIFF
--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -282,7 +282,9 @@ class ProjectTask(models.Model):
     def _get_portal_total_hours_dict(self):
         if not (timesheetable_tasks := self.filtered('allow_timesheets')):
             return {}
+        sub_tasks = timesheetable_tasks._get_all_subtasks()
+        tasks_for_total = timesheetable_tasks - sub_tasks
         return {
-            'allocated_hours': sum(timesheetable_tasks.mapped('allocated_hours')),
-            'effective_hours': sum(timesheetable_tasks.mapped('effective_hours')),
+            'allocated_hours': sum(tasks_for_total.mapped('allocated_hours')),
+            'effective_hours': sum(tasks_for_total.mapped('total_hours_spent')),
         }

--- a/addons/hr_timesheet/tests/test_portal_timesheet.py
+++ b/addons/hr_timesheet/tests/test_portal_timesheet.py
@@ -68,3 +68,60 @@ class TestPortalTimesheet(TestProjectSharingCommon):
                 self.assertEqual(view_id, form_view_id)
             elif view_type == 'kanban':
                 self.assertEqual(view_id, kanban_view_id)
+
+    def test_portal_task_hours_no_double_counting(self):
+        """ Test that totals for both allocated and spent hours are calculated correctly, preventing double-counting.
+
+            Test Cases:
+            1. Parent + all sub-tasks in same group -> Totals are based on the parent.
+            2. Parent alone in group -> Totals are based on the parent's value.
+            3. Sub-task alone in group -> Totals are based on the sub-task's value.
+            4. Parent + distant sub-task in same group -> Totals are based on the parent.
+        """
+
+        parent_task = self.env['project.task'].create({
+            'name': 'Parent Task',
+            'project_id': self.project_portal.id,
+            'allocated_hours': 500.0,
+        })
+        sub_task_1 = self.env['project.task'].create({
+            'name': 'Sub-task 1',
+            'project_id': self.project_portal.id,
+            'parent_id': parent_task.id,
+            'allocated_hours': 50.0,
+        })
+        sub_task_2 = self.env['project.task'].create({
+            'name': 'Sub-task 2',
+            'project_id': self.project_portal.id,
+            'parent_id': sub_task_1.id,
+            'allocated_hours': 25.0,
+        })
+
+        employee = self.env['hr.employee'].create({'name': 'Test Employee'})
+        self.env['account.analytic.line'].create([
+            {'name': 'Time on parent', 'project_id': self.project_portal.id, 'task_id': parent_task.id, 'unit_amount': 50, 'employee_id': employee.id},
+            {'name': 'Time on sub-task 1', 'project_id': self.project_portal.id, 'task_id': sub_task_1.id, 'unit_amount': 25, 'employee_id': employee.id},
+            {'name': 'Time on sub-task 2', 'project_id': self.project_portal.id, 'task_id': sub_task_2.id, 'unit_amount': 15, 'employee_id': employee.id},
+        ])
+
+        # Test Case 1: A group containing parent and its all sub-tasks
+        group_with_all_tasks = parent_task | sub_task_1 | sub_task_2
+        result_group_all = group_with_all_tasks._get_portal_total_hours_dict()
+        self.assertEqual(result_group_all.get('allocated_hours'), 500.0, "Should only count the parent's allocated hours (500h).")
+        self.assertEqual(result_group_all.get('effective_hours'), 90.0, "Should be the parent's total hours spent (90h).")
+
+        # Test Case 2: A group containing only the parent task
+        result_group_parent_only = parent_task._get_portal_total_hours_dict()
+        self.assertEqual(result_group_parent_only.get('allocated_hours'), 500.0, "Should be the parent's allocated hours (500h).")
+        self.assertEqual(result_group_parent_only.get('effective_hours'), 90.0, "Should be the parent's total hours spent (90h).")
+
+        # Test Case 3: A group containing only the intermediate sub-task
+        result_group_sub_only = sub_task_1._get_portal_total_hours_dict()
+        self.assertEqual(result_group_sub_only.get('allocated_hours'), 50.0, "Should be the sub-task's allocated hours (50h).")
+        self.assertEqual(result_group_sub_only.get('effective_hours'), 40.0, "Should be the sub-task's total hours spent (40h).")
+
+        # Test Case 4: A group with a parent and a distant sub-task
+        group_with_ancestor = parent_task | sub_task_2
+        result_group_ancestor = group_with_ancestor._get_portal_total_hours_dict()
+        self.assertEqual(result_group_ancestor.get('allocated_hours'), 500.0, "Should only count the parent's allocated hours (500h).")
+        self.assertEqual(result_group_ancestor.get('effective_hours'), 90.0, "Should be the parent's total hours spent (90h).")


### PR DESCRIPTION
Steps to Reproduce:
-
1. In the Project app, create a new project and enable "Timesheets".
2. Create a parent task with allocated hours (e.g., 20h).
3. Create one or more sub-tasks under the parent, also with allocated hours (e.g., 8h and 5h).
4. Log in to the portal and navigate to the project's task list.
5. Observe the "Total" allocated time shown in the list header.

Issue:
-
- The total allocated time displayed in the portal incorrectly sums the hours of the parent task and all its sub-tasks (e.g., 20h + 8h + 5h = 33h). This leads to an inflated and confusing total for the customer.

Cause:
-
- The `_get_portal_total_hours_dict` method calculated the sum of `allocated_hours` on the entire recordset of tasks passed to it, without distinguishing between parent tasks and their children when both were present.

Fix:
-
- This commit excludes sub-task hours from the total allocated time computation if their parent task is also present in the view.
- The total time spent now uses parent `total_hours_spent` which includes both time spent on parent and sub-task.

task-4939234