### PR TITLE
[FIX] pos_self_order: Restore `NumpadDropdown` display

### DIFF
--- a/addons/pos_self_order/static/src/overrides/components/qr_order_button/qr_order_button.xml
+++ b/addons/pos_self_order/static/src/overrides/components/qr_order_button/qr_order_button.xml
@@ -3,11 +3,9 @@
 <templates xml:space="preserve">
 
     <t t-name="pos_self_order.QrOrderButton">
-        <div class="qr-order-button d-flex gap-2 p-2 align-items-center overflow-auto">
-            <button class="oe_qr_order_btn new-order btn btn-primary btn-lg lh-lg" t-on-click.prevent="doRedirectToQrForm.call" t-att-disabled="doRedirectToQrForm.status == 'loading'">
-                <i class="fa fa-qrcode fa-fw" role="img" aria-label="Get QR Codes" title="Get QR Codes"></i><span class="ms-1">Get QR Codes</span>
-            </button>
-        </div>
+        <button class="oe_qr_order_btn new-order btn btn-primary btn-lg lh-lg" t-on-click.prevent="doRedirectToQrForm.call" t-att-disabled="doRedirectToQrForm.status == 'loading'">
+            <i class="fa fa-qrcode fa-fw" role="img" aria-label="Get QR Codes" title="Get QR Codes"></i><span class="ms-1">Get QR Codes</span>
+        </button>
     </t>
 
 </templates>

--- a/addons/pos_self_order/static/src/overrides/screens/floor_screen/floor_screen.xml
+++ b/addons/pos_self_order/static/src/overrides/screens/floor_screen/floor_screen.xml
@@ -3,10 +3,8 @@
 <templates xml:space="preserve">
 
     <t t-name="pos_self_order.FloorScreen" t-inherit="pos_restaurant.FloorScreen" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('edit-buttons')]" position="after">
-            <t t-if="!pos.isEditMode">
-                <QrOrderButton/>
-            </t>
+        <xpath expr="//NumpadDropdown" position="before">
+            <QrOrderButton/>
         </xpath>
     </t>
 


### PR DESCRIPTION
The forwardport https://github.com/odoo/odoo/commit/621bc2ed48ce4e2486f1604fdfe4d85cc4dc179b introduced a `t-if=!isEditMode` that was making the latest `t-else` statement never reached, thus making `NumpadDropdown` never displayed.

Therefore, we simply remove the t-if statement and adjust the xpath inherit to place the `QrOrderButton` just before the `NumpadDropdown` button

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
