### PR TITLE
[FIX] website: prevent adding class in view

### DIFF
--- a/addons/website_cf_turnstile/static/src/js/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/js/turnstile.js
@@ -72,11 +72,24 @@ export const turnStile = {
     },
 
     /**
+     * Remove spinner if any and enable the button.
+     */
+    cleanSpinner() {
+        const buttonEl = this.spinnerEl?.parentElement;
+        if (buttonEl) {
+            buttonEl.disabled = false;
+            buttonEl.classList.remove("disabled");
+            this.spinnerEl.remove();
+        }
+    },
+
+    /**
      * @override
      * Discard all library changes to reset the state of the Html.
      */
     destroy: function () {
         this.cleanTurnstile();
+        this.cleanSpinner();
         this._super(...arguments);
     },
 
@@ -114,20 +127,20 @@ export const turnStile = {
      * same as addSpinner but does not set innerText
      */
     addSpinnerNoMangle(button) {
-        const spinner = this._createSpinner();
-        spinner.classList.add("me-1");
+        this.spinnerEl = this._createSpinner();
+        this.spinnerEl.classList.add("me-1");
         button.disabled = true;
         button.classList.add("disabled");
-        button.prepend(spinner);
+        button.prepend(this.spinnerEl);
     },
 
     addSpinner(button) {
-        const spinner = this._createSpinner();
+        this.spinnerEl = this._createSpinner();
         // avoids double-spacing if the button already contains a space
         button.innerText = " " + button.innerText;
         button.disabled = true;
         button.classList.add("disabled");
-        button.prepend(spinner);
+        button.prepend(this.spinnerEl);
     },
 };
 


### PR DESCRIPTION
Steps to reproduce:
1. Install the `website_cf_turnstile` module.
2. Enter valid Cloudflare Turnstile credentials in the configuration.
3. Go to the Website Editor.
4. Add or edit a form (e.g. contact form) and save the page.
5. Notice that the form’s submit button temporarily shows a spinner and
   gets a 'disabled' class while Turnstile is initializing.
6. After saving the page, these temporary elements and classes
   (e.g. .turnstile-spinner and 'disabled') are incorrectly saved into
   the form’s HTML.
7. If you later remove or uninstall the website_cf_turnstile module,
   the submit button remains disabled and the spinner icon still
   appears, even though Turnstile is no longer active.

After this commit:
Now, when you save a website form in the editor, any temporary
classes or elements added by Cloudflare Turnstile are removed. This
prevents unwanted changes from being saved to forms.

task-4951470