### PR TITLE
[FIX] website_sale_collect: add notification feature if product out of stock

### DIFF
--- a/addons/website_sale_collect/static/src/js/website_sale.js
+++ b/addons/website_sale_collect/static/src/js/website_sale.js
@@ -2,6 +2,21 @@ import { Component } from '@odoo/owl';
 import { WebsiteSale } from '@website_sale/js/website_sale';
 
 WebsiteSale.include({
+    events: Object.assign({}, WebsiteSale.prototype.events, {
+        'click #product_stock_notification_message': '_onClickProductStockNotificationMessage',
+        'click #product_stock_notification_form_submit_button': '_onClickSubmitProductStockNotificationForm',
+    }),
+
+    _onClickProductStockNotificationMessage(ev) {
+        this._handleClickStockNotificationMessage(ev);
+    },
+
+    _onClickSubmitProductStockNotificationForm(ev) {
+        const formEl = ev.currentTarget.closest('#stock_notification_form');
+        const productId = parseInt(formEl.querySelector('input[name="product_id"]').value);
+        this._handleClickSubmitStockNotificationForm(ev, productId);
+    },
+
     /**
      * Trigger a state update of the ClickAndCollectAvailability component when the combination info
      * is updated.

--- a/addons/website_sale_collect/views/delivery_form_templates.xml
+++ b/addons/website_sale_collect/views/delivery_form_templates.xml
@@ -24,6 +24,46 @@
                     <t t-out="order_line.product_id.name"/>
                     ( <t t-out="order_line.shop_warning"/> )
                     <div name="o_wsale_unavailable_line_button_container">
+                        <t t-set="line_product" t-value="order_line.product_id"/>
+                        <div t-if="not line_product.allow_out_of_stock_order" id="stock_notification_div">
+                            <div
+                                t-if="line_product not in (products_with_stock_notification or [])"
+                                id="product_stock_notification_message"
+                                class="btn btn-link px-0"
+                            >
+                                <small>
+                                    <i class="fa fa-envelope-o me-2"/>Get notified when back in stock
+                                </small>
+                            </div>
+                            <div id="stock_notification_form" class="d-none">
+                                <div class="input-group">
+                                    <input
+                                        class="form-control"
+                                        id="stock_notification_input"
+                                        name="email"
+                                        type="text"
+                                        placeholder="johndoe@example.com"
+                                        t-att-value="stock_notification_email or ''"
+                                    />
+                                    <input name="product_id" type="hidden" t-att-value="line_product.id"/>
+                                    <div id="product_stock_notification_form_submit_button" class="btn btn-primary">
+                                        <i class="fa fa-paper-plane"/>
+                                    </div>
+                                </div>
+                                <div id="stock_notification_input_incorrect" class="d-none form-text text-danger">
+                                    Invalid email
+                                </div>
+                            </div>
+                            <div
+                                id="stock_notification_success_message"
+                                t-att-class="'text-muted' if has_stock_notification else 'd-none'"
+                            >
+                                <small>
+                                    <i class="fa fa-bell"/>
+                                    We'll notify you once the product is back in stock.
+                                </small>
+                            </div>
+                        </div>
                         <a
                             title="Remove from cart"
                             href='#'


### PR DESCRIPTION
## Versions
18.4+ to limit templates impact.

## Issue
Users can't choose to be notified when a product becomes available again on the checkout page.

## Steps to reproduce
Ensure eCommerce website is set up with a shop;
- In Settings app:
  - Enable "Click & Collect" and click "Configure Pickup Locations":
    - Add a company as a warehouse and publish the "Pick up in store" location;
- In Sales app:
  - Create a product with the following attributes:
    - Name: A;
    - Product Type: Goods;
    - Track Inventory: enabled;
    - Sales: enabled;
    - Under Sales tab:
      - Out-of-Stock (Continue Selling): disabled;
    - On Hand: 1.
  - Click "Go to Website":
    - Add 1 to cart then go to cart;
    - Click the "Checkout" button;
    - Under "Choose a delivery method", select "Pick up in store" then "Select a Location";
    - Choose a location.
- (In another browser tab) Go to the product's page:
  - Set "On Hand" quantity to 0.
- (Back in the checkout tab) Refresh the page:
  - The product appears as unavailable under the pick-up location:
    - No option is available to request a back-in-stock notification.

## Solution
Apply `website_sale_stock` logic
https://github.com/odoo/odoo/blob/7bc57a49e5bf9061cfb66e179075538cd17bfd2f/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml#L1-L61 as in `website_sale_stock_wishlist`
https://github.com/odoo/odoo/blob/7bc57a49e5bf9061cfb66e179075538cd17bfd2f/addons/website_sale_stock_wishlist/views/website_sale_stock_wishlist_templates.xml#L7-L45

opw-4979335