### PR TITLE
[FIX] l10n_id_efaktur_coretax: fixing coretax product code search in product template

### DIFF
--- a/addons/l10n_id_efaktur_coretax/models/product_code.py
+++ b/addons/l10n_id_efaktur_coretax/models/product_code.py
@@ -1,10 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.osv import expression
 
 class EfakturProductCode(models.Model):
     _name = "l10n_id_efaktur_coretax.product.code"
     _description = "Product categorization according to E-Faktur"
+    _rec_name = "code"
 
     code = fields.Char()
     description = fields.Text()
@@ -14,3 +16,22 @@ class EfakturProductCode(models.Model):
         for record in self:
             result.append((record.id, f"{record.code} - {record.description}"))
         return result
+    
+    @api.model
+    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+        args = args or []
+
+        # Try to reverse the `name_get` structure
+        parts = name.split(' - ')
+        if len(parts) == 2:
+            domain = [('code', operator, parts[0]), ('description', operator, parts[1])]
+            return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
+        
+        if name and operator == 'ilike':
+            domain = ['|',
+                ('code', operator, name),
+                ('description', operator, name),
+            ]
+            return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
+        
+        return super()._name_search(name=name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)

--- a/addons/l10n_id_efaktur_coretax/models/product_code.py
+++ b/addons/l10n_id_efaktur_coretax/models/product_code.py
@@ -16,7 +16,7 @@ class EfakturProductCode(models.Model):
         for record in self:
             result.append((record.id, f"{record.code} - {record.description}"))
         return result
-    
+
     @api.model
     def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
         args = args or []
@@ -26,12 +26,12 @@ class EfakturProductCode(models.Model):
         if len(parts) == 2:
             domain = [('code', operator, parts[0]), ('description', operator, parts[1])]
             return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-        
+
         if name and operator == 'ilike':
             domain = ['|',
                 ('code', operator, name),
                 ('description', operator, name),
             ]
             return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-        
+
         return super()._name_search(name=name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Because `l10n_id_efaktur_coretax.product.code` model does not have a `name` field and does not use` _rec_name`, search record in m2o field or searchview is difficult and not normal.

so this uses `_rec_name = "code"` for fixing in searchview, and overrides `_name_search()` to be able to search using field `code` or `description` or like `name_get()` string

Current behavior before PR:
<img width="821" height="353" alt="Before fixing coretax product code search 1" src="https://github.com/user-attachments/assets/12ca3248-0bea-4ef3-bb04-116d63520517" />
<img width="832" height="432" alt="Before fixing coretax product code search 2" src="https://github.com/user-attachments/assets/ced291b7-c4c6-42e7-a453-7a1f18945637" />
<img width="988" height="568" alt="Before fixing coretax product code search 3" src="https://github.com/user-attachments/assets/bbac4ae1-a31d-49bd-b520-a68a1a945e78" />


Desired behavior after PR is merged:
<img width="438" height="314" alt="After fixing coretax product code search 1" src="https://github.com/user-attachments/assets/4469bb5b-0830-49af-af1c-f05b81dcb10c" />
<img width="467" height="331" alt="After fixing coretax product code search 2" src="https://github.com/user-attachments/assets/5528db34-e279-4d2d-98f0-644f7a618ead" />
<img width="991" height="619" alt="After fixing coretax product code search 3" src="https://github.com/user-attachments/assets/fec53a0c-ab29-46c5-b366-46653b51d7e4" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
