### PR TITLE
[FIX] pos_restaurant, product: move back pizza demo data

### DIFF
--- a/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <!-- IMPORTANT: do not reference demo data from other modules -->
     <data noupdate="1">
         <record id="base.group_user" model="res.groups">
             <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
@@ -36,6 +37,39 @@
         <record id="pav_sides_grilled_vegetables" model="product.attribute.value">
             <field name="name">Grilled vegetables</field>
             <field name="attribute_id" ref="pa_sides"/>
+        </record>
+
+        <!-- Extras product attribute -->
+        <record id="pa_extras_pizza" model="product.attribute" >
+            <field name="name">Extras</field>
+            <field name="create_variant">no_variant</field>
+            <field name="display_type">multi</field>
+            <field name="sequence">70</field>
+        </record>
+
+        <record id="pav_extras_pizza_pepperoni" model="product.attribute.value">
+            <field name="name">Pepperoni</field>
+            <field name="attribute_id" ref="pa_extras_pizza"/>
+        </record>
+
+        <record id="pav_extras_pizza_mushroom" model="product.attribute.value">
+            <field name="name">Mushroom</field>
+            <field name="attribute_id" ref="pa_extras_pizza"/>
+        </record>
+
+        <record id="pav_extras_pizza_black_olives" model="product.attribute.value">
+            <field name="name">Black olives</field>
+            <field name="attribute_id" ref="pa_extras_pizza"/>
+        </record>
+
+        <record id="pav_extras_pizza_anchovy" model="product.attribute.value">
+            <field name="name">Anchovy</field>
+            <field name="attribute_id" ref="pa_extras_pizza"/>
+        </record>
+
+        <record id="pav_extras_pizza_extra_cheese" model="product.attribute.value">
+            <field name="name">Extra cheese</field>
+            <field name="attribute_id" ref="pa_extras_pizza"/>
         </record>
 
         <!-- Food products -->
@@ -135,15 +169,15 @@
 
         <record model="product.template.attribute.line" id="product_attribute_line_pizza_extra">
             <field name="product_tmpl_id" ref="pos_restaurant.product_pizza_margherita_template"/>
-            <field name="attribute_id" ref="product.pa_extras_pizza"/>
+            <field name="attribute_id" ref="pa_extras_pizza"/>
             <field
                 name="value_ids"
                 eval="[Command.set([
-                    ref('product.pav_extras_pizza_pepperoni'),
-                    ref('product.pav_extras_pizza_mushroom'),
-                    ref('product.pav_extras_pizza_black_olives'),
-                    ref('product.pav_extras_pizza_anchovy'),
-                    ref('product.pav_extras_pizza_extra_cheese'),
+                    ref('pav_extras_pizza_pepperoni'),
+                    ref('pav_extras_pizza_mushroom'),
+                    ref('pav_extras_pizza_black_olives'),
+                    ref('pav_extras_pizza_anchovy'),
+                    ref('pav_extras_pizza_extra_cheese'),
             ])]" />
         </record>
 
@@ -217,15 +251,15 @@
 
         <record model="product.template.attribute.line" id="product_attribute_line_pizza_vege_extra">
             <field name="product_tmpl_id" ref="pos_restaurant.product_pizza_vegetarian_template"/>
-            <field name="attribute_id" ref="product.pa_extras_pizza"/>
+            <field name="attribute_id" ref="pa_extras_pizza"/>
             <field
                 name="value_ids"
                 eval="[Command.set([
-                    ref('product.pav_extras_pizza_pepperoni'),
-                    ref('product.pav_extras_pizza_mushroom'),
-                    ref('product.pav_extras_pizza_black_olives'),
-                    ref('product.pav_extras_pizza_anchovy'),
-                    ref('product.pav_extras_pizza_extra_cheese'),
+                    ref('pav_extras_pizza_pepperoni'),
+                    ref('pav_extras_pizza_mushroom'),
+                    ref('pav_extras_pizza_black_olives'),
+                    ref('pav_extras_pizza_anchovy'),
+                    ref('pav_extras_pizza_extra_cheese'),
             ])]" />
         </record>
 
@@ -299,12 +333,12 @@
 
         <record model="product.template.attribute.line" id="product_attribute_line_pasta_extra">
             <field name="product_tmpl_id" ref="pos_restaurant.product_pasta_4_formaggi_template"/>
-            <field name="attribute_id" ref="product.pa_extras_pizza"/>
+            <field name="attribute_id" ref="pa_extras_pizza"/>
             <field
                 name="value_ids"
                 eval="[Command.set([
-                    ref('product.pav_extras_pizza_extra_cheese'),
-                    ref('product.pav_extras_pizza_mushroom'),
+                    ref('pav_extras_pizza_extra_cheese'),
+                    ref('pav_extras_pizza_mushroom'),
             ])]" />
         </record>
 

--- a/addons/product/data/product_attribute_demo.xml
+++ b/addons/product/data/product_attribute_demo.xml
@@ -430,39 +430,6 @@
         <field name="attribute_id" ref="pa_duration"/>
     </record>
 
-    <!-- Extras -->
-    <record id="pa_extras_pizza" model="product.attribute" >
-        <field name="name">Extras</field>
-        <field name="create_variant">no_variant</field>
-        <field name="display_type">multi</field>
-        <field name="sequence">70</field>
-    </record>
-
-    <record id="pav_extras_pizza_pepperoni" model="product.attribute.value">
-        <field name="name">Pepperoni</field>
-        <field name="attribute_id" ref="pa_extras_pizza"/>
-    </record>
-
-    <record id="pav_extras_pizza_mushroom" model="product.attribute.value">
-        <field name="name">Mushroom</field>
-        <field name="attribute_id" ref="pa_extras_pizza"/>
-    </record>
-
-    <record id="pav_extras_pizza_black_olives" model="product.attribute.value">
-        <field name="name">Black olives</field>
-        <field name="attribute_id" ref="pa_extras_pizza"/>
-    </record>
-
-    <record id="pav_extras_pizza_anchovy" model="product.attribute.value">
-        <field name="name">Anchovy</field>
-        <field name="attribute_id" ref="pa_extras_pizza"/>
-    </record>
-
-    <record id="pav_extras_pizza_extra_cheese" model="product.attribute.value">
-        <field name="name">Extra cheese</field>
-        <field name="attribute_id" ref="pa_extras_pizza"/>
-    </record>
-
     <!-- Fabric -->
     <record id="pa_fabric" model="product.attribute">
         <field name="name">Fabric</field>

--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -21,9 +21,6 @@
             <field name="preview_variants">visible</field>
             <field name="is_thumbnail_visible" eval="True"/>
         </record>
-        <record id="product.pa_extras_pizza" model="product.attribute">
-            <field name="visibility">hidden</field>
-        </record>
         <record id="product.pa_shoe_size" model="product.attribute">
             <field name="visibility">hidden</field>
         </record>


### PR DESCRIPTION
Versions
--------
- saas-18.4+

Steps
-----
1. Set up a database without demo data;
2. open restaurant POS;
3. go to register;
4. load sample data.

Issue
-----
Data doesn't load.

Cause
-----
Commit ffb976c3ed5fb moved demo data from `pos_restaurant` to `product`. Issue is that `pos_restaurant` uses a custom "scenario" flow where demo data gets loaded for a specific scenario. As a consequence, any reference to demo data from `product` will cause an error.

Solution
--------
Commit b15cf569c766f already moved back the burger sides data.
This commit does the same for the pizza extras data.

opw-4989005