### PR TITLE
[IMP] mrp: add gantt view to MO

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -9,7 +9,7 @@
     'category': 'Supply Chain/Manufacturing',
     'sequence': 55,
     'summary': 'Manufacturing Orders & BOMs',
-    'depends': ['product', 'stock', 'resource'],
+    'depends': ['product', 'stock', 'resource', 'web_gantt'],
     'data': [
         'security/mrp_security.xml',
         'security/ir.model.access.csv',

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -159,6 +159,7 @@ class MrpProduction(models.Model):
              " * To Close: The production is done, the MO has to be closed.\n"
              " * Done: The MO is closed, the stock moves are posted. \n"
              " * Cancelled: The MO has been cancelled, can't be confirmed anymore.")
+    state_color = fields.Integer("State Color", compute='_compute_state_color')
     reservation_state = fields.Selection([
         ('confirmed', 'Waiting'),
         ('assigned', 'Ready'),
@@ -564,6 +565,12 @@ class MrpProduction(models.Model):
                 or any(production.move_raw_ids.mapped('picked'))
             ):
                 production.state = 'progress'
+
+    @api.depends('state')
+    def _compute_state_color(self):
+        colors = {'draft': 0, 'confirmed': 4, 'progress': 3, 'to_close': 5, 'done': 10, 'cancel': 1}
+        for production in self:
+            production.state_color = colors[production.state]
 
     @api.depends('bom_id', 'product_id', 'product_qty', 'product_uom_id', 'never_product_template_attribute_value_ids')
     def _compute_workorder_ids(self):

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -578,6 +578,40 @@
             </field>
         </record>
 
+        <record id="mrp_production_kanban_view_inherit" model="ir.ui.view">
+        <field name="name">mrp.production.kanban</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_kanban_view"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//footer" position="after">
+                <field name="date_deadline" invisible="1"/>
+                <field name="is_delayed" invisible="1"/>
+                <p class="text-warning mt-2 mb-0" t-if="record.is_delayed.raw_value">
+                    The deadline of this MO is on  <t t-out="record.date_deadline.value"/>
+                </p>
+            </xpath>
+        </field>
+        </record>
+
+        <record id="mrp_production_gantt_view" model="ir.ui.view">
+            <field name="name">mrp.production.gantt</field>
+            <field name="model">mrp.production</field>
+            <field name="arch" type="xml">
+                <gantt 
+                kanban_view_id="%(mrp.mrp_production_kanban_view_inherit)d"
+                date_start="date_start"
+                date_stop="date_finished"
+                default_group_by="product_id"
+                default_range="week"
+                default_scale="week"
+                string="Manufacturing Orders"
+                color="state_color"
+                decoration-warning="is_delayed">
+                </gantt>
+            </field>
+        </record>
+
         <record id="view_production_calendar" model="ir.ui.view">
             <field name="name">mrp.production.calendar</field>
             <field name="model">mrp.production</field>
@@ -689,7 +723,7 @@
             <field name="name">Manufacturing Orders</field>
             <field name="path">manufacturing</field>
             <field name="res_model">mrp.production</field>
-            <field name="view_mode">list,kanban,form,calendar,pivot,graph,activity</field>
+            <field name="view_mode">list,kanban,form,calendar,pivot,graph,activity,gantt</field>
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="view_mrp_production_filter"/>
             <field name="context">{'search_default_todo': True, 'default_company_id': allowed_company_ids[0]}</field>


### PR DESCRIPTION
**Desired behavior after PR is merged:**
- Gantt Chart was added to make it easier to visualize scheduled MOs, expected duration and their status.

Task: 4931085






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
