### PR TITLE
[IMP] account: hide outstanding credits/debits message for draft state

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -804,22 +804,22 @@
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
-                         invisible="move_type not in ('out_invoice', 'out_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
+                         invisible="state != 'posted' or move_type not in ('out_invoice', 'out_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> listed below for this customer.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
-                         invisible="move_type not in ('in_invoice', 'in_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
+                         invisible="state != 'posted' or move_type not in ('in_invoice', 'in_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> listed below for this vendor.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
-                         invisible="move_type != 'out_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
+                         invisible="state != 'posted' or move_type != 'out_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> listed below for this customer.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
-                         invisible="move_type != 'in_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
+                         invisible="state != 'posted' or move_type != 'in_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> listed below for this vendor.
                     </div>
                     <div class="alert alert-info" role="alert"


### PR DESCRIPTION
Before this commit:
---
Draft invoices can be reconciled with payments via the Bank Reconciliation screen, but the Outstanding Payments widget is hidden to avoid confusion. However, outstanding credits/debits messages were still displayed on draft invoices, leading to inconsistency.

In this commit:
---
Updated the form to hide outstanding credits/debits messages when the invoice is in draft, making the behavior consistent.

Before:
---
<img width="1258" height="298" alt="image" src="https://github.com/user-attachments/assets/376b3799-e721-4bd6-bf9c-cb56ca02bb5f" />

After:
---
<img width="1258" height="257" alt="image" src="https://github.com/user-attachments/assets/374e33d5-c406-44c1-9309-40c124b45451" />


task-4987833