### PR TITLE
[FIX] purchase: switch from onchange to compute for currency_id

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -89,8 +89,13 @@ class PurchaseOrder(models.Model):
     dest_address_id = fields.Many2one('res.partner', check_company=True, string='Dropship Address',
         help="Put an address if you want to deliver directly from the vendor to the customer. "
              "Otherwise, keep empty to deliver to your own company.")
-    currency_id = fields.Many2one('res.currency', 'Currency', required=True,
-        default=lambda self: self.env.company.currency_id.id)
+    currency_id = fields.Many2one('res.currency', 'Currency',
+        required=True,
+        compute='_compute_currency_id',
+        store=True,
+        readonly=False,
+        precompute=True,
+    )
     state = fields.Selection([
         ('draft', 'RFQ'),
         ('sent', 'RFQ Sent'),
@@ -332,17 +337,23 @@ class PurchaseOrder(models.Model):
         # are taken with the company of the order
         # if not defined, with_company doesn't change anything.
         self = self.with_company(self.company_id)
-        default_currency = self._context.get("default_currency_id")
         if not self.partner_id:
             self.fiscal_position_id = False
-            self.currency_id = default_currency or self.env.company.currency_id.id
         else:
             self.fiscal_position_id = self.env['account.fiscal.position']._get_fiscal_position(self.partner_id)
             self.payment_term_id = self.partner_id.property_supplier_payment_term_id.id
-            self.currency_id = default_currency or self.partner_id.property_purchase_currency_id.id or self.env.company.currency_id.id
             if self.partner_id.buyer_id:
                 self.user_id = self.partner_id.buyer_id
         return {}
+
+    @api.depends('partner_id', 'company_id')
+    def _compute_currency_id(self):
+        for order in self:
+            order = order.with_company(order.company_id)
+            if not order.partner_id:
+                order.currency_id = order.company_id.currency_id
+            else:
+                order.currency_id = order.partner_id.property_purchase_currency_id or order.company_id.currency_id
 
     @api.onchange('fiscal_position_id', 'company_id')
     def _compute_tax_id(self):

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -1050,3 +1050,19 @@ class TestPurchase(AccountTestInvoicingCommon):
         po = po_form.save()
         self.assertEqual(po.order_line.product_qty, 10.0)
         self.assertEqual(po.order_line.name, '[HHH] product_a')
+
+    def test_currency_computed_from_partner(self):
+        """Test that the currency of the purchase order is computed from the partner
+        when the partner is set, and that default_currency_id in context overrides compute.
+        """
+        eur = self.env.ref('base.EUR')
+        gbp = self.env.ref('base.GBP')
+        self.partner_a.property_purchase_currency_id = eur
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+        self.assertEqual(po.currency_id, eur, "The currency should be computed from the partner's purchase currency")
+        po_2 = self.env['purchase.order'].with_context(default_currency_id=gbp).create({
+            'partner_id': self.partner_a.id,
+        })
+        self.assertEqual(po_2.currency_id, gbp, "The currency should be set from context default_currency_id, bypassing the compute")


### PR DESCRIPTION
Steps to reproduce:
- Go to Invoicing > Configuration > Accounting > Currencies:
    - Enable the Euro currency
- Set company currency to USD
- Go to any partner form (e.g. Azure Interior):
    - In Sales & Purchase tab: - Set Supplier Currency to Euro
- Create a purchase order from the UI:
    - Select Azure Interior → Currency is correctly updated to Euro (via onchange)

- Install the Approvals module
- Create a storable product "P1":
    - Under Purchase tab: - Vendor: Azure Interior - Price unit: 5 EUR
- Create an approval request:
    - Request Owner: Marc Demo
    - Product: P1
    - Approver: Mitchel Admin
- Submit and approve the request
- Click on "Create Purchase Order"

Issue:
The purchase order is created with the correct partner and product. But the currency is incorrectly set to the company currency (USD), instead of the supplier's currency (Euro).

Cause:
The currency was updated via an `@onchange`, which is only triggered in the UI.
When creating a PO programmatically (e.g. via approvals or in a test), the onchange is not executed and the currency falls back to the company default.

Solution:
Replace the `@onchange` logic for `currency_id` with a stored compute field.
This ensures that the correct currency is always computed, regardless of how the purchase order is created.

opw-4938390
