### PR TITLE
[FIX] delivery: allow delivery of combo products

### DIFF
--- a/addons/delivery/models/sale_order_line.py
+++ b/addons/delivery/models/sale_order_line.py
@@ -36,6 +36,15 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         return self.is_delivery
 
+    def _get_invalid_delivery_weight_lines(self):
+        """Retrieve lines containing physical products with no weight defined."""
+        return self.filtered(
+            lambda line:
+                line.product_qty > 0
+                and line.product_id.type not in ('service', 'combo')
+                and line.product_id.weight == 0,
+        )
+
     # override to allow deletion of delivery line in a confirmed order
     def _check_line_unlink(self):
         """


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a combo product Foo;
2. ensure the combo items have a weight set;
3. enable & publish a shipping connector;
4. add combo product to cart;
5. go to checkout;
6. attempt to select shipping connector as delivery method.

A similar message appears when trying to add a delivery method to a backend order if the order has downpayment lines.

Issue
-----
> The estimated shipping price cannot be computed because the weight is
  missing for the following product(s): Foo

Cause
-----
The combo product doesn't have a weight, as it's not a discrete item, but a collection of multiple items.

The shipping connectors haven't been updated yet to account for this, and still expect every non-service product to have a weight.

Solution
--------
When looking for lines without weight, filter out products of type `combo` (similar to how `service` products are handled) using a new `_get_invalid_delivery_weight_liens` helper method, added to `sale.order.line`.

Also ignore lines where `product_qty` is zero, e.g. `display_type` lines & down payment lines.

Enterprise PR: https://github.com/odoo/enterprise/pull/91243

opw-4940973