### PR TITLE
[IMP] Update name to "Retenciones IRPF 19% (Compra consejero de sociedad y Resto de rentas)"

### DIFF
--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -4859,7 +4859,7 @@
     <record id="account_tax_template_p_irpf19cs" model="account.tax.template">
         <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">purchase</field>
-        <field name="name">Retenciones IRPF 19% (Compra consejero de sociedad)</field>
+        <field name="name">Retenciones IRPF 19% (Compra consejero de sociedad y Resto de rentas)</field>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="-19"/>
         <field name="amount_type">percent</field>

--- a/addons/l10n_es/i18n/es.po
+++ b/addons/l10n_es/i18n/es.po
@@ -8574,8 +8574,8 @@ msgstr "Retenciones IRPF 19% (Compra consejero de persona física)"
 #. module: l10n_es
 #: model:account.tax,name:l10n_es.2_account_tax_template_p_irpf19cs
 #: model:account.tax.template,name:l10n_es.account_tax_template_p_irpf19cs
-msgid "Retenciones IRPF 19% (Compra consejero de sociedad)"
-msgstr "Retenciones IRPF 19% (Compra consejero de sociedad)"
+msgid "Retenciones IRPF 19% (Compra consejero de sociedad y Resto de rentas)"
+msgstr "Retenciones IRPF 19% (Compra consejero de sociedad y Resto de rentas)"
 
 #. module: l10n_es
 #: model:account.tax,name:l10n_es.2_account_tax_template_p_irpf2

--- a/addons/l10n_es/i18n/l10n_es.pot
+++ b/addons/l10n_es/i18n/l10n_es.pot
@@ -8244,7 +8244,7 @@ msgstr ""
 #. module: l10n_es
 #: model:account.tax,name:l10n_es.2_account_tax_template_p_irpf19cs
 #: model:account.tax.template,name:l10n_es.account_tax_template_p_irpf19cs
-msgid "Retenciones IRPF 19% (Compra consejero de sociedad)"
+msgid "Retenciones IRPF 19% (Compra consejero de sociedad y Resto de rentas)"
 msgstr ""
 
 #. module: l10n_es


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The tax template "Retenciones IRPF 19% (Compra consejero de sociedad)" covers more cases.

Current behavior before PR:

When spanish chart template is loaded, Odoo create a tax with name "Retenciones IRPF 19% (Compra consejero de sociedad)".

Desired behavior after PR is merged:

Odoo create a tax with name "Retenciones IRPF 19% (Compra consejero de sociedad y Resto de rentas)" when a spanish chart template is loaded.

@rafaelbn @arantxasudon

@moduon MT-11013

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
