### PR TITLE
[IMP] point_of_sale: Edit and merge config/combo products from orderline

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -223,6 +223,7 @@
             "point_of_sale/static/src/app/components/odoo_logo/*",
             "point_of_sale/static/src/app/components/orderline/*",
             "point_of_sale/static/src/app/components/centered_icon/*",
+            "point_of_sale/static/src/app/utils/use_timed_press.js",
             "point_of_sale/static/src/utils.js",
             "point_of_sale/static/src/customer_display/**/*",
             ('remove', 'point_of_sale/static/src/customer_display/customer_display_adapter.js'),

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.js
@@ -1,4 +1,5 @@
-import { Component } from "@odoo/owl";
+import { Component, useRef } from "@odoo/owl";
+import { useTimedPress } from "@point_of_sale/app/utils/use_timed_press";
 import { formatCurrency } from "@web/core/currency";
 
 export class Orderline extends Component {
@@ -11,6 +12,8 @@ export class Orderline extends Component {
         showTaxGroup: { type: Boolean, optional: true },
         mode: { type: String, optional: true }, // display, receipt
         basic_receipt: { type: Boolean, optional: true },
+        onClick: { type: Function, optional: true },
+        onLongPress: { type: Function, optional: true },
     };
     static defaultProps = {
         showImage: false,
@@ -18,6 +21,8 @@ export class Orderline extends Component {
         showTaxGroup: false,
         mode: "display",
         basic_receipt: false,
+        onClick: () => {},
+        onLongPress: () => {},
     };
 
     formatCurrency(amount) {
@@ -36,5 +41,27 @@ export class Orderline extends Component {
                     .filter((label) => label)
             ),
         ].join(" ");
+    }
+
+    setup() {
+        this.root = useRef("root");
+        if (this.props.mode === "display") {
+            useTimedPress(this.root, [
+                {
+                    type: "release",
+                    maxDelay: 500,
+                    callback: (event, duration) => {
+                        this.props.onClick(event, duration);
+                    },
+                },
+                {
+                    type: "hold",
+                    delay: 500,
+                    callback: (event, duration) => {
+                        this.props.onLongPress(event, duration);
+                    },
+                },
+            ]);
+        }
     }
 }

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.Orderline">
-        <li t-if="line.order_id" class="orderline position-relative d-flex align-items-center lh-sm cursor-pointer"
+        <li t-ref="root" t-if="line.order_id" class="orderline position-relative d-flex align-items-center lh-sm cursor-pointer"
             t-attf-class="{{ line.combo_parent_id?.getFullProductName() ? 'orderline-combo fst-italic ms-4 border-start' : '' }}"
             t-att-class="{'selected' : line.isSelected() and this.props.mode === 'display', ...line.getDisplayClasses(), ...(props.class || [])}">
             <div class="product-order"></div>

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -70,7 +70,7 @@
 
             <select class="configurator_select form-select form-select-md" t-on-change="(e) => this.onChange(e)">
                 <t t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
-                    <option t-att-value="value.id" t-att-class="{'ptav-not-available': value.excluded}">
+                    <option t-att-value="value.id" t-att-class="{'ptav-not-available': value.excluded}" t-att-selected="props.selected?.id === value.id ? 'selected' : ''">
                         <t t-set="is_custom" t-value="is_custom || (value.is_custom and value.id == props.selected.id)"/>
                         <t t-esc="value.name"/>
                         <t t-if="value.price_extra">
@@ -170,8 +170,8 @@
                         customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
                         allSelectedValues="this.selectedValues"/>
                     <MultiProductAttribute t-elif="attribute.attribute_id.display_type === 'multi'" attribute="attribute" 
-                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
-                        customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
+                        selected="this.state.attributes[attribute.attribute_id.id]?.selected" setSelected="this.setSelected(attribute)" 
+                        customValue="this.state.attributes[attribute.attribute_id.id]?.custom_value" setCustomValue="setCustomValue(attribute)"
                         allSelectedValues="this.selectedValues"/>
                 </div>
             </div>
@@ -183,7 +183,7 @@
                             t-on-click="confirm">
                             Add
                         </button>
-                    <button class="btn btn-secondary btn-lg lh-lg w-50 o-default-button" t-on-click="close">Discard</button>
+                    <button class="btn btn-secondary btn-lg lh-lg w-50 o-default-button" t-on-click="props.close">Discard</button>
                 </div>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -17,6 +17,11 @@ export class DataServiceOptions {
                 condition: (record) =>
                     record.pos_order_id?.finalized && typeof record.pos_order_id.id === "number",
             },
+            "product.attribute.custom.value": {
+                key: "id",
+                condition: (record) =>
+                    record.order_id?.finalized && typeof record.order_id.id === "number",
+            },
         };
     }
 

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1071,9 +1071,16 @@ export class PosOrder extends Base {
                 }
             });
             return resultLines;
-        } else {
-            return this.lines;
         }
