### PR TITLE
[IMP] mail: search messages and activities with access using SQL + remove fetch override

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1017,12 +1017,14 @@ class CalendarEvent(models.Model):
 
     def _mail_get_operation_for_mail_message_operation(self, message_operation):
         # reading messages on private events requires write access, not just read access
-        private = self.filtered(
-            lambda event: event.privacy == "private" and self.env.user.partner_id not in event.attendee_ids.partner_id
-        ) if message_operation == "read" else self.browse()
-        result = super(CalendarEvent, self - private)._mail_get_operation_for_mail_message_operation(message_operation)
-        result.update(dict.fromkeys(private, 'write'))
-        return result
+        operations = super()._mail_get_operation_for_mail_message_operation(message_operation)
+        if message_operation == 'read':
+            domain_private = Domain('privacy', '=', 'private') & (~Domain('attendee_ids.partner_id', '=', self.env.user.partner_id.id)).optimize(self)
+            return (
+                (domain_private, 'write'),
+                *operations,
+            )
+        return operations
 
     def _attendees_values(self, partner_commands):
         """

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -31,7 +31,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=476):  # crm 476 / com 476 / ent 605
+        with self.assertQueryCount(user_sales_manager=545):  # crm 545 / com 545 / ent 545
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -49,7 +49,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=452):  # crm 428 / com 428 / ent 452
+        with self.assertQueryCount(user_sales_manager=520):  # crm 497 / com 497 / ent 520
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -31,7 +31,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=531):  # crm 605 / com 605 / ent 605
+        with self.assertQueryCount(user_sales_manager=476):  # crm 476 / com 476 / ent 605
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -49,7 +49,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=483):  # crm 544 / com 546 / ent 585
+        with self.assertQueryCount(user_sales_manager=452):  # crm 428 / com 428 / ent 452
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)

--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -18,7 +18,7 @@ class ChatbotScriptStep(models.Model):
 
     def _chatbot_crm_prepare_lead_values(self, discuss_channel, description):
         name = self.env._("%s's New Lead", self.chatbot_script_id.title)
-        if msg := self._find_first_user_free_input(discuss_channel):
+        if msg := self._find_first_user_free_input(discuss_channel.sudo()):
             name = html2plaintext(msg.body)[:100]
         partner = self.env.user.partner_id
         team = self.crm_team_id

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -667,7 +667,7 @@ class EventEvent(models.Model):
             # allow the registration desk users to post messages on Event
             # can not be done with "_mail_post_access" otherwise public user will be
             # able to post on published Event (see website_event)
-            return dict.fromkeys(self, 'read')
+            return [(Domain.TRUE, 'read')]
         return super()._mail_get_operation_for_mail_message_operation(message_operation)
 
     def _set_tz_context(self):

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -49,7 +49,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     @users('__system__', 'admin')
     @warmup
     def test_performance_leave_create(self):
-        with self.assertQueryCount(__system__=72, admin=72):
+        with self.assertQueryCount(__system__=73, admin=73):
             leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_refuse()
 

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -210,12 +210,12 @@ class ChatbotScriptStep(models.Model):
     def _find_first_user_free_input(self, discuss_channel):
         """Find the first message from the visitor responding to a free_input step."""
         chatbot_partner = self.chatbot_script_id.operator_partner_id
-        user_answers = discuss_channel.chatbot_message_ids.filtered(
-            lambda m: m.mail_message_id.author_id != chatbot_partner
-        ).sorted("id")
-        for answer in user_answers:
-            if answer.script_step_id.step_type in ("free_input_single", "free_input_multi"):
-                return answer.mail_message_id
+        for answer in discuss_channel.chatbot_message_ids.sorted("id"):
+            if answer.script_step_id.step_type not in ("free_input_single", "free_input_multi"):
+                continue
+            message = answer.mail_message_id
+            if message.has_access('read') and message.author_id != chatbot_partner:
+                return message.with_prefetch()
         return self.env["mail.message"]
 
     def _fetch_next_step(self, selected_answer_ids):

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -39,8 +39,10 @@ class ThreadController(http.Controller):
         behavior is to rely on _mail_post_access but it might be customized.
         See '_mail_get_operation_for_mail_message_operation'. """
         thread_su = request.env[thread_model].sudo().browse(int(thread_id))
-        access_mode = thread_su._mail_get_operation_for_mail_message_operation('create')[thread_su]
-        if not access_mode:
+        for document_domain, access_mode in thread_su._mail_get_operation_for_mail_message_operation('create'):
+            if thread_su.filtered_domain(document_domain):
+                break
+        else:
             return request.env[thread_model]  # match _get_thread_with_access void result
         return cls._get_thread_with_access(thread_model, thread_id, mode=access_mode, **kwargs)
 

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -15,7 +15,7 @@ from odoo.tools.misc import clean_context, get_lang, groupby
 from odoo.tools.translate import LazyTranslate
 from odoo.addons.base.models.ir_attachment import condition_values
 from odoo.addons.mail.tools.discuss import Store
-from .mail_message import _find_allowed_doc_ids
+from .mail_message import MAX_COMODELS_FOR_DOMAIN, _find_allowed_doc_ids, exists_in_cache
 
 _logger = logging.getLogger(__name__)
 _lt = LazyTranslate(__name__)
