### PR TITLE
[IMP] web, *: improve group configuration menu behavior

### DIFF
--- a/addons/base_automation/static/src/group_config_menu_patch.js
+++ b/addons/base_automation/static/src/group_config_menu_patch.js
@@ -90,6 +90,7 @@ registry.category("group_config_items").add(
         method: "openAutomations",
         isVisible: ({ permissions }) => permissions.canEditAutomations,
         class: "o_column_automations",
+        icon: "fa-magic",
     },
     { sequence: 25, force: true }
 );

--- a/addons/purchase_requisition/static/src/widgets/purchase_order_alternatives_widget.xml
+++ b/addons/purchase_requisition/static/src/widgets/purchase_order_alternatives_widget.xml
@@ -3,7 +3,7 @@
 
     <!-- Ensure we can't unlink a PO from itself (i.e. confusing behavior) -->
     <t t-name="purchase_requisition.AltPOsListRenderer.RecordRow" t-inherit="web.ListRenderer.RecordRow" t-inherit-mode="primary">
-        <xpath expr="//t[@t-if='displayOptionalFields or hasX2ManyAction']" position="attributes">
+        <xpath expr="//t[@t-if='displayOptionalFields or props.list.isGrouped or hasX2ManyAction']" position="attributes">
             <attribute name="t-if">(displayOptionalFields or hasX2ManyAction) and !isCurrentRecord(record)</attribute>
         </xpath>
     </t>

--- a/addons/resource/static/src/section_list_renderer.xml
+++ b/addons/resource/static/src/section_list_renderer.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="resource.SectionListRenderer.RecordRow" t-inherit="web.ListRenderer.RecordRow">
-        <xpath expr="//t[@t-if='displayOptionalFields or hasX2ManyAction']" position="attributes">
+        <xpath expr="//t[@t-if='displayOptionalFields or props.list.isGrouped or hasX2ManyAction']" position="attributes">
             <attribute name="t-if">(displayOptionalFields or hasX2ManyAction) and !isSection(record)</attribute>
         </xpath>
     </t>

--- a/addons/web/static/src/views/kanban/kanban_header.js
+++ b/addons/web/static/src/views/kanban/kanban_header.js
@@ -76,6 +76,7 @@ export class KanbanHeader extends Component {
                             o_kanban_toggle_fold: true,
                             disabled: this.props.list.model.useSampleModel,
                         }),
+                        icon: "fa-compress",
                     },
                 ],
                 ...registry.category("group_config_items").getEntries(),

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -323,7 +323,9 @@ export class ListRenderer extends Component {
         return !!(
             this.displayOptionalFields ||
             this.activeActions.onDelete ||
-            this.hasOptionalOpenFormViewColumn
+            this.hasOptionalOpenFormViewColumn ||
+            // spare some space to display the cog icon in group headers
+            this.props.list.isGrouped
         );
     }
 
