### PR TITLE
[FIX] mrp: create draft MO for MTSO when BOM has no components or operations

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -37,7 +37,9 @@ class StockRule(models.Model):
         super(StockRule, remaining)._compute_picking_type_code_domain()
 
     def _should_auto_confirm_procurement_mo(self, p):
-        return (not p.orderpoint_id and p.move_raw_ids) or (p.move_dest_ids.procure_method != 'make_to_order' and not p.move_raw_ids and not p.workorder_ids)
+        if not p.move_raw_ids:
+            return (not p.workorder_ids and (p.orderpoint_id or p.move_dest_ids.procure_method == 'make_to_stock'))
+        return not p.orderpoint_id
 
     @api.model
     def _run_manufacture(self, procurements):

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import timedelta
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.exceptions import UserError
@@ -352,6 +352,50 @@ class TestProcurement(TestMrpCommon):
 
         move_dest._action_assign()
         self.assertEqual(move_dest.quantity, 10.0)
+
+    def test_mtso_with_empty_bom(self):
+        """Test to ensure that a Manufacturing Order is created in 'draft' state
+        via MTSO route when BoM has no components or operations.
+        """
+        route_manufacture = self.warehouse_1.manufacture_pull_id.route_id
+        # Set up MTSO route.
+        route_mto = self.warehouse_1.mto_pull_id.route_id
+        route_mto.rule_ids.procure_method = "mts_else_mto"
+
+        # Create a product with a BoM that has no components or operations.
+        product = self.env['product.product'].create({
+            'name': 'Product',
+            'route_ids': [Command.link(route_manufacture.id), Command.link(route_mto.id)],
+        })
+        self.env['mrp.bom'].create({
+            'product_id': product.id,
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'product_qty': 1.0,
+        })
+
+        pg = self.env['procurement.group'].create({'name': 'Test-mtso'})
+        self.env['procurement.group'].run([
+            pg.Procurement(
+                product,
+                1.0,
+                product.uom_id,
+                self.warehouse_1.lot_stock_id,
+                'test_mtso',
+                'test_mtso',
+                self.warehouse_1.company_id,
+                {
+                    'warehouse_id': self.warehouse_1,
+                    'group_id': pg,
+                },
+            ),
+        ])
+
+        # Check that the MO is created and remains in 'draft' state.
+        production = self.env['mrp.production'].search([('product_id', '=', product.id)])
+        self.assertEqual(len(production), 1, "The manufacturing order was not automatically created.")
+        self.assertFalse(production.move_raw_ids)
+        self.assertFalse(production.workorder_ids)
+        self.assertEqual(production.state, "draft", "MO with empty BoM created via MTSO should remain in draft state.")
 
     def test_auto_assign(self):
         """ When auto reordering rule exists, check for when:


### PR DESCRIPTION
Issue Before This Commit:
============================
Currently, if a BOM has `no components or operations` and is triggered via `MTSO`, 
the generated Manufacturing Order (MO) is automatically set to a `confirmed` state. 
This behaviour is inconsistent and not meaningful, as there's nothing to produce or track.

Steps to Reproduce:
============================

- Install the `mrp and sale` module.
- Enable MTSO route.
- Create a product with a BOM that has `no components or operations`.
- Create a sale order for that product.  MO is created in a `confirmed` state.

With This Commit:
============================
This commit ensures that MOs triggered via `MTO(Already worked) or MTSO` are 
created in draft state if their BOM has no components and no operations.

This allows the user to manually add required details before confirming the MO.
supporting custom use cases.

TaskID:- 4920195
