### PR TITLE
[REF] http: inline transactionning

### DIFF
--- a/addons/web/tests/test_assets.py
+++ b/addons/web/tests/test_assets.py
@@ -149,6 +149,7 @@ class TestWebAssetsCursors(HttpCase):
         """
         cursors = []
         original_cursor = self.env.registry.cursor
+
         def cursor(readonly=False):
             cursor = original_cursor(readonly=readonly)
             cursors.append(('ro' if cursor.readonly else 'rw', '(ro_requested)' if readonly else '(rw_requested)'))
@@ -158,9 +159,7 @@ class TestWebAssetsCursors(HttpCase):
             response = self.url_open(f'/web/assets/{self.bundle_version}/{self.bundle_name}.min.css', allow_redirects=False)
             self.assertEqual(response.status_code, 200)
 
-        # remove the check_signaling cursor
-        self.assertEqual(cursors[0][1], '(ro_requested)', "the first cursor used for match and check signaling should be ro")
-        return cursors[1:]
+        return cursors
 
     def test_web_binary_keep_cursor_ro(self):
         """


### PR DESCRIPTION
Use the same cursor for signaling as for the query.
See commit message.

Performance gain 0.1-0.5ms on my machine for each HTTP call that can use the same cursor.

Using #223318, this is what we have today and we can remove that second cursor request when *transactionning*.
<img width="294" height="534" alt="image" src="https://github.com/user-attachments/assets/847b7a84-74e7-4582-abd7-d91d89d9aff3" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