@@ -367,24 +367,82 @@ class MailActivity(models.Model):
             logic is detailed in :meth:`~._check_access`.
             Superusers bypass this and perform a standard search.
         """
+        domain = Domain(domain).optimize(self)
 
         if any(
             condition.field_expr == 'date_done' and condition.value
-            for condition in Domain(domain).iter_conditions()
+            for condition in domain.iter_conditions()
         ):
             kwargs['active_test'] = False
 
         # Rules do not apply to administrator or when we search only activities assigned to the current user
         domain = Domain(domain).optimize(self)
-        if self.env.su or bypass_access or tuple(condition_values(self, 'user_id', domain) or ()) == (self.env.uid,):
+        if self.env.su or bypass_access or domain.is_false() or tuple(condition_values(self, 'user_id', domain) or ()) == (self.env.uid,):
             return super()._search(domain, offset, limit, order, bypass_access=bypass_access, **kwargs)
         if self.env.context.get('_read_groupby'):
             raise ValueError("Cannot group by mail.activity")
 
-        # retrieve activities and filter using their security rules
-        query = super()._search(domain, offset, limit, order, **kwargs)
-        records = self._fetch_query(query, [self._fields[f] for f in SECURITY_FIELDS])
-        return records._filtered_access('read')._as_query(ordered=bool(order))
+        # search by ids
+        if (ids := condition_values(self, 'id', domain)) is not None:
+            if (not order or order[:2] == 'id') and domain.map_conditions(lambda d: Domain.TRUE if d.field_expr == 'id' and d.operator == 'in' else d).is_true():
+                # trivial domain, can skip search, in most cases check access removes inexisting records
+                records = exists_in_cache(self.browse(ids), hint_field='res_model')
+                records = records._filtered_access('read')
+                if order:
+                    records = records.sorted(order)
+            else:
+                records = self.browse(super()._search(domain, order=order, **kwargs))
+                records = records._filtered_access('read')
+            if offset > 0:
+                records = records[offset:]
+            if limit is not None:
+                records = records[:limit]
+            return records._as_query(ordered=bool(order))
+
+        # searching for all messages or a subset of models
+        res_model_names = condition_values(self, 'res_model', domain) or ()
+        if not (0 < len(res_model_names) <= MAX_COMODELS_FOR_DOMAIN):
+            query = super()._search(domain, offset, limit, order, **kwargs)
+            records = self._fetch_query(query, [self._fields[f] for f in SECURITY_FIELDS])
+            return records._filtered_access('read')._as_query(ordered=bool(order))
+
+        # search by model and res_id
+        sec_domain = Domain('user_id', '=', self.env.uid)
+        env = self.with_context(active_test=False).env
+        for res_model_name in res_model_names:
+            if res_model_name not in env:
+                continue
+            comodel = env[res_model_name]
+            codomain = Domain('res_model', '=', comodel._name)
+            comodel_res_ids = condition_values(self, 'res_id', domain.map_conditions(
+                lambda cond: codomain & cond if cond.field_expr == 'res_model' else cond
+            ))
+            # similar implementation to what is in mail.message._search
+            comodel_domain = Domain.FALSE
+            comodel_domain_remaining = Domain.TRUE
+            for domain_operation, doc_operation in comodel._mail_get_operation_for_mail_message_operation('read'):
+                domain_operation, comodel_domain_remaining = (
+                    comodel_domain_remaining & domain_operation,
+                    comodel_domain_remaining & ~domain_operation,
+                )
+                if not comodel.has_access(doc_operation):
+                    continue
+                if doc_operation == 'read':
+                    comodel_rule = Domain.TRUE  # covered by the search below
+                else:
+                    comodel_rule = self.env['ir.rule']._compute_domain(comodel._name, doc_operation)
+                comodel_domain |= (domain_operation & comodel_rule)
+            if comodel_res_ids is not None:
+                comodel_domain &= Domain('id', 'in', comodel_res_ids)
+            comodel_domain = comodel_domain.optimize_full(comodel.sudo())
+            query = comodel._search(comodel_domain)
+            if query.is_empty():
+                continue
+            if query.where_clause:
+                codomain &= Domain('res_id', 'any!', query)
+            sec_domain |= codomain
+
+        return super()._search(domain & sec_domain, offset, limit, order, **kwargs)
 
     @api.depends('summary', 'activity_type_id')
     def _compute_display_name(self):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -15,10 +15,35 @@ from odoo.exceptions import AccessError, MissingError
 from odoo.fields import Command, Domain
 from odoo.tools import clean_context, groupby, SQL
 from odoo.tools.misc import OrderedSet
+from odoo.addons.base.models.ir_attachment import condition_values
 from odoo.addons.mail.tools.discuss import Store
 
 _logger = logging.getLogger(__name__)
 _image_dataurl = re.compile(r'(data:image/[a-z]+?);base64,([a-z0-9+/\n]{3,}=*)\n*([\'"])(?: data-filename="([^"]*)")?', re.I)
+
+MAX_COMODELS_FOR_DOMAIN = 5
+
+
+def exists_in_cache(records, *, hint_field=''):
+    """Like Model.exists(), but checks the cache when possible and avoids a
+    call to `Model.exists()`."""
+    # see test_record_unlinked_orphan_activities
+    # TODO once cache pollution is solved, move this into Model.fetch()
+    try:
+        if hint_field:
+            records.sudo().mapped(hint_field)
+            return records
+        for field in records._fields.values():
+            if (
+                field.store and field.column_type
+                and field.prefetch is True
+                and records._has_field_access(field, 'read')
+            ):
+                records.sudo().mapped(field.name)
+                return records
+    except MissingError:
+        pass
+    return records.exists()
 
 
 def _find_allowed_doc_ids(env, model_ids, operation):
@@ -38,23 +63,7 @@ def _find_allowed_doc_ids(env, model_ids, operation):
     """
     allowed_ids = set()
     for doc_model, doc_dict in model_ids.items():
