### PR TITLE
[IMP] account: match amount

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -150,10 +150,10 @@ class AccountReconcileModel(models.Model):
                 except re.error:
                     raise UserError(_('The regex is not valid'))
 
-    @api.depends('mapped_partner_id', 'match_label', 'match_partner_ids', 'trigger')
+    @api.depends('mapped_partner_id', 'match_label', 'match_amount', 'match_partner_ids', 'trigger')
     def _compute_can_be_proposed(self):
         for model in self:
-            model.can_be_proposed = not model.mapped_partner_id and (model.match_label or model.match_partner_ids or model.trigger == 'auto_reconcile')
+            model.can_be_proposed = not model.mapped_partner_id and (model.match_label or model.match_amount or model.match_partner_ids or model.trigger == 'auto_reconcile')
 
     @api.depends('match_label', 'line_ids.partner_id', 'line_ids.account_id')
     def _compute_partner_mapping(self):


### PR DESCRIPTION
Before this commit, having a reco model with a match amount alone was never applied to statement line since the can_be_proposed field was False. This commit will add the match_amount to the compute

notask-id




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
