### PR TITLE
[FIX] pos_restaurant: set default order on restaurant.table

### DIFF
--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -89,6 +89,7 @@ class RestaurantFloor(models.Model):
 
 class RestaurantTable(models.Model):
     _name = 'restaurant.table'
+    _order = 'floor_id, table_number'
 
     _description = 'Restaurant Table'
     _inherit = ['pos.load.mixin']


### PR DESCRIPTION
Ensure tables are consistently ordered by `floor_id` and `table_number` in ascending order. This improves the UX in places such as the Floor form view and the table selection popup in pos_self_order.