### PR TITLE
[IMP] mail, mail_bot: clean ux of canned responses

### DIFF
--- a/addons/mail/models/mail_canned_response.py
+++ b/addons/mail/models/mail_canned_response.py
@@ -15,16 +15,19 @@ class MailCannedResponse(models.Model):
     source = fields.Char(
         "Shortcut", required=True, index="trigram",
         help="Canned response that will automatically be substituted with longer content in your messages."
-        " Type ':' followed by the name of your shortcut (e.g. :hello) to use in your messages.",
+        " Type '::' followed by the name of your shortcut (e.g. ::hello) to use in your messages.",
     )
     substitution = fields.Text(
         "Substitution",
         required=True,
         help="Content that will automatically replace the shortcut of your choosing. This content can still be adapted before sending your message.",
     )
-    description = fields.Char("Description")
     last_used = fields.Datetime("Last Used", help="Last time this canned_response was used")
-    group_ids = fields.Many2many("res.groups", string="Authorized Groups")
+    group_ids = fields.Many2many(
+        "res.groups",
+        string="Authorized Groups",
+        domain=lambda self: [("id", "in", self.env.user.all_group_ids.ids)],
+    )
     is_shared = fields.Boolean(
         string="Determines if the canned_response is currently shared with other users",
         compute="_compute_is_shared",

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -317,10 +317,11 @@
         </record>
 
         <record id="ir_rule_mail_canned_response_admin" model="ir.rule">
-            <field name="name">Canned response: admin can do all</field>
+            <field name="name">Canned response: admin has all access on shared canned response</field>
             <field name="model_id" ref="model_mail_canned_response"/>
             <field name="groups" eval="[Command.link(ref('group_mail_canned_response_admin'))]"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[('is_shared', '=', True)]</field>
+            <field name="perm_create" eval="False"/>
         </record>
 
         <!-- Internal user: rationale is that they read their own or the one belonging to

--- a/addons/mail/static/src/views/web/fields/shortcut_char_field/shortcut_char_field.js
+++ b/addons/mail/static/src/views/web/fields/shortcut_char_field/shortcut_char_field.js
@@ -1,0 +1,22 @@
+import { Component } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { CharField } from "@web/views/fields/char/char_field";
+
+export class ShortcutCharField extends Component {
+    static template = "mail.ShortcutCharField";
+    static components = { CharField };
+    static props = { ...CharField.props };
+
+    get charProps() {
+        return {
+            ...this.props,
+            placeholder: _t("e.g. hello"),
+        };
+    }
+}
+
+registry.category("fields").add("shortcut", {
+    component: ShortcutCharField,
+});

--- a/addons/mail/static/src/views/web/fields/shortcut_char_field/shortcut_char_field.xml
+++ b/addons/mail/static/src/views/web/fields/shortcut_char_field/shortcut_char_field.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="mail.ShortcutCharField">
+        <div class="d-flex align-items-center">
+            <span class="text-nowrap">::</span>
+            <CharField t-props="charProps"/>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/tests/mock_server/mock_models/mail_canned_response.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_canned_response.js
@@ -5,6 +5,28 @@ import { getKwArgs, makeKwArgs, models } from "@web/../tests/web_test_helpers";
 export class MailCannedResponse extends models.ServerModel {
     _name = "mail.canned.response";
 
+    _views = {
+        list: `
+            <list>
+                <field name="source" widget="shortcut"/>
+            </list>
+        `,
+        form: `
+            <form>
+                <field name="source" widget="shortcut"/>
+            </form>
+        `,
+        kanban: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <field name="source" widget="shortcut"/>
+                    </t>
+                </templates>
+            </kanban>
+        `,
+    };
+
     create() {
         const cannedReponseIds = super.create(...arguments);
         this._broadcast(cannedReponseIds);

--- a/addons/mail/static/tests/web/fields/shortcut_char_field.test.js
+++ b/addons/mail/static/tests/web/fields/shortcut_char_field.test.js
@@ -1,0 +1,43 @@
+import {
+    click,
+    contains,
+    defineMailModels,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { describe, test } from "@odoo/hoot";
+import { getService, switchView } from "@web/../tests/web_test_helpers";
+
+defineMailModels();
+describe.current.tags("desktop");
+
+test('shortcut widget displays the appropriate "::" icon across views', async () => {
+    const pyEnv = await startServer();
+    pyEnv["mail.canned.response"].create([{ source: "hello" }]);
+    await start();
+    await getService("action").doAction({
+        res_model: "mail.canned.response",
+        type: "ir.actions.act_window",
+        views: [
+            [false, "list"],
+            [false, "form"],
+            [false, "kanban"],
+        ],
+    });
+    const selector = `div[name='source']`;
+
+    await contains(`.o_control_panel_navigation .o_cp_switch_buttons`);
+    await contains(`.o_switch_view`, { count: 2 });
+
+    await contains(".o_list_view .o_content");
+    await contains(selector, { text: "::hello" });
+
+    await switchView("kanban");
+    await contains(".o_kanban_view .o_content");
+    await contains(selector, { text: "::hello" });
+
+    await click(".o_control_panel_main_buttons .o-kanban-button-new");
+    await contains(`.o_form_view .o_content`);
+    await contains(`${selector} input[type='text']`);
+    await contains(selector, { text: "::" });
+});

--- a/addons/mail/views/mail_canned_response_views.xml
+++ b/addons/mail/views/mail_canned_response_views.xml
@@ -9,8 +9,11 @@
                 <search string="Canned Responses Search">
                     <field name="source"/>
                     <field name="substitution"/>
-                    <filter string="My canned responses" name="filter_create_uid" domain="[('create_uid', '=', uid)]"/>
-                    <filter string="Shared canned responses" name="filter_is_shared" domain="[('is_shared', '=', True)]"/>
+                    <filter string="Private" name="filter_create_uid" domain="[('is_shared', '=', False)]"/>
+                    <filter string="Shared" name="filter_is_shared" domain="[('is_shared', '=', True)]"/>
+                    <group>
+                        <filter string="Authorized Groups" name="group_by_group_ids" context="{'group_by': 'group_ids'}"/>
+                    </group>
                 </search>
             </field>
         </record>
@@ -20,12 +23,11 @@
             <field name="model">mail.canned.response</field>
             <field name="arch" type="xml">
                 <list string="Canned responses" editable="bottom" default_order="is_shared" sample="1">
-                    <field name="source" readonly="not is_editable"/>
-                    <field name="substitution" readonly="not is_editable"/>
-                    <field name="description" readonly="not is_editable"/>
-                    <field name="create_uid" widget="many2one_avatar_user"/>
-                    <field name="group_ids" widget="many2many_tags" readonly="not is_editable"/>
-                    <field name="last_used" readonly="1"/>
+                    <field name="source" placeholder="e.g. hello" widget="shortcut" readonly="not is_editable"/>
+                    <field name="substitution" placeholder="e.g. Hello, how may I help you?" readonly="not is_editable"/>
+                    <field name="create_uid" widget="many2one_avatar_user" optional="hide"/>
+                    <field name="group_ids" widget="many2many_tags" readonly="not is_editable" optional="hide"/>
+                    <field name="last_used" readonly="1" optional="hide"/>
                     <field name="is_editable" column_invisible="True"/>
                     <field name="is_shared" column_invisible="True"/>
                 </list>
@@ -39,10 +41,8 @@
                 <form string="Canned response">
                     <sheet>
                         <group>
-                            <field name="source" readonly="not is_editable"/>
-                            <field name="substitution" readonly="not is_editable"/>
-                            <field name="description" readonly="not is_editable"/>
-                            <field name="create_uid" widget="many2one_avatar_user"/>
+                            <field name="source" widget="shortcut" readonly="not is_editable"/>
+                            <field name="substitution" placeholder="e.g. Hello, how may I help you?" readonly="not is_editable"/>
                             <field name="group_ids" widget="many2many_tags" readonly="not is_editable"/>
                             <field name="is_editable" invisible="True"/>
                         </group>
@@ -51,14 +51,36 @@
             </field>
         </record>
 
+        <record id="mail_canned_response_view_kanban" model="ir.ui.view">
+            <field name="name">mail.canned.response.kanban</field>
+            <field name="model">mail.canned.response</field>
+            <field name="arch" type="xml">
+                <kanban class="o_kanban_mobile" sample="1">
+                    <templates>
+                        <t t-name="card">
+                            <div class="oe_kanban_global_click p-2 d-flex flex-column gap-1">
+                                <div class="fw-bold fs-5">
+                                    <field name="source" widget="shortcut"/>
+                                </div>
+                                <div class="text-truncate" t-att-title="record.substitution.value">
+                                    <field name="substitution"/>
+                                </div>
+                                <div class="pt-1">
+                                    <field name="group_ids" widget="many2many_tags"/>
+                                </div>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>
+            </field>
+        </record>
+
         <record id="mail_canned_response_action" model="ir.actions.act_window">
             <field name="name">Canned Responses</field>
             <field name="res_model">mail.canned.response</field>
-            <field name="view_mode">list,form</field>
+            <field name="view_mode">list,form,kanban</field>
             <field name="search_view_id" ref="mail_canned_response_view_search"/>
-            <field name="context">{
-                'search_default_filter_create_uid': 1,
-            }</field>
+            <field name="context">{}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No canned response found. Let's create one!

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -16,7 +16,7 @@
     />
     <menuitem
         id="mail.menu_channel"
-        name="Channel"
+        name="Channels"
         parent="mail.menu_root_discuss"
         action="mail.discuss_channel_action"
         sequence="2"

--- a/addons/mail_bot/models/mail_bot.py
+++ b/addons/mail_bot/models/mail_bot.py
@@ -90,7 +90,6 @@ class MailBot(models.AbstractModel):
                 self.env["mail.canned.response"].create({
                     "source": source,
                     "substitution": _("Thanks for your feedback. Goodbye!"),
-                    "description": description,
                 })
                 self.env.user.odoobot_failed = False
                 self.env.user.odoobot_state = "onboarding_canned"
@@ -103,7 +102,6 @@ class MailBot(models.AbstractModel):
                 self.env["mail.canned.response"].search([
                     ("create_uid", "=", self.env.user.id),
                     ("source", "=", source),
-                    ("description", "=", description),
                 ]).unlink()
                 self.env.user.odoobot_failed = False
                 self.env.user.odoobot_state = "idle"


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Cleans the UX of Canned Responses

**Desired behaviour after PR is merged:**

- Renamed discuss menu item Channel to `Channels`.
- Renamed filters: My canned responses → `Private`, Shared canned responses → `Shared`.
- Added widget for source (shortcut) `::`
- Added a placeholder for shortcut and substitution fields
- Added a hover on substitution text in kanban view
- Added a group by filter on Authorized Groups.
- Added a kanban view for mobile.
- Removed the default ordering/filter.
- Modified admin access rules to hide private responses of other users.
- Users can only select groups they are part of when assigning authorized
groups to a canned response.
- Performed minor cleanup `:` -> `::`.

Related Upgrade PR: https://github.com/odoo/upgrade/pull/8165
Related Documentation PR: https://github.com/odoo/documentation/pull/14464

---
Before / After : 
<img width="180" height="127" alt="image" src="https://github.com/user-attachments/assets/45ef473a-852f-4472-8132-8139da481e0d" /> <img width="180" height="127" alt="image" src="https://github.com/user-attachments/assets/7ab7ac54-f992-473e-b4e5-730fe908fc26" />


task-[4967078](https://www.odoo.com/odoo/project/1519/tasks/4967078)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
