### PR TITLE
[FIX] website: SelectTranslateDialog props type

### DIFF
--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -64,7 +64,15 @@ export class SelectTranslateDialog extends Component {
     </WebsiteDialog>
     `;
     static props = {
-        node: String,
+        node: {
+            // type: Object doesn't work in firefox.
+            // the node is in an iframe, so its Object prototype
+            // isn't the same as the rest of the page.
+            validate: (node) => {
+                // if the object has those two, should be a node
+                return "nodeType" in node && "nodeName" in node;
+            },
+        },
         close: Function,
     };
     setup() {


### PR DESCRIPTION
**PROBLEM**
In debug mode, props type errors pop up when clicking on a selection field to translate it.

**STEP TO REPRODUCE**
1. Create a form with a selection field in a page.
2. Ensure you're in debug mode assets.
3. Go in translate mode, and click on a string of the selection field to translate it.
4. Props type error should pop up.

**CAUSE**
`node` is actually of type `Object` (its the target of a jquery event), the props validations expect it to be of type `String`.

opw-4896491