### PR TITLE
[FIX] website: prevent syntaxerror in PG12 and PG14

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -2181,7 +2181,7 @@ class Website(models.Model):
             query = SQL("""
                 SELECT id,
                     MAX(similarity) as _best_similarity
-                FROM (%s)
+                FROM (%s) sub
                 GROUP BY id
                 ORDER BY _best_similarity DESC
                 LIMIT 1000


### PR DESCRIPTION
Currently the trigram similarty query raises a syntax error on both PG12 and PG14. This is coming from a lack of alias on the subquery. Starting PG16 subquery aliases are optional
https://pganalyze.com/blog/5mins-postgres-waiting-for-postgres-16-subquery-alias-optional But that's not the case in PG12 and PG14. Since we are requiring min. PG12 for on-prem database, this commit adds an explicit subquery alias to make the website code runnable on a PG12/14 cluster.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
