### PR TITLE
[FIX] point_of_sale: fix hoot tests running offline

### DIFF
--- a/addons/point_of_sale/static/tests/unit/data_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/data_service.test.js
@@ -130,6 +130,7 @@ class ResPartner extends models.ServerModel {
     }
 }
 test("don't retry sending data to the server if the reason that caused the failure is not a network error", async () => {
+    onRpc("/pos/ping", () => {});
     defineModels({ PosSession, ResPartner });
     onRpc("pos.session", "filter_local_data", () => ({}));
     await makeMockEnv();


### PR DESCRIPTION
Ensure hoot tests are correctly running offline.

rb-error: 226900




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
