### PR TITLE
[IMP] project: auto set dates on project created from templates

### DIFF
--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -215,6 +215,77 @@
             <field name="privacy_visibility">portal</field>
         </record>
 
+        <!-- Project Template -->
+        <record id="project_template_1" model="project.project">
+            <field name="name">Product Launch Campaign</field>
+            <field name="is_template" eval="True"/>
+            <field name="date_start">2025-06-01 09:00:00</field>
+            <field name="date">2025-06-30 18:00:00</field>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="type_ids" eval="[
+                Command.link(ref('project_stage_0')),
+                Command.link(ref('project_stage_1')),
+                Command.link(ref('project_stage_2')),
+                Command.link(ref('project_stage_3'))
+            ]"/>
+        </record>
+
+        <record id="project_template_1_task_1" model="project.task">
+            <field name="name">Market Analysis</field>
+            <field name="project_id" ref="project_template_1"/>
+        </record>
+
+        <record id="project_template_1_task_2" model="project.task">
+            <field name="name">Define Target Audience</field>
+            <field name="project_id" ref="project_template_1"/>
+            <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_1'))]"/>
+        </record>
+
+        <record id="project_template_1_task_3" model="project.task">
+            <field name="name">Write Press Release</field>
+            <field name="project_id" ref="project_template_1"/>
+            <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_2'))]"/>
+        </record>
+
+        <record id="project_template_1_task_4" model="project.task">
+            <field name="name">Design Visual Assets</field>
+            <field name="project_id" ref="project_template_1"/>
+            <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_2'))]"/>
+        </record>
+
+        <record id="project_template_1_task_5" model="project.task">
+            <field name="name">Publish Landing Page</field>
+            <field name="project_id" ref="project_template_1"/>
+            <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_4'))]"/>
+        </record>
+
+        <record id="project_template_1_task_6" model="project.task">
+            <field name="name">Send Press Kit</field>
+            <field name="project_id" ref="project_template_1"/>
+            <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_3'))]"/>
+        </record>
+
+        <record id="project_template_1_task_7" model="project.task">
+            <field name="name">Social Media Follow-up</field>
+            <field name="project_id" ref="project_template_1"/>
+            <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_6'))]"/>
+        </record>
+
+        <record id="project_template_1_task_8" model="project.task">
+            <field name="name">Collect Customer Feedback</field>
+            <field name="project_id" ref="project_template_1"/>
+            <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_5'))]"/>
+        </record>
+
+        <record id="project_template_1_task_9" model="project.task">
+            <field name="name">Campaign Performance Review</field>
+            <field name="project_id" ref="project_template_1"/>
+            <field name="depend_on_ids" eval="[
+                Command.link(ref('project_template_1_task_7')),
+                Command.link(ref('project_template_1_task_8'))
+            ]"/>
+        </record>
+
         <!-- Personal Stages: Mitchell Admin-->
         <record id="project_personal_stage_admin_0" model="project.task.type">
             <field name="sequence">1</field>

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1383,6 +1383,13 @@ class ProjectProject(models.Model):
     def action_create_from_template(self, values=None, role_to_users_mapping=None):
         self.ensure_one()
         values = values or {}
+
+        if self.date_start and self.date:
+            if not values.get("date_start"):
+                values["date_start"] = fields.Date.today()
+            if not values.get("date"):
+                values["date"] = values["date_start"] + (self.date - self.date_start)
+
         default = {
             key.removeprefix('default_'): value
             for key, value in self.env.context.items()

--- a/addons/project/wizard/project_template_create_wizard.py
+++ b/addons/project/wizard/project_template_create_wizard.py
@@ -18,7 +18,13 @@ class ProjectTemplateCreateWizard(models.TransientModel):
     alias_name = fields.Char(string="Alias Name")
     alias_domain_id = fields.Many2one("mail.alias.domain", string="Alias Domain")
     template_id = fields.Many2one("project.project", default=lambda self: self.env.context.get('template_id'))
+    template_has_dates = fields.Boolean(compute="_compute_template_has_dates")
     role_to_users_ids = fields.One2many('project.template.role.to.users.map', 'wizard_id', default=_default_role_to_users_ids)
+
+    @api.depends("template_id")
+    def _compute_template_has_dates(self):
+        for wizard in self:
+            wizard.template_has_dates = wizard.template_id.date_start and wizard.template_id.date
 
     def _get_template_whitelist_fields(self):
         """

--- a/addons/project/wizard/project_template_create_wizard.xml
+++ b/addons/project/wizard/project_template_create_wizard.xml
@@ -14,7 +14,8 @@
                 </div>
                 <group>
                     <group>
-                        <field name="date_start" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": "1"}'/>
+                        <field name="date" required="not template_has_dates and date_start" invisible="1"/>
+                        <field name="date_start" required="not template_has_dates and date" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": "1"}'/>
                         <label for="alias_name" string="Create tasks by sending an email to" class="pe-2"/>
                         <div class="d-inline-flex">
                             <field name="alias_name" placeholder="e.g. office-party"/>@ <field name="alias_domain_id" placeholder="e.g. mycompany.com" options="{'no_create': True, 'no_open': True}"/>


### PR DESCRIPTION
This PR allows automatically setting dates when creating a project from a template.
If no dates are set on creation, the start date defaults to today, and the end date is calculated according to the duration of the template, if it has planned dates.

Task-4700745