### PR TITLE
[FIX] hr_holidays: avoid collision between similar TimeOffs

### DIFF
--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1449,3 +1449,55 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'default_request_unit_hours': True,
         }).default_get(list(self.env['hr.leave'].fields_get()) + ['holiday_status_id'])
         self.assertEqual(hr_leave_default_value.get('holiday_status_id'), False)
+
+    def test_coextensive_holidays_one_include_public_leave(self):
+        """
+            The purpose is to test whether two holidays that span the same time frame,
+            one with the include_public_leave active, will both work correctly.
+        """
+        employee = self.employee_emp
+        employee_hr = self.employee_hrmanager
+        calendar = employee.resource_calendar_id
+        calendar = employee_hr.resource_calendar_id
+
+        sick_leave_type = self.env['hr.leave.type'].create({
+            'name': 'Sick Leave (days)',
+            'request_unit': 'day',
+            'leave_validation_type': 'hr',
+        })
+
+        sick_leave_type.include_public_holidays_in_duration = True
+
+        sick_leave = self.env['hr.leave'].create({
+            'name': 'Sick 3 days',
+            'employee_id': employee.id,
+            'holiday_status_id': sick_leave_type.id,
+            'request_date_from': '2021-11-15',
+            'request_date_to': '2021-11-17',
+        })
+
+        self.assertEqual(sick_leave.duration_display, '3 days')
+
+        sick_leave_type_paid = self.env['hr.leave.type'].create({
+            'name': 'Paid Leave (days)',
+            'request_unit': 'day',
+            'leave_validation_type': 'hr',
+        })
+
+        sick_leave_hr = self.env['hr.leave'].create({
+            'name': 'Paid 3 days',
+            'employee_id': employee_hr.id,
+            'holiday_status_id': sick_leave_type_paid.id,
+            'request_date_from': '2021-11-15',
+            'request_date_to': '2021-11-17',
+        })
+
+        calendar.global_leave_ids = [Command.create({
+            'name': 'Autumn Holidays',
+            'date_from': '2021-11-16 00:00:00',
+            'date_to': '2021-11-16 23:59:59',
+            'time_type': 'leave',
+        })]
+
+        self.assertEqual(sick_leave.duration_display, '3 days', "hr_holidays: duration_display should not update after adding an overlapping holiday")
+        self.assertEqual(sick_leave_hr.duration_display, '2 days')


### PR DESCRIPTION
When two timeoff (one with Ignore Public Holidays and the other without) have the same dates, if you modify a public holidays that happend during that time, it will trigger a traceback.

Steps to reproduce:
-------------------
* Marc demo and Abigail Peterson using the same calendar
* Create a "Paid time off" leave for marc demo: June 19 - June 20
* Create a "Extra time off" for abigail: same date
* Update Time off type "Extra Time Off" to "Ignore Public Holidays"
* Approve both leave request previously created
* Create public holidays on June 19 --> traceback

Observation:

When both time off have the same dates it will overide the value in the dictonary
https://github.com/odoo/odoo/commit/0d846ecd1ec7ff5149d580d3494b1a4bab1e68d2#diff-38469def2f870bb866f971f57797dd7c21b6a95d52a8eae72f832f0eea2434f9R464
and when it will try to call the employe_id it will trigger the traceback
https://github.com/odoo/odoo/commit/f72ac3a14d76d4fb53ec3a092d08afafe4c35888#diff-38469def2f870bb866f971f57797dd7c21b6a95d52a8eae72f832f0eea2434f9R561

Why the fix:
------------
Avoid collision between two similar Timeoff

opw-4933820
