### PR TITLE
[FIX] hr_holidays_attendance: correct overtime creation

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -69,15 +69,12 @@ class HRLeave(models.Model):
                 })
 
     def action_reset_confirm(self):
-        overtime_leaves = self.filtered('overtime_deductible')
         res = super().action_reset_confirm()
-        overtime_leaves.overtime_id.sudo().unlink()
-        return res
-    
-    def action_confirm(self):
-        res = super().action_confirm()
         self._check_overtime_deductible(self)
         return res
+
+    def action_confirm(self):  # TODO: remove in master
+        pass
 
     def action_refuse(self):
         res = super().action_refuse()

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -121,8 +121,8 @@ class TestHolidaysOvertime(TransactionCase):
         self.assertEqual(self.employee.total_overtime, 8)
 
         leave.action_reset_confirm()
-        self.assertFalse(leave.overtime_id.exists(), "Overtime should not be created")
-        self.assertEqual(self.employee.total_overtime, 8)
+        self.assertTrue(leave.overtime_id.adjustment, "Overtime should be created")
+        self.assertEqual(self.employee.total_overtime, 0)
 
         overtime = leave.overtime_id
         leave.unlink()


### PR DESCRIPTION
**Issue**
- Create a leave for a time off type deducting extra hours.
- Check: a negative overtime (`hr.attendance.overtime`) has been created.
- Approve, refuse and reset the leave.
- Inconsistency: state is in "confirm" state, but no overtime exists.
- Approve the leave.
- Issue: no overtime exists.

**Cause**
The forward port 8dd74bc723fe8ddffaac718f537f6284f341bfe6 didn't correctly consider the removal of the "Draft" leave state.

**Change**
Ensure leaves in "Confirm" and next steps have an associated negative overtime.

opw-4815190