### PR TITLE
[FIX] pos_loyalty: prevent using loyalty points again in partial refund

### DIFF
--- a/addons/pos_loyalty/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/app/screens/payment_screen/payment_screen.js
@@ -105,6 +105,7 @@ patch(PaymentScreen.prototype, {
             }
             return agg;
         }, {});
+        const isRefundOrder = order.lines.some((line) => line.refunded_qty > 0);
         for (const line of rewardLines) {
             const reward = line.reward_id;
             const couponId = line.coupon_id.id;
@@ -125,8 +126,9 @@ patch(PaymentScreen.prototype, {
             if (!couponData[couponId].line_codes.includes(line.reward_identifier_code)) {
                 !couponData[couponId].line_codes.push(line.reward_identifier_code);
             }
-            couponData[couponId].points =
-                line.refunded_qty > 0 ? 0.0 : couponData[couponId].points - line.points_cost;
+            couponData[couponId].points = isRefundOrder
+                ? 0.0
+                : couponData[couponId].points - line.points_cost;
         }
         // We actually do not care about coupons for 'current' programs that did not claim any reward, they will be lost if not validated
         couponData = Object.fromEntries(

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -2,6 +2,7 @@ import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util"
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selection_popup_util";
 import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
@@ -625,19 +626,19 @@ registry.category("web_tour.tours").add("test_refund_does_not_decrease_points", 
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("Refunding Guy"),
             ProductScreen.clickDisplayedProduct("Refund Product"),
+            ProductScreen.clickDisplayedProduct("Other Product"),
             ProductScreen.clickControlButton("Reward"),
             SelectionPopup.has("$ 1 per point on your order", { run: "click" }),
-            PosLoyalty.finalizeOrder("Cash", "200"),
+            PosLoyalty.finalizeOrder("Cash", "300"),
             ProductScreen.clickRefund(),
             TicketScreen.selectOrder("001"),
             ProductScreen.clickNumpad("1"),
-            ProductScreen.clickLine("$ 1 per point on your order"),
-            ProductScreen.clickNumpad("1"),
             TicketScreen.confirmRefund(),
-            PosLoyalty.orderTotalIs("-200.00"),
+            PosLoyalty.orderTotalIs("-300.00"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2997,13 +2997,21 @@ class TestUi(TestPointOfSaleHttpCommon):
                 'discount_mode': 'per_point',
             })],
         })
-        self.product_refund = self.env["product.product"].create({
-            "name": "Refund Product",
-            "is_storable": True,
-            "list_price": 300,
-            "available_in_pos": True,
-            "taxes_id": False,
-        })
+        self.env["product.product"].create([
+            {
+                "name": "Refund Product",
+                "is_storable": True,
+                "list_price": 300,
+                "available_in_pos": True,
+                "taxes_id": False,
+            }, {
+                "name": "Other Product",
+                "is_storable": True,
+                "list_price": 100,
+                "available_in_pos": True,
+                "taxes_id": False,
+            },
+        ])
         partner_refunding = self.env['res.partner'].create({'name': 'Refunding Guy'})
         card = self.env['loyalty.card'].create({
             'partner_id': partner_refunding.id,
@@ -3012,7 +3020,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_refund_does_not_decrease_points', login="pos_user")
-        self.assertEqual(card.points, 30)
+        self.assertEqual(card.points, 40)
 
     def test_loyalty_reward_with_variant(self):
         self.env['loyalty.program'].search([]).write({'active': False})


### PR DESCRIPTION
**Steps to reproduce:**
- Make a purchase in POS using a reward such as $1 for every point
- Refund this purchase, but not the reward line
- The points are deducted again

**Problem:**
When refunding an order that has some rewards in it, but not refunding the reward line, the loyalty points used for the order will be used again. This only happens if we don't refund the reward line.

**Why the fix:**
By not refunding the reward line, the order was not treated as a refund, as we only checked if the reward line had a refunded_qty. So if we refund another product, the reward line will still be found, but the refund_qty will be 0, so it is treated as a non-refund line. We now check if the current order is a refund before altering the points. If it is a refund, we do not make the customer pay the points again.

opw-4771724