### PR TITLE
[FIX] mail: reset thread's hasLoadingFailed flag after successful fetch

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -677,6 +677,7 @@ export class Thread extends Record {
         try {
             const { data, messages } = await this.fetchMessagesData({ after, around, before });
             this.store.insert(data, { html: true });
+            this.hasLoadingFailed = false;
             return this.store.Message.insert(messages.reverse());
         } catch (e) {
             this.hasLoadingFailed = true;

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1889,6 +1889,8 @@ test("Retry loading more messages on failed load more messages should load more 
     messageFetchShouldFail = false;
     await click("button", { text: "Click here to retry" });
     await contains(".o-mail-Message", { count: 60 });
+    await scroll(".o-mail-Thread", 0);
+    await contains(".o-mail-Message", { count: 90 });
 });
 
 test("composer state: attachments save and restore", async () => {


### PR DESCRIPTION
**Description of the issue this PR addresses:**
When a thread fails to fetch its messages (e.g., due to a network error), the `hasLoadingFailed` flag is set to `true`. However, even if the next fetch attempt succeeds, the flag is not reset. As a result, the UI may continue to show an error state even though the data has successfully loaded.

**Steps to Reproduce:**
- Open a thread with many messages.
- Go offline.
- Scroll up to load older messages → failure message appears.
- <img width="311" height="68" alt="image" src="https://github.com/user-attachments/assets/e18832cb-5d37-4add-a126-fdc301131721" />
- Go back online and click Retry → messages load successfully.
- Scroll again → failure message still appears, even though you’re online.
 - <img width="311" height="68" alt="image" src="https://github.com/user-attachments/assets/e18832cb-5d37-4add-a126-fdc301131721" />


**Current behavior before PR:**
After a failed attempt to fetch messages in a thread, the `hasLoadingFailed` flag remains set to `true`. Even if the user goes back online and the subsequent fetch succeeds, the UI continues to show a failure state.

**Desired behavior after PR is merged:**
After a successful fetch of a thread’s messages, the `hasLoadingFailed` flag is reset to `false`, ensuring the UI no longer shows a failure state once the data has been correctly loaded.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
