### PR TITLE
[FIX] orm, *: prevent int to be used as the Selection field label

### DIFF
--- a/odoo/orm/fields_selection.py
+++ b/odoo/orm/fields_selection.py
@@ -202,7 +202,9 @@ class Selection(Field[str | typing.Literal[False]]):
         """
         selection = self.selection
         if isinstance(selection, str) or callable(selection):
-            return determine(selection, env[self.model_name])
+            selection = determine(selection, env[self.model_name])
+            # force all values to be strings (check _get_year_selection)
+            return [(str(key), str(label)) for key, label in selection]
 
         # translate selection labels
         if env.lang:


### PR DESCRIPTION
*: fleet

This commit fixes an issue that would occur when integers as the
label of a selection. For example, if the selection returned
['1970', 1970], a crash would've occured in the webclient,
because in commit (1), the field widget now uses the SelectMenu
component, which verifies the received props.

Previously of this commit, it was supported in practice, while
not being correct from an ORM point of view.

Now an assert has been added as well, preventing the use of
integers or other types as the label given.

1) 0923409082ead5ffdf2c28f3b063fbd91ebce553