### PR TITLE
[FIX] purchase: select supplier info based on min_qty if same vendor

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -469,6 +469,7 @@ class PurchaseOrderLine(models.Model):
             partner_id=self.order_id.partner_id,
             quantity=None,
             date=self.order_id.date_order and self.order_id.date_order.date() or fields.Date.context_today(self),
+            ordered_by='min_qty',
             params=self._get_select_sellers_params(),
         )
         if seller_min_qty:

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -894,6 +894,15 @@ class TestPurchase(AccountTestInvoicingCommon):
                 'date_end': fields.Date.today() + timedelta(days=3),
                 'product_code': 'HHH',
             },
+            {
+                'partner_id': self.partner_a.id,
+                'product_id': self.product_a.id,
+                'min_qty': 20,
+                'price': 80,
+                'date_start': fields.Date.today() - timedelta(days=5),
+                'date_end': fields.Date.today() + timedelta(days=3),
+                'product_code': 'HHH-min_qty_20',
+            },
         ])
         po_form = Form(self.env['purchase.order'])
         po_form.partner_id = self.partner_a


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”
    - Under the Purchase tab:
        - add two vendor pricelist entries:
        1:/
        - Vendor: Azure Interior
        - min_qty: 1
        - Price: $5 
         2:/
          - Vendor: Azure Interior
          - min_qty: 100
          - Price: $2

- Create a purchase order:
    - vendor: Azure Interior
    - Try to add the product P1

**Problem:**
When adding a product to a purchase order, if multiple supplier info
lines exist for the same vendor,  the one with the lowest price will be
selected, instead of the one matching the smallest applicable quantity
(min_qty).

This regression was introduced by the following commit, which
tried to fix an unrelated bug with supplier info date matching:
https://github.com/odoo/odoo/commit/7eabfcff402993f32f5c835e18e07c91782a7b33#diff-5684edced9bdfc98021a85de4c6cdf691ea7add74e56ab50334a1d7db9ef4224L470

As part of that fix, the logic was changed to use the _select_seller
method, which by default sorts supplier info lines by price_discounted
and returns the first one — regardless of whether the min_qty is met.

Previously, the logic correctly selected the supplier line based
on min_qty when multiple lines existed for the same vendor.

**_Note:_** This bug is no longer present as of version 18.1, because
the date-related issue was fixed differently in the following commit:
https://github.com/odoo/odoo/commit/19c65c4884a3746b44b6272694662eb32a6bf32f

That later fix preserved the original behavior of respecting min_qty.

**Solution:**
Explicitly pass ordered_by='min_qty' when calling _select_seller.
This ensures that supplier info lines are prioritized based on the
lowest applicable min_qty, not the lowest price, when the vendor is the
same.

opw-4942819