### PR TITLE
[FIX] hr_work_entry: update renamed fields references

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -92,8 +92,8 @@ class HrWorkEntry(models.Model):
                         hr_version AS hc
                     ON
                         hwe.employee_id=hc.employee_id AND
-                        hwe.date_start >= hc.date_start AND
-                        hwe.date_stop < COALESCE(hc.date_end + integer '1', '9999-12-31 23:59:59')
+                        hwe.date_start >= hc.contract_date_start AND
+                        hwe.date_stop < COALESCE(hc.contract_date_end + integer '1', '9999-12-31 23:59:59')
                     WHERE
                         hwe.version_id IS NULL
                     GROUP BY


### PR DESCRIPTION
- When migrating from `saas~18.3` to `saas~18.4` upgrade is blocked.

Issue
-
- The model `hr.contract` was [renamed](https://github.com/odoo/upgrade/blob/815644044a3cf9ec41b2cf7580da47abdf6d3553/migrations/hr/saas~18.4.1.1/pre-migrate.py#L25) to `hr.version`. The fields `date_start` and `date_end` were also [renamed](https://github.com/odoo/upgrade/blob/815644044a3cf9ec41b2cf7580da47abdf6d3553/migrations/hr/saas~18.4.1.1/pre-migrate.py#L30-L31) to `contract_date_start` and `contract_date_end` in the hr.version model.
- These fields were still referenced in this module, causing issues.

Solution:
-
- Updated the references from `date_start` and `date_end` to `contract_date_start` and `contract_date_end` to resolve the issue.
- Reference [PR](https://github.com/odoo/odoo/pull/202869/files)

Traceback:
-
```python3
Traceback (most recent call last):
  File "/home/odoo/src/odoo/saas-18.4/odoo/service/server.py", line 1410, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
  File "<decorator-gen-6>", line 2, in new
  File "/home/odoo/src/odoo/saas-18.4/odoo/tools/func.py", line 89, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/registry.py", line 175, in new
    load_modules(
  File "/home/odoo/src/odoo/saas-18.4/odoo/modules/loading.py", line 450, in load_modules
    load_module_graph(
  File "/home/odoo/src/odoo/saas-18.4/odoo/modules/loading.py", line 201, in load_module_graph
    registry.init_models(env.cr, model_names, {'module': package.name}, new_install)
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/registry.py", line 719, in init_models
    model._auto_init()
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/models.py", line 2908, in _auto_init
    new = field.update_db(self, columns)
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/fields_relational.py", line 284, in update_db
    return super().update_db(model, columns)
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/fields.py", line 1120, in update_db
    self.update_db_notnull(model, column)
  File "/home/odoo/src/odoo/saas-18.4/odoo/orm/fields.py", line 1173, in update_db_notnull
    model._init_column(self.name)
  File "/home/odoo/src/odoo/saas-18.4/addons/hr_work_entry/models/hr_work_entry.py", line 82, in _init_column
    self.env.cr.execute("""
  File "/home/odoo/src/odoo/saas-18.4/odoo/sql_db.py", line 426, in execute
    self._obj.execute(query, params)
psycopg2.errors.UndefinedColumn: column hc.date_start does not exist
LINE 14:                         hwe.date_start >= hc.date_start AND
                                                   ^
HINT:  Perhaps you meant to reference the column "hwe.date_start".
```

- OPW - 4996246
- UPG - 3056379

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
