### PR TITLE
[FIX] mrp: add user group in multistep manufacturing test setup

### DIFF
--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -16,6 +16,8 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         cls.env.user.groups_id += cls.env.ref('uom.group_uom')
         # Required for `manufacture_steps` to be visible in the view
         cls.env.user.groups_id += cls.env.ref('stock.group_adv_location')
+        # Required for `product_id` to be visible in the view
+        cls.env.user.groups_id += cls.env.ref('product.group_product_variant')
         # Create warehouse
         cls.customer_location = cls.env['ir.model.data']._xmlid_to_res_id('stock.stock_location_customers')
         warehouse_form = Form(cls.env['stock.warehouse'])


### PR DESCRIPTION
### Issue:

The setUpClass of the `TestMultistepManufacturingWarehouse` test class fails without demo data since the `product_id` field is invisible in the bom view when the `product.group_product_variant` and is not automatic without demo data's:
https://github.com/odoo/odoo/blob/7391082cfa42afdc62d17f1dac5cad97cf177e81/addons/product/data/product_demo.xml#L4-L7 https://github.com/odoo/odoo/blob/7391082cfa42afdc62d17f1dac5cad97cf177e81/addons/mrp/views/mrp_bom_views.xml#L63

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
