### PR TITLE
[FIX] account_payment: don't try to turn string into float

### DIFF
--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -39,7 +39,7 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
             access_token=access_token,
             **kwargs)
 
-        amount_custom = amount and float('amount') or 0.0
+        amount_custom = float(amount or 0.0)
         values |= {
             **common_view_values,
             'amount_custom': amount_custom,


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Go to Accounting/Invoicing;
2. open an unpaid invoice;
3. generate payment link;
4. open payment link.

Issue
-----
Traceback on a `ValueError`.

Cause
-----
Commit 5697493e00915 added a `amount and float('amount')`, trying to convert a string into a float.

Solution
--------
Convert the variable into a float instead.

opw-4996783