### PR TITLE
[FIX] sale_project: don't overwrite analytic plans on confirmation

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -135,7 +135,8 @@ class SaleOrderLine(models.Model):
 
     @api.depends('order_id.partner_id', 'product_id', 'order_id.project_id')
     def _compute_analytic_distribution(self):
-        super()._compute_analytic_distribution()
+        if not self.order_id.project_id:
+            super()._compute_analytic_distribution()
         for line in self:
             project = line.product_id.project_id or line.order_id.project_id
             if line.display_type or not line.product_id or not project:


### PR DESCRIPTION
Problem: When a user creates an analytic distribution model and is applied to a product that creates a project when ordered, any other analytic account, that are not included in the distribution model, added to the quotation will get overwritten upon confirming the quotation. The override on `_compute_analytic_distribution` in sale_project depends on the order's project. In the case where a project gets created upon order, the compute will trigger, which effectively recomputes the analytic distribution based on the model, overwriting other analytic account not defined on the model.

Solution: The override on `compute_analytic_distribution` in sale_project should not call `super` when it gets triggered based on any change to the order's project. If the compute is triggered based on a change to the order's project, only the project's analytic account should get added onto the existing analytic distribution on the sale order line. This will ensure that any other analytic accounts added to the sale order line will not get overwritten by the recompute.

Purpose: Implementing this change will save the user the extra step of needing to add the mandated analytic accounts again to the sale order line. Before the change, the user will need to add the mandated analytic account in order to confirm the quotation. Since the mandated analytic account gets overwritten from the compute based on the distribution models, the user will have to add the mandated analytic account back to the sale order line in order to create an invoice.

Steps to Reproduce on  Runbot:
1. Install Sales, Accounting, Project
2. Enable Analyic Accounting in Settings > Analytic Accounting
3. Create an Analytic Distribution Model with 2 different analytic account and set the product category to All
4. Create a new analytic plan that is mandatory
5. Create a new analytic account linked to the new analytic plan
6. Create a new product that is a service under the 'All' category and creates a project on order
7. Create a sales order with the new product and notice that the analytic distribution is from the model and not from the mandated analytic plan.
8. manually Add the mandated analytic account
9. Confirm the sales order and notice that the mandated analytic account is gone

opw-4934291

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
