### PR TITLE
[IMP] mail: rename "Starred" to "Starred messages"

### DIFF
--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -45,7 +45,7 @@ const StorePatch = {
             model: "mail.box",
         };
         this.starred = {
-            display_name: _t("Starred"),
+            display_name: _t("Starred messages"),
             id: "starred",
             model: "mail.box",
         };

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -178,12 +178,12 @@ test("Message (hard) delete notification", async () => {
     await openDiscuss();
     await click("[title='Mark as Todo']");
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
-    await contains("button", { text: "Starred", contains: [".badge", { text: "1" }] });
+    await contains("button", { text: "Starred messages", contains: [".badge", { text: "1" }] });
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
     pyEnv["bus.bus"]._sendone(partner, "mail.message/delete", {
         message_ids: [messageId],
     });
     await contains(".o-mail-Message", { count: 0 });
     await contains("button", { text: "Inbox", contains: [".badge", { count: 0 }] });
-    await contains("button", { text: "Starred", contains: [".badge", { count: 0 }] });
+    await contains("button", { text: "Starred messages", contains: [".badge", { count: 0 }] });
 });

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -531,7 +531,7 @@ test("basic rendering: sidebar", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebar button", { text: "Inbox" });
-    await contains(".o-mail-DiscussSidebar button", { text: "Starred" });
+    await contains(".o-mail-DiscussSidebar button", { text: "Starred messages" });
     await contains(".o-mail-DiscussSidebar button", { text: "History" });
     await contains(".o-mail-DiscussSidebarCategory", { count: 2 });
     await contains(".o-mail-DiscussSidebarCategory-channel", { text: "Channels" });
@@ -554,10 +554,10 @@ test("sidebar: change active", async () => {
     await start();
     await openDiscuss();
     await contains("button.o-active", { text: "Inbox" });
-    await contains("button:not(.o-active)", { text: "Starred" });
-    await click("button", { text: "Starred" });
+    await contains("button:not(.o-active)", { text: "Starred messages" });
+    await click("button", { text: "Starred messages" });
     await contains("button:not(.o-active)", { text: "Inbox" });
-    await contains("button.o-active", { text: "Starred" });
+    await contains("button.o-active", { text: "Starred messages" });
 });
 
 test("sidebar: basic channel rendering", async () => {
@@ -645,7 +645,7 @@ test("initially load messages from inbox", async () => {
 test("default active id on mailbox", async () => {
     await start();
     await openDiscuss("mail.box_starred");
-    await contains("button.o-active", { text: "Starred" });
+    await contains("button.o-active", { text: "Starred messages" });
 });
 
 test("basic top bar rendering", async () => {
@@ -655,9 +655,9 @@ test("basic top bar rendering", async () => {
     await openDiscuss();
     await contains("button:disabled", { text: "Mark all read" });
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
-    await click("button", { text: "Starred" });
+    await click("button", { text: "Starred messages" });
     await contains("button:disabled", { text: "Unstar all" });
-    await contains(".o-mail-Discuss-threadName", { value: "Starred" });
+    await contains(".o-mail-Discuss-threadName", { value: "Starred messages" });
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-Discuss-threadName", { value: "General" });
     await contains(".o-mail-Discuss-header button", { count: 9 });
@@ -977,9 +977,9 @@ test("starred: unstar all", async () => {
     await start();
     await openDiscuss("mail.box_starred");
     await contains(".o-mail-Message", { count: 2 });
-    await contains("button", { text: "Starred", contains: [".badge", { text: "2" }] });
+    await contains("button", { text: "Starred messages", contains: [".badge", { text: "2" }] });
     await click("button:enabled", { text: "Unstar all" });
-    await contains("button", { text: "Starred", contains: [".badge", { count: 0 }] });
+    await contains("button", { text: "Starred messages", contains: [".badge", { count: 0 }] });
     await contains(".o-mail-Message", { count: 0 });
     await contains("button:disabled", { text: "Unstar all" });
 });
@@ -1719,9 +1719,9 @@ test("select another mailbox", async () => {
     await openDiscuss();
     await contains(".o-mail-Discuss");
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
-    await click("button", { text: "Starred" });
+    await click("button", { text: "Starred messages" });
     await contains("button:disabled", { text: "Unstar all" });
-    await contains(".o-mail-Discuss-threadName", { value: "Starred" });
+    await contains(".o-mail-Discuss-threadName", { value: "Starred messages" });
 });
 
 test('auto-select "Inbox nav bar" when discuss had inbox as active thread', async () => {

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -203,15 +203,15 @@ test("default thread rendering", async () => {
     await start();
     await openDiscuss();
     await contains("button", { text: "Inbox" });
-    await contains("button", { text: "Starred" });
+    await contains("button", { text: "Starred messages" });
     await contains("button", { text: "History" });
     await contains(".o-mail-DiscussSidebar-item", { text: "General" });
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-Thread", {
         text: "Your inbox is emptyChange your preferences to receive new notifications in your inbox.",
     });
-    await click("button", { text: "Starred" });
-    await contains("button.o-active", { text: "Starred" });
+    await click("button", { text: "Starred messages" });
+    await contains("button.o-active", { text: "Starred messages" });
     await contains(".o-mail-Thread", {
         text: "No starred messages You can mark any message as 'starred', and it shows up in this mailbox.",
     });
@@ -1272,7 +1272,7 @@ test("Redirect to the thread containing the starred message and highlight the me
     await openDiscuss();
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await click(".o-mail-Message [title='Mark as Todo']");
-    await click("button", { text: "Starred", contains: [".badge", { count: 1 }] });
+    await click("button", { text: "Starred messages", contains: [".badge", { count: 1 }] });
     await click(".o-mail-Message-header a", { text: "#General" });
     await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "General" });
     await contains(".o-mail-Message.o-highlighted", { text: "Hello there!!!" });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -964,14 +964,14 @@ test("toggle_star message", async () => {
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo']");
     await contains(".o-mail-Message [title='Mark as Todo']" + " i.fa-star-o");
-    await contains("button", { text: "Starred", contains: [".badge", { count: 0 }] });
+    await contains("button", { text: "Starred messages", contains: [".badge", { count: 0 }] });
     await click(".o-mail-Message [title='Mark as Todo']");
-    await contains("button", { text: "Starred", contains: [".badge", { text: "1" }] });
+    await contains("button", { text: "Starred messages", contains: [".badge", { text: "1" }] });
     await waitForSteps(["rpc:toggle_message_starred"]);
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo']" + " i.fa-star");
     await click(".o-mail-Message [title='Mark as Todo']");
-    await contains("button", { text: "Starred", contains: [".badge", { count: 0 }] });
+    await contains("button", { text: "Starred messages", contains: [".badge", { count: 0 }] });
     await waitForSteps(["rpc:toggle_message_starred"]);
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo']" + " i.fa-star-o");
@@ -1293,7 +1293,7 @@ test("Toggle star should update starred counter on all tabs", async () => {
     await click(".o-mail-Message [title='Mark as Todo']", { target: env1 });
     await contains("button", {
         target: env2,
-        text: "Starred",
+        text: "Starred messages",
         contains: [".badge", { text: "1" }],
     });
 });

--- a/addons/mail/static/tests/tours/discuss_go_back_to_thread_from_breadcrumbs_tour.js
+++ b/addons/mail/static/tests/tours/discuss_go_back_to_thread_from_breadcrumbs_tour.js
@@ -3,9 +3,9 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("discuss_go_back_to_thread_from_breadcrumbs.js", {
     steps: () => [
         { trigger: ".o-mail-Discuss-threadName[title='Inbox']" },
-        { trigger: ".o-mail-DiscussSidebar-item:contains(Starred)", run: "click" },
+        { trigger: ".o-mail-DiscussSidebar-item:contains('Starred messages')", run: "click" },
         { trigger: "button[title='View or join channels']", run: "click" },
-        { trigger: ".breadcrumb-item:contains(Starred)", run: "click" },
-        { trigger: ".o-mail-Discuss-threadName[title='Starred']" },
+        { trigger: ".breadcrumb-item:contains('Starred messages')", run: "click" },
+        { trigger: ".o-mail-Discuss-threadName[title='Starred messages']" },
     ],
 });


### PR DESCRIPTION
This commit renames "Starred" into "Starred messages".

Part of task-4967071
