### PR TITLE
[FIX] html_builder, website: use default value during option preview

### DIFF
--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -618,6 +618,16 @@ function useOperationWithReload(callApply, reload) {
         await env.editor.config.reloadEditor({ target, url });
     };
 }
+
+function getValueWithDefault(userInputValue, defaultValue, formatRawValue) {
+    if (defaultValue !== undefined) {
+        if (!userInputValue || (typeof userInputValue === "string" && !userInputValue.trim())) {
+            return formatRawValue(defaultValue);
+        }
+    }
+    return userInputValue;
+}
+
 export function useInputBuilderComponent({
     id,
     defaultValue,
@@ -670,11 +680,7 @@ export function useInputBuilderComponent({
     }
 
     function commit(userInputValue) {
-        if (defaultValue !== undefined) {
-            if (!userInputValue || (typeof userInputValue === "string" && !userInputValue.trim())) {
-                userInputValue = formatRawValue(defaultValue);
-            }
-        }
+        userInputValue = getValueWithDefault(userInputValue, defaultValue, formatRawValue);
         const rawValue = parseDisplayValue(userInputValue);
         if (reload) {
             callOperation(operationWithReload, { userInputValue: rawValue });
@@ -696,6 +702,7 @@ export function useInputBuilderComponent({
     const shouldPreview = useHasPreview(getAllActions);
     function preview(userInputValue) {
         if (shouldPreview) {
+            userInputValue = getValueWithDefault(userInputValue, defaultValue, formatRawValue);
             callOperation(applyOperation.preview, {
                 preview: true,
                 userInputValue: parseDisplayValue(userInputValue),

--- a/addons/website/static/src/builder/plugins/options/progress_bar_option.xml
+++ b/addons/website/static/src/builder/plugins/options/progress_bar_option.xml
@@ -14,7 +14,7 @@
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Colors">
-        <BuilderColorPicker applyTo="'.progress-bar'" styleAction="'background-color'"/>
+        <BuilderColorPicker applyTo="'.progress-bar'" styleAction="'background-color'" enabledTabs="['solid', 'custom']"/>
     </BuilderRow>
     <BuilderRow label.translate="Striped">
         <BuilderCheckbox id="'progress_striped_opt'" classAction="'progress-bar-striped'" applyTo="'.progress-bar'"/>

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
@@ -210,7 +210,7 @@ describe("default value", () => {
         await delay();
         input.dispatchEvent(new Event("change"));
         await delay();
-        expect.verifySteps(["customAction ", "customAction 20"]);
+        expect.verifySteps(["customAction 20", "customAction 20"]);
         expect(input).toHaveValue("20");
     });
     test("clear BuilderNumberInput without default value", async () => {
@@ -237,6 +237,8 @@ describe("default value", () => {
         expect("[data-action-id='customAction'] input").toHaveValue("10");
 
         await clear();
+        expect("[data-action-id='customAction'] input").toHaveValue("");
+        expect(":iframe .test-options-target").toHaveInnerHTML("0"); //Check that default value is used during preview
         await click(".options-container");
         expect("[data-action-id='customAction'] input").toHaveValue("0");
         expect(":iframe .test-options-target").toHaveInnerHTML("0");
@@ -780,7 +782,7 @@ describe("sanitized values", () => {
         `);
         await contains(":iframe .test-options-target").click();
         await contains(".options-container input").edit("-1", { instantly: true });
-        expect.verifySteps(["customAction ", "customAction 0"]); // input, change
+        expect.verifySteps(["customAction 0", "customAction 0"]); // input, change
         expect(".options-container input").toHaveValue("0");
     });
     test("use max when the given value is bigger", async () => {
@@ -805,7 +807,7 @@ describe("sanitized values", () => {
         await contains(":iframe .test-options-target").click();
         await contains(".options-container input").edit("11", { instantly: true });
         await animationFrame();
-        expect.verifySteps(["customAction ", "customAction 10"]); // input, change
+        expect.verifySteps(["customAction 0", "customAction 10"]); // input, change
         expect(".options-container input").toHaveValue("10");
     });
     test("multi values: trailing space in BuilderNumberInput is ignored", async () => {


### PR DESCRIPTION
This commit add a fallback to default value during option preview, as it
was already the case in the commit.

Steps to reproduce:
- Drop `s_progress_bar` snippet
- Click on it
- Empty "Value" field
- NaN appears on progress bar during the preview
- Default value of BuilderNumberInput is not used

Additionally, progress bar color picker was showing theme and gradient
tabs.