### PR TITLE
[FIX] marketing_card: allow portal users to read cards

### DIFF
--- a/addons/marketing_card/security/ir.model.access.csv
+++ b/addons/marketing_card/security/ir.model.access.csv
@@ -5,5 +5,6 @@ access_card_campaign_user,card.campaign.user,model_card_campaign,marketing_card.
 access_card_template_user,card.template.user,model_card_template,marketing_card.marketing_card_group_user,1,0,0,0
 access_card_template_system,card.template.system,model_card_template,base.group_system,1,1,1,1
 access_card_card_user,card.card.user,model_card_card,base.group_user,1,1,1,0
+access_card_card_portal,card.card.portal,model_card_card,base.group_portal,1,0,0,0
 access_card_card_public,card.card.user,model_card_card,base.group_public,1,0,0,0
 access_card_card_manager,card.card.manager,model_card_card,marketing_card.marketing_card_group_manager,1,1,1,1


### PR DESCRIPTION
The access right that allows public users to read cards should obviously apply equaly to portal users.

Recipients will very often be partners so them not being allowed is very annoying.

task-5000332
