### PR TITLE
[FIX] purchase_stock: conversion of price included tax amount

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -307,8 +307,14 @@ class PurchaseOrderLine(models.Model):
     def _prepare_account_move_line(self, move=False):
         res = super()._prepare_account_move_line(move=move)
         if 'balance' not in res:
+            total_wo_tax = self.taxes_id.with_context(round=False, round_base=False).compute_all(
+                self.price_unit_discounted,
+                currency=self.order_id.currency_id,
+                quantity=self.qty_to_invoice,
+                product=self.product_id
+            )['total_excluded']
             res['balance'] = self.currency_id._convert(
-                self.price_unit_discounted * self.qty_to_invoice,
+                total_wo_tax,
                 self.company_id.currency_id,
                 round=False,
             )


### PR DESCRIPTION
**Steps to reproduce**

- Setup a foreign currency [CUR] with rate
- Create a purchase order
- Add [CUR] as currency
- Add an order line with price included tax
- Confirm and receive
- Create Bill
- Check generated lines values

**Issue**

Balance of the move lines will be off, as if it was computed using the wrong conversion rate

**Investigation**

It occurs because when preparing the move values, the system add the balance calculated from the product price.
This does not work for price included taxes, as the balance of the invoice line need to have the tax amount deducted

opw-4954649