### PR TITLE
[FIX] sale_loyalty: keep track of coupon changes on confirmed orders

### DIFF
--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -88,13 +88,16 @@ class SaleOrderLine(models.Model):
     def write(self, vals):
         cost_in_vals = 'points_cost' in vals
         if cost_in_vals:
-            previous_cost = {l: l.points_cost for l in self}
+            previous_vals = {line: (line.points_cost, line.coupon_id) for line in self}
         res = super().write(vals)
         if cost_in_vals:
             # Update our coupon points if the order is in a confirmed state
-            for line in self:
-                if previous_cost[line] != line.points_cost and line.state == 'sale':
-                    line.coupon_id.points += (previous_cost[line] - line.points_cost)
+            for line, (previous_cost, previous_coupon) in previous_vals.items():
+                if line.state != 'sale':
+                    continue
+                if line.points_cost != previous_cost or line.coupon_id != previous_coupon:
+                    previous_coupon.points += previous_cost
+                    line.coupon_id.points -= line.points_cost
         return res
 
     def unlink(self):

--- a/addons/sale_loyalty/tests/test_program_with_code_operations.py
+++ b/addons/sale_loyalty/tests/test_program_with_code_operations.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
+from odoo import Command
 from odoo.exceptions import ValidationError
+
+from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
 
 
 class TestProgramWithCodeOperations(TestSaleCouponCommon):
@@ -331,3 +333,46 @@ class TestProgramWithCodeOperations(TestSaleCouponCommon):
         self._apply_promo_code(order, 'test')
         # But the above line should not add any reward
         self.assertEqual(len(order.order_line), 2, "You should get a discount line") # product + discount
+
+    def test_change_reward_on_confirmed_order(self):
+        """Check that changing rewards on a confirmed order restores points on the coupon.
+        Tested flow:
+            - have a coupon program with 2 discount rewards;
+            - have confirmed order;
+            - apply a 10% discount reward, costing 1 point;
+            - change to a 50% discount reward, costing 5 points;
+            - check that there are still 5 points left on the coupon.
+        """
+        program = self.code_promotion_program_with_discount
+        program.update({
+            'rule_ids': [Command.clear()],
+            'reward_ids': [Command.create({
+                'discount': 50,
+                'discount_mode': 'percent',
+                'discount_applicability': 'order',
+                'required_points': 5,
+            })],
+        })
+        discount10, discount50 = program.reward_ids
+
+        self.env['loyalty.generate.wizard'].with_context(active_id=program.id).create({
+            'coupon_qty': 1,
+            'points_granted': 10,
+        }).generate_coupons()
+        coupon = program.coupon_ids
+
+        order = self.empty_order
+        order.order_line = [Command.create({'product_id': self.product_C.id})]
+        order.action_confirm()
+
+        order.order_line.product_updatable = True  # in case `sale_project` is installed
+        order._apply_program_reward(discount10, coupon)
+        reward_line = order.order_line.filtered('is_reward_line')
+        self.assertEqual(order.amount_total, 90, "10% discount should be applied")
+        self.assertEqual(coupon.points, 9, "10% discount reward should use 1 point")
+
+        order.order_line.product_updatable = True  # in case `sale_project` is installed
+        order._apply_program_reward(discount50, coupon)
+        self.assertIn(reward_line, order.order_line, "Reward line should be re-used")
+        self.assertEqual(order.amount_total, 50, "50% discount should be applied")
+        self.assertEqual(coupon.points, 5, "50% discount reward should use 5 points")


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have a coupon program;
2. add a 10% discount on order reward for 1 point;
3. add a 50% discount on order reward for 5 points;
4. generate a coupon with 10 points;
5. use coupon code on a confirmed order;
6. select 10% discount reward;
7. change to a 50% discount reward;
8. check coupon point total.

Issue
-----
Even though the 5 point reward was used, only 4 out of 10 points remain.

Cause
-----
When updating the reward line of a confirmed order, it keeps track of point cost changes before & after a write. Its purpose is to restore back the point difference on the coupon record.

The issue is that while point changes are stored, coupon changes are not. When updating reward lines, `_reset_loyalty` is used, which removes the `coupon_id` from the lines. As a consequence, attempting to restore the point difference on `line.coupon_id` after an update, it writes to an empty record.

Solution
--------
Store both coupons & their used points before write. After write, restore the previous points to the previous coupon, and subtract the current point cost from the current coupon.

This way, any combination of coupon/point changes should have the points updated as expected.

opw-4910922