### PR TITLE
[FIX] stock: fix config access error

### DIFF
--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -61,7 +61,7 @@ class ResConfigSettings(models.TransientModel):
             self.replenish_on_order = route.active
 
     def _inverse_replenish_on_order(self):
-        route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False)
+        route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False).sudo()
         if route:
             route.active = self.replenish_on_order
 


### PR DESCRIPTION
**PROBLEM**
Saving the settings with a user that have access to the purchase app, but doesn't have the manager right on the stock app will cause an access error.

**STEP TO REPRODUCE**
1. On runbot connect as Mitchell Admin.
2. Remove your manager right to the inventory apps (set to User or None).
3. Go to the setting app and save.
4. There is a record access error (no right to modify stock.route).

**CAUSE**
The field `replenish_on_order` is set when creating the `res.config.settings`, this calls its inverse function which tries to write on the 'stock.route_warehouse0_mto' record. With the purchase_stock module installed, `replenish_on_order` appear is inserted in the purchase settings tab, so saving does create a `res.config.settings` and try setting this field.

**FIX**
To access to the purchase or stock settings, the user need to be a manager of those apps. Adding a sudo() to `_inverse_replenish_on_order()` fixes the issue.

opw-4977223
