### PR TITLE
[FIX] mail: help message in messaging menu quick search

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -32,7 +32,7 @@
             </div>
         </xpath>
         <xpath expr="//*[@name='threads']" position="before">
-            <div t-if="store.channels.status !== 'fetching' and !hasPreviews" class="d-flex justify-content-center py-4 px-2 text-muted">
+            <div t-if="store.channels.status !== 'fetching' and !hasPreviews and !store.discuss.searchTerm" class="d-flex justify-content-center py-4 px-2 text-muted">
                 No conversation yet...
             </div>
             <div t-if="store.discuss.searchTerm and !threads.length" class="d-flex justify-content-center py-4 px-2 text-muted">

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -1226,6 +1226,9 @@ test("Can quick search when more than 20 items", async () => {
     await insertText(".o-mail-MessagingMenu input", "admin");
     await contains(".o-mail-NotificationItem", { count: 1 });
     await contains(".o-mail-NotificationItem", { text: "Mitchell Admin" });
+    await insertText(".o-mail-MessagingMenu input", "no threads", { replace: true });
+    await contains(".o-mail-MessagingMenu div.text-muted", { text: "No thread found." });
+    expect(".o-mail-MessagingMenu-list").toHaveText("No thread found."); // list should contain only this text
 });
 
 test("keyboard navigation", async () => {


### PR DESCRIPTION
**Steps to reproduce:**

- Open the messaging menu with 20+ threads (quick search btn shows on 20+ threads)
- Dismiss (or install) the 'Install Odoo' notification
- Dismiss (or allow) the 'Turn on notifications' notification
- Use quick search to look for a thread that doesn't exist

=> Both 'No thread found.' and 'No conversation yet...' messages are displayed

This happens due to an incorrectly handled condition.

This PR ensures only the relevant message is shown:
- 'No thread found.' is displayed when the search yields no results.
- 'No conversation yet...' is shown only when the user has no threads at all.

<img width="565" height="279" alt="image" src="https://github.com/user-attachments/assets/689bc007-dfb4-4041-8543-18bc4ad2e19d" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
