### PR TITLE
[IMP] point_of_sale: display only surname on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -271,7 +271,7 @@ export class PosOrder extends Base {
     }
 
     getCashierName() {
-        return this.user_id?.name;
+        return this.user_id?.name?.split(" ").at(0);
     }
     canPay() {
         return this.lines.length;

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -31,7 +31,7 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             PaymentScreen.shippingLaterHighlighted(),
             PaymentScreen.clickValidate(),
             ReceiptScreen.receiptIsThere(),
-            ReceiptScreen.cashierNameExists("A simple PoS man!"),
+            ReceiptScreen.cashierNameExists("A"), // A simple PoS man! (Take the first word)
             Dialog.confirm("Continue with limited functionality"),
             //receipt had expected delivery printed
             ReceiptScreen.shippingDateExists(),

--- a/addons/pos_hr/static/src/app/models/pos_order.js
+++ b/addons/pos_hr/static/src/app/models/pos_order.js
@@ -4,6 +4,6 @@ import { patch } from "@web/core/utils/patch";
 patch(PosOrder.prototype, {
     // @Override
     getCashierName() {
-        return this.employee_id?.name || super.getCashierName(...arguments);
+        return this.employee_id?.name?.split(" ").at(0) || super.getCashierName(...arguments);
     },
 });

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -221,7 +221,7 @@ registry.category("web_tour.tours").add("test_cashier_changed_in_receipt", {
             PosHr.clickCashierName(),
             SelectionPopup.has("Test Employee 3", { run: "click" }),
             PaymentScreen.clickValidate(),
-            ReceiptScreen.cashierNameExists("Test Employee 3"),
+            ReceiptScreen.cashierNameExists("Test"), // Test Employee 3 (Take the first word)
             ReceiptScreen.clickNextOrder(),
         ].flat(),
 });


### PR DESCRIPTION
Task: [#4945889](https://www.odoo.com/odoo/my-tasks/4945889)

---
To address privacy and security concerns, the receipt now displays only the **first name** of the user who processed the order.

Since the `res.users.name` field contains both the first name and the surname in a single string, we assume the first name is the **first word** of the full name.
This approach provides a simple way to anonymize users while keeping the receipt understandable.

For example:
- "Giovanni Di Lorenzo" → "Giovanni"
- "Carlos María del Pilar" → "Carlos"

This change avoids disclosing the full identity while maintaining clarity for internal use.

