### PR TITLE
[FIX] web: Make “New” button work consistently in Bank Reconciliation

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.js
@@ -110,6 +110,9 @@ export class KanbanQuickCreateController extends Component {
                     for (const selector of ACTION_SELECTORS) {
                         const closestEl = target.closest(selector);
                         if (closestEl) {
+                            if (closestEl.classList.contains('o-kanban-button-new')) {
+                                this.validate("add");
+                            }
                             force = true;
                             break;
                         }

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -11570,7 +11570,7 @@ test("quick create record and click outside (no dirty input)", async () => {
     await createKanbanRecord();
 
     expect.verifySteps(["create record"]);
-    expect(".o_kanban_quick_create").toHaveCount(0);
+    expect(".o_kanban_quick_create").toHaveCount(1);
 });
 
 test.tags("desktop");
@@ -11636,7 +11636,7 @@ test("quick create record and click outside (with dirty input)", async () => {
     await createKanbanRecord();
 
     expect.verifySteps(["create record"]);
-    expect(".o_kanban_quick_create").toHaveCount(0);
+    expect(".o_kanban_quick_create").toHaveCount(1);
 });
 
 test("quick create record and click on 'Load more'", async () => {


### PR DESCRIPTION
Issue:
- In the Bank Reconciliation view, clicking the “New” button for the first time opens the quick create dialog correctly.
- But if the dialog was already open, clicking “New” again did nothing.
- This makes the button effectless and literal dead button.

Fix:
- If the current record is valid, it gets saved and a fresh dialog opens for the next transaction.
- If not valid, it will notify the validation error.

Impact:
- Users can now click “New” repeatedly to add bank transaction records without having to close or reset the dialog manually.
- This behavior is now consistent across all Kanban quick create views.


TaskID-4974759
