### PR TITLE
[FIX] stock_picking_batch: prevent traceback when merging batches

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -320,6 +320,8 @@ class StockPickingBatch(models.Model):
     def action_merge(self):
         if not self:
             return
+        if len(self) < 2:
+            raise UserError(self.env._('Please select at least two batch/wave transfers to merge.'))
         if len(self.picking_type_id) > 1:
             raise UserError(_('Batch/Wave transfers with different operation types cannot be merged.'))
         if len(set(self.mapped('is_wave'))) > 1:
@@ -331,7 +333,7 @@ class StockPickingBatch(models.Model):
 
         target_batch = self[:1]
         other_batches = self[1:]
-        earliest_batch = self.sorted(key=lambda b: b.scheduled_date)[0]
+        earliest_batch = self.filtered(lambda b: b.scheduled_date).sorted(key=lambda b: b.scheduled_date)[0]
         merged_batch_vals = earliest_batch._get_merged_batch_vals()
         target_batch.move_line_ids |= other_batches.move_line_ids
         target_batch.picking_ids |= other_batches.picking_ids


### PR DESCRIPTION
Issue Before This Commit:
============================
- Merging a batch that lacks a `scheduled_date` causes a traceback: `TypeError: '<' not supported between instances of 'datetime.datetime' and 'bool'.`
- Merging a single batch does nothing but still proceeds silently, even though merging a single record has no practical effect.

Steps to Reproduce:
============================

- Install the `stock_picking_batch` module.
- Create two batches, one with a scheduled_date, one without.
- Try merging only one batch → it proceeds silently, which makes no sense.
- Try merging both; a traceback error occurs due to a missing scheduled date.

With This Commit:
============================
- Raise a proper UserError when the user tries to merge fewer than two batches.
- Prevent traceback by filtering out batches without a scheduled date before finding the earliest one.

This commit ensures that users can proceed with the batch merging process without encountering a traceback when one or more batches have no scheduled date. It also introduces a UserError when attempting to merge only a single batch, similar to the behaviour in purchase order merging. Since merging a single record has no practical effect.
