### PR TITLE
[FIX] website_sale: fix filmstrip image size

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -254,6 +254,7 @@ $input-border-color: $gray-400;
             --o-wsale-filmstrip-item-image-width: 75%;
 
             --o-wsale-filmstrip-item-span-display: inline-block;
+            --o-wsale-filmstrip-item-span-width: 100%;
             --o-wsale-filmstrip-item-span-overflow: hidden;
             --o-wsale-filmstrip-item-span-text-overflow: ellipsis;
         }
@@ -288,6 +289,7 @@ $input-border-color: $gray-400;
             --o-wsale-filmstrip-item-image-width: 45%;
 
             --o-wsale-filmstrip-item-span-display: inline-block;
+            --o-wsale-filmstrip-item-span-width: 100%;
             --o-wsale-filmstrip-item-span-overflow: hidden;
             --o-wsale-filmstrip-item-span-text-overflow: ellipsis;
 
@@ -339,6 +341,7 @@ $input-border-color: $gray-400;
             --o-wsale-filmstrip-item-image-height: 100%;
 
             --o-wsale-filmstrip-item-span-display: inline-block;
+            --o-wsale-filmstrip-item-span-width: 100%;
             --o-wsale-filmstrip-item-span-overflow: hidden;
             --o-wsale-filmstrip-item-span-text-overflow: ellipsis;
 
@@ -465,6 +468,7 @@ $input-border-color: $gray-400;
                     span {
                         display: var(--o-wsale-filmstrip-item-span-display, flex);
                         align-items: center;
+                        width: var(--o-wsale-filmstrip-item-span-width);
                         height: var(--o-wsale-filmstrip-item-span-height);
                         overflow: var(--o-wsale-filmstrip-item-span-overflow);
                         text-overflow: var(--o-wsale-filmstrip-item-span-text-overflow);

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1566,7 +1566,7 @@
                                     role="img"
                                     aria-label="Category image"
                                 />
-                                <span class="w-100" t-field="c.name"/>
+                                <span t-field="c.name"/>
                             </div>
                         </a>
                     </li>


### PR DESCRIPTION
This PR fixes an undesired reduction of image size for `default` and `bordered` filmstrip designs, introduced in commit https://github.com/odoo/odoo/pull/220178/commits/0684c5d0833b717ff72fd9aed108555255e73196.

task-4999654

| Current | Should Be |
|--------|--------|
| <img width="307" height="119" alt="Screenshot 2025-08-06 at 09 18 22" src="https://github.com/user-attachments/assets/4ed4130c-15e9-437a-8d95-88aa53e4e9f9" /> | <img width="305" height="117" alt="Screenshot 2025-08-06 at 09 18 58" src="https://github.com/user-attachments/assets/20da5a8e-f1b3-41ca-b0b5-a74de4f529bd" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
