### PR TITLE
[FIX] account: remove download option from S&P wizard

### DIFF
--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -128,7 +128,7 @@ class AccountMoveSendWizard(models.TransientModel):
         methods = self.env['ir.model.fields'].get_field_selection('res.partner', 'invoice_sending_method')
 
         # We never want to display the manual method.
-        methods = [method for method in methods if method != ('manual', 'Manual')]
+        methods = [method for method in methods if method[0] != 'manual']
 
         for wizard in self:
             preferred_methods = self._get_default_sending_methods(wizard.move_id)


### PR DESCRIPTION
Since 7ad7a1d976391e81eaa03be7076cc61f4a6cfcbe we don't show
Download option in the Send & Print wizard.
However, we were checking the tuple `(value, label)` which
works only if language is set to English.

With this commit, we only check the technical value

opw-4965650
