### PR TITLE
[PERF] project: Speed-up `ir.rules`

### DIFF
--- a/addons/hr_timesheet/models/project_collaborator.py
+++ b/addons/hr_timesheet/models/project_collaborator.py
@@ -8,8 +8,8 @@ class ProjectCollaborator(models.Model):
     _inherit = 'project.collaborator'
 
     @api.model
-    def _toggle_project_sharing_portal_rules(self, active):
-        super()._toggle_project_sharing_portal_rules(active)
+    def _set_project_sharing_portal_rules(self, active):
+        super()._set_project_sharing_portal_rules(active)
         # ir.model.access
         access_timesheet_portal = self.env.ref('hr_timesheet.access_account_analytic_line_portal_user').sudo()
         if access_timesheet_portal.active != active:

--- a/addons/project/__init__.py
+++ b/addons/project/__init__.py
@@ -17,7 +17,7 @@ def _check_exists_collaborators_for_project_sharing(env):
     collaborator = env['project.collaborator'].search([], limit=1)
     if collaborator:
         # Then we need to enable the access rights linked to project sharing for the portal user
-        env['project.collaborator']._toggle_project_sharing_portal_rules(True)
+        env['project.collaborator']._set_project_sharing_portal_rules(True)
 
 
 def _project_post_init(env):

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -200,6 +200,8 @@ class ProjectProject(models.Model):
     is_milestone_deadline_exceeded = fields.Boolean(compute='_compute_next_milestone_id', groups="project.group_project_milestone", export_string_translation=False)
     is_template = fields.Boolean(copy=False, export_string_translation=False)
 
+    _private_project_idx = models.Index("(id) WHERE privacy_visibility IN ('followers')")
+
     _project_date_greater = models.Constraint(
         'check(date >= date_start)',
         "The project's start date must be before its end date.",
@@ -586,7 +588,7 @@ class ProjectProject(models.Model):
         # Here we modify the project's stage according to the selected company (selecting the first
         # stage in sequence that is linked to the company).
         company_id = vals.get('company_id')
-        if self.env.user.has_group('project.group_project_stages') and company_id:
+        if company_id and self.env.user.has_group('project.group_project_stages'):
             projects_already_with_company = self.filtered(lambda p: p.company_id.id == company_id)
             if projects_already_with_company:
                 projects_already_with_company.write({key: value for key, value in vals.items() if key != 'company_id'})

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -71,7 +71,7 @@
         <field name="model_id" ref="model_project_project"/>
         <field name="domain_force">['|',
                                         ('privacy_visibility', '!=', 'followers'),
-                                        ('message_partner_ids', 'in', [user.partner_id.id])
+                                        ('message_is_follower', 'in', [user.partner_id.id])
                                     ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
@@ -90,15 +90,14 @@
         <field name="perm_unlink" eval="False"/>
         <field name="domain_force">[
             '|',
-                '&amp;',
-                    ('project_id', '!=', False),
-                    '|',
-                        ('project_id.privacy_visibility', '!=', 'followers'),
-                        ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                # Non-follower projects are accessible
+                ('is_visibility_followers', '=', False),
+                # For follower-only projects, user must be follower of project/task OR assigned to task
                 '|',
-                    ('message_partner_ids', 'in', [user.partner_id.id]),
+                    # message_is_follower has a special search override for project.task to include followers of the task's project
+                    ('message_is_follower', '=', True),
                     # to subscribe check access to the record, follower is not enough at creation
-                    ('user_ids', 'in', user.id)
+                    ('user_ids', 'in', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
     </record>
@@ -155,15 +154,14 @@
         <field name="perm_read" eval="False"/>
         <field name="domain_force">[
             '|',
-                '&amp;',
-                    ('project_id', '!=', False),
-                    '|',
-                        ('project_id.privacy_visibility', '!=', 'followers'),
-                        ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                # Non-follower projects are accessible
+                ('is_visibility_followers', '=', False),
+                # For follower-only projects, user must be follower of project/task OR assigned to task
                 '|',
-                    ('message_partner_ids', 'in', [user.partner_id.id]),
+                    # message_is_follower has a special search override for project.task to include followers of the task's project
+                    ('message_is_follower', '=', True),
                     # to subscribe check access to the record, follower is not enough at creation
-                    ('user_ids', 'in', user.id)
+                    ('user_ids', 'in', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>
@@ -172,10 +170,8 @@
         <field name="name">Project: See private tasks</field>
         <field name="model_id" ref="project.model_project_task"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '!=', 'followers'),
-            '|', '|', ('project_id', '!=', False),
-                      ('parent_id', '!=', False),
-                 ('user_ids', 'in', user.id),
+            ('project_id', '=', False),
+            ('user_ids', 'in', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>
@@ -206,7 +202,7 @@
         <field name="name">Project/Task: portal users: can only see a task if he's a collaborator of the project and a follower of the task</field>
         <field name="model_id" ref="project.model_project_task"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '=', 'portal'),
+            ('project_privacy_visibility', '=', 'portal'),
             ('active', '=', True),
             '|',
                 ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
@@ -227,7 +223,7 @@
         <field name="model_id" ref="project.model_project_task"/>
         <field name="active">0</field>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '=', 'portal'),
+            ('project_privacy_visibility', '=', 'portal'),
             ('active', '=', True),
             '|',
                 ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
@@ -254,12 +250,14 @@
         <field name="model_id" ref="model_project_update"/>
         <field name="domain_force">[
         '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
-            '|',
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+            ('project_id', 'any', [
                 '|',
+                    '|',
+                        ('privacy_visibility', '!=', 'followers'),
+                        ('message_is_follower', '=', True),
                     ('user_id', '=', user.id),
-                    ('project_id.user_id', '=', user.id)
+            ]),
+            ('user_id', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
     </record>
@@ -323,11 +321,12 @@
         <field name="name">Project/Milestone: employees: follow required for follower-only projects</field>
         <field name="model_id" ref="model_project_milestone"/>
         <field name="domain_force">[
-        '|',
-            ('project_id.privacy_visibility', '!=', 'followers'),
-            '|',
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                ('project_id.user_id', '=', user.id),
+            ('project_id', 'any', [
+                '|',
+                    '|', ('privacy_visibility', '!=', 'followers'),
+                         ('message_is_follower', '=', True),
+                    ('user_id', '=', user.id),
+            ])
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
@@ -343,8 +342,10 @@
         <field name="name">Project/milestone portal users: portal user can read with project sharing feature</field>
         <field name="model_id" ref="project.model_project_milestone"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '=', 'portal'),
-            ('project_id.collaborator_ids.partner_id', 'in', [user.partner_id.id]),
+            ('project_id', 'any', [
+                ('privacy_visibility', '=', 'portal'),
+                ('collaborator_ids.partner_id', 'in', [user.partner_id.id]),
+            ])
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>


### PR DESCRIPTION
Description
-----------
This commit aims at keeping the same behavior and specification for the visibility of tasks but just simplifies the rules to be faster and scale better in more complex user filters.

This is achieved by using two search methods:

- `_search_message_is_follower` - since on average we presume a user follows few projects, we can inject the IDs of followed projects directly, not only if one is a follower of tasks. This prevents joining the `project_project` table in the final query, which might be more elaborate.
- `_search_is_visibility_followers` - we suppose that on average, private projects are the minority, and therefore if a search on tasks depends on project only to determine the `privacy_visibility`, we can early resolve the IDs of the projects and inject them in the final query instead. This prevents joining the `project_project` table in the final query.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
