### PR TITLE
[IMP] google_gmail, miscosoft_outlook: allow using IAP instead of local credentials

### DIFF
--- a/addons/google_gmail/__manifest__.py
+++ b/addons/google_gmail/__manifest__.py
@@ -18,9 +18,4 @@
     "auto_install": True,
     "author": "Odoo S.A.",
     "license": "LGPL-3",
-    "assets": {
-        "web.assets_backend": [
-            "google_gmail/static/src/scss/google_gmail.scss",
-        ]
-    },
 }

--- a/addons/google_gmail/controllers/main.py
+++ b/addons/google_gmail/controllers/main.py
@@ -53,6 +53,20 @@ class GoogleGmailController(http.Controller):
 
         return self._check_email_and_redirect_to_gmail_record(access_token, expiration, refresh_token, record_sudo)
 
+    @http.route('/google_gmail/iap_confirm', type='http', auth='user')
+    def google_gmail_iap_callback(self, model, rec_id, csrf_token, access_token, refresh_token, expiration):
+        """Receive back the refresh token and access token from IAP.
+
+        The authentication process with IAP is done in 4 steps;
+        1. User database make a request to `<IAP>/api/mail_oauth/1/gmail`
+        2. User browser is redirected to the URL we received from IAP
+        3. User browser is redirected to `<IAP>/api/mail_oauth/1/gmail_callback`
+           with the authorization_code
+        4. User browser is redirected to `<DB>/google_gmail/iap_confirm`
+        """
+        record = self._get_gmail_record(model, rec_id, csrf_token)
+        return self._check_email_and_redirect_to_gmail_record(access_token, expiration, refresh_token, record)
+
     def _get_gmail_record(self, model_name, rec_id, csrf_token):
         """Return the record after checking the CSRF token."""
         model = request.env[model_name]

--- a/addons/google_gmail/controllers/main.py
+++ b/addons/google_gmail/controllers/main.py
@@ -10,7 +10,7 @@ from werkzeug.exceptions import Forbidden
 from odoo import _, http
 from odoo.exceptions import UserError
 from odoo.http import request
-from odoo.tools import consteq
+from odoo.tools import consteq, email_normalize
 from odoo.addons.google_gmail.models.google_gmail_mixin import GMAIL_TOKEN_REQUEST_TIMEOUT
 
 _logger = logging.getLogger(__name__)
@@ -103,7 +103,7 @@ class GoogleGmailController(http.Controller):
 
             response = response.json()
 
