### PR TITLE
[FIX] html_builder, html_editor: fix floating point precision

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -92,13 +92,17 @@ export class BuilderNumberInput extends Component {
     }
 
     clampValue(value) {
-        if (parseFloat(value) < this.props.min) {
+        if (!value) {
+            return value;
+        }
+        value = parseFloat(value);
+        if (value < this.props.min) {
             return `${this.props.min}`;
         }
-        if (parseFloat(value) > this.props.max) {
+        if (value > this.props.max) {
             return `${this.props.max}`;
         }
-        return value;
+        return +value.toFixed(3);
     }
 
     parseDisplayValue(displayValue) {
@@ -122,7 +126,7 @@ export class BuilderNumberInput extends Component {
                 // Only keep "-" if it is at the start
                 .replace(/(?<!^)-/g, "")
                 // Only keep the first "."
-                .replace(/^([^.]*)\.?(.*)/, (_, a, b) => a + (b ? '.' + b.replace(/\./g, '') : ''));
+                .replace(/^([^.]*)\.?(.*)/, (_, a, b) => a + (b ? "." + b.replace(/\./g, "") : ""));
         }
         displayValue = displayValue.split(" ").map(this.clampValue.bind(this)).join(" ");
 

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -193,7 +193,7 @@ export function convertNumericToUnit(value, unitFrom, unitTo, htmlStyle) {
     if (converter === undefined) {
         throw new Error(`Cannot convert '${unitFrom}' units into '${unitTo}' units !`);
     }
-    return value * converter(htmlStyle);
+    return parseFloat((value * converter(htmlStyle)).toFixed(3));
 }
 
 export function getHtmlStyle(document) {

--- a/addons/html_editor/static/tests/utils/numeric_to_unit_converter.test.js
+++ b/addons/html_editor/static/tests/utils/numeric_to_unit_converter.test.js
@@ -1,0 +1,8 @@
+import { convertNumericToUnit } from "@html_editor/utils/formatting";
+import { describe, expect, test } from "@odoo/hoot";
+
+describe("NumericToUnitConverter", () => {
+    test("displays the correct value (no floating point precision error)", () => {
+        expect(convertNumericToUnit(1400, "ms", "s")).toBe(1.4);
+    });
+});


### PR DESCRIPTION
Sometimes in `BuilderNumberInput` we receive a floating point precision error (IEEE-754).

To see the issue:
- Open website and drop a carousel snippet
- Start incrementing its speed option with the arrow up key

=> Soon enough, you see that instead of 10.3 it displays 10.299999999... 

---
This happens because 0.1 can't be stored exactly right. 
Explanation of this can be found [here].

[here]: https://en.wikipedia.org/wiki/Floating-point_arithmetic#Accuracy_problems