### PR TITLE
[FIX] hr_holidays: fix the tour employee_holidays_archived_tour

### DIFF
--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -106,27 +106,3 @@ registry.category("web_tour.tours").add('hr_holidays_launch', {
         },
     ]
 });
-
-registry.category("web_tour.tours").add('employee_holidays_archived_tour', {
-    url: '/web',
-    steps: () => [
-        stepUtils.showAppsMenuItem(),
-        {
-            trigger: '.o_app[data-menu-xmlid="hr.menu_hr_root"]',
-            run: "click",
-        },
-        {
-            trigger: '.o_kanban_record:contains("test_user")',
-            run: "click",
-        },
-        {
-            trigger: '.o_stat_info:contains("Time Off")',
-            run: () => {
-                const time_off_stats = $('.o_stat_info:contains("Time Off")');
-                if (time_off_stats.toArray().some(el => $(el).text().includes('10'))) {
-                    throw new Error('The archived time off should not be displayed!');
-                }
-            }
-        },
-    ]
-});

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -343,3 +343,32 @@ class TestAllocations(TestHrHolidaysCommon):
 
         self.assertEqual(leave_request.employee_id, self.employee)
         self.assertEqual(leave_request.state, 'validate')
+
+    def test_employee_holidays_archived_display(self):
+        admin_user = self.env.ref('base.user_admin')
+
+        employee = self.env['hr.employee'].create({
+            'name': 'test_employee',
+        })
+
+        leave_type = self.env['hr.leave.type'].with_user(admin_user)
+
+        holidays_type_1 = leave_type.create({
+            'name': 'archived_holidays',
+        })
+
+        self.env['hr.leave.allocation'].create({
+            'name': 'archived_holidays_allocation',
+            'employee_id': employee.id,
+            'holiday_status_id': holidays_type_1.id,
+            'number_of_days': 10,
+            'state': 'confirm',
+            'date_from': '2022-01-01',
+        })
+
+        self.assertEqual(employee.allocation_display, '10')
+
+        holidays_type_1.active = False
+        employee._compute_allocation_remaining_display()
+
+        self.assertEqual(employee.allocation_display, '0')

--- a/addons/hr_holidays/tests/test_hr_holidays_tour.py
+++ b/addons/hr_holidays/tests/test_hr_holidays_tour.py
@@ -49,37 +49,3 @@ class TestHrHolidaysTour(HttpCase):
         self.env.ref("base.lang_sr@latin").active = True
         admin_user.lang = "sr@latin"
         self.start_tour("/web", "hr_holidays_launch", login="admin")
-
-    @freeze_time('01/17/2022')
-    def test_employee_holidays_archived_tour(self):
-        admin_user = self.env.ref('base.user_admin')
-
-        test_user = self.env['res.users'].create({
-            'name': 'test_user',
-            'login': 'test_user',
-            'email': 'test_user@yourcompany.com',
-            'company_id': admin_user.company_id.id
-        })
-
-        employee = self.env['hr.employee'].create({
-            'name': 'test_user',
-            'user_id': test_user.id,
-        })
-
-        leave_type = self.env['hr.leave.type'].with_user(admin_user)
-
-        holidays_type_1 = leave_type.create({
-            'name': 'archived_holidays',
-            'active': False
-        })
-
-        self.env['hr.leave.allocation'].create({
-            'name': 'archived_holidays_allocation',
-            'employee_id': employee.id,
-            'holiday_status_id': holidays_type_1.id,
-            'number_of_days': 10,
-            'state': 'confirm',
-            'date_from': '2022-01-01',
-        })
-
-        self.start_tour('/web', 'employee_holidays_archived_tour', login="admin")


### PR DESCRIPTION
The #217517 PR is causing a test failure on runbot.
The problem was due to use of ```$('.o_stat_info:contains("Time Off")')``` to get the element in tour.
To avoid unnecessary use of tour, the test is re-written.

runbot-230486
