### PR TITLE
[FIX] website: improve footer slideout behavior and option layout

### DIFF
--- a/addons/website/static/src/builder/plugins/options/footer_option.xml
+++ b/addons/website/static/src/builder/plugins/options/footer_option.xml
@@ -90,7 +90,7 @@
                 Slide Hover
             </BuilderSelectItem>
             <BuilderSelectItem actionParam="{ views: ['website.template_footer_slideout'], vars: { 'footer-effect': 'slideout_shadow' } }">
-                Shadow
+                Slide Hover + Shadow
             </BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/footer_option_plugin.js
@@ -2,16 +2,32 @@ import { registry } from "@web/core/registry";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { rpc } from "@web/core/network/rpc";
-import { after, SNIPPET_SPECIFIC_NEXT } from "@html_builder/utils/option_sequence";
+import { SNIPPET_SPECIFIC_END, SNIPPET_SPECIFIC_NEXT, splitBetween } from "@html_builder/utils/option_sequence";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
-export const FOOTER_TEMPLATE = SNIPPET_SPECIFIC_NEXT;
-export const FOOTER_WIDTH = after(FOOTER_TEMPLATE);
-export const FOOTER_SLIDEOUT = after(FOOTER_WIDTH);
-export const FOOTER_BORDER = after(FOOTER_SLIDEOUT);
-export const FOOTER_COLORS = after(FOOTER_BORDER);
-export const FOOTER_SCROLL_TO = after(FOOTER_COLORS);
-export const FOOTER_COPYRIGHT = after(FOOTER_SCROLL_TO);
+const [
+    FOOTER_TEMPLATE,
+    FOOTER_COLORS,
+    FOOTER_WIDTH,
+    FOOTER_SLIDEOUT,
+    FOOTER_SCROLL_TO,
+    FOOTER_COPYRIGHT,
+    FOOTER_BORDER,
+    ...__ERROR_CHECK__
+] = splitBetween(SNIPPET_SPECIFIC_NEXT, SNIPPET_SPECIFIC_END, 7);
+if (__ERROR_CHECK__.length > 0) {
+    console.error("Wrong count in footer option split");
+}
+
+export {
+    FOOTER_TEMPLATE,
+    FOOTER_COLORS,
+    FOOTER_WIDTH,
+    FOOTER_SLIDEOUT,
+    FOOTER_SCROLL_TO,
+    FOOTER_COPYRIGHT,
+    FOOTER_BORDER,
+}
 
 class FooterOptionPlugin extends Plugin {
     static id = "footerOption";

--- a/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
@@ -20,7 +20,7 @@
 </t>
 
 <t t-name="website.HideFooterOption">
-    <BuilderRow label.translate="Page Visibility">
+    <BuilderRow label.translate="Page Visibility" tooltip.translate="Enable to hide the footer on this page">
         <BuilderCheckbox action="'setWebsiteFooterVisible'"/>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/interactions/footer_slideout.js
+++ b/addons/website/static/src/interactions/footer_slideout.js
@@ -4,17 +4,6 @@ import { registry } from "@web/core/registry";
 export class FooterSlideout extends Interaction {
     static selector = "#wrapwrap";
     static selectorHas = ".o_footer_slideout";
-    dynamicContent = {
-        _root: {
-            "t-att-class": () => ({
-                "o_footer_effect_enable": this.slideoutEffect,
-            }),
-        },
-    };
-
-    setup() {
-        this.slideoutEffect = this.el.querySelector(":scope > main").offsetHeight >= window.innerHeight;
-    }
 
     start() {
         // On safari, add a pixel div over the footer, after in the DOM, and add

--- a/addons/website/static/tests/interactions/footer_slideout.test.js
+++ b/addons/website/static/tests/interactions/footer_slideout.test.js
@@ -21,19 +21,7 @@ test("footer_slideout does nothing if the effect is not enabled", async () => {
     expect(core.interactions).toHaveLength(0);
 });
 
-test("footer_slideout only adds a class if the effect is enabled on non-safari", async () => {
-    mockUserAgent("android");
-    const { core } = await startInteractions(`
-        <div id="wrapwrap">
-            <main style="min-height: 1000px">Main Content</main>
-            <footer class="o_footer_slideout">Footer Content</footer>
-        </div>
-    `);
-    expect(core.interactions).toHaveLength(1);
-    expect("#wrapwrap").toHaveClass("o_footer_effect_enable");
-});
-
-test("footer_slideout adds a class and a pixel if the effect is enabled on safari", async () => {
+test("footer_slideout adds a pixel if the effect is enabled on safari", async () => {
     mockUserAgent("safari");
     const { core } = await startInteractions(`
         <div id="wrapwrap">
@@ -42,7 +30,6 @@ test("footer_slideout adds a class and a pixel if the effect is enabled on safar
         </div>
     `);
     expect(core.interactions).toHaveLength(1);
-    expect("#wrapwrap").toHaveClass("o_footer_effect_enable");
     expect(queryAll("#wrapwrap > div")).toHaveLength(1);
     expect("#wrapwrap > div").toHaveStyle({ "width": "1px" });
     core.stopInteractions();

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2148,6 +2148,9 @@
     <xpath expr="//footer[@id='bottom']" position="attributes">
         <attribute name="t-attf-class" add="o_footer_slideout" separator=" "/>
     </xpath>
+    <xpath expr="//div[@id='wrapwrap']" position="attributes">
+        <attribute name="t-attf-class" add="o_footer_effect_enable" separator=" "/>
+    </xpath>
 </template>
 
 <!-- Hide Copyright -->


### PR DESCRIPTION
Before this commit:
The footer slideout effect did not work properly when we first changed
footer slideout option. Adding a snippet larger than the body content
caused the slideout to behave unexpectedly.

After this commit:
The footer slideout effect works as expected. In addition, a tooltip has
been added to the page visibility option, and the footer option layout
has been improved for better usability.

task-4991435
