### PR TITLE
[FIX] html_editor: properly convert image dimensions to CSS with units

### DIFF
--- a/addons/html_editor/static/src/utils/sanitize.js
+++ b/addons/html_editor/static/src/utils/sanitize.js
@@ -25,8 +25,10 @@ export function initElementForEdition(element, options = {}) {
         const height = img.getAttribute("height");
         img.removeAttribute("height");
         img.removeAttribute("width");
-        img.style.setProperty("width", width);
-        img.style.setProperty("height", height);
+        let unit = !isNaN(Number(width)) ? "px" : "";
+        img.style.setProperty("width", `${width}${unit}`);
+        unit = !isNaN(Number(height)) ? "px" : "";
+        img.style.setProperty("height", `${height}${unit}`);
     }
 }
 


### PR DESCRIPTION
In `initElementForEdition()`, the `height` and `width` attributes of an image were being converted to CSS properties without specifying units, leading to incorrect rendering. This fix ensures the values are suffixed with 'px' when converting, preserving the intended dimensions.

Steps to reproduce:
1. In Website, navigate to `/slides` via the Courses tab.
2. Enter edit mode.
3. Notice that the "current rank" image (number 2) appears enlarged due to missing units in the applied styles.
