### PR TITLE
[IMP] mail: improve discuss notification item style

### DIFF
--- a/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
@@ -1,4 +1,4 @@
 .o-mail-MessagingMenu {
     --mail-MessagingMenu-bg: #{mix($gray-100, $gray-200, 65%)};
-    --mail-MessagingMenu-activeBorderTopColor: #{lighten($primary, 5%)};
+    --mail-MessagingMenu-listBorderColor: #{rgba($gray-300, .25)};
 }

--- a/addons/mail/static/src/core/public_web/messaging_menu.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.scss
@@ -7,15 +7,7 @@
 
 .o-mail-MessagingMenu-list {
     background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
-}
-
-.o-mail-MessagingMenu-navbar button {
-    border-top: 2px solid !important;
-    border-color: transparent !important;
-
-    &.o-active {
-        border-top-color: var(--mail-MessagingMenu-activeBorderTopColor, rgba($primary, .75)) !important;
-    }
+    --list-group-border-color: #{var(--mail-MessagingMenu-listBorderColor, rgba($gray-200, .5))};
 }
 
 .o-mail-MessagingMenu-tabCounter, .o-mail-MessagingMenu-tabUnread {

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -7,7 +7,7 @@
 
 <t t-name="mail.MessagingMenu.content">
     <div t-if="!(ui.isSmall and env.inDiscussApp and store.discuss.activeTab === 'main')" t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu ${ui.isSmall ? 'o-small' : ''}`">
-        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto o-scrollbar-thin flex-grow-1 list-group list-group-flush px-2 py-1 gap-1 o-scrollbar-thin" t-ref="notification-list">
+        <div t-if="!env.inDiscussApp or store.discuss.activeTab !== 'main'" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto o-scrollbar-thin flex-grow-1 list-group list-group-flush o-scrollbar-thin" t-ref="notification-list">
             <t t-foreach="threads" name="threads" t-as="thread" t-key="thread.localId">
                 <t t-set="message" t-value="thread.isChatChannel or (thread.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentOfAllMessage : thread.needactionMessages.at(-1)"/>
                 <NotificationItem
@@ -15,6 +15,7 @@
                     counter="thread.needactionCounter"
                     datetime="message?.datetime"
                     iconSrc="thread.avatarUrl"
+                    important="thread.needactionCounter"
                     hasMarkAsReadButton="thread.isUnread"
                     muted="thread.selfMember?.mute_until_dt ? 2 : !thread.isUnread ? 1 : 0"
                     onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread)"
@@ -55,14 +56,14 @@
             </t>
         </div>
     </div>
-    <div t-if="ui.isSmall" class="o-mail-MessagingMenu-navbar d-flex bg-view shadow-lg w-100 btn-group">
-        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 rounded-0 bg-transparent position-relative" t-att-class="{
-            'text-primary fw-bold o-active': store.discuss.activeTab === tab.id,
+    <div t-if="ui.isSmall" class="o-mail-MessagingMenu-navbar d-flex bg-view border-top shadow-lg w-100 btn-group o-px-1_5">
+        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 rounded-0 bg-transparent position-relative border-0" t-att-class="{
+            'o-fw-600 o-active': store.discuss.activeTab === tab.id,
             'pb-4': isIosPwa,
             'pb-2': !isIosPwa,
         }" t-on-click="() => this.onClickNavTab(tab.id)">
-            <i t-attf-class="p-1 fs-2 {{ tab.icon }}" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id, 'opacity-50': store.discuss.activeTab !== tab.id }"/>
-            <span class="smaller" t-esc="tab.label" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id, 'opacity-50': store.discuss.activeTab !== tab.id }"/>
+            <i t-attf-class="p-1 fs-2 {{ tab.icon }}" t-att-class="{ 'o-opacity-35': store.discuss.activeTab !== tab.id }"/>
+            <span class="smaller text-truncate" t-esc="tab.label" t-att-class="{ 'o-opacity-35': store.discuss.activeTab !== tab.id }"/>
             <span t-if="tab.counter" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabCounter overflow-visible d-inline-block" t-esc="tab.counter"/>
             <span t-elif="tab.channelHasUnread" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabUnread overflow-visible d-inline-block ms-2"><i class="fa fa-circle"/></span>
         </button>

--- a/addons/mail/static/src/core/public_web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.dark.scss
@@ -1,12 +1,3 @@
 .o-mail-NotificationItem {
     --mail-NotificationItem-activeOutlineOpacity: 1;
-    --mail-NotificationItem-bg: #{lighten(mix($gray-100, $gray-200, 65%), 1.5%)};
-
-    &.o-important {
-        background-color: mix($gray-100, darken($info, 5%), 82.5%) !important;
-        border-color: lighten(mix($gray-100, darken($info, 5%), 82.5%), 5%) !important;
-    }
-    &:hover, &.o-active {
-        background-color: mix($o-gray-200, $o-gray-300) !important;
-    }
 }

--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -17,6 +17,7 @@ export class NotificationItem extends Component {
         "first?",
         "hasMarkAsReadButton?",
         "iconSrc?",
+        "important?",
         "muted?",
         "onClick",
         "onSwipeLeft?",

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -1,24 +1,15 @@
 .o-mail-NotificationItem {
     outline: 1px solid transparent;
     outline-offset: -1px;
-    background-color: var(--mail-NotificationItem-bg, mix($gray-100, $o-view-background-color, 95%));
 
-    &.o-important {
-        background-color: mix($o-view-background-color, lighten($info, 5%), 87.5%);
-        border-color: darken(mix($o-view-background-color, $info, 87.5%), 7.5%) !important;
-    }
-    &:not(.o-important) {
+    &:not(.o-interest) {
         --border-opacity: .35;
     }
     &.o-active {
         outline-color: rgba($o-action, var(--mail-NotificationItem-activeOutlineOpacity, 0.5));
     }
     &:hover, &.o-active {
-        background-color: mix($o-gray-100, $o-gray-200) !important;
-
-        &.o-important {
-            background-color: mix($o-gray-100, $o-info, 87.5%) !important;
-        }
+        filter: contrast(.9);
     }
 }
 
@@ -29,18 +20,35 @@
     margin-bottom: map-get($spacers, 1) / 2;
 
     &.o-small {
-        margin: map-get($spacers, 1);
+        height: 52px;
     }
 }
 
 .o-mail-NotificationItem-badge {
     padding: 3px 6px !important;
+    &.o-discuss-badge:not(.o-important) {
+        --o-discuss-badge-bg: #{$gray-500};
+    }
+}
+
+.o-mail-NotificationItem-counter.o-empty {
+    font-size: 0.5rem !important;
+    aspect-ratio: 1;
+
+    &:before {
+        // invisible character so that typing status bar has constant height, regardless of text content.
+        content: "\200b"; /* unicode zero width space character */
+    }
 }
 
 .o-mail-NotificationItem-country {
     width: 16px;
     bottom: -2px;
     left: -4px;
+}
+
+.o-mail-NotificationItem-line {
+    line-height: 1.15rem;
 }
 
 .o-mail-NotificationItem-markAsRead {
@@ -58,7 +66,11 @@
     }
 }
 
-.o-mail-NotificationItem-text:before {
-    // invisible character so that typing status bar has constant height, regardless of text content.
-    content: "\200b"; /* unicode zero width space character */
+.o-mail-NotificationItem-text {
+    opacity: .5;
+
+    &:before {
+        // invisible character so that typing status bar has constant height, regardless of text content.
+        content: "\200b"; /* unicode zero width space character */
+    }
 }

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -3,44 +3,45 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border o-rounded-bubble o-py-1_5 shadow-sm" t-on-click="onClick" t-ref="root" t-att-class="{
-            'o-important': props.muted === 0,
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 position-relative o-py-1_5 bg-transparent" t-on-click="onClick" t-ref="root" t-att-class="{
+            'o-important': props.important,
+            'o-interest': props.muted === 0,
             'text-muted border-secondary': props.muted === 1,
             'opacity-50 border-secondary': props.muted === 2,
-            'px-1 o-small': ui.isSmall,
+            'px-3 gap-1 o-small': ui.isSmall,
             'border-top-0': props.first,
-            'p-2': !ui.isSmall,
+            'o-px-2_5 gap-2': !ui.isSmall,
             'o-active': props.isActive,
         }">
             <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
-                <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
+                <img class="o_avatar w-100 h-100" t-att-class="{ 'rounded-3': ui.isSmall, 'rounded': !ui.isSmall }" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>
-            <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto o-scrollbar-thin ps-1">
-                <div class="d-flex text-nowrap">
-                    <span class="o-mail-NotificationItem-name" t-att-class="{ 'fw-bold': props.muted, 'o-fw-600': !props.muted, 'fs-5': ui.isSmall }" t-att-style="props.nameMaxLine !== undefined ? webkitLineClamp(props.nameMaxLine) : ''">
+            <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto o-scrollbar-thin" t-att-class="{ 'o-ps-1_5': ui.isSmall, 'ps-1': !ui.isSmall }">
+                <div class="o-mail-NotificationItem-line d-flex text-nowrap">
+                    <span class="o-mail-NotificationItem-name o-fw-600" t-att-class="{ 'fs-5': ui.isSmall }" t-att-style="props.nameMaxLine !== undefined ? webkitLineClamp(props.nameMaxLine) : ''">
                         <t t-slot="name"/>
                     </span>
                     <span class="flex-grow-1"/>
-                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 me-1 flex-shrink-0 align-self-end" t-att-class="{ 'opacity-75': props.muted, 'o-fw-600': !props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
+                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2 me-1 flex-shrink-0 align-self-end smaller" t-att-class="{ 'opacity-75': props.muted, 'o-fw-600': !props.muted }" t-att-title="props.datetime?.toLocaleString(DateTime.DATETIME_SHORT) ?? ''">
                         <t t-esc="dateText"/>
                     </small>
+                    <t t-if="props.slots and props.slots.sideContent">
+                        <t t-slot="sideContent"/>
+                    </t>
                 </div>
-                <div class="d-flex">
-                    <div class="o-mail-NotificationItem-text opacity-75" t-att-class="{ 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate  }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
+                <div class="d-flex o-mail-NotificationItem-line">
+                    <div class="o-mail-NotificationItem-text" t-att-class="{ 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate, 'small': !ui.isSmall }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
                         <t t-slot="body-icon"/>
                         <t t-if="props.slots?.body" name="notificationBody" t-slot="body"/>
                     </div>
                     <div class="flex-grow-1"/>
                     <div class="d-flex align-items-start">
-                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter shadow-sm"><t t-esc="props.counter"/></span>
-                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 rounded-3 fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer shadow-sm" title="Mark As Read" t-ref="markAsRead"/>
+                        <span t-if="!props.muted and !(rootHover.isHover and props.hasMarkAsReadButton)" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{ props.counter > 0 and props.muted === 2 ? 'o-muted' : '' }} {{ props.important ? 'o-important' : '' }} {{ props.counter === 0 ? 'o-empty me-1' : '' }} d-flex align-items-center justify-content-center m-0 o-mx-0_5 badge rounded-pill fw-bold o-mail-NotificationItem-counter shadow-sm"><t t-if="props.counter" t-esc="props.counter"/></span>
+                        <span t-elif="props.hasMarkAsReadButton" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 rounded fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-50 opacity-100-hover cursor-pointer shadow-sm" t-att-class="{ invisible: !rootHover.isHover }" title="Mark As Read" t-ref="markAsRead"/>
                     </div>
                 </div>
             </div>
-            <t t-if="props.slots and props.slots.sideContent">
-                <t t-slot="sideContent" />
-            </t>
         </button>
     </ActionSwiper>
 </t>

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -18,13 +18,13 @@
 
     <t t-inherit="mail.MessagingMenu.content" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='notification-list']" position="before">
-            <div class="o-mail-MessagingMenu-header d-flex" t-att-class="{'border-start-0 border-end-0': ui.isSmall, 'flex-shrink-0': !env.inDiscussApp }">
+            <div class="o-mail-MessagingMenu-header d-flex o-px-1_5" t-att-class="{'border-start-0 border-end-0': ui.isSmall, 'flex-shrink-0': !env.inDiscussApp }">
                 <t t-if="!ui.isSmall">
                     <MessagingMenuQuickSearch t-if="state.searchOpen" onClose.bind="toggleSearch"/>
                     <t t-else="">
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
                         <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
                         <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                     </t>
@@ -41,6 +41,7 @@
             <t t-set="itemIndex" t-value="0"/>
             <t t-if="installationRequest.isShown and !store.discuss.searchTerm">
                 <NotificationItem
+                    important="1"
                     isActive="state.activeIndex === itemIndex"
                     iconSrc="installationRequest.iconSrc"
                     onClick="installationRequest.onClick"
@@ -52,17 +53,20 @@
                         <ImStatus persona="installationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
                     <t t-set-slot="sideContent">
-                        <a t-if="ui.isSmall" class="btn fa fa-cloud-download" />
-                        <t t-else="">
-                            <a class="btn btn-primary px-2 py-1 smaller">Install</a>
-                            <span t-if="!hasTouch()" t-on-click.stop="() => this.pwa.decline()" class="text-dark bg-transparent oi oi-close opacity-50 opacity-100-hover" title="Dismiss"></span>
-                        </t>
+                        <div class="d-flex align-items-center justify-content-center o-gap-1_5" t-att-class="{ 'pe-1': !ui.isSmall }">
+                            <a t-if="ui.isSmall" class="btn fa fa-cloud-download px-0"/>
+                            <t t-else="">
+                                <a class="btn btn-primary px-2 py-1 smaller">Install</a>
+                                <span t-if="!hasTouch()" t-on-click.stop="() => this.pwa.decline()" class="text-dark bg-transparent oi oi-close opacity-50 opacity-100-hover" title="Dismiss"></span>
+                            </t>
+                        </div>
                     </t>
                 </NotificationItem>
                 <t t-set="itemIndex" t-value="itemIndex + 1"/>
             </t>
             <t t-if="notificationRequest.isShown and !store.discuss.searchTerm">
                 <NotificationItem
+                    important="1"
                     isActive="state.activeIndex === itemIndex"
                     iconSrc="notificationRequest.iconSrc"
                     onClick="() => notification.requestPermission()"
@@ -73,11 +77,13 @@
                         <ImStatus persona="notificationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
                     <t t-set-slot="sideContent">
-                        <a t-if="ui.isSmall" class="btn fa fa-bell" />
-                        <t t-else="">
-                            <a class="btn btn-primary px-2 py-1 smaller">Enable</a>
-                            <span t-if="!hasTouch()" t-on-click.stop="() => this.store.isNotificationPermissionDismissed = true" class="text-dark bg-transparent oi oi-close opacity-50 opacity-100-hover" title="Dismiss"></span>
-                        </t>
+                        <div class="d-flex align-items-center justify-content-center o-gap-1_5" t-att-class="{ 'pe-1': !ui.isSmall }">
+                            <a t-if="ui.isSmall" class="btn fa fa-bell px-0"/>
+                            <t t-else="">
+                                <a class="btn btn-primary btn-sm px-1 py-0">Enable</a>
+                                <span t-if="!hasTouch()" t-on-click.stop="() => this.store.isNotificationPermissionDismissed = true" class="text-dark bg-transparent oi oi-close opacity-50 opacity-100-hover" title="Dismiss"></span>
+                            </t>
+                        </div>
                     </t>
                 </NotificationItem>
                 <t t-set="itemIndex" t-value="itemIndex + 1"/>
@@ -85,6 +91,7 @@
             <t t-if="store.discuss.activeTab === 'main' and !env.inDiscussApp and !store.discuss.searchTerm">
                 <t t-foreach="store.failures" t-as="failure" t-key="failure.id">
                     <NotificationItem
+                        important="1"
                         isActive="state.activeIndex === itemIndex"
                         counter="failure.notifications.length > 1 ? failure.notifications.length : undefined"
                         datetime="failure.datetime"

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1729,7 +1729,7 @@ test('auto-select "Inbox nav bar" when discuss had inbox as active thread', asyn
     await start();
     await openDiscuss();
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
-    await contains(".o-mail-MessagingMenu-navbar button.fw-bold", { text: "Mailboxes" });
+    await contains(".o-mail-MessagingMenu-navbar button.o-active", { text: "Mailboxes" });
     await contains("button.active.o-active", { text: "Inbox" });
     await contains("h4", { text: "Your inbox is empty" });
 });

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -581,7 +581,7 @@ test("mobile: active icon is highlighted", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-MessagingMenu-tab", { text: "Chats" });
-    await contains(".o-mail-MessagingMenu-tab.fw-bold", { text: "Chats" });
+    await contains(".o-mail-MessagingMenu-tab.o-active", { text: "Chats" });
 });
 
 test("open chat window from preview", async () => {

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -27,9 +27,9 @@ test("auto-select 'Inbox' when discuss had channel as active thread", async () =
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-ChatWindow [title*='Close Chat Window']");
-    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bold", { text: "Channels" });
+    await contains(".o-mail-MessagingMenu-tab.o-active", { text: "Channels" });
     await click("button", { text: "Mailboxes" });
-    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bold", { text: "Mailboxes" });
+    await contains(".o-mail-MessagingMenu-tab.o-active", { text: "Mailboxes" });
     await contains("button.active", { text: "Inbox" });
 });
 


### PR DESCRIPTION
This commit improves messaging menu style as follow:
- removed box design on notification items
- no bg color with important notifications: counter is enough
- important items with no counter should small bullet of same color as counter bg
- unread conversations have grey bullet to match with unread indicators used in many other places.

Part of task-4967066

Before / After
<img width="295" height="639" alt="before" src="https://github.com/user-attachments/assets/09216ea2-8dd8-4f0b-85bb-87053deb2769" /> <img width="295" height="639" alt="after" src="https://github.com/user-attachments/assets/653558bd-367c-441d-99f3-494c9fe87203" />


