### PR TITLE
[FIX] l10n_it_edi: fix upgrade of demo data

### DIFF
--- a/addons/l10n_it_edi/data/account_invoice_demo.xml
+++ b/addons/l10n_it_edi/data/account_invoice_demo.xml
@@ -60,7 +60,7 @@
             <field name="l10n_it_pa_index">SOOTJS</field>
         </record>
 
-        <record id="demo_l10n_it_edi_partner_pa_fiscal_position" model="ir.property">
+        <record id="demo_l10n_it_edi_partner_pa_fiscal_position" model="ir.property" forcecreate="0">
             <field name="name">property_account_position_id</field>
             <field name="fields_id" search="[('model', '=', 'res.partner'), ('name', '=', 'property_account_position_id')]"/>
             <field name="res_id" model="res.partner" eval="'res.partner,' + str(obj().env.ref('l10n_it_edi.demo_l10n_it_edi_partner_pa').id)"/>


### PR DESCRIPTION
The upgrade 15->16 of `l10n_it_edi` (and related modules) is broken as soon as demo data is present in the DB.

Steps to reproduce:
1. In 15.0 intall `l10n_it_edi`
2. Upgrade to 16.0

Error:
```
2025-08-04 14:58:29,741 429275 ERROR test_15_16 odoo.tools.convert.init: Could not eval('account.fiscal.position,'                  + str(ref('l10n_it.' + str(ref('l10n_it.demo_company_it')) + '_split_payment_fiscal_position'))) for value in {}
2025-08-04 14:58:29,741 429275 WARNING test_15_16 odoo.modules.loading: Module l10n_it_edi demo data failed to install, installed without demo data
Traceback (most recent call last):
...
```

Root issue: when this file is loaded the fiscal position doesn't exist. In 16.0 it is create by the CoA load
https://github.com/odoo/odoo/blob/9ab9e254cb0658e38dc0b9c4fe54c317e184bb04/addons/account/models/chart_template.py#L885-L886

Solution: do not create the property value during the upgrade since it doesn't look essential.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
