### PR TITLE
[PERF] mail: avoid fetching all group members to compute name

### DIFF
--- a/addons/mail/static/tests/discuss/core/common/channel_group_name.test.js
+++ b/addons/mail/static/tests/discuss/core/common/channel_group_name.test.js
@@ -1,0 +1,55 @@
+import {
+    click,
+    contains,
+    defineMailModels,
+    insertText,
+    openDiscuss,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+
+import { describe, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
+
+defineMailModels();
+describe.current.tags("desktop");
+
+test("Group name is based on channel members when name is not set", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].create(
+        ["Alice", "Bob", "Eve", "John", "Sam"].map((name) => ({
+            name,
+            partner_id: pyEnv["res.partner"].create({ name }),
+        }))
+    );
+    const channelId = pyEnv["discuss.channel"].create({ channel_type: "group" });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Discuss-threadName[title='Mitchell Admin']");
+    await click("button[title='Invite People']");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "Alice" });
+    await click("button", { text: "Invite to Group Chat" });
+    await contains(".o-mail-Discuss-threadName[title='Mitchell Admin and Alice']");
+    await click("button[title='Invite People']");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "Bob" });
+    await click("button", { text: "Invite to Group Chat" });
+    await contains(".o-mail-Discuss-threadName[title='Mitchell Admin, Alice, and Bob']");
+    await click("button[title='Invite People']");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "Eve" });
+    await click("button", { text: "Invite to Group Chat" });
+    await contains(".o-mail-Discuss-threadName[title='Mitchell Admin, Alice, Bob, and 1 other']");
+    await click("button[title='Invite People']");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "John" });
+    await click("button", { text: "Invite to Group Chat" });
+    await contains(".o-mail-Discuss-threadName[title='Mitchell Admin, Alice, Bob, and 2 others']");
+    await click(".o-mail-Discuss-threadName");
+    await insertText(".o-mail-Discuss-threadName.o-focused", "Custom name", { replace: true });
+    await contains(".o-mail-Discuss-threadName[title='Custom name']");
+    await press("Enter");
+    // Ensure that after setting the name, members are not taken into account for the group name.
+    await click("button[title='Invite People']");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "Sam" });
+    await click("button", { text: "Invite to Group Chat" });
+    await contains(".o_mail_notification", { text: "invited Sam to the channel" });
+    await contains(".o-mail-Discuss-threadName[title='Custom name']");
+});

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -1,12 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+import json
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 from unittest.mock import patch
 from markupsafe import Markup
 
 from odoo import Command, fields
+from odoo.addons.bus.models.bus import json_dump
 from odoo.addons.mail.models.discuss.discuss_channel import channel_avatar, group_avatar
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.common import MailCommon
@@ -63,6 +65,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             member = self.env["discuss.channel.member"].search([], order="id desc", limit=1)
             return (
                 [
+                    (self.cr.dbname, "discuss.channel", test_group.id),
                     (self.cr.dbname, "res.partner", self.test_partner.id),
                     (self.cr.dbname, "discuss.channel", test_group.id),
                     (self.cr.dbname, "res.partner", self.partner_employee.id),
@@ -915,3 +918,90 @@ class TestChannelInternals(MailCommon, HttpCase):
             ],
         ):
             channel._message_update_content(message, Markup("<p>Test update</p>"), [])
