### PR TITLE
[FIX] web: fix crash when `type_` is missing in `_view_info`

### DIFF
--- a/addons/web/models/ir_ui_view.py
+++ b/addons/web/models/ir_ui_view.py
@@ -16,7 +16,7 @@ class View(models.Model):
             }
             for (type_, display_name)
             in self.fields_get(['type'], ['selection'])['type']['selection']
-            if type_ != 'qweb'
+            if type_ != 'qweb' and type_ in _view_info
         }
 
     def _get_view_info(self):


### PR DESCRIPTION
Currently, an error occurs when the user tries to install multiple modules and, during
installation user tries to access any app.

This issue happens because line [1] tries to get view info by view name, like `hierarchy`.
Normally, we get the view information from the `_get_view_info`  method (see [2]), and we
override this method to add another view to the returned data (as in [3]).

But during installation, when the user tries to access any app, the view is already loaded into the
database. So when the `fields_get` method is called, the view is found. However, since the module
isn't fully loaded yet, the overridden `get_view_info` method hasn't taken effect. As a result, the
additional view we expect isn’t included, and accessing that view key causes an error.

This commit fixes the above error by ensuring that `_view_info` is accessed only when
`type_` is present in `_view_info` at [1].

[1]: https://github.com/odoo/odoo/blob/80976e3579db4862c16cafab2ec183a7a0d0b63c/addons/web/models/ir_ui_view.py#L14
[2]: https://github.com/odoo/odoo/blob/80976e3579db4862c16cafab2ec183a7a0d0b63c/addons/web/models/ir_ui_view.py#L22-L31
[3]: https://github.com/odoo/odoo/blob/80976e3579db4862c16cafab2ec183a7a0d0b63c/addons/web_hierarchy/models/ir_ui_view.py#L56-L57

sentry-5661154820

