### PR TITLE
[FIX] calendar: fixed button to eliminate videocall from appointment

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -355,6 +355,7 @@
                             options="{'no_quick_create': True}"
                             context="{'form_view_ref': 'base.view_partner_simple_form'}"
                         />
+                        <field name="location"/>
                         <label for="videocall_location" class="opacity-100"/>
                         <div col="2">
                             <field name="videocall_location" string="Meeting Link" widget="CopyClipboardChar" force_save="1" readonly="videocall_source == 'discuss'"/>

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -46,7 +46,7 @@ class CalendarEvent(models.Model):
     @api.model
     def _get_google_synced_fields(self):
         return {'name', 'description', 'allday', 'start', 'date_end', 'stop',
-                'attendee_ids', 'alarm_ids', 'location', 'privacy', 'active', 'show_as'}
+                'attendee_ids', 'alarm_ids', 'location', 'privacy', 'active', 'show_as', 'videocall_location'}
 
     @api.model
     def _restart_google_sync(self):
@@ -335,6 +335,8 @@ class CalendarEvent(models.Model):
         }
         if not self.google_id and not self.videocall_location and not self.location:
             values['conferenceData'] = {'createRequest': {'requestId': uuid4().hex}}
+        if self.google_id and not self.videocall_location:
+            values['conferenceData'] = None
         if self.privacy:
             values['visibility'] = self.privacy
         if self.show_as:

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -83,7 +83,7 @@ class GoogleCalendarService():
     @requires_auth_token
     def patch(self, event_id, values, token=None, timeout=TIMEOUT):
         send_updates = self.google_service._context.get('send_updates', True)
-        url = "/calendar/v3/calendars/primary/events/%s?sendUpdates=%s" % (event_id, "all" if send_updates else "none")
+        url = "/calendar/v3/calendars/primary/events/%s?sendUpdates=%s&conferenceDataVersion=1" % (event_id, "all" if send_updates else "none")
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
         self.google_service._do_request(url, json.dumps(values), headers, method='PATCH', timeout=timeout)
 


### PR DESCRIPTION
When creating an appointment without a location while google calendar sync is active, a google meet link is automatically created and assigned to the appointment. If the creation of the meet room is not wanted, there is a button to cancel it but its scope was restricted to the Odoo side and the meet link was still present in Google Calendar. This is a mismatch which can cause confusion in the user and this PR solves the problem by updating the meet link in Google Calendar when it changes locally.

Task: 4985565
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
