### PR TITLE
[FIX] website_sale: set dataset only for Category List snippet on drop

### DIFF
--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_category_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_category_option_plugin.js
@@ -34,22 +34,24 @@ export class DynamicSnippetCategoryOptionPlugin extends Plugin {
     };
 
     async onSnippetDropped({ snippetEl }) {
-        for (const [optionName, value] of [
-            ['showParent', true],
-            ['columns', 2],
-            ['rounded', 2],
-            ['gap', 2],
-            ['size', 'medium'],
-            ['button', 'Explore Now'],
-            ['alignment', 'left'],
-        ]) {
-            setDatasetIfUndefined(snippetEl, optionName, value);
+        if (snippetEl.matches(this.selector)) {
+            for (const [optionName, value] of [
+                ['showParent', true],
+                ['columns', 2],
+                ['rounded', 2],
+                ['gap', 2],
+                ['size', 'medium'],
+                ['button', 'Explore Now'],
+                ['alignment', 'left'],
+            ]) {
+                setDatasetIfUndefined(snippetEl, optionName, value);
+            }
+            await this.dependencies.dynamicSnippetOption.setOptionsDefaultValues(
+                snippetEl,
+                this.modelNameFilter,
+                [],
+            );
         }
-        await this.dependencies.dynamicSnippetOption.setOptionsDefaultValues(
-            snippetEl,
-            this.modelNameFilter,
-            [],
-        );
     }
 }
 


### PR DESCRIPTION
Commit c21f69b436ceaddc62dabdaab102c3f78284a731 introduced the Category List snippet, which has a Plugin that sets dataset with `on_snippet_dropped_handlers` hook.

However, this hook is called for all snippets. As a result, the required dataset intended only for Category List snippet was being set on all dropped snippets unnecessarily.

This commit ensures that the dataset is applied only when the dropped snippet is Category List snippet, avoiding unintended side effects.
