### PR TITLE
[FIX] mass_mailing: fix parameter for mailing templates

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -367,14 +367,14 @@ export class MassMailingHtmlField extends HtmlField {
         const templatesParams = result.map(values => {
             return {
                 id: values.id,
-                modelId: values.mailing_model_id.id,
-                modelName: values.mailing_model_id.display_name,
+                modelId: values.mailing_model_id[0],
+                modelName: values.mailing_model_id[1],
                 name: `template_${values.id}`,
                 nowrap: true,
                 subject: values.subject,
                 template: values.body_arch,
-                userId: values.user_id.id,
-                userName: values.user_id.display_name,
+                userId: values.user_id[0],
+                userName: values.user_id[1],
             };
         });
 


### PR DESCRIPTION
Step to reproduce:
- install email marketing and open it
- create a new record, add name and add something in email body
- click on "Add to Templates"
- click on new

Observation:
- The newly created template is not shown as option for new record.

Cause:
- https://github.com/odoo/odoo/pull/205486 convert arrays value to object, [exact change](https://github.com/odoo/odoo/commit/f79b2edb614fd08b19b18beeb16be38743f637b2#diff-0b4e81825324dc36e89543232f3f8f8704acddc4ec21031c6ccea78ee93b00eeR368-R379) but in this case, we actually return values_list, i.e. a tuple for m2o fields

https://github.com/odoo/odoo/blob/ea1767e3a016f501d5bc4012cc5e964fc05955a3/addons/mass_mailing/models/mailing.py#L816-L834

- Hence, using a key evaluates to `undefined`
- so, the values return by `action_fetch_favorites` are not rendered

Fix:
- use index instead of keys

opw-4960103

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