-        documents = env[doc_model].browse(doc_dict)
-        try:
-            # Check that records really exist;
-            # lengthy way of checking first in cache and avoiding exists() call.
-            # see test_record_unlinked_orphan_activities
-            for field in documents._fields.values():
-                if (
-                    field.store and field.column_type
-                    and field.prefetch is True
-                    and documents._has_field_access(field, 'read')
-                ):
-                    documents.sudo().mapped(field.name)
-                    break
-            else:
-                documents = documents.exists()
-        except MissingError:
-            documents = documents.exists()
+        documents = exists_in_cache(env[doc_model].browse(doc_dict))
         for document_domain, operation_res_ids in documents._mail_get_operation_for_mail_message_operation(operation):
             if not documents:
                 break
@@ -373,65 +382,89 @@ class MailMessage(models.Model):
         ids uid could not see according to our custom rules. Please refer to
         :meth:`_check_access` for more details about those rules.
         """
-        # Rules do not apply to administrator
-        if self.env.su or bypass_access:
+        domain = Domain(domain).optimize(self)
+        if self.env.su or bypass_access or domain.is_false():
             return super()._search(domain, offset, limit, order, bypass_access=True, **kwargs)
         if self.env.context.get('_read_groupby'):
             raise ValueError("Cannot group by mail.message")
 
         # Non-employee see only messages with a subtype and not internal
-        domain = self._get_search_domain_share() & Domain(domain)
+        domain = self._get_search_domain_share() & domain
+        domain = domain.optimize_dynamic(self)
 
-        # make the search query with the default rules
-        query = super()._search(domain, offset, limit, order, **kwargs)
+        # search by ids
+        if condition_values(self, 'id', domain) is not None:
+            query = super()._search(domain, order=order, **kwargs)
+            records = self.browse()._filter_accessible_from_query(query, 'read')
+            if offset > 0:
+                records = records[offset:]
+            if limit is not None:
+                records = records[:limit]
+            return records._as_query(ordered=bool(order))
 
-        # retrieve matching records and determine which ones are truly accessible
-        self.flush_model(['model', 'res_id', 'author_id', 'message_type', 'partner_ids'])
-        self.env['mail.notification'].flush_model(['mail_message_id', 'res_partner_id'])
+        # searching for all messages or a subset of models
+        res_model_names = condition_values(self, 'model', domain) or ()
+        if not (0 < len(res_model_names) <= MAX_COMODELS_FOR_DOMAIN):
+            query = super()._search(domain, offset, limit, order, **kwargs)
+            records = self.browse()._filter_accessible_from_query(query, 'read')
+            return records._as_query(ordered=bool(order))
 
-        pid = self.env.user.partner_id.id
-        ids = []
-        allowed_ids = set()
-        model_ids = defaultdict(lambda: defaultdict(set))
+        # search by model and res_id
+        model_codomains = Domain.FALSE  # (model = a & res_id in ...) | (model = b & ...)
+        env = self.with_context(active_test=False).env
+        for res_model_name in res_model_names:
+            if res_model_name not in env:
+                continue
+            comodel = env[res_model_name]
+            codomain = Domain('model', '=', comodel._name)
+            comodel_res_ids = condition_values(self, 'res_id', domain.map_conditions(
+                lambda cond: codomain & cond if cond.field_expr == 'model' else cond
+            ))
+            # For each model, build a query with accessible comodel ids.
+            # Start with a false domain and at each step:
+            # 1. domain_operation is the remaining records
+            # 2. update the remaining to remove currently handled records
+            # 3. add to comodel_domain, the records with their access rule
+            # Then: add known ids for simpler query and optimize with sudo
+            # (because the rules are applied with sudo permissions) and search.
+            comodel_domain = Domain.FALSE
+            comodel_domain_remaining = Domain.TRUE
+            for domain_operation, doc_operation in comodel._mail_get_operation_for_mail_message_operation('read'):
+                domain_operation, comodel_domain_remaining = (
+                    comodel_domain_remaining & domain_operation,
+                    comodel_domain_remaining & ~domain_operation,
+                )
+                if not comodel.has_access(doc_operation):
+                    continue
+                if doc_operation == 'read':
+                    comodel_rule = Domain.TRUE  # covered by the search below
+                else:
+                    comodel_rule = self.env['ir.rule']._compute_domain(comodel._name, doc_operation)
+                comodel_domain |= (domain_operation & comodel_rule)
+            if comodel_res_ids is not None:
+                comodel_domain &= Domain('id', 'in', comodel_res_ids)
+            comodel_domain = comodel_domain.optimize_full(comodel.sudo())
+            query = comodel._search(comodel_domain)
+            if query.is_empty():
+                continue
+            if query.where_clause:
+                codomain &= Domain('res_id', 'any!', query)
+            model_codomains |= codomain
 
-        rel_alias = query.make_alias(self._table, 'partner_ids')
-        query.add_join("LEFT JOIN", rel_alias, 'mail_message_res_partner_rel', SQL(
-            "%s = %s AND %s = %s",
-            SQL.identifier(self._table, 'id'),
-            SQL.identifier(rel_alias, 'mail_message_id'),
-            SQL.identifier(rel_alias, 'res_partner_id'),
-            pid,
+        partner = self.env.user.partner_id
+        domain &= Domain.OR((
+            Domain('author_id', '=', partner.id),
+            Domain('create_uid', '=', self.env.uid),
+            # force an IN condition with a list of values
+            Domain('partner_ids', 'any!', partner._as_query()),
+            Domain('notified_partner_ids', 'any!', partner._as_query()),
+            # User_notification notified relevant partners, hence covered by
+            # 'partner_ids' domain part (which is why it is ok to exclude them
+            # complete from records-based domain).
+            model_codomains & Domain('message_type', '!=', 'user_notification'),
         ))
-        notif_alias = query.make_alias(self._table, 'notification_ids')
-        query.add_join("LEFT JOIN", notif_alias, 'mail_notification', SQL(
-            "%s = %s AND %s = %s",
-            SQL.identifier(self._table, 'id'),
-            SQL.identifier(notif_alias, 'mail_message_id'),
-            SQL.identifier(notif_alias, 'res_partner_id'),
-            pid,
-        ))
-        self.env.cr.execute(query.select(
-            SQL.identifier(self._table, 'id'),
-            SQL.identifier(self._table, 'model'),
-            SQL.identifier(self._table, 'res_id'),
-            SQL.identifier(self._table, 'author_id'),
-            SQL.identifier(self._table, 'message_type'),
-            SQL(
-                "COALESCE(%s, %s)",
-                SQL.identifier(rel_alias, 'res_partner_id'),
-                SQL.identifier(notif_alias, 'res_partner_id'),
-            ),
-        ))
-        for id_, model, res_id, author_id, message_type, notified in self.env.cr.fetchall():
-            ids.append(id_)
-            if author_id == pid or notified:
-                allowed_ids.add(id_)
-            elif model and res_id and message_type != 'user_notification':
-                model_ids[model][res_id].add(id_)
 
-        allowed_ids.update(_find_allowed_doc_ids(self.env, model_ids, 'read'))
-        allowed = self.browse(id_ for id_ in ids if id_ in allowed_ids)
-        return allowed._as_query(order)
+        return super()._search(domain, offset, limit, order, **kwargs)
 
     def _get_search_domain_share(self):
         if self.env.user._is_internal():
@@ -471,30 +504,37 @@ class MailMessage(models.Model):
 
         # discard forbidden records, and check remaining ones
         messages = self - result[0] if result else self
-        if messages and (forbidden := messages._get_forbidden_access(operation)):
+
+        query = self.sudo()._search(self._get_search_domain_share() & Domain('id', 'in', messages.ids), active_test=False)
+        accessible_messages = messages._filter_accessible_from_query(query, operation)
+        if messages != accessible_messages:
+            forbidden = messages - accessible_messages
             if result:
                 result = (result[0] + forbidden, result[1])
             else:
                 result = (forbidden, lambda: forbidden._make_access_error(operation))
         return result
 
-    def _get_forbidden_access(self, operation: str) -> Self:
-        """ Return the subset of ``self`` that does not satisfy the specific
-        conditions for messages.
+    def _filter_accessible_from_query(self, query: models.Query, operation: str) -> Self:
+        """ Return the subset of ``self`` that satisfies the specific conditions
+        for messages. Flush current recordset or the model on empty self.
         """
