### PR TITLE
[PERF] mrp_workorder: batch write on button_finish

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -655,6 +655,7 @@ class MrpWorkorder(models.Model):
 
     def button_finish(self):
         date_finished = fields.Datetime.now()
+        all_vals_dict = defaultdict(lambda: self.env['mrp.workorder'])
         for workorder in self:
             if workorder.state in ('done', 'cancel'):
                 continue
@@ -667,7 +668,9 @@ class MrpWorkorder(models.Model):
             }
             if not workorder.date_start or date_finished < workorder.date_start:
                 vals['date_start'] = date_finished
-            workorder.with_context(bypass_duration_calculation=True).write(vals)
+            all_vals_dict[frozenset(vals.items())] |= workorder
+        for frozen_vals, workorders in all_vals_dict.items():
+            workorders.with_context(bypass_duration_calculation=True).write(dict(frozen_vals))
         return True
 
     def end_previous(self, doall=False):


### PR DESCRIPTION
### Description:

Improves the performance of `button_finish` when confirming many work orders. Previously, the method would update each work order individually, leading to slow performance. This PR changes the way the write is executed to do it by batch, which is much faster, especially when work orders share the same manufacturing order.

### Benchmark (in 18.0):

| N° of work orders | Before | After |
|-----------------|--------|-------|
|            250  |    14s | 610ms |
|            500  |    53s |    1s |

### Reference:

opw-4957774