### PR TITLE
[FIX] point_of_sale: set preset even without a customer

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -221,6 +221,9 @@ export class PosStore extends WithLazyGetterTrap {
         if (savedCashier) {
             this.setCashier(savedCashier);
         }
+        else {
+            this.setCashier(this.user);
+        }
     }
 
     setCashier(user) {

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -974,3 +974,21 @@ registry.category("web_tour.tours").add("test_preset_customer_selection", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_default_preset_requires_customer", {
+    steps: () =>
+        [
+            {
+                content: "Click Discard",
+                trigger: 'button.backend-button.button.btn.btn-lg.btn-secondary:contains("Discard")',
+                run: "click",
+            },
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.selectPreset("Preset", "Delivery"),
+            PartnerList.clickPartner("Addison Olson"),
+            Chrome.clickOrders(),
+            TicketScreen.nthRowContains(1, "Addison Olson"),
+            TicketScreen.nthRowContains(1, "Delivery", false),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2774,6 +2774,30 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_preset_customer_selection')
 
+    def test_default_preset_requires_customer(self):
+        """
+        Tests that when the default preset requires a customer in order to
+        work, we can still close the PoS before selecting a customer. Also
+        tests that when going back to the PoS, we can still select a customer.
+        """
+        preset_delivery, preset_eat_in = self.env['pos.preset'].create([
+            {
+            'name': 'Delivery',
+            'identification': 'address',
+            }, {
+            'name': 'Eat in',
+            }
+        ])
+
+        self.main_pos_config.write({
+            'use_presets': True,
+            'default_preset_id': preset_delivery.id,
+            'available_preset_ids': [(6, 0, [preset_delivery.id, preset_eat_in.id])],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_default_preset_requires_customer', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
**Steps to reproduce:**
- Enable presets, chose the 3 default ones
- The default should be a preset that requires a customer (like delivery)
- Go in the PoS, and instead of opening the register, discard
- An error shows up
- Go back to the PoS and open the register
- Try to select a client, an error shows up

**Problem:**
When the default preset needs a client to operate, if we do not set the customer as soon as possible when opening the PoS, an error will show up. So if we press discard on either the open register pop up or the client pop up that comes right after, we have an error.

Another bug was that only on a new database or in incognito mode, with the same config, an error would be raised as the cashier is only set after looking at the preset but is retrieved from the cache before setting the preset.
Meaning that if the cashier was in the cache, it will work fine, but if it was not, the PoS will crash.


**Why the fix:**
When we have a default preset that requires a customer, we try to read the data from the preset before it is set. The way it worked before this fix is, we set a customer and once this is done, we set the preset.

The problem with this is if we do NOT select a customer and exit the PoS, we try to read data from the preset, which has not been set as we did not chose a customer. If we then open the PoS again, we will not be able to pick a customer from the automatic pop up, as it does not appear. So we will be locked in a PoS with no preset with no way of putting it back on without closing the register. We will also have an error if we try and select a customer manually, as it tries to access some of the preset data. 

The way it works after this commit is that we set the preset before chosing the customer. If we chose discard, we can go on with the order, but we will have to pick a customer before paying for the order, as a pop up prevents us from doing so if a customer is not selected. This is how it was done before the 18.3 refactoring. This way, the preset will
always be active, even if no customer are selected.

opw-4989001