### PR TITLE
[FIX] crm: prevent traceback on drag & drop to empty kanban stage

### DIFF
--- a/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
+++ b/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
@@ -8,6 +8,7 @@
             <t t-if="showRecurringRevenue">
                 <t t-set="rrmAggregate" t-value="getRecurringRevenueGroupAggregate(props.group)"/>
                 <AnimatedNumber
+                    t-if="rrmAggregate.value !== false"
                     value="rrmAggregate.value"
                     title="rrmAggregate.title"
                     duration="1000"


### PR DESCRIPTION
**Steps to reproduce:**
1.Install crm
2.Enable 'Recurring Revenues' from settings
3.Go to CRM > 'My pipeline' > Create a record here
4.Enable debug mode
5.Either create a new stage or move records from any stage to make an empty stage
6.Move created record to an empty stage

**Issue:**
This Traceback accurs :
"Uncaught Promise > Invalid props for component 'AnimatedNumber': 'value' is not a number"

**Cause:**
https://github.com/odoo/odoo/blob/5ade756227abf58769ff904651628a3ccaf8e19a/addons/web/static/src/views/view_components/animated_number.js#L8-L21
AnimatedNumber expects a numeric value for its value prop. When moving to an empty stage, the aggregate value is false, which is not a valid number for the component.

**Solution:**
Check for the rrmAggregate value to render the component.


opw-4972672