### PR TITLE
[FIX] pos_loyalty: ensure pricelist_id in POS config (runbot error)

### DIFF
--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2962,6 +2962,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'program_id': self.loyalty_program.id,
             'points': 100,
         })
+        self.main_pos_config.write({'use_pricelist': True})
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_refund_does_not_decrease_points', login="pos_user")
         self.assertEqual(card.points, 30)


### PR DESCRIPTION
Task: [#4974070](https://www.odoo.com/odoo/my-tasks/4974070)
Runbot build error: [#229672](https://runbot.odoo.com/odoo/runbot.build.error/229672)

---
## Error
FAILED: [12/46] Tour test_refund_does_not_decrease_points → Step selection popup has '$ 1 per point on your order' (trigger: .selection-item:contains("$ 1 per point on your order")).

## Qualifiers
{
	"module": "pos_loyalty",
	"test_path": "/pos_loyalty/tests/test_frontend.py",
	"tour_name": "test_refund_does_not_decrease_points",
	"tour_step": ".selection-item:contains(\"$ 1 per point on your order\")",
	"test_class": "TestUi",
	"test_method": "test_refund_does_not_decrease_points",
	"test_module": "pos_loyalty"
}

## Fix
In some cases, the POS config's `pricelist_id` was not available in the frontend, causing loyalty program conditions to be skipped when checking for a matching pricelist.

By explicitly setting `use_pricelist` to True on the POS config, we ensure that `config.pricelist_id` is properly loaded and available at runtime, allowing loyalty programs with pricelist conditions to behave as expected.