### PR TITLE
[FIX] website: prevent error when editing form with missing model

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -51,6 +51,8 @@ class website_form_model(models.Model):
     @api.model
     def get_authorized_fields(self, model_name, property_origins):
         """ Return the fields of the given model name as a mapping like method `fields_get`. """
+        if model_name not in self.env:
+            return {}
         model = self.env[model_name]
         fields_get = model.fields_get()
 
@@ -155,7 +157,7 @@ class website_form_model_fields(models.Model):
         :return: nothing of import
         """
         # postgres does *not* like ``in [EMPTY TUPLE]`` queries
-        if not fields:
+        if not fields or model not in self.env:
             return False
 
         # only allow users who can change the website structure

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -102,6 +102,7 @@ import wUtils from '@website/js/utils';
         start: function () {
             // Reset the form first, as it is still filled when coming back
             // after a redirect.
+            this.validateFormModel();
             this.resetForm();
 
             // Prepare visibility data and update field visibilities
@@ -489,6 +490,39 @@ import wUtils from '@website/js/utils';
                     'error',
                     error.status && error.status === 413 ? _t("Uploaded file is too large.") : "",
                 );
+            });
+        },
+
+        validateFormModel: async function () {
+            if (!await user.hasGroup("website.group_website_designer")) {
+                return;
+            }
+
+            let exists = false;
+            const modelName = this.el.dataset.model_name;
+
+            try {
+                exists = await this.orm.searchCount('ir.model', [['model', '=', modelName]]) > 0;
+            } catch {
+                exists = false;
+            }
+
+            this.__started.then(() => {
+                const container = this.el.closest('.s_title_form');
+                if (!container) {
+                    return;
+                }
+
+                const oldBanner = container.querySelector('.o_website_form_model_not_found_banner');
+                if (!exists && !oldBanner) {
+                    const newNode = renderToElement('website.website_form_model_not_found_banner', {
+                        modelName: modelName,
+                    });
+                    container.insertBefore(newNode, container.firstChild);
+                }
+                else if (exists && oldBanner) {
+                    oldBanner.remove();
+                }
             });
         },
 

--- a/addons/website/static/src/xml/website_form.xml
+++ b/addons/website/static/src/xml/website_form.xml
@@ -25,4 +25,15 @@
             </div>
         </div>
     </t>
+
+    <t t-name="website.website_form_model_not_found_banner">
+        <div class="o_not_editable o_website_form_model_not_found_banner">
+            <div class="container alert alert-info text-center d-lg-flex justify-content-between align-items-center">
+                <p class="m-lg-0 text-info">
+                    The model "<t t-esc="modelName"/>" does not exist. Please update or remove your form.
+                </p>
+            </div>
+        </div>
+    </t>
+
 </templates>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -144,7 +144,10 @@
         <div data-js="WebsiteFormFieldRequired" data-selector=".s_website_form .s_website_form_model_required">
             <!-- Disable the delete option of model required fields and show
             alert and tooltip on delete buttons -->
-            <we-alert class="mt-2"></we-alert>
+        </div>
+
+        <div data-js="WebsiteFormModelExist" data-selector=".s_website_form .s_website_form_field">
+            <!-- Show alert if model does not exist in DB -->
         </div>
 
         <div data-js='WebsiteFieldEditor' data-selector=".s_website_form_field"


### PR DESCRIPTION
When a user tries to edit a page that contains a website form linked to a model that no longer exists in the database, the editor crashes with a `KeyError`.

**Steps to produce:-**
- Install the `crm` and `website` modules.
- Go to the website and add the "Create an Opportunity" form, then save.
- Uninstall the `crm` module.
- Return to the website, try to edit the page, and click save.

**Error:-**
`KeyError: 'crm.lead'`

**Root cause:-**
- When trying to edit a form whose model is no longer available, the editor crashes at [1].
- Adding any additional content to the same page also fails at [2].

**Solution:-**
- Added model existence checks in `get_authorized_fields` and `formbuilder_whitelist`.
- Raised a user-friendly error when the model is missing.
- Improved error messaging for better clarity.

[1]: https://github.com/odoo/odoo/blob/df8e01393d427f83c5e671674fe9b9b2ed868f31/addons/website/models/website_form.py#L54
[2]: https://github.com/odoo/odoo/blob/df8e01393d427f83c5e671674fe9b9b2ed868f31/addons/website/models/website_form.py#L164

**sentry-6782968050**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