+        // Group the combo lines with their parent line
+        return this.lines.reduce((acc, line) => {
+            if (line.combo_line_ids?.length > 0) {
+                acc.push(line, ...line.combo_line_ids);
+            } else if (!line.combo_parent_id) {
+                acc.push(line);
+            }
+            return acc;
+        }, []);
     }
     getName() {
         return this.floatingOrderName || "";

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -118,6 +118,37 @@ export class PosOrderline extends Base {
         return this.models["stock.picking.type"].getFirst();
     }
 
+    get selectedComboIds() {
+        const allLines = this.getAllLinesInCombo();
+        return allLines.reduce((acc, line) => {
+            if (!line.combo_item_id) {
+                return acc;
+            }
+
+            acc[line.combo_item_id.combo_id.id] = line.combo_item_id.id;
+            return acc;
+        }, {});
+    }
+
+    get selectedAttributes() {
+        return this.attribute_value_ids.reduce((acc, attrValue) => {
+            const customValue =
+                this.custom_attribute_value_ids.find(
+                    (c) => c.custom_product_template_attribute_value_id.id === attrValue.id
+                )?.custom_value || "";
+
+            if (attrValue.attribute_id.display_type === "multi") {
+                if (!acc[attrValue.attribute_id.id]) {
+                    acc[attrValue.attribute_id.id] = { selected: [], custom_value: customValue };
+                }
+                acc[attrValue.attribute_id.id].selected.push(attrValue);
+            } else {
+                acc[attrValue.attribute_id.id] = { selected: attrValue, custom_value: customValue };
+            }
+            return acc;
+        }, {});
+    }
+
     // To be overrided
     getDisplayClasses() {
         return {};

--- a/addons/point_of_sale/static/src/app/models/product_attribute_custom_value.js
+++ b/addons/point_of_sale/static/src/app/models/product_attribute_custom_value.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+import { Base } from "./related_models";
+
+export class ProductAttributeCustomValue extends Base {
+    static pythonModel = "product.attribute.custom.value";
+
+    get order_id() {
+        return this.pos_order_line_id?.order_id;
+    }
+}
+
+registry
+    .category("pos_available_models")
+    .add(ProductAttributeCustomValue.pythonModel, ProductAttributeCustomValue);

--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -28,7 +28,7 @@ export const computeComboItems = (
         if (comboItem.id == childLineConf[childLineConf.length - 1].combo_item_id.id) {
             priceUnit += remainingTotal;
         }
-        const attribute_value_ids = conf.configuration?.attribute_value_ids.map(
+        const attribute_value_ids = conf.configuration?.attribute_value_ids?.map(
             (id) => productTemplateAttributeValueById[id]
         );
         const attributesPriceExtra = (attribute_value_ids ?? [])

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -44,18 +44,107 @@ export class OrderSummary extends Component {
     }
 
     clickLine(ev, orderline) {
-        if (ev.detail === 2) {
-            clearTimeout(this.singleClick);
-            return;
-        }
         this.numberBuffer.reset();
+
         if (!orderline.isSelected()) {
             this.pos.selectOrderLine(this.currentOrder, orderline);
         } else {
-            this.singleClick = setTimeout(() => {
-                this.pos.getOrder().uiState.selected_orderline_uuid = null;
-            }, 300);
+            this.pos.getOrder().uiState.selected_orderline_uuid = null;
         }
+    }
+
+    async onOrderlineLongPress(ev, orderline) {
+        const order = this.currentOrder;
+        order.assertEditable();
+
+        // If combo line, edit its parent instead
+        if (orderline.combo_parent_id) {
+            orderline = orderline.combo_parent_id;
+        }
+
+        // Prevent if already sent to kitchen
+        if (typeof order.id === "number") {
+            const preparation_data = await this.pos.data.call(
+                "pos.order",
+                "get_preparation_change",
+                [order.id]
+            );
+            const prep = JSON.parse(preparation_data.last_order_preparation_change || "{}");
+            if (prep.lines && Object.keys(prep.lines).some((l) => l === orderline.uuid)) {
+                this.dialog.add(AlertDialog, {
+                    title: _t("Cannot edit orderline"),
+                    body: _t(
+                        "This orderline has already been sent to the kitchen and cannot be edited."
+                    ),
+                });
+                return;
+            }
+        }
+
+        // Init orderline
+        const productTemplate = orderline.product_id.product_tmpl_id;
+        const values = {
+            product_tmpl_id: productTemplate,
+            product_id: orderline.product_id,
+            qty: orderline.qty,
+            price_extra: 0,
+        };
+
+        // Configurable product
+        let keepGoing = await this.pos.handleConfigurableProduct(
+            values,
+            productTemplate,
+            {},
+            true,
+            {
+                line: orderline,
+            }
+        );
+        if (keepGoing === false) {
+            return;
+        }
+
+        // Combo product
+        keepGoing = await this.pos.handleComboProduct(values, order, true, {
+            line: orderline,
+        });
+        if (keepGoing === false) {
+            return;
+        }
+
+        // Price unit
+        this.pos.handlePriceUnit(values, order, undefined);
+
+        // Update orderline
+        if (values.attribute_value_ids !== undefined) {
+            orderline.attribute_value_ids = values.attribute_value_ids.map((a) => a[1]);
+        }
+        if (values.custom_attribute_value_ids !== undefined) {
+            const createManyCustomAttributeValues = values.custom_attribute_value_ids.map(
+                (a) => a[1]
+            );
+            orderline.custom_attribute_value_ids = this.pos.models[
+                "product.attribute.custom.value"
+            ].createMany(createManyCustomAttributeValues);
+        }
+        orderline.price_extra = values.price_extra;
+        orderline.qty = values.qty;
+        if (values.product_id) {
+            orderline.product_id = values.product_id;
+        }
+        if (values.combo_line_ids !== undefined) {
+            while (orderline.combo_line_ids.length > 0) {
+                this.pos.models["pos.order.line"].delete(orderline.combo_line_ids[0]);
+            }
+            orderline.combo_line_ids = values.combo_line_ids || [];
+        }
+        if (values.price_unit !== undefined) {
+            orderline.price_unit = values.price_unit;
+        }
+        orderline.setFullProductName();
+
+        // Try to merge the orderline
+        this.pos.tryMergeOrderline(order, orderline, orderline.price_type !== "manual");
     }
 
     async updateSelectedOrderline({ buffer, key }) {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -3,7 +3,9 @@
     <t t-name="point_of_sale.OrderSummary">
 		<OrderDisplay order="currentOrder" t-slot-scope="scope">
 			<t t-set="line" t-value="scope.line" />
-			<Orderline line="line" t-on-click="(event) => this.clickLine(event, line)">
+			<Orderline line="line"
+				onClick="(ev, duration) => this.clickLine(ev, line)"
+				onLongPress="(ev, duration) => this.onOrderlineLongPress(ev, line)">
 				<t t-set-slot="pack-lot-icon">
 					<i t-if="line.getProduct()?.product_tmpl_id?.isTracked()"
 						t-on-click.stop="() => this.editPackLotLines(line)" role="img"

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -685,6 +685,7 @@ export class PosStore extends WithLazyGetterTrap {
                 productTemplate: pTemplate,
                 hideAlwaysVariants: opts.hideAlwaysVariants,
                 forceVariantValue: opts.forceVariantValue,
+                line: opts.line,
             });
         }
         return {
@@ -793,126 +794,23 @@ export class PosStore extends WithLazyGetterTrap {
         // We assign the payload to the current values object.
         // ---
         // This actions cannot be handled inside pos_order.js or pos_order_line.js
-        if (productTemplate.isConfigurable() && configure) {
-            const payload = await this.openConfigurator(productTemplate, opts);
-
-            if (payload) {
-                // Find candidate based on instantly created variants.
-                const attributeValues = this.models["product.template.attribute.value"]
-                    .readMany(payload.attribute_value_ids)
-                    .filter((value) => value.attribute_id.create_variant !== "no_variant")
-                    .map((value) => value.id);
-
-                let candidate = productTemplate.product_variant_ids.find((variant) => {
-                    const attributeIds = variant.product_template_attribute_value_ids.map(
-                        (value) => value.id
-                    );
-                    return (
-                        attributeValues.every((id) => attributeIds.includes(id)) &&
-                        attributeValues.length
-                    );
-                });
-
-                const isDynamic = productTemplate.attribute_line_ids.some(
-                    (line) => line.attribute_id.create_variant === "dynamic"
-                );
-
-                if (!candidate && isDynamic) {
-                    // Need to create the new product.
-                    const result = await this.data.callRelated(
-                        "product.template",
-                        "create_product_variant_from_pos",
-                        [productTemplate.id, payload.attribute_value_ids, this.config.id]
-                    );
-                    candidate = result["product.product"][0];
-                }
-
-                Object.assign(values, {
-                    attribute_value_ids: payload.attribute_value_ids.map((id) => [
-                        "link",
-                        this.models["product.template.attribute.value"].get(id),
-                    ]),
-                    custom_attribute_value_ids: Object.entries(payload.attribute_custom_values).map(
-                        ([id, cus]) => [
-                            "create",
-                            {
-                                custom_product_template_attribute_value_id:
-                                    this.models["product.template.attribute.value"].get(id),
-                                custom_value: cus,
-                            },
-                        ]
-                    ),
-                    price_extra: values.price_extra + payload.price_extra,
-                    qty: payload.qty || values.qty,
-                    product_id: candidate || productTemplate.product_variant_ids[0],
-                });
-            } else {
-                return;
-            }
-        } else if (values.product_id.product_template_variant_value_ids.length > 0) {
-            // Verify price extra of variant products
-            const priceExtra = values.product_id.product_template_variant_value_ids
-                .filter((attr) => attr.attribute_id.create_variant !== "always")
-                .reduce((acc, attr) => acc + attr.price_extra, 0);
-
-            values.price_extra += priceExtra;
-            values.attribute_value_ids = values.product_id.product_template_variant_value_ids.map(
-                (attr) => ["link", attr]
-            );
+        let keepGoing = await this.handleConfigurableProduct(
+            values,
+            productTemplate,
+            opts,
+            configure
+        );
+        if (keepGoing === false) {
+            return;
         }
 
         // In case of clicking a combo product a popup will be shown to the user
         // It will return the combo prices and the selected products
         // ---
         // This actions cannot be handled inside pos_order.js or pos_order_line.js
-        if (values.product_tmpl_id.isCombo() && configure) {
-            const payload = await makeAwaitable(this.dialog, ComboConfiguratorPopup, {
-                productTemplate: values.product_tmpl_id,
-            });
-
-            if (!payload) {
-                return;
-            }
-
-            // Product template of combo should not have more than 1 variant.
-            const comboPrices = computeComboItems(
-                values.product_tmpl_id.product_variant_ids[0],
-                payload,
-                order.pricelist_id,
-                this.data.models["decimal.precision"].getAll(),
-                this.data.models["product.template.attribute.value"].getAllBy("id"),
-                this.currency
-            );
-
-            values.combo_line_ids = comboPrices.map((comboItem) => [
-                "create",
-                {
-                    product_id: comboItem.combo_item_id.product_id,
-                    tax_ids: comboItem.combo_item_id.product_id.taxes_id.map((tax) => [
-                        "link",
-                        tax,
-                    ]),
-                    combo_item_id: comboItem.combo_item_id,
-                    price_unit: comboItem.price_unit,
-                    price_type: "automatic",
-                    order_id: order,
-                    qty: 1,
-                    attribute_value_ids: comboItem.attribute_value_ids?.map((attr) => [
-                        "link",
-                        attr,
-                    ]),
-                    custom_attribute_value_ids: Object.entries(
-                        comboItem.attribute_custom_values
-                    ).map(([id, cus]) => [
-                        "create",
-                        {
-                            custom_product_template_attribute_value_id:
-                                this.data.models["product.template.attribute.value"].get(id),
-                            custom_value: cus,
-                        },
-                    ]),
-                },
-            ]);
+        keepGoing = await this.handleComboProduct(values, order, configure);
+        if (keepGoing === false) {
+            return;
         }
 
         // In the case of a product with tracking enabled, we need to ask the user for the lot/serial number.
@@ -977,15 +875,7 @@ export class PosStore extends WithLazyGetterTrap {
         }
 
         // Handle price unit
-        if (!values.product_tmpl_id.isCombo() && vals.price_unit === undefined) {
-            values.price_unit = values.product_id.getPrice(
-                order.pricelist_id,
-                values.qty,
-                values.price_extra,
-                false,
-                values.product_id
-            );
-        }
+        this.handlePriceUnit(values, order, vals.price_unit);
 
         const line = this.data.models["pos.order.line"].create({ ...values, order_id: order });
         line.setOptions(options);
@@ -1001,22 +891,8 @@ export class PosStore extends WithLazyGetterTrap {
             });
         }
 
-        let to_merge_orderline;
-        for (const curLine of order.lines) {
-            if (curLine.id !== line.id) {
-                if (curLine.canBeMergedWith(line) && merge !== false) {
-                    to_merge_orderline = curLine;
-                }
-            }
-        }
-
-        if (to_merge_orderline) {
-            to_merge_orderline.merge(line);
-            line.delete();
-            this.selectOrderLine(order, to_merge_orderline);
-        } else if (!selectedOrderline) {
-            this.selectOrderLine(order, order.getLastOrderline());
-        }
+        // Merge orderline if needed
+        this.tryMergeOrderline(order, line, merge, selectedOrderline);
 
         if (configure) {
             this.numberBuffer.reset();
@@ -1043,6 +919,191 @@ export class PosStore extends WithLazyGetterTrap {
         }, 3000);
 
         return order.getSelectedOrderline();
+    }
+
+    /**
+     * In case of configurable product a popup will be shown to the user
+     * We assign the payload to the current values object.
+     * ---
+     * This actions cannot be handled inside pos_order.js or pos_order_line.js
+     */
+    async handleConfigurableProduct(
+        values,
+        productTemplate,
+        opts = {},
+        configure = true,
+        props = {}
+    ) {
+        if (productTemplate.isConfigurable() && configure) {
+            const payload = await this.openConfigurator(productTemplate, {
+                ...opts,
+                line: props.line,
+            });
+            if (!payload) {
+                return false;
+            }
+
+            // Find candidate based on instantly created variants.
+            const attributeValues = this.models["product.template.attribute.value"]
+                .readMany(payload.attribute_value_ids)
+                .filter((value) => value.attribute_id.create_variant !== "no_variant")
+                .map((value) => value.id);
+
+            let candidate = productTemplate.product_variant_ids.find((variant) => {
+                const attributeIds = variant.product_template_attribute_value_ids.map(
+                    (value) => value.id
+                );
+                return (
+                    attributeValues.every((id) => attributeIds.includes(id)) &&
+                    attributeValues.length
+                );
+            });
+
+            const isDynamic = productTemplate.attribute_line_ids.some(
+                (line) => line.attribute_id.create_variant === "dynamic"
+            );
+
+            if (!candidate && isDynamic) {
+                // Need to create the new product.
+                const result = await this.data.callRelated(
+                    "product.template",
+                    "create_product_variant_from_pos",
+                    [productTemplate.id, payload.attribute_value_ids, this.config.id]
+                );
+                candidate = result["product.product"][0];
+            }
+
+            Object.assign(values, {
+                attribute_value_ids: payload.attribute_value_ids.map((id) => [
+                    "link",
+                    this.models["product.template.attribute.value"].get(id),
+                ]),
+                custom_attribute_value_ids: Object.entries(payload.attribute_custom_values).map(
+                    ([id, cus]) => [
+                        "create",
+                        {
+                            custom_product_template_attribute_value_id:
+                                this.models["product.template.attribute.value"].get(id),
+                            custom_value: cus,
+                        },
+                    ]
+                ),
+                price_extra: values.price_extra + payload.price_extra,
+                qty: payload.qty || values.qty,
+                product_id: candidate || productTemplate.product_variant_ids[0],
+            });
+        } else if (values.product_id.product_template_variant_value_ids.length > 0) {
+            // Verify price extra of variant products
+            const priceExtra = values.product_id.product_template_variant_value_ids
+                .filter((attr) => attr.attribute_id.create_variant !== "always")
+                .reduce((acc, attr) => acc + attr.price_extra, 0);
+
+            values.price_extra += priceExtra;
+            values.attribute_value_ids = values.product_id.product_template_variant_value_ids.map(
+                (attr) => ["link", attr]
+            );
+        }
+    }
+
+    /**
+     * In case of clicking a combo product a popup will be shown to the user
+     * It will return the combo prices and the selected products
+     * ---
+     * This actions cannot be handled inside pos_order.js or pos_order_line.js
+     */
+    async handleComboProduct(values, order, configure = true, { line } = {}) {
+        if (values.product_tmpl_id.isCombo() && configure) {
+            const payload = await makeAwaitable(this.dialog, ComboConfiguratorPopup, {
+                productTemplate: values.product_tmpl_id,
+                line,
+            });
+
+            if (!payload) {
+                return false;
+            }
+
+            // Product template of combo should not have more than 1 variant.
+            const comboPrices = computeComboItems(
+                values.product_tmpl_id.product_variant_ids[0],
+                payload,
+                order.pricelist_id,
+                this.data.models["decimal.precision"].getAll(),
+                this.data.models["product.template.attribute.value"].getAllBy("id"),
+                this.currency
+            );
+
+            values.combo_line_ids = comboPrices.map((comboItem) => [
+                "create",
+                {
+                    product_id: comboItem.combo_item_id.product_id,
+                    tax_ids: comboItem.combo_item_id.product_id.taxes_id.map((tax) => [
+                        "link",
+                        tax,
+                    ]),
+                    combo_item_id: comboItem.combo_item_id,
+                    price_unit: comboItem.price_unit,
+                    price_type: "automatic",
+                    order_id: order,
+                    qty: 1,
+                    attribute_value_ids: comboItem.attribute_value_ids?.map((attr) => [
+                        "link",
+                        attr,
+                    ]),
+                    custom_attribute_value_ids: Object.entries(
+                        comboItem.attribute_custom_values
+                    ).map(([id, cus]) => [
+                        "create",
+                        {
+                            custom_product_template_attribute_value_id:
+                                this.data.models["product.template.attribute.value"].get(id),
+                            custom_value: cus,
+                        },
+                    ]),
+                },
+            ]);
+        }
+
+        this.getOrder().recomputeOrderData();
+    }
+
+    /**
+     * Handle price unit for the order line.
+     */
+    handlePriceUnit(values, order, price_unit) {
+        if (!values.product_tmpl_id.isCombo() && price_unit === undefined) {
+            values.price_unit = values.product_id.getPrice(
+                order.pricelist_id,
+                values.qty,
+                values.price_extra,
+                false,
+                values.product_id
+            );
+        }
+    }
+
+    /**
+     * Try to merge the orderline with another one in the order.
+     * If no orderline can be merged, select the last orderline.
+     * If merge is false, do not merge the orderline.
+     */
+    tryMergeOrderline(order, line, merge, selectedOrderline) {
+        selectedOrderline = selectedOrderline || order.getSelectedOrderline();
+        let to_merge_orderline;
+        for (const curLine of order.lines) {
+            if (curLine.id !== line.id) {
+                if (curLine.canBeMergedWith(line) && merge !== false) {
+                    to_merge_orderline = curLine;
+                }
+            }
+        }
+
+        if (to_merge_orderline) {
+            to_merge_orderline.merge(line);
+            line.delete();
+            this.selectOrderLine(order, to_merge_orderline);
+        } else if (!selectedOrderline) {
+            this.selectOrderLine(order, order.getLastOrderline());
+        }
     }
 
     createPrinter(config) {

--- a/addons/point_of_sale/static/src/app/utils/use_timed_press.js
+++ b/addons/point_of_sale/static/src/app/utils/use_timed_press.js
@@ -1,0 +1,108 @@
+import { onMounted, onWillUnmount } from "@odoo/owl";
+
+/**
+ * `useTimedPress` — A hook to detect and respond to different press durations on a DOM element.
+ *
+ * It supports two types of interactions:
+ * - `"release"` (default): Triggers the callback **after the pointer is released**, if the duration falls within the defined delay range.
+ * - `"hold"`: Triggers the callback after a given delay **while the pointer is held down**.
+ *
+ * This hook is compatible with mouse, touch, and stylus inputs via `pointer` events.
+ *
+ * @param {Ref} ref - An OWL `useRef` pointing to the target DOM element.
+ * @param {Array<Object>} ranges - An array of press range objects defining when and how to trigger callbacks.
+ *   Each object supports the following properties:
+ *   @param {number} [ranges[].delay=0] - Minimum duration in milliseconds before the callback can be triggered.
+ *   @param {number} [ranges[].maxDelay] - Optional maximum duration; if specified, the callback is only triggered if the press duration is less than this value.
+ *   @param {Function} ranges[].callback - The function to execute. It receives the original pointer event and the press duration in milliseconds (for `"release"`).
+ *     Signature: `(event: PointerEvent, duration: number) => void`
+ *   @param {string} [ranges[].type="release"] - Determines when to trigger the callback:
+ *     - `"hold"`: triggers while holding the press after `delay`
+ *     - `"release"`: triggers after release if the press duration is within `[delay, maxDelay)`
+ *
+ * @example
+ * useTimedPress(myRef, [
+ *   {
+ *     delay: 600,
+ *     callback: (e, duration) => console.log("Long press while holding"),
+ *     type: "hold",
+ *   },
+ *   {
+ *     delay: 0,
+ *     maxDelay: 200,
+ *     callback: (e, duration) => console.log("Tap released", duration),
+ *     type: "release",
+ *   },
+ *   {
+ *     delay: 600,
+ *     callback: (e, duration) => console.log("Long press released", duration),
+ *     type: "release",
+ *   },
+ * ]);
+ */
+export function useTimedPress(ref, ranges = []) {
+    let timerStart = null;
+    let holdTimers = [];
+
+    const handlePointerDown = (event) => {
+        if (event.button !== 0) {
+            return;
+        }
+        timerStart = performance.now();
+
+        for (const { delay = 0, type = "release", callback } of ranges) {
+            if (type === "hold" && typeof callback === "function") {
+                const timer = setTimeout(() => {
+                    callback(event, delay);
+                }, delay);
+                holdTimers.push(timer);
+            }
+        }
+    };
+
+    const handlePointerUp = (event) => {
+        if (timerStart === null) {
+            return;
+        }
+
+        const elapsed = performance.now() - timerStart;
+        timerStart = null;
+        clearAllHoldTimers();
+
+        for (const { delay = 0, maxDelay, type = "release", callback } of ranges) {
+            if (type === "release" && typeof callback === "function") {
+                if (elapsed >= delay && (maxDelay === undefined || elapsed < maxDelay)) {
+                    callback(event, elapsed);
+                }
+            }
+        }
+    };
+
+    const cancel = () => {
+        timerStart = null;
+        clearAllHoldTimers();
+    };
+
+    const clearAllHoldTimers = () => {
+        for (const timer of holdTimers) {
+            clearTimeout(timer);
+        }
+        holdTimers = [];
+    };
+
+    onMounted(() => {
+        const el = ref.el;
+        el?.addEventListener("pointerdown", handlePointerDown);
+        el?.addEventListener("pointerup", handlePointerUp);
+        el?.addEventListener("pointerleave", cancel);
+        el?.addEventListener("pointercancel", cancel);
+    });
+
+    onWillUnmount(() => {
+        const el = ref.el;
+        el?.removeEventListener("pointerdown", handlePointerDown);
+        el?.removeEventListener("pointerup", handlePointerUp);
+        el?.removeEventListener("pointerleave", cancel);
+        el?.removeEventListener("pointercancel", cancel);
+    });
+}

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -21,7 +21,12 @@ registry.category("web_tour.tours").add("ProductComboPriceTaxIncludedTour", {
             combo.select("Combo Product 9"),
             // Check Product Configurator is open
             Dialog.is("Attribute selection"),
-            Dialog.discard(),
+            {
+                content: "dialog discard",
+                trigger:
+                    ".modal-footer .o-default-button:contains(/^Add$/) + .o-default-button:contains(/^Discard$/)",
+                run: "click",
+            },
             combo.select("Combo Product 5"),
             combo.select("Combo Product 7"),
             combo.isSelected("Combo Product 7"),

--- a/addons/point_of_sale/static/tests/pos/tours/pos_line_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_line_configurator_tour.js
@@ -1,0 +1,156 @@
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as combo from "@point_of_sale/../tests/pos/tours/utils/combo_popup_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import { refresh } from "@point_of_sale/../tests/generic_helpers/utils";
+import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import { registry } from "@web/core/registry";
+import * as ProductConfigurator from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
+
+const setupProductConfigurator = [
+    ProductConfigurator.pickColor("Blue"),
+    ProductConfigurator.pickSelect("Wood"),
+    ProductConfigurator.pickRadio("Other"),
+    ProductConfigurator.fillCustomAttribute("Azerty"),
+    ProductConfigurator.pickMulti("Cushion"),
+    ProductConfigurator.pickMulti("Headrest"),
+].flat();
+
+const checkProductConfigurator = [
+    ProductConfigurator.selectedColor("Blue"),
+    ProductConfigurator.selectedSelect("Wood"),
+    ProductConfigurator.selectedRadio("Other"),
+    ProductConfigurator.selectedCustomAttribute("Azerty"),
+    ProductConfigurator.selectedMulti("Cushion"),
+    ProductConfigurator.selectedMulti("Headrest"),
+].flat();
+
+const checkConfiguredLine = (isCombo = false) => {
+    const method = isCombo ? ProductScreen.orderComboLineHas : ProductScreen.orderLineHas;
+    return [
+        method(
+            "Configurable Chair",
+            "1.0",
+            "",
+            "Blue, Wood, Fabrics: Other: Azerty, Cushion, Headrest"
+        ),
+    ].flat();
+};
+
+registry.category("web_tour.tours").add("test_line_configurators_product", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.clickDisplayedProduct("Configurable Chair"),
+            ...setupProductConfigurator,
+            Dialog.confirm(),
+
+            inLeftSide([
+                ...ProductScreen.longPressOrderline("Configurable Chair"),
+                Dialog.discard(),
+                ...checkConfiguredLine(false),
+                ...ProductScreen.longPressOrderline("Configurable Chair"),
+                ...checkProductConfigurator,
+                Dialog.confirm(),
+                ...checkConfiguredLine(false),
+            ]),
+            refresh(),
+            inLeftSide([
+                ...checkConfiguredLine(false),
+                ...ProductScreen.longPressOrderline("Configurable Chair"),
+                ...checkProductConfigurator,
+                Dialog.discard(),
+                ...checkConfiguredLine(false),
+            ]),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_line_configurators_combo", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            // Select first combo (combo 1)
+            combo.select("Combo Product 2"),
+            combo.isSelected("Combo Product 2"),
+
+            // Open Product Configurator + Configure + Confirm (combo 2)
+            combo.select("Configurable Chair"),
+            ...setupProductConfigurator,
+            Dialog.confirm(),
+
+            // Select it again should not have saved attributes since the line isn't yet added to the order
+            combo.select("Configurable Chair"),
+            ProductConfigurator.selectedColor("Red"), // This line check the reset of the attributes
+            Dialog.discard(),
+            combo.isNotSelected("Configurable Chair"),
+
+            // Select it again
+            combo.select("Configurable Chair"),
+            ...setupProductConfigurator,
+            Dialog.confirm(),
+
+            // Select last combo (combo 3)
+            combo.select("Combo Product 6"),
+            combo.isSelected("Combo Product 6"),
+            Dialog.confirm(),
+
+            inLeftSide([
+                ...ProductScreen.orderComboLineHas("Combo Product 2", "1.0"),
+                ...checkConfiguredLine(true),
+                ...ProductScreen.orderComboLineHas("Combo Product 6", "1.0"),
+
+                // Edit combo
+                ...ProductScreen.longPressOrderline("Office Combo"),
+                combo.isSelected("Combo Product 2"),
+                combo.isSelected("Configurable Chair"),
+                combo.isSelected("Combo Product 6"),
+
+                // Edit the configurable chair
+                combo.select("Configurable Chair"),
+                ...checkProductConfigurator,
+                Dialog.discard(),
+                combo.isNotSelected("Configurable Chair"),
+                combo.select("Configurable Chair"),
+                ...checkProductConfigurator,
+                Dialog.confirm(),
+                Dialog.confirm("Add to Order"),
+
+                ...ProductScreen.orderComboLineHas("Combo Product 2", "1.0"),
+                ...checkConfiguredLine(true),
+                ...ProductScreen.orderComboLineHas("Combo Product 6", "1.0"),
+            ]),
+            refresh(),
+            inLeftSide([
+                ...ProductScreen.longPressOrderline("Office Combo"),
+                combo.isSelected("Combo Product 2"),
+                combo.isSelected("Configurable Chair"),
+                combo.isSelected("Combo Product 6"),
+
+                // Edit the configurable chair
+                combo.select("Configurable Chair"),
+                ...checkProductConfigurator,
+                Dialog.discard(),
+                combo.isNotSelected("Configurable Chair"),
+                combo.select("Configurable Chair"),
+                ...checkProductConfigurator,
+                Dialog.confirm(),
+                Dialog.confirm("Add to Order"),
+
+                ...ProductScreen.orderComboLineHas("Combo Product 2", "1.0"),
+                ...checkConfiguredLine(true),
+                ...ProductScreen.orderComboLineHas("Combo Product 6", "1.0"),
+
+                ...ProductScreen.longPressOrderline("Office Combo"),
+                combo.select("Configurable Chair"),
+                Dialog.discard(),
+                combo.isNotSelected("Configurable Chair"),
+                Dialog.cancel(),
+                ...ProductScreen.longPressOrderline("Office Combo"),
+                combo.isSelected("Configurable Chair"),
+                Dialog.confirm("Add to Order"),
+            ]),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -15,6 +15,9 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
 
             // Click on Configurable Chair product
             ProductScreen.clickDisplayedProduct("Configurable Chair"),
+            ProductConfigurator.selectedColor("Red"),
+            ProductConfigurator.selectedSelect("Metal"),
+            ProductConfigurator.selectedRadio("Leather"),
 
             // Cancel configuration, not product should be in order
             Dialog.cancel(),
@@ -23,48 +26,45 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             // Click on Configurable Chair product
             ProductScreen.clickDisplayedProduct("Configurable Chair"),
 
-            // Pick Color
-            ProductConfigurator.pickColor("Red"),
-
-            // Pick Radio
-            ProductConfigurator.pickSelect("Metal"),
-
-            // Pick Select
+            // Select attributes
             ProductConfigurator.pickRadio("Other"),
-
-            // Fill in custom attribute
             ProductConfigurator.fillCustomAttribute("Custom Fabric"),
+            ProductConfigurator.pickMulti("Cushion"),
+            ProductConfigurator.pickMulti("Headrest"),
 
-            // Confirm configuration
-            Dialog.confirm(),
+            ProductConfigurator.selectedColor("Red"),
+            ProductConfigurator.selectedSelect("Metal"),
+            ProductConfigurator.selectedRadio("Other"),
+            ProductConfigurator.selectedCustomAttribute("Custom Fabric"),
+            ProductConfigurator.selectedMulti("Cushion"),
+            ProductConfigurator.selectedMulti("Headrest"),
 
             // Check that the product has been added to the order with correct attributes and price
+            Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
                 "Configurable Chair",
                 "1",
                 "11.0",
-                "Red, Metal, Fabrics: Other: Custom Fabric"
+                "Red, Metal, Fabrics: Other: Custom Fabric, Cushion, Headrest"
             ),
 
             // Orderlines with the same attributes should be merged
             ProductScreen.clickDisplayedProduct("Configurable Chair"),
-            ProductConfigurator.pickColor("Red"),
-            ProductConfigurator.pickSelect("Metal"),
             ProductConfigurator.pickRadio("Other"),
             ProductConfigurator.fillCustomAttribute("Custom Fabric"),
+            ProductConfigurator.pickMulti("Cushion"),
+            ProductConfigurator.pickMulti("Headrest"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
                 "Configurable Chair",
                 "2",
                 "22.0",
-                "Red, Metal, Fabrics: Other: Custom Fabric"
+                "Red, Metal, Fabrics: Other: Custom Fabric, Cushion, Headrest"
             ),
 
             // Orderlines with different attributes shouldn't be merged
             ProductScreen.clickDisplayedProduct("Configurable Chair"),
             ProductConfigurator.pickColor("Blue"),
-            ProductConfigurator.pickSelect("Metal"),
-            ProductConfigurator.pickRadio("Leather"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas(
                 "Configurable Chair",
@@ -77,8 +77,28 @@ registry.category("web_tour.tours").add("ProductConfiguratorTour", {
             ProductScreen.clickDisplayedProduct("Configurable Chair"),
             // Active: Other and Leather, Inactive: Wool
             ProductConfigurator.numberRadioOptions(2),
-            Dialog.confirm(),
-            Chrome.endTour(),
+            Dialog.cancel(),
+
+            // Reopen configuration and discard changes --> Come back to previous attributes
+            ProductScreen.openCartMobile(),
+            ProductScreen.longPressOrderline("Configurable Chair"),
+            ProductConfigurator.selectedColor("Red"),
+            ProductConfigurator.selectedSelect("Metal"),
+            ProductConfigurator.selectedRadio("Other"),
+            ProductConfigurator.selectedCustomAttribute("Custom Fabric"),
+            ProductConfigurator.selectedMulti("Cushion"),
+            ProductConfigurator.selectedMulti("Headrest"),
+
+            ProductConfigurator.pickColor("Blue"),
+            ProductConfigurator.fillCustomAttribute("Azerty"),
+            Dialog.cancel(),
+            ProductScreen.clickLine("Configurable Chair", 2),
+            ProductScreen.selectedOrderlineHasDirect(
+                "Configurable Chair",
+                "2",
+                "22.0",
+                "Red, Metal, Fabrics: Other: Custom Fabric, Cushion, Headrest"
+            ),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -12,8 +12,6 @@ import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 import { run, negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
-import { renderToElement } from "@web/core/utils/render";
-import { formatCurrency } from "@web/core/currency";
 
 registry.category("web_tour.tours").add("ReceiptScreenTour", {
     steps: () =>
@@ -213,26 +211,19 @@ registry.category("web_tour.tours").add("point_of_sale.test_printed_receipt_tour
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.receiptIsThere(),
-            run(() => {
-                const line = posmodel.getOrder().lines[0];
-                const context = {
-                    line,
-                    props: { basic_receipt: true },
-                    formatCurrency: (amount) => formatCurrency(amount, line.currency.id),
+
+            run(async () => {
+                window.print = (e) => {
+                    const rendered = e.innerHTML;
+                    if (!rendered.includes("Desk Pad")) {
+                        throw new Error("Desk Pad is not present on the ticket");
+                    }
+
+                    if (rendered.includes("5.00 / Units")) {
+                        throw new Error("The price should not be included on a basic receipt");
+                    }
                 };
-
-                const rendered = renderToElement("point_of_sale.Orderline", {
-                    this: context,
-                    ...context,
-                });
-
-                if (!rendered.innerHTML.includes("Desk Pad")) {
-                    throw new Error("Desk Pad is not present on the ticket");
-                }
-
-                if (rendered.innerHTML.includes("5.00 / Units")) {
-                    throw new Error("The price should not be included on a basic receipt");
-                }
+                await posmodel.printReceipt({ basic: true });
             }, "Basic receipt doesn't have price"),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/combo_popup_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/combo_popup_util.js
@@ -1,8 +1,5 @@
-import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
-
 const productTrigger = (productName) =>
     `label.combo-item article.product:has(.product-name:contains("${productName}"))`;
-const isComboSelectedTrigger = (productName) => `input:checked ~ ${productTrigger(productName)}`;
 const confirmationButtonTrigger = `footer button.confirm`;
 
 export function select(productName) {
@@ -15,15 +12,13 @@ export function select(productName) {
 export function isSelected(productName) {
     return {
         content: `Check that ${productName} is selected`,
-        trigger: `.modal ${isComboSelectedTrigger(productName)}`,
-        run: "click",
+        trigger: `.modal input.selected ~ ${productTrigger(productName)}`,
     };
 }
 export function isNotSelected(productName) {
     return {
         content: `Check that ${productName} is not selected`,
-        trigger: `.modal ${negate(isComboSelectedTrigger(productName), ".modal-body")}`,
-        run: "click",
+        trigger: `.modal input:not(.selected) ~ ${productTrigger(productName)}`,
     };
 }
 export function isConfirmationButtonDisabled() {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
@@ -1,3 +1,5 @@
+import { queryAll } from "@odoo/hoot-dom";
+
 export function pickRadio(name) {
     return [
         {
@@ -7,15 +9,74 @@ export function pickRadio(name) {
         },
     ];
 }
+export function selectedRadio(name) {
+    return [
+        {
+            content: `checking selected radio attribute with name ${name}`,
+            trigger: `.modal .attribute-name-cell:contains('${name}') input:checked`,
+        },
+    ];
+}
+export function pickMulti(name) {
+    return [
+        {
+            content: `picking multi attribute with name ${name}`,
+            trigger: `.modal label[for^="multi-"]:contains('${name}')`,
+            run: "click",
+        },
+    ];
+}
+export function selectedMulti(name) {
+    return [
+        {
+            content: `checking selected multi attribute with name ${name}`,
+            trigger: `.modal label[for^="multi-"].active:contains('${name}')`,
+        },
+    ];
+}
 export function pickSelect(name) {
     return [
         {
             content: `picking select attribute with name ${name}`,
             trigger: `.modal .configurator_select:has(option:contains('${name}'))`,
-            run: `select ${name}`,
+            run: () => {
+                const selects = queryAll`.modal .configurator_select`;
+                for (const select of selects) {
+                    const option = Array.from(select.options).find(
+                        (opt) => opt.textContent.trim() === name
+                    );
+                    if (option) {
+                        select.value = option.value;
+                        // Manually trigger change event
+                        select.dispatchEvent(new Event("change", { bubbles: true }));
+                        return;
+                    }
+                }
+                throw new Error(`Option "${name}" not found in any select`);
+            },
         },
     ];
 }
+
+export function selectedSelect(name) {
+    return [
+        {
+            content: `check selected value for select containing option "${name}"`,
+            trigger: `.modal .configurator_select:has(option:contains(${name}))`,
+            run: () => {
+                const selects = queryAll`.modal .configurator_select:has(option:contains(${name}))`;
+                for (const select of selects) {
+                    const selected = select.options[select.selectedIndex];
+                    if (selected?.textContent.trim() === name) {
+                        return true;
+                    }
+                }
+                throw new Error(`No select found with option "${name}" selected`);
+            },
+        },
+    ];
+}
+
 export function pickColor(name) {
     return [
         {
@@ -25,12 +86,40 @@ export function pickColor(name) {
         },
     ];
 }
+export function selectedColor(name) {
+    return [
+        {
+            content: `checking selected color attribute with name ${name}`,
+            trigger: `.modal .configurator_color[data-color='${name}'].active`,
+        },
+    ];
+}
 export function fillCustomAttribute(value) {
     return [
         {
             content: `filling custom attribute with value ${value}`,
             trigger: `.modal .custom_value`,
             run: `edit ${value}`,
+        },
+    ];
+}
+
+export function selectedCustomAttribute(value) {
+    return [
+        {
+            content: `checking selected custom attribute with value "${value}"`,
+            // trigger: `.modal .custom_value:contains('${value}')`,
+            trigger: `.modal .custom_value`,
+            run: () => {
+                const inputs = queryAll(".modal .custom_value");
+                for (const input of inputs) {
+                    const actual = input.value?.trim();
+                    if (actual === value) {
+                        return true;
+                    }
+                }
+                throw new Error(`No custom input found with value "${value}"`);
+            },
         },
     ];
 }

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -5,6 +5,7 @@ import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_li
 import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import { queryFirst, waitFor } from "@odoo/hoot-dom";
 
 export function firstProductIsFavorite(name) {
     return [
@@ -525,11 +526,12 @@ export function selectedOrderlineHasDirect(productName, quantity, price) {
         price,
     });
 }
-export function orderComboLineHas(productName, quantity, priceUnit) {
+export function orderComboLineHas(productName, quantity, priceUnit, attributeLine = "") {
     return Order.hasLine({
         productName,
         quantity,
         priceUnit,
+        attributeLine,
     });
 }
 export function orderLineHas(productName, quantity, price) {
@@ -872,4 +874,34 @@ export function createProductFromFrontend(name, barcode, list_price, category) {
 
 export function editProductFromFrontend(name, barcode, list_price) {
     return productInputSteps(name, barcode, list_price);
+}
+
+export function longPressOrderline(productName, delay = 500) {
+    return [
+        {
+            content: `long press on orderline with product '${productName}'`,
+            trigger: `.order-container .orderline:has(.product-name:contains("${productName}"))`,
+            run: async () => {
+                const el = queryFirst`.order-container .orderline:has(.product-name:contains("${productName}"))`;
+                if (!el) {
+                    throw new Error(`Orderline with product '${productName}' not found`);
+                }
+                el.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+                await new Promise((resolve) => setTimeout(resolve, delay));
+                el.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+                await waitFor(".modal", { timeout: delay + 1000 });
+            },
+        },
+    ];
+}
+
+export function openCartMobile() {
+    return [
+        {
+            content: "Mobile - open cart",
+            trigger: ".switchpane .btn-switchpane:contains('Cart')",
+            run: "click",
+            isActive: ["mobile"],
+        },
+    ];
 }

--- a/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -58,7 +58,7 @@ patch(TicketScreen.prototype, {
 
             order.state = "draft";
             this.pos.selectedOrderUuid = order.uuid;
-            this.pos.setTip(amount);
+            await this.pos.setTip(amount);
             order.state = "paid";
             order.uiState.screen_data.value = { name: "", props: {} };
 

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -65,6 +65,7 @@
             "point_of_sale/static/src/app/utils/printer/base_printer.js",
             "point_of_sale/static/src/app/services/printer_service.js",
             'point_of_sale/static/src/app/utils/html-to-image.js',
+            'point_of_sale/static/src/app/utils/use_timed_press.js',
             "point_of_sale/static/src/app/services/render_service.js",
             "pos_self_order/static/src/app/**/*",
             "point_of_sale/static/src/app/utils/printer/hw_printer.js",


### PR DESCRIPTION

Task: [#4890396](https://www.odoo.com/odoo/my-tasks/4890396)
Community PR: [#221924](https://github.com/odoo/odoo/pull/221924)

---
Improves the POS experience by allowing users to reopen and edit
configurable and combo products directly from their orderlines. When a
product is edited to match another existing line, the lines are
automatically merged to avoid duplicates.

- Introduced `useTimedPress` to support both click and long press
interactions.
- Reopening a configurator now pre-fills default attributes,
custom values, and combo selections.
- Removed click delay when selecting an orderline, improving
responsiveness.
- Extracted logic for configurator, combo choice, unit price
computation, and orderline merging from `addProductToOrder` into
dedicated functions (`tryMergeOrderline`, etc.) for reuse across
the codebase.

---

The Combo/Product Configurator popups no longer receive default
values directly.
Instead, they now work with the orderline passed as a prop.

** Combo Configurator Popup **
- Use `props.line.selectedComboIds` as the source for default values.
- Save the initial `state.combo` so it can be restored on discard.
- Add a **Discard** button in the popup footer.

** Product Configurator Popup **
- Use `props.line.selectedAttributes` for the default values.
- If there is no orderline like new combo item, fall back to
`props.comboItem?.saveStateAttributes`.
- Save the initial `state.selectedAttributes` so it can be restored on
discard.
- Expose `selectedAttributes` on `pos.orderline` as a function so it can
be recomputed at any time.

** Bug Fix: Price **
- Fixed a bug where updating a combo item directly from the Order
Summary used the wrong price (ignoring the combo).
- We now open the **Combo Configurator** instead of the
**Product Configurator** when editing a combo item from the Order
Summary.

---

When refreshing the page, we also lose the `free text` of the
`custom_attribute_value`.
By adding the model `product.attribute.custom.value` to the
`get databaseTable()` from `DataServiceOptions`, we ensure that the
records are saved in IndexedDB
