### PR TITLE
[FIX] pos_self_order: display sub categories on mobile

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -154,10 +154,7 @@ export class ProductListPage extends Component {
     }
 
     getProducts(category) {
-        if (this.selfOrder.kioskMode && category.child_ids?.length > 0) {
-            return category.associatedProducts;
-        }
-        return this.selfOrder.productByCategIds[category.id] || [];
+        return category.associatedProducts || this.selfOrder.productByCategIds[category.id] || [];
     }
 
     toggleSubCategoryPanel() {

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -158,12 +158,9 @@ export class SelfOrder extends Reactive {
     getAvailableCategories() {
         let now = luxon.DateTime.now();
         now = now.hour + now.minute / 60;
-        const isKiosk = this.config.self_ordering_mode === "kiosk";
         const availableCategories = this.productCategories
             .filter(
-                (c) =>
-                    this.productByCategIds[c.id]?.length > 0 ||
-                    (isKiosk && c.child_ids.some((child) => child.id in this.productByCategIds))
+                (c) => this.productByCategIds[c.id]?.length > 0 || c.associatedProducts?.length > 0
             )
             .sort((a, b) => a.sequence - b.sequence);
         return availableCategories.filter((c) => {

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -383,6 +383,17 @@ registry.category("web_tour.tours").add("test_order_table_assignement_meal", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_sub_categories_products_displayed", {
+    steps: () =>
+        [
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickCategory("Miscellaneous"),
+            ProductPage.clickProduct("Coca-Cola"),
+            ProductPage.clickCategory("Parent"),
+            ProductPage.clickProduct("Fanta"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_mobile_self_order_preparation_changes", {
     steps: () =>
         [


### PR DESCRIPTION
**Steps to reproduce:**
- Make a sub category, such as Soda for Drinks in PoS product categories
- Make a product and assign this sub category to it
- Allow the category in the PoS configuration for a Mobile order Session
- Open the Session, the product will not be displayed

**Problem:**
When a product has a subcategory, it is not displayed in the mobile interface, even if said category is allowed in the settings.
This problem does not occur in the Kiosk, only on the mobile sessions.

**Why the fix:**
The products should be displayed if their category has been added to the available categories in the settings. It now works as it does in the PoS and the Kiosk, meaning it is displayed as long as the sub category is mentioned in the Restrict Categories section of the configuration.

Also, in case you have categories A -> A/B -> A/B/C and you don't have products associated to A but you have some in C,
they won't show up in the self.

Currently, products from child categories can be shown in the self when all their parent categories had products associated to them.

When computing the available categories, we would only return categories which had products directly related to them, regardless if their nth child had some. Thus in the setting mentioned previously, only the category C was returned.

However this logic is not correct with the fact that the self, not in kiosk mode, only shows the top categories, meaning only the categories without parents. 
https://github.com/odoo/odoo/blob/434e8cf53a039cc2efc3cb531608028182928ad9/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js#L146-L151

The self was not showing the products from C as C had a parent category. In order for the product from C to be shown, the category A had to be included in the list of available categories.

opw-4934728