### PR TITLE
[FIX] point_of_sale: prevent error on loading demo data

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -944,6 +944,9 @@ class PosConfig(models.Model):
         self.ensure_one()
         convert.convert_file(self._env_with_clean_context(), 'point_of_sale', 'data/scenarios/clothes_category_data.xml', idref=None, mode='init', noupdate=True)
         if with_demo_data:
+            product_module = self.env['ir.module.module'].search([('name', '=', 'product')])
+            if not product_module.demo:
+                convert.convert_file(self._env_with_clean_context(), 'product', 'data/product_attribute_demo.xml', idref=None, mode='init', noupdate=True)
             convert.convert_file(self._env_with_clean_context(), 'point_of_sale', 'data/scenarios/clothes_data.xml', idref=None, mode='init', noupdate=True)
         clothes_categories = self.get_record_by_ref([
             'point_of_sale.pos_category_upper',


### PR DESCRIPTION
Currently, an error occurs when the user tries to load the sample data.

Steps to reproduce:
---
-  Install `pos_restaurant` module (without demo)
- Open `Clothes` and click on `Load Sample` in pos config

Traceback:
---
```py
ValueError: External ID not found in the system: product.pa_color

ParseError: while parsing /home/odoo/src/odoo/saas-18.4/addons/point_of_sale/data/scenarios/clothes_data.xml:31, somewhere inside <record model="product.template.attribute.line" id="product_attribute_line_color">
            <field name="product_tmpl_id" ref="point_of_sale.casual_t_shirt_product_template"/>
            <field name="attribute_id" ref="product.pa_color"/>
            <field name="value_ids" eval="[Command.set([                     ref('product.pav_color_black'),                     ref('product.pav_color_white'),                     ref('product.pav_color_purple'),                     ref('product.pav_color_green'),             ])]"/>
        </record>
```

The issue arises because the `pos_restaurant` module uses a custom `scenario` flow, where demo data is loaded only for a specific scenario. This means that demo records—like `Color` defined in `product_attribute_demo.xml`—are only available when demo data is explicitly installed. If the database is set up without demo data, these records won't exist. As a result, any part of the POS data that directly references such demo records (e.g., 'Color') will lead to errors due to missing dependencies.

- Commit https://github.com/odoo/odoo/commit/ffb976c3ed5fbcff2e5d06a3183bab2fbe0307ff moved demo data from `point_of_sale` to `product` 
- Related PR: https://github.com/odoo/odoo/pull/221801

sentry-6790044159

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
