### PR TITLE
[FIX] html_editor: fix image scaling issue with numeric width/height

### DIFF
--- a/addons/html_editor/static/src/utils/sanitize.js
+++ b/addons/html_editor/static/src/utils/sanitize.js
@@ -25,8 +25,8 @@ export function initElementForEdition(element, options = {}) {
         const height = img.getAttribute("height");
         img.removeAttribute("height");
         img.removeAttribute("width");
-        img.style.setProperty("width", width);
-        img.style.setProperty("height", height);
+        img.style.setProperty("width", isNaN(width) ? width : `${width}px`);
+        img.style.setProperty("height", isNaN(height) ? height : `${height}px`);
     }
 }
 

--- a/addons/html_editor/static/tests/editor.test.js
+++ b/addons/html_editor/static/tests/editor.test.js
@@ -148,3 +148,14 @@ test("Remove `width`, `height` attributes from image and apply them to style", a
         `<div class="o-paragraph"> <img src="#" style="width: 50%; height: 50%;"> </div>`
     );
 });
+
+test("Remove `width`, `height` attributes from image and apply them to style with default unit (px)", async () => {
+    const { el } = await setupEditor(`
+        <div>
+            <img src="#" width="50" height="50">
+        </div>
+    `);
+    expect(el.innerHTML.trim().replace(/\s+/g, " ")).toBe(
+        `<div class="o-paragraph"> <img src="#" style="width: 50px; height: 50px;"> </div>`
+    );
+});


### PR DESCRIPTION
Problem:
On the Courses page, the user rank badge image becomes much larger when entering edit mode.

Cause:
During HTML sanitization, `img.width` is removed and its value is moved to `img.style.width`. If `img.width` is a number (e.g., `100`), it is interpreted as `100px`. However, when assigned to `img.style.width` without a unit, the style is considered invalid, and the image defaults to its original size. The same applies to `img.height`.

Solution:
When transferring width or height to style, ensure a unit is added. If the original attribute is a plain number without a unit, default to `px`.

Steps to reproduce:
- Open Website > Courses
- Observe the user rank badge is appropriately sized
- Enter edit mode
> The badge image becomes much larger than expected

opw-4993038

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
