### PR TITLE
[FIX] mail: avoid active domain on missing active field

### DIFF
--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -170,6 +170,7 @@ class ResUsers(models.Model):
                 'name': meeting_label,
                 'model': 'calendar.event',
                 'icon': modules.module.get_module_icon(EventModel._original_module),
+                'domain': [('active', 'in', [True, False])],
                 'meetings': meetings_lines,
                 "view_type": EventModel._systray_view,
             }

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -441,6 +441,8 @@ class ResUsers(models.Model):
                 "model": model_name,
                 "type": "activity",
                 "icon": icon,
+                # activity more important than archived status, active_test is too broad
+                "domain": [('active', 'in', [True, False])] if model_name != "mail.activity" and "active" in Model else [],
                 "total_count": model_activity_states[model_name]['total_count'],
                 "today_count": model_activity_states[model_name]['today_count'],
                 "overdue_count": model_activity_states[model_name]['overdue_count'],

--- a/addons/mail/static/src/core/web/activity_menu.js
+++ b/addons/mail/static/src/core/web/activity_menu.js
@@ -66,8 +66,7 @@ export class ActivityMenu extends Component {
             context["search_default_activities_upcoming_all"] = 1;
         }
 
-        // include archived records, as activities are more important than archived
-        let domain = [["active", "in", [true, false]]];
+        let domain = [];
         if (group.domain) {
             domain = Domain.and([domain, group.domain]).toList();
         }

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -167,6 +167,10 @@ export class ResUsers extends webModels.ResUsers {
                     id: modelName, // for simplicity
                     model: modelName,
                     name: modelName,
+                    domain:
+                        modelName && "active" in this.env[modelName]._fields
+                            ? [["active", "in", [true, false]]]
+                            : [],
                     overdue_count: 0,
                     planned_count: 0,
                     today_count: 0,

--- a/addons/mass_mailing_sms/models/res_users.py
+++ b/addons/mass_mailing_sms/models/res_users.py
@@ -54,6 +54,7 @@ class ResUsers(models.Model):
                             'model': 'mailing.mailing',
                             'type': 'activity',
                             'icon': icon,
+                            'domain': [('active', 'in', [True, False])],
                             'total_count': 0, 'today_count': 0, 'overdue_count': 0, 'planned_count': 0,
                             'res_ids': res_ids,
                             "view_type": view_type,
@@ -65,7 +66,10 @@ class ResUsers(models.Model):
 
                 for mailing_type in user_activities.keys():
                     user_activities[mailing_type].update({
-                        'domain': json.dumps([['activity_ids.res_id', 'in', list(user_activities[mailing_type]['res_ids'])]])
+                        'domain': json.dumps([
+                            ['active', 'in', [True, False]],
+                            ['activity_ids.res_id', 'in', list(user_activities[mailing_type]['res_ids'])],
+                        ])
                     })
                 activities.extend(list(user_activities.values()))
                 break

--- a/addons/project_todo/models/res_users.py
+++ b/addons/project_todo/models/res_users.py
@@ -59,6 +59,7 @@ class ResUsers(models.Model):
                     'model': 'project.task',
                     'type': 'activity',
                     'icon': icon,
+                    'domain': [('active', 'in', [True, False])],
                     'total_count': 0, 'today_count': 0, 'overdue_count': 0, 'planned_count': 0,
                     'res_ids': set(),
                     'view_type': view_type,
@@ -70,7 +71,10 @@ class ResUsers(models.Model):
 
         for group in user_activities.values():
             group.update({
-                'domain': json.dumps([['activity_ids.res_id', 'in', list(group['res_ids'])]])
+                'domain': json.dumps([
+                    ['active', 'in', [True, False]],
+                    ['activity_ids.res_id', 'in', list(group['res_ids'])]
+                ])
             })
         activity_groups.extend(list(user_activities.values()))
 

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -365,6 +365,7 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
                         {
                             "type": "activity",
                             "view_type": "list",
+                            "domain": [],
                             "overdue_count": 0,
                             "planned_count": 0,
                             "today_count": len(expected_other_activities),
@@ -386,6 +387,7 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
                 self.assertIn(test_model_name, activity_groups_by_model)
                 self.assertDictEqual(
                     {
+                        "domain": [],
                         "type": "activity",
                         "view_type": "list",
                         "overdue_count": 0,


### PR DESCRIPTION
In this forward-port [1]
`active_test=False` is replaced with `[('active', 'in', [True, False])]`
to prevent "active_test" from applying on the activities, which should
not be displayed when archived by default.

The change cannot be applied generically because not all activity mixin
models have an "active" field.

Instead the groups can define their domain depending on their individual
fields. "group domains" are conveniently already supported for use cases
like "fake" groups for todo tasks and the likes.

[1]: https://github.com/odoo/odoo/commit/1cd920a2c7ed251d5e74a890f7183a7620bc06a3