### PR TITLE
[FIX] website_sale: fix image 404 due to outdated `.jpg` reference

### DIFF
--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -93,7 +93,7 @@
                                 <p>The minimum height is 65 cm, and for standing work the maximum height position is 125 cm.</p>
                             </div>
                             <div class="pt16 pb16 col-lg-6">
-                                <img src="/website/static/src/img/snippets_demo/s_text_image.jpg" class="img img-fluid mx-auto rounded" alt=""/>
+                                <img src="/website/static/src/img/snippets_demo/s_text_image.webp" class="img img-fluid mx-auto rounded" alt=""/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Prior to Commit[^1], the default format for website images was `.jpeg`

As WEBP offers superior compression compared to JPEG, resulting in smaller file sizes and faster website loading times, all the images were updated to `.webp, but the `src` attribute of this snippet occurrence was still referencing the old `.jpg` version, resulting in a 404.

Updated the `src` to use the correct `.webp` file.

task-4990467

[^1]: https://github.com/odoo/odoo/commit/b25ae74a256e571907a06e3c133e3e9e9f5f5a20

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
