### PR TITLE
[FIX] html_editor: keep selection when reverting preview

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1251,6 +1251,7 @@ export class HistoryPlugin extends Plugin {
                 revertOperation();
                 revertOperation = this.makeSavePoint();
                 this.isPreviewing = true;
+                this.stageSelection();
                 operation(...args);
                 // todo: We should not add a step on preview as it would send
                 // unnecessary steps in collaboration and let the other peer see

--- a/addons/website/static/tests/tours/text_highlights.js
+++ b/addons/website/static/tests/tours/text_highlights.js
@@ -3,6 +3,7 @@ import {
     registerWebsitePreviewTour,
     clickToolbarButton,
 } from '@website/js/tours/tour_utils';
+import { editorsWeakMap } from "@html_editor/../tests/tours/helpers/editor";
 
 registerWebsitePreviewTour("text_highlights", {
     url: "/",
@@ -48,6 +49,8 @@ registerWebsitePreviewTour("text_highlights", {
             const secondLine = document.createElement("i");
             secondLine.textContent = "Text content line B";
             this.anchor.replaceChildren(firstLine, document.createElement("br"), secondLine);
+            const editor = editorsWeakMap.get(this.anchor.ownerDocument);
+            editor.shared.history.addStep();
             // Select the whole content.
             const range = iframeDOC.createRange();
             const selection = iframeDOC.getSelection();


### PR DESCRIPTION
Steps to Reproduce:

- Go to To-do and create a new item.
- Type something in the editor.
- Select all the text using Ctrl + A (keyboard).
- Try to change the color/background color.
- The toolbar closes suddenly.

Current behavior before PR:

- The selection was only being saved when using a mouse. Keyboard-based selections (like Ctrl + A) were not staged.
- As a result, when undoing a preview, the editor couldn't restore the selection.

Desired behavior after PR is merged:

- Now the selection is saved earlier, so it can be restored properly when reverting to previous step.
- This keeps the toolbar open and working as expected.

task-4941601

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
