### PR TITLE
[FIX] website_sale: avoid relying on icon in +/- button on product page

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -323,7 +323,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
         const max = parseFloat(input.dataset.max || Infinity);
         const previousQty = parseFloat(input.value || 0, 10);
         const quantity = (
-            ev.currentTarget.querySelector('i').classList.contains('oi-minus') ? -1 : 1
+            ev.currentTarget.name === 'remove_one' ? -1 : 1
         ) + previousQty;
         const newQty = quantity > min ? (quantity < max ? quantity : max) : min;
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2462,6 +2462,7 @@
                     class="css_quantity_minus btn btn-link pe-2 js_add_cart_json border-0"
                     aria-label="Remove one"
                     title="Remove one"
+                    name="remove_one"
                 >
                     <i class="oi oi-minus text-600"/>
                 </a>


### PR DESCRIPTION
The implementation of `_onChangeQuantity` in `website_sale.js` was not robust to changes in its buttons.

Removing the icon caused a crash when the button is used, and the icons cannot be added back the same way.

With this commit, the order of the button is used to tell whether it should increment

Steps to reproduce:
- On `/shop/<product>`, open website builder
- Click on the "-" icon near the "Add to cart" button
- Delete it (press delete)
- Save
- Click the button
- Bug: crash because it did not find the icon

task-4367641