### PR TITLE
[IMP] http_routing, website: sitemap and canonical for homepage url

### DIFF
--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -131,7 +131,7 @@ function testCommonProperties(url, canPublish, modifiedUrl = undefined) {
                 trigger: `:visible :iframe #top_menu a[href="${modifiedUrl}"]`,
             },
             stepUtils.goToUrl(getClientActionUrl("/")),
-            ...assertPageCanonicalUrlIs(modifiedUrl),
+            ...assertPageCanonicalUrlIs("/"),
             stepUtils.goToUrl(getClientActionUrl(modifiedUrl)),
         ],
         teardown: [
@@ -253,7 +253,7 @@ function testWebsitePageProperties() {
             content: "Verify page title",
             trigger: ":iframe head:hidden title:contains(/Cool Page/)",
         },
-        ...assertPageCanonicalUrlIs("/cool-page"),
+        ...assertPageCanonicalUrlIs("/"),
         stepUtils.goToUrl(getClientActionUrl("/new-page")),
         assertPathName("/cool-page", "body"),
         {

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -93,9 +93,6 @@ class Website(Home):
         def match(loc):
             return not qs or qs.lower() in loc.lower()
 
-        if homepage_url and homepage_url != '/' and match(homepage_url):
-            yield {'loc': homepage_url}
-            return
         website_page = env['website.page'].sudo().search([
             ('url', '=', '/'),
             ('is_published', '=', True),
@@ -298,7 +295,7 @@ class Website(Home):
             sitemaps.unlink()
 
             pages = 0
-            locs = request.website.with_user(request.website.user_id)._enumerate_pages()
+            locs = request.website.with_user(request.website.user_id)._enumerate_pages(ignore_custom_homepage=True)
             while True:
                 values = {
                     'locs': islice(locs, 0, LOC_PER_SITEMAP),

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1582,13 +1582,15 @@ class Website(models.CachedModel):
         return all(p.name in rule._converters for p in params
                    if p.kind in supported_kinds and p.default is inspect.Parameter.empty)
 
-    def _enumerate_pages(self, query_string=None, force=False):
+    def _enumerate_pages(self, query_string=None, force=False, ignore_custom_homepage=False):
         """ Available pages in the website/CMS. This is mostly used for links
             generation and can be overridden by modules setting up new HTML
             controllers for dynamic pages (e.g. blog).
             By default, returns template views marked as pages.
             :param str query_string: a (user-provided) string, fetches pages
                                      matching the string
+            :param boolean ignore_custom_homepage: used to exclude the hompage url
+                from the page list if the homepage is not ``/``
             :returns: a list of mappings with two keys: ``name`` is the displayable
                       name of the resource (page), ``url`` is the absolute URL
                       of the same.
@@ -1607,9 +1609,12 @@ class Website(models.CachedModel):
         if query_string:
             domain += [('url', 'like', query_string)]
 
+        homepage_url = self.homepage_url
         pages = self._get_website_pages(domain)
 
         for page in pages:
+            if ignore_custom_homepage and homepage_url == page['url']:
+                continue
             record = {'loc': page['url'], 'id': page['id'], 'name': page['name']}
             if page.view_id.priority != 16:
                 record['priority'] = min(round(page.view_id.priority / 32.0, 1), 1)
@@ -1621,6 +1626,9 @@ class Website(models.CachedModel):
         # ==== CONTROLLERS ====
         router = self.env['ir.http'].routing_map()
         url_set = set()
+
+        if ignore_custom_homepage and homepage_url != '/':
+            url_set.add(homepage_url)
 
         sitemap_endpoint_done = set()
 
@@ -1880,8 +1888,12 @@ class Website(models.CachedModel):
     def _get_canonical_url(self):
         """ Returns the canonical URL of the current request. """
         self.ensure_one()
+        # Homepage's canonical url is always '/'
+        url = request.httprequest.path
+        if url == self.homepage_url:
+            url = '/'
         return self.env['ir.http']._url_localized(
-            lang_code=request.lang.code, canonical_domain=self.get_base_url()
+            url=url, lang_code=request.lang.code, canonical_domain=self.get_base_url()
         )
 
     def _is_canonical_url(self):


### PR DESCRIPTION
This PR updates the canonical of a page if it's the homepage.
The canonical of a homepage is always `/` now.
Also updates the sitemap.xml, if the homepage is not `/`,
then the homepage url does not appear in the sitemap.xml.

Example: the user selected `/a` as the homepage.

1 - Page `/a` and `/` indicate as a canonical URL `/`
2 - `/a` is not in the sitemap.xml

If there are multiple languages installed in the website,
the language reference should stay in the canonical url.
The canonical URL of `/fr/a` will be `/fr`.

task-4563867