### PR TITLE
[FIX] pos_loyalty: display the customer on the receipt

### DIFF
--- a/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -3,15 +3,16 @@
 
     <t t-name="pos_coupon.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('pos-receipt')]//div[hasclass('before-footer')]" position="inside">
+            <t t-if="order.partner_id and order.preset_id?.identification != 'address'">
+                <br/>
+                <div class="d-flex pb-1" style="font-size: 75%;">
+                    <span>Customer</span>
+                    <span t-out="order.partner_id.name" class="ms-auto fw-bolder"/>
+                </div>
+            </t>
             <t t-if="order.new_coupon_info and order.new_coupon_info.length !== 0">
                 <div class="pos-coupon-rewards pt-3">
                     <t t-foreach="order.new_coupon_info" t-as="coupon_info" t-key="coupon_info.code">
-                        <t t-if="order.partner_id and order.preset_id?.identification != 'address'">
-                            <div class="d-flex pb-1" style="font-size: 75%;">
-                                <span>Customer</span>
-                                <span t-out="order.partner_id.name" class="ms-auto fw-bolder"/>
-                            </div>
-                        </t>
                         <div class="coupon-container">
                             <div class="row g-2">
                                 <div class="col-6">

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -630,3 +630,21 @@ registry.category("web_tour.tours").add("test_refund_does_not_decrease_points", 
             PaymentScreen.clickValidate(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_customer_name_in_receipt", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAA Partner"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            {
+                content: "Check that the customer's name is in the receipt",
+                trigger: ".before-footer .d-flex span.ms-auto.fw-bolder:contains('AAA Partner')",
+            },
+        ].flat(),
+});


### PR DESCRIPTION
**Steps to reproduce:**
- With pos_loyalty installed, launch the PoS
- Select a customer and make a purchase
- This needs to create a new loyalty coupon (new customer or program)
- The customer name is not displayed on the receipt

**Problem:**
When a customer is set for an order in pos_loyalty, it should appear on the receipt. Before this commit, sometimes it was not displayed.

**Why the fix:**
The customer was not displayed everytime because it was displayed inside this if statement, https://github.com/odoo/odoo/blob/033c7a63bdf3d10d9d2c5084959fd34f52011bea/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml#L6 So the customer would only be displayed if there was a new coupon being created, and not if we were updating a new one. This behavior was introduced in a REF in 18.3 461359e The behavior does not make sense as it displays the customer for each new coupon we have in this order, so it might be displayed multiple times.
With this commit, we display the customer all the time, as it is weird to only display it if a new coupon is created or if loyalty logic is involved, as said here 879b415

opw-4929076
opw-4976885