### PR TITLE
[FIX] web: prevent IME input from vanishing on iOS devices

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -588,11 +588,25 @@ export class SearchBar extends Component {
         }
         const query = ev.target.value;
         if (query.trim()) {
-            this.inputDropdownState.open();
+            if (!ev.isComposing) {
+                // Protection for IME input
+                this.inputDropdownState.open();
+            }
             this.computeState({ query, expanded: [], subItems: [] });
         } else if (this.items.length) {
             this.inputDropdownState.close();
             this.resetState();
+        }
+    }
+    
+    /**
+     * @param {CompositionEvent} ev
+     */
+    onCompositionEnd(ev) {
+        const query = ev.target.value;
+        if (query.trim()) {
+            // Open dropdown after IME composition is complete
+            this.inputDropdownState.open();
         }
     }
 

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -120,6 +120,7 @@
                             t-on-keydown="onSearchKeydown"
                             t-on-click="onSearchClick"
                             t-on-input="onSearchInput"
+                            t-on-compositionend="onCompositionEnd"
                         />
                     </div>
                 </div>


### PR DESCRIPTION
Problem:
When using Chinese or Japanese keyboards (IME - Input Method Editor) on iOS devices,
typed characters vanish immediately after pressing Enter or selecting a character
suggestion. This makes it impossible for users to input text in these languages
on iOS devices (iPhone/iPad).

This regression was introduced between versions 18.0 and 18.2 when the search bar
was modified to automatically open the suggestion dropdown during typing.

Purpose:
This commit fixes the IME input issue by preventing the suggestion dropdown from
opening while the user is composing text with an IME. Opening the dropdown during
IME composition disrupts the input process on iOS Safari, causing the composed
text to disappear.

The fix ensures that the dropdown only opens after IME composition is complete,
allowing Chinese, Japanese, and other IME-based language users to properly input
text on iOS devices.

Steps to Reproduce on Runbot:
1. Access Odoo instance (version 18.2) on an iOS device (iPhone or iPad)
2. Switch keyboard to Chinese (Pinyin) or Japanese (Romaji) input method
3. Click on the search bar in any view (e.g., Customers, Sales Orders)
4. Type characters that require IME conversion:
-For Chinese: type "ni" (for 你)
-For Japanese: type "ka" (for か)
5. When the IME suggestion appears, press Enter or tap the suggested character
6. Bug: The text vanishes instead of being inserted into the search field

Current behavior before PR:
The character disappears immediately after selection

Desired behavior after PR is merged:
The selected character should be inserted into the search field

Notes:
-This issue only affects iOS devices (Safari/WebKit) due to how they handle
 DOM manipulation during IME composition events
-The issue does not occur on Android devices or desktop browsers
-The fix checks the `isComposing` property of the input event to avoid
 opening the dropdown during IME composition
-No test added as IME input behavior is difficult to simulate in automated tests

opw-4958130

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