-        if not self:
-            return self
+        assert query._model._name == self._name
+        if query.is_empty():
+            return self.browse()
 
         # Read the value of messages in order to determine their accessibility.
         # The values are put in 'messages_to_check', and entries are popped
         # once we know they are accessible. At the end, the remaining entries
         # are the invalid ones.
-        self.flush_recordset(['model', 'res_id', 'author_id', 'create_uid', 'parent_id', 'message_type', 'partner_ids'])
+        if self:
+            self.flush_recordset(['model', 'res_id', 'author_id', 'create_uid', 'parent_id', 'message_type', 'partner_ids'])
+        else:
+            self.flush_model(['model', 'res_id', 'author_id', 'create_uid', 'parent_id', 'message_type', 'partner_ids'])
         self.env['mail.notification'].flush_model(['mail_message_id', 'res_partner_id'])
         pid = self.env.user.partner_id.id
 
         # Non internal users see only non-private messages
-        query = self.sudo()._search(self._get_search_domain_share() & Domain('id', 'in', self.ids), active_test=False)
         table = query.table
         if operation in ('read', 'write'):
             id_sql = table.id
@@ -521,10 +561,9 @@ class MailMessage(models.Model):
             values['id']: values
             for values in self.env.cr.dictfetchall()
         }
-        # Not found messages are forbidden
-        forbidden = self - self.browse(messages_to_check)
+        accessible = self.browse(messages_to_check)
         if not messages_to_check:
-            return forbidden
+            return accessible
 
         # Author condition (READ, WRITE, CREATE (private))
         if operation == 'read':
@@ -550,7 +589,7 @@ class MailMessage(models.Model):
             }
 
         if not messages_to_check:
-            return forbidden
+            return accessible
 
         # Recipients condition, for read and write (partner_ids)
         # keep on top, useful for systray notifications
@@ -561,7 +600,7 @@ class MailMessage(models.Model):
                 if not message['notified']
             }
             if not messages_to_check:
