### PR TITLE
[FIX] web_editor: preserve line break when splitting paragraph

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/enter.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/enter.js
@@ -57,10 +57,22 @@ HTMLElement.prototype.oEnter = function (offset, firstSplit = true) {
         restore = prepareUpdate(this, offset);
     }
 
+    let currentOffset = offset;
     // First split the node in two and move half the children in the clone.
     let splitEl = this.cloneNode(false);
-    while (offset < this.childNodes.length) {
-        splitEl.appendChild(this.childNodes[offset]);
+    while (currentOffset < this.childNodes.length) {
+        const child = this.childNodes[currentOffset];
+        // Handle browser line break behavior: When SHIFT+ENTER is pressed at the end of text
+        // (e.g., `<p>abc[]</p>`), the browser creates two consecutive <br> elements with the
+        // cursor positioned between them. The second <br> makes the line break visible and
+        // gets automatically removed when typing begins. To preserve this line break during
+        // node splitting, we keep the second <br> in the original element.
+        if (child.nodeName === "BR" && child.previousSibling?.nodeName === "BR") {
+            splitEl.appendChild(document.createElement("br"));
+            currentOffset++;
+        } else {
+            splitEl.appendChild(child);
+        }
     }
     if (isBlock(this) || splitEl.hasChildNodes()) {
         this.after(splitEl);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -4014,6 +4014,16 @@ X[]
                         contentAfter: '<div><a>ab</a><br>[]cd</div>',
                     });
                 });
+                it('should keep the last line break in the old paragraph', async () => {
+                    const pressEnter = editor => {
+                        editor.document.execCommand('insertParagraph');
+                    };
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div><p>abc<br>[]<br></p></div>',
+                        stepFunction: pressEnter,
+                        contentAfter: '<div><p>abc<br><br></p><p>[]<br></p></div>',
+                    });
+                });
                 it('should insert a paragraph break outside the starting edge of an anchor', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><a>[]ab</a></p>',


### PR DESCRIPTION
Problem:
When at the end of a paragraph, pressing SHIFT+ENTER followed by ENTER creates a new paragraph, but the previous one loses its last line break.

Cause:
When splitting an element, the `<br>` at the selection point is moved to the newly created split element. However, to render an empty line visibly, two `<br>` elements are needed. Moving the existing `<br>` makes the last line break in the original paragraph invisible.

Solution:
In this special case, instead of moving the `<br>` at the selection point, insert a new `<br>` in the new element, preserving the visual line break in the original paragraph.

Steps to reproduce:
- Add a paragraph
- Type some text, then press SHIFT+ENTER
- Press ENTER to create a new paragraph
-> The last line break in the first paragraph is lost

opw-4987922

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
