### PR TITLE
[FIX] stock: reset quantity on location change

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -999,8 +999,7 @@ class StockQuant(models.Model):
             quant = self._gather(
                 self.product_id, self.location_id, lot_id=self.lot_id,
                 package_id=self.package_id, owner_id=self.owner_id, strict=True)
-            if quant:
-                self.quantity = sum(quant.filtered(lambda q: q.lot_id == self.lot_id).mapped('quantity'))
+            self.quantity = sum(quant.filtered(lambda q: q.lot_id == self.lot_id).mapped('quantity'))
 
             # Special case: directly set the quantity to one for serial numbers,
             # it'll trigger `inventory_quantity` compute.

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1188,6 +1188,29 @@ class StockQuant(TransactionCase):
             'lot_id': False,
         }])
 
+    def test_onchange_location_quantity(self):
+        """
+        Ensure that the quantity is correctly updated when changing the product or location,
+        based on existing quants in that location.
+        """
+        product = self.env['product.product'].create({
+            'name': 'ELCT',
+            'type': 'product',
+        })
+        quant = self.env['stock.quant'].create({
+            'location_id': self.stock_location.id,
+            'product_id': product.id,
+            'inventory_quantity': 10,
+        })
+        quant.action_apply_inventory()
+
+        form = Form(self.env['stock.quant'].with_context({'inventory_mode': True}))
+        form.product_id = product
+        form.location_id = self.stock_location
+        self.assertEqual(form.quantity, 10.0)
+        form.location_id = self.stock_subloc2
+        self.assertEqual(form.quantity, 0.0)
+
 
 class StockQuantRemovalStrategy(TransactionCase):
     def setUp(self):


### PR DESCRIPTION
Fixes an issue where the quantity was incorrectly retained from another location during the onchange.

The quantity should reflect the available quantity for the selected product and location only. When changing to a location without stock, it should default to 0.

Steps to reproduce in 17.0:
1.) Create a storable product.
2.) Create a quant for that product in Location A with quantity 10.
3.) Open a new quant in inventory mode and select the product and Location A.
→ Quantity is correctly set to 10.

4.) Change the location to Location B (which has no stock).
→ Quantity incorrectly remains 10 instead of resetting to 0.

Expected behavior:
Quantity should reflect stock for the selected location only and be 0.0 if no stock exists in that location.

This is essentially a backport of this PR.
https://github.com/odoo/odoo/pull/166132

The bug only exists in version 17.0, as the fix is already present in 18.0 and later.

opw-4942564

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