-                return forbidden
+                return accessible
 
         # CRUD: Access rights related to the document
         # {document_model_name: {document_id: message_ids}}
@@ -578,7 +617,7 @@ class MailMessage(models.Model):
             messages_to_check.pop(mid)
 
         if not messages_to_check:
-            return forbidden
+            return accessible
 
         # Parent condition, for create (check for received notifications for the created message parent)
         if operation == 'create':
@@ -600,10 +639,9 @@ class MailMessage(models.Model):
                         messages_to_check.pop(mid)
 
             if not messages_to_check:
-                return forbidden
+                return accessible
 
-        forbidden += self.browse(messages_to_check)
-        return forbidden
+        return accessible - self.browse(messages_to_check)
 
     def _make_access_error(self, operation: str) -> AccessError:
         return AccessError(_(
@@ -633,7 +671,8 @@ class MailMessage(models.Model):
             # incorrect due to historically having no reason to allow operations on messages to
             # public user before the introduction of guests. Even with ignoring the rights,
             # check_access_rule and its sub methods are already covering all the cases properly.
-            if not message.sudo(False)._get_forbidden_access(mode):
+            query = message.sudo()._search(self._get_search_domain_share() & Domain('id', 'in', message.ids))
+            if message.sudo(False)._filter_accessible_from_query(query, mode):
                 return message
         else:
             if message.sudo(False).has_access(mode):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -5056,7 +5056,12 @@ class MailThread(models.AbstractModel):
         if res.is_for_current_user():
             res.attr("hasReadAccess", lambda t: t.sudo(False).has_access("read"))
             res.attr("hasWriteAccess", lambda t: t.sudo(False).has_access("write"))
-            res.attr("canPostOnReadonly", self._mail_get_operation_for_mail_message_operation('create').get(self) == "read")
+            can_post = False
+            for domain, operation in self._mail_get_operation_for_mail_message_operation('create'):
+                if self.sudo().filtered_domain(domain):
+                    can_post = operation == "read"
+                    break
+            res.attr("canPostOnReadonly", can_post)
         if "activities" in request_list and isinstance(self, self.env.registry["mail.activity.mixin"]):
             res.many(
                 "activities",

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
@@ -8,6 +7,7 @@ from markupsafe import Markup
 
 from odoo import api, exceptions, models, tools, _
 from odoo.addons.mail.tools.alias_error import AliasError
+from odoo.fields import Domain
 from odoo.tools import parse_contact_from_email
 from odoo.tools.mail import email_normalize, email_split_and_format
 
@@ -55,10 +55,34 @@ class Base(models.AbstractModel):
     # CHECK ACCESS
     # ------------------------------------------------------------
 
+    @api.model
     def _mail_get_operation_for_mail_message_operation(self, message_operation):
         """ Give document permission based on mail.message check permission.
         This is used when no other checks already granted permission (e.g.
-        being notified, being author, ...). """
+        being notified, being author, ...).
+
+        Return value is a list of tuples (domain, operation). The operation to
+        apply on a record is the first operation where the record satisfies the
+        domain.
+
+        A list ``[(dom1, op1), (dom2, op2)]`` is means that the operation to
+        check for a given document is equivalent to::
+
+            if record.sudo().filtered_domain(dom1):
+                return op1
+            if record.sudo().filtered_domain(dom2):
+                return op2
+
+        .. code-block:: python
+
+            for domain, operation in self._mail_get_operation_for_mail_message_operation(...):
+                if record.sudo().filtered_domain(domain):
+                    record.check_access(operation)
+                    break
+            else:
+                # should not happen in real live as we tend to end with Domain.TRUE
+                raise AccessError  # no matching operation
+        """
         valid_operations = {'read', 'write', 'unlink', 'create'}
         if message_operation not in valid_operations:
             raise ValueError('Invalid message operation, should be a valid ORM operation type')
@@ -72,19 +96,7 @@ class Base(models.AbstractModel):
             check_access = mail_post_access
         else:
             check_access = 'write'
-        return dict.fromkeys(self, check_access)
-
-    def _mail_group_by_operation_for_mail_message_operation(self, message_operation):
-        """ Globally reverse result of '_mail_get_operation_for_mail_message_operation'
-        aka return documents for a given access to check on them. """
-        document_operations = self._mail_get_operation_for_mail_message_operation(message_operation)
-        operation_documents = defaultdict(lambda: self.env[self._name])
-        for record, record_operation in document_operations.items():
-            operation_documents[record_operation] += record
-        # force prefetch in a post-loop as recordset concatenation may lose it
-        for operation, records in operation_documents.items():
-            records = records.with_prefetch(self.ids)
-        return operation_documents
+        return ((Domain.TRUE, check_access),)
 
     # ------------------------------------------------------------
     # FIELDS HELPERS

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -29,6 +29,19 @@ class TestMailMessage(common.MailCommon):
         self.assertTrue(inexisting_message.browse().has_access('read'))
         self.assertFalse(inexisting_message.has_access('read'))
 
+    def test_mail_message_read_access(self):
+        self.env['res.company'].invalidate_model(['name'])
+        message_c1 = self._add_messages(self.env.company, "Company Note 1", author=self.user_employee.partner_id)
+        message_c2 = self._add_messages(self.company_2, "Company Note 2", author=self.user_employee_c2.partner_id)
+        search_result = (
+            self.env["mail.message"]
+            .with_context(allowed_company_ids=[self.env.company.id])
+            .with_user(self.user_employee)
+            .search([("model", "=", "res.company")])
+        )
+        self.assertIn(message_c1, search_result)
+        self.assertNotIn(message_c2, search_result)
+
     def test_unlink_failure_message_notify_author(self):
         recipient = new_test_user(self.env, login="Bob", email="invalid_email_addr")
         with self.mock_mail_gateway():

--- a/addons/product_email_template/tests/test_account_move.py
+++ b/addons/product_email_template/tests/test_account_move.py
@@ -43,11 +43,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         """
         Test scenario of a product ordered through the portal.
         """
-        id_max = self.env['mail.message'].search([], order='id desc', limit=1)
-        if id_max:
-            id_max = id_max[0].id
-        else:
-            id_max = 0
+        id_max = self.env['mail.message'].sudo().search([], order='id desc', limit=1).id or 0
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
             'partner_id': self.customer.id,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -88,10 +88,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch res_users
     #       - search discuss_channel_member
     #       - fetch discuss_channel
-    #   2: channels_as_member
-    #       - search_fetch channel (channels)
-    #       - search_count member (has_unpinned_channels)
-    #   34: store add channel:
+    #   2: _get_channels_as_member
+    #       - search discuss_channel (member_domain)
+    #       - search discuss_channel (pinned_member_domain)
+    #   34: channel _to_store_defaults:
+    #       - read mail.message model for get_annotatable models and check access
     #       - read group member (prefetch _compute_self_member_id from _compute_is_member)
     #       - read group member (_compute_invited_member_ids)
     #       - search discuss_channel_rtc_session
@@ -153,7 +154,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search user (author)
     #       - fetch user (author)
     #       - fetch discuss_call_history
-    _query_count_discuss_channels = 63
+    # TODO use assertQueries
+    _query_count_discuss_channels = 64
 
     def setUp(self):
         super().setUp()

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -49,9 +49,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #   2: _init_messaging_global_fields (discuss)
     #       - fetch discuss_channel_member (is_self)
     #       - _compute_message_unread
-    #   2: _init_messaging_global_fields (mail)
+    #   4: _init_messaging (mail)
+    #       - search bus_bus (_bus_last_id)
     #       - _get_needaction_count (inbox counter)
     #       - search mail_message (starred counter)
+    #           - _check_access
     #   23: _process_request_for_all (discuss):
     #       - search discuss_channel (channels_domain)
     #       22: store add channel:
@@ -79,7 +81,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #           - search discuss_channel_res_groups_rel (group_ids)
     #           - search_fetch ir_attachment (_compute_avatar_cache_key -> _compute_avatar_128)
     #           - fetch res_groups (group_public_id)
-    _query_count_init_messaging = 34
+    _query_count_init_messaging = 36
     # Queries for _query_count_discuss_channels (in order):
     #   1: insert res_device_log
     #   3: _search_is_member (for current user, first occurence channels_as_member)

--- a/addons/test_mail/models/mail_test_access.py
+++ b/addons/test_mail/models/mail_test_access.py
@@ -1,4 +1,5 @@
 from odoo import fields, models, tools
+from odoo.fields import Domain
 
 
 class MailTestAccess(models.Model):
@@ -56,13 +57,15 @@ class MailTestAccessCusto(models.Model):
     def _mail_get_operation_for_mail_message_operation(self, message_operation):
         # customize message creation: only unlocked, except admins
         if message_operation == "create" and not self.env.user._is_admin():
-            return dict.fromkeys(self.filtered(lambda r: not r.is_locked), 'read')
+            return (
+                (Domain('is_locked', '=', False), 'read'),
+            )
         # customize read: read access on unlocked, write access on locked
         elif message_operation == "read":
-            return {
-                record: 'write' if record.is_locked else 'read'
-                for record in self
-            }
+            return (
+                (Domain('is_locked', '=', True), 'write'),
+                (Domain.TRUE, 'read'),
+            )
         return super()._mail_get_operation_for_mail_message_operation(message_operation)
 
 

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -883,6 +883,7 @@ class TestMailMessageAccess(MessageAccessCommon):
         # hence messages are out of search, symmetrical to reading therm
         records[2].write({'is_locked': True, 'name': 'Locked !'})
         records[2].flush_recordset()
+        self.env.transaction.clear_access_cache()
         found_emp = self.env['mail.message'].with_user(self.user_employee).search([
             ('body', 'ilike', 'AnchorForSearch')
         ])

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -431,7 +431,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(admin=35, employee=35):
+        with self.assertQueryCount(admin=37, employee=37):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -452,7 +452,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer.id)],
             })
 
-        with self.assertQueryCount(admin=38, employee=38):
+        with self.assertQueryCount(admin=40, employee=40):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -476,7 +476,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=55, employee=55):  # tm 54/54
+        with self.assertQueryCount(admin=57, employee=57):  # tm 57/57
             composer._action_send_mail()
 
         # notifications
@@ -521,7 +521,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(admin=35, employee=35):
+        with self.assertQueryCount(admin=37, employee=37):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -539,7 +539,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=34, employee=34):
+        with self.assertQueryCount(admin=36, employee=36):
             composer._action_send_mail()
 
         # notifications
@@ -566,7 +566,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=42, employee=42):
+        with self.assertQueryCount(admin=44, employee=44):
             composer._action_send_mail()
 
         # notifications
@@ -598,7 +598,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=50, employee=50):
+        with self.assertQueryCount(admin=52, employee=52):
             composer._action_send_mail()
 
         # notifications
@@ -628,7 +628,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=67, employee=67):
+        with self.assertQueryCount(admin=69, employee=69):
             composer._action_send_mail()
 
         # notifications
@@ -664,7 +664,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=21, employee=20):
+        with self.assertQueryCount(admin=23, employee=22):
             record.write({
                 'user_id': self.user_emp_inbox.id,
             })
@@ -750,7 +750,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_post_one_inbox_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=17, employee=17):
+        with self.assertQueryCount(admin=19, employee=19):
             record.message_post(
                 body=Markup('<p>Test Post Performances with an inbox ping</p>'),
                 partner_ids=self.user_emp_inbox.partner_id.ids,
@@ -1062,7 +1062,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=92, employee=92):
+        with self.assertQueryCount(admin=112, employee=112):
             messages_as_sudo = test_records.message_post_with_source(
                 'test_mail.mail_template_simple_test',
                 render_values={'partner': self.user_emp_inbox.partner_id},
@@ -1362,7 +1362,7 @@ class TestMailAccessPerformance(BaseMailPerformance):
         # filter records: 1 / model (access rules done in batch)
         # _get_mail_message_access: 3 on custom implementation, no prefetching
         profile = self.profile() if self.warm else nullcontext()
-        with self.assertQueryCount(employee=4), profile:
+        with self.assertQueryCount(employee=5), profile:
             found = self.messages.with_env(self.env).search([('body', 'ilike', 'Posting on ')])
         self.assertEqual(found, self.messages - self.messages_emp_nope)
 
@@ -1510,7 +1510,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         """
         messages_all = self.messages_all.with_env(self.env)
 
-        with self.assertQueryCount(employee=26):  # tm 25
+        with self.assertQueryCount(employee=27):  # tm 26
             res = Store().add(messages_all, "_store_message_fields").get_result()
 
         self.assertEqual(len(res["mail.message"]), 2 * 2)
@@ -1523,7 +1523,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
     def test_store_add_message_single(self):
         message = self.messages_all[0].with_env(self.env)
 
-        with self.assertQueryCount(employee=26):  # tm 25
+        with self.assertQueryCount(employee=27):  # tm 26
             res = Store().add(message, "_store_message_fields").get_result()
 
         self.assertEqual(len(res["mail.message"]), 1)
@@ -1544,14 +1544,14 @@ class TestMessageToStorePerformance(BaseMailPerformance):
             'res_id': record.id
         } for record in records])
 
