### PR TITLE
[IMP] l10n_ae_hr_payroll : group sick leaves in one salary rule

### DIFF
--- a/addons/hr_holidays/data/hr_leave_type_data.xml
+++ b/addons/hr_holidays/data/hr_leave_type_data.xml
@@ -91,27 +91,6 @@
         <field name="sequence">5</field>
     </record>
 
-<!-- AE : United Arab Emirates -->
-    <record id="l10n_ae_leave_type_sick_leave_50" model="hr.leave.type">
-        <field name="name">Sick Leave 50%</field>
-        <field name="requires_allocation">False</field>
-        <field name="leave_validation_type">hr</field>
-        <field name="support_document">True</field>
-        <field name="icon_id" ref="hr_holidays.icon_21"/>
-        <field name="company_id" eval="False"/>
-        <field name="country_id" ref="base.ae"/>
-    </record>
-
-    <record id="l10n_ae_leave_type_sick_leave_0" model="hr.leave.type">
-        <field name="name">Sick Leave 0%</field>
-        <field name="requires_allocation">False</field>
-        <field name="leave_validation_type">hr</field>
-        <field name="support_document">True</field>
-        <field name="icon_id" ref="hr_holidays.icon_21"/>
-        <field name="company_id" eval="False"/>
-        <field name="country_id" ref="base.ae"/>
-    </record>
-
 <!-- BE : Belgium -->
     <record id="l10n_be_leave_type_small_unemployment" model="hr.leave.type">
         <field name="name">Small Unemployment</field>

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -71,18 +71,6 @@
     </record>
 
 <!-- AE : United Arab Emirates -->
-    <record id="uae_sick_leave_50_entry_type" model="hr.work.entry.type">
-        <field name="name">Sick Leave 50</field>
-        <field name="code">AESICKLEAVE50</field>
-        <field name="country_id" ref="base.ae"/>
-    </record>
-
-    <record id="uae_sick_leave_0_entry_type" model="hr.work.entry.type">
-        <field name="name">Sick Leave 0</field>
-        <field name="code">AESICKLEAVE0</field>
-        <field name="country_id" ref="base.ae"/>
-    </record>
-
     <record id="uae_public_holiday_entry_type" model="hr.work.entry.type">
         <field name="name">Public Holiday</field>
         <field name="code">AEPUBLICH</field>

--- a/addons/hr_work_entry_holidays/data/hr_leave_type_data.xml
+++ b/addons/hr_work_entry_holidays/data/hr_leave_type_data.xml
@@ -18,15 +18,6 @@
     </record>
 </data>
 
-<!-- AE : United Arab Emirates -->
-    <record id="hr_holidays.l10n_ae_leave_type_sick_leave_50" model="hr.leave.type">
-        <field name="work_entry_type_id" ref="hr_work_entry.uae_sick_leave_50_entry_type"/>
-    </record>
-
-    <record id="hr_holidays.l10n_ae_leave_type_sick_leave_0" model="hr.leave.type">
-        <field name="work_entry_type_id" ref="hr_work_entry.uae_sick_leave_0_entry_type"/>
-    </record>
-
 <!-- BE : Belgium -->
     <record id="hr_holidays.l10n_be_leave_type_small_unemployment" model="hr.leave.type">
         <field name="work_entry_type_id" ref="hr_work_entry.l10n_be_work_entry_type_small_unemployment"/>


### PR DESCRIPTION
Originally, each sick leave in the UAE's  localization has its own salary rule. The logic for all the sick leave types has been grouped into one salary rule.
