### PR TITLE
[FIX] website_sale: avoid livechat bubble on top of floating bar

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -710,12 +710,8 @@ body:not(.editor_enable) #category_header {
         }
 
         @include media-breakpoint-down(sm) {
-            #o_wsale_floating_bar.o_wsale_has_pricelist {
+            #o_wsale_floating_bar {
                 bottom: calc(10px + 70px);
-            }
-
-            &:not(:has(#o_wsale_floating_bar.o_wsale_has_pricelist)) {
-                right: calc(px + 70px);
             }
         }
 


### PR DESCRIPTION
In odoo/odoo@860dccec53cb0940212fe7d9161c7e3c805867f7 the floating toolbar layout was introduced, but there was an issue with the livechat bubble which was overlapping the floating bar on mobile when there was no priceslit (error with the calc()).

This PR fixes this issue by displaying the floatingbar above the livechat bubble, taking the same style when there is a pricelist or not.

task-4966406



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
