### PR TITLE
[FIX] website_event_booth_exhibitor: test_register tour

### DIFF
--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -18,33 +18,49 @@
         expectUnloadPage: true,
     }, {
         content: 'Wait for the first item to be properly selected before proceeding',
-        trigger: 'label.d-block:has(input:checked) h5[name=booth_category_name]',
+        trigger: 'label.d-block:has(input:checked) h5[name=booth_category_name]:contains(standard booth)',
     }, {
         content: 'Choose Premium Booths',
-        trigger: 'img[alt="Premium Booth"]',
+        trigger: 'label:has(img[alt="Premium Booth"])',
         run: "click",
-    }, {
-        content: 'Choose Booth',
-        trigger: ".o_wbooth_booths div:contains(OpenWood Demonstrator 2) input:not(:visible)",
-        run: "click",
-    }, {
-        content: "Validate attendees details",
-        trigger: 'button:enabled:contains("Book my Booth(s)")',
-        run: 'click',
-        expectUnloadPage: true,
-    }, {
-        content: "Fill booth details",
-        trigger: 'form[id="o_wbooth_contact_details_form"]',
-        run: function () {
-            document.querySelector("input[name='sponsor_name']").value = "Patrick Sponsor";
-            document.querySelector("input[name='sponsor_email']").value = "patrick.sponssor@test.example.com";
-            document.querySelector("input[name='sponsor_phone']").value = "+32456001122";
-            document.querySelector("input[name='sponsor_slogan']").value = "Patrick is Your Sponsor";
-            document.querySelector("textarea[name='sponsor_description']").textContent = "Really eager to meet you !";
-        },
+    },{
+        trigger:
+            "label.d-block:has(input:checked) h5[name=booth_category_name]:contains(premium booth)",
     },
     {
-        trigger: "input[name='sponsor_name'], input[name='sponsor_email'], input[name='sponsor_phone']",
+        content: 'Choose Booth',
+        trigger: ".o_wbooth_booths label:contains(OpenWood Demonstrator 2)",
+        run: "click",
+    },
+    {
+        content: "Validate attendees details",
+        trigger: 'button:contains("Book my Booth(s)")',
+        run: 'click',
+        expectUnloadPage: true,
+    },
+    {
+        content: "Fill booth details",
+        trigger: "form[id=o_wbooth_contact_details_form]",
+    },
+    {
+        trigger: "input[name=sponsor_name]",
+        run: "edit Patrick Sponsor",
+    },
+    {
+        trigger: "input[name=sponsor_email]",
+        run: "edit patrick.sponssor@test.example.com",
+    },
+    {
+        trigger: "input[name=sponsor_phone]",
+        run: "edit +32456001122",
+    },
+    {
+        trigger: "input[name=sponsor_slogan]",
+        run: "edit Patrick is Your Sponsor",
+    },
+    {
+        trigger: "textarea[name=sponsor_description]",
+        run: "edit Really eager to meet you !",
     },
     {
         content: "Validate booth details",

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor_steps.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor_steps.js
@@ -4,7 +4,7 @@ class FinalSteps {
 
     _getSteps() {
         return [{
-            trigger: 'h3:contains("Booth Registration completed!")',
+            trigger: 'h4:contains("Booth Registration completed!")',
         }];
     }
 


### PR DESCRIPTION
In this commit, we fix the tour webooth_exhibitor_register It stucks when click on OpenWood Demonstrator 2 because the trigger is not relevant. A user should never be able to click on an invisible input. So in tour, it's the same. Instead of click on div and then invisible input, click on label as you do when you run tour by hand. I'm taking advantage of this commit to remove trivial :enabled on button (implicit) and to change programmatic **run** to declarative **run** to use Hoot event and make them more readable.