### PR TITLE
[FIX] pos_loyalty: update discount product list using reactive update

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -599,9 +599,11 @@ patch(PosStore.prototype, {
         const domain = new Domain(reward_product_domain);
 
         try {
-            reward.all_discount_product_ids = [
-                ["link", ...products.filter((p) => domain.contains(p.serialize()))],
-            ];
+            reward.update({
+                all_discount_product_ids: [
+                    ["link", ...products.filter((p) => domain.contains(p.serialize()))],
+                ],
+            });
         } catch (error) {
             if (!(error instanceof InvalidDomainError || error instanceof TypeError)) {
                 throw error;

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -640,3 +640,15 @@ registry.category("web_tour.tours").add("test_refund_does_not_decrease_points", 
             PaymentScreen.clickValidate(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_discount_after_unknown_scan", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Test Product A", "1"),
+            scan_barcode("00998877665544332211"), //should be unknown
+            PosLoyalty.hasRewardLine("10% on Test Product A", "-0.50"),
+            ProductScreen.totalAmountIs("4.50"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -3087,3 +3087,49 @@ class TestUi(TestPointOfSaleHttpCommon):
             "test_combo_product_dont_grant_point",
             login="pos_user",
         )
+
+    def test_discount_after_unknown_scan(self):
+        """
+        Make sure discount is still applied after scanning an unknow barcode
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        product_category = self.env['product.category'].create({
+            'name': 'Discount category',
+        })
+        self.product_a = self.env['product.product'].create({
+            'name': 'Test Product A',
+            'is_storable': True,
+            'list_price': 5,
+            'available_in_pos': True,
+            'taxes_id': False,
+            'categ_id': product_category.id,
+        })
+        self.env['loyalty.program'].create({
+            'name': 'Discount on category',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [(0, 0, {
+                'reward_point_mode': 'order',
+                'reward_point_amount': 1,
+                'minimum_amount': 1,
+                'minimum_qty': 1,
+                'product_category_id': product_category.id,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'required_points': 1,
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'specific',
+                'discount_product_category_id': product_category.id,
+            })],
+            'pos_config_ids': [Command.link(self.main_pos_config.id)],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "test_discount_after_unknown_scan",
+            login="pos_user",
+        )


### PR DESCRIPTION
With a discount applied on specific products,
after scanning an unknown product, the discount disappeared and could not be reapplied.

Steps to reproduce:
-------------------
* Create a promotion program that grants a discount on a specific product category
* Open PoS
* Add to the order a product that triggers the discount
* Scan an unknown barcode
* (Try to reapply the discount)
> Observation:
The discount disappears and cannot be reapplied

Why the fix:
------------
In v18.0, the method used `reward.update(...)` to apply the computed list of discountable products, ensuring proper handling by the reactive OWL model.
In v18.2, a direct assignment was used instead, which did not properly set the internal state. When the filtered product list was empty, the resulting structure `[['link']]` became invalid, causing the discount to disappear and preventing it from being reapplied.

opw-4923687


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
