### PR TITLE
[FIX] website: nav bar internal links should be prefixed as normal links

### DIFF
--- a/addons/website/static/src/js/editor/html_editor.js
+++ b/addons/website/static/src/js/editor/html_editor.js
@@ -51,7 +51,6 @@ export class AutoCompleteInLinkPopover extends AutoComplete {
 
 patch(LinkPopover, {
     components: { ...LinkPopover.components, AutoCompleteInLinkPopover },
-    template: "website.linkPopover",
 });
 
 /* patch the LinkPopover component to maintain the option source for the

--- a/addons/website/static/src/xml/html_editor.xml
+++ b/addons/website/static/src/xml/html_editor.xml
@@ -39,7 +39,7 @@
     </AutoCompleteInLinkPopover>
 </t>
 
-<t t-name="website.linkPopover" t-inherit="html_editor.linkPopover" t-inherit-mode="primary">
+<t t-inherit="html_editor.linkPopover" t-inherit-mode="extension">
     <xpath expr="//input[@name='o_linkpopover_url']" position="replace">
         <t t-call="website.InputURLAutoComplete"/>
     </xpath>


### PR DESCRIPTION
Reproduction:
1. click a nav bar menu link, wait for the popover
2. click the link in the popover, the page is opened in another tab out of the backend. For a link having an internal link in the normal editing zone, the opened page is in backend, e.g. the `Edit` button is shown.

After this commit:
we set the website link_popover template inherit mode as `extension` to alter the template directly instead of creating a new one. All the inheritance of the link_popover will be properly have website feature when website is installed


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
