### PR TITLE
[FIX] project_stock: prevent error when clicking 'From WH' Button

### DIFF
--- a/addons/project_stock/models/project_project.py
+++ b/addons/project_stock/models/project_project.py
@@ -27,11 +27,14 @@ class ProjectProject(models.Model):
             context['restricted_picking_type_code'] = picking_type
             if picking_type == 'outgoing':
                 context['default_partner_id'] = self.partner_id.id
+        view_mode = "list,kanban,form,calendar"
+        if picking_type != 'outgoing':
+            view_mode += ",activity"
         return {
             'name': action_name,
             'type': 'ir.actions.act_window',
             'res_model': 'stock.picking',
-            'view_mode': f"list,kanban,form,calendar,{'map' if picking_type == 'outgoing' else 'activity'}",
+            'view_mode': view_mode,
             'domain': domain,
             'context': context,
             'help': self.env['ir.ui.view']._render_template(


### PR DESCRIPTION
* STEP TO REPRODUCE: go to task of a project, enable 'From WH' in top bar button. Click on it -> error because no map view

* SOLUTION: in community version we should remove map view then in enterprise we can overide to add it

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