-            if not response.get('verified_email') or response.get('email') != record[record._email_field]:
+            if not response.get('verified_email') or email_normalize(response.get('email')) != email_normalize(record[record._email_field]):
                 _logger.error('Google Gmail: Invalid email address: %r != %s.', response, record[record._email_field])
                 return request.render('google_gmail.google_gmail_oauth_error', {
                     'error': _(

--- a/addons/google_gmail/models/google_gmail_mixin.py
+++ b/addons/google_gmail/models/google_gmail_mixin.py
@@ -8,7 +8,7 @@ import requests
 
 from werkzeug.urls import url_encode
 
-from odoo import _, api, fields, models, tools
+from odoo import _, fields, models, tools
 from odoo.exceptions import AccessError, UserError
 from odoo.tools.urls import urljoin as url_join
 
@@ -27,31 +27,29 @@ class GoogleGmailMixin(models.AbstractModel):
     _description = 'Google Gmail Mixin'
 
     _SERVICE_SCOPE = 'https://mail.google.com/ https://www.googleapis.com/auth/userinfo.email'
+    _DEFAULT_GMAIL_IAP_ENDPOINT = 'https://gmail.api.odoo.com'
 
     active = fields.Boolean(default=True)
 
-    google_gmail_authorization_code = fields.Char(string='Authorization Code', groups='base.group_system', copy=False)
     google_gmail_refresh_token = fields.Char(string='Refresh Token', groups='base.group_system', copy=False)
     google_gmail_access_token = fields.Char(string='Access Token', groups='base.group_system', copy=False)
     google_gmail_access_token_expiration = fields.Integer(string='Access Token Expiration Timestamp', groups='base.group_system', copy=False)
     google_gmail_uri = fields.Char(compute='_compute_gmail_uri', string='URI', help='The URL to generate the authorization code from Google', groups='base.group_system')
 
-    @api.depends('google_gmail_authorization_code')
     def _compute_gmail_uri(self):
         Config = self.env['ir.config_parameter'].sudo()
         google_gmail_client_id = Config.get_param('google_gmail_client_id')
         google_gmail_client_secret = Config.get_param('google_gmail_client_secret')
+        is_configured = google_gmail_client_id and google_gmail_client_secret
         base_url = self.get_base_url()
 
-        redirect_uri = url_join(base_url, '/google_gmail/confirm')
-
-        if not google_gmail_client_id or not google_gmail_client_secret:
+        if not is_configured:
             self.google_gmail_uri = False
         else:
             for record in self:
                 google_gmail_uri = 'https://accounts.google.com/o/oauth2/v2/auth?%s' % url_encode({
                     'client_id': google_gmail_client_id,
-                    'redirect_uri': redirect_uri,
+                    'redirect_uri': url_join(base_url, '/google_gmail/confirm'),
                     'response_type': 'code',
                     'scope': self._SERVICE_SCOPE,
                     # access_type and prompt needed to get a refresh token
@@ -77,12 +75,57 @@ class GoogleGmailMixin(models.AbstractModel):
         if not self.env.is_admin():
             raise AccessError(_('Only the administrator can link a Gmail mail server.'))
 
-        if not self.google_gmail_uri:
+        email_normalized = tools.email_normalize(self[self._email_field])
+        if not email_normalized:
+            raise UserError(_('Please enter a valid email address.'))
+
+        Config = self.env['ir.config_parameter'].sudo()
+        google_gmail_client_id = Config.get_param('google_gmail_client_id')
+        google_gmail_client_secret = Config.get_param('google_gmail_client_secret')
+        is_configured = google_gmail_client_id and google_gmail_client_secret
+
+        if not is_configured:  # use IAP (see '/google_gmail/iap_confirm')
+            gmail_iap_endpoint = self.env['ir.config_parameter'].sudo().get_param(
+                'mail.server.gmail.iap.endpoint',
+                self._DEFAULT_GMAIL_IAP_ENDPOINT,
+            )
+            db_uuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
+
+            # final callback URL that will receive the token from IAP
+            callback_params = url_encode({
+                'model': self._name,
+                'rec_id': self.id,
+                'csrf_token': self._get_gmail_csrf_token(),
+            })
+            callback_url = url_join(self.get_base_url(), f'/google_gmail/iap_confirm?{callback_params}')
+
+            iap_url = url_join(gmail_iap_endpoint, '/api/mail_oauth/1/gmail')
+            try:
+                response = requests.get(
+                    iap_url,
+                    params={'db_uuid': db_uuid, 'callback_url': callback_url},
+                    timeout=GMAIL_TOKEN_REQUEST_TIMEOUT)
+                response.raise_for_status()
+            except requests.exceptions.RequestException as e:
+                _logger.error('Can not contact IAP: %s.', e)
+                raise UserError(_('Oops, we could not authenticate you. Please try again later.'))
+
+            response = response.json()
+            if 'error' in response:
+                self._raise_iap_error(response['error'])
+
+            # URL on IAP that will redirect to Gmail login page
+            google_gmail_uri = response['url']
+
+        else:
+            google_gmail_uri = self.google_gmail_uri
+
+        if not google_gmail_uri:
             raise UserError(_('Please configure your Gmail credentials.'))
 
         return {
             'type': 'ir.actions.act_url',
-            'url': self.google_gmail_uri,
+            'url': google_gmail_uri,
             'target': 'self',
         }
 
@@ -106,8 +149,14 @@ class GoogleGmailMixin(models.AbstractModel):
         :return:
             access_token, access_token_expiration
         """
-        response = self._fetch_gmail_token('refresh_token', refresh_token=refresh_token)
+        Config = self.env['ir.config_parameter'].sudo()
 
+        google_gmail_client_id = Config.get_param('google_gmail_client_id')
+        google_gmail_client_secret = Config.get_param('google_gmail_client_secret')
+        if not google_gmail_client_id or not google_gmail_client_secret:
+            return self._fetch_gmail_access_token_iap(refresh_token)
+
+        response = self._fetch_gmail_token('refresh_token', refresh_token=refresh_token)
         return (
             response['access_token'],
             int(time.time()) + response['expires_in'],
@@ -143,6 +192,44 @@ class GoogleGmailMixin(models.AbstractModel):
             raise UserError(_('An error occurred when fetching the access token.'))
 
         return response.json()
+
+    def _fetch_gmail_access_token_iap(self, refresh_token):
+        """Fetch the access token using IAP.
+
+        Make a HTTP request to IAP, that will make a HTTP request
+        to the Gmail API and give us the result.
+
+        :return:
+            access_token, access_token_expiration
+        """
+        gmail_iap_endpoint = self.env['ir.config_parameter'].sudo().get_param(
+            'mail.server.gmail.iap.endpoint',
+            self.env['google.gmail.mixin']._DEFAULT_GMAIL_IAP_ENDPOINT,
+        )
+        db_uuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
+
+        response = requests.get(
+            url_join(gmail_iap_endpoint, '/api/mail_oauth/1/gmail_access_token'),
+            params={'refresh_token': refresh_token, 'db_uuid': db_uuid},
+            timeout=GMAIL_TOKEN_REQUEST_TIMEOUT,
+        )
+
+        if not response.ok:
+            _logger.error('Can not contact IAP: %s.', response.text)
+            raise UserError(_('Oops, we could not authenticate you. Please try again later.'))
+
+        response = response.json()
+        if 'error' in response:
+            self._raise_iap_error(response['error'])
+
+        return response
+
+    def _raise_iap_error(self, error):
+        errors = {
+            "not_configured": _("Gmail is not configured on IAP."),
+            "no_subscription": _("You don't have an active subscription."),
+        }
+        raise UserError(_('An error occurred: %s.', errors.get(error, error)))
 
     def _generate_oauth2_string(self, user, refresh_token):
         """Generate a OAuth2 string which can be used for authentication.

--- a/addons/google_gmail/models/ir_mail_server.py
+++ b/addons/google_gmail/models/ir_mail_server.py
@@ -39,7 +39,6 @@ class IrMail_Server(models.Model):
             self.smtp_encryption = 'starttls'
             self.smtp_port = 587
         else:
-            self.google_gmail_authorization_code = False
             self.google_gmail_refresh_token = False
             self.google_gmail_access_token = False
             self.google_gmail_access_token_expiration = False

--- a/addons/google_gmail/models/res_users.py
+++ b/addons/google_gmail/models/res_users.py
@@ -12,12 +12,6 @@ class ResUsers(models.Model):
     )
 
     @api.model
-    def _get_personal_server_type(self, smtp_server):
-        if smtp_server.smtp_authentication == "gmail":
-            return "gmail"
-        return super()._get_personal_server_type(smtp_server)
-
-    @api.model
     def _get_mail_server_values(self, server_type):
         values = super()._get_mail_server_values(server_type)
         if server_type == "gmail":

--- a/addons/google_gmail/static/src/scss/google_gmail.scss
+++ b/addons/google_gmail/static/src/scss/google_gmail.scss
@@ -1,4 +1,0 @@
-span.o_field_char[name="google_gmail_authorization_code"] {
-    max-width: 150px !important;
-    overflow: hidden;
-}

--- a/addons/google_gmail/views/fetchmail_server_views.xml
+++ b/addons/google_gmail/views/fetchmail_server_views.xml
@@ -16,20 +16,14 @@
                     </span>
                     <button type="object"
                         name="open_google_gmail_uri" class="btn-link px-0"
-                        invisible="not google_gmail_uri or server_type != 'gmail' or google_gmail_refresh_token">
+                        invisible="server_type != 'gmail' or google_gmail_refresh_token">
                         <i class="oi oi-arrow-right"/>
                         Connect your Gmail account
                     </button>
                     <button type="object"
                         name="open_google_gmail_uri" class="btn-link px-0 ms-2"
-                        invisible="not google_gmail_uri or server_type != 'gmail' or not google_gmail_refresh_token">
+                        invisible="server_type != 'gmail' or not google_gmail_refresh_token">
                         <i class="fa fa-cog" title="Edit Settings"/>
-                    </button>
-                    <button class="alert alert-warning d-block mt-2 text-start"
-                        icon="oi-arrow-right" type="action" role="alert"
-                        name="%(base.res_config_setting_act_window)d"
-                        invisible="server_type != 'gmail' or google_gmail_uri">
-                        Setup your Gmail API credentials in the general settings to link a Gmail account.
                     </button>
                 </div>
             </field>

--- a/addons/google_gmail/views/ir_mail_server_views.xml
+++ b/addons/google_gmail/views/ir_mail_server_views.xml
@@ -16,20 +16,14 @@
                     </span>
                     <button type="object"
                         name="open_google_gmail_uri" class="btn-link px-0"
-                        invisible="not google_gmail_uri or smtp_authentication != 'gmail' or google_gmail_refresh_token">
+                        invisible="smtp_authentication != 'gmail' or google_gmail_refresh_token">
                         <i class="oi oi-arrow-right"/>
                         Connect your Gmail account
                     </button>
                     <button type="object"
                         name="open_google_gmail_uri" class="btn-link px-0 ms-2"
-                        invisible="not google_gmail_uri or smtp_authentication != 'gmail' or not google_gmail_refresh_token">
+                        invisible="smtp_authentication != 'gmail' or not google_gmail_refresh_token">
                         <i class="fa fa-cog" title="Edit Settings"/>
-                    </button>
-                    <button class="alert alert-warning d-block mt-2 text-start"
-                        icon="oi-arrow-right" type="action" role="alert"
-                        name="%(base.res_config_setting_act_window)d"
-                        invisible="smtp_authentication != 'gmail' or google_gmail_uri">
-                        Setup your Gmail API credentials in the general settings to link a Gmail account.
                     </button>
                 </div>
             </field>

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -74,6 +74,8 @@ class IrConfig_Parameter(models.Model):
     #   * 'mail.use_twilio_rtc_servers', 'mail.sfu_server_url' and 'mail.
     #     sfu_server_key': rtc server usage and configuration;
     #   * 'discuss.tenor_api_key': used for gif fetch service;
+    #   * 'mail.server.outlook.iap.endpoint': URL of the IAP endpoint
+    #     for outlook oauth server
     _inherit = 'ir.config_parameter'
 
     @api.model

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -76,6 +76,9 @@ class IrConfig_Parameter(models.Model):
     #   * 'discuss.tenor_api_key': used for gif fetch service;
     #   * 'mail.server.outlook.iap.endpoint': URL of the IAP endpoint
     #     for outlook oauth server
+    #   * 'mail.server.gmail.iap.endpoint': URL of the IAP endpoint
+    #     for gmail oauth server
+
     _inherit = 'ir.config_parameter'
 
     @api.model

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -35,6 +35,9 @@ class IrConfig_Parameter(models.Model):
     #    50 by default;
     # * 'mail.render.cron.limit': used in cron involving rendering of content
     #   and/or templates, like event mail scheduler cron. Defaults to 1000;
+    # * 'mail.server.personal.limit.minutes': used when sending email using
+    #   personal mail servers, maximum number of emails that can be sent in
+    #   one minute
 
     # Mail Gateway
     #   * 'mail.gateway.loop.minutes' and 'mail.gateway.loop.threshold': block

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -76,6 +76,7 @@ class MailMail(models.Model):
         # generic
         ("unknown", "Unknown error"),
         # mail
+        ("mail_spam", "Detected As Spam"),
         ("mail_email_invalid", "Invalid email address"),
         ("mail_email_missing", "Missing email"),
         ("mail_from_invalid", "Invalid from address"),
@@ -840,6 +841,11 @@ class MailMail(models.Model):
                         failure_type = "mail_from_invalid"
                     elif error_code in (IrMailServer.NO_FOUND_FROM, IrMailServer.NO_FOUND_SMTP_FROM):
                         failure_type = "mail_from_missing"
+
+                if isinstance(e, MailDeliveryException) and "OutboundSpamException" in str(e):
+                    # OutboundSpamException: Outlook spam error
+                    failure_type = "mail_spam"
+
                 # generic (unknown) error as fallback
                 if not failure_reason:
                     failure_reason = tools.exception_to_unicode(e)

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -11,6 +11,7 @@ import re
 import smtplib
 from collections import defaultdict
 
+from datetime import timedelta
 from dateutil.parser import parse
 
 from odoo import _, api, fields, models, modules, SUPERUSER_ID, tools
@@ -576,6 +577,94 @@ class MailMail(models.Model):
             for batch_ids in tools.split_every(batch_size, record_ids):
                 yield mail_server_id, alias_domain_id, smtp_from, batch_ids
 
+    def _split_by_delayed_batch(self, mail_server):
+        """To not flag personal email servers as spam, we throttle them at X emails / minutes."""
+        if not mail_server or not mail_server.owner_user_id:
+            return self
+
+        MAX_SEND = mail_server._get_personal_mail_servers_limit()
+
+        current_minute = datetime.datetime.now().replace(second=0, microsecond=0)
+        server_limit_minute = (
+            mail_server.owner_limit_time
+            if mail_server.owner_limit_time
+            else current_minute - timedelta(minutes=1)
+        )
+
+        if server_limit_minute < current_minute:
+            # Server limit is old, we can send up to the limit
+            server_limit_minute = current_minute
+            mail_server.owner_limit_time = current_minute
+            mail_server.owner_limit_count = 0
+
+        elif server_limit_minute > current_minute:
+            # Should not happen except if we manually write on the field
+            mail_server.owner_limit_time = current_minute
+            mail_server.owner_limit_count = 0
+            _logger.error(
+                "Mail: invalid owner_limit_time %s > %s for %s",
+                server_limit_minute,
+                current_minute,
+                mail_server.name,
+            )
+
+        # Send the oldest mails in priority if the CRON is late
+        to_send = self.browse()
+        to_delay = self.browse()
+        notifs = self.env['mail.notification'].sudo().search([
+            ('notification_type', '=', 'email'),
+            ('mail_mail_id', 'in', self.ids),
+            ('notification_status', 'not in', ('sent', 'canceled'))
+        ])
+        for mail in self.sorted(lambda k: (k.create_date, k.id)):
+            if mail_server.owner_limit_count >= MAX_SEND:
+                to_delay |= mail
+            elif mail_server.owner_limit_count + (len(mail.recipient_ids) or 1) > MAX_SEND:
+                # Because we split for each recipient, if we want to
+                # respect the limit we have to create new mails
+                # (the first one keep the email_to and the email_cc
+                # so it might send 2 emails instead of 1,
+                # see `_prepare_outgoing_list`)
+                to_keep = MAX_SEND - mail_server.owner_limit_count
+                recipient_ids = mail.recipient_ids
+                new_mail = mail.with_user(mail.create_uid).sudo().copy({
+                    'headers': mail.headers,
+                    'mail_message_id': mail.mail_message_id.id,
+                    'recipient_ids': recipient_ids[:to_keep].ids,
+                })
+                mail.write({
+                    'recipient_ids': recipient_ids[to_keep:],
+                    'email_cc': False,
+                    'email_to': False,
+                })
+                mail_server.owner_limit_count += to_keep or 1
+                notifs.filtered(lambda n: n.mail_mail_id == mail and n.res_partner_id in recipient_ids[:to_keep]).mail_mail_id = new_mail
+                to_send |= new_mail
+                to_delay |= mail
+            else:
+                to_send |= mail
+                mail_server.owner_limit_count += len(mail.recipient_ids) or 1
+
+        # Delay if necessary
+        if to_delay:
+            owner_limit_count = mail_server.owner_limit_count
+            for mail in to_delay:
+                if owner_limit_count < MAX_SEND:
+                    owner_limit_count += len(mail.recipient_ids) or 1
+                else:
+                    owner_limit_count = len(mail.recipient_ids) or 1
+                    server_limit_minute += timedelta(minutes=1)
+
+                mail.scheduled_date = server_limit_minute
+
+            self.env.ref('mail.ir_cron_mail_scheduler_action')._trigger(
+                min(to_delay.mapped('scheduled_date')) + timedelta(seconds=59))
+
+        _logger.info(
+            "Mail: personal server %s: %s emails about to be sent / %s emails delayed",
+            mail_server.name, len(to_send), len(to_delay))
+        return to_send
+
     def send_after_commit(self):
         """Queues the email to be sent after the commit of the current cursor.
 
@@ -617,6 +706,14 @@ class MailMail(models.Model):
             :return: True
         """
         for mail_server_id, alias_domain_id, smtp_from, batch_ids in self._split_by_mail_configuration():
+            mail_server = self.env["ir.mail_server"].browse(mail_server_id)
+
+            if mail_server and mail_server.owner_user_id:
+                # Throttle the sending that use personal mail servers
+                batch_ids = self.browse(batch_ids)._split_by_delayed_batch(mail_server).ids
+                if not batch_ids:
+                    continue
+
             smtp_session = None
             try:
                 smtp_session = self.env['ir.mail_server']._connect__(mail_server_id=mail_server_id, smtp_from=smtp_from)
@@ -630,7 +727,6 @@ class MailMail(models.Model):
                     batch.write({'state': 'exception', 'failure_reason': tools.exception_to_unicode(exc)})
                     batch._postprocess_sent_message(success_pids=[], success_emails=[], failure_type="mail_smtp")
             else:
-                mail_server = self.env['ir.mail_server'].browse(mail_server_id)
                 self.browse(batch_ids)._send(
                     auto_commit=auto_commit,
                     raise_exception=raise_exception,

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -36,6 +36,7 @@ class MailMessage(models.Model):
         # mail
         "mail_email_invalid", "mail_smtp", "mail_email_missing",
         "mail_from_invalid", "mail_from_missing",
+        "mail_spam"
         # sms (SMS addon)
         'sms_number_missing', 'sms_number_format', 'sms_credit',
         'sms_server', 'sms_acc'

--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -45,6 +45,7 @@ class MailNotification(models.Model):
         ("unknown", "Unknown error"),
         # mail
         ("mail_bounce", "Bounce"),
+        ("mail_spam", "Detected As Spam"),
         ("mail_email_invalid", "Invalid email address"),
         ("mail_email_missing", "Missing email address"),
         ("mail_from_invalid", "Invalid from address"),

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -113,7 +113,7 @@ class ResUsers(models.Model):
         mail_servers = self.env['ir.mail_server'].sudo().search(fields.Domain.AND([
             [('from_filter', 'ilike', '_@_')],
             fields.Domain.OR([[
-                ('from_filter', '=', user.email),
+                ('from_filter', '=', user.email_normalized),
                 ('smtp_user', '=', user.email),
                 ('owner_user_id', '=', user._origin.id),
             ] for user in self]),
@@ -122,11 +122,12 @@ class ResUsers(models.Model):
         for user in self:
             server = mail_servers.get(user) or self.env['ir.mail_server']
             user.outgoing_mail_server_id = server.id
-            user.outgoing_mail_server_type = self._get_personal_server_type(server)
-
-    @api.model
-    def _get_personal_server_type(self, smtp_server):
-        return 'default'
+            type_options = self._fields['outgoing_mail_server_type']._selection
+            user.outgoing_mail_server_type = (
+                server.smtp_authentication
+                if server.smtp_authentication in type_options
+                else 'default'
+            )
 
     # ------------------------------------------------------------
     # CRUD
@@ -176,8 +177,8 @@ class ResUsers(models.Model):
         if vals.get('email'):
             previous_email_by_user = {
                 user: user.email
-                for user in self.filtered(lambda user: bool(email_normalize(user.email)))
-                if email_normalize(user.email) != email_normalize(vals['email'])
+                for user in self.filtered(lambda user: bool(user.email_normalized))
+                if user.email_normalized != email_normalize(vals['email'])
             }
         if 'notification_type' in vals:
             user_notification_type_modified = self.filtered(lambda user: user.notification_type != vals['notification_type'])

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -111,13 +111,13 @@ export class Notification extends Record {
             case "pending":
                 return "fa fa-paper-plane-o";
             case "sent":
-                return `fa ${!this.isFollowerNotification ? "fa-check" : "fa-user-o"}`;
+                return "fa fa-check";
             case "bounce":
                 return "fa fa-exclamation";
             case "exception":
                 return "fa fa-times text-danger";
             case "ready":
-                return `fa ${!this.isFollowerNotification ? "fa-send-o" : "fa-user-o"}`;
+                return "fa fa-send-o";
             case "canceled":
                 if (this.autoCanceledFailureType) {
                     return "fa fa-remove";
@@ -140,7 +140,7 @@ export class Notification extends Record {
             case "exception":
                 return _t("Error");
             case "ready":
-                return _t("Ready");
+                return _t("Queued");
             case "canceled":
                 return this.autoCanceledFailureType || _t("Cancelled");
         }

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -56,6 +56,8 @@ export class Notification extends Record {
                 return _t("Invalid from address");
             case "mail_from_missing":
                 return _t("Missing from address");
+            case "mail_spam":
+                return _t("Detected As Spam");
             default:
                 return _t("Exception");
         }

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -17,10 +17,6 @@ class MailMail(models.Model):
     mailing_id = fields.Many2one('mailing.mailing', string='Mass Mailing')
     mailing_trace_ids = fields.One2many('mailing.trace', 'mail_mail_id', string='Statistics')
 
-    @api.constrains('mail_message_id', 'mail_server_id', 'mailing_id')
-    def _check_mail_server_id(self):
-        super()._check_mail_server_id()
-
     def _get_tracking_url(self):
         token = self._generate_mail_recipient_token(self.id)
         return tools.urls.urljoin(
@@ -31,18 +27,6 @@ class MailMail(models.Model):
     @api.model
     def _generate_mail_recipient_token(self, mail_id):
         return tools.hmac(self.env(su=True), 'mass_mailing-mail_mail-open', mail_id)
-
-    def _filter_mail_mail_servers(self, mail_servers):
-        """Allow personal servers for emails where the mailing is created by the owner."""
-        message_create_uid_servers = super()._filter_mail_mail_servers(mail_servers)
-        if (
-            len(self.mailing_id.create_uid) > 1 or  # multiple create_uids -> subset that's allowed for all
-            self.env['ir.config_parameter'].sudo().get_param('mail.disable_personal_mail_servers', False)
-        ):
-            mailing_create_uid_servers = mail_servers.filtered(lambda server: not server.owner_user_id)
-        else:
-            mailing_create_uid_servers = mail_servers.filtered(lambda server: server.owner_user_id in [self.env['res.users'], self.mailing_id.create_uid])
-        return message_create_uid_servers | mailing_create_uid_servers
 
     def _prepare_outgoing_body(self):
         """ Override to add the tracking URL to the body and to add trace ID in

--- a/addons/mass_mailing/models/mailing_trace.py
+++ b/addons/mass_mailing/models/mailing_trace.py
@@ -99,6 +99,7 @@ class MailingTrace(models.Model):
         ("unknown", "Unknown error"),
         # mail
         ("mail_bounce", "Bounce"),
+        ("mail_spam", "Detected As Spam"),
         ("mail_email_invalid", "Invalid email address"),
         ("mail_email_missing", "Missing email address"),
         ("mail_from_invalid", "Invalid from address"),

--- a/addons/microsoft_outlook/controllers/main.py
+++ b/addons/microsoft_outlook/controllers/main.py
@@ -52,6 +52,20 @@ class MicrosoftOutlookController(http.Controller):
 
         return self._check_email_and_redirect_to_outlook_record(access_token, expiration, refresh_token, record_sudo)
 
+    @http.route('/microsoft_outlook/iap_confirm', type='http', auth='user')
+    def microsoft_outlook_iap_callback(self, model, rec_id, csrf_token, access_token, refresh_token, expiration):
+        """Receive back the refresh token and access token from IAP.
+
+        The authentication process with IAP is done in 4 steps;
+        1. User database make a request to `<IAP>/api/mail_oauth/1/outlook`
+        2. User browser is redirected to the URL we received from IAP
+        3. User browser is redirected to `<IAP>/api/mail_oauth/1/outlook_callback`
+           with the authorization_code
+        4. User browser is redirected to `<DB>/microsoft_outlook/iap_confirm`
+        """
+        record = self._get_outlook_record(model, rec_id, csrf_token)
+        return self._check_email_and_redirect_to_outlook_record(access_token, expiration, refresh_token, record)
+
     def _get_outlook_record(self, model_name, rec_id, csrf_token):
         """Return the given record after checking the CSRF token."""
         model = request.env[model_name]

--- a/addons/microsoft_outlook/controllers/main.py
+++ b/addons/microsoft_outlook/controllers/main.py
@@ -10,7 +10,7 @@ from werkzeug.exceptions import Forbidden
 from odoo import _, http
 from odoo.exceptions import UserError
 from odoo.http import request
-from odoo.tools import consteq
+from odoo.tools import consteq, email_normalize
 
 _logger = logging.getLogger(__name__)
 
@@ -100,8 +100,7 @@ class MicrosoftOutlookController(http.Controller):
             id_token_data = id_token.split(".")[1]
             id_token_data += '=' * (-len(id_token_data) % 4)  # `=` padding can be missing
             email = json.loads(base64.b64decode(id_token_data)).get('email')
-
-            if email != record[record._email_field]:
+            if not email or email_normalize(email) != email_normalize(record[record._email_field]):
                 _logger.error('Microsoft Outlook: Invalid email address: %r != %s.', email, record[record._email_field])
                 return request.render('microsoft_outlook.microsoft_outlook_oauth_error', {
                     'error': _(

--- a/addons/microsoft_outlook/models/fetchmail_server.py
+++ b/addons/microsoft_outlook/models/fetchmail_server.py
@@ -23,12 +23,6 @@ class FetchmailServer(models.Model):
             'the permissions.')
         super(FetchmailServer, self - outlook_servers)._compute_server_type_info()
 
-    @api.depends('server_type')
-    def _compute_is_microsoft_outlook_configured(self):
-        outlook_servers = self.filtered(lambda server: server.server_type == 'outlook')
-        (self - outlook_servers).is_microsoft_outlook_configured = False
-        super(FetchmailServer, outlook_servers)._compute_is_microsoft_outlook_configured()
-
     @api.constrains('server_type', 'is_ssl')
     def _check_use_microsoft_outlook_service(self):
         for server in self:

--- a/addons/microsoft_outlook/models/ir_mail_server.py
+++ b/addons/microsoft_outlook/models/ir_mail_server.py
@@ -19,12 +19,6 @@ class IrMail_Server(models.Model):
         selection_add=[('outlook', 'Outlook OAuth Authentication')],
         ondelete={'outlook': 'set default'})
 
-    @api.depends('smtp_authentication')
-    def _compute_is_microsoft_outlook_configured(self):
-        outlook_servers = self.filtered(lambda server: server.smtp_authentication == 'outlook')
-        (self - outlook_servers).is_microsoft_outlook_configured = False
-        super(IrMail_Server, outlook_servers)._compute_is_microsoft_outlook_configured()
-
     def _compute_smtp_authentication_info(self):
         outlook_servers = self.filtered(lambda server: server.smtp_authentication == 'outlook')
         outlook_servers.smtp_authentication_info = _(

--- a/addons/microsoft_outlook/models/ir_mail_server.py
+++ b/addons/microsoft_outlook/models/ir_mail_server.py
@@ -79,3 +79,14 @@ class IrMail_Server(models.Model):
             connection.docmd('AUTH', f'XOAUTH2 {oauth_param}')
         else:
             super()._smtp_login__(connection, smtp_user, smtp_password)
+
+    def _get_personal_mail_servers_limit(self):
+        """Return the number of email we can send in 1 minutes for this outgoing server.
+
+        0 fallbacks to 30 to avoid blocking servers.
+        """
+        if self.smtp_authentication == 'outlook':
+            # Outlook flag way faster email as spam, so we set a lower limit
+            return int(self.env['ir.config_parameter'].sudo()
+                .get_param('mail.server.personal.limit.minutes_outlook')) or 10
+        return super()._get_personal_mail_servers_limit()

--- a/addons/microsoft_outlook/models/microsoft_outlook_mixin.py
+++ b/addons/microsoft_outlook/models/microsoft_outlook_mixin.py
@@ -53,7 +53,7 @@ class MicrosoftOutlookMixin(models.AbstractModel):
                 'redirect_uri': url_join(base_url, '/microsoft_outlook/confirm'),
                 'response_mode': 'query',
                 # offline_access is needed to have the refresh_token
-                'scope': f'offline_access https://outlook.office.com/User.read {self._OUTLOOK_SCOPE}',
+                'scope': f'openid email offline_access https://outlook.office.com/User.read {self._OUTLOOK_SCOPE}',
                 'state': json.dumps({
                     'model': record._name,
                     'id': record.id,
@@ -131,7 +131,7 @@ class MicrosoftOutlookMixin(models.AbstractModel):
         """Request the refresh token and the initial access token from the authorization code.
 
         :return:
-            refresh_token, access_token, access_token_expiration
+            refresh_token, access_token, id_token, access_token_expiration
         """
         response = self._fetch_outlook_token('authorization_code', code=authorization_code)
         return (
@@ -156,6 +156,7 @@ class MicrosoftOutlookMixin(models.AbstractModel):
         return (
             response['refresh_token'],
             response['access_token'],
+            response['id_token'],
             int(time.time()) + int(response['expires_in']),
         )
 
@@ -177,7 +178,7 @@ class MicrosoftOutlookMixin(models.AbstractModel):
             data={
                 'client_id': microsoft_outlook_client_id,
                 'client_secret': microsoft_outlook_client_secret,
-                'scope': f'offline_access https://outlook.office.com/User.read {self._OUTLOOK_SCOPE}',
+                'scope': f'openid email offline_access https://outlook.office.com/User.read {self._OUTLOOK_SCOPE}',
                 'redirect_uri': url_join(base_url, '/microsoft_outlook/confirm'),
                 'grant_type': grant_type,
                 **values,
@@ -248,6 +249,7 @@ class MicrosoftOutlookMixin(models.AbstractModel):
             (
                 self.microsoft_outlook_refresh_token,
                 self.microsoft_outlook_access_token,
+                _id_token,
                 self.microsoft_outlook_access_token_expiration,
             ) = self._fetch_outlook_access_token(self.microsoft_outlook_refresh_token)
             _logger.info(

--- a/addons/microsoft_outlook/models/res_users.py
+++ b/addons/microsoft_outlook/models/res_users.py
@@ -12,12 +12,6 @@ class ResUsers(models.Model):
     )
 
     @api.model
-    def _get_personal_server_type(self, smtp_server):
-        if smtp_server.smtp_authentication == 'outlook':
-            return 'outlook'
-        return super()._get_personal_server_type(smtp_server)
-
-    @api.model
     def _get_mail_server_values(self, server_type):
         values = super()._get_mail_server_values(server_type)
         if server_type == "outlook":

--- a/addons/microsoft_outlook/views/fetchmail_server_views.xml
+++ b/addons/microsoft_outlook/views/fetchmail_server_views.xml
@@ -16,20 +16,14 @@
                     </span>
                     <button type="object"
                         name="open_microsoft_outlook_uri" class="btn-link px-0"
-                        invisible="not is_microsoft_outlook_configured or server_type != 'outlook' or microsoft_outlook_refresh_token">
+                        invisible="server_type != 'outlook' or microsoft_outlook_refresh_token">
                         <i class="oi oi-arrow-right"/>
                         Connect your Outlook account
                     </button>
                     <button type="object"
                         name="open_microsoft_outlook_uri" class="btn-link px-0 ms-2"
-                        invisible="not is_microsoft_outlook_configured or server_type != 'outlook' or not microsoft_outlook_refresh_token">
+                        invisible="server_type != 'outlook' or not microsoft_outlook_refresh_token">
                         <i class="fa fa-cog" title="Edit Settings"/>
-                    </button>
-                    <button class="alert alert-warning d-block mt-2 text-start"
-                        icon="oi-arrow-right" type="action" role="alert"
-                        name="%(base.res_config_setting_act_window)d"
-                        invisible="is_microsoft_outlook_configured or server_type != 'outlook'">
-                        Setup your Outlook API credentials in the general settings to link a Outlook account.
                     </button>
                 </div>
             </field>

--- a/addons/microsoft_outlook/views/ir_mail_server_views.xml
+++ b/addons/microsoft_outlook/views/ir_mail_server_views.xml
@@ -16,20 +16,14 @@
                     </span>
                     <button type="object"
                         name="open_microsoft_outlook_uri" class="btn-link px-0"
-                        invisible="not is_microsoft_outlook_configured or smtp_authentication != 'outlook' or microsoft_outlook_refresh_token">
+                        invisible="smtp_authentication != 'outlook' or microsoft_outlook_refresh_token">
                         <i class="oi oi-arrow-right"/>
                         Connect your Outlook account
                     </button>
                     <button type="object"
                         name="open_microsoft_outlook_uri" class="btn-link px-0 ms-2"
-                        invisible="not is_microsoft_outlook_configured or smtp_authentication != 'outlook' or not microsoft_outlook_refresh_token">
+                        invisible="smtp_authentication != 'outlook' or not microsoft_outlook_refresh_token">
                         <i class="fa fa-cog" title="Edit Settings"/>
-                    </button>
-                    <button class="alert alert-warning d-block mt-2 text-start"
-                        icon="oi-arrow-right" type="action" role="alert"
-                        name="%(base.res_config_setting_act_window)d"
-                        invisible="is_microsoft_outlook_configured or smtp_authentication != 'outlook'">
-                        Setup your Outlook API credentials in the general settings to link a Outlook account.
                     </button>
                 </div>
             </field>

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -764,9 +764,10 @@ class TestMailMail(MailCommon):
 
             # MailDeliveryException: should be catched; other issues are sub-catched under
             # a MailDeliveryException and are catched
-            for error, msg in [
-                    (MailDeliveryException("Some exception"), 'Some exception'),
-                    (ValueError("Unexpected issue"), 'Unexpected issue')]:
+            for error, msg, failure_type in [
+                    (MailDeliveryException("Some exception"), 'Some exception', 'unknown'),
+                    (MailDeliveryException("OutboundSpamException"), 'OutboundSpamException', 'mail_spam'),
+                    (ValueError("Unexpected issue"), 'Unexpected issue', 'unknown')]:
                 def _send_email(*args, **kwargs):
                     raise error
                 self.send_email_mocked.side_effect = _send_email
@@ -774,10 +775,10 @@ class TestMailMail(MailCommon):
                 self._reset_data()
                 mail.send(raise_exception=False)
                 self.assertEqual(mail.failure_reason, msg)
-                self.assertEqual(mail.failure_type, 'unknown', 'Mail: unlogged failure type to fix')
+                self.assertEqual(mail.failure_type, failure_type)
                 self.assertEqual(mail.state, 'exception')
                 self.assertEqual(notification.failure_reason, msg)
-                self.assertEqual(notification.failure_type, 'unknown', 'Mail: generic failure type')
+                self.assertEqual(notification.failure_type, failure_type)
                 self.assertEqual(notification.notification_status, 'exception')
 
             self.send_email_mocked.side_effect = _send_current

--- a/addons/test_mail_full/tests/test_ir_mail_server.py
+++ b/addons/test_mail_full/tests/test_ir_mail_server.py
@@ -41,32 +41,6 @@ class TestIrMailServerPersonal(MailCommon):
             yield
 
     @users('admin', 'employee')
-    def test_personal_mail_server_allowed_mailing(self):
-        """Check a mailing can be sent with a personal server, only if the mailing was created by the owner."""
-        mailing_values = {
-            'subject': 'Hello from Personal Server',
-            'mailing_model_id': self.env['ir.model']._get_id('res.partner'),
-            'mailing_domain': repr([('id', '=', self.test_partner.id)]),
-            'email_from': self.user_employee.email_formatted
-        }
-        employee_mailing = self.env['mailing.mailing'].with_user(self.user_employee).create(mailing_values)
-        with self.mock_mail_connect():
-            employee_mailing.action_send_mail()
-
-        self.assertEqual(len(self.connected_server_ids), 1)
-        self.assertEqual(self.connected_server_ids[0], self.mail_server_user.id)
-
-        employee_impersonate_mailing = self.env['mailing.mailing'].create(mailing_values)
-        with self.mock_mail_connect():
-            employee_impersonate_mailing.action_send_mail()
-
-        self.assertEqual(len(self.connected_server_ids), 1)
-        if self.env.user == self.mail_server_user.owner_user_id:
-            self.assertEqual(self.connected_server_ids[0], self.mail_server_user.id)
-        else:
-            self.assertNotEqual(self.connected_server_ids[0], self.mail_server_user.id)
-
-    @users('admin', 'employee')
     def test_personal_mail_server_allowed_post(self):
         """Check that only the owner of the mail server can create mails that will be sent from it."""
         test_record = self.test_partner.with_user(self.env.user)


### PR DESCRIPTION
Purpose
=======
Create a new IAP application that act like a proxy between the
Gmail / Outlook API and the customer database. That way, the customer
won't need to create their API credentials and they will be
able to use ours.

The application secret is stored on IAP, so when the database will
need to update its token, it will make a call to IAP that will make
the call to the Gmail / Outlook server.

Because we depend on the Gmail / Outlook API, we don't want to block
the emails of the users, and so we set a maximum of 20 emails send
per minutes. One email is sent per recipient, so we need to duplicate
the mail if it has more recipients than the current limit allows. The
limit is "per personal mail server".

Task-3061856