### PR TITLE
[IMP] project: add 'parent task' group by option in portal

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -320,6 +320,7 @@ class ProjectCustomerPortal(CustomerPortal):
             'state': {'label': _('Status'), 'sequence': 40},
             'priority': {'label': _('Priority'), 'sequence': 60},
             'partner_id': {'label': _('Customer'), 'sequence': 70},
+            'parent_id': {'label': self.env._('Parent Task'), 'sequence': 90},
         }
         if not project:
             values['project_id'] = {'label': _('Project'), 'sequence': 30}
@@ -339,6 +340,7 @@ class ProjectCustomerPortal(CustomerPortal):
             'status': {'input': 'status', 'label': _('Search in Status'), 'sequence': 40},
             'priority': {'input': 'priority', 'label': _('Search in Priority'), 'sequence': 60},
             'partner_id': {'input': 'partner_id', 'label': _('Search in Customer'), 'sequence': 80},
+            'parent_id': {'input': 'parent_id', 'label': self.env._('Search in Parent Task'), 'sequence': 110},
         }
         if not project:
             values['project_id'] = {'input': 'project_id', 'label': _('Search in Project'), 'sequence': 50}

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -75,6 +75,12 @@
                                         t-field="tasks[0].sudo().partner_id.name"/>
                                     <span t-else="">No Customer</span>
                                 </t>
+                                <t t-if="groupby == 'parent_id'">
+                                    <span t-if="tasks[0].sudo().parent_id"
+                                        class="text-truncate"
+                                        t-field="tasks[0].sudo().parent_id.name"/>
+                                    <span t-else="">No Parent Task</span>
+                                </t>
                             </th>
                             <th name="state_col" t-if="groupby != 'state'"/>
                             <th name="stage_id_col" t-if="groupby != 'stage_id'"/>


### PR DESCRIPTION

**Before this commit:**
The portal task list did not allow users to group tasks by their parent.
This made it harder to track related sub-tasks under a common parent task.

**After this commit :**
Added a new “Parent Task” option in “Group By” drop down
on the portal task list view.

**Impact:**
Makes it easier to view and manage related tasks under the same parent.

Task - 4935943



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