-        with self.assertQueryCount(employee=3):
+        with self.assertQueryCount(employee=5):
             res = Store().add(messages, "_store_message_fields").get_result()
             self.assertEqual(len(res["mail.message"]), 6)
 
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=15):  # tm: 14
+        with self.assertQueryCount(employee=16):  # tm: 15
             res = Store().add(messages, "_store_message_fields").get_result()
             self.assertEqual(len(res["mail.message"]), 6)
 
@@ -1813,7 +1813,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
 
         self.env.invalidate_all()
         with self.assertBus(get_params=get_bus_params):
-            with self.assertQueryCount(18):
+            with self.assertQueryCount(21):
                 record.message_post(
                     body=Markup("<p>Test Post Performances with multiple inbox ping!</p>"),
                     message_type="comment",
@@ -1906,7 +1906,7 @@ class TestPerformance(BaseMailPostPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=85):
+        with self.assertQueryCount(employee=88):
             ticket.message_post(
                 attachments=attachments_vals,
                 attachment_ids=attachments.ids,
@@ -1951,7 +1951,7 @@ class TestPerformance(BaseMailPostPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=850):  # tm: 841
+        with self.assertQueryCount(employee=880):  # tm: 841
             for ticket, attachments in zip(tickets, attachments_all, strict=True):
                 ticket.message_post(
                     attachments=attachments_vals,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -379,7 +379,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=13, employee=13):  # tm: 11 / 11
+        with self.assertQueryCount(admin=12, employee=12):  # tm: 10 / 10
             record.action_close('Dupe feedback')
 
         self.assertEqual(record.activity_ids, self.env['mail.activity'])
@@ -405,7 +405,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=15, employee=15):  # tm 13 / 13
+        with self.assertQueryCount(admin=14, employee=14):  # tm: 12 / 12
             record.action_close('Dupe feedback', attachment_ids=attachments.ids)
 
         # notifications

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1341,7 +1341,7 @@ class TestMailAccessPerformance(BaseMailPerformance):
     @warmup
     def test_message_read(self):
         # queries
-        # fetch messages: 1
+        # search messages: 1
         # filter records: 1 / model (except the one with _get_mail_message_access)
         # _get_mail_message_access: 2 on custom implementation, no prefetching (one unreachable)
         # 'read': 1

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -655,7 +655,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         # use another user already pre-defined with the email notification type,
         # so the ormcache is preserved.
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=41, employee=40):
+        with self.assertQueryCount(admin=42, employee=41):
             record.write({
                 'user_id': self.user_emp_email.id,
             })
