### PR TITLE
[FIX] website: fix comparison of contact option in many2one action

### DIFF
--- a/addons/website/static/src/builder/plugins/options/many2one_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/many2one_option_plugin.js
@@ -52,12 +52,12 @@ export class Many2OneAction extends BuilderAction {
         const { id, name } = JSON.parse(value);
         const { oeModel, oeId, oeField, oeContactOptions } = editingElement.dataset;
 
-        for (const el of [
-            ...this.editable.querySelectorAll(
-                `[data-oe-model="${oeModel}"][data-oe-id="${oeId}"][data-oe-field="${oeField}"]:not([data-oe-contact-options='${oeContactOptions}'])`
-            ),
-            editingElement,
-        ]) {
+        const selector =
+            `[data-oe-model="${oeModel}"][data-oe-id="${oeId}"][data-oe-field="${oeField}"]` +
+            (oeContactOptions === undefined
+                ? "[data-oe-contact-options]"
+                : `:not([data-oe-contact-options='${oeContactOptions}'])`);
+        for (const el of [...this.editable.querySelectorAll(selector), editingElement]) {
             el.dataset.oeMany2oneId = id;
             if (el.dataset.oeType === "contact") {
                 el.replaceChildren(


### PR DESCRIPTION
If the editing element has no `oeContactOptions`, the selector would compare against the string `"undefined"`. That selector is supposed to select the ones with a different option, but in that case, other fields without contact options would get selected. The selector was ported from the previous builder during the intial [website builder refactor]

This caused the editing element to be present twice in the loop if it had no contact options (in addition to contain extra elements). And setting twice the same text content triggers a bug in the history, which behaves incorrectly when it is undone. (the bug is known and described in the code by a comment `@todo: this removes mutation records that change the node reference. Fix this`)

Steps to reproduce:
- On `/blog`, open website builder
- Change a post's category (name next to the folder icon under summary)
- Undo
- Bug: the text content is the concatenation of both category

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
