### PR TITLE
[FIX] account: Add a test to ensure the product description is correct

### DIFF
--- a/addons/account/static/tests/account_move_form.test.js
+++ b/addons/account/static/tests/account_move_form.test.js
@@ -7,7 +7,7 @@ import {
     triggerHotkey
 } from "@mail/../tests/mail_test_helpers";
 import { expect, test } from "@odoo/hoot";
-import { asyncStep, contains, onRpc, waitForSteps } from "@web/../tests/web_test_helpers";
+import { asyncStep, contains, defineModels, fields, onRpc, models, waitForSteps} from "@web/../tests/web_test_helpers";
 import { defineAccountModels } from "./account_test_helpers";
 
 defineAccountModels();
@@ -61,4 +61,64 @@ test("Confirmation dialog on delete contains a warning", async () => {
     expect(".o_dialog div.text-danger").toHaveText("This operation will create a gap in the sequence.", {
         message: "warning message has been added in the dialog"
     });
+});
+class AccountMove extends models.Model {
+    line_ids = fields.One2many({
+        string: "Invoice Lines",
+        relation: "account.move.line",
+    })
+
+    _records = [{ id: 1, name: "account.move" }]
+}
+class AccountMoveLine extends models.Model {
+    name = fields.Char();
+    product_id = fields.Many2one({
+        string:"Product",
+        relation:"product",
+    });
+    move_id = fields.Many2one({
+        string: "Account Move",
+        relation: "account.move",
+    })
+}
+class Product extends models.Model {
+    name = fields.Char();
+    _records = [{ id: 1, name: "testProduct" }];
+}
+
+defineModels({ Product, AccountMoveLine, AccountMove });
+
+test("Update description on product line", async() => {
+    const pyEnv = await startServer();
+    const productId = pyEnv["product"].browse([1]);
+    const accountMove = pyEnv["account.move"].browse([1]);
+    pyEnv["account.move.line"].create({ name: productId[0].name, product_id: productId[0].id, move_id: accountMove[0].id });
+    await start();
+    onRpc("account.move", "web_save", () => { asyncStep("save")});
+    await openFormView("account.move", accountMove[0].id, {
+        arch: `<form js_class="account_move_form">
+            <sheet>
+                <notebook>
+                    <page id="invoice_tab" name="invoice_tab" string="Invoice Lines">
+                        <field name="invoice_line_ids" mode="list" widget="product_label_section_and_note_field_o2m">
+                            <list name="journal_items" editable="bottom" string="Journal Items">
+                                <field name="product_id" widget="product_label_section_and_note_field" readonly="0"/>
+                                <field name="name" widget="section_and_note_text" optional="show"/>
+                            </list>
+                        </field>
+                    </page>
+                </notebook>
+            </sheet>
+        </form>`,
+    });
+
+    await click(".o_many2one");
+    await contains("#labelVisibilityButtonId").click()
+    await insertText("textarea[placeholder='Enter a description']", "testDescription");
+    await click(".o_form_button_save");
+    await waitForSteps(["save"]);
+
+    const line = pyEnv["account.move.line"].browse([1])[0];
+    expect(line.name).toBe("testProduct\ntestDescription");
+
 });


### PR DESCRIPTION
Issue: If a description is added on a product line, the printed invoice PDF only shows
the description without the product name.

Purpose of this PR:
To add a test to ensure that the product description is correctly reflected on invoice PDF.

Original issue was fixed by this PR: https://github.com/odoo/odoo/pull/222589

opw-4985815
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
