### PR TITLE
[FIX] l10n_es_edi_verifactu: use `self.env.cr.commit`

### DIFF
--- a/addons/l10n_es_edi_verifactu/models/account_move_send.py
+++ b/addons/l10n_es_edi_verifactu/models/account_move_send.py
@@ -82,4 +82,4 @@ class AccountMoveSend(models.AbstractModel):
                 }
 
         if created_document and self._can_commit():
-            self._cr.commit()
+            self.env.cr.commit()

--- a/addons/l10n_es_edi_verifactu/models/verifactu_document.py
+++ b/addons/l10n_es_edi_verifactu/models/verifactu_document.py
@@ -1141,7 +1141,7 @@ class L10nEsEdiVerifactuDocument(models.Model):
 
             # To avoid losing data we commit after every document
             if self.env['account.move']._can_commit():
-                self._cr.commit()
+                self.env.cr.commit()
 
         waiting_time_seconds = info.get('waiting_time_seconds')
         if waiting_time_seconds:
@@ -1152,7 +1152,7 @@ class L10nEsEdiVerifactuDocument(models.Model):
         self._cancel_after_sending(info)
 
         if self.env['account.move']._can_commit():
-            self._cr.commit()
+            self.env.cr.commit()
 
         return batch_dict, info
 


### PR DESCRIPTION
The use of `self._cr` is deprecated since commit
d49fc64cc077b18db968745214946ee7d9ab7cd4 .
This commit replaces usages of  `self._cr` with `self.env.cr.commit`.

task-None
