### PR TITLE
[FIX] website_event{_track/exhibitor}: make event/track/sponser searchable for other languages

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -76,7 +76,7 @@
                     <div class="w-100 flex-grow-1">
                         <t t-call="website.website_search_box_input">
                             <t t-set="_classes" t-valuef="o_wevent_event_searchbar_form flex-grow-1"/>
-                            <t t-set="search_type">events</t>
+                            <t t-set="search_type" t-translation="off">events</t>
                             <t t-set="action" t-value="'/event/'"/>
                             <t t-set="display_description" t-valuef="true"/>
                             <t t-set="display_detail" t-valuef="false"/>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -40,7 +40,7 @@
         <div class="d-flex w-100 w-lg-auto">
             <t t-call="website.website_search_box_input">
                 <t t-set="_classes" t-valuef="o_wevent_event_sponsor_searchbar_form flex-grow-1"/>
-                <t t-set="search_type">sponsor</t>
+                <t t-set="search_type" t-translation="off">sponsor</t>
                 <t t-set="action" t-value="'/event/%s/exhibitors' % (slug(event))"/>
                 <t t-set="display_detail" t-valuef="false"/>
                 <t t-set="search" t-value="search or searches and searches['search']"/>

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -55,7 +55,7 @@
             <div class="o_wevent_search d-flex w-100 w-lg-auto">
                 <t t-call="website.website_search_box_input">
                     <t t-set="_classes" t-valuef="o_wevent_event_track_searchbar_form flex-grow-1"/>
-                    <t t-set="search_type">track</t>
+                    <t t-set="search_type" t-translation="off">track</t>
                     <t t-set="action" t-value="'/event/%s/track' % (slug(event))"/>
                     <t t-set="display_detail" t-valuef="false"/>
                     <t t-set="search" t-value="search or searches and searches['search']"/>


### PR DESCRIPTION
**Issue:**
- After https://github.com/odoo/odoo/commit/777cb220259e1c1529b960761a6f59ec6115038e we are not able to search for event/track/sponser when we have other language
selected except `en_US`.
- This is because of how `search_type` attribute is set in related templates.
- currently it gets translated as according to  website's language,
for e.g when website's language is `Spanish (AR) / Español (AR)`

'events' get translated to 'eventos' and
'track' get translated to 'sesión'
- hence the parameter for search get altered, failing the search.
https://github.com/odoo/odoo/blob/ac5ea3cbd075db650c8e538d59e24657a0f04bb9/addons/website/static/src/snippets/s_searchbar/000.js#L118-L121

**Step to reproduce:**
- Add another language except en_US, say ,spanish
- install website_event
- open events from website and switch language to spanish
- search for event

**Observation:**
- No search result

**Fix:**
- set the search_type attribute correctly, i.e using `t-valuef`

opw-4972519

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
