### PR TITLE
[FIX] hr: Available hours on week bug

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1353,7 +1353,7 @@ class HrEmployee(models.Model):
                 # if employee is under fully flexible contract, use timezone of the employee
                 calendar_tz = timezone(version.resource_calendar_id.tz) if version.resource_calendar_id else timezone(employee.resource_id.tz)
                 date_start = datetime.combine(
-                    version.date_start,
+                    version.contract_date_start,
                     time(0, 0, 0)
                 ).replace(tzinfo=calendar_tz).astimezone(utc)
                 if version.date_end:
@@ -1438,12 +1438,15 @@ class HrEmployee(models.Model):
                 domain=[('company_id', 'in', [False, self.company_id.id])])[self.resource_id.id]
             return calendar_intervals
         duration_data = Intervals()
+        version_prev = datetime.combine(valid_versions[0].date_start, time.min, employee_tz)
         for version in valid_versions:
             version_start = datetime.combine(version.date_start, time.min, employee_tz)
+            contract_start = datetime.combine(version.contract_date_start, time.min, employee_tz)
             version_end = datetime.combine(version.date_end or date.max, time.max, employee_tz)
             calendar = version.resource_calendar_id or version.company_id.resource_calendar_id
+            start_date = version_start if version_prev < version_start else contract_start
             version_intervals = calendar._work_intervals_batch(
-                                    max(date_from, version_start),
+                                    max(date_from, start_date),
                                     min(date_to, version_end),
                                     tz=employee_tz,
                                     resources=self.resource_id,

--- a/addons/hr/tests/test_attendances.py
+++ b/addons/hr/tests/test_attendances.py
@@ -46,8 +46,15 @@ class TestAttendances(TestHrCommon):
         cls.employee.create_version({
             'resource_calendar_id': resource_calendar_half_time.id,
             'contract_date_start': date(2024, 6, 1),
+            'contract_date_end': date(2024, 7, 31),
             'wage': 1,
             'date_version': date(2024, 7, 1),
+        })
+
+        cls.employee.create_version({
+            'contract_date_start': date(2024, 8, 1),
+            'wage': 1,
+            'date_version': date(2024, 9, 1),
         })
 
         cls.employee.resource_calendar_id = contract_now.resource_calendar_id
@@ -63,3 +70,8 @@ class TestAttendances(TestHrCommon):
         check_out_tz = datetime.combine(datetime(2024, 7, 31), datetime.max.time()).astimezone(tz)
         intervals = self.employee._employee_attendance_intervals(check_in_tz, check_out_tz, lunch=False)
         self.assertEqual(len(intervals), 25)
+
+        check_in_tz = datetime.combine(datetime(2024, 8, 1), datetime.min.time()).astimezone(tz)
+        check_out_tz = datetime.combine(datetime(2024, 8, 31), datetime.max.time()).astimezone(tz)
+        intervals = self.employee._employee_attendance_intervals(check_in_tz, check_out_tz, lunch=False)
+        self.assertEqual(len(intervals), 20)


### PR DESCRIPTION
**Issue / current behavior:**
When you create an employee with version date = today and set him an occupation
starting in the past and then when we try to assign him a working schedule
24h/week it shows 0 working hours.

**Required behavior:**
It should display 24 working hours or whatever selected.

**Solution:**
Changed the field of available time of the week to contract_start_date from the 
version_start_date.

task-4985887

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
