### PR TITLE
[IMP] hr: adjust quick access to version form based on access rights

### DIFF
--- a/addons/hr/static/src/components/version_quick_access/version_quick_access.js
+++ b/addons/hr/static/src/components/version_quick_access/version_quick_access.js
@@ -1,0 +1,62 @@
+import { Component, onWillStart } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { Many2One, computeM2OProps } from "@web/views/fields/many2one/many2one";
+import { buildM2OFieldDescription, Many2OneField } from "@web/views/fields/many2one/many2one_field";
+
+export class VersionQuickAccess extends Component {
+    static template = "hr.version_quick_access";
+    static components = { Many2One };
+    static props = { ...Many2OneField.props };
+
+    setup() {
+        this.action = useService("action");
+        this.orm = useService("orm");
+        onWillStart(async () => {
+            this.globalVersionTemplates = this.props.record.data[this.props.name]?.id
+                ? await this.orm.searchRead("hr.version", [["employee_id", "=", false]], ["id"])
+                : undefined;
+        });
+    }
+
+    get m2oProps() {
+        const { record, name } = this.props;
+        const contractTemplateId = record.data[name].id;
+        const employeeId = this.props.record.data.employee_id?.id;
+        const isGlobalVersionTemplates = (this.globalVersionTemplates || []).some(
+            (template) => template.id === contractTemplateId
+        );
+        if (contractTemplateId && employeeId && !isGlobalVersionTemplates) {
+            return {
+                ...computeM2OProps(this.props),
+                openRecordAction: () => this.openRecordInAction(),
+            };
+        }
+        return computeM2OProps(this.props);
+    }
+
+    async openRecordInAction() {
+        const employeeId = this.props.record.data.employee_id?.id;
+        const versionId =
+            this.props.record.data.contract_template_id?.id ||
+            this.props.record.data.version_id?.id;
+
+        if (employeeId && versionId) {
+            const context = {
+                ...this.props.context,
+                version_id: versionId,
+            };
+            const action = await this.orm.call(
+                "hr.employee",
+                "get_formview_action",
+                [[employeeId]],
+                { context }
+            );
+            return this.action.doAction(action);
+        }
+    }
+}
+
+registry.category("fields").add("version_quick_access", {
+    ...buildM2OFieldDescription(VersionQuickAccess),
+});

--- a/addons/hr/static/src/components/version_quick_access/version_quick_access.xml
+++ b/addons/hr/static/src/components/version_quick_access/version_quick_access.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+
+    <t t-name="hr.version_quick_access">
+        <Many2One t-props="m2oProps"/>
+    </t>
+
+</templates>


### PR DESCRIPTION
*= hr_payroll, hr_contract_salary

Purpose of this PR:
- Make version quick access open employee form with selected version if the user has access.
- Only HR users/managers can access version form, others can not see quick access.

This PR includes:
- Added new helper action on hr.version to open the employee form.
- Override get_formview_action in payslip and offer models to redirect quick access to employee form with selected version.
- Adjusted view fields to restrict version access:
  - Users with access can open the version from quick access.
  - Others can see it without the quick access (using no_open option).

task-4963805