### PR TITLE
[FIX] stock: make sure default_group_id is used when set for stock picking

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -851,6 +851,10 @@ class Picking(models.Model):
 
         pickings = super().create(vals_list)
 
+        default_group_id = self.env['procurement.group'].browse(self.env.context.get('default_group_id'))
+        if default_group_id:
+            pickings.filtered(lambda p: not p.group_id).group_id = default_group_id
+
         for picking, scheduled_date in zip(pickings, scheduled_dates):
             if scheduled_date:
                 picking.with_context(mail_notrack=True).write({'scheduled_date': scheduled_date})


### PR DESCRIPTION
## Issue: ##
When creating a delivery (stock.picking) with a default_group_id, the group_id is cleared in some case
For example, from a New Quotation linked to a CRM Lead, the correct procurement group (group_id) is initially set
However, upon saving the new picking, the group_id is cleared

## Cause: ##
The `stock.picking.group_id` is related to its `stock.move` lines `group_id`
When opening the pickings from a Sale Order, `the default_group_id` is set in the context
(see https://github.com/odoo/odoo/blob/c55a1f7b5783dfa9a66b9a3c816b59a5adabe6d8/addons/sale_stock/models/sale_order.py#L235)
But the `default_get()` is used to set the `group_id` using the context `active_model` and `active_id`
(see https://github.com/odoo/odoo/blob/689e9c6eb24a3a154a5aee1faa031a143b6484fd/addons/sale_stock/models/stock.py#L22-L25)

In this use case, the `active_model` is `crm.lead` so the `group_id` can't be set that way
The `stock.move`s are created during the `stock.picking` creation but there is a clean context making the moves not able to get the default value
(see https://github.com/odoo/odoo/blob/0a420ad89fd41d785aa6999a18b4f3ff9a149716/odoo/models.py#L4899-L4901)

As a result, `picking.move_ids.group_id` is empty, and since `picking.group_id` is related to the moves, it will be empty too

## Steps to reproduce: ##
- Enable Debug Mode (to view Procurement Group)
- Create a New Quotation from a CRM Lead
- Confirm the Sale Order with a move line
- Click on the Delivery Smart Button and create a New Delivery
- In Additional Info, the Procurement Group should be set
- Add a product and Save
- The Procurement Group is reset

opw-4865843