### PR TITLE
[FIX] l10n_*: use correct method name set_to_invoice on pos.order

### DIFF
--- a/addons/l10n_ar_pos/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/l10n_ar_pos/static/src/app/screens/payment_screen/payment_screen.js
@@ -5,7 +5,7 @@ patch(PaymentScreen.prototype, {
     onMounted() {
         super.onMounted();
         if (this.pos.isArgentineanCompany()) {
-            this.currentOrder.setToInvoice(true);
+            this.currentOrder.set_to_invoice(true);
         }
     },
 });

--- a/addons/l10n_pe_pos/static/src/overrides/components/paymentt_screen/payment_screen.js
+++ b/addons/l10n_pe_pos/static/src/overrides/components/paymentt_screen/payment_screen.js
@@ -7,7 +7,7 @@ patch(PaymentScreen.prototype, {
     onMounted() {
         super.onMounted();
         if (this.pos.isPeruvianCompany()) {
-            this.currentOrder.setToInvoice(true);
+            this.currentOrder.set_to_invoice(true);
         }
     },
     async _isOrderValid(isForceValidate) {

--- a/addons/l10n_uy_pos/static/src/overrides/component/payment_screen/payment_screen.js
+++ b/addons/l10n_uy_pos/static/src/overrides/component/payment_screen/payment_screen.js
@@ -5,7 +5,7 @@ patch(PaymentScreen.prototype, {
     onMounted() {
         super.onMounted();
         if (this.pos.company.country_id?.code == "UY") {
-            this.currentOrder.setToInvoice(true);
+            this.currentOrder.set_to_invoice(true);
         }
     },
 });


### PR DESCRIPTION
In commit https://github.com/odoo/odoo/commit/bfe2a0aea699439480990bb192bfeea7df2117e2, the method `setToInvoice` was mistakenly called on `pos.order`, but this method does not exist. The correct method name is `set_to_invoice`.

opw-4992393

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
