### PR TITLE
[FIX] mrp: exclude service products from product catalog in mo

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -3047,6 +3047,9 @@ class MrpProduction(models.Model):
         lines = self[child_field].filtered(lambda line: line.product_id.id in product_ids)
         return lines.grouped(lambda line: line.product_id)
 
+    def _get_product_catalog_domain(self):
+        return super()._get_product_catalog_domain() & Domain('type', '=', 'consu')
+
     def _update_order_line_info(self, product_id, quantity, *, child_field=False, **kwargs):
         if not child_field:
             return 0

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -488,7 +488,7 @@
                                         <create string="Add a line"/>
                                         <button name="action_add_from_catalog_byproduct" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>
                                     </control>
-                                    <field name="product_id" context="{'default_is_storable': True}" domain="[('id', '!=', parent.product_id)]" required="1" readonly="move_lines_count &gt; 0 or state == 'cancel' or (state != 'draft' and not additional)"/>
+                                    <field name="product_id" context="{'default_is_storable': True}" domain="[('type', '=', 'consu')]" required="1" readonly="move_lines_count &gt; 0 or state == 'cancel' or (state != 'draft' and not additional)"/>
                                     <field name="location_dest_id" string="To" readonly="1" force_save="1" groups="stock.group_stock_multi_locations"/>
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="allowed_operation_ids" column_invisible="True"/>

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -74,6 +74,9 @@
                             name="products_in_mo"
                             domain="[('product_catalog_product_is_in_mo', '=', True)]"/>
                 </filter>
+                <filter name="services" position="attributes">
+                    <attribute name="invisible">context.get('product_catalog_order_model') == 'mrp.production'</attribute>
+                </filter>
             </field>
         </record>
 


### PR DESCRIPTION
Issue:
======
User can add `service type` products in the MO catalog which is not valid.
When we manufacture the products, allowing service products in the
MO catalog is not valid. These products are not stockable or traceable,
and therefore cannot be consumed as raw materials or produced as by-products.

How to reproduce:
=================
1. Install mrp.
2. Create MO.
3. Open catalog for `Components` or `By-Products`.
4. User can add `Service` type products from here.

Cause of the issue:
===================
- Domain for product catalog doesn't contain `('type', '=', 'consu')`.

Solution:
=========
- Added `('type', '=', 'consu')` in product catalog domain.

With this commit, users can now select only consumable products from the
`Add a line` or `Catalog` in the MO `Components` and `By-Products` sections.
Also removed the `Services filter` from the MO catalog, since there are
no service-type products in the catalog, so it doesn’t make sense to
keep this filter.

TaskId : 4904067
