### PR TITLE
[FIX] web: add body as a fallback of #wrapwrap

### DIFF
--- a/addons/web/static/src/public/interaction_service.js
+++ b/addons/web/static/src/public/interaction_service.js
@@ -195,11 +195,8 @@ class InteractionService {
 registry.category("services").add("public.interactions", {
     dependencies: ["localization"],
     async start(env) {
-        const el = document.querySelector("#wrapwrap");
-        if (!el) {
-            // if this is an issue, maybe we should make the wrapwrap configurable
-            return null;
-        }
+        // fallback if #wrapwrap is not present in the dom
+        const el = document.querySelector("#wrapwrap") || document.querySelector("body");
         const Interactions = registry.category("public.interactions").getAll();
         const service = new InteractionService(el, env);
         service.activate(Interactions);

--- a/addons/web/static/tests/public/interaction_service.test.js
+++ b/addons/web/static/tests/public/interaction_service.test.js
@@ -9,9 +9,9 @@ import { startInteraction } from "./helpers";
 
 describe.current.tags("interaction_dev");
 
-test("properly handles case where we have no match for wrapwrap", async () => {
+test("properly fallback to body when we have no match for wrapwrap", async () => {
     const env = await makeMockEnv();
-    expect(env.services["public.interactions"]).toBe(null);
+    expect(env.services["public.interactions"].el).toBe(document.querySelector("body"));
 });
 
 test("wait for translation before starting interactions", async () => {


### PR DESCRIPTION
**Before this PR:**
The screen appears blank in places like meeting room booking view, install kiosk app page (events, attendance, rooms, frontdesk), etc.

**Version:**
Although this issue exists in future versions, it is fixed in the version where public interactions are introduced.


**Technical reason:**
The issue was introduced by this commit: https://github.com/odoo/odoo/commit/dd13994674d4ef4683f5a4d46a1f604650cfb92b

Happens while loading frontend assets.
Here, if `#wrapwrap` is absent in dom then interaction service is not started and returned as a null. Now we keep `body` as a fallback of `#wrapwrap`.

**After this PR:**
The screen will load correctly and will no longer be blank.

Task-4915155