### PR TITLE
[FIX] point_of_sale: Fix mobile vertical scroll on product screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
@@ -10,7 +10,7 @@
     }
 
     @include media-breakpoint-down(sm) {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(auto-fill, 1fr);
     }
 }
 

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -23,6 +23,16 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
             // Go by default to home category
 
             Chrome.startPoS(),
+            // Make sure we don't have any scroll bar on the product list
+            {
+                trigger: ".product-list",
+                run: function () {
+                    const productList = document.querySelector(".product-list");
+                    if (productList.scrollWidth > document.documentElement.scrollWidth) {
+                        throw new Error("Product list is overflowing");
+                    }
+                },
+            },
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "1.0", "5.10"),
             ProductScreen.clickDisplayedProduct("Desk Organizer", true, "2.0", "10.20"),
             ProductScreen.clickDisplayedProduct("Letter Tray", true, "1.0", "5.28"),


### PR DESCRIPTION
- This commit fixes the issue of vertical scrolling on mobile devices, now we responsively display the correct number of product lists by line, instead of forcing the display of 3 per lines.
- Also add a test to ensure that the product list does not overflow on mobile devices.

backport of commit (8dba5b2781d40c0817829ce330aeea2c6b0bff36)

task-id: 4922341




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
