### PR TITLE
[FIX] website_event_track: public user access to event track outlook reminder

### DIFF
--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -652,7 +652,7 @@ class EventTrack(models.Model):
             cal_track.add('summary').value = track.name
             cal_track.add('description').value = track._get_track_calendar_description()
             if track.event_id.address_inline or track.location_id:
-                cal_track.add('location').value = ', '.join([track.event_id.address_inline, track.location_id.name or ''])
+                cal_track.add('location').value = ', '.join([track.event_id.address_inline, track.location_id.sudo().name or ''])
 
             result[track.id] = cal.serialize().encode('utf-8')
         return result


### PR DESCRIPTION
In this bug, it is not possible to access outlook calender
reminder, because of lack of access to event location.

To reproduce:
1- Create an event and publish it
2- Create a track and publish it
3- Add a location to this track
4- Send the track using reminder template
5- Copy the calender link and paste it into incontio mode
6- As you see the access is denied

To fix the issue, the location can be accessed using sudo.

opw-4975617

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
