### PR TITLE
[IMP] account: new section widget

### DIFF
--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -18,7 +18,7 @@
                     <t t-set-slot="content">
                         <t t-if="this.isSectionInPage(record)">
                             <DropdownItem onSelected="() => this.addRowInSection(record, false)">
-                                <i class="me-1 fa fa-fw fa-plus"/><span>Add a product</span>
+                                <i class="me-1 fa fa-fw fa-plus"/><span>Add a line</span>
                             </DropdownItem>
                             <t t-if="this.isTopSection(record)">
                                 <DropdownItem onSelected="() => this.addRowAfterSection(record, false)">
@@ -35,6 +35,12 @@
                                     <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
                                 </DropdownItem>
                             </t>
+                            <DropdownItem t-if="showPricesButton" onSelected="() => this.toggleHidePrices(record)">
+                                <i class="me-1 fa fa-fw" t-att-class="hidePrices ? 'fa-eye' : 'fa-eye-slash'"/><span t-out="hidePrices ? 'Show Prices' : 'Hide Prices'"/>
+                            </DropdownItem>
+                            <DropdownItem t-if="showCompositionButton" onSelected="() => this.toggleHideComposition(record)">
+                                <i class="me-1 fa fa-fw" t-att-class="hideCompositions ? 'fa-eye' : 'fa-eye-slash'"/><span t-out="hideCompositions ? 'Show Composition' : 'Hide Composition'"/>
+                            </DropdownItem>
                             <DropdownItem onSelected="() => this.addNoteInSection(record)">
                                 <i class="me-1 fa fa-fw fa-sticky-note-o"/><span>Add a note</span>
                             </DropdownItem>

--- a/addons/account/static/tests/section_and_note.test.js
+++ b/addons/account/static/tests/section_and_note.test.js
@@ -71,7 +71,7 @@ defineMailModels();
 
 onRpc("has_group", () => true);
 
