### PR TITLE
[FIX] pos_loyalty: ensure pricelist_id in POS config (runbot error)

### DIFF
--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1170,6 +1170,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'points': 100,
         })
 
+        self.main_pos_config.write({'use_pricelist': True})
         self.main_pos_config.open_ui()
         self.start_pos_tour("PosLoyaltyTour6")
 


### PR DESCRIPTION
Task: [#4974071](https://www.odoo.com/odoo/my-tasks/4974071)
Runbot build error: [#182003](https://runbot.odoo.com/odoo/runbot.build.error/182003)

## Error
FAILED: [9/16] Tour PosLoyaltyTour6 → Step .loyalty-points-won:contains("26.5"). Element (.loyalty-points-won:contains("26.5")) has not been found.

## Qualifiers
{
"module": "pos_loyalty",
"test_path": "/pos_loyalty/tests/test_frontend.py", "tour_name": "PosLoyaltyTour6",
"tour_step": ".loyalty-points-won:contains("26.5")", "test_class": "TestUi",
"test_method": "test_point_per_money_spent",
"test_module": "pos_loyalty"
}

## Fix
In some cases, the POS config's pricelist_id was not available in the frontend, causing some issues. By explicitly setting use_pricelist to True on the POS config, we ensure that config.pricelist_id is properly loaded.