### PR TITLE
[FIX] pos_loyalty: correct points won by loyalty program

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -623,6 +623,9 @@ patch(Order.prototype, {
      */
     _getPointsCorrection(program) {
         const rewardLines = this.orderlines.filter((line) => line.is_reward_line);
+        if (!this._canGenerateRewards(program, this.get_total_with_tax(), this.get_total_without_tax())) {
+            return 0;
+        }
         let res = 0;
         for (const rule of program.rules) {
             for (const line of rewardLines) {

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -551,3 +551,21 @@ registry.category("web_tour.tours").add("PosRewardProductScanGS1", {
             PosLoyalty.finalizeOrder("Cash", "575.00"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_min_qty_points_awarded", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            PosLoyalty.clickRewardButton(),
+            SelectionPopup.clickItem("Free Product"),
+            PosLoyalty.pointsTotalIs(90),
+            PosLoyalty.orderTotalIs("0.0"),
+            PosLoyalty.finalizeOrder("Cash", "0.0"),
+        ].flat(),
+});
+

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTourMethods.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTourMethods.js
@@ -156,6 +156,14 @@ export function pointsAwardedAre(points_str) {
         },
     ];
 }
+export function pointsTotalIs(points_str) {
+    return [
+        {
+            content: 'loyalty points awarded ' + points_str,
+            trigger: '.loyalty-points-total .value:contains("' + points_str + '")',
+        },
+    ];
+}
 export function notificationMessageContains(str) {
     return [
         {


### PR DESCRIPTION
Loyalty points were not being awarded correctly for some orders. The system granted points even when the minimum required quantity of items was not reached. In some cases, it also added negative loyalty points, which led to an excessive deduction for the customer —sometimes just for claiming a single free product.

> Setup of the Loyalty Program (Discount & Loyalty):
Program Type : Loyalty Card
Rule : minimum 5 items => 10 Loyalty Points per $
Reward : Free product (Simple Pen) => in exchange of 5 Loyalty Points

Steps to reproduce:
-------------------
* Open the pos Shop
* Select a customer with loyalty points
* Add a Simple Pen
* Click on * Reward > Free Product - Loyalty Program

> Observation:
Customer shouldn't 'win' points here
New Total is mathematically correct but not logic

Why the fix:
------------
We need to verify that the order is eligible to generate reward points based on the configured rules, before adding the won points.

opw-4914774

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
