### PR TITLE
[FIX] base: Use docutils.findall() when available (Python 3.11+)

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -117,7 +117,14 @@ class MyFilterMessages(Transform):
     default_priority = 870
 
     def apply(self):
-        for node in self.document.traverse(nodes.system_message):
+        # Use `findall()` if available (docutils >= 0.20), otherwise fallback to `traverse()`.
+        # This ensures compatibility across environments with different docutils versions.
+        if hasattr(self.document, 'findall'):
+            nodes_iter = self.document.findall(nodes.system_message)
+        else:
+            nodes_iter = self.document.traverse(nodes.system_message)
+
+        for node in nodes_iter:
             _logger.warning("docutils' system message present: %s", str(node))
             node.parent.remove(node)
 


### PR DESCRIPTION
Odoo 17.0 supports Python ≥3.11, which installs docutils==0.20.1. This version deprecates `Node.traverse()` in favor of `Node.findall()`.

To avoid deprecation warnings and ensure compatibility with both docutils 0.17 and 0.20.1, this patch uses `findall()` if available and falls back to `traverse()` otherwise.

This change is backward-compatible and safe to cherry-pick to >= 18.0.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
