### PR TITLE
[IMP] base, orm: allow raising `MissingError` from `exists` method

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -365,9 +365,15 @@ class IrActionsAct_Window(models.Model):
         self.env.registry.clear_cache()
         return super().unlink()
 
-    def exists(self):
+    def exists(self, raise_if_missing=False):
         ids = self._existing()
         existing = self.filtered(lambda rec: rec.id in ids)
+        if raise_if_missing and (missing := self - existing):
+            raise MissingError(_(
+                "Some records do not exist or have been deleted.\n"
+                "(Records: %(records)s, User: %(user)s)",
+                records=str(missing), user=self.env.uid,
+            )) from None
         return existing
 
     @api.model

--- a/odoo/addons/base/tests/test_orm.py
+++ b/odoo/addons/base/tests/test_orm.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.exceptions import AccessError, LockError
+from odoo.exceptions import AccessError, LockError, MissingError
 from odoo.tests.common import TransactionCase, tagged
 from odoo.tools import mute_logger
 from odoo import Command
@@ -151,6 +151,8 @@ class TestORM(TransactionCase):
         # check that there is no record with id 0
         recs = partner.browse([0])
         self.assertFalse(recs.exists())
+        with self.assertRaises(MissingError):
+            self.assertFalse(recs.exists(raise_if_missing=True))
 
     def test_lock_for_update(self):
         partner = self.env['res.partner']


### PR DESCRIPTION
The base `_pre_dispatch` method attempts to check whether records are accessible before continuing. It handles both access & missing errors, thrown from the `check_access` method.

This works as expected outside of `sudo` mode, but in `sudo` mode, `check_access` always returns `True`, regardless of whether the records exists. This can cause a `MissingError` to get thrown later on in dispatching, when the accessing the record's fields.

This PR aims to fix this by adding an optional `raise_if_missing` parameter to the `exists` method, allowing us to handle `MissingError` in `sudo` mode before attempting to access a missing record's fields.