### PR TITLE
[IMP] pos, pos_self_order: add availability section to product info popup

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -33,4 +33,7 @@ export class ProductInfoPopup extends Component {
             is_favorite: !this.props.productTemplate.is_favorite,
         });
     }
+    get showAvailabilitySection() {
+        return false;
+    }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -17,6 +17,8 @@
                 </h3>
                 <t t-out="props.productTemplate.productDescriptionMarkup" />
             </div>
+            <!-- meant to override -->
+            <div t-if="showAvailabilitySection" class="section-availability mt-3 mb-4 pb-4 border-bottom text-start d-flex flex-column gap-2" />
             <div class="section-inventory mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.info?.productInfo?.warehouses?.length > 0">
                 <h3 class="section-title">
                     Inventory

--- a/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.js
+++ b/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.js
@@ -7,4 +7,12 @@ patch(ProductInfoPopup.prototype, {
             self_order_available: !this.props.productTemplate.self_order_available,
         });
     },
+    get showSelfOrderAvailability() {
+        return (
+            this.pos.cashier._role !== "minimal" && this.pos.config.self_ordering_mode != "nothing"
+        );
+    },
+    get showAvailabilitySection() {
+        return super.showAvailabilitySection || this.showSelfOrderAvailability;
+    },
 });

--- a/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.xml
+++ b/addons/pos_self_order/static/src/overrides/components/product_info_popup/product_info_popup.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.ProductInfoPopup" t-inherit="point_of_sale.ProductInfoPopup" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('section-inventory')]" position="before">
-            <div t-if="this.pos.cashier._role !== 'minimal' and this.pos.config.self_ordering_mode != 'nothing'" class="section-self-order-availability mt-3 mb-4 pb-4 border-bottom text-start d-flex align-items-center">
+        <xpath expr="//div[hasclass('section-availability')]" position="inside">
+            <div t-if="this.showSelfOrderAvailability" class="text-start d-flex align-items-center">
                 <h3 class="section-title">Self-ordering:</h3>
-                <div class="section-self-order-availability-body d-flex ms-auto">
+                <div class="section-body d-flex ms-auto">
                     <div class="form-check form-switch">
-                            <input class="form-check-input" type="checkbox"
-                                t-att-checked="props.productTemplate.self_order_available"
-                                t-on-click="() => this.switchSelfAvailability()"/>
+                        <input class="form-check-input" type="checkbox" t-att-checked="props.productTemplate.self_order_available"
+                            t-on-click="() => this.switchSelfAvailability()"/>
                     </div>
                     <span>
                         <t t-if="props.productTemplate.self_order_available">Available</t>


### PR DESCRIPTION
- This commit introduces an Availability section in the product info popup within the Point of Sale.
- The section is designed to be extensible and can be overridden to support availability toggles for features like Self-Ordering and Food Delivery.

Task: 4951476

Related: https://github.com/odoo/enterprise/pull/91681