### PR TITLE
[FIX] hr_holidays: Fix force limit 1 on accrual levels

### DIFF
--- a/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.js
+++ b/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.js
@@ -120,7 +120,8 @@ export const accrualLevels = {
     component: AccrualLevels,
     fieldDependencies: [
         { name: "carryover_day", type: "integer" }
-    ]
+    ],
+    relatedFields: () => [{ name: "id", type: "integer" }],
 };
 
 registry.category("fields").add("accrual_levels", accrualLevels);


### PR DESCRIPTION
This commit addresses the issue where the force limit of 1 on accrual levels was imposed even when the x2many field is visible. The fix ensures that all milestones are correctly displayed, and not only a single milestone. The issue appeared after the following commit https://github.com/odoo/odoo/commit/bd4b6d02fed5fdc5ce628cb7d76df4cfdd2d1b3b#diff-416c768d6ee27678f525c2ddc1bfe00a84f50695e4110462c3ae09f13bc9326dR623

task-4982668

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
