### PR TITLE
[FIX] website: stop parallax interaction when changing img's position

### DIFF
--- a/addons/website/static/src/builder/plugins/background_option/background_position_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_position_option_plugin.js
@@ -66,8 +66,13 @@ export class SetBackgroundSizeAction extends BuilderAction {
 
 export class BackgroundPositionOverlayAction extends BuilderAction {
     static id = "backgroundPositionOverlay";
-    static dependencies = ["overlayButtons", "overlay"];
+    static dependencies = ["overlayButtons", "overlay", "edit_interaction"];
     async load({ editingElement }) {
+        const editInteraction = this.dependencies.edit_interaction;
+        const parallaxEl = editingElement.closest(".parallax");
+        if (parallaxEl) {
+            editInteraction.stopInteractions(editingElement.closest(".parallax"));
+        }
         let imgEl;
         await new Promise((resolve) => {
             imgEl = document.createElement("img");
@@ -93,16 +98,25 @@ export class BackgroundPositionOverlayAction extends BuilderAction {
             const applyPosition = (bgPosition) => {
                 appliedBgPosition = bgPosition;
                 overlay.close();
+                if (parallaxEl) {
+                    editInteraction.restartInteractions(editingElement.closest(".parallax"));
+                }
+            };
+            const discardPosition = () => {
+                overlay.close();
+                if (parallaxEl) {
+                    editInteraction.restartInteractions(editingElement.closest(".parallax"));
+                }
             };
             overlay.open({
                 target: editingElement,
                 props: {
                     outerHtmlEditingElement: markup(this.safeCloneOuterHTML(copyEl)),
-                    editingElement: editingElement,
-                    mockEditingElOnImg: imgEl,
-                    applyPosition: applyPosition,
-                    discardPosition: () => overlay.close(),
                     editable: this.editable,
+                    mockEditingElOnImg: imgEl,
+                    applyPosition,
+                    discardPosition,
+                    editingElement,
                 },
             });
         });

--- a/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
+++ b/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
@@ -5,7 +5,7 @@ import { registry } from "@web/core/registry";
 export class EditInteractionPlugin extends Plugin {
     static id = "edit_interaction";
 
-    static shared = ["restartInteractions", "stopInteraction"];
+    static shared = ["restartInteractions", "stopInteraction", "stopInteractions"];
 
     resources = {
         normalize_handlers: this.refreshInteractions.bind(this),


### PR DESCRIPTION
Following the [html_builder refactoring], we had the issue with image's
background overlay when we were changing its background position, which
happened because the parallax interaction would change image's
dimensions.
To reproduce the issue:
- open website, start editing
- drop the `s_cover parallax` snippet and click on it
- change its Scroll Effect option to "Zoom In"
- Click on the Image Position option's crosshair

=> Observe that the image's dimensions and position are messed up.

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb