### PR TITLE
[FIX] mrp: responsive layout

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -247,8 +247,8 @@
                             <field name="company_id" invisible="1"/>
                             <field name="product_description_variants" invisible="product_description_variants in (False, '')" readonly="state != 'draft'"/>
                             <label for="product_qty" string="Quantity"/>
-                            <div class="o_row g-0 d-flex">
-                                <div invisible="state == 'draft'" class="o_row flex-grow-1">
+                            <div class="o_row g-0 d-flex flex-wrap align-items-center">
+                                <div invisible="state == 'draft'" class="o_row flex-grow-1 min-w-0">
                                     <field name="qty_producing" class="text-start text-truncate" readonly="state == 'cancel' or (state == 'done' and is_locked)"/>
                                     /
                                 </div>
@@ -257,7 +257,7 @@
                                     context="{'default_mo_id': id}" class="oe_link oe_inline" style="margin: 0px; padding: 0px;" invisible="state in ('draft', 'done', 'cancel') or not id">
                                     <field name="product_qty" class="oe_inline" readonly="state != 'draft'"/>
                                 </button>
-                                <label for="product_uom_id" string="" class="oe_inline"/>
+                                <label for="product_uom_id" string="" class="oe_inline flex-shrink-0"/>
                                 <field name="product_uom_category_id" invisible="1"/>
                                 <field name="product_uom_id" groups="!uom.group_uom" invisible="1"/>
                                 <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" readonly="state != 'draft'" class="flex-grow-0" style="width:auto!important"/>


### PR DESCRIPTION
Responsive layout prevent product_qty field overlap on small screens

The quantity section in MRP production form view has responsive layout issues
where product_qty field gets overlapped by product_uom_id field when the screen
is resized to smaller widths. This makes quantity information unreadable on
mobile devices and narrow browser windows.

Video:

https://github.com/user-attachments/assets/5448c65e-c744-47f5-8760-0da4c6d149ea


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
