### PR TITLE
[FIX] stock_account: prevent error when applying inventory adjustment

### DIFF
--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.tools.misc import groupby
 
 
@@ -93,7 +93,13 @@ class StockQuant(models.Model):
         if not self.env.context.get('inventory_name'):
             force_period_date = self.env.context.get('force_period_date', False)
             if force_period_date:
-                res_move['name'] += _(' [Accounted on %s]', force_period_date)
+                if self.product_uom_id.is_zero(qty):
+                    name = _('Product Quantity Confirmed')
+                else:
+                    name = _('Product Quantity Updated')
+                if self.env.uid and self.env.uid != SUPERUSER_ID:
+                    name += f' ({self.env.user.display_name})'
+                res_move['inventory_name'] = name + _(' [Accounted on %s]', force_period_date)
         return res_move
 
     @api.model


### PR DESCRIPTION
When a user tries to apply an inventory adjustment with an accounting date, the system raises error.

**Steps to produce:-**
- Install the `Inventory` and `Accounting modules` with demo data.
- `Navigate to Inventory > Reporting > Stock`.
- Click the pencil icon next to a product that already has an on-hand quantity.
- Set an `Accounting Date` (any date)(if not showing accounting date then add from the column dropdown).
- `Modify the Quantity` and click `Apply`.

**Error:-**
`KeyError: 'name'`

**Root cause:-**
- The `_get_inventory_move_values` method in the `stock_account` module overrides the corresponding method from the base stock module. It attempts to modify the name.
- However, the parent method in the stock module was changed in [commit](https://github.com/odoo/enterprise/commit/d0c1e7845feeee1c2e85a21b5d40570d051458d3), and it no longer returns a 'name' key in its result dictionary.

**Solution:-**
- This fix adjusts the logic in `_get_inventory_move_values` to properly set
  `inventory_name` with the accounted date and user information.

**sentry-6791413899**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
