### PR TITLE
[IMP] website_mass_mailing: show all mailing lists in newsletter snippet

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -236,8 +236,9 @@ class MassMailController(http.Controller):
         # as there may be several contacts / email -> consider any opt-in overrides
         # opt-out
         contacts = self._fetch_contacts(email)
+        # private mailing lists are managed directly from received emails, with unsubscription links
         lists_optin = contacts.subscription_ids.filtered(
-            lambda sub: not sub.opt_out
+            lambda sub: not sub.opt_out and sub.list_id.is_public
         ).list_id.filtered('active')
         lists_optout = contacts.subscription_ids.filtered(
             lambda sub: sub.opt_out and sub.list_id not in lists_optin

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
@@ -35,6 +35,10 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_my", {
             trigger: "body:not(:has(li.list-group-item:contains('List5')))",
         },
         {
+            content: "List6 is not proposed (member and not public)",
+            trigger: "body:not(:has(li.list-group-item:contains('List6')))",
+        },
+        {
             trigger: "div#o_mailing_portal_subscription:not(fieldset)",
         },
         {

--- a/addons/mass_mailing/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing/tests/test_mailing_controllers.py
@@ -496,6 +496,13 @@ class TestMailingControllers(TestMailingControllersCommon):
         })
         private_list.subscription_ids[0].opt_out = True
 
+        # non-public list should not be displayed even if user is subscribed
+        self.env['mailing.list'].create({
+            'contact_ids': [(0, 0, {'name': 'Déboulonneur User', 'email': 'fleurus@example.com'})],
+            'name': 'List6',
+            'is_public': False,
+        })
+
         # launch 'my' mailing' tour
         self.authenticate(portal_user.login, portal_user.login)
         with freeze_time(self._reference_now):

--- a/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option_plugin.js
@@ -73,7 +73,7 @@ class MailingListSubscribeOptionPlugin extends Plugin {
             const response = await this.services.orm.call(
                 "mailing.list",
                 "name_search",
-                ["", [["is_public", "=", true]]],
+                [],
                 { context }
             );
             this.mailingLists = [];


### PR DESCRIPTION
Previously, the newsletter snippet only displayed mailing lists marked with 'Show in Preferences'. This behavior was misleading, as that setting is meant for user subscription management, not for restricting availability in the snippet picker.

This commit removes the restrictive domain from the 'fetchMailingLists's orm call to ensure all mailing lists are available when configuring the snippet.

Task-4979120