@@ -738,7 +738,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_post_one_email_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=30, employee=30):
+        with self.assertQueryCount(admin=31, employee=31):
             record.message_post(
                 body=Markup('<p>Test Post Performances with an email ping</p>'),
                 partner_ids=self.customer.ids,
@@ -1019,7 +1019,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         record = self.container.with_user(self.env.user)
 
         # about 20 (19?) queries per additional customer group
-        with self.assertQueryCount(admin=55, employee=56):
+        with self.assertQueryCount(admin=56, employee=57):
             record.message_post(
                 body=Markup('<p>Test Post Performances</p>'),
                 message_type='comment',
@@ -1037,7 +1037,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=69, employee=70):
+        with self.assertQueryCount(admin=70, employee=71):
             record.message_post_with_source(
                 template,
                 message_type='comment',
@@ -1152,7 +1152,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=42, employee=42):
+        with self.assertQueryCount(admin=43, employee=43):
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -1172,7 +1172,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(admin=94, employee=94):
+        with self.assertQueryCount(admin=95, employee=95):
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,
@@ -1906,7 +1906,7 @@ class TestPerformance(BaseMailPostPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=83):  # tm: 83
+        with self.assertQueryCount(employee=85):
             ticket.message_post(
                 attachments=attachments_vals,
                 attachment_ids=attachments.ids,
@@ -1951,7 +1951,7 @@ class TestPerformance(BaseMailPostPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=839):  # tm: 830
+        with self.assertQueryCount(employee=850):  # tm: 841
             for ticket, attachments in zip(tickets, attachments_all, strict=True):
                 ticket.message_post(
                     attachments=attachments_vals,

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -75,7 +75,7 @@ class TestMailPerformance(FullBaseMailPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=106):  # test_mail_full: 106
+        with self.assertQueryCount(employee=110):  # test_mail_full: 108
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body=Markup('<p>Test Content</p>'),

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -415,25 +415,25 @@ class TestRatingPerformance(FullBaseMailPerformance):
     @users('employee')
     @warmup
     def test_rating_last_value_perfs(self):
-        with self.assertQueryCount(employee=274):  # tmf: 274
+        with self.assertQueryCount(employee=314):  # tmf: 274
             self.create_ratings('mail.test.rating.thread')
 
-        with self.assertQueryCount(employee=283):  # tmf: 283
+        with self.assertQueryCount(employee=323):  # tmf: 283
             self.apply_ratings(1)
 
-        with self.assertQueryCount(employee=242):  # tmf: 242
+        with self.assertQueryCount(employee=282):  # tmf: 242
             self.apply_ratings(5)
 
     @users('employee')
     @warmup
     def test_rating_last_value_perfs_with_rating_mixin(self):
-        with self.assertQueryCount(employee=317):  # tmf: 297
+        with self.assertQueryCount(employee=357):  # tmf: 297
             self.create_ratings('mail.test.rating')
 
-        with self.assertQueryCount(employee=325):  # tmf: 325
+        with self.assertQueryCount(employee=364):  # tmf: 325
             self.apply_ratings(1)
 
-        with self.assertQueryCount(employee=304):  # tmf: 304
+        with self.assertQueryCount(employee=343):  # tmf: 304
             self.apply_ratings(5)
 
         with self.assertQueryCount(employee=1):

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -36,7 +36,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_1_partner(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.customer.ids
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=30):  # tms: 30
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=32):  # tms: 32
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -51,7 +51,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_10_partners(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.partners.ids
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=30):  # tms: 30
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=32):  # tms: 32
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -65,7 +65,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     @warmup
     def test_message_sms_record_default(self):
         record = self.test_record.with_user(self.env.user)
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=31):  # tms: 31
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=33):  # tms: 33
             messages = record._message_sms(
                 body='Performance Test',
             )

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -729,11 +729,10 @@ class ForumPost(models.Model):
     # ----------------------------------------------------------------------
 
     def _mail_get_operation_for_mail_message_operation(self, message_operation):
