### PR TITLE
[IMP] website_slides{_survey}: improve course homepage

### DIFF
--- a/addons/website_slides/controllers/__init__.py
+++ b/addons/website_slides/controllers/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import legacy
 from . import main

--- a/addons/website_slides/controllers/legacy.py
+++ b/addons/website_slides/controllers/legacy.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.http import request
+from odoo.addons.base.models.ir_qweb import keep_query
+
+
+class WebsiteSlidesLegacy(http.Controller):
+    """
+        Retro compatibility layer for legacy endpoint
+    """
+
+    @http.route(['/slides/all', '/slides/all/tag/<string:slug_tags>'], type='http', auth="public", website=True,
+                sitemap=True, readonly=True)
+    def slides_channel_all(self, slug_tags=None, **post):
+        """ "All" in < 19 was different from "Home". Both have been merged, but we keep
+        some backward compatibility for saved links, even if the display is going to
+        change a bit. """
+        if slug_tags:
+            return request.redirect(f"/slides/tag/{slug_tags}?{keep_query('*')}")
+        return request.redirect(f"/slides?{keep_query('*')}")

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -10,6 +10,7 @@ import math
 import werkzeug
 
 from odoo import fields, http, tools, _
+from odoo.addons.base.models.ir_qweb import keep_query
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.addons.website.models.ir_http import sitemap_qs2dom
 from odoo.addons.website_profile.controllers.main import WebsiteProfile
@@ -337,17 +338,19 @@ class WebsiteSlides(WebsiteProfile):
     # SLIDE.CHANNEL MAIN / SEARCH
     # --------------------------------------------------
 
-    @http.route('/slides', type='http', auth="public", website=True, sitemap=True, readonly=True, list_as_website_content=_lt("eLearning"))
-    def slides_channel_home(self, **post):
-        """ Home page for eLearning platform. Is mainly a container page, does not allow search / filter. """
-        channels_all = tools.lazy(lambda: request.env['slide.channel'].search(request.website.website_domain() & Domain('is_visible', '=', True)))
-        if not request.env.user._is_public():
-            #If a course is completed, we don't want to see it in first position but in last
-            channels_my = tools.lazy(lambda: channels_all.filtered(lambda channel: channel.is_member).sorted(lambda channel: 0 if channel.completed else channel.completion, reverse=True)[:3])
-        else:
-            channels_my = request.env['slide.channel']
-        channels_popular = tools.lazy(lambda: channels_all.sorted('total_votes', reverse=True)[:3])
-        channels_newest = tools.lazy(lambda: channels_all.sorted('create_date', reverse=True)[:3])
+    def _slides_channel_user_values(self, compute_channels_my=True):
+        """ Get user slide values (challenge done, top user to compare to, ...). """
+        render_values = {}
+        if compute_channels_my:
+            if not request.env.user._is_public():
+                channels_my_all = tools.lazy(lambda: request.env['slide.channel'].search(
+                    request.website.website_domain() & Domain([('is_visible', '=', True), ('is_member', '=', True)])))
+                # Order: Started but not finished > Not started > Finished
+                channels_my = tools.lazy(lambda: channels_my_all.filtered(lambda channel: channel.is_member).sorted(
+                    lambda channel: -1 if channel.completed else channel.completion, reverse=True))
+            else:
+                channels_my = request.env['slide.channel']
+            render_values['channels_my'] = channels_my
 
         achievements = tools.lazy(lambda: request.env['gamification.badge.user'].sudo().search([('badge_id.is_published', '=', True)], limit=5))
         if request.env.user._is_public():
@@ -368,23 +371,17 @@ class WebsiteSlides(WebsiteProfile):
             ('karma', '>', 0),
             ('website_published', '=', True)], limit=5, order='karma desc'))
 
-        render_values = self._slide_render_context_base()
-        render_values.update(self._prepare_user_values(**post))
         render_values.update({
-            'channels_my': channels_my,
-            'channels_popular': channels_popular,
-            'channels_newest': channels_newest,
             'achievements': achievements,
             'users': users,
             'top3_users': tools.lazy(self._get_top3_users),
             'challenges': challenges,
             'challenges_done': challenges_done,
             'search_tags': request.env['slide.channel.tag'],
-            'slide_query_url': QueryURL('/slides/all', ['tag']),
+            'slide_query_url': QueryURL('/slides', ['tag']),
             'slugify_tags': self._slugify_tags,
         })
-
-        return request.render('website_slides.courses_home', render_values)
+        return render_values
 
     def _get_slide_channel_search_options(self, my=None, slug_tags=None, slide_category=None, **post):
         return {
@@ -399,8 +396,15 @@ class WebsiteSlides(WebsiteProfile):
             'slide_category': slide_category,
         }
 
