### PR TITLE
[FIX] website: crash when you close pick a theme

### DIFF
--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -255,7 +255,7 @@ export const websiteService = {
                 action.doAction("website.website_preview", {
                     clearBreadcrumbs: true,
                     props: {
-                        websiteId: websiteId || currentWebsiteId,
+                        websiteId: websiteId || currentWebsiteId || false,
                         path: path || (contentWindow && contentWindow.location.href) || '/',
                         enableEditor: edition,
                         editTranslations: translation,


### PR DESCRIPTION
How to reproduce:
================
- Switch to debug mode
- Edit a website page
- Switch to the theme tab
- Click on switch theme
- Click on ok (dialog)
- Close the Pick a Theme action (close button).

Before this commit:
    We have an error validating the props. websiteId is equal to null which
    is not an accepted value.

After this commit:
    The action closes correctly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