-test("can add a product in a section", async () => {
+test("can add a line in a section", async () => {
     await mountView({
         type: "form",
         resModel: "invoice",
@@ -85,7 +85,7 @@ test("can add a product in a section", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -113,7 +113,7 @@ test("can add a product in a section", async () => {
         "C1",
     ]);
     await contains(".o_list_section_options:eq(0) button").click();
-    await contains(".o-dropdown-item:contains(Add a product)").click();
+    await contains(".o-dropdown-item:contains(Add a line)").click();
     await edit("A3");
     await contains(getFixture()).click();
     expect(queryAllTexts(".o_data_row")).toEqual([
@@ -134,7 +134,7 @@ test("can add a product in a section", async () => {
     ]);
 });
 
-test("can add a product in a subsection", async () => {
+test("can add a line in a subsection", async () => {
     await mountView({
         type: "form",
         resModel: "invoice",
@@ -148,7 +148,7 @@ test("can add a product in a subsection", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -176,7 +176,7 @@ test("can add a product in a subsection", async () => {
         "C1",
     ]);
     await contains(".o_list_section_options:last button").click();
-    await contains(".o-dropdown-item:contains(Add a product)").click();
+    await contains(".o-dropdown-item:contains(Add a line)").click();
     await edit("Ca3");
     await contains(getFixture()).click();
     expect(queryAllTexts(".o_data_row")).toEqual([
@@ -211,7 +211,7 @@ test("can add a subsection in a section", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -284,7 +284,7 @@ test("can't add a subsection if value not in selection", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -314,7 +314,7 @@ test("can add a section after another", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -378,7 +378,7 @@ test("can add a subsection after another", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -442,7 +442,7 @@ test("can delete sections", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -488,7 +488,7 @@ test("can delete subsections", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -545,7 +545,7 @@ test("can duplicate sections", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -611,7 +611,7 @@ test("can duplicate subsections", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -694,7 +694,7 @@ test("can resequence records inside sections", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -788,7 +788,7 @@ test("resequence can be discarded", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -864,7 +864,7 @@ test("can resequence sections", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -905,7 +905,7 @@ test("add a section", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -969,7 +969,7 @@ test("add note", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -1033,7 +1033,7 @@ test("section_and_note_text widget", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -1097,7 +1097,7 @@ test("sections with required content field", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -1167,7 +1167,7 @@ test("sections duplicate with many2many", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>
@@ -1270,7 +1270,7 @@ test("swap sections and subsections", async () => {
                 >
                     <list editable="bottom">
                         <control>
-                            <create name="add_line_control" string="Add a product"/>
+                            <create name="add_line_control" string="Add a line"/>
                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                         </control>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1128,7 +1128,8 @@
                                            'default_currency_id': currency_id or company_currency_id,
                                            'default_display_type': 'product',
                                            'quick_encoding_vals': quick_encoding_vals,
-                                       }" readonly="state != 'draft'">
+                                       }" readonly="state != 'draft'"
+                                       aggregated_fields="price_subtotal,price_total">
                                     <list name="journal_items" editable="bottom" string="Journal Items" default_order="sequence, id">
                                         <control>
                                             <create name="add_line_control" string="Add a line"/>
@@ -1205,6 +1206,9 @@
                                         <field name="company_id" column_invisible="True"/>
                                         <field name="company_currency_id" column_invisible="True"/>
                                         <field name="display_type" force_save="1" column_invisible="True"/>
+                                        <field name="collapse_prices" column_invisible="True"/>
+                                        <field name="collapse_composition" column_invisible="True"/>
+                                        <field name="parent_id" column_invisible="True"/>
                                     </list>
                                     <kanban class="o_kanban_mobile">
                                         <!-- Displayed fields -->

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -168,17 +168,47 @@
                                 <t t-set="current_subtotal" t-value="0"/>
                                 <t t-set="current_total" t-value="0"/>
                                 <t t-set="lines" t-value="o.invoice_line_ids.sorted(key=lambda l: (-l.sequence, l.date, l.move_name, -l.id), reverse=True)"/>
+                                <t t-set="treated_lines" t-value="[]"/>
 
                                 <t t-foreach="lines" t-as="line">
-                                    <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                                     <t t-set="current_total" t-value="current_total + line.price_total"/>
+                                    <t t-set="hide_details" t-value="line.collapse_composition"/>
 
                                     <tr t-att-class="{
                                         'fw-bolder': line.display_type == 'line_section',
                                         'fw-bold': line.display_type == 'line_subsection',
                                         'fst-italic': line.display_type == 'line_note',
                                     }" >
-                                        <t t-if="line.display_type == 'product'" name="account_invoice_line_accountable">
+                                        <t t-if="line.id in treated_lines"/>
+                                        <t t-elif="hide_details">
+                                            <t t-set="grouped_lines" t-value="line.get_lines_grouped_by_section()"/>
+                                            <t t-set="current_subtotal" t-value="0"/>
+                                            <t t-foreach="grouped_lines" t-as="grouped_line">
+                                                <t t-set="current_subtotal" t-value="current_subtotal + grouped_line['price_subtotal']"/>
+                                                <tr>
+                                                    <t t-set="treated_lines" t-value="treated_lines + grouped_line['ids']"/>
+                                                    <td name="account_invoice_line_name_grouped">
+                                                        <span t-out="grouped_line['name']" t-options="{'widget': 'text'}">Group 1</span>
+                                                    </td>
+                                                    <td name="td_quantity_grouped" class="o_td_quantity text-end">
+                                                        <span>1.00</span>
+                                                    </td>
+                                                    <td name="td_price_unit_grouped" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                                        <span t-if="not line.collapse_prices" t-out="grouped_line['price_subtotal']" class="text-nowrap">9.00</span>
+                                                    </td>
+                                                    <td name="td_discount_grouped" t-if="display_discount"/>
+                                                    <td name="td_taxes_grouped" t-if="display_taxes" class="text-end">
+                                                        <span t-out="','.join(grouped_line['taxes'])" id="line_tax_ids">Tax 15%</span>
+                                                    </td>
+                                                    <td name="td_subtotal_grouped" class="text-end o_price_total">
+                                                        <span t-if="not line.collapse_prices and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-out="grouped_line['price_subtotal']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>27.00</span>
+                                                        <span t-if="not line.collapse_prices and o.company_price_include == 'tax_included'" class="text-nowrap" t-out="grouped_line['price_total']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>31.05</span>
+                                                    </td>
+                                                </tr>
+                                            </t>
+                                        </t>
+                                        <t t-elif="line.display_type == 'product'" name="account_invoice_line_accountable">
+                                            <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                                             <td name="account_invoice_line_name">
                                                 <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
                                             </td>
@@ -192,7 +222,7 @@
                                                 </span>
                                             </td>
                                             <td name="td_price_unit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                                <span class="text-nowrap" t-field="line.price_unit">9.00</span>
+                                                <span t-if="not line.collapse_prices" class="text-nowrap" t-field="line.price_unit">9.00</span>
                                             </td>
                                             <td name="td_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                                 <span class="text-nowrap" t-field="line.discount">0</span>
@@ -202,13 +232,17 @@
                                                 <span t-out="taxes" id="line_tax_ids">Tax 15%</span>
                                             </td>
                                             <td name="td_subtotal" class="text-end o_price_total">
-                                                <span t-if="o.company_price_include == 'tax_excluded'" class="text-nowrap" t-field="line.price_subtotal">27.00</span>
-                                                <span t-if="o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
+                                                <span t-if="not line.collapse_prices and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-field="line.price_subtotal">27.00</span>
+                                                <span t-if="not line.collapse_prices and o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
                                             </td>
                                         </t>
                                         <t t-elif="line.display_type in ('line_section', 'line_subsection')">
-                                            <td colspan="99">
+                                            <t t-set="section_subtotal" t-value="line.get_section_subtotal()"/>
+                                            <td colspan="4">
                                                 <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
+                                            </td>
+                                            <td colspan="1" class="text-end o_price_total">
+                                                <span t-out="section_subtotal" class="text-nowrap" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                             </td>
                                             <t t-set="current_section" t-value="line"/>
                                             <t t-set="current_subtotal" t-value="0"/>
@@ -219,7 +253,7 @@
                                             </td>
                                         </t>
                                     </tr>
-                                    <t t-if="current_section and (line_last or lines[line_index+1].display_type in ('line_section', 'line_subsection'))">
+                                    <t t-if="not line.collapse_prices and current_section and (line_last or lines[line_index+1].display_type in ('line_section', 'line_subsection'))">
                                         <tr class="is-subtotal text-end">
                                             <td colspan="99">
                                                 <strong class="mr16">Subtotal</strong>

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -127,9 +127,9 @@
         </td>
 
         <!-- use latam prices (to include/exclude VAT) -->
-        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="before">
+        <xpath expr="//t[@t-foreach='lines']/t" position="before">
             <t t-set="l10n_ar_values" t-value="line._l10n_ar_prices_and_taxes()"/>
-        </t>
+        </xpath>
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
             <attribute name="t-field"></attribute>
             <attribute name="t-out">l10n_ar_values['price_unit']</attribute>

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -98,7 +98,14 @@
                     <t t-foreach="lines_to_report" t-as="line">
 
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
+
+                        <t
+                            t-if="line.display_type not in ('line_section', 'line_subsection')
+                                or line.product_type == 'combo'
+                                or not line.collapse_composition"
+                        >
                         <tr
+                            t-if="not line.collapse_composition"
                             t-att-class="{
                                 'fw-bolder o_line_section': line.display_type == 'line_section' or line.product_type == 'combo',
                                 'fw-bold o_line_subsection': line.display_type == 'line_subsection',
@@ -116,7 +123,12 @@
                                     </span>
                                 </td>
                                 <td name="td_priceunit" class="text-end text-nowrap">
-                                    <span t-field="line.price_unit">3</span>
+                                    <span
+                                        t-if="not line.collapse_prices"
+                                        t-field="line.price_unit"
+                                    >
+                                        3
+                                    </span>
                                 </td>
                                 <td name="td_discount" t-if="display_discount" class="text-end">
                                     <span t-field="line.discount">-</span>
@@ -126,15 +138,25 @@
                                     <span t-out="taxes">Tax 15%</span>
                                 </td>
                                 <td t-if="not line.is_downpayment" name="td_subtotal" class="text-end o_price_total">
-                                    <span t-field="line.price_subtotal">27.00</span>
+                                    <span
+                                        t-if="not line.collapse_prices"
+                                        t-field="line.price_subtotal"
+                                    >
+                                        27.00
+                                    </span>
                                 </td>
                             </t>
-                            <t t-elif="line.display_type in ('line_section', 'line_subsection') or line.product_type == 'combo'">
+                            <t
+                                t-elif="line.display_type in ('line_section', 'line_subsection')
+                                    or line.product_type == 'combo'"
+                            >
                                 <td name="td_section_line" colspan="99">
                                     <span t-field="line.name">A section title</span>
                                 </td>
-                                <t t-set="current_section" t-value="line"/>
-                                <t t-set="current_subtotal" t-value="0"/>
+                                <t t-if="line.display_type == 'line_section'">
+                                    <t t-set="current_section" t-value="line"/>
+                                    <t t-set="current_subtotal" t-value="0"/>
+                                </t>
                             </t>
                             <t t-elif="line.display_type == 'line_note'">
                                 <td name="td_note_line" colspan="99">
@@ -142,6 +164,51 @@
                                 </td>
                             </t>
                         </tr>
+                        </t>
+
+                        <t
+                            t-elif="(
+                                    line.display_type == 'line_subsection'
+                                    and not line.parent_id.collapse_composition
+                                )
+                                or line.display_type == 'line_section'"
+                        >
+                            <tr
+                                t-foreach="line._get_grouped_section_summary()"
+                                t-as="section_line"
+                                class="o_line_section"
+                            >
+                                <td name="td_name">
+                                    <span t-out="section_line['name']">Section Summary</span>
+                                </td>
+                                <td name="td_quantity" class="text-end text-nowrap">
+                                    <span>1.00 Units</span>
+                                </td>
+                                <td name="td_priceunit" class="text-end text-nowrap">
+                                    <span t-out="section_line['price_subtotal']"/>
+                                </td>
+                                <td name="td_discount" t-if="display_discount"/>
+                                <td
+                                    name="td_taxes"
+                                    t-if="display_taxes"
+                                    t-attf-class="text-end {{ 'text-nowrap' if len(section_line['taxes']) &lt; 10 else '' }}"
+                                >
+                                    <span t-out="', '.join(section_line['taxes'])">
+                                        Tax 15%
+                                    </span>
+                                </td>
+                                <td class="text-end o_price_total">
+                                    <span t-out="section_line['price_subtotal']">
+                                        31.05
+                                    </span>
+                                </td>
+                            </tr>
+                            <t t-if="line.display_type == 'line_section'">                                
+                                <t t-set="current_section" t-value="line"/>
+                                <t t-set="current_subtotal" t-value="0"/>
+                            </t>
+                        </t>
+
                         <t
                             t-if="current_section and (
                                 line_last
@@ -151,7 +218,9 @@
                                     line.combo_item_id
                                     and not lines_to_report[line_index+1].combo_item_id
                                 )
-                            ) and not line.is_downpayment"
+                            )
+                            and not line.is_downpayment
+                            and not current_section.collapse_composition"
                         >
                             <t t-set="current_section" t-value="None"/>
                             <tr class="is-subtotal text-end">

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -614,6 +614,9 @@
                                 <field name="selected_combo_items" column_invisible="1"/>
                                 <field name="virtual_id" column_invisible="1"/>
                                 <field name="linked_virtual_id" column_invisible="1"/>
+                                <field name="parent_id" column_invisible="True"/>
+                                <field name="collapse_prices" column_invisible="1"/>
+                                <field name="collapse_composition" column_invisible="1"/>
 
                                 <!-- Currency, needed for monetary widgets to display the currency symbol -->
                                 <field name="currency_id" column_invisible="True"/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -724,7 +724,14 @@
 
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                                 <t t-set="is_note" t-value="line.display_type == 'line_note'"/>
+
+                                <!-- TODO VFE NIPL merge t-if -->
+                                <t t-if="line.display_type not in ('line_section', 'line_subsection')
+                                         or line.product_type == 'combo'
+                                         or not line.collapse_composition"
+                                >
                                 <tr
+                                    t-if="not line.collapse_composition"
                                     t-att-class="{
                                         'fw-bolder o_line_section': line.display_type == 'line_section' or line.product_type == 'combo',
                                         'fw-bold o_line_subsection': line.display_type == 'line_subsection',
@@ -746,7 +753,7 @@
                                         </td>
                                         <td t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
                                             <div
-                                                t-if="line.discount &gt;= 0"
+                                                t-if="line.discount &gt;= 0 and not line.collapse_prices"
                                                 t-field="line.price_unit"
                                                 t-att-style="line.discount and 'text-decoration: line-through' or None"
                                                 t-att-class="(line.discount and 'text-danger' or '') + ' text-end'"
@@ -764,15 +771,24 @@
                                             <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
                                         </td>
                                         <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
-                                        <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
+                                            <span
+                                                t-if="not line.collapse_prices"
+                                                class="oe_order_line_price_subtotal"
+                                                t-field="line.price_subtotal"
+                                            />
                                         </td>
                                     </t>
-                                    <t t-if="line.display_type in ('line_section', 'line_subsection') or line.product_type == 'combo'">
+                                    <t
+                                        t-if="line.display_type in ('line_section','line_subsection')
+                                            or line.product_type == 'combo'"
+                                    >
                                         <td colspan="99">
                                             <span t-field="line.name"/>
                                         </td>
-                                        <t t-set="current_section" t-value="line"/>
-                                        <t t-set="current_subtotal" t-value="0"/>
+                                        <t t-if="line.display_type == 'line_section'">
+                                            <t t-set="current_section" t-value="line"/>
+                                            <t t-set="current_subtotal" t-value="0"/>
+                                        </t>
                                     </t>
                                     <t t-if="is_note">
                                         <td colspan="99">
@@ -780,16 +796,62 @@
                                         </td>
                                     </t>
                                 </tr>
+                                </t>
+
+                                <t
+                                    t-elif="(
+                                            line.display_type == 'line_subsection'
+                                            and not line.parent_id.collapse_composition
+                                        )
+                                        or line.display_type == 'line_section'"
+                                >
+                                    <tr
+                                        t-foreach="line._get_grouped_section_summary()"
+                                        t-as="section_line"
+                                        class="o_line_section"
+                                    >
+                                        <td name="td_name">
+                                            <span t-out="section_line['name']">Section Summary</span>
+                                        </td>
+                                        <td name="td_quantity" class="text-end text-nowrap">
+                                            <span>1.00 Units</span>
+                                        </td>
+                                        <td name="td_priceunit" class="text-end text-nowrap">
+                                            <span t-out="section_line['price_subtotal']"/>
+                                        </td>
+                                        <td name="td_discount" t-if="display_discount"/>
+                                        <td
+                                            name="td_taxes"
+                                            t-if="display_taxes"
+                                            t-attf-class="text-end {{ 'text-nowrap' if len(section_line['taxes']) &lt; 10 else '' }}"
+                                        >
+                                            <span t-out="', '.join(section_line['taxes'])">
+                                                Tax 15%
+                                            </span>
+                                        </td>
+                                        <td class="text-end o_price_total">
+                                            <span t-out="section_line['price_subtotal']">
+                                                31.05
+                                            </span>
+                                        </td>
+                                    </tr>
+                                    <t t-if="line.display_type == 'line_section'">
+                                        <t t-set="current_section" t-value="line"/>
+                                        <t t-set="current_subtotal" t-value="0"/>
+                                    </t>
+                                </t>
                                 <tr
                                     t-if="current_section and (
                                         line_last
-                                        or lines_to_report[line_index+1].display_type in ('line_section', 'line_subsection')
+                                        or lines_to_report[line_index+1].display_type == 'line_section'
                                         or lines_to_report[line_index+1].product_type == 'combo'
                                         or (
                                             line.combo_item_id
                                             and not lines_to_report[line_index+1].combo_item_id
                                         )
-                                    ) and not line.is_downpayment"
+                                    )
+                                    and not line.is_downpayment
+                                    and current_section.collapse_composition"
                                     class="is-subtotal text-end"
                                 >
                                     <t t-set="current_section" t-value="None"/>


### PR DESCRIPTION
This commit implement the new Section widgets into account moves views.

This also add the Hide prices and Hide composition features:

- Hide prices: hide the prices of invoice lines in the pdf report.
- Hide composition: group the section or subsection into a single line in the pdf report, grouping by set of taxes.

This is just the first step, we will implement this feature in all edi's.

task-4966574