### PR TITLE
[FIX] account: product description overlapping table header in invoice PDF

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -104,8 +104,9 @@
 
                         <t t-set="display_discount" t-value="any(l.discount for l in o.invoice_line_ids)"/>
                         <div class="oe_structure"></div>
+                        <t t-set="has_long_desc" t-value="any(line.name and line.name.count('\n') > 30 for line in o.invoice_line_ids if line.name)"/>
                         <table class="table table-sm o_main_table table-borderless" name="invoice_line_table">
-                            <thead>
+                            <thead t-attf-style="#{has_long_desc and 'display: table-row-group;' or ''}">
                                 <tr>
                                     <th name="th_description" class="text-start"><span>Description</span></th>
                                     <th name="th_quantity" class="text-end"><span>Quantity</span></th>


### PR DESCRIPTION
**Steps to reproduce**:
1. Install the `account` module.
2. Create a Invoice using this any product.
3. add long descripition (approx. 40-45 lines).
4. Print the PDF of Invoice (via gear icon).

**Observation**:
The long product description overlaps with the table header when the table spans multiple pages in the generated PDF.

**Issue**:
wkhtmltopdf does not handle multi-page table headers properly by default. causing header/content overlap when the table breaks across pages.

**Solution**:
Apply a known wkhtmltopdf workaround by explicitly setting:
  `<thead style='display: table-row-group;'>`
This ensures headers will not repeat same as this. [#53909](https://github.com/odoo/odoo/pull/53909)

before:
<img width="818" height="231" alt="image" src="https://github.com/user-attachments/assets/8bcc6ced-5911-4abd-b91e-97ffa8fb735e" />

after:
<img width="821" height="253" alt="image" src="https://github.com/user-attachments/assets/2ccc6995-c239-4beb-8f68-53d548b7f2f2" />

opw-4982735