@@ -1057,6 +1059,7 @@ export class ListRenderer extends Component {
         const index = reversedColumns.findIndex(
             (col) =>
                 col.name in aggregates &&
+                col.widget !== "handle" &&
                 AGGREGATABLE_FIELD_TYPES.includes(this.fields[col.name].type)
         );
         return index > -1 ? this.columns.length - index - 1 : -1;
@@ -1090,9 +1093,6 @@ export class ListRenderer extends Component {
         let colspan;
         if (lastAggregateIndex > -1) {
             colspan = this.columns.length - lastAggregateIndex - 1;
-            if (this.displayOptionalFields) {
-                colspan++;
-            }
         } else {
             colspan = this.columns.length > 1 ? DEFAULT_GROUP_PAGER_COLSPAN : 0;
         }
@@ -1939,7 +1939,9 @@ export class ListRenderer extends Component {
             return false;
         }
         const focusableEls = getTabableElements(cell).filter(
-            (el) => el === document.activeElement || ["INPUT", "BUTTON", "TEXTAREA"].includes(el.tagName)
+            (el) =>
+                el === document.activeElement ||
+                ["INPUT", "BUTTON", "TEXTAREA"].includes(el.tagName)
         );
         const index = focusableEls.indexOf(document.activeElement);
         return (

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -237,7 +237,6 @@
                     <div t-if="showGroupPager(group)" t-on-click.stop="" class="ms-auto">
                         <Pager t-props="getGroupPagerProps(group)"/>
                     </div>
-                    <GroupConfigMenu t-if="showGroupConfigMenu(group)" t-props="getGroupConfigMenuProps(group)"/>
                 </div>
             </th>
             <td t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-foreach="getAggregateColumns(group)" t-as="column" t-key="column.id" t-att-class="{'o_list_number': column.type === 'field'}">
@@ -251,6 +250,9 @@
             </td>
             <t t-set="groupPagerColspan" t-value="getGroupPagerCellColspan(group)"/>
             <th t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-if="groupPagerColspan > 0" t-att-colspan="groupPagerColspan"/>
+            <th class="p-0" t-on-keydown="(ev) => this.onCellKeydown(ev, group)">
+                <GroupConfigMenu t-if="showGroupConfigMenu(group)" t-props="getGroupConfigMenuProps(group)"/>
+            </th>
         </tr>
     </t>
 
@@ -331,7 +333,7 @@
 
             <t t-set="useUnlink" t-value="'unlink' in activeActions" />
             <t t-set="hasX2ManyAction" t-value="isX2Many and (useUnlink ? activeActions.unlink : activeActions.delete)" />
-            <t t-if="displayOptionalFields or hasX2ManyAction">
+            <t t-if="displayOptionalFields or props.list.isGrouped or hasX2ManyAction">
                 <t t-if="hasX2ManyAction">
                     <t t-set="hasDeleteButton" t-value="this.displayDeleteIcon(record)"/>
                     <td class="o_list_record_remove w-print-0 p-print-0 text-center"

--- a/addons/web/static/src/views/view_components/group_config_menu.js
+++ b/addons/web/static/src/views/view_components/group_config_menu.js
@@ -29,6 +29,7 @@ export class GroupConfigMenu extends Component {
             key,
             label: desc.label,
             class: typeof desc.class === "function" ? desc.class(args) : desc.class,
+            icon: desc.icon,
             isVisible: typeof desc.isVisible === "function" ? desc.isVisible(args) : desc.isVisible,
             method: typeof desc.method === "function" ? desc.method : this[desc.method].bind(this),
         }));
@@ -87,6 +88,7 @@ groupConfigItems.add(
         label: _t("Edit"),
         isVisible: ({ permissions }) => permissions.canEditGroup,
         class: "o_group_edit",
+        icon: "fa-pencil",
         method: "editGroup",
     },
     { sequence: 20 }
@@ -96,7 +98,8 @@ groupConfigItems.add(
     {
         label: _t("Delete"),
         isVisible: ({ permissions }) => permissions.canDeleteGroup,
-        class: "o_group_delete",
+        class: "o_group_delete text-danger",
+        icon: "fa-trash",
         method: "deleteGroup",
     },
     { sequence: 30 }

--- a/addons/web/static/src/views/view_components/group_config_menu.xml
+++ b/addons/web/static/src/views/view_components/group_config_menu.xml
@@ -9,6 +9,7 @@
                 <t t-set-slot="content">
                     <t t-foreach="configItems" t-as="item" t-key="item.key">
                         <DropdownItem t-if="item.isVisible" class="item.class" onSelected="() => item.method()">
+                            <i t-if="item.icon" class="fa pe-2" t-att-class="item.icon"/>
                             <t t-esc="item.label"/>
                         </DropdownItem>
                     </t>

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -249,7 +249,7 @@ test(`width computation: with records, lot of fields, grouped`, async () => {
         groupBy: ["int_field"],
     });
     expect(`.o_resize`).toHaveCount(9);
-    expectedColumnWidthsToBeCloseTo([40, 29, 89, 80, 89, 102, 99, 188, 114, 45]);
+    expectedColumnWidthsToBeCloseTo([40, 29, 89, 80, 89, 102, 99, 188, 114, 34, 32]);
 });
 
 test(`width computation: with records, few fields`, async () => {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1888,16 +1888,16 @@ test(`basic grouped list rendering with widget="handle" col`, async () => {
     `,
         groupBy: ["bar"],
     });
-    expect(`thead th:not(.o_list_record_selector)`).toHaveCount(3, {
+    expect(`thead th:not(.o_list_record_selector)`).toHaveCount(4, {
         message:
-            "should have 1 th for checkbox (desktop only), 1 th for handle, 1 th for Foo, 1 th for Bar",
+            "should have 1 th for checkbox (desktop only), 1 th for handle, 1 th for Foo, 1 th for Bar and 1 for eventual cog",
     });
     expect(`thead th[data-name=foo]`).toHaveCount(1);
     expect(`thead th[data-name=bar]`).toHaveCount(1);
     expect(`thead th[data-name=int_field]`).toHaveCount(1);
     expect(`tr.o_group_header`).toHaveCount(2);
     expect(`th.o_group_name`).toHaveCount(2);
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2); // group name + colspan 2
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3); // group name + colspan 2 + cog placeholder
     expect(`.o_group_header:eq(0) .o_list_number`).toHaveCount(0);
 });
 
@@ -1914,13 +1914,15 @@ test(`basic grouped list rendering with a date field between two fields with a a
         `,
         groupBy: ["bar"],
     });
-    expect(`thead th:not(.o_list_record_selector)`).toHaveCount(3, {
-        message: "should have 1 th for checkbox (desktop only), 1 th for Foo, 1 Int, 1 Date, 1 Int",
+    expect(`thead th:not(.o_list_record_selector)`).toHaveCount(4, {
+        message:
+            "should have 1 th for checkbox (desktop only), 1 th for Foo, 1 Int, 1 Date, 1 Int, 1 cog placeholder",
     });
     expect(queryAllTexts(`thead th:not(.o_list_record_selector)`)).toEqual([
         "Int field",
         "Date",
         "Int field",
+        "",
     ]);
     expect(`tr.o_group_header`).toHaveCount(2);
     expect(`th.o_group_name`).toHaveCount(2);
@@ -1935,7 +1937,7 @@ test(`basic grouped list rendering 1 col without selector`, async () => {
         groupBy: ["bar"],
         allowSelectors: false,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(1);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "1");
 });
 
@@ -1947,7 +1949,7 @@ test(`basic grouped list rendering 1 col with selector on desktop`, async () => 
         arch: `<list><field name="foo"/></list>`,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(1);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
 });
 
@@ -1959,7 +1961,7 @@ test(`basic grouped list rendering 1 col with selector on mobile`, async () => {
         arch: `<list><field name="foo"/></list>`,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(1);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "1");
 });
 
@@ -1971,7 +1973,7 @@ test(`basic grouped list rendering 2 cols without selector`, async () => {
         groupBy: ["bar"],
         allowSelectors: false,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "1");
 });
 
@@ -1983,7 +1985,7 @@ test(`basic grouped list rendering 3 cols without selector`, async () => {
         groupBy: ["bar"],
         allowSelectors: false,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
 });
 
@@ -1996,7 +1998,7 @@ test(`basic grouped list rendering 2 col with selector on desktop`, async () => 
         groupBy: ["bar"],
         allowSelectors: true,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
 });
 
@@ -2009,7 +2011,7 @@ test(`basic grouped list rendering 2 col with selector on mobile`, async () => {
         groupBy: ["bar"],
         allowSelectors: true,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "1");
 });
 
@@ -2023,7 +2025,7 @@ test(`basic grouped list rendering 3 cols with selector on desktop`, async () =>
         allowSelectors: true,
     });
 
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "3");
 });
 
@@ -2037,7 +2039,7 @@ test(`basic grouped list rendering 3 cols with selector on mobile`, async () => 
         allowSelectors: true,
     });
 
-    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(3);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
 });
 
@@ -2059,14 +2061,13 @@ test(`basic grouped list rendering 7 cols with aggregates and selector on deskto
         `,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(5);
+    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(6);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "3");
     expect(`.o_group_header:eq(0) td`).toHaveCount(3, {
         message: "there should be 3 tds (aggregates + fields in between)",
     });
-    expect(`.o_group_header th:eq(-1)`).toHaveAttribute("colspan", "2", {
-        message:
-            "header last cell should span on the two last fields (to give space for the pager) (colspan 2)",
+    expect(`.o_group_header th:eq(4)`).toHaveAttribute("colspan", "2", {
+        message: "pager cell in the group header should span on the two last fields (colspan 2)",
     });
 });
 
@@ -2088,14 +2089,13 @@ test(`basic grouped list rendering 7 cols with aggregates and selector on mobile
         `,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(5);
+    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(6);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
     expect(`.o_group_header:eq(0) td`).toHaveCount(3, {
         message: "there should be 3 tds (aggregates + fields in between)",
     });
-    expect(`.o_group_header th:eq(-1)`).toHaveAttribute("colspan", "2", {
-        message:
-            "header last cell should span on the two last fields (to give space for the pager) (colspan 2)",
+    expect(`.o_group_header th:eq(-2)`).toHaveAttribute("colspan", "2", {
+        message: "pager cell in the group header should span on the two last fields (colspan 2)",
     });
 });
 
@@ -2117,14 +2117,13 @@ test(`basic grouped list rendering 7 cols with aggregates, selector and optional
         `,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(5);
+    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(6);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "3");
     expect(`.o_group_header:eq(0) td`).toHaveCount(3, {
         message: "there should be 3 tds (aggregates + fields in between)",
     });
-    expect(`.o_group_header th:eq(-1)`).toHaveAttribute("colspan", "3", {
-        message:
-            "header last cell should span on the two last fields (to give space for the pager) (colspan 2)",
+    expect(`.o_group_header th:eq(-2)`).toHaveAttribute("colspan", "2", {
+        message: "pager cell in the group header should span on the two last fields (colspan 2)",
     });
 });
 
@@ -2146,14 +2145,13 @@ test(`basic grouped list rendering 7 cols with aggregates, selector and optional
         `,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(5);
+    expect(`.o_group_header:eq(0) th, .o_group_header:eq(0) td`).toHaveCount(6);
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
     expect(`.o_group_header:eq(0) td`).toHaveCount(3, {
         message: "there should be 3 tds (aggregates + fields in between)",
     });
-    expect(`.o_group_header th:eq(-1)`).toHaveAttribute("colspan", "3", {
-        message:
-            "header last cell should span on the two last fields (to give space for the pager) (colspan 2)",
+    expect(`.o_group_header th:eq(-2)`).toHaveAttribute("colspan", "2", {
+        message: "pager cell in the group header should span on the two last fields (colspan 2)",
     });
 });
 
@@ -2167,13 +2165,14 @@ test(`basic grouped list rendering 4 cols with aggregates, selector and openForm
                 <field name="datetime"/>
                 <field name="int_field" sum="Sum1"/>
                 <field name="bar"/>
+                <field name="m2o"/>
                 <field name="qux" sum="Sum2" optional="hide"/>
             </list>
         `,
         groupBy: ["bar"],
     });
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
-    expect(`.o_group_header th:eq(-1)`).toHaveAttribute("colspan", "2");
+    expect(`.o_group_header th:eq(-2)`).toHaveAttribute("colspan", "2");
 });
 
 test.tags("mobile");
@@ -2186,13 +2185,14 @@ test(`basic grouped list rendering 4 cols with aggregates, selector and openForm
                 <field name="datetime"/>
                 <field name="int_field" sum="Sum1"/>
                 <field name="bar"/>
+                <field name="m2o"/>
                 <field name="qux" sum="Sum2" optional="hide"/>
             </list>
         `,
         groupBy: ["bar"],
     });
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "1");
-    expect(`.o_group_header th:eq(-1)`).toHaveAttribute("colspan", "2");
+    expect(`.o_group_header th:eq(-2)`).toHaveAttribute("colspan", "2");
 });
 
 test.tags("desktop");
@@ -2211,7 +2211,7 @@ test(`basic grouped list rendering 4 cols with aggregates, selector, optional an
         groupBy: ["bar"],
     });
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "2");
-    expect(`.o_group_header th:eq(-1)`).toHaveAttribute("colspan", "1");
+    expect(`.o_group_header th:eq(-1)`).not.toHaveAttribute("colspan");
 });
 
 test.tags("mobile");
