### PR TITLE
[FIX] spreadsheet: remove `console.log` from test

### DIFF
--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -299,11 +299,10 @@ test("Domain of simple date filter", async function () {
         list: { 1: { chain: "date", type: "date" } },
         chart: { [chartId]: { chain: "date", type: "date" } },
     });
-    const result = await setGlobalFilterValue(model, {
+    await setGlobalFilterValue(model, {
         id: THIS_YEAR_GLOBAL_FILTER.id,
         value: { type: "year", year: 2021 },
     });
-    console.log(result);
     const pivotDomain = model.getters.getPivotComputedDomain("PIVOT#1");
     expect(pivotDomain[0]).toBe("&");
     expect(pivotDomain[1]).toEqual(["date", ">=", "2021-01-01"]);


### PR DESCRIPTION
There was a `console.log` leftover in the test
`Domain of simple date filter`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
