### PR TITLE
[FIX] html_editor: overlay: don't close child overlay

### DIFF
--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -1,4 +1,5 @@
 import { Component, onWillDestroy, useEffect, useExternalListener, useRef, xml } from "@odoo/owl";
+import { OVERLAY_SYMBOL } from "@web/core/overlay/overlay_container";
 import { usePosition } from "@web/core/position/position_hook";
 import { useActiveElement } from "@web/core/ui/ui_service";
 import { closestScrollableY } from "@web/core/utils/scrolling";
@@ -71,11 +72,16 @@ export class EditorOverlay extends Component {
         }
 
         if (this.props.closeOnPointerdown) {
+            const clickAway = (ev) => {
+                if (!this.env[OVERLAY_SYMBOL]?.contains(ev.composedPath()[0])) {
+                    this.props.close();
+                }
+            };
             const editableDocument = this.props.editable.ownerDocument;
-            useExternalListener(editableDocument, "pointerdown", this.props.close);
+            useExternalListener(editableDocument, "pointerdown", clickAway);
             // Listen to pointerdown outside the iframe
             if (editableDocument !== document) {
-                useExternalListener(document, "pointerdown", this.props.close);
+                useExternalListener(document, "pointerdown", clickAway);
             }
         }
 


### PR DESCRIPTION
Have an oerlay in the editor that will spawn an overlay on its own. Interact in the second popover.

Before this commit: the main popover closes, making it impossible to interact in a meaningful way.

After this commit, the feature of the overlay (`overlay_service.js`) that handles overlay parenthood is leveraged, both overlays are fully able to be interacted with.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
