### PR TITLE
[IMP] core: cache access and record rules 

### DIFF
--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1028,7 +1028,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         record = self.container.with_user(self.env.user)
 
         # about 20 (19?) queries per additional customer group
-        with self.assertQueryCount(admin=56, employee=57):
+        with self.assertQueryCount(admin=55, employee=57):
             record.message_post(
                 body=Markup('<p>Test Post Performances</p>'),
                 message_type='comment',
@@ -1046,7 +1046,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=70, employee=71):
+        with self.assertQueryCount(admin=69, employee=71):
             record.message_post_with_source(
                 template,
                 message_type='comment',

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2124,28 +2124,6 @@ class IrModelAccess(models.Model):
     perm_unlink = fields.Boolean(string='Delete Access')
 
     @api.model
-    def group_names_with_access(self, model_name, access_mode):
-        """ Return the names of visible groups which have been granted
-            ``access_mode`` on the model ``model_name``.
-
-           :rtype: list
-        """
-        assert access_mode in ('read', 'write', 'create', 'unlink'), 'Invalid access mode'
-        lang = self.env.lang or 'en_US'
-        self.env.cr.execute(f"""
-            SELECT COALESCE(c.name->>%s, c.name->>'en_US'), COALESCE(g.name->>%s, g.name->>'en_US')
-              FROM ir_model_access a
-              JOIN ir_model m ON (a.model_id = m.id)
-              JOIN res_groups g ON (a.group_id = g.id)
-         LEFT JOIN res_groups_privilege c ON (c.id = g.privilege_id)
-             WHERE m.model = %s
-               AND a.active = TRUE
-               AND a.perm_{access_mode} = TRUE
-          ORDER BY c.name, g.name NULLS LAST
-        """, [lang, lang, model_name])
-        return [('%s/%s' % x) if x[0] else x[1] for x in self.env.cr.fetchall()]
-
-    @api.model
     @tools.ormcache(cache='stable')
     def _get_all_access_groups(self):
         """ Return all active access permissions.
@@ -2174,20 +2152,6 @@ class IrModelAccess(models.Model):
             })
             for mode, mode_access in access_by_mode.items()
         })
-
-    @api.model
-    @tools.ormcache('model_name', 'access_mode', cache='stable')
-    def _get_access_groups(self, model_name, access_mode='read'):
-        """ Return the group expression object that represents the users who
-        have ``access_mode`` to the model ``model_name``.
-        """
-        accesses = self._get_all_access_groups()[access_mode].get(model_name, ())
-        group_definitions = self.env['res.groups']._get_group_definitions()
-        if not accesses:
-            return group_definitions.empty
-        if False in accesses:  # there is some global access
-            return group_definitions.universe
-        return group_definitions.from_ids(accesses)
 
     # The context parameter is useful when the method translates error messages.
     # But as the method raises an exception in that case,  the key 'lang' might
@@ -2232,7 +2196,20 @@ class IrModelAccess(models.Model):
             'document_model': model,
         }
 
-        groups = "\n".join(f"\t- {g}" for g in self.group_names_with_access(model, mode))
+        lang = self.env.lang or 'en_US'
+        self.env.cr.execute(f"""
+            SELECT COALESCE(COALESCE(c.name->>%s, c.name->>'en_US') || '/', '') || COALESCE(g.name->>%s, g.name->>'en_US')
+              FROM ir_model_access a
+              JOIN ir_model m ON (a.model_id = m.id)
+              JOIN res_groups g ON (a.group_id = g.id)
+         LEFT JOIN res_groups_privilege c ON (c.id = g.privilege_id)
+             WHERE m.model = %s
+               AND a.active = TRUE
+               AND a.perm_{mode} = TRUE
+          ORDER BY c.name, g.name NULLS LAST
+        """, [lang, lang, model])
+        rows = self.env.cr.fetchall()
+        groups = "\n".join(f"\t- {g}" for (g,) in rows)
         if groups:
             group_info = str(ACCESS_ERROR_GROUPS) % {'groups_list': groups}
         else:

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -424,11 +424,16 @@ class IrModel(models.Model):
         if 'field_id' in vals:
             vals['field_id'] = [op for op in vals['field_id'] if op[0] != 4]
         res = super().write(vals)
+        if not any(self._ids):
+            return res
         # ordering has been changed, reload registry to reflect update + signaling
         if 'order' in vals or 'fold_name' in vals:
             self.env.flush_all()  # _setup_models__ need to fetch the updated values from the db
             # incremental setup will reload custom models
             self.pool._setup_models__(self.env.cr, [])
+        if 'rule_ids' in vals or 'access_ids' in vals:
+            # for env['ir.model.access']._get_all_access_groups
+            self.env.registry.clear_cache('stable')
         return res
 
     @api.model_create_multi
@@ -444,6 +449,9 @@ class IrModel(models.Model):
             self.pool._setup_models__(self.env.cr, [])
             # update database schema
             self.pool.init_models(self.env.cr, manual_models, dict(self.env.context, update_custom_fields=True))
+        if res:
+            # for env['ir.model.access']._get_all_access_groups
+            self.env.registry.clear_cache('stable')
         return res
 
     @api.model
@@ -2138,23 +2146,48 @@ class IrModelAccess(models.Model):
         return [('%s/%s' % x) if x[0] else x[1] for x in self.env.cr.fetchall()]
 
     @api.model
+    @tools.ormcache(cache='stable')
+    def _get_all_access_groups(self):
+        """ Return all active access permissions.
+
+        :return: Dict {mode: {model_name: [group_ids]}}
+        """
+        modes = ('read', 'write', 'create', 'unlink')
+        self.flush_model()
+        all_access = self.env.execute_query_dict(SQL(
+            """
+            SELECT m.model, a.group_id, a.perm_read, a.perm_write, a.perm_create, a.perm_unlink
+            FROM ir_model_access a
+            LEFT JOIN ir_model m
+            ON m.id = a.model_id
+            WHERE a.active IS TRUE
+            """
+        ))
+        access_by_mode = {
+            mode: tools.groupby((a for a in all_access if a[f'perm_{mode}']), itemgetter('model'))
+            for mode in modes
+        }
+        return frozendict({
+            mode: frozendict({
+                model: frozenset(a['group_id'] or False for a in model_access)
+                for model, model_access in mode_access
+            })
+            for mode, mode_access in access_by_mode.items()
+        })
+
+    @api.model
     @tools.ormcache('model_name', 'access_mode', cache='stable')
     def _get_access_groups(self, model_name, access_mode='read'):
         """ Return the group expression object that represents the users who
         have ``access_mode`` to the model ``model_name``.
         """
-        assert access_mode in ('read', 'write', 'create', 'unlink'), 'Invalid access mode'
-        model = self.env['ir.model']._get(model_name)
-        accesses = self.sudo().search([
-            (f'perm_{access_mode}', '=', True), ('model_id', '=', model.id),
-        ])
-
+        accesses = self._get_all_access_groups()[access_mode].get(model_name, ())
         group_definitions = self.env['res.groups']._get_group_definitions()
         if not accesses:
             return group_definitions.empty
-        if not all(access.group_id for access in accesses):  # there is some global access
+        if False in accesses:  # there is some global access
             return group_definitions.universe
-        return group_definitions.from_ids(accesses.group_id.ids)
+        return group_definitions.from_ids(accesses)
 
     # The context parameter is useful when the method translates error messages.
     # But as the method raises an exception in that case,  the key 'lang' might
@@ -2163,24 +2196,16 @@ class IrModelAccess(models.Model):
 
     @tools.ormcache('self.env.uid', 'mode')
     def _get_allowed_models(self, mode='read'):
-        assert mode in ('read', 'write', 'create', 'unlink'), 'Invalid access mode'
-
-        group_ids = self.env.user._get_group_ids()
-        self.flush_model()
-        rows = self.env.execute_query(SQL("""
-            SELECT m.model
-              FROM ir_model_access a
-              JOIN ir_model m ON (m.id = a.model_id)
-             WHERE a.perm_%s
-               AND a.active
-               AND (
-                    a.group_id IS NULL OR
-                    a.group_id IN %s
-                )
-            GROUP BY m.model
-        """, SQL(mode), tuple(group_ids) or (None,)))
-
-        return frozenset(v[0] for v in rows)
+        access_by_model = self._get_all_access_groups().get(mode)
+        if not access_by_model:
+            return frozenset()
+        # include False to catch global access rules
+        user_group_ids = {*self.env.user._get_group_ids(), False}
+        return frozenset(
+            model
+            for model, accesses in access_by_model.items()
+            if not user_group_ids.isdisjoint(accesses)
+        )
 
     @api.model
     def check(self, model, mode='read', raise_exception=True):

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -1,14 +1,23 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import ast
 import logging
+import typing
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import AccessError, ValidationError
 from odoo.fields import Domain
-from odoo.tools import config, SQL
-from odoo.tools.safe_eval import safe_eval, time
+from odoo.tools import config, frozendict
+from odoo.tools.safe_eval import safe_eval
 
 
 _logger = logging.getLogger(__name__)
+
+
+class RuleInfo(typing.NamedTuple):
+    rule_id: int
+    group_id: int
+    mode: str
+    domain: Domain | str
 
 
 class IrRule(models.Model):
@@ -17,11 +26,12 @@ class IrRule(models.Model):
     _order = 'model_id DESC,id'
     _MODES = ('read', 'write', 'create', 'unlink')
     _allow_sudo_commands = False
-    _clear_cache_name = 'default'
+    _clear_cache_name = 'stable'
 
     name = fields.Char()
     active = fields.Boolean(default=True, help="If you uncheck the active field, it will disable the record rule without deleting it (if you delete a native record rule, it may be re-created when you reload the module).")
     model_id = fields.Many2one('ir.model', string='Model', index=True, required=True, ondelete="cascade")
+    model_name = fields.Char(related='model_id.model', string='Model Name')
     groups = fields.Many2many('res.groups', 'rule_group_rel', 'rule_group_id', 'group_id', ondelete='restrict')
     domain_force = fields.Text(string='Domain')
     perm_read = fields.Boolean(string='Read', default=True)
@@ -86,50 +96,70 @@ class IrRule(models.Model):
         rules get AND-ed and can each fail)
         """
         Model = for_records.browse(()).sudo()
+        record_ids = for_records.ids
         eval_context = self._eval_context()
-
-        all_rules = self._get_rules(Model._name, mode=mode).sudo()
+        failing_ids = set()
+        rules = [r for r in self._get_all_rules().get(Model._name, ()) if r.mode == mode]
 
         # first check if the group rules fail for any record (aka if
         # searching on (records, group_rules) filters out some of the records)
-        group_rules = all_rules.filtered(lambda r: r.groups and r.groups & self.env.user.all_group_ids)
+        user_group_ids = set(self.env.user._get_group_ids())
         group_domains = Domain.OR(
-            safe_eval(r.domain_force, eval_context) if r.domain_force else []
-            for r in group_rules
+            r.domain if isinstance(r.domain, Domain) else Domain(safe_eval(r.domain, eval_context))
+            for r in rules
+            if r.group_id in user_group_ids
         )
+
         # if all records get returned, the group rules are not failing
-        if Model.search_count(group_domains & Domain('id', 'in', for_records.ids)) == len(for_records):
-            group_rules = self.browse(())
+        if Model.search_count(group_domains & Domain('id', 'in', record_ids)) < len(record_ids):
+            failing_ids.update(r.rule_id for r in rules if r.group_id in user_group_ids)
 
-        # failing rules are previously selected group rules or any failing global rule
-        def is_failing(r, ids=for_records.ids):
-            dom = Domain(safe_eval(r.domain_force, eval_context) if r.domain_force else [])
-            return Model.search_count(dom & Domain('id', 'in', ids)) < len(ids)
+        # check failing global rules
+        for r in rules:
+            if r.group_id:
+                continue
+            dom = r.domain if isinstance(r.domain, Domain) else Domain(safe_eval(r.domain, eval_context))
+            if Model.search_count(dom & Domain('id', 'in', record_ids)) < len(record_ids):
+                failing_ids.add(r.rule_id)
 
-        return all_rules.filtered(lambda r: r in group_rules or (not r.groups and is_failing(r))).with_user(self.env.user)
+        # re-filter to keep the order from rules
+        return self.browse(id_ for r in rules if (id_ := r.rule_id) in failing_ids)
 
-    def _get_rules(self, model_name, mode='read'):
-        """ Returns all the rules matching the model for the mode for the
-        current user.
+    @api.model
+    @tools.ormcache(cache='stable')
+    def _get_all_rules(self) -> dict[str, tuple[RuleInfo, ...]]:
+        """ Returns all the active record rules.
+
+        :return: Dict {model_name: [RuleInfo]}
         """
-        if mode not in self._MODES:
-            raise ValueError('Invalid mode: %r' % (mode,))
+        all_rules = self.sudo().search_fetch(
+            [('active', '=', True)],
+            ['model_name', 'groups', 'domain_force', *(f'perm_{mode}' for mode in self._MODES)],
+            order='id',
+        )
+        # pre-evaluate domains if possible (once per rule)
+        domains = {}
+        env = self.env(su=True)
+        for rule in all_rules:
+            domain = (rule.domain_force or '').strip()
+            try:
+                domain = ast.literal_eval(domain) if domain else Domain.TRUE
+            except ValueError:
+                domains[rule] = domain
+            else:
+                domains[rule] = Domain(domain).optimize(env[rule.model_name])
 
-        if self.env.su:
-            return self.browse(())
-
-        self.flush_model()
-        sql = SQL("""
-            SELECT r.id FROM ir_rule r
-            JOIN ir_model m ON (r.model_id=m.id)
-            WHERE m.model = %s AND r.active AND r.perm_%s
-                AND (r.global OR r.id IN (
-                    SELECT rule_group_id FROM rule_group_rel rg
-                    WHERE rg.group_id IN %s
-                ))
-            ORDER BY r.id
-        """, model_name, SQL(mode), tuple(self.env.user._get_group_ids()) or (None,))
-        return self.browse(v for v, in self.env.execute_query(sql))
+        return frozendict({
+            model_name: tuple(
+                RuleInfo(rule.id, group.id, mode, domains[rule])
+                for rule in model_rules
+                for mode in self._MODES
+                if rule[f'perm_{mode}']
+                # iterate over all groups, or just once with an empty group (for global rules)
+                for group in rule.groups or (rule.groups,)
+            )
+            for model_name, model_rules in all_rules.grouped('model_name').items()
+        })
 
     @api.model
     @tools.conditional(
@@ -138,7 +168,9 @@ class IrRule(models.Model):
                        'tuple(self._compute_domain_context_values())'),
     )
     def _compute_domain(self, model_name: str, mode: str = "read", *, include_inherits=True) -> Domain:
-        model = self.env[model_name]
+        model = self.sudo().env[model_name]
+        if self.env.su:
+            return Domain.TRUE
 
         # add rules for parent models
         global_domains: list[Domain] = []
@@ -147,23 +179,26 @@ class IrRule(models.Model):
                 if domain := self._compute_domain(parent_model_name, mode):
                     global_domains.append(Domain(parent_field_name, 'any', domain))
 
-        rules = self._get_rules(model_name, mode=mode)
-        if not rules:
-            return Domain.AND(global_domains).optimize(model)
-
-        # browse user and rules with sudo to avoid access errors!
-        eval_context = self._eval_context()
-        user_groups = self.env.user.all_group_ids
+        # fetch the model's rules
+        rules = self._get_all_rules().get(model_name, ())
         group_domains: list[Domain] = []
-        for rule in rules.sudo():
-            if rule.groups and not (rule.groups & user_groups):
-                continue
-            # evaluate the domain for the current user
-            dom = Domain(safe_eval(rule.domain_force, eval_context)) if rule.domain_force else Domain.TRUE
-            if rule.groups:
-                group_domains.append(dom)
-            else:
-                global_domains.append(dom)
+        if rules:
+            # include False to catch global rules
+            user_group_ids = {*self.env.user._get_group_ids(), False}
+            # some domains have been pre-evaluated, evaluate only if needed
+            eval_context = None
+            for rule in rules:
+                if rule.mode != mode or rule.group_id not in user_group_ids:
+                    continue
+                domain = rule.domain
+                if not isinstance(domain, Domain):
+                    if eval_context is None:
+                        eval_context = self._eval_context()
+                    domain = Domain(safe_eval(domain, eval_context))
+                if rule.group_id:
+                    group_domains.append(domain)
+                else:
+                    global_domains.append(domain)
 
         # combine global domains and group domains
         if group_domains:

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1453,7 +1453,7 @@ actual arch.
         parent_name_manager = node_info['name_manager'] if node_info else None
 
         # combine model access groups with this model's access groups
-        model_groups &= self.env['ir.model.access']._get_access_groups(model_name)
+        model_groups &= self._get_access_groups(group_definitions, model_name)
 
         name_manager = NameManager(model, parent=parent_name_manager, model_groups=model_groups)
 
@@ -1524,6 +1524,14 @@ actual arch.
             self._postprocess_on_change(root, model)
 
         return name_manager
+
+    def _get_access_groups(self, group_definitions, model_name):
+        group_list = self.env['ir.model.access']._get_all_access_groups()['read'].get(model_name, ())
+        if not group_list:
+            return group_definitions.empty
+        if False in group_list:  # there is some global access
+            return group_definitions.universe
+        return group_definitions.from_ids(group_list)
 
     def _add_missing_fields(self, node, name_manager):
         """ Add the fields required for evaluating expressions in the view given by ``node``. """
@@ -1816,7 +1824,7 @@ actual arch.
         parent_name_manager = node_info['name_manager'] if node_info else None
 
         # combine model access groups with this model's access groups
-        model_groups &= self.env['ir.model.access']._get_access_groups(model_name)
+        model_groups &= self._get_access_groups(group_definitions, model_name)
 
         # fields_get() optimization: validation does not require translations
         model = self.env[model_name].with_context(lang=None)

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -874,8 +874,7 @@ class TestDomainOptimize(TransactionCase):
 
         with self.assertRaises(ValueError):
             Domain('number', 'access', 'read').optimize_dynamic(model)
-        with self.assertRaises(AssertionError):
-            assert not model.sudo(False).env.su, 'Just raise an assert for super-user'
+        with self.assertRaises(ValueError):
             Domain('currency_id', 'access', 'blabla').optimize_dynamic(model)
 
     def test_not_optimize(self):

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1904,6 +1904,8 @@ def _operator_access_rule_domain(condition, model):
     access_domain = comodel._access_domain(operation)
     if access_domain.is_false():
         # no access to the comodel for any record
+        if operation not in model.env.registry['ir.rule']._MODES:
+            condition._raise("Invalid value for 'access' operator")
         return Domain.FALSE
     if access_domain.is_true() or comodel.env.su:
         # access to all or edge-case for super user

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -70,7 +70,7 @@ _CACHES_BY_KEY = {
     'stable': ('stable', 'default', 'templates.cached_values'),
     'templates': ('templates', 'templates.cached_values'),
     'routing': ('routing', 'routing.rewrites', 'templates.cached_values'),
-    'groups': ('groups', 'templates', 'templates.cached_values'),  # The processing of groups is saved in the view
+    'groups': ('groups', 'default', 'templates', 'templates.cached_values'),  # The processing of groups is saved in the view
 }
 
 _REPLICA_RETRY_TIME = 20 * 60  # 20 minutes


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
After introducing the stable cache (#221540), we can use it to store access permissions.

Currenly, for each user, we check the database for access and put the
result in the default cache. Since that cache is quite often
invalidated, we redo this for each user of the database. Access rules
change only rarely.

Goal: do one query for model access and one query for record rules and store them in the stable cache. We still use the default cache for per-user access, but now it can be computed quickly from the stable cache without additional database queries.

We address also a small inconsistency in the cache of `_get_access_groups` where 'stable' and 'groups' cache are independent.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