+
+    def test_member_based_channel_naming(self):
+        john = mail_new_test_user(self.env, groups="base.group_user", login="john")
+        bob = mail_new_test_user(self.env, groups="base.group_user", login="bob")
+        alice = mail_new_test_user(self.env, groups="base.group_user", login="alice")
+        eve = mail_new_test_user(self.env, groups="base.group_user", login="eve")
+        group = self.env["discuss.channel"].create({"name": "", "channel_type": "group"})
+        channel = self.env["discuss.channel"].create({"name": "General"})
+
+        # Each test case represents a flow of member changes on a given channel.
+        # The format is: (channel, flow) where `flow` is a list of tuples
+        # (user, operation, expected_users).
+        #
+        # Those cases ensure that we only send `channel_name_member_ids` updates
+        # for channels listed in `_member_based_naming_channel_types`, and only
+        # when relevant members (those contributing to the computed name) are affected.
+        cases = [
+            # Channel does not use member-based naming (not in `_member_based_naming_channel_types`).
+            (
+                channel,
+                [(john, "add", False), (john, "remove", False)],
+            ),
+            # Group uses member-based naming (in `_member_based_naming_channel_types`).
+            # Name is computed from the first 3 members. Updates are only sent when those change.
+            (
+                group,
+                [
+                    (john, "add", [self.env.user, john]),
+                    (bob, "add", [self.env.user, john, bob]),
+                    # Alice is added: we already have 3 members to compute the name, no update.
+                    (alice, "add", False),
+                    (eve, "add", False),
+                    # Eve is removed: not taken into account for name computation, no update.
+                    (eve, "remove", False),
+                    # John is removed: was used in naming, update.
+                    (john, "remove", [self.env.user, bob, alice]),
+                ],
+            ),
+        ]
+
+        for channel, flow in cases:
+            with self.subTest(
+                f"Test member-based channel name: channel_type={channel.channel_type}, channel_name={channel.name}"
+            ):
+                for user, operation, expected_users in flow:
+                    self._reset_bus()
+                    if operation == "add":
+                        channel._add_members(users=user, post_joined_message=False)
+                    else:
+                        channel.with_user(user).action_unfollow()
+                    self.cr.precommit.run()
+                    matching_data = None
+                    for notification in self.env["bus.bus"].search(
+                        [("channel", "=", json_dump((self.cr.dbname, "discuss.channel", channel.id)))]
+                    ):
+                        message = json.loads(notification.message)
+                        if message["type"] != "mail.record/insert":
+                            continue
+                        if "discuss.channel" not in message["payload"]:
+                            continue
+                        matching_data = next(
+                            (
+                                data
+                                for data in message["payload"]["discuss.channel"]
+                                if data["id"] == channel.id and "channel_name_member_ids" in data
+                            ),
+                            None,
+                        )
+                        if matching_data:
+                            break
+
+                    if expected_users is False:
+                        self.assertIsNone(
+                            matching_data, "Unexpected channel_name_member_ids update"
+                        )
+                    else:
+                        self.assertIsNotNone(
+                            matching_data, "Missing channel_name_member_ids update"
+                        )
+                        expected_member_ids = [
+                            member.id
+                            for member in channel.channel_member_ids
+                            if member.partner_id.main_user_id in expected_users
+                        ]
+                        self.assertEqual(
+                            matching_data["channel_name_member_ids"], expected_member_ids
+                        )

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -949,6 +949,8 @@ class TestChannelRTC(MailCommon):
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda member: member.guest_id == test_guest)
         found_bus_notifs = self.assertBusNotifications(
             [
+                # mail.record/insert - discuss.channel (channel_name_member_ids)
+                (self.cr.dbname, "discuss.channel", channel.id),
                 # discuss.channel/joined
                 (self.cr.dbname, "res.partner", test_user.partner_id.id),
                 # mail.record/insert - discuss.channel (last_interest_dt)

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -96,6 +96,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search discuss_channel_rtc_session
     #       - fetch discuss_channel_rtc_session
     #       - search member (channel_member_ids)
+    #       - search member (channel_name_member_ids)
     #       - fetch discuss_channel_member (manual prefetch)
     #       18: member _to_store:
     #           - search im_livechat_channel_member_history (livechat member type)
@@ -150,7 +151,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch discuss_call_history
     #       - search mail_tracking_value
     #       - _compute_rating_stats
-    _query_count_discuss_channels = 61
+    _query_count_discuss_channels = 62
 
     def setUp(self):
         super().setUp()
@@ -635,6 +636,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         members = channel.channel_member_ids
         member_0 = members.filtered(lambda m: m.partner_id == self.users[0].partner_id)
         member_2 = members.filtered(lambda m: m.partner_id == self.users[2].partner_id)
+        member_12 = members.filtered(lambda m: m.partner_id == self.users[12].partner_id)
         last_interest_dt = fields.Datetime.to_string(channel.last_interest_dt)
         if channel == self.channel_general:
             return {
@@ -760,6 +762,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if channel == self.channel_group_1:
             return {
                 "avatar_cache_key": channel.avatar_cache_key,
+                "channel_name_member_ids": [member_0.id, member_12.id],
                 "channel_type": "group",
                 "create_uid": self.env.user.id,
                 "default_display_mode": False,


### PR DESCRIPTION
Previously, the display name of group channels was computed on the
client side by retrieving all channel members.

This approach had performance issues, especially for large group
channels with potentially hundreds of members. It was also not
user-friendly, as displaying hundred of names isn't readable.

This commit limits the fetch to the first three members of each group,
using a lateral join to further reduce the performance impact. In the UI,
the display name is now composed of these three member names plus an
"and X others" suffix, which is sufficient for clarity.

task-4242262