### PR TITLE
[FIX] pos_self_order: stop displaying default kiosk images in website

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -4,7 +4,6 @@ import base64
 import zipfile
 import qrcode
 from io import BytesIO
-from os.path import join as opj
 from typing import Optional, List, Dict
 from urllib.parse import unquote
 from odoo.exceptions import UserError, ValidationError, AccessError
@@ -110,9 +109,6 @@ class PosConfig(models.Model):
 
     @api.model
     def _prepare_self_order_splash_screen(self, vals_list, is_new=False):
-        def read_image_datas(image_name):
-            with file_open(opj("pos_self_order/static/img", image_name), "rb") as f:
-                return base64.b64encode(f.read())
         for vals in vals_list:
             if not vals.get('self_ordering_mode'):
                 return True
@@ -120,17 +116,17 @@ class PosConfig(models.Model):
             if not vals.get('self_ordering_image_home_ids'):
                 vals['self_ordering_image_home_ids'] = [(0, 0, {
                     'name': image_name,
-                    'datas': read_image_datas(image_name),
+                    'type': 'url',
+                    'url': f'/pos_self_order/static/img/{image_name}',
                     'res_model': 'pos.config',
-                    'type': 'binary',
                 }) for image_name in ['landing_01.jpg', 'landing_02.jpg', 'landing_03.jpg']]
 
             if is_new and not vals.get('self_ordering_image_background_ids'):
                 vals['self_ordering_image_background_ids'] = [(0, 0, {
                     'name': "background.jpg",
-                    'datas': read_image_datas("kiosk_background.jpg"),
+                    'type': 'url',
+                    'url': '/pos_self_order/static/img/kiosk_background.jpg',
                     'res_model': 'pos.config',
-                    'type': 'binary',
                 })]
 
         return True


### PR DESCRIPTION
Commit [1] forced kiosk image and background attachments to be public, therefore making them displayed in the website media dialog in edit mode, as a suggestion.

Steps to reproduce:
1. Install website and pos_self_order
2. Go to the website, edit a page, add a block with an image
3. Double-click on the image => the media dialog is empty
4. Save, go to "Point of Sale"
5. Create a "bar", configure it to be a self-order kiosk, add products with the right categories, etc.
6. Go back to the website, edit the page, double-click on an image => the media dialog now shows the kiosk images and background images

This commit solves the issue by making it so that the *default* ones are not displayed in the website media dialog. To do that, while keeping them public, we use "url" type attachment pointing to Odoo static files, which are excluded from the website media dialog because that's the way default snippet images for the website are defined too.

For user-chosen kiosk images, we keep the behavior of suggesting them in the website media dialog. After all, they are user-chosen public images, it make sense for the user to potentially use them in their website. At least, with this commit, the website media dialog is less polluted while demoing on runbot.

[1]: https://github.com/odoo/odoo/commit/b12c49bffafaf81e59ec97a3a51d1b4e05726142