+        operations = super()._mail_get_operation_for_mail_message_operation(message_operation)
         if message_operation in ('write', 'unlink'):
-            filtered_self = self.filtered(lambda post: post.can_edit)
-        else:
-            filtered_self = self
-        return super(ForumPost, filtered_self)._mail_get_operation_for_mail_message_operation(message_operation)
+            operations = [(Domain('can_edit', '=', True) & domain, op) for domain, op in operations]
+        return operations
 
     def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -614,10 +614,13 @@ class SlideChannel(models.Model):
 
     def _mail_get_operation_for_mail_message_operation(self, message_operation):
         # posting messages on channels user is a member requires only read access
-        is_member = self.filtered('is_member') if message_operation == "create" else self.browse()
-        result = super(SlideChannel, self - is_member)._mail_get_operation_for_mail_message_operation(message_operation)
-        result.update(dict.fromkeys(is_member, 'read'))
-        return result
+        operations = super()._mail_get_operation_for_mail_message_operation(message_operation)
+        if message_operation == 'create':
+            return (
+                (Domain('is_member', '=', True), 'read'),
+                *operations,
+            )
+        return operations
 
     # ---------------------------------------------------------
     # Business / Actions


### PR DESCRIPTION
When searching for messages or activities, perform the access checks in SQL.
We can translate rules that have restriction on model values directly into a Domain.

We keep the fallback to search without access rights and filter afterwards for other cases. We will always limit the number of returned results from the query to avoid checking the whole table.

The goal is to remove the hack (sudo in fetch) and align access and permission checks in both `_search` and `_check_access`.

https://github.com/odoo/enterprise/pull/98774
task-5238007
