### PR TITLE
[FIX] iot_drivers: ensure session_id using longpolling and fdm

### DIFF
--- a/addons/iot_drivers/controllers/driver.py
+++ b/addons/iot_drivers/controllers/driver.py
@@ -40,6 +40,7 @@ class DriverController(http.Controller):
             _logger.warning("IoT Device with identifier %s not found", device_identifier)
             return False
 
+        data['session_id'] = session_id  # ensure session_id is in data as for websocket communication
         _logger.debug("Calling action %s for device %s", data.get('action', ''), device_identifier)
         iot_device.action(data)
         return True

--- a/addons/iot_drivers/iot_handlers/drivers/serial_base_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_base_driver.py
@@ -128,9 +128,8 @@ class SerialDriver(Driver):
         """Establish a connection with the device if needed and have it perform a specific action.
 
         :param data: the `_actions` key mapped to the action method we want to call
-        :type data: string
         """
-
+        self.data['owner'] = data.get('session_id')
         if self._connection and self._connection.isOpen():
             self._do_action(data)
         else:


### PR DESCRIPTION
As we now provide the session_id from the action method, we need to also provide it on the overridden method of the serial driver.

In addition, as this id is not provided inside of the data object using longpolling, we need to add it manually to the dictionary.