### PR TITLE
[IMP] mail: visible call cards to store

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -91,63 +91,11 @@ export class Call extends Component {
     }
 
     /** @returns {CardData[]} */
-    get visibleCards() {
-        const raisingHandCards = [];
-        const sessionCards = [];
-        const invitationCards = [];
-        const filterVideos = this.store.settings.showOnlyVideo && this.channel.videoCount > 0;
-        for (const session of this.channel.rtc_session_ids) {
-            const target = session.raisingHand ? raisingHandCards : sessionCards;
-            const cameraStream = session.is_camera_on
-                ? session.videoStreams.get("camera")
-                : undefined;
-            if (!filterVideos || cameraStream) {
-                target.push({
-                    key: "session_main_" + session.id,
-                    session,
-                    type: "camera",
-                    videoStream: cameraStream,
-                });
-            }
-            const screenStream = session.is_screen_sharing_on
-                ? session.videoStreams.get("screen")
-                : undefined;
-            if (screenStream) {
-                target.push({
-                    key: "session_secondary_" + session.id,
-                    session,
-                    type: "screen",
-                    videoStream: screenStream,
-                });
-            }
-        }
-        if (!filterVideos) {
-            for (const member of this.channel.invited_member_ids) {
-                invitationCards.push({
-                    key: "member_" + member.id,
-                    member,
-                });
-            }
-        }
-        raisingHandCards.sort((c1, c2) => c1.session.raisingHand - c2.session.raisingHand);
-        sessionCards.sort(
-            (c1, c2) =>
-                c1.session.channel_member_id?.persona?.name?.localeCompare(
-                    c2.session.channel_member_id?.persona?.name
-                ) ?? 1
-        );
-        invitationCards.sort(
-            (c1, c2) => c1.member.persona?.name?.localeCompare(c2.member.persona?.name) ?? 1
-        );
-        return raisingHandCards.concat(sessionCards, invitationCards);
-    }
-
-    /** @returns {CardData[]} */
     get visibleMainCards() {
         const activeSession = this.channel.activeRtcSession;
         if (!activeSession) {
             this.state.insetCard = undefined;
-            return this.visibleCards;
+            return this.channel.visibleCards;
         }
         const type = activeSession.mainVideoStreamType;
         if (type === "screen" || activeSession.is_screen_sharing_on) {

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -53,7 +53,7 @@
                 </div>
             </div>
             <div t-if="state.sidebar and channel.activeRtcSession" class="o-discuss-Call-sidebar d-flex align-items-center h-100 flex-column">
-                <CallParticipantCard t-foreach="visibleCards" t-as="cardData" t-key="cardData.key"
+                <CallParticipantCard t-foreach="channel.visibleCards" t-as="cardData" t-key="cardData.key"
                     cardData="cardData"
                     className="'o-discuss-Call-sidebarCard w-100 p-1'"
                     thread="channel"


### PR DESCRIPTION
The discuss call views displays one card per user in the call. When they are a lot of users talking, changing their session state, joining, leaving or when the window is resized the call component can render quite a lot. Each time, the `visibleCards` getter is called. It does quite heavy operations, array filtering, sorting. Doing this a lot can lead to performance issues (especially visible when many participants are in the call). This commit moves the getter to the rtc session model, benefiting from compute caching.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
