### PR TITLE
[FIX] l10n_in_ewaybill: header alignment

### DIFF
--- a/addons/l10n_in_ewaybill/report/ewaybill_report.xml
+++ b/addons/l10n_in_ewaybill/report/ewaybill_report.xml
@@ -16,24 +16,29 @@
                                 }
                             </style>
                             <t t-set="ewaybill_states" t-value="('generated', 'cancel')"/>
-                            <table class="border-bottom border-dark">
-                                <tr class="d-flex justify-content-between align-items-center px-4 py-3">
-                                    <td style="width: 8rem;">
-                                        <img t-if="doc.company_id.logo" t-att-src="image_data_uri(doc.company_id.logo)"
-                                             style="max-width: 8rem; height: auto;" alt="Company Logo"/>
-                                    </td>
-                                    <td id="ewaybill_header">
-                                        <t t-name="ewaybill_header">
-                                            <h4 style="margin-top: 1rem;">e-Way Bill</h4>
-                                        </t>
-                                    </td>
-                                    <td t-if="doc.state in ewaybill_states">
-                                        <img t-if="doc.name != False"
-                                             t-att-src="'/report/barcode/QR/' + str(doc.name) + '/' + str(doc.company_id.vat) + '/' + str(doc.ewaybill_date)"
-                                             style="width: 6.25rem; height: 6.25rem;" alt="Barcode"/>
-                                    </td>
-                                </tr>
-                            </table>
+                            <div class="container-fluid border-bottom py-3">
+                                <div class="row align-items-center">
+                                    <!-- Left: Logo -->
+                                    <div class="col">
+                                        <img t-if="doc.company_id.logo"
+                                             t-att-src="image_data_uri(doc.company_id.logo)"
+                                             style="max-width: 8rem; height: auto;"
+                                             alt="Company Logo"/>
+                                    </div>
+                                    <!-- Center: Title -->
+                                    <div class="col text-center">
+                                        <h4 id="ewaybill_header">e-Way Bill</h4>
+                                    </div>
+                                    <!-- Right: QR Code -->
+                                    <div class="col text-end">
+                                        <img t-if="doc.name and doc.state in ewaybill_states"
+                                        style="width: 6.25rem; height: 6.25rem;"
+                                         t-att-src="'/report/barcode/QR/' + str(doc.name) + '/' + str(doc.company_id.vat) + '/' + str(doc.ewaybill_date)"
+                                         alt="QR Code"/>
+                                    </div>
+                                </div>
+                            </div>
+
                             <br/>
 
                             <t t-set="generate_json" t-value="doc._ewaybill_generate_direct_json()"/>

--- a/addons/l10n_in_ewaybill_stock/report/ewaybill_report_inherit.xml
+++ b/addons/l10n_in_ewaybill_stock/report/ewaybill_report_inherit.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <template id="l10n_in_ewaybill_stock_inherit_report" inherit_id="l10n_in_ewaybill.report_ewaybill">
-        <xpath expr="//t[@t-name='ewaybill_header']" position="replace">
-            <h4 t-if="doc.state not in ewaybill_states and doc.picking_id"
-                style="margin-top: 1rem;">
+        <xpath expr="//h4[@id='ewaybill_header']" position="replace">
+            <h4 t-if="doc.state not in ewaybill_states and doc.picking_id">
                 Delivery Challan
             </h4>
-            <h4 t-else="" style="margin-top: 1rem;">e-Way Bill</h4>
+            <h4 t-else="">e-Way Bill</h4>
         </xpath>
         <xpath expr="//t[@t-out='doc.type_id.sub_type']" position="after">
             <t t-if="doc.type_description">


### PR DESCRIPTION
Before this commit-
Ewaybill header was not properly aligned

After this commit-
We fix the ewaybill header aligned in
order Company logo in left, Title in Center
and QR code in right

Before:
<img width="759" height="143" alt="image" src="https://github.com/user-attachments/assets/b0a54c82-8e48-4c15-bd0e-d08abea75f52" />

After:
<img width="780" height="146" alt="image" src="https://github.com/user-attachments/assets/b0b3e04d-33ec-483b-a916-4118e437aff8" />



task-5000160



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