@@ -2230,7 +2230,7 @@ test(`basic grouped list rendering 4 cols with aggregates, selector, optional an
         groupBy: ["bar"],
     });
     expect(`.o_group_header th:eq(0)`).toHaveAttribute("colspan", "1");
-    expect(`.o_group_header th:eq(-1)`).toHaveAttribute("colspan", "1");
+    expect(`.o_group_header th:eq(-2)`).toHaveAttribute("colspan", "1");
 });
 
 test(`group a list view with the aggregable field 'value'`, async () => {
@@ -2346,7 +2346,7 @@ test(`grouped list rendering with default_group_by m2o field: add group`, async 
         type: "list",
         arch: `<list default_group_by="m2o"><field name="foo"/></list>`,
     });
-    expect(`.o_group_header:eq(0) th`).toHaveCount(1);
+    expect(`.o_group_header:eq(0) th`).toHaveCount(2);
     expect(queryAllTexts(".o_group_name")).toEqual(["Value 1 (3)", "Value 2 (1)"]);
     expect(`.o_list_footer td > button`).toHaveText("Add a M2o");
     await contains(`.o_list_footer td > button`).click();
@@ -2393,7 +2393,7 @@ test(`grouped list rendering with groupby m2o field: edit group`, async () => {
     await getService("action").doAction(1);
 
     expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1 (3)", "Value 2 (1)"]);
-    expect(`.o_group_header:first .o_group_config`).toHaveCount(1);
+    expect(`.o_group_header:first th:last .o_group_config`).toHaveCount(1);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     expect(`.o-dropdown--group-config-menu`).toHaveCount(1);
     await contains(`.o-dropdown--group-config-menu .o_group_edit`).click();
@@ -10322,16 +10322,16 @@ test(`editable grouped list with handle widget`, async () => {
     await contains(`.o_group_header:last`).click();
     expect(`.o_group_header:first`).toHaveText("No (1)\n 0");
     expect(`.o_group_header:last`).toHaveText("Yes (3)\n 2,000");
-    expect(`tbody .o_data_row:eq(0) td:last`).toHaveText("0", {
+    expect(`tbody .o_data_row:eq(0) td:eq(-2)`).toHaveText("0", {
         message: "default fourth record should have amount 0",
     });
-    expect(`tbody .o_data_row:eq(1) td:last`).toHaveText("1,200", {
+    expect(`tbody .o_data_row:eq(1) td:eq(-2)`).toHaveText("1,200", {
         message: "default first record should have amount 1,200",
     });
-    expect(`tbody .o_data_row:eq(2) td:last`).toHaveText("500", {
+    expect(`tbody .o_data_row:eq(2) td:eq(-2)`).toHaveText("500", {
         message: "default second record should have amount 500",
     });
-    expect(`tbody .o_data_row:eq(3) td:last`).toHaveText("300", {
+    expect(`tbody .o_data_row:eq(3) td:eq(-2)`).toHaveText("300", {
         message: "default third record should have amount 300",
     });
 
@@ -10346,21 +10346,21 @@ test(`editable grouped list with handle widget`, async () => {
     // Aggregates are not updated, todo later?
     expect(`.o_group_header:first`).toHaveText("No (2)\n 0");
     expect(`.o_group_header:last`).toHaveText("Yes (2)\n 2,000");
-    expect(`tbody .o_data_row:eq(0) td:last`).toHaveText("300", {
+    expect(`tbody .o_data_row:eq(0) td:eq(-2)`).toHaveText("300", {
         message: "new first record should have amount 300",
     });
-    expect(`tbody .o_data_row:eq(1) td:last`).toHaveText("0", {
+    expect(`tbody .o_data_row:eq(1) td:eq(-2)`).toHaveText("0", {
         message: "new second record should have amount 0",
     });
-    expect(`tbody .o_data_row:eq(2) td:last`).toHaveText("1,200", {
+    expect(`tbody .o_data_row:eq(2) td:eq(-2)`).toHaveText("1,200", {
         message: "new third record should have amount 1,200",
     });
-    expect(`tbody .o_data_row:eq(3) td:last`).toHaveText("500", {
+    expect(`tbody .o_data_row:eq(3) td:eq(-2)`).toHaveText("500", {
         message: "new fourth record should have amount 500",
     });
 
     await contains(`tbody .o_data_row:eq(0) div[name='amount']`).click();
-    expect(`tbody .o_data_row:eq(0) td:last input`).toHaveValue("300", {
+    expect(`tbody .o_data_row:eq(0) td:eq(-2) input`).toHaveValue("300", {
         message: "the edited record should be the good one",
     });
 });
@@ -17396,7 +17396,7 @@ test(`properties: optional show/hide (at reload, config from local storage)`, as
     // list is grouped, no record displayed
     expect(`.o_group_header`).toHaveCount(2);
     expect(`.o_data_row`).toHaveCount(0);
-    expect(`.o_list_table thead th:not(.o_list_record_selector)`).toHaveCount(1);
+    expect(`.o_list_table thead th:not(.o_list_record_selector)`).toHaveCount(2);
     expect(`.o_list_table thead th[data-name=m2o]`).toHaveCount(1);
 
     await contains(`.o_group_header`).click(); // open group Value 1


### PR DESCRIPTION
*: base_automation, purchase_requisition, resource

This commit introduces several usability improvements to the group configuration cog menu in list and kanban views:

- Relocation: the list view's group configuration cog menu is moved from next to the group name to the end of the group header row, reducing the risk of accidental clicks since it only appears on row hover.

- Conditional display: the menu is shown only when the view is grouped by its default group (if defined). In kanban, it is replaced by a fold icon when another grouping is applied.

- Visual improvements: icons are added to all available actions inside the cog menu and the delete action is colored in red.

These changes make group configuration more intuitive and reduce confusion when interacting with grouped views.

task-4988827