### PR TITLE
[IMP] mail: harmonize discuss actions (part 2)

### DIFF
--- a/addons/crm_livechat/static/src/core/thread_actions.js
+++ b/addons/crm_livechat/static/src/core/thread_actions.js
@@ -11,7 +11,7 @@ import { usePopover } from "@web/core/popover/popover_hook";
 threadActionsRegistry.add("create-lead", {
     close: (component, action) => action.popover?.close(),
     component: LivechatCommandDialog,
-    componentProps: (action) => ({
+    componentProps: (component, action) => ({
         close: () => action.close(),
         commandName: "lead",
         placeholderText: _t("e.g. Product pricing"),

--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -1,4 +1,4 @@
-export class DiscussActionDefinition {
+export class Action {
     /** User-defined explicit definition of this action */
     explicitDefinition;
     /** Component in which the action is being used */
@@ -37,6 +37,13 @@ export class DiscussActionDefinition {
     /** Determines whether this action opens a dropdown on selection. Value is shaped { template, menuClass } */
     get dropdown() {
         return this.explicitDefinition.dropdown;
+    }
+
+    /** Determines whether this action has a keyboard hotkey to trigger the onSelected */
+    get hotkey() {
+        return typeof this.explicitDefinition.hotkey === "function"
+            ? this.explicitDefinition.hotkey(this._component)
+            : this.explicitDefinition.hotkey;
     }
 
     /**

--- a/addons/mail/static/src/core/common/action_list.dark.scss
+++ b/addons/mail/static/src/core/common/action_list.dark.scss
@@ -1,0 +1,8 @@
+.o-mail-ActionList {
+    --mail-ActionList-activeItemColor: #{white};
+    --mail-ActionList-activeItemBgColor: #{rgba(mix($gray-300, $gray-400), .75)};
+    --mail-ActionList-dangerBgColor: #{rgba(saturate($danger, 20%), .5)};
+    --mail-ActionList-successBgColor: #{rgba(saturate($success, 20%), .5)};
+    --mail-ActionList-buttonInlineIconOpacity: #{85%};
+    --mail-ActionList-dangerColor: #{lighten($danger, 5%)};
+}

--- a/addons/mail/static/src/core/common/action_list.js
+++ b/addons/mail/static/src/core/common/action_list.js
@@ -4,7 +4,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
 import { useService } from "@web/core/utils/hooks";
 
-export class DiscussActions extends Component {
+export class ActionList extends Component {
     static components = { Dropdown, DropdownItem };
     static props = [
         "inline?",
@@ -15,7 +15,7 @@ export class DiscussActions extends Component {
         "odooControlPanelSwitchStyle?",
         "thread?",
     ];
-    static template = "mail.DiscussActions";
+    static template = "mail.ActionList";
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -1,4 +1,4 @@
-.o-mail-DiscussActions-group {
+.o-mail-ActionList-group {
     &.o-inline {
         gap: 1px;
     }
@@ -7,7 +7,7 @@
     }
 }
 
-.o-mail-DiscussActions {
+.o-mail-ActionList {
     hr {
         opacity: 12.5% !important;
     }
@@ -17,7 +17,7 @@
         --btn-disabled-opacity: 0.25;
 
         &.o-danger {
-            color: var(--mail-DiscussActions-dangerColor, darken($danger, 5%)) !important;
+            color: var(--mail-ActionList-dangerColor, darken($danger, 5%)) !important;
         }
 
         &.o-success {
@@ -30,7 +30,7 @@
 
         &.o-inline {
             i {
-                opacity: var(--mail-DiscussActions-buttonInlineIconOpacity, 65%);
+                opacity: var(--mail-ActionList-buttonInlineIconOpacity, 65%);
             }
             &.o-mail-ChatWindow-command i {
                 opacity: 35%;
@@ -43,7 +43,7 @@
             }
         }
 
-        .o-mail-DiscussActions-actionLabel {
+        .o-mail-ActionList-actionLabel {
             opacity: 65%;
             .o_bottom_sheet_sheet:has(&) {
                 opacity: 100%;
@@ -51,20 +51,20 @@
         }
 
         &:hover:not(.o-dropdown-item), &.o-isActive, &.o-active, &.focus, &.show {
-            .o-mail-DiscussActions-actionLabel {
+            .o-mail-ActionList-actionLabel {
                 opacity: 100%;
             }
 
-            color: var(--mail-DiscussActions-activeItemColor, $body-color);
+            color: var(--mail-ActionList-activeItemColor, $body-color);
             &:not(.o-inline) {
                 background-color: $dropdown-link-hover-bg !important;
             }
             &.o-danger {
-                    background-color: var(--mail-DiscussActions-dangerBgColor, rgba($danger, .75)) !important;
+                    background-color: var(--mail-ActionList-dangerBgColor, rgba($danger, .75)) !important;
                     color: white !important;
             }
             &.o-success {
-                    background-color: var(--mail-DiscussActions-successBgColor, rgba($success, .6)) !important;
+                    background-color: var(--mail-ActionList-successBgColor, rgba($success, .6)) !important;
                     color: white !important;
             }
             z-index: 2 !important;

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -1,50 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-<t t-name="mail.DiscussActions">
-    <div class="o-mail-DiscussActions flex-shrink-0 d-flex" t-att-class="{ 'align-items-center': props.inline,'flex-column': !props.inline }">
+<t t-name="mail.ActionList">
+    <div class="o-mail-ActionList flex-shrink-0 d-flex" t-att-class="{ 'align-items-center': props.inline,'flex-column': !props.inline }">
         <t t-set="groupAttClass" t-value="{ 'flex-column w-100': !props.inline, 'o-inline': props.inline, 'o-rounded-bubble': props.inline and !props.odooControlPanelSwitchStyle, 'o-odooControlPanelSwitchStyle': props.odooControlPanelSwitchStyle }"/>
-        <span t-if="props.quick?.length" class="o-mail-DiscussActions-group btn-group" t-att-class="groupAttClass">
+        <span t-if="props.quick?.length" class="o-mail-ActionList-group btn-group" t-att-class="groupAttClass">
             <t t-set="groupBefore" t-value="true"/>
-            <t t-foreach="props.quick" t-as="action" t-key="action.id" t-call="mail.DiscussActions.action">
+            <t t-foreach="props.quick" t-as="action" t-key="action.id" t-call="mail.ActionList.action">
                 <t t-set="action" t-value="action"/>
                 <t t-set="groupSize" t-value="props.quick.length"/>
             </t>
         </span>
         <t t-else="" t-set="groupBefore" t-value="false"/>
-        <t t-if="groupBefore" t-call="mail.DiscussActions.groupSeparator"/>
-        <span t-if="props.other?.length" class="o-mail-DiscussActions-group btn-group" t-att-class="groupAttClass">
+        <t t-if="groupBefore" t-call="mail.ActionList.groupSeparator"/>
+        <span t-if="props.other?.length" class="o-mail-ActionList-group btn-group" t-att-class="groupAttClass">
             <t t-set="groupBefore" t-value="true"/>
-            <t t-foreach="props.other" t-as="action" t-key="action.id" t-call="mail.DiscussActions.action">
+            <t t-foreach="props.other" t-as="action" t-key="action.id" t-call="mail.ActionList.action">
                 <t t-set="action" t-value="action"/>
                 <t t-set="groupSize" t-value="props.other.length"/>
             </t>
         </span>
         <t t-else="" t-set="groupBefore" t-value="false"/>
-        <t t-if="groupBefore" t-call="mail.DiscussActions.groupSeparator"/>
+        <t t-if="groupBefore" t-call="mail.ActionList.groupSeparator"/>
         <t t-if="props.inline" t-set="group" t-value="(props.group ?? []).slice().reverse()"/>
         <t t-else="" t-set="group" t-value="(props.group ?? [])"/>
         <t t-foreach="group" t-as="group" t-key="group_index">
-            <span t-if="group.length" class="o-mail-DiscussActions-group btn-group" t-att-class="groupAttClass">
-                <t t-foreach="group" t-as="action" t-key="action.id" t-call="mail.DiscussActions.action">
+            <span t-if="group.length" class="o-mail-ActionList-group btn-group" t-att-class="groupAttClass">
+                <t t-foreach="group" t-as="action" t-key="action.id" t-call="mail.ActionList.action">
                     <t t-set="action" t-value="action"/>
                     <t t-set="groupSize" t-value="group.length"/>
                 </t>
             </span>
-            <t t-if="!group_last" t-call="mail.DiscussActions.groupSeparator"/>
+            <t t-if="!group_last" t-call="mail.ActionList.groupSeparator"/>
         </t>
     </div>
 </t>
 
-<t t-name="mail.DiscussActions.groupSeparator">
+<t t-name="mail.ActionList.groupSeparator">
     <span t-if="props.inline" class="text-muted align-self-stretch" t-att-class="{ 'ms-2 me-1': env.inDiscussApp }"/>
     <hr t-else="" class="mx-2 my-1 o-rounded-bubble"/>
 </t>
 
-<t t-name="mail.DiscussActions.action">
+<t t-name="mail.ActionList.action">
     <t t-if="action.dropdown">
         <Dropdown menuClass="(action.dropdown.menuClass || ' ') + ' o-discuss-dropdownMenu'">
-            <t t-call="mail.DiscussActions.actionMain"/>
+            <t t-call="mail.ActionList.actionMain"/>
             <t t-set-slot="content">
                 <t t-call="{{ action.dropdown.template }}">
                     <t t-set="templateParams" t-value="action.dropdown.templateParams?.(this)"/>
@@ -52,10 +52,10 @@
             </t>
         </Dropdown>
     </t>
-    <t t-else="" t-call="mail.DiscussActions.actionMain"/>
+    <t t-else="" t-call="mail.ActionList.actionMain"/>
 </t>
 
-<t t-name="mail.DiscussActions.actionMain">
+<t t-name="mail.ActionList.actionMain">
     <t t-set="btnClass" t-value="Object.entries({
         'btn btn-secondary m-0 btn-group-item': true,
         'o-first': action_first,
@@ -77,19 +77,19 @@
     }).filter(([_, val]) => val).map(([key, _]) => key).join(' ')"/>
     <t t-set="attrs" t-value="{ 'disabled': action.disabledCondition, 'title': action.name, 'name': action.id }"/>
     <DropdownItem t-if="props.dropdown" class="btnClass + ' d-flex align-items-center gap-1'" tag="'button'" onSelected="(ev) => action.onSelected(ev)">        
-        <t t-call="mail.DiscussActions.actionContent"/>
+        <t t-call="mail.ActionList.actionContent"/>
     </DropdownItem>
     <button t-else="" t-att-class="btnClass" t-att="attrs" t-on-click="(ev) => action.onSelected(ev)">
-        <t t-call="mail.DiscussActions.actionContent"/>
+        <t t-call="mail.ActionList.actionContent"/>
     </button>
 </t>
 
-<t t-name="mail.DiscussActions.actionContent">
+<t t-name="mail.ActionList.actionContent">
     <t t-if="action.icon?.template" t-call="{{ action.icon.template }}">
         <t t-set="templateParams" t-value="action.icon.params"/>
     </t>
     <i t-elif="props.inline and action.iconLarge" t-attf-class="{{ action.iconLarge }}" class="fa-fw"/><i t-elif="action.icon" t-attf-class="{{ action.icon }}" t-att-class="{ 'o-fs-small': props.dropdown }" class="fa-fw"/><span t-elif="action.name" t-esc="action.name"/>
-    <span t-if="!props.inline" class="o-mail-DiscussActions-actionLabel fw-bold mx-1" t-attf-class="{{ action.nameClass }}" t-out="action.name"/>
+    <span t-if="!props.inline" class="o-mail-ActionList-actionLabel fw-bold mx-1" t-attf-class="{{ action.nameClass }}" t-out="action.name"/>
 </t>
 
 </templates>

--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -1,5 +1,5 @@
 import { ChatWindow } from "@mail/core/common/chat_window";
-import { DiscussActions } from "./discuss_actions";
+import { ActionList } from "./action_list";
 import { useHover, useMovable } from "@mail/utils/common/hooks";
 import { Component, useEffect, useExternalListener, useRef, useState } from "@odoo/owl";
 
@@ -13,7 +13,7 @@ import { isMobileOS } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 
 export class ChatHub extends Component {
-    static components = { ChatBubble, ChatWindow, DiscussActions, Dropdown };
+    static components = { ActionList, ChatBubble, ChatWindow, Dropdown };
     static props = [];
     static template = "mail.ChatHub";
 

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -13,7 +13,7 @@
                 <Dropdown t-if="(chatHub.showConversations and !chatHub.compact) or position.dragged" state="options" position="'top-end'" menuClass="'d-flex flex-column o-discuss-dropdownMenu m-0 mb-1 border-secondary'">
                     <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn bg-100 mt-1 fs-3" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !position.dragged and !options.isOpen and !isMobileOS, 'o-bubblesHover': (bubblesHover.isHover or position.dragged) and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"><i class="oi oi-ellipsis-h"/></button>
                     <t t-set-slot="content">
-                        <DiscussActions dropdown="true" group="[optionActions]"/>
+                        <ActionList dropdown="true" group="[optionActions]"/>
                     </t>
                 </Dropdown>
                 <t t-if="store.chatHub.compact" t-call="mail.ChatHub.compactButton"/>

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -1,5 +1,5 @@
+import { ActionList } from "@mail/core/common/action_list";
 import { Composer } from "@mail/core/common/composer";
-import { DiscussActions } from "@mail/core/common/discuss_actions";
 import { ImStatus } from "@mail/core/common/im_status";
 import { Thread } from "@mail/core/common/thread";
 import { AutoresizeInput } from "@mail/core/common/autoresize_input";
@@ -27,8 +27,8 @@ import { isMobileOS } from "@web/core/browser/feature_detection";
  */
 export class ChatWindow extends Component {
     static components = {
+        ActionList,
         CountryFlag,
-        DiscussActions,
         Dropdown,
         Thread,
         Composer,

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -25,7 +25,7 @@
                         </button>
                         <t t-set-slot="content">
                             <t t-set="quickActionsInDropdown" t-value="partitionedActions.quick.slice(ui.isSmall ? 2 : 4)"/>
-                            <DiscussActions dropdown="true" quick="quickActionsInDropdown" group="partitionedActions.group" other="partitionedActions.other" thread="thread"/>
+                            <ActionList dropdown="true" quick="quickActionsInDropdown" group="partitionedActions.group" other="partitionedActions.other" thread="thread"/>
                         </t>
                     </Dropdown>
                 </div>
@@ -47,7 +47,7 @@
             </div>
             <div class="ms-1 flex-grow-1"/>
             <div class="d-flex flex-shrink-0 o-me-1_5">
-                <DiscussActions inline="true" quick="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 4).reverse()" thread="thread"/>
+                <ActionList inline="true" quick="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 4).reverse()" thread="thread"/>
             </div>
             <t t-if="this.store.inPublicPage and !this.store.self_partner">
                 <button class="btn ps-1" t-if="!state.editingGuestName">

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -36,7 +36,7 @@ import { isDisplayStandalone, isIOS, isMobileOS } from "@web/core/browser/featur
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useComposerActions } from "./composer_actions";
-import { DiscussActions } from "./discuss_actions";
+import { ActionList } from "./action_list";
 
 const EDIT_CLICK_TYPE = {
     CANCEL: "cancel",
@@ -58,8 +58,8 @@ const EDIT_CLICK_TYPE = {
  */
 export class Composer extends Component {
     static components = {
+        ActionList,
         AttachmentList,
-        DiscussActions,
         Dropdown,
         DropdownItem,
         FileUploader,

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -55,7 +55,7 @@
                         <Dropdown t-if="partitionedActions.other.length > 0" position="'top-start'" menuClass="'d-flex flex-column o-discuss-dropdownMenu border-secondary'">
                             <t t-call="mail.Composer.moreActions"/>
                             <t t-set-slot="content">
-                                <DiscussActions dropdown="true" group="[partitionedActions.other]"/>
+                                <ActionList dropdown="true" group="[partitionedActions.other]"/>
                             </t>
                         </Dropdown>
                     </div>

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -144,20 +144,8 @@ class ComposerActionDefinition extends DiscussActionDefinition {
             : this.explicitDefinition.btnClass;
     }
 
-    get component() {
-        return this.explicitDefinition.component;
-    }
-
-    get componentProps() {
-        return this.explicitDefinition.componentProps?.(this._component, this);
-    }
-
     get condition() {
         return composerActionsInternal.condition(this._component, this.id, this.explicitDefinition);
-    }
-
-    get disabledCondition() {
-        return this.explicitDefinition.disabledCondition?.(this._component);
     }
 
     get hotkey() {
@@ -166,24 +154,8 @@ class ComposerActionDefinition extends DiscussActionDefinition {
             : this.explicitDefinition.hotkey;
     }
 
-    get icon() {
-        return typeof this.explicitDefinition.icon === "function"
-            ? this.explicitDefinition.icon(this._component)
-            : this.explicitDefinition.icon;
-    }
-
     get isPicker() {
         return this.explicitDefinition.isPicker;
-    }
-
-    get name() {
-        return typeof this.explicitDefinition.name === "function"
-            ? this.explicitDefinition.name(this._component)
-            : this.explicitDefinition.name;
-    }
-
-    onSelected(ev) {
-        this.explicitDefinition.onSelected?.(this._component, this, ev);
     }
 
     get pickerName() {

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -4,7 +4,7 @@ import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { markEventHandled } from "@web/core/utils/misc";
-import { DiscussActionDefinition } from "./discuss_actions_definition";
+import { Action } from "./action";
 
 export const composerActionsRegistry = registry.category("mail.composer/actions");
 
@@ -137,7 +137,7 @@ composerActionsRegistry
         sequence: 5,
     });
 
-class ComposerActionDefinition extends DiscussActionDefinition {
+class ComposerAction extends Action {
     get btnClass() {
         return typeof this.explicitDefinition.btnClass === "function"
             ? this.explicitDefinition.btnClass(this._component)
@@ -146,12 +146,6 @@ class ComposerActionDefinition extends DiscussActionDefinition {
 
     get condition() {
         return composerActionsInternal.condition(this._component, this.id, this.explicitDefinition);
-    }
-
-    get hotkey() {
-        return typeof this.explicitDefinition.hotkey === "function"
-            ? this.explicitDefinition.hotkey(this._component)
-            : this.explicitDefinition.hotkey;
     }
 
     get isPicker() {
@@ -192,7 +186,7 @@ export function useComposerActions() {
     const component = useComponent();
     const transformedActions = composerActionsRegistry
         .getEntries()
-        .map(([id, action]) => new ComposerActionDefinition(component, id, action));
+        .map(([id, action]) => new ComposerAction(component, id, action));
     for (const action of transformedActions) {
         if (action.setup) {
             action.setup(action);

--- a/addons/mail/static/src/core/common/discuss_actions.dark.scss
+++ b/addons/mail/static/src/core/common/discuss_actions.dark.scss
@@ -1,9 +1,0 @@
-.o-mail-DiscussActions {
-    --mail-DiscussActions-activeItemColor: #{white};
-    --mail-DiscussActions-activeItemBgColor: #{rgba(mix($gray-300, $gray-400), .75)};
-    --mail-DiscussSidebarChannelActions-activeColor: #{white};
-    --mail-DiscussActions-dangerBgColor: #{rgba(saturate($danger, 20%), .5)};
-    --mail-DiscussActions-successBgColor: #{rgba(saturate($success, 20%), .5)};
-    --mail-DiscussActions-buttonInlineIconOpacity: #{85%};
-    --mail-DiscussActions-dangerColor: #{lighten($danger, 5%)};
-}

--- a/addons/mail/static/src/core/common/discuss_actions.xml
+++ b/addons/mail/static/src/core/common/discuss_actions.xml
@@ -88,7 +88,7 @@
     <t t-if="action.icon?.template" t-call="{{ action.icon.template }}">
         <t t-set="templateParams" t-value="action.icon.params"/>
     </t>
-    <i t-elif="props.inline and action.iconLarge" t-attf-class="{{ action.iconLarge }}" class="fa-fw"/><i t-elif="action.icon" t-attf-class="{{ action.icon }}" t-att-class="{ 'o-fs-small': props.dropdown }" class="fa-fw"/> <span t-if="action.text" t-esc="action.text"/>
+    <i t-elif="props.inline and action.iconLarge" t-attf-class="{{ action.iconLarge }}" class="fa-fw"/><i t-elif="action.icon" t-attf-class="{{ action.icon }}" t-att-class="{ 'o-fs-small': props.dropdown }" class="fa-fw"/><span t-elif="action.name" t-esc="action.name"/>
     <span t-if="!props.inline" class="o-mail-DiscussActions-actionLabel fw-bold mx-1" t-attf-class="{{ action.nameClass }}" t-out="action.name"/>
 </t>
 

--- a/addons/mail/static/src/core/common/discuss_actions_definition.js
+++ b/addons/mail/static/src/core/common/discuss_actions_definition.js
@@ -1,24 +1,40 @@
-export function transformDiscussAction(component, id, action) {
-    return {
-        /** If set, this is considered as a danger (destructive) action. */
-        get danger() {
-            return typeof action.danger === "function" ? action.danger(component) : action.danger;
-        },
-        /** Unique id of this action. */
-        id,
-        /** Determines the order of this action (smaller first). */
-        get sequence() {
-            return typeof action.sequence === "function"
-                ? action.sequence(component)
-                : action.sequence;
-        },
-        /** Component setup to execute when this action is registered. */
-        setup: action.setup,
-        /** If set, this is considered as a success (high-commitment positive) action. */
-        get success() {
-            return typeof action.success === "function"
-                ? action.success(component)
-                : action.success;
-        },
-    };
+export class DiscussActionDefinition {
+    /** User-defined explicit definition of this action */
+    explicitDefinition;
+    /** Component in which the action is being used */
+    _component;
+    /** Unique id of this action. */
+    id;
+
+    constructor(component, id, explicitDefinition) {
+        this.explicitDefinition = explicitDefinition;
+        this.id = id;
+        this._component = component;
+    }
+
+    /** If set, this is considered as a danger (destructive) action. */
+    get danger() {
+        return typeof this.explicitDefinition.danger === "function"
+            ? this.explicitDefinition.danger(this._component)
+            : this.explicitDefinition.danger;
+    }
+
+    /** Determines the order of this action (smaller first). */
+    get sequence() {
+        return typeof this.explicitDefinition.sequence === "function"
+            ? this.explicitDefinition.sequence(this._component)
+            : this.explicitDefinition.sequence;
+    }
+
+    /** Component setup to execute when this action is registered. */
+    setup(...args) {
+        return this.explicitDefinition.setup?.(...args);
+    }
+
+    /** If set, this is considered as a success (high-commitment positive) action. */
+    get success() {
+        return typeof this.explicitDefinition.success === "function"
+            ? this.explicitDefinition.success(this._component)
+            : this.explicitDefinition.success;
+    }
 }

--- a/addons/mail/static/src/core/common/discuss_actions_definition.js
+++ b/addons/mail/static/src/core/common/discuss_actions_definition.js
@@ -1,0 +1,24 @@
+export function transformDiscussAction(component, id, action) {
+    return {
+        /** If set, this is considered as a danger (destructive) action. */
+        get danger() {
+            return typeof action.danger === "function" ? action.danger(component) : action.danger;
+        },
+        /** Unique id of this action. */
+        id,
+        /** Determines the order of this action (smaller first). */
+        get sequence() {
+            return typeof action.sequence === "function"
+                ? action.sequence(component)
+                : action.sequence;
+        },
+        /** Component setup to execute when this action is registered. */
+        setup: action.setup,
+        /** If set, this is considered as a success (high-commitment positive) action. */
+        get success() {
+            return typeof action.success === "function"
+                ? action.success(component)
+                : action.success;
+        },
+    };
+}

--- a/addons/mail/static/src/core/common/discuss_actions_definition.js
+++ b/addons/mail/static/src/core/common/discuss_actions_definition.js
@@ -12,11 +12,67 @@ export class DiscussActionDefinition {
         this._component = component;
     }
 
+    /** Optional component that should be displayed in the view when this action is active. */
+    get component() {
+        return this.explicitDefinition.component;
+    }
+
+    /** Props to pass to the component of this action. */
+    get componentProps() {
+        return this.explicitDefinition.componentProps?.(this._component, this);
+    }
+
     /** If set, this is considered as a danger (destructive) action. */
     get danger() {
         return typeof this.explicitDefinition.danger === "function"
             ? this.explicitDefinition.danger(this._component)
             : this.explicitDefinition.danger;
+    }
+
+    /** Condition to disable the button of this action (but still display it). */
+    get disabledCondition() {
+        return this.explicitDefinition.disabledCondition?.(this._component);
+    }
+
+    /** Determines whether this action opens a dropdown on selection. Value is shaped { template, menuClass } */
+    get dropdown() {
+        return this.explicitDefinition.dropdown;
+    }
+
+    /**
+     * Icon for the button this action.
+     * - When a string, this is considered an icon as classname (.fa and .oi).
+     * - When an object with property `template`, this is an icon rendered in template.
+     *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
+     */
+    get icon() {
+        return typeof this.explicitDefinition.icon === "function"
+            ? this.explicitDefinition.icon(this._component)
+            : this.explicitDefinition.icon;
+    }
+
+    /**
+     * Large icon for the button this action.
+     * - When a string, this is considered an icon as classname (.fa and .oi).
+     * - When an object with property `template`, this is an icon rendered in template.
+     *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
+     */
+    get iconLarge() {
+        return typeof this.explicitDefinition.iconLarge === "function"
+            ? this.explicitDefinition.iconLarge(this._component)
+            : this.explicitDefinition.iconLarge ?? this.explicitDefinition.icon;
+    }
+
+    /** Name of this action, displayed to the user. */
+    get name() {
+        return typeof this.explicitDefinition.name === "function"
+            ? this.explicitDefinition.name(this._component)
+            : this.explicitDefinition.name;
+    }
+
+    /** Action to execute when this action is selected */
+    onSelected(ev) {
+        return this.explicitDefinition.onSelected?.(this._component, this, ev);
     }
 
     /** Determines the order of this action (smaller first). */

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -40,7 +40,7 @@ import { rpc } from "@web/core/network/rpc";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { NotificationMessage } from "./notification_message";
 import { useLongPress } from "@mail/utils/common/hooks";
-import { DiscussActions } from "./discuss_actions";
+import { ActionList } from "./action_list";
 
 /**
  * @typedef {Object} Props
@@ -60,10 +60,10 @@ export class Message extends Component {
     static SHADOW_HIGHLIGHT_COLOR = "#e99d00bf";
     static SHADOW_LINK_HOVER_COLOR = "#564b79";
     static components = {
+        ActionList,
         ActionSwiper,
         AttachmentList,
         Composer,
-        DiscussActions,
         Dropdown,
         ImStatus,
         MessageInReply,

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -184,7 +184,7 @@
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }"/>
-                    <button t-else="" class="o-mail-Message-actionsBtn btn border-0 p-0 rounded-0" t-att-title="action.name" t-att-name="action.id" t-on-click.stop="action.onSelected" t-att-class="{
+                    <button t-else="" class="o-mail-Message-actionsBtn btn border-0 p-0 rounded-0" t-att-title="action.name" t-att-name="action.id" t-on-click.stop="(ev) => action.onSelected(ev)" t-att-class="{
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }">

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -169,7 +169,7 @@
             <Dropdown state="optionsDropdown" menuClass="'o-discuss-dropdownMenu'">
                 <button class="d-none"/>
                 <t t-set-slot="content">
-                    <DiscussActions dropdown="true" group="[messageActions.actions]"/>
+                    <ActionList dropdown="true" group="[messageActions.actions]"/>
                 </t>
             </Dropdown>
         </t>
@@ -195,7 +195,7 @@
                     <Dropdown state="optionsDropdown" position="props.message.threadAsNewest  ? 'top-start' : 'bottom-start'" menuClass="'d-flex flex-column o-mail-Message-moreMenu o-discuss-dropdownMenu border-secondary'" >
                         <t t-call="mail.Message.expandAction"/>
                         <t t-set-slot="content">
-                            <DiscussActions dropdown="true" group="[messageActions.actions.slice(quickActionCount - 1)]"/>
+                            <ActionList dropdown="true" group="[messageActions.actions.slice(quickActionCount - 1)]"/>
                         </t>
                     </Dropdown>
                 </div>

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -180,7 +180,7 @@
                 <t t-foreach="quickActions" t-as="action" t-key="action.id">
                     <t t-set="isStart" t-value="(!isReverse and action.isFirst) or (isReverse and action.isLast)"/>
                     <t t-set="isEnd" t-value="(!isReverse and action.isLast) or (isReverse and action.isFirst)"/>
-                    <t t-if="action.component" t-component="action.component" t-props="action.props" classNames="{
+                    <t t-if="action.component" t-component="action.component" t-props="action.componentProps" classNames="{
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }"/>

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -18,7 +18,7 @@ export const messageActionsRegistry = registry.category("mail.message/actions");
 messageActionsRegistry
     .add("reaction", {
         component: QuickReactionMenu,
-        props: (component) => ({
+        componentProps: (component) => ({
             message: component.props.message,
             action: messageActionsRegistry.get("reaction"),
             messageActive: component.isActive,
@@ -88,7 +88,6 @@ messageActionsRegistry
         onSelected: (component) => component.openReactionMenu(),
         sequence: 50,
         mobileCloseAfterClick: false,
-        dropdown: true,
     })
     .add("unfollow", {
         condition: (component) => component.props.message.canUnfollow(component.props.thread),
@@ -178,10 +177,6 @@ messageActionsRegistry
     });
 
 class MessageActionDefinition extends DiscussActionDefinition {
-    get component() {
-        return this.explicitDefinition.component;
-    }
-
     get mobileCloseAfterClick() {
         return this.explicitDefinition.mobileCloseAfterClick ?? true;
     }
@@ -189,30 +184,6 @@ class MessageActionDefinition extends DiscussActionDefinition {
     /** Condition to display this action. */
     get condition() {
         return messageActionsInternal.condition(this._component, this.id, this.explicitDefinition);
-    }
-
-    /** Icon for the button this action. */
-    get icon() {
-        return typeof this.explicitDefinition.icon === "function"
-            ? this.explicitDefinition.icon(this._component)
-            : this.explicitDefinition.icon;
-    }
-
-    /** Name of this action, displayed to the user. */
-    get name() {
-        const res =
-            this.isActive && this.explicitDefinition.nameActive
-                ? this.explicitDefinition.nameActive
-                : this.explicitDefinition.name;
-        return typeof res === "function" ? res(this._component) : res;
-    }
-
-    get props() {
-        return this.explicitDefinition.props(this._component);
-    }
-
-    onSelected(ev) {
-        return this.explicitDefinition.onSelected?.(this._component, this, ev);
     }
 }
 

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -9,7 +9,7 @@ import { Deferred } from "@web/core/utils/concurrency";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
 import { isMobileOS } from "@web/core/browser/feature_detection";
-import { DiscussActionDefinition } from "./discuss_actions_definition";
+import { Action } from "./action";
 
 const { DateTime } = luxon;
 
@@ -176,7 +176,7 @@ messageActionsRegistry
         sequence: 110,
     });
 
-class MessageActionDefinition extends DiscussActionDefinition {
+class MessageAction extends Action {
     get mobileCloseAfterClick() {
         return this.explicitDefinition.mobileCloseAfterClick ?? true;
     }
@@ -200,7 +200,7 @@ export function useMessageActions() {
     const component = useComponent();
     const transformedActions = messageActionsRegistry
         .getEntries()
-        .map(([id, action]) => new MessageActionDefinition(component, id, action));
+        .map(([id, action]) => new MessageAction(component, id, action));
     for (const action of transformedActions) {
         if (action.setup) {
             action.setup(action);

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { SearchMessagesPanel } from "@mail/core/common/search_messages_panel";
 import { markEventHandled } from "@web/core/utils/misc";
-import { DiscussActionDefinition } from "./discuss_actions_definition";
+import { Action } from "./action";
 
 export const threadActionsRegistry = registry.category("mail.thread/actions");
 
@@ -87,7 +87,7 @@ threadActionsRegistry
         toggle: true,
     });
 
-class ThreadActionDefinition extends DiscussActionDefinition {
+class ThreadAction extends Action {
     /** Determines whether this is a popover linked to this action. */
     popover = null;
 
@@ -261,7 +261,7 @@ export function useThreadActions() {
     const component = useComponent();
     const transformedActions = threadActionsRegistry
         .getEntries()
-        .map(([id, action]) => new ThreadActionDefinition(component, id, action));
+        .map(([id, action]) => new ThreadAction(component, id, action));
     for (const action of transformedActions) {
         if (action.setup) {
             action.setup(action);

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { SearchMessagesPanel } from "@mail/core/common/search_messages_panel";
 import { markEventHandled } from "@web/core/utils/misc";
-import { transformDiscussAction } from "./discuss_actions_definition";
+import { DiscussActionDefinition } from "./discuss_actions_definition";
 
 export const threadActionsRegistry = registry.category("mail.thread/actions");
 
@@ -87,156 +87,213 @@ threadActionsRegistry
         toggle: true,
     });
 
-function transformAction(component, id, action) {
-    return {
-        /** Closes this action. */
-        close() {
-            if (this.toggle) {
-                component.threadActions.activeAction = component.threadActions.actionStack.pop();
-            }
-            action.close?.(component, this);
-        },
-        /** Optional component that should be displayed in the view when this action is active. */
-        component: action.component,
-        /** Condition to display the component of this action. */
-        get componentCondition() {
-            return this.isActive && this.component && this.condition && !this.popover;
-        },
-        /** Props to pass to the component of this action. */
-        get componentProps() {
-            return action.componentProps?.(this, component);
-        },
-        /** Condition to display this action. */
-        get condition() {
-            return threadActionsInternal.condition(component, id, action);
-        },
-        /** Condition to disable the button of this action (but still display it). */
-        get disabledCondition() {
-            return action.disabledCondition?.(component);
-        },
-        /** Determines whether this action opens a dropdown on selection. Value is shaped { template, menuClass } */
-        dropdown: action.dropdown,
-        /**
-         * Icon for the button this action.
-         * - When a string, this is considered an icon as classname (.fa and .oi).
-         * - When an object with property `template`, this is an icon rendered in template.
-         *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
-         */
-        get icon() {
-            return typeof action.icon === "function" ? action.icon(component) : action.icon;
-        },
-        /**
-         * Large icon for the button this action.
-         * - When a string, this is considered an icon as classname (.fa and .oi).
-         * - When an object with property `template`, this is an icon rendered in template.
-         *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
-         */
-        get iconLarge() {
-            return typeof action.iconLarge === "function"
-                ? action.iconLarge(component)
-                : action.iconLarge ?? action.icon;
-        },
-        /** States whether this action is currently active. */
-        get isActive() {
-            return id === component.threadActions.activeAction?.id;
-        },
-        /** Name of this action, displayed to the user. */
-        get name() {
-            const res = this.isActive && action.nameActive ? action.nameActive : action.name;
-            return typeof res === "function" ? res(component) : res;
-        },
-        /** ClassName on name of this action */
-        get nameClass() {
-            return typeof action.nameClass === "function"
-                ? action.nameClass(component)
-                : action.nameClass;
-        },
-        /**
-         * Action to execute when this action is selected (on or off).
-         *
-         * @param {MouseEvent} [ev]
-         * @param {object} [param0]
-         * @param {boolean} [param0.keepPrevious] Whether the previous action
-         * should be kept so that closing the current action goes back
-         * to the previous one.
-         * */
-        onSelected(ev, { keepPrevious } = {}) {
-            if (ev) {
-                markEventHandled(ev, "DiscussAction.onSelected");
-            }
-            if (this.toggle && this.isActive) {
-                this.close();
-            } else {
-                this.open({ keepPrevious });
-            }
-        },
-        /**
-         * Opens this action.
-         *
-         * @param {object} [param0]
-         * @param {boolean} [param0.keepPrevious] Whether the previous action
-         * should be kept so that closing the current action goes back
-         * to the previous one.
-         * */
-        open({ keepPrevious } = {}) {
-            if (this.toggle) {
-                if (component.threadActions.activeAction) {
-                    if (keepPrevious) {
-                        component.threadActions.actionStack.push(
-                            component.threadActions.activeAction
-                        );
-                    } else {
-                        component.threadActions.activeAction.close();
-                    }
+class ThreadActionDefinition extends DiscussActionDefinition {
+    /** Determines whether this is a popover linked to this action. */
+    popover = null;
+
+    /** Closes this action. */
+    close() {
+        if (this.toggle) {
+            this._component.threadActions.activeAction =
+                this._component.threadActions.actionStack.pop();
+        }
+        this.explicitDefinition.close?.(this._component, this);
+    }
+
+    /** Optional component that should be displayed in the view when this action is active. */
+    get component() {
+        return this.explicitDefinition.component;
+    }
+
+    /** Condition to display the component of this action. */
+    get componentCondition() {
+        return this.isActive && this.component && this.condition && !this.popover;
+    }
+
+    /** Props to pass to the component of this action. */
+    get componentProps() {
+        return this.explicitDefinition.componentProps?.(this, this._component);
+    }
+
+    /** Condition to display this action. */
+    get condition() {
+        return threadActionsInternal.condition(this._component, this.id, this.explicitDefinition);
+    }
+
+    /** Condition to disable the button of this action (but still display it). */
+    get disabledCondition() {
+        return this.explicitDefinition.disabledCondition?.(this._component);
+    }
+
+    /** Determines whether this action opens a dropdown on selection. Value is shaped { template, menuClass } */
+    get dropdown() {
+        return this.explicitDefinition.dropdown;
+    }
+
+    /**
+     * Icon for the button this action.
+     * - When a string, this is considered an icon as classname (.fa and .oi).
+     * - When an object with property `template`, this is an icon rendered in template.
+     *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
+     */
+    get icon() {
+        return typeof this.explicitDefinition.icon === "function"
+            ? this.explicitDefinition.icon(this._component)
+            : this.explicitDefinition.icon;
+    }
+
+    /**
+     * Large icon for the button this action.
+     * - When a string, this is considered an icon as classname (.fa and .oi).
+     * - When an object with property `template`, this is an icon rendered in template.
+     *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
+     */
+    get iconLarge() {
+        return typeof this.explicitDefinition.iconLarge === "function"
+            ? this.explicitDefinition.iconLarge(this._component)
+            : this.explicitDefinition.iconLarge ?? this.explicitDefinition.icon;
+    }
+
+    /** States whether this action is currently active. */
+    get isActive() {
+        return this.id === this._component.threadActions.activeAction?.id;
+    }
+
+    /** Name of this action, displayed to the user. */
+    get name() {
+        const res =
+            this.isActive && this.explicitDefinition.nameActive
+                ? this.explicitDefinition.nameActive
+                : this.explicitDefinition.name;
+        return typeof res === "function" ? res(this._component) : res;
+    }
+
+    /** ClassName on name of this action */
+    get nameClass() {
+        return typeof this.explicitDefinition.nameClass === "function"
+            ? this.explicitDefinition.nameClass(this._component)
+            : this.explicitDefinition.nameClass;
+    }
+
+    /**
+     * Action to execute when this action is selected (on or off).
+     *
+     * @param {MouseEvent} [ev]
+     * @param {object} [param0]
+     * @param {boolean} [param0.keepPrevious] Whether the previous action
+     * should be kept so that closing the current action goes back
+     * to the previous one.
+     * */
+    onSelected(ev, { keepPrevious } = {}) {
+        if (ev) {
+            markEventHandled(ev, "DiscussAction.onSelected");
+        }
+        if (this.toggle && this.isActive) {
+            this.close();
+        } else {
+            this.open({ keepPrevious });
+        }
+    }
+
+    /**
+     * Opens this action.
+     *
+     * @param {object} [param0]
+     * @param {boolean} [param0.keepPrevious] Whether the previous action
+     * should be kept so that closing the current action goes back
+     * to the previous one.
+     * */
+    open({ keepPrevious } = {}) {
+        if (this.toggle) {
+            if (this._component.threadActions.activeAction) {
+                if (keepPrevious) {
+                    this._component.threadActions.actionStack.push(
+                        this._component.threadActions.activeAction
+                    );
+                } else {
+                    this._component.threadActions.activeAction.close();
                 }
-                component.threadActions.activeAction = this;
             }
-            action.open?.(component, this);
-        },
-        get panelOuterClass() {
-            return typeof action.panelOuterClass === "function"
-                ? action.panelOuterClass(component)
-                : action.panelOuterClass;
-        },
-        /**
-         * - In action definition: indicate whether the action is elligible as partition actions. @see useThreadActions::partition
-         * - While action is being used: indicate that the action is being used as a partitioned action.
-         */
-        get partition() {
-            if (action._partition) {
-                return action._partition;
-            }
-            return typeof action.partition === "function"
-                ? action.partition(component)
-                : action.partition ?? true;
-        },
-        set partition(partition) {
-            action._partition = partition;
-        },
-        /** Determines whether this is a popover linked to this action. */
-        popover: null,
-        get sequenceGroup() {
-            return typeof action.sequenceGroup === "function"
-                ? action.sequenceGroup(component)
-                : action.sequenceGroup;
-        },
-        get sequenceQuick() {
-            return typeof action.sequenceQuick === "function"
-                ? action.sequenceQuick(component)
-                : action.sequenceQuick;
-        },
-        /**
-         * - In action definition: indicate whether the action is elligible as sidebar actions. @see useThreadActions::sidebarActions
-         * - While action is being used: indicate that the action is being used as a sidebar action.
-         */
-        sidebar: action.sidebar ?? action.sidebarSequence ?? false,
-        sidebarSequence: action.sidebarSequence,
-        sidebarSequenceGroup: action.sidebarSequenceGroup,
-        /** Text for the button of this action */
-        text: action.text,
-        /** Determines whether this action is a one time effect or can be toggled (on or off). */
-        toggle: action.toggle,
-    };
+            this._component.threadActions.activeAction = this;
+        }
+        this.explicitDefinition.open?.(this._component, this);
+    }
+
+    get panelOuterClass() {
+        return typeof this.explicitDefinition.panelOuterClass === "function"
+            ? this.explicitDefinition.panelOuterClass(this._component)
+            : this.explicitDefinition.panelOuterClass;
+    }
+
+    /**
+     * - In action definition: indicate whether the action is elligible as partition actions. @see useThreadActions::partition
+     * - While action is being used: indicate that the action is being used as a partitioned action.
+     */
+    get partition() {
+        if (this.explicitDefinition._partition) {
+            return this.explicitDefinition._partition;
+        }
+        return typeof this.explicitDefinition.partition === "function"
+            ? this.explicitDefinition.partition(this._component)
+            : this.explicitDefinition.partition ?? true;
+    }
+
+    set partition(partition) {
+        this.explicitDefinition._partition = partition;
+    }
+
+    get sequenceGroup() {
+        return typeof this.explicitDefinition.sequenceGroup === "function"
+            ? this.explicitDefinition.sequenceGroup(this._component)
+            : this.explicitDefinition.sequenceGroup;
+    }
+
+    get sequenceQuick() {
+        return typeof this.explicitDefinition.sequenceQuick === "function"
+            ? this.explicitDefinition.sequenceQuick(this._component)
+            : this.explicitDefinition.sequenceQuick;
+    }
+
+    /**
+     * - In action definition: indicate whether the action is elligible as sidebar actions. @see useThreadActions::sidebarActions
+     * - While action is being used: indicate that the action is being used as a sidebar action.
+     */
+    get sidebar() {
+        return (
+            this._sidebar ??
+            this.explicitDefinition.sidebar ??
+            this.explicitDefinition.sidebarSequence ??
+            false
+        );
+    }
+
+    set sidebar(sidebar) {
+        this._sidebar = sidebar;
+    }
+
+    get sidebarSequence() {
+        return typeof this.explicitDefinition.sidebarSequence === "function"
+            ? this.explicitDefinition.sidebarSequence(this._component)
+            : this.explicitDefinition.sidebarSequence;
+    }
+
+    get sidebarSequenceGroup() {
+        return typeof this.explicitDefinition.sidebarSequenceGroup === "function"
+            ? this.explicitDefinition.sidebarSequenceGroup(this._component)
+            : this.explicitDefinition.sidebarSequenceGroup;
+    }
+
+    /** Text for the button of this action */
+    get text() {
+        return typeof this.explicitDefinition.text === "function"
+            ? this.explicitDefinition.text(this._component)
+            : this.explicitDefinition.text;
+    }
+
+    /** Determines whether this action is a one time effect or can be toggled (on or off). */
+    get toggle() {
+        return this.explicitDefinition.toggle;
+    }
 }
 
 export const threadActionsInternal = {
@@ -254,11 +311,9 @@ function makeContextualAction(action, ctx) {
 
 export function useThreadActions() {
     const component = useComponent();
-    const transformedActions = threadActionsRegistry.getEntries().map(([id, action]) => {
-        const act = transformAction(component, id, action);
-        Object.setPrototypeOf(act, transformDiscussAction(component, id, action));
-        return act;
-    });
+    const transformedActions = threadActionsRegistry
+        .getEntries()
+        .map(([id, action]) => new ThreadActionDefinition(component, id, action));
     for (const action of transformedActions) {
         if (action.setup) {
             action.setup(action);

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -100,19 +100,9 @@ class ThreadActionDefinition extends DiscussActionDefinition {
         this.explicitDefinition.close?.(this._component, this);
     }
 
-    /** Optional component that should be displayed in the view when this action is active. */
-    get component() {
-        return this.explicitDefinition.component;
-    }
-
     /** Condition to display the component of this action. */
     get componentCondition() {
         return this.isActive && this.component && this.condition && !this.popover;
-    }
-
-    /** Props to pass to the component of this action. */
-    get componentProps() {
-        return this.explicitDefinition.componentProps?.(this, this._component);
     }
 
     /** Condition to display this action. */
@@ -120,46 +110,12 @@ class ThreadActionDefinition extends DiscussActionDefinition {
         return threadActionsInternal.condition(this._component, this.id, this.explicitDefinition);
     }
 
-    /** Condition to disable the button of this action (but still display it). */
-    get disabledCondition() {
-        return this.explicitDefinition.disabledCondition?.(this._component);
-    }
-
-    /** Determines whether this action opens a dropdown on selection. Value is shaped { template, menuClass } */
-    get dropdown() {
-        return this.explicitDefinition.dropdown;
-    }
-
-    /**
-     * Icon for the button this action.
-     * - When a string, this is considered an icon as classname (.fa and .oi).
-     * - When an object with property `template`, this is an icon rendered in template.
-     *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
-     */
-    get icon() {
-        return typeof this.explicitDefinition.icon === "function"
-            ? this.explicitDefinition.icon(this._component)
-            : this.explicitDefinition.icon;
-    }
-
-    /**
-     * Large icon for the button this action.
-     * - When a string, this is considered an icon as classname (.fa and .oi).
-     * - When an object with property `template`, this is an icon rendered in template.
-     *   Template params are provided in `params` and passed to template as a `t-set="templateParams"`
-     */
-    get iconLarge() {
-        return typeof this.explicitDefinition.iconLarge === "function"
-            ? this.explicitDefinition.iconLarge(this._component)
-            : this.explicitDefinition.iconLarge ?? this.explicitDefinition.icon;
-    }
-
     /** States whether this action is currently active. */
     get isActive() {
         return this.id === this._component.threadActions.activeAction?.id;
     }
 
-    /** Name of this action, displayed to the user. */
+    /** @override **/
     get name() {
         const res =
             this.isActive && this.explicitDefinition.nameActive
@@ -176,8 +132,7 @@ class ThreadActionDefinition extends DiscussActionDefinition {
     }
 
     /**
-     * Action to execute when this action is selected (on or off).
-     *
+     * @override
      * @param {MouseEvent} [ev]
      * @param {object} [param0]
      * @param {boolean} [param0.keepPrevious] Whether the previous action
@@ -281,13 +236,6 @@ class ThreadActionDefinition extends DiscussActionDefinition {
         return typeof this.explicitDefinition.sidebarSequenceGroup === "function"
             ? this.explicitDefinition.sidebarSequenceGroup(this._component)
             : this.explicitDefinition.sidebarSequenceGroup;
-    }
-
-    /** Text for the button of this action */
-    get text() {
-        return typeof this.explicitDefinition.text === "function"
-            ? this.explicitDefinition.text(this._component)
-            : this.explicitDefinition.text;
     }
 
     /** Determines whether this action is a one time effect or can be toggled (on or off). */

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -1,7 +1,7 @@
 import { AutoresizeInput } from "@mail/core/common/autoresize_input";
 import { Composer } from "@mail/core/common/composer";
 import { CountryFlag } from "@mail/core/common/country_flag";
-import { DiscussActions } from "@mail/core/common/discuss_actions";
+import { ActionList } from "@mail/core/common/action_list";
 import { ImStatus } from "@mail/core/common/im_status";
 import { Thread } from "@mail/core/common/thread";
 import { useThreadActions } from "@mail/core/common/thread_actions";
@@ -19,9 +19,9 @@ import { MessagingMenu } from "@mail/core/public_web/messaging_menu";
 
 export class Discuss extends Component {
     static components = {
+        ActionList,
         AutoresizeInput,
         CountryFlag,
-        DiscussActions,
         DiscussSidebar,
         Thread,
         ThreadIcon,

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -47,7 +47,7 @@
                         </t>
                         <div class="ms-1 flex-grow-1"/>
                         <div class="pe-1">
-                            <DiscussActions inline="true" odooControlPanelSwitchStyle="true" quick="partitionedActions.quick" group="partitionedActions.group" other="partitionedActions.other" thread="thread"/>
+                            <ActionList inline="true" odooControlPanelSwitchStyle="true" quick="partitionedActions.quick" group="partitionedActions.group" other="partitionedActions.other" thread="thread"/>
                         </div>
                     </div>
                     <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.js
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.js
@@ -1,7 +1,7 @@
 import { useHover } from "@mail/utils/common/hooks";
 import { Component, onMounted, useSubEnv } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
-import { DiscussActions } from "../common/discuss_actions";
+import { ActionList } from "../common/action_list";
 
 import { registry } from "@web/core/registry";
 import { ResizablePanel } from "@web/core/resizable_panel/resizable_panel";
@@ -17,7 +17,7 @@ export const discussSidebarItemsRegistry = registry.category("mail.discuss_sideb
 export class DiscussSidebar extends Component {
     static template = "mail.DiscussSidebar";
     static props = {};
-    static components = { DiscussActions, Dropdown, ResizablePanel };
+    static components = { ActionList, Dropdown, ResizablePanel };
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/web/thread_actions.js
+++ b/addons/mail/static/src/core/web/thread_actions.js
@@ -16,7 +16,7 @@ threadActionsRegistry
             component.orm.silent.call("mail.message", "mark_all_as_read");
         },
         sequence: 1,
-        text: _t("Mark all read"),
+        name: _t("Mark all read"),
     })
     .add("unstar-all", {
         condition(component) {
@@ -33,5 +33,5 @@ threadActionsRegistry
             const component = useComponent();
             component.store = useService("mail.store");
         },
-        text: _t("Unstar all"),
+        name: _t("Unstar all"),
     });

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -59,7 +59,7 @@ threadActionsRegistry
     })
     .add("call-settings", {
         component: CallSettings,
-        componentProps(action) {
+        componentProps(component, action) {
             return { isCompact: true };
         },
         condition(component) {

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -98,7 +98,7 @@ threadActionsRegistry
             action.popover?.close();
         },
         component: ChannelInvitation,
-        componentProps(action) {
+        componentProps(component, action) {
             return { close: () => action.close() };
         },
         condition(component) {
@@ -159,7 +159,7 @@ threadActionsRegistry
                 (!component.props.chatWindow || component.props.chatWindow.isOpen)
             );
         },
-        componentProps(action, component) {
+        componentProps(component, action) {
             return {
                 openChannelInvitePanel({ keepPrevious } = {}) {
                     component.threadActions.actions

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.js
@@ -1,4 +1,4 @@
-import { DiscussActions } from "@mail/core/common/discuss_actions";
+import { ActionList } from "@mail/core/common/action_list";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 
 import { Component } from "@odoo/owl";
@@ -12,7 +12,7 @@ import { useService } from "@web/core/utils/hooks";
 export class DiscussSidebarChannelActions extends Component {
     static template = "mail.DiscussSidebarChannelActions";
     static props = ["thread"];
-    static components = { DiscussActions };
+    static components = { ActionList };
 
     setup() {
         this.store = useService("mail.store");

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarChannelActions">
-        <DiscussActions dropdown="true" group="threadActions.sidebarActions" thread="thread"/>
+        <ActionList dropdown="true" group="threadActions.sidebarActions" thread="thread"/>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_actions.js
@@ -15,7 +15,7 @@ threadActionsRegistry.add("show-threads", {
     iconLarge: "fa fa-fw fa-lg fa-comments-o",
     name: _t("Threads"),
     component: SubChannelList,
-    componentProps(action) {
+    componentProps(component, action) {
         return { close: () => action.close() };
     },
     setup(action) {


### PR DESCRIPTION
This PR changes internal code of discuss actions to share most of their features.
To do so, a new file `discuss_action_definition.js` is defined with shared internal code, and compatible actions (thread, message, composer) try to use most of the shared features.

The internal code of actions were written with plain functions and objects. State was managed by scope. These are simple primitive that worked fine in isolation, but with sharing code this is complex to do especially when sharing only a few lines of code. This PR rewrites internal code with class syntax, making it more flexible to define state and share style while allowing custom code on specific actions that are still too opinionated at the moment like thread actions with panels management.