### PR TITLE
[FIX] account: partner not reset when changed journal manually in payments

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -576,13 +576,8 @@ class AccountPayment(models.Model):
         for pay in self:
             pay.currency_id = pay.journal_id.currency_id or pay.journal_id.company_id.currency_id
 
-    @api.depends('journal_id')
     def _compute_partner_id(self):
-        for pay in self:
-            if pay.partner_id == pay.journal_id.company_id.partner_id:
-                pay.partner_id = False
-            else:
-                pay.partner_id = pay.partner_id
+        pass
 
     @api.depends('payment_method_line_id')
     def _compute_outstanding_account_id(self):


### PR DESCRIPTION
Reproducing steps:
- Create a payment and select a journal.
- Partner is set to the journal's company partner.
- Try to change the journal manually.

Before this PR:
- Partner is reset to the journal's company partner.
- Cannot assign a different journal for the journal's company partner.

After this PR:
- Removed unwanted compute dependency.
- Partner is no longer reset and can be changed manually.

opw-4769153
