### PR TITLE
[FIX] website_sale: prevent repeated clicks on add to cart button

### DIFF
--- a/addons/website_sale/static/src/snippets/s_add_to_cart/000.js
+++ b/addons/website_sale/static/src/snippets/s_add_to_cart/000.js
@@ -4,6 +4,7 @@ import publicWidget from '@web/legacy/js/public/public_widget';
 import { cartHandlerMixin } from '@website_sale/js/website_sale_utils';
 import { WebsiteSale } from '@website_sale/js/website_sale';
 import { _t } from "@web/core/l10n/translation";
+import dom from "@web/legacy/js/core/dom";
 
 publicWidget.registry.AddToCartSnippet = WebsiteSale.extend(cartHandlerMixin, {
     selector: '.s_add_to_cart_btn',
@@ -17,32 +18,37 @@ publicWidget.registry.AddToCartSnippet = WebsiteSale.extend(cartHandlerMixin, {
     },
 
     _onClickAddToCartButton: async function (ev) {
-        const dataset = ev.currentTarget.dataset;
+        const buttonEl = ev.currentTarget;
+        const dataset = buttonEl.dataset;
+        const removeBtnLoading = dom.addButtonLoadingEffect(buttonEl);
+        try {
+            const visitorChoice = dataset.visitorChoice === 'true';
+            const action = dataset.action;
+            const productId = parseInt(dataset.productVariantId);
 
-        const visitorChoice = dataset.visitorChoice === 'true';
-        const action = dataset.action;
-        const productId = parseInt(dataset.productVariantId);
-
-        if (!productId) {
-            return;
-        }
-
-        if (visitorChoice) {
-            this._handleAdd($(ev.currentTarget.closest('div')));
-        } else {
-            const isAddToCartAllowed = await this.rpc(`/shop/product/is_add_to_cart_allowed`, {
-                product_id: productId,
-            });
-            if (!isAddToCartAllowed) {
-                this.notification.add(
-                    _t('This product does not exist therefore it cannot be added to cart.'),
-                    { title: 'User Error', type: 'warning' }
-                );
+            if (!productId) {
                 return;
             }
-            this.isBuyNow = action === 'buy_now';
-            this.stayOnPageOption = !this.isBuyNow;
-            this.addToCart({product_id: productId, add_qty: 1});
+
+            if (visitorChoice) {
+                this._handleAdd($(buttonEl.closest('div')));
+            } else {
+                const isAddToCartAllowed = await this.rpc(`/shop/product/is_add_to_cart_allowed`, {
+                    product_id: productId,
+                });
+                if (!isAddToCartAllowed) {
+                    this.notification.add(
+                        _t('This product does not exist therefore it cannot be added to cart.'),
+                        { title: 'User Error', type: 'warning' }
+                    );
+                    return;
+                }
+                this.isBuyNow = action === 'buy_now';
+                this.stayOnPageOption = !this.isBuyNow;
+                this.addToCart({product_id: productId, add_qty: 1});
+            }
+        } finally {
+            removeBtnLoading();
         }
     },
 });


### PR DESCRIPTION
This commit prevents user from clicking the "Add to Cart" button multiple times by adding a loading effect and disabling the button while the request is in progress.

task-4979205