### PR TITLE
[IMP] project: improve project creation wizard design

### DIFF
--- a/addons/project/static/src/views/project_role_users_list/project_role_users_list.js
+++ b/addons/project/static/src/views/project_role_users_list/project_role_users_list.js
@@ -1,0 +1,14 @@
+import { Component } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { Many2ManyTagsAvatarUserField } from "@mail/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field";
+
+export class ProjectRoleUsersList extends Component {
+    static template = "ProjectRoleUsersList";
+    static props = standardFieldProps;
+    static components = { Many2ManyTagsAvatarUserField };
+}
+
+registry.category("fields").add("project_role_users_list", {
+    component: ProjectRoleUsersList,
+});

--- a/addons/project/static/src/views/project_role_users_list/project_role_users_list.xml
+++ b/addons/project/static/src/views/project_role_users_list/project_role_users_list.xml
@@ -1,0 +1,24 @@
+<template>
+    <t t-name="ProjectRoleUsersList">
+        <div class="o_project_role_users_list_container mt-4">
+            <div class="d-flex flex-column gap-3">
+                <t t-foreach="this.props.record.data.role_to_users_ids.records" t-as="item" t-key="item.data.role_id.id">
+                    <div class="row align-items-center mb-2">
+                        <span
+                            class="col-12 col-md-6 fw-bold text-truncate"
+                            t-att-title="item.data.role_id.display_name"
+                            t-esc="item.data.role_id.display_name"
+                        />
+                        <div class="col-12 col-md-6 o_field_widget o_field_many2many_tags d-flex">
+                            <Many2ManyTagsAvatarUserField
+                                name="'user_ids'"
+                                record="item"
+                                readonly="false"
+                            />
+                        </div>
+                    </div>
+                </t>
+            </div>
+        </div>
+    </t>
+</template>

--- a/addons/project/static/tests/tours/project_templates_tour.js
+++ b/addons/project/static/tests/tours/project_templates_tour.js
@@ -24,6 +24,27 @@ registry.category("web_tour.tours").add("project_templates_tour", {
             run: "edit New Project",
         },
         {
+            trigger: '.modal span[title="Developer"] + div .o-autocomplete--input',
+            run: 'click',
+        },
+        {
+            trigger: '.ui-autocomplete .o-autocomplete--dropdown-item:contains("Developer User")',
+            content: "set Mitchell Admin in Designer role",
+            run: 'click',
+        },
+        {
+            trigger: 'body:not(:has(.ui-autocomplete:visible))',
+        },
+        {
+            trigger: '.modal span[title="Designer"] + div .o-autocomplete--input',
+            run: 'click',
+        },
+        {
+            trigger: '.ui-autocomplete .o-autocomplete--dropdown-item:contains("Designer User")',
+            content: "set Marc Demo in Designer role",
+            run: 'click',
+        },
+        {
             trigger: 'button[name="create_project_from_template"]',
             run: "click",
         },

--- a/addons/project/tests/test_project_template_ui.py
+++ b/addons/project/tests/test_project_template_ui.py
@@ -6,14 +6,36 @@ class TestProjectTemplatesTour(HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        role_developer, role_designer = cls.env['project.role'].create([
+            {'name': 'Developer'},
+            {'name': 'Designer'},
+        ])
         cls.project_template = cls.env["project.project"].create({
             "name": "Project Template",
             "is_template": True,
         })
-        cls.task_inside_template = cls.env["project.task"].create({
+        cls.task_inside_template = cls.env["project.task"].create([{
             "name": "Task in Project Template",
             "project_id": cls.project_template.id,
-        })
+            'role_ids': [role_developer.id],
+        }, {
+            "name": "Task in Project Template1",
+            "project_id": cls.project_template.id,
+            'role_ids': [role_designer.id],
+        }, {
+            "name": "Task in Project Template2",
+            "project_id": cls.project_template.id,
+            'role_ids': [role_developer.id, role_designer.id],
+        }])
+        cls.user_developer, cls.user_designer = cls.env['res.users'].create([{
+            'login': 'user_developer',
+            'name': 'Developer User',
+            'group_ids': [(6, 0, [cls.env.ref('project.group_project_user').id])],
+        }, {
+            'login': 'user_designer',
+            'name': 'Designer User',
+            'group_ids': [(6, 0, [cls.env.ref('project.group_project_user').id])],
+        }])
 
     def test_project_templates_tour(self):
         user_admin = self.env.ref('base.user_admin')
@@ -21,3 +43,21 @@ class TestProjectTemplatesTour(HttpCase):
             'email': 'mitchell.admin@example.com',
         })
         self.start_tour("/odoo", "project_templates_tour", login="admin")
+
+        new_project = self.env["project.project"].search([('name', '=', 'New Project')])
+        tasks = new_project.task_ids
+        self.assertEqual(
+            tasks[0].user_ids,
+            self.user_developer,
+            "Task with only the Developer role should be assigned to the Developer User",
+        )
+        self.assertEqual(
+            tasks[1].user_ids,
+            self.user_designer,
+            "Task with only the Designer role should be assigned to the Designer User",
+        )
+        self.assertEqual(
+            tasks[2].user_ids,
+            self.user_developer | self.user_designer,
+            "Task with both roles should be assigned to both Developer and Designer Users",
+        )

--- a/addons/project/wizard/project_template_create_wizard.xml
+++ b/addons/project/wizard/project_template_create_wizard.xml
@@ -22,7 +22,7 @@
                         </div>
                     </group>
                 </group>
-                <field name="role_to_users_ids" invisible="not role_to_users_ids">
+                <field name="role_to_users_ids" invisible="not role_to_users_ids" widget="project_role_users_list">
                     <list create="0" delete="0" no_open="1" editable="bottom">
                         <field name="role_id" force_save="1" readonly="1" options="{'no_open': True}"/>
                         <field name="user_ids" widget="many2many_avatar_user" options="{'no_open': True, 'no_quick_create': True}"/>


### PR DESCRIPTION
Before this commit:
- All role/assignee mappings loaded immediately
- No option to add additional roles beyond template defaults

After this commit:
- Added "Add a line" functionality to include roles not present in template
- User is now able to add a new project role during project creation from a template

task-489121