### PR TITLE
[FIX] hr_holidays: add "new" button on timeoff allocation kanban view

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -368,7 +368,7 @@
         <field name="name">hr.leave.allocation.view.kanban</field>
         <field name="model">hr.leave.allocation</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_mobile" create="0" sample="1">
+            <kanban class="o_kanban_mobile" sample="1">
                 <field name="can_approve"/>
                 <templates>
                     <t t-name="menu" groups="base.group_user">


### PR DESCRIPTION
On mobile the "new" button in the time off allocation is not present

Steps to reproduce:
-------------------
* Open Time_off app
* Select Management>Allocations
* Open Kanban view (If you are on phone it's the standard view)
* Issue : "New" button is missing

Observation:
The create "0" don't allow to create on kanban view https://github.com/odoo/odoo/blob/2b109261bc6e7550b23a0d444a4e7c63496e4c55/addons/hr_holidays/views/hr_leave_allocation_views.xml#L371

Why the fix:
------------
- It's misleading on phone.
- Align with the change on 18.3. https://github.com/odoo/odoo/commit/944c11e61abead4f5157a7a7cb7b1f536bc14411 

opw-4898359
