### PR TITLE
[FIX] mrp: avoid traceback when computing WO cost in running WO

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -589,7 +589,7 @@ class MrpWorkorder(models.Model):
         for workorder in self:
             intervals = Intervals([
                 [t.date_start, t.date_end, t]
-                for t in workorder.time_ids if not date or t.date_end < date
+                for t in workorder.time_ids if t.date_end and (not date or t.date_end < date)
             ])
             duration = sum_intervals(intervals)
             total += duration * workorder.workcenter_id.costs_hour


### PR DESCRIPTION
#### Issue:
- Traceback when calculating the cost of a workorder

#### Step to reproduce:
- with apps: mrp, accountant
- create a MO for a product
- add a WO
- confirm
- start the WO
- Action > "Post WIP Accounting entry"

#### Current Behavior:
- get a traceback

#### Expected behaviour
- open the WIP wizard

#### Cause of the issue:
- to calculate the cost of production, wizard use all WO including the one still running. However as it is still running its end date is registered as `False`. It raises a traceback when it compares the end of the WO with a limit date because `bool` and `datetime.datetime` are not compatible for '<'.

#### Solution:
- check if the end date of the WO is defined


In module mrp_workorder an override of [button_start](https://github.com/odoo/enterprise/blob/18.0/mrp_workorder/models/mrp_workorder.py#L284-L295) change how work order are launched. Therefore, the test should be launched on an Enterprise run.

opw-4961873

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
