### PR TITLE
[FIX] html_builder: make sizing promise resolver always available

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
@@ -467,12 +467,8 @@ export class BuilderOverlay {
 
         // Lock the mutex.
         let sizingResolve;
-        this.next(
-            async () => {
-                await new Promise((resolve) => (sizingResolve = () => resolve()));
-            },
-            { withLoadingEffect: false }
-        );
+        const sizingProm = new Promise((resolve) => (sizingResolve = () => resolve()));
+        this.next(async () => await sizingProm, { withLoadingEffect: false });
         const cancelSizing = this.history.makeSavePoint();
 
         const handleEl = ev.currentTarget;


### PR DESCRIPTION
This commit declares the sizing promise (awaited by the mutex) before calling the mutex, instead of in the mutex, allowing `sizingResolve` to always have a value during the sizing.

Indeed, it seems that sometimes, a traceback may appear when resizing, because this resolver is undefined (surely because the sizing was quick enough to end before the mutex was called).

task-4367641