### PR TITLE
[FIX] base: fix traceback when adding tags on contact

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -178,7 +178,7 @@ class PartnerCategory(models.Model):
     def _search_display_name(self, operator, value):
         domain = super()._search_display_name(operator, value)
         if operator.endswith('like'):
-            return [('id', 'child_of', self._search(domain))]
+            return [('id', 'child_of', self._search(list(domain)))]
         return domain
 
 class PartnerTitle(models.Model):


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the "Contacts" app.
2. Go to Contacts > Open any contact.
3. Click on the "Tags" (Partner Category) field to add a tag.

**Issue:**
A traceback is raised:
`TypeError: can only concatenate list (not "_ProtectedDomain") to list`

**Cause:**
- Due to recent changes in https://github.com/odoo/odoo/commit/cd5f29b8b50ef4228be8f58a02bb328548208f77, default domains like `TRUE_DOMAIN` are now defined using
a `_ProtectedDomain` class (a tuple subclass) instead of regular lists, to make them immutable.

- This breaks code that tries to modify or concatenate domains assuming they are lists.

- In this case, `res.partner.category._search_display_name` returned a `_ProtectedDomain` which was passed
 to `_search()`, leading to the error when Odoo tried to prepend additional filters.

Solution:
- Before using the domain in _search(), convert it to a regular list using list(domain).

opw-4991994