### PR TITLE
[FIX] stock: prevent sn duplicated warning in Physical Inventory

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -216,7 +216,7 @@ class StockQuant(models.Model):
     @api.depends('lot_id')
     def _compute_sn_duplicated(self):
         self.sn_duplicated = False
-        domain = [('tracking', '=', 'serial'), ('lot_id', 'in', self.lot_id.ids), ('location_id.usage', 'in', ['internal', 'transit'])]
+        domain = [('tracking', '=', 'serial'), ('lot_id', 'in', self.lot_id.ids), ('quantity', '>', 0), ('location_id.usage', 'in', ['internal', 'transit'])]
         results = self._read_group(domain, ['lot_id'], having=[('__count', '>', 1)])
         duplicated_sn_ids = [lot.id for [lot] in results]
         quants_with_duplicated_sn = self.env['stock.quant'].search([('lot_id', 'in', duplicated_sn_ids)])

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -912,6 +912,12 @@ class StockQuant(TransactionCase):
         with self.assertRaises(UserError):
             quant_2.with_context(inventory_mode=True).write({'location_id': self.stock_subloc2})
 
+        self.env['stock.quant']._update_available_quantity(product, self.stock_subloc2, -1.0, lot_id=sn1)
+        self.assertRecordValues(product.stock_quant_ids.sorted('id'), [
+            {'location_id': self.stock_subloc2.id, 'quantity': 0.0, 'sn_duplicated': False},
+            {'location_id': self.stock_subloc3.id, 'quantity': 1.0, 'sn_duplicated': False},
+        ])
+
     def test_update_quant_with_forbidden_field_02(self):
         """
         Test that updating the package from the quant raise an error


### PR DESCRIPTION
## Issue: ##
A warning appears in Physical Inventory when transferring a product with a serial number between two locations

## Cause: ##
The `_compute_sn_duplicated()` method incorrectly considered `stock.quant` records with quantity 0
That mean that it will considered a duplication even if the quant indicate that the product isn't in that location

Additionally, the system parameter `stock.skip_quant_tasks` is enabled on all SaaS environments since version 18.2  
It was added for performance issues:
(see: https://github.com/odoo/odoo/commit/207ba01819577cf6a2a686fae39dd3d673aec6dd)
When enabled, the quant merging and removal of zero quants are skipped when opening a Physical Inventory, causing this issue to appear

## Steps to reproduce: ##
- Enable Developer Mode
- Create a New System Parameter (Key: stock.skip_quant_tasks, Value: True)
- In Settings, enable Storage Locations and Lots & Serial Numbers
- Duplicate WH/Stock as WH/Stock (copy)
- Create a product tracked by Unique Serial Number
- Update its quantity: one at WH/Stock
- Process an Internal Transfert from WH/Stock to WH/Stock (copy)
- Go in Operations > Adjustments > Physical Inventory

opw-4944011