### PR TITLE
[FIX] html_builder: only consider leading "-" in numeric input

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -108,12 +108,21 @@ export class BuilderNumberInput extends Component {
         displayValue = displayValue.replace(/,/g, ".");
         // Only accept 0-9, dot, - sign and space if multiple values are allowed
         if (this.props.composable) {
-            displayValue = displayValue.replace(/[^0-9.-\s]/g, "");
+            displayValue = displayValue
+                .trim()
+                .replace(/[^0-9.-\s]/g, "")
+                .replace(/(?<!^|\s)-/g, "");
         } else {
             displayValue = displayValue
                 .trim()
+                // Remove any space after a "-" to accept "- 10" as "-10"
+                .replace(/-\s*/g, "-")
                 .split(" ")[0]
-                .replace(/[^0-9.-]/g, "");
+                .replace(/[^0-9.-]/g, "")
+                // Only keep "-" if it is at the start
+                .replace(/(?<!^)-/g, "")
+                // Only keep the first "."
+                .replace(/^([^.]*)\.?(.*)/, (_, a, b) => a + (b ? '.' + b.replace(/\./g, '') : ''));
         }
         displayValue = displayValue.split(" ").map(this.clampValue.bind(this)).join(" ");
 


### PR DESCRIPTION
Before this commit, adding a "-" in a numeric input in the edit mode sidebar would sometime open a traceback. This was due to the "-" that was allowed for negative value, but could be present anywhere in the string and wouldn't be removed.

This commit removes all non-leading "-" in the input to solve the issue.

Steps to reproduce:
- Drop a form
- Click on it
- In the "width" field, put "-300" 
      nothing happen
- In the "width" field, put "300-" 
      an error occur when you type "-"
