### PR TITLE
[FIX] hr_attendance: fix absence detection

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -4,7 +4,7 @@ import pytz
 
 from calendar import monthrange
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from operator import itemgetter
 from pytz import timezone
@@ -752,9 +752,12 @@ class HrAttendance(models.Model):
                                                                           ('adjustment', '=', False)]).employee_id
 
         technical_attendances_vals = []
-        absent_employees = self.env['hr.employee'].search([('id', 'not in', checked_in_employees.ids),
-                                                           ('company_id', 'in', companies.ids),
-                                                           ('resource_calendar_id.flexible_hours', '=', False)])
+        absent_employees = self.env['hr.employee'].search([
+            ('id', 'not in', checked_in_employees.ids),
+            ('company_id', 'in', companies.ids),
+            ('resource_calendar_id.flexible_hours', '=', False),
+            ('current_version_id.contract_date_start', '<=', date.today() - relativedelta(days=1))
+        ])
 
         for emp in absent_employees:
             local_day_start = pytz.utc.localize(yesterday).astimezone(pytz.timezone(emp._get_tz()))

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -77,6 +77,23 @@ class TestHrAttendanceOvertime(TransactionCase):
         })
         set_calendar_and_tz(cls.europe_employee, 'Europe/Brussels')
 
+        cls.no_contract_employee = cls.env['hr.employee'].create({
+            'name': 'No Contract',
+            'company_id': cls.company.id,
+            'tz': 'UTC',
+            'resource_calendar_id': cls.company.resource_calendar_id.id,
+            'date_version': date(2020, 1, 1),
+            'contract_date_start': False,
+        })
+        cls.future_contract_employee = cls.env['hr.employee'].create({
+            'name': 'Future contract',
+            'company_id': cls.company.id,
+            'tz': 'UTC',
+            'resource_calendar_id': cls.company.resource_calendar_id.id,
+            'date_version': date(2020, 1, 1),
+            'contract_date_start': date(2030, 1, 1),
+        })
+
         cls.calendar_flex_40h = cls.env['resource.calendar'].create({
             'name': 'Flexible 40 hours/week',
             'company_id': cls.company.id,
@@ -641,6 +658,10 @@ class TestHrAttendanceOvertime(TransactionCase):
 
         # Other company with setting disabled
         self.assertAlmostEqual(self.europe_employee.total_overtime, 0, 2)
+
+        # Employee with no contract or future contract
+        self.assertAlmostEqual(self.no_contract_employee.total_overtime, 0, 2)
+        self.assertAlmostEqual(self.future_contract_employee.total_overtime, 0, 2)
 
     def test_overtime_hours_flexible_resource(self):
         """ Test the computation of overtime hours for a single flexible resource with 8 hours_per_day.

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import pytz
-from datetime import datetime
+from datetime import date, datetime
 from unittest.mock import patch
 
 from odoo import fields
@@ -110,6 +110,8 @@ class TestHrAttendance(TransactionCase):
         employee = self.env['hr.employee'].create({
             'name': "James P. Sullivan",
             'company_id': company.id,
+            'date_version': date(2021, 1, 1),
+            'contract_date_start': date(2021, 1, 1),
         })
 
         self.env['hr.attendance']._cron_absence_detection()


### PR DESCRIPTION
To register absence, the cron looks for all employees that did not check in the previous day. However, it was not checking if the employee was in contract for that day. This commit fixes the issue by adding a check on the contract date start.

task-4987428
