### PR TITLE
[IMP] hr_payroll: edit scaffold for payroll localization

### DIFF
--- a/odoo/cli/templates/l10n_payroll/data/hr_salary_rule_data.xml.template
+++ b/odoo/cli/templates/l10n_payroll/data/hr_salary_rule_data.xml.template
@@ -29,7 +29,7 @@ result = categories.BASIC
 result_rate = payslip.rule_parameter('l10n_{{code}}_social_employer_rate')
 result = categories.BASIC
         </field>
-        <field name="appears_on_payslip" eval="False"/>
+        <field name="appears_on_payslip">never</field>
         <field name="struct_id" ref="l10n_{{code}}_hr_payroll.l10n_{{code}}_hr_payroll_structure_{{code}}_employee_salary"/>
     </record>
 
@@ -43,7 +43,7 @@ result = categories.BASIC
         <field name="amount_python_compute">
 result = categories['SOCIAL.EMPLOYEE']
         </field>
-        <field name="appears_on_payslip" eval="True"/>
+        <field name="appears_on_payslip">always</field>
         <field name="struct_id" ref="l10n_{{code}}_hr_payroll.l10n_{{code}}_hr_payroll_structure_{{code}}_employee_salary"/>
     </record>
 
@@ -57,7 +57,7 @@ result = categories['SOCIAL.EMPLOYEE']
         <field name="amount_python_compute">
 result = categories['SOCIAL.EMPLOYER']
         </field>
-        <field name="appears_on_payslip" eval="False"/>
+        <field name="appears_on_payslip">never</field>
         <field name="struct_id" ref="l10n_{{code}}_hr_payroll.l10n_{{code}}_hr_payroll_structure_{{code}}_employee_salary"/>
     </record>
 
@@ -71,7 +71,7 @@ result = categories['SOCIAL.EMPLOYER']
         <field name="amount_python_compute">
 result = categories.GROSS
         </field>
-        <field name="appears_on_payslip" eval="True"/>
+        <field name="appears_on_payslip">always</field>
         <field name="struct_id" ref="l10n_{{code}}_hr_payroll.l10n_{{code}}_hr_payroll_structure_{{code}}_employee_salary"/>
     </record>
 
@@ -92,7 +92,7 @@ for low, high, prev, rate in brackets:
         if low &lt;= taxable &lt; high:
             result = -(prev + (taxable - low) * rate / 100)
         </field>
-        <field name="appears_on_payslip" eval="True"/>
+        <field name="appears_on_payslip">always</field>
         <field name="struct_id" ref="l10n_{{code}}_hr_payroll.l10n_{{code}}_hr_payroll_structure_{{code}}_employee_salary"/>
     </record>
 
@@ -117,7 +117,7 @@ elif children == 3:
 elif children &gt;= 4:
     result = amounts[0] + amounts[1] + amounts[2] + (children - 3) * amounts[3]
         </field>
-        <field name="appears_on_payslip" eval="True"/>
+        <field name="appears_on_payslip">always</field>
         <field name="struct_id" ref="l10n_{{code}}_hr_payroll.l10n_{{code}}_hr_payroll_structure_{{code}}_employee_salary"/>
     </record>
 


### PR DESCRIPTION
Converted the appears_on_payslip field from a boolean to a Selection field. 
Adjustments have been made in the scaffold for the l10n_payroll salary rule template to reflect this change.

task-4979423
