### PR TITLE
[IMP] spreadsheet_dashboard: remember last opened dashboard when returning

### DIFF
--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -117,6 +117,35 @@ test("can switch spreadsheet", async () => {
     expect(spreadsheets[2]).not.toHaveClass("active");
 });
 
+test("Opens the first dashboard by default if localStorage key is missing", async () => {
+    await createSpreadsheetDashboard();
+
+    const dashboards = queryAll(".o_search_panel li");
+    expect(dashboards[0]).toHaveClass("active");
+    expect(dashboards[0].textContent.trim()).toBe("Dashboard CRM 1");
+});
+
+test("Restores the last opened dashboard from localStorage if key is present", async () => {
+    browser.localStorage.setItem("spreadsheet_dashboard.last_opened_dashboard_id", "3");
+    await createSpreadsheetDashboard();
+
+    const dashboards = queryAll(".o_search_panel li");
+    const active = Array.from(dashboards).find((el) => el.classList.contains("active"));
+    expect(active.textContent.trim()).toBe("Dashboard Accounting 1");
+});
+
+test("Selecting a dashboard updates localStorage with its ID", async () => {
+    await createSpreadsheetDashboard();
+
+    const dashboards = queryAll(".o_search_panel li");
+    await contains(dashboards[1]).click();
+
+    expect(dashboards[1]).toHaveClass("active");
+    expect(browser.localStorage.getItem("spreadsheet_dashboard.last_opened_dashboard_id")).toBe(
+        "2"
+    );
+});
+
 test("display no dashboard message", async () => {
     await createSpreadsheetDashboard({
         mockRPC: function (route, { model, method, args }) {


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The Dashboards view did not persist the user's last selected dashboard, causing a loss of context whenever users navigated away and returned. This required users to manually reselect their desired dashboard every time.

---

**Current behavior before PR:**

* Dashboard selection is not persistent; always opens the first dashboard.
* User context is lost on navigation.

---

**Desired behavior after PR is merged:**

* The user's last selected dashboard is automatically restored when reopening the Dashboards view.
* Context is preserved across navigation, improving usability.

---

**Task:** 4984594

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
