### PR TITLE
[FIX] base_automation: fix on_message_received trigger

### DIFF
--- a/doc/cla/individual/johnny-longneck.md
+++ b/doc/cla/individual/johnny-longneck.md
@@ -1,0 +1,9 @@
+Germany, 2025-08-06
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+John Herholz j.longneck@gmail.com https://github.com/johnny-longneck


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Let's say the company partner's e-mail is info@company.org and you have the alias domain default_from as 'info'.
This will trigger all automation rules with trigger "incoming mail" as the company partner has "partner_share" to true.
~~This PR recomputes the partner_share on the mail module to consider the company's e-mail domain.~~
This PR uses the message_type 'email' which is supposed to be incoming mails for evaluation.

<img width="645" height="539" alt="image" src="https://github.com/user-attachments/assets/db67dd1f-ff95-450f-85dc-ccc0bbbbd9f8" />


Addresses Ticket #221812 

Current behavior before PR:

All outgoing mails are triggering base_automation trigger "incoming message".

Desired behavior after PR is merged:

All outgoing mails are not triggering base_automation trigger "incoming message", but outgoing.

Odoo support Ticket: 5016831
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr