### PR TITLE
[FIX] l10n_my_edi: prioritize invoice line's Malaysian classification code

### DIFF
--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -331,7 +331,8 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         super()._add_invoice_line_item_nodes(line_node, vals)
 
         base_line = vals['base_line']
-        class_code = base_line['record'].product_id.product_tmpl_id.l10n_my_edi_classification_code
+        class_code = base_line['record'].l10n_my_edi_classification_code or \
+                     base_line['record'].product_id.product_tmpl_id.l10n_my_edi_classification_code
         if class_code:
             line_node['cac:Item']['cac:CommodityClassification'] = {
                 'cbc:ItemClassificationCode': {

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -638,6 +638,31 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
             attributes={'currencyID': self.other_currency.name}
         )
 
+    def test_14_prioritize_invoice_line_classification_code(self):
+        """
+        Check if the classification code of invoice line is prioritized over the classification code of product
+        when the two codes differ.
+        """
+        invoice = self.init_invoice(
+            'out_invoice', products=self.product_a,
+        )
+        invoice.line_ids[0].write({
+            'l10n_my_edi_classification_code': '002',
+        })
+        invoice.action_post()
+
+        file, errors = invoice._l10n_my_edi_generate_invoice_xml()
+        self.assertFalse(errors)
+
+        root = etree.fromstring(file)
+        class_root = root.xpath('cac:InvoiceLine/cac:Item/cac:CommodityClassification', namespaces=NS_MAP)[0]
+
+        self._assert_node_values(
+            class_root,
+            'cbc:ItemClassificationCode[@listID="CLASS"]',
+            invoice.line_ids[0].l10n_my_edi_classification_code,
+        )
+
     def _assert_node_values(self, root, node_path, text, attributes=None):
         node = root.xpath(node_path, namespaces=NS_MAP)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Prioritizes the Malaysian classification code from the invoice line over the one from the product. This ensures that line-specific override or manual selection of the code is correctly used when submitting e-invoices. Adds one unit test to verify this priority logic.

Current behavior before PR:
Submission of e-invoice uses products' classification code and ignores invoice lines' code.

Desired behavior after PR is merged:
Submission of e-invoice uses invoice lines' classificatio`n code. If the code is not available, the submission uses products' classification code.

Task-4945679

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