-    @http.route(['/slides/all', '/slides/all/tag/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=True, readonly=True)
-    def slides_channel_all(self, slide_category=None, slug_tags=None, my=False, **post):
+    def _has_slide_channel_search(self, my=None, slug_tags=None, slide_category=None, **post):
+        return my or post.get('search') or slug_tags or post.get('tag') or slide_category
+
+    @http.route(['/slides', '/slides/page/<int:page>',
+                 '/slides/tag/<string:slug_tags>', '/slides/tag/<string:slug_tags>/page/<int:page>'],
+                type='http', auth="public", website=True, sitemap=True, readonly=True,
+                list_as_website_content=_lt("eLearning"))
+    def slides_channel(self, slide_category=None, slug_tags=None, my=0, page=1, **post):
+        my = 1 if str(my) == '1' else 0  # if in the URL parameters, it will be a string instead of a number
         if slug_tags and slug_tags.count(',') > 0 and request.httprequest.method == 'GET' and not post.get('prevent_redirect'):
             # Previously, the tags were searched using GET, which caused issues with crawlers (too many hits)
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
@@ -408,12 +412,18 @@ class WebsiteSlides(WebsiteProfile):
             # TODO: remove in a few stable versions (v19?), including the "prevent_redirect" param in templates
             # Note: We allow a single tag to be GET, to keep crawlers & indexes on those pages
             # What we really want to avoid is combinatorial explosions
-            return request.redirect('/slides/all', code=301)
+            return request.redirect('/slides', code=301)
 
-        render_values = self.slides_channel_all_values(slide_category=slide_category, slug_tags=slug_tags, my=my, **post)
-        return request.render('website_slides.courses_all', render_values)
+        render_values = self.slides_channel_values(
+            slide_category=slide_category, slug_tags=slug_tags, my=my, page=page, **post)
+        if page > 1 and not render_values['channels']:
+            # Refining search may reduce results; if no results and not on page 1, reset to page 1.
+            if slug_tags:
+                return request.redirect(f"/slides/tag/{slug_tags}?{keep_query('*')}")
+            return request.redirect(f"/slides?{keep_query('*')}")
+        return request.render('website_slides.courses_home', render_values)
 
-    def slides_channel_all_values(self, slide_category=None, slug_tags=None, my=False, **post):
+    def slides_channel_values(self, slide_category=None, slug_tags=None, my=0, page=None, page_size=12, **post):
         """ Home page displaying a list of courses displayed according to some
         criterion and search terms.
 
@@ -425,21 +435,24 @@ class WebsiteSlides(WebsiteProfile):
           :param bool my: if provided, filter the slide.channels for which the
            current user is a member of
           :param dict post: post parameters, including
+          :param int|None page: The current page number. Set to None to disable pagination (default).
+          :param int page_size: number of element per page
 
            * ``search``: filter on course description / name;
         """
-        options = self._get_slide_channel_search_options(
-            my=my,
-            slug_tags=slug_tags,
-            slide_category=slide_category,
+        search_args = {
+            'my': my,
+            'slug_tags': slug_tags,
+            'slide_category': slide_category,
             **post
-        )
+        }
+        options = self._get_slide_channel_search_options(**search_args)
         search = post.get('search')
         order = self._channel_order_by_criterion.get(post.get('sorting'))
-        search_count, details, fuzzy_search_term = request.website._search_with_fuzzy("slide_channels_only", search,
-            limit=1000, order=order, options=options)
-        channels = details[0].get('results', request.env['slide.channel'])
-
+        search_count, details, fuzzy_search_term = request.website._search_with_fuzzy(
+            "slide_channels_only", search, limit=page * page_size if page else 1000, order=order, options=options)
+        channels_all = details[0].get('results', request.env['slide.channel'])
+        channels = channels_all[(page - 1) * page_size:page * page_size] if page else channels_all
         tag_groups = request.env['slide.channel.tag.group'].search(
             ['&', ('tag_ids', '!=', False), ('website_published', '=', True)])
         if slug_tags:
@@ -451,6 +464,8 @@ class WebsiteSlides(WebsiteProfile):
 
         render_values = self._slide_render_context_base()
         render_values.update(self._prepare_user_values(**post))
+        render_values.update(self._slides_channel_user_values(
+            compute_channels_my=not self._has_slide_channel_search(**search_args)))
         render_values.update({
             'channels': channels,
             'tag_groups': tag_groups,
@@ -462,7 +477,14 @@ class WebsiteSlides(WebsiteProfile):
             'search_count': search_count,
             'top3_users': self._get_top3_users(),
             'slugify_tags': self._slugify_tags,
-            'slide_query_url': QueryURL('/slides/all', ['tag']),
+            'slide_query_url': QueryURL('/slides', ['tag']),
+            'pager': request.website.pager(
+                url=request.httprequest.path.partition('/page/')[0],
+                url_args=request.httprequest.args.to_dict(),
+                total=search_count,
+                page=page,
+                step=page_size,
+                scope=3) if page else False,
         })
 
         return render_values

--- a/addons/website_slides/data/mail_template_data.xml
+++ b/addons/website_slides/data/mail_template_data.xml
@@ -85,7 +85,7 @@
                         <p>Check out the other available courses.</p><br/>
 
                         <div style="padding: 16px 8px 16px 8px; text-align: center;">
-                            <a href="/slides/all" t-attf-style="background-color: {{object.channel_id.user_id.company_id.email_secondary_color or '#875A7B'}}; padding: 8px 16px 8px 16px; text-decoration: none; color: {{object.channel_id.user_id.company_id.email_primary_color or '#FFFFFF'}}; border-radius: 5px;">
+                            <a href="/slides" t-attf-style="background-color: {{object.channel_id.user_id.company_id.email_secondary_color or '#875A7B'}}; padding: 8px 16px 8px 16px; text-decoration: none; color: {{object.channel_id.user_id.company_id.email_primary_color or '#FFFFFF'}}; border-radius: 5px;">
                                 Explore courses
                             </a>
                         </div>

--- a/addons/website_slides/data/slide_channel_demo.xml
+++ b/addons/website_slides/data/slide_channel_demo.xml
@@ -13,8 +13,8 @@
         <field name="tag_ids" eval="[(5, 0),
                                      (4, ref('website_slides.slide_channel_tag_level_basic')),
                                      (4, ref('website_slides.slide_channel_tag_role_gardener')),
-                                     (4, ref('website_slides.slide_channel_tag_other_0')),
-                                     (4, ref('website_slides.slide_channel_tag_other_2'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_quiz')),
+                                     (4, ref('website_slides.slide_channel_tag_dog_friendly'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_gardening.jpg"/>
         <field name="description">Learn the basics of gardening!</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=8)"/>
@@ -32,7 +32,7 @@
         <field name="tag_ids" eval="[(5, 0),
                                      (4, ref('website_slides.slide_channel_tag_level_intermediate')),
                                      (4, ref('website_slides.slide_channel_tag_role_gardener')),
-                                     (4, ref('website_slides.slide_channel_tag_other_0'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_quiz'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_gardening_2.jpg"/>
         <field name="description">Learn how to take care of your favorite trees. Learn when to plant, how to manage potted trees, ...</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=7)"/>
@@ -54,8 +54,8 @@
                                      (4, ref('website_slides.slide_channel_tag_level_intermediate')),
                                      (4, ref('website_slides.slide_channel_tag_role_gardener')),
                                      (4, ref('website_slides.slide_channel_tag_role_carpenter')),
-                                     (4, ref('website_slides.slide_channel_tag_other_0')),
-                                     (4, ref('website_slides.slide_channel_tag_other_2'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_quiz')),
+                                     (4, ref('website_slides.slide_channel_tag_dog_friendly'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_gardening_3.jpg"/>
         <field name="description">A lot of nice documentation: trees, wood, gardens. A gold mine for references.</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=6)"/>
@@ -75,7 +75,7 @@
                                      (4, ref('website_slides.slide_channel_tag_role_gardener')),
                                      (4, ref('website_slides.slide_channel_tag_role_carpenter')),
                                      (4, ref('website_slides.slide_channel_tag_role_furniture')),
-                                     (4, ref('website_slides.slide_channel_tag_other_2'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_dog_friendly'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_tree_1.jpg"/>
         <field name="description">Knowing which kind of wood to use depending on your application is important. In this course you
 will learn the basics of wood characteristics.</field>
@@ -111,8 +111,7 @@ will learn the basics of wood characteristics.</field>
         <field name="tag_ids" eval="[(5, 0),
                                      (4, ref('website_slides.slide_channel_tag_level_intermediate')),
                                      (4, ref('website_slides.slide_channel_tag_role_furniture')),
-                                     (4, ref('website_slides.slide_channel_tag_other_0')),
-                                     (4, ref('website_slides.slide_channel_tag_other_1'))]"/>
+                                     (4, ref('website_slides.slide_channel_tag_quiz'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_furniture_2.jpg"/>
         <field name="description">All you need to know about furniture creation.</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=3)"/>
@@ -131,8 +130,7 @@ will learn the basics of wood characteristics.</field>
         <field name="tag_ids" eval="[(5, 0),
                                  (4, ref('website_slides.slide_channel_tag_level_advanced')),
                                  (4, ref('website_slides.slide_channel_tag_role_carpenter')),
-                                 (4, ref('website_slides.slide_channel_tag_role_furniture')),
-                                 (4, ref('website_slides.slide_channel_tag_other_1'))]"/>
+                                 (4, ref('website_slides.slide_channel_tag_role_furniture'))]"/>
         <field name="image_1920" type="base64" file="website_slides/static/src/img/channel_demo_furniture_3.jpg"/>
         <field name="description">So much amazing certification.</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=2)"/>

--- a/addons/website_slides/data/slide_channel_tag_demo.xml
+++ b/addons/website_slides/data/slide_channel_tag_demo.xml
@@ -20,16 +20,11 @@
         <field name="group_id" ref="website_slides.slide_channel_tag_group_role"/>
     </record>
 
-    <record id="slide_channel_tag_other_0" model="slide.channel.tag">
+    <record id="slide_channel_tag_quiz" model="slide.channel.tag">
         <field name="name">Quiz</field>
         <field name="group_id" ref="website_slides.slide_channel_tag_group_data_other"/>
     </record>
-    <record id="slide_channel_tag_other_1" model="slide.channel.tag">
-        <field name="name">Certification</field>
-        <field name="color">7</field>
-        <field name="group_id" ref="website_slides.slide_channel_tag_group_data_other"/>
-    </record>
-    <record id="slide_channel_tag_other_2" model="slide.channel.tag">
+    <record id="slide_channel_tag_dog_friendly" model="slide.channel.tag">
         <field name="name">Dog Friendly</field>
         <field name="group_id" ref="website_slides.slide_channel_tag_group_data_other"/>
     </record>

--- a/addons/website_slides/static/src/website_builder/slides_searchbar_option.xml
+++ b/addons/website_slides/static/src/website_builder/slides_searchbar_option.xml
@@ -3,7 +3,7 @@
 
 <t t-inherit="website.SearchbarOption" t-inherit-mode="extension">
     <xpath expr="//BuilderSelect[@id=&quot;'scope_opt'&quot;]" position="inside">
-        <BuilderSelectItem dataAttributeActionValue="'slides'" actionValue="'/slides/all'" id="'search_slides_opt'">
+        <BuilderSelectItem dataAttributeActionValue="'slides'" actionValue="'/slides'" id="'search_slides_opt'">
             Courses
         </BuilderSelectItem>
     </xpath>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -46,7 +46,7 @@
                         <t t-set="_input_classes" t-valuef="border-0 rounded-0 bg-transparent"/>
                         <t t-set="_submit_classes" t-valuef="btn-link rounded-0 pe-1"/>
                         <t t-set="search_type" t-valuef="slides"/>
-                        <t t-set="action" t-valuef="/slides/all"/>
+                        <t t-set="action" t-valuef="/slides"/>
                         <t t-set="display_description" t-valuef="true"/>
                         <t t-set="display_detail" t-valuef="false"/>
                         <t t-set="placeholder">Search courses</t>

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -1,166 +1,145 @@
 <?xml version="1.0" ?>
 <odoo><data>
 
+<template id="courses_home_side_bar">
+    <div class="container o_wslides_home_main">
+        <div class="row">
+            <t t-set="has_side_column" t-value="is_view_active('website_slides.toggle_leaderboard')"/>
+            <t t-if="is_public_user">
+                <div t-if="has_side_column">
+                    <div class="row">
+                        <div class="col-12 col-md-5 col-lg-12">
+                            <div class="ps-md-5 ps-lg-0">
+                                <t t-call="website_slides.slides_home_users_small"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </t>
+            <div t-else="">
+                <t t-set="has_side_column" t-value="True"/>
+                <div class="o_wslides_home_aside_loggedin card p-3 p-lg-0 mb-4">
+                    <div class="o_wslides_home_aside_title">
+                        <div class="d-flex align-items-center">
+                            <t t-call="website_slides.slides_misc_user_image">
+                                <t t-set="img_class" t-value="'rounded-circle me-1'"/>
+                                <t t-set="img_style" t-value="'width: 22px; height: 22px;'"/>
+                            </t>
+                            <h5 t-out="user.name" class="d-flex flex-grow-1 mb-0"/>
+                            <a class="d-none d-lg-block" t-att-href="'/profile/user/%s' % user.id">View</a>
+                            <a class="d-lg-none btn btn-sm bg-white border" href="#" data-bs-toggle="collapse" data-bs-target="#o_wslides_home_aside_content">More info</a>
+                        </div>
+                        <hr class="d-none d-lg-block mt-2 mb-2 mb-1"/>
+                    </div>
+                    <div id="o_wslides_home_aside_content" class="collapse d-lg-block">
+                        <div class="row g-0 mb-5 mt-3 mt-lg-0">
+                            <div class="col-12 col-sm-6 col-lg-12">
+                                <t t-call="website_slides.slides_home_user_profile_small"/>
+                            </div>
+                            <div class="col-12 col-sm-6 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4">
+                                <t t-call="website_slides.slides_home_user_achievements_small"/>
+                            </div>
+                            <div class="col-12 col-md-7 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4 mb-3">
+                                <t t-call="website_slides.slides_home_achievements_small"/>
+                            </div>
+                            <div class="col-12 col-sm-6 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4">
+                                <t t-call="website_slides.slides_home_users_small"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<template id="courses_my">
+    <div t-if="channels_my" class="container">
+        <div class="o_wslides_home_content_section mb-4">
+            <div t-foreach="channels_my[:5]" t-as="channel">
+                <div class="row">
+                    <div class="col-5 d-flex align-items-center my-2">
+                        <a t-attf-href="/slides/#{slug(channel)}" t-out="channel.name"/>
+                        <span t-if="not channel.is_published" class="badge text-bg-danger ms-1">Unpublished</span>
+                    </div>
+                    <div class="col-5 d-flex justify-content-between align-items-center">
+                        <div t-if="channel.completed" class="badge rounded-pill text-bg-success pull-right">
+                            <i class="fa fa-check"/> Completed
+                        </div>
+                        <t t-elif="not channel.completion">
+                            <div class="text-success d-none d-md-block">0 % (not started yet)</div>
+                            <div class="d-md-none">0 %</div>
+                        </t>
+                        <t t-else="">
+                            <div class="d-none d-md-block flex-grow-1">
+                                <div class="progress me-3" style="height: 6px">
+                                    <div class="progress-bar" role="progressbar" t-att-aria-valuenow="channel.completion" aria-valuemin="0" aria-valuemax="100" t-attf-style="width:#{channel.completion}%;" aria-label="Progress bar"/>
+                                </div>
+                            </div>
+                            <div class="text-start" style="width: 6ch;"><t t-out="channel.completion"/> %</div>
+                        </t>
+                        <div class="text-muted d-flex">
+                            <div t-out="'{:.1f}'.format(channel.total_time or 0).removesuffix('.0') if channel.total_time &lt; 1 else round(channel.total_time)" class="text-end pe-1" style="width: 3ch;"/>
+                            hours
+                        </div>
+                    </div>
+                    <div t-if="not channel.completed" class="col-2 d-flex flex-row-reverse align-items-center">
+                        <a t-if="not channel.completion" role="button" class="btn btn-primary d-none d-md-block" t-attf-href="/slides/#{slug(channel)}">
+                            <span>Start now !</span>
+                        </a>
+                        <a t-else="" role="button" class="align-items-center d-none d-md-flex" t-attf-href="/slides/#{slug(channel)}">
+                            <div class="me-2">Continue</div><i class="oi oi-arrow-right me-1"/>
+                        </a>
+                        <a t-attf-href="/slides/#{slug(channel)}" class="d-md-none">
+                            <i class="oi oi-arrow-right me-1"/>
+                        </a>
+                    </div>
+                    <div t-else="" class="col-2">&amp;nbsp;</div>
+                </div>
+                <div t-if="not channel_last" class="row mx-1 my-1">
+                    <hr class="m-0"/>
+                </div>
+            </div>
+            <div t-if="channels_my[5:]" class="text-end mt-2">
+                <a href="/slides?my=1">See all my courses (<t t-out="len(channels_my)"/>)</a>
+            </div>
+        </div>
+    </div>
+</template>
+
 <!-- Channels home template -->
 <template id='courses_home' name="Odoo Courses Homepage">
     <t t-set="body_classname" t-value="'o_wslides_body'"/>
+    <t t-set="has_side_column" t-value="not is_public_user or is_view_active('website_slides.toggle_leaderboard')"/>
     <t t-call="website.layout">
         <div id="wrap" class="wrap o_wslides_wrap">
-            <div class="oe_structure oe_empty">
-            <section class="s_banner overflow-hidden" style="background-color:(0, 0, 0, 0); background-image: url(&quot;/website_slides/static/src/img/banner_default.svg&quot;); background-size: cover; background-position: 55% 65%" data-snippet="s_banner">
-                <div class="container align-items-center d-flex mb-5 mt-lg-5 pt-lg-4 pb-lg-1">
-                    <div class="text-white">
-                        <h1 class="display-3 mb-0">Reach new heights</h1>
-                        <h2 class="mb-4">Start your online course today!</h2>
-                        <div class="row mt-1 mb-3">
-                            <div class="col">
-                                <p>Skill up and have an impact! Your business career starts here.<br/>Time to start a course.</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-            </div>
-            <div class="container mt16 o_wslides_home_nav position-relative">
-                <nav class="navbar navbar-expand-lg navbar-light shadow-sm">
-                    <t t-call="website.website_search_box_input">
-                        <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right order-lg-3"/>
-                        <t t-set="search_type" t-valuef="slides"/>
-                        <t t-set="action" t-valuef="/slides/all"/>
-                        <t t-set="display_description" t-valuef="true"/>
-                        <t t-set="display_detail" t-valuef="false"/>
-                        <t t-set="placeholder">Search courses</t>
-                        <input type="hidden" name="prevent_redirect" value="True"/>
-                    </t>
-                    <button class="navbar-toggler px-2 order-1" type="button"
-                        data-bs-toggle="collapse" data-bs-target="#navbarSlidesHomepage"
-                        aria-controls="navbarSlidesHomepage" aria-expanded="false" aria-label="Toggle navigation">
-                        <span class="navbar-toggler-icon"/>
-                    </button>
-                    <div class="collapse navbar-collapse order-2" id="navbarSlidesHomepage">
-                        <div class="navbar-nav pt-3 pt-lg-0">
-                            <a class="nav-link nav-link me-md-2 o_wslides_home_all_slides" href="/slides/all"><i class="fa fa-graduation-cap me-1"/>All courses</a>
-                        </div>
-                    </div>
-                </nav>
-                <div class="o_wprofile_email_validation_container">
-                    <t t-call="website_profile.email_validation_banner">
-                        <t t-set="redirect_url" t-value="'/slides'"/>
-                        <t t-set="send_alert_classes" t-value="'alert alert-danger alert-dismissable mt-4 mb-0'"/>
-                        <t t-set="done_alert_classes" t-value="'alert alert-success alert-dismissable mt-4 mb-0'"/>
-                        <t t-set="additional_validation_email_message"> and join this Community</t>
-                        <t t-set="additional_validated_email_message"> You may now participate in our eLearning.</t>
-                    </t>
-                </div>
-            </div>
-
-            <div class="container o_wslides_home_main">
+            <div class="oe_structure oe_empty"/>
+            <div class="container-fluid mt-2">
                 <div class="row">
-                    <t t-set="has_side_column" t-value="is_view_active('website_slides.toggle_leaderboard')"/>
-                    <t t-if="is_public_user">
-                        <div t-if="has_side_column" class="col-lg-3 order-3 order-lg-2">
-                            <div class="row">
-                                <div class="col-12 col-md-5 col-lg-12">
-                                    <div class="ps-md-5 ps-lg-0">
-                                        <t t-call="website_slides.slides_home_users_small"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </t>
-                    <div t-else="" class="col-lg-3 order-lg-2">
-                        <t t-set="has_side_column" t-value="True"/>
-                        <div class="o_wslides_home_aside_loggedin card p-3 p-lg-0 mb-4">
-                            <div class="o_wslides_home_aside_title">
-                                <div class="d-flex align-items-center">
-                                    <t t-call="website_slides.slides_misc_user_image">
-                                        <t t-set="img_class" t-value="'rounded-circle me-1'"/>
-                                        <t t-set="img_style" t-value="'width: 22px; height: 22px;'"/>
-                                    </t>
-                                    <h5 t-out="user.name" class="d-flex flex-grow-1 mb-0"/>
-                                    <a class="d-none d-lg-block" t-att-href="'/profile/user/%s' % user.id">View</a>
-                                    <a class="d-lg-none btn btn-sm bg-white border" href="#" data-bs-toggle="collapse" data-bs-target="#o_wslides_home_aside_content">More info</a>
-                                </div>
-                                <hr class="d-none d-lg-block mt-2 mb-2 mb-1"/>
-                            </div>
-                            <div id="o_wslides_home_aside_content" class="collapse d-lg-block">
-                                <div class="row g-0 mb-5 mt-3 mt-lg-0">
-                                    <div class="col-12 col-sm-6 col-lg-12">
-                                        <t t-call="website_slides.slides_home_user_profile_small"/>
-                                    </div>
-                                    <div class="col-12 col-sm-6 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4">
-                                        <t t-call="website_slides.slides_home_user_achievements_small"/>
-                                    </div>
-                                    <div class="col-12 col-md-7 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4 mb-3">
-                                        <t t-call="website_slides.slides_home_achievements_small"/>
-                                    </div>
-                                    <div class="col-12 col-sm-6 col-lg-12 ps-md-5 ps-lg-0 mt-lg-4">
-                                        <t t-call="website_slides.slides_home_users_small"/>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div t-att-class="'col-lg-9 pe-lg-5 order-lg-1' if has_side_column else 'col-lg pr-lg'">
+                    <div t-attf-class="#{'col-12 col-lg-9 order-2 order-lg-1' if has_side_column else 'col-12'}">
                         <div t-if="invite_error_msg" role="alert" class="o_not_editable alert alert-danger text-center" t-out="invite_error_msg"/>
-                        <div class="o_wslides_home_content_section mb-3"
-                            t-if="not channels_popular">
+                        <div class="container o_wslides_home_nav">
+                            <div class="o_wprofile_email_validation_container">
+                                <t t-call="website_profile.email_validation_banner">
+                                    <t t-set="redirect_url" t-value="'/slides'"/>
+                                    <t t-set="send_alert_classes" t-value="'alert alert-danger alert-dismissable mt-4 mb-0'"/>
+                                    <t t-set="done_alert_classes" t-value="'alert alert-success alert-dismissable mt-4 mb-0'"/>
+                                    <t t-set="additional_validation_email_message"> and join this Community</t>
+                                    <t t-set="additional_validated_email_message"> You may now participate in our eLearning.</t>
+                                </t>
+                            </div>
+                        </div>
+                        <t t-call="website_slides.courses_search_bar"/>
+                        <div class="container o_wslides_home_content_section mb-3"
+                            t-if="not len(channels)">
                             <p class="h2">No Course created yet.</p>
                             <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
                         </div>
-                        <t t-if="channels_my">
-                            <t t-set="void_count" t-value="3 - len(channels_my[:3])"/>
-                            <div class="o_wslides_home_content_section mb-3">
-                                <div class="row o_wslides_home_content_section_title align-items-center">
-                                    <div class="col">
-                                        <a href="/slides/all?my=1" class="float-end">View all</a>
-                                        <h5 class="m-0">My courses</h5>
-                                        <hr class="mt-2 mb-2"/>
-                                    </div>
-                                </div>
-                                <div class="row mx-n2 mt8">
-                                    <t t-foreach="channels_my[:3]" t-as="channel">
-                                        <div class="col-md-4 col-sm-6 px-2 col-xs-12 d-flex">
-                                            <t t-call="website_slides.course_card"/>
-                                        </div>
-                                    </t>
-                                </div>
-                            </div>
-                        </t>
-                        <div class="o_wslides_home_content_section mb-3"
-                            t-if="channels_popular">
-                            <div class="row o_wslides_home_content_section_title align-items-center">
-                                <div class="col">
-                                    <a href="slides/all" class="float-end">View all</a>
-                                    <h5 class="m-0">Most popular courses</h5>
-                                    <hr class="mt-2 mb-2"/>
-                                </div>
-                            </div>
-                            <div class="row mx-n2 mt8">
-                                <t t-foreach="channels_popular[:3]" t-as="channel">
-                                    <div class="col-md-4 col-sm-6 px-2 col-xs-12 d-flex">
-                                        <t t-call="website_slides.course_card"/>
-                                    </div>
-                                </t>
-                            </div>
-                        </div>
-                        <div class="o_wslides_home_content_section mb-3"
-                            t-if="channels_newest">
-                            <div class="row o_wslides_home_content_section_title align-items-center">
-                                <div class="col">
-                                    <a href="slides/all" class="float-end">View all</a>
-                                    <h5 class="m-0">Newest courses</h5>
-                                    <hr class="mt-2 mb-2"/>
-                                </div>
-                            </div>
-                            <div class="row mx-n2 mt8">
-                                <t t-foreach="channels_newest[:3]" t-as="channel">
-                                    <div class="col-md-4 col-sm-6 px-2 col-xs-12 d-flex">
-                                        <t t-call="website_slides.course_card"/>
-                                    </div>
-                                </t>
-                            </div>
-                        </div>
+                        <t t-call="website_slides.courses_my"/>
+                        <t t-call="website_slides.courses_search_results"/>
+                    </div>
+                    <div t-if="has_side_column" class="col-12 col-lg-3 order-1 order-lg-2 mt-1">
+                        <t t-call="website_slides.courses_home_side_bar"/>
                     </div>
                 </div>
             </div>
@@ -169,164 +148,137 @@
     </t>
 </template>
 
-<!-- Channel all/main template -->
-<template id='courses_all' name="Odoo All Courses">
-    <t t-set="body_classname" t-value="'o_wslides_body'"/>
-    <t t-call="website.layout">
-        <div id="wrap" class="wrap o_wslides_wrap">
-            <!-- Repeat structure for every section to allow customization through website editor. !-->
-            <div class="oe_structure oe_empty" t-if="search_my">
-                <section class="s_banner" data-snippet="s_banner"
-                         style="background-color:(0, 0, 0, 0); background-image: url(&quot;/website_slides/static/src/img/banner_default_all.svg&quot;); background-size: cover; background-position: 80% 20%">
-                    <div class="container py-5"><h1 class="display-3 mb-0 text-white">My Courses</h1></div>
-                </section>
+<template id="courses_search_bar">
+    <div class="container o_wslides_home_nav">
+        <!-- Navbar dynamically composed using displayed channel tag groups. -->
+        <nav class="navbar navbar-expand-md navbar-light shadow-sm px-2 mb-4">
+            <a class="fw-bold" href="/slides">Online Courses</a>
+            <!-- Clear filtering (mobile)-->
+            <div class="text-nowrap ms-auto d-md-none" t-if="search_slide_category or search_tags">
+                <a href="/slides" class="btn btn-info me-2" role="button" title="Clear filters">
+                    <i class="fa fa-eraser"/> Clear filters
+                </a>
             </div>
-            <div class="oe_structure oe_empty" t-elif="search_slide_category == 'certification'">
-               <section class="s_banner" data-snippet="s_banner"
-                        style="background-color:(0, 0, 0, 0); background-image: url(&quot;/website_slides/static/src/img/banner_default_all.svg&quot;); background-size: cover; background-position: 80% 20%">
-                    <div class="container py-5"><h1 class="display-3 mb-0 text-white">Certifications</h1></div>
-                </section>
-            </div>
-            <div class="oe_structure oe_empty" t-else="">
-                <section class="s_banner" data-snippet="s_banner"
-                         style="background-color:(0, 0, 0, 0); background-image: url(&quot;/website_slides/static/src/img/banner_default_all.svg&quot;); background-size: cover; background-position: 80% 20%">
-                    <div class="container py-5"><h1 class="display-3 mb-0 text-white">All Courses</h1></div>
-                </section>
-            </div>
-            <div class="container mt16 o_wslides_home_nav position-relative">
-                <!-- Navbar dynamically composed using displayed channel tag groups. -->
-                <nav class="navbar navbar-expand-md navbar-light shadow-sm ps-0">
-                    <div class="navbar-nav border-end">
-                        <a class="nav-link nav-item px-3" href="/slides"><i class="oi oi-chevron-left"/></a>
-                    </div>
-                    <!-- Clear filtering (mobile)-->
-                    <div class="text-nowrap ms-auto d-md-none" t-if="search_slide_category or search_my or search_tags">
-                        <a href="/slides/all" class="btn btn-info me-2" role="button" title="Clear filters">
-                            <i class="fa fa-eraser"/> Clear filters
-                        </a>
-                    </div>
-                    <t t-else="" t-call="website.website_search_box_input">
-                        <!-- Search box (mobile)-->
-                        <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-md-none"/>
-                        <t t-set="search_type" t-valuef="slides"/>
-                        <!-- No action: remain on same URL -->
-                        <t t-set="display_description" t-valuef="true"/>
-                        <t t-set="display_detail" t-valuef="false"/>
-                        <t t-set="placeholder">Search courses</t>
-                        <t t-set="search" t-value="original_search or search_term"/>
-                        <input t-if="search_my" type="hidden" name="my" t-att-value="1"/>
-                        <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
-                        <input type="hidden" name="prevent_redirect" value="True"/>
-                    </t>
-                    <button class="navbar-toggler px-1" type="button"
-                        data-bs-toggle="collapse" data-bs-target="#navbarTagGroups"
-                        aria-controls="navbarTagGroups" aria-expanded="false" aria-label="Toggle navigation">
-                        <span class="navbar-toggler-icon small"/>
-                    </button>
-                    <div class="collapse navbar-collapse" id="navbarTagGroups">
-                        <t t-set="search_tag_groups" t-value="search_tags.mapped('group_id')"/>
-                        <ul class="navbar-nav flex-grow-1">
-                            <t t-foreach="tag_groups" t-as="tag_group">
-                                <t t-set="group_frontend_tags" t-value="tag_group.tag_ids.filtered(lambda tag: tag.color)"/>
-                                <li class="nav-item dropdown ml16" t-if="group_frontend_tags">
-                                    <a t-att-class="'nav-link dropdown-toggle %s' % ('active' if tag_group in search_tag_groups else '')"
-                                        href="/slides/all"
-                                        t-att-data-bs-target="'#navToogleTagGroup%s' % tag_group.id"
-                                        role="button" data-bs-toggle="dropdown"
-                                        aria-haspopup="true" aria-expanded="false"
-                                        t-out="tag_group.name"/>
-                                    <div class="dropdown-menu" t-att-id="'navToogleTagGroup%s' % tag_group.id">
-                                        <t t-foreach="group_frontend_tags" t-as="tag">
-                                            <span t-att-class="'post_link cursor-pointer dropdown-item %s' % ('active' if tag in search_tags else '')"
-                                                t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                                t-out="tag.name"/>
-                                        </t>
-                                    </div>
-                                </li>
-                            </t>
-                        </ul>
-                        <!-- Clear filtering (desktop)-->
-                        <div class="ms-auto d-none d-md-flex" t-if="search_slide_category or search_my or search_tags">
-                            <a href="/slides/all" class="btn btn-info text-nowrap me-2" role="button" title="Clear filters">
-                                <i class="fa fa-eraser"/> Clear filters
-                            </a>
-                        </div>
-                        <!-- Search box (desktop) -->
-                        <t t-call="website.website_search_box_input">
-                            <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-none d-md-flex"/>
-                            <t t-set="search_type" t-valuef="slides"/>
-                            <!-- No action: remain on same URL -->
-                            <t t-set="display_description" t-valuef="true"/>
-                            <t t-set="display_detail" t-valuef="false"/>
-                            <t t-set="placeholder">Search courses</t>
-                            <t t-set="search" t-value="original_search or search_term"/>
-                            <input t-if="search_my" type="hidden" name="my" t-att-value="1"/>
-                            <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
-                            <input type="hidden" name="prevent_redirect" value="True"/>
-                        </t>
-                    </div>
-                </nav>
-                <div class="o_wprofile_email_validation_container mb16 mt16">
-                    <t t-call="website_profile.email_validation_banner">
-                        <t t-set="redirect_url" t-value="'/slides'"/>
-                        <t t-set="additional_validation_email_message"> and join this Community</t>
-                        <t t-set="additional_validated_email_message"> You may now participate in our eLearning.</t>
-                    </t>
-                </div>
-                <!-- Display tags -->
-                <t t-if="search_my">
-                      <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
-                      <i class="fa fa-tag me-2 text-muted"/>
-                      My Courses
-                      <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), search=search_term, prevent_redirect=True)"
-                         class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
-                    </span>
-                </t>
-                <t t-if="search_term">
-                      <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
-                      <i class="fa fa-tag me-2 text-muted"/>
-                      <t t-out="search_term"/>
-                      <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, slide_category=search_slide_category, prevent_redirect=True)"
-                         class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
-                    </span>
-                </t>
-                <t t-foreach="search_tags" t-as="tag">
-                    <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
-                        <i class="fa fa-tag me-2 text-muted"/>
-                        <t t-out="tag.display_name"/>
-                        <span t-att-data-post='slide_query_url(tag=slugify_tags(search_tags.ids, tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)'
-                            class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
-                    </span>
-                </t>
-            </div>
-            <div class="container o_wslides_home_main pb-5">
-                <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags">
-                    <p class="h2">No Course created yet.</p>
-                    <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
-                </div>
-                <div t-elif="search_term and not channels" class="alert alert-info mb-5">
-                    No course was found matching your search <code><t t-out="search_term"/></code>.
-                </div>
-                <div t-elif="not channels" class="alert alert-info mb-5">
-                    No course was found matching your search.
-                </div>
-                <t t-else="">
-                    <div t-if="original_search" class="alert alert-warning mb-5">
-                        No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="search_term"/>'.
-                    </div>
-                    <div class="row mx-n2">
-                        <t t-foreach="channels" t-as="channel">
-                            <div class="col-12 col-sm-6 col-md-4 col-lg-3 px-2 d-flex">
-                                <t t-call="website_slides.course_card"/>
+            <t t-else="" t-call="website.website_search_box_input">
+                <!-- Search box (mobile)-->
+                <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-md-none"/>
+                <t t-set="search_type" t-valuef="slides"/>
+                <!-- No action: remain on same URL -->
+                <t t-set="display_description" t-valuef="true"/>
+                <t t-set="display_detail" t-valuef="false"/>
+                <t t-set="placeholder">Search courses</t>
+                <t t-set="search" t-value="original_search or search_term"/>
+                <input type="hidden" name="my" t-attf-value="#{1 if search_my else 0}"/>
+                <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
+                <input type="hidden" name="prevent_redirect" value="True"/>
+            </t>
+            <button class="navbar-toggler px-1" type="button"
+                data-bs-toggle="collapse" data-bs-target="#navbarTagGroups"
+                aria-controls="navbarTagGroups" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon small"/>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarTagGroups">
+                <t t-set="search_tag_groups" t-value="search_tags.mapped('group_id')"/>
+                <ul class="navbar-nav flex-grow-1">
+                    <t t-foreach="tag_groups" t-as="tag_group">
+                        <t t-set="group_frontend_tags" t-value="tag_group.tag_ids.filtered(lambda tag: tag.color)"/>
+                        <li class="nav-item dropdown ml16" t-if="group_frontend_tags">
+                            <a t-att-class="'nav-link dropdown-toggle %s' % ('active' if tag_group in search_tag_groups else '')"
+                                href="/slides"
+                                t-att-data-bs-target="'#navToogleTagGroup%s' % tag_group.id"
+                                role="button" data-bs-toggle="dropdown"
+                                aria-haspopup="true" aria-expanded="false"
+                                t-out="tag_group.name"/>
+                            <div class="dropdown-menu" t-att-id="'navToogleTagGroup%s' % tag_group.id">
+                                <t t-foreach="group_frontend_tags" t-as="tag">
+                                    <span t-att-class="'post_link cursor-pointer dropdown-item %s' % ('active' if tag in search_tags else '')"
+                                          t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
+                                          t-out="tag.name"/>
+                                </t>
                             </div>
-                        </t>
+                        </li>
+                    </t>
+                </ul>
+                <!-- Clear filtering (desktop)-->
+                <div class="ms-auto d-none d-md-flex" t-if="search_slide_category or search_tags">
+                    <a href="/slides" class="btn btn-info text-nowrap me-2" role="button" title="Clear filters">
+                        <i class="fa fa-eraser"/> Clear filters
+                    </a>
+                </div>
+                <!-- Search box (desktop) -->
+                <t t-call="website.website_search_box_input">
+                    <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-none d-md-flex"/>
+                    <t t-set="search_type" t-valuef="slides"/>
+                    <!-- No action: remain on same URL -->
+                    <t t-set="display_description" t-valuef="true"/>
+                    <t t-set="display_detail" t-valuef="false"/>
+                    <t t-set="placeholder">Search courses</t>
+                    <t t-set="search" t-value="original_search or search_term"/>
+                    <input type="hidden" name="my" t-attf-value="#{1 if search_my else 0}"/>
+                    <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
+                    <input type="hidden" name="prevent_redirect" value="True"/>
+                </t>
+            </div>
+        </nav>
+    </div>
+</template>
+
+<template id="courses_search_tags">
+    <t t-if="search_my">
+          <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
+          <i class="fa fa-tag me-2 text-muted"/>
+          My Courses
+          <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), search=search_term, prevent_redirect=True)"
+             class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
+        </span>
+    </t>
+    <t t-if="search_term">
+          <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
+          <i class="fa fa-tag me-2 text-muted"/>
+          <t t-out="search_term"/>
+          <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, slide_category=search_slide_category, prevent_redirect=True)"
+                         class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
+        </span>
+    </t>
+    <t t-foreach="search_tags" t-as="tag">
+        <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
+            <i class="fa fa-tag me-2 text-muted"/>
+            <t t-out="tag.display_name"/>
+            <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
+                         class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
+        </span>
+    </t>
+</template>
+
+<template id="courses_search_results">
+    <div class="container o_wslides_home_main pb-5">
+        <t t-call="website_slides.courses_search_tags"/>
+        <div t-if="not channels and not search_term and not search_slide_category and not search_my and not search_tags">
+            <p class="h2">No Course created yet.</p>
+            <p groups="website_slides.group_website_slides_officer">Click on "New" in the top-right corner to write your first course.</p>
+        </div>
+        <div t-elif="search_term and not channels" class="alert alert-info mb-5">
+            No course was found matching your search <code><t t-out="search_term"/></code>.
+        </div>
+        <div t-elif="not channels" class="alert alert-info mb-5">
+            No course was found matching your search.
+        </div>
+        <t t-else="">
+            <div t-if="original_search" class="alert alert-warning mb-5">
+                No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="search_term"/>'.
+            </div>
+            <div class="row mx-n2">
+                <t t-foreach="channels" t-as="channel">
+                    <div class="col-12 col-sm-6 col-md-4 col-lg-3 px-2 d-flex">
+                        <t t-call="website_slides.course_card"/>
                     </div>
                 </t>
             </div>
-
-            <t t-call="website_slides.courses_footer"></t>
+        </t>
+        <div class="d-flex justify-content-center" t-if="pager">
+            <t t-call="website.pager"/>
         </div>
-    </t>
+    </div>
 </template>
 
 <template id='courses_footer'>
@@ -371,7 +323,7 @@
                     <div t-elif="channel.is_member and channel.channel_type != 'documentation'" class="progress w-50" style="height: 6px">
                         <div class="progress-bar" role="progressbar" t-att-aria-valuenow="channel.completion" aria-valuemin="0" aria-valuemax="100" t-attf-style="width:#{channel.completion}%;" aria-label="Progress bar"/>
                     </div>
-                    <small t-else=""><b t-out="channel.total_slides"/> steps</small>
+                    <small t-else="" class="fw-bold"><t t-out="channel.total_slides"/> steps</small>
                 </div>
             </div>
         </div>

--- a/addons/website_slides/views/website_slides_templates_profile.xml
+++ b/addons/website_slides/views/website_slides_templates_profile.xml
@@ -25,7 +25,7 @@
                     </div>
                     <div t-else="" class="text-muted d-inline-block">No completed courses yet!</div>
                     <div t-if="request.env.user != user" class="text-end d-inline-block pull-right">
-                        <a href="/slides/all" class="btn btn-link btn-sm"><i class="oi oi-arrow-right me-1"/>All Courses</a>
+                        <a href="/slides" class="btn btn-link btn-sm"><i class="oi oi-arrow-right me-1"/>All Courses</a>
                     </div>
                 </div>
                 <div class="mb32">
@@ -57,7 +57,7 @@
 
                             <div class="overflow-hidden mb-1" style="height:24px">
                                 <t t-foreach="course.channel_id.tag_ids.filtered(lambda tag: tag.color)" t-as="tag">
-                                    <a t-att-href="'/slides/all/tag/%s' % slug(tag)" onclick="event.stopPropagation()" t-attf-class="badge o_wslides_channel_tag post_link #{'o_color_'+str(tag.color)}" t-out="tag.name"/>
+                                    <a t-att-href="'/slides/tag/%s' % slug(tag)" onclick="event.stopPropagation()" t-attf-class="badge o_wslides_channel_tag post_link #{'o_color_'+str(tag.color)}" t-out="tag.name"/>
                                 </t>
                             </div>
 

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -35,7 +35,7 @@
                 <t t-if="not user_inputs">
                     <p t-if="certification_search_terms">No certification found for the given search term.</p>
                     <p t-else="">You have not taken any certification yet.</p>
-                    <a href="/slides/all?slide_category=certification">
+                    <a href="/slides?slide_category=certification">
                         <i class="oi oi-arrow-right"/> See Certifications
                     </a>
                 </t>
@@ -96,7 +96,7 @@
          <t t-elif="my_profile">
             <div class="text-muted d-inline-block">
                 Certifications are exams that you successfully passed. <br />
-                <a href="/slides/all?slide_type=certification" class="btn-link">
+                <a href="/slides?slide_type=certification" class="btn-link">
                     <i class="fa fa-arrow-right"></i> Get Certified
                 </a>
             </div>
@@ -104,7 +104,7 @@
         <t t-else="">
             <div class="text-muted d-inline-block">No certifications yet!</div>
             <div class="text-end d-inline-block pull-right">
-                <a href="/slides/all?slide_category=certification" class="btn btn-link btn-sm"><i class="oi oi-arrow-right me-1"/>All Certifications</a>
+                <a href="/slides?slide_category=certification" class="btn btn-link btn-sm"><i class="oi oi-arrow-right me-1"/>All Certifications</a>
             </div>
         </t>
     </template>

--- a/addons/website_slides_survey/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_homepage.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <template id="courses_home_inherit_survey" inherit_id="website_slides.courses_home">
-            <xpath expr="//a[hasclass('o_wslides_home_all_slides')]" position="after">
-                <a class="nav-link nav-link d-flex" href="/slides/all?slide_category=certification">
+        <template id="courses_search_bar_inherit_survey" inherit_id="website_slides.courses_search_bar">
+            <xpath expr="//div[@id='navbarTagGroups']" position="before">
+                <a t-if="search_slide_category != 'certification'" class="nav-link nav-link d-flex mx-3" href="/slides?slide_category=certification">
                     <t t-call="website_slides_survey.o_wss_certification_icon"/>
                     <span class="ms-1">Certifications</span>
                 </a>

--- a/addons/website_slides_survey/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_homepage.xml
@@ -3,7 +3,8 @@
     <data>
         <template id="courses_search_bar_inherit_survey" inherit_id="website_slides.courses_search_bar">
             <xpath expr="//div[@id='navbarTagGroups']" position="before">
-                <a t-if="search_slide_category != 'certification'" class="nav-link nav-link d-flex mx-3" href="/slides?slide_category=certification">
+                <a t-if="search_slide_category != 'certification'" class="nav-link nav-link d-flex mx-3"
+                   t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, search=search_term, slide_category='certification')">
                     <t t-call="website_slides_survey.o_wss_certification_icon"/>
                     <span class="ms-1">Certifications</span>
                 </a>
@@ -15,6 +16,20 @@
                 <div t-if="channel.nbr_certification > 0" class="position-absolute py-1 px-2 h5" style="right:0; top:0">
                     <t t-call="website_slides_survey.o_wss_certification_icon"/>
                 </div>
+            </xpath>
+        </template>
+
+        <template id="courses_search_results_inherit_survey" inherit_id="website_slides.courses_search_results">
+            <xpath expr="//t[@t-call='website_slides.courses_search_tags']" position="before">
+                <t t-if="search_slide_category == 'certification'">
+                    <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
+                        <span class="align-items-center me-1">
+                            <t t-call="website_slides_survey.o_wss_certification_icon"/>
+                        </span>
+                        Certification
+                        <a t-att-href="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, search=search_term)" class="btn border-0 py-1 post_link">&#215;</a>
+                    </span>
+                </t>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
We merge the page /slides/all into the home page /slides, allowing to search course on the home page while still displaying the ongoing course and progression. We also add a pager for the search results.

The new home page is basically the old “slides/all” page with the sidebar of the old home page and with the user courses displayed at the top (ordered and limited to 5). The user course list is only displayed if there are no active
search. At the end of that list if the user has more than 5 courses, there is a link to activate the “my course” search which will display all user courses (paginated without the list on the top as a search is then active).

[IMP] website_slides_survey: improve slide category filter

When the certification filter is enabled through the "certification button", a tag label is displayed allowing to remove that filter like for the tags.

We also keep the filters when the "certification button" is pressed which was not the case before, so it behave like other filters.

[IMP] website_slides: remove certification tag from demo data

To avoid confusion with the certification filter (slide_category=certification) in the course page, we remove the tag certification in the demo data.

Technical note: As we had anyway to rename the tag id because we remove the slide_channel_tag_other_2 among the 3 tags of the demo data, we rename them with meaningful names.

Task-3893028