### PR TITLE
[FIX] orm: ensure model_year selection returns string values

### DIFF
--- a/odoo/orm/fields_selection.py
+++ b/odoo/orm/fields_selection.py
@@ -202,7 +202,9 @@ class Selection(Field[str | typing.Literal[False]]):
         """
         selection = self.selection
         if isinstance(selection, str) or callable(selection):
-            return determine(selection, env[self.model_name])
+            selection = determine(selection, env[self.model_name])
+            # force all values to be strings (check _get_year_selection)
+            return [(str(key), str(label)) for key, label in selection]
 
         # translate selection labels
         if env.lang:


### PR DESCRIPTION
Currently, when users import a CSV or XLSX file into the Fleet app containing the `model_year` field as an integer, an error is raised.

**Steps to Reproduce:**
1) Install **Fleet** app(with Demo Data).
2) Open Fleet App and Import [this file](https://docs.google.com/spreadsheets/d/1KJgVTM7KeAVcHR-TQg86gO4in53G7NyR/edit?usp=sharing&ouid=101212513075316114369&rtpof=true&sd=true). 
3) Click on Test or Import.

**Error:**
`UndefinedFunction: operator does not exist: text = integer`

**Root Cause:**
Since PR https://github.com/odoo/odoo/pull/197440, the `model_year` field was changed from a `char` to a `selection`. The selection values are generated by the `_get_year_selection` method at [1], which returns a list of integers.
However, when these integer value is compared at [2], a type mismatch occurs because the expected type is `text`, not `integer`.

**Solution:**
This fix ensures that `_get_year_selection` returns a list of **strings** instead of `integers`, so that the values match the expected type at [2]

[1]- https://github.com/odoo/odoo/blob/4806b08dcfc965cdbd463269be078f8da9f48863/addons/fleet/models/fleet_vehicle.py#L34-L36

[2]- https://github.com/odoo/odoo/blob/4806b08dcfc965cdbd463269be078f8da9f48863/odoo/addons/base/models/ir_fields.py#L451

sentry-**6663249660**
