### PR TITLE
[FIX] project: subtask access for employee in private projects

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -804,7 +804,7 @@ class ProjectTask(models.Model):
     @api.depends('is_template', 'parent_id.has_template_ancestor')
     def _compute_has_template_ancestor(self):
         for task in self:
-            task.has_template_ancestor = task.is_template or (task.parent_id and task.parent_id.has_template_ancestor)
+            task.has_template_ancestor = task.is_template or (task.parent_id and task.parent_id.sudo().has_template_ancestor)
 
     def _search_has_template_ancestor(self, operator, value):
         if operator not in ['=', '!='] or not isinstance(value, bool):

--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -621,10 +621,12 @@ class TestProjectSubtasks(TestProjectCommon):
             'user_ids': [(4, employee.id)],
         })
 
-        # Ensure the employee can read subtask fields
+        # Ensure the employee can read subtask fields that depends on the parent task
+        parent_dependent_fields = [
+            name for name, field in self.env['project.task']._fields.items()
+            if field.compute and any(dep.startswith('parent_id') for dep in field.get_depends(self.env['project.task'])[0])
+        ]
 
-        # List to be extended in future fixes if more fields give same error
-        fields_to_read = ["display_in_project"]
         self.env.invalidate_all()
-        subtask_data = subtask.with_user(employee).read(fields_to_read)
+        subtask_data = subtask.with_user(employee).read(parent_dependent_fields)
         self.assertTrue(subtask_data, "The employee should be able to read the subtask data.")


### PR DESCRIPTION
same as https://github.com/odoo/odoo/commit/0d75ce1d3912bbd94c5ce3bc199b40134dfab69f but different field `has_template_ancestor`.
the test was fragile and didn't cover the case correctly, it was improved in this commit.

opw-4980443

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
