### PR TITLE
[FIX] orm: skip empty index creation

### DIFF
--- a/odoo/orm/table_objects.py
+++ b/odoo/orm/table_objects.py
@@ -167,6 +167,10 @@ class Index(TableObject):
             definition_clause = self._index_definition(model.pool)
         else:
             definition_clause = self._index_definition
+        if not definition_clause:
+            # Don't create index with an empty definition
+            return
+
         model.pool.post_constraint(cr, lambda cr: sql.add_index(
             cr,
             conname,


### PR DESCRIPTION
Currently when trying to create an index with a falsy definition, either a string or a callable, psql raises a SyntaxError preventing the installation of the module.

This commit fixes that by skipping the index creation in case of a falsy definition.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
