### PR TITLE
[IMP] l10n_sa: change the label and help of delivery_date

### DIFF
--- a/addons/l10n_sa/__manifest__.py
+++ b/addons/l10n_sa/__manifest__.py
@@ -28,6 +28,7 @@ Activates:
         'data/account_data.xml',
         'data/account_tax_report_data.xml',
         'data/report_paperformat_data.xml',
+        'views/account_move.xml',
         'views/report_invoice.xml',
         'views/report_templates_views.xml'
     ],

--- a/addons/l10n_sa/views/account_move.xml
+++ b/addons/l10n_sa/views/account_move.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+	<record id="view_move_form" model="ir.ui.view">
+		<field name="name">account.move.form.inherit.l10n_sa</field>
+		<field name="model">account.move</field>
+		<field name="inherit_id" ref="account.view_move_form"/>
+		<field name="arch" type="xml">
+			<xpath expr="//field[@name='delivery_date']" position="attributes">
+				<attribute name="invisible" add="country_code == 'SA'" separator=" or "/>
+			</xpath> 
+            <xpath expr="//field[@name='delivery_date']" position="after">
+                <field name="delivery_date" string="Supply Date" invisible="not show_delivery_date or country_code != 'SA'" readonly="state != 'draft'" help="Date when the supply of the goods and services is performed. You can set this date to when you want ZATCA to recognize the VAT Due Liability, as ZATCA will consider the earlier of this date and the Confirmation Date. In case of multiple deliveries, you should take the date of the latest one."/>
+			</xpath>
+			<xpath expr="//group[@id='other_tab_group']/group/field[@name='delivery_date']" position="attributes">
+				<attribute name="invisible" add="country_code == 'SA'" separator=" or "/>
+			</xpath>
+			<xpath expr="//group[@id='other_tab_group']/group/field[@name='delivery_date']" position="after">
+                <field name="delivery_date" string="Supply Date" invisible="not show_delivery_date or country_code != 'SA'" readonly="state != 'draft'" help="Date when the supply of the goods and services is performed. You can set this date to when you want ZATCA to recognize the VAT Due Liability, as ZATCA will consider the earlier of this date and the Confirmation Date. In case of multiple deliveries, you should take the date of the latest one."/>
+			</xpath>
+		</field>
+	</record>
+</odoo>


### PR DESCRIPTION
Renamed the standard delivery_date field label to "Supply Date" on Saudi account move entries. In addition Added help text explaining its role in ZATCA VAT due liability recognition.

task-4922130
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
