### PR TITLE
[IMP] l10n_es: change account type of account 411000 to current liabilities

### DIFF
--- a/addons/l10n_es/data/template/account.account-es_common.csv
+++ b/addons/l10n_es/data/template/account.account-es_common.csv
@@ -184,7 +184,7 @@
 "account_common_4100","Payables for the rendering of services (euros)","Acreedores por prestaciones de servicios (euros)","Creditors per prestacions de serveis (euros)","4100","liability_payable","True",""
 "account_common_4104","Payables for the rendering of services (foreign currency)","Acreedores por prestaciones de servicios (moneda extranjera)","Creditors per prestacions de serveis (moneda estrangera)","4104","liability_payable","True",""
 "account_common_4109","Payables for the rendering of services, pending invoices","Acreedores por prestaciones de servicios, facturas pendientes de recibir o de formalizar","Creditors per prestacions de serveis, factures pendents de rebre o de formalitzar","4109","liability_payable","True",""
-"account_common_411","Trade bills payable","Acreedores, efectos comerciales a pagar","Creditors, efectes comercials a pagar","411","asset_current","True",""
+"account_common_411","Trade bills payable","Acreedores, efectos comerciales a pagar","Creditors, efectes comercials a pagar","411","liability_current","True",""
 "account_common_419","Payables for profit-sharing agreements","Acreedores por operaciones en común","Creditors per operacions en comú","419","liability_payable","True",""
 "account_common_4300","Trade receivables (euros)","Clientes (euros)","Clients (euros)","4300","asset_receivable","True",""
 "account_common_4301","Trade receivables (euros) (PoS)","Clientes (euros) (PoS)","Clients (euros) (PoS)","4301","asset_receivable","True",""


### PR DESCRIPTION
This commit changes the account type for account `411000 Acreedores, efectos comerciales a pagar`. It was previously set as a `Current Asset` and now its account type is `Current Liability`.

Task : 4757149

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
