### PR TITLE
[FIX] website: remove empty links that are created in website

### DIFF
--- a/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
@@ -1,5 +1,7 @@
+import { LinkPlugin } from "@html_editor/main/link/link_plugin";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
 
 export class TranslateLinkInlinePlugin extends Plugin {
     static id = "translateLinkInline";
@@ -7,5 +9,12 @@ export class TranslateLinkInlinePlugin extends Plugin {
         create_link_handlers: (linkEl) => linkEl.classList.add("o_translate_inline"),
     };
 }
+
+patch(LinkPlugin.prototype, {
+    setup() {
+        super.setup();
+        this.ignoredClasses.add("o_translate_inline");
+    },
+});
 
 registry.category("website-plugins").add(TranslateLinkInlinePlugin.id, TranslateLinkInlinePlugin);

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -380,6 +380,20 @@ test("Drag and drop from the page should only mark the concerned elements as dir
     expect(":iframe .o_dirty").toHaveCount(0);
 });
 
+test("empty links with o_translate_inline are removed on save", async () => {
+    setupSaveAndReloadIframe();
+    await setupWebsiteBuilder(
+        `<section><a href="http://test.test" class="o_translate_inline">x</a></section>`
+    );
+    const link = queryOne(":iframe a");
+    link.replaceChildren("");
+    expect(":iframe a").toHaveCount(1);
+    expect(":iframe a").toHaveText("");
+    await contains(".o-snippets-top-actions button:contains(Save)").click();
+    await animationFrame();
+    expect(":iframe a").toHaveCount(0);
+});
+
 function setupSaveAndReloadIframe() {
     const resultSave = [];
     onRpc("ir.ui.view", "save", ({ args }) => {


### PR DESCRIPTION
The commit f65ac79631180e77aca5a53fc557b3e1acfcbd65 added the class `o_translate-inline` on links created in the website. The link plugin only removes empty links if it has no significant classes or attributes, but that class was not in the list of non-significant classes. Thus, empty links created in website were not removed by the link plugin.

This commits patch the link plugin to add that class to its list of non-significant classes.o

Steps to reproduce:
- Open website builder
- Create a new link
- Make the link appear as a button to easily see it
- Delete its label (but not the link itself)
- Save
- Bug: the empty link has not been removed

task-4975547
