### PR TITLE
[PERF] website_sale: Speedup product attribute query

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -451,12 +451,16 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ProductAttribute = request.env['product.attribute']
         if products:
             # get all products without limit
-            attributes = lazy(lambda: ProductAttribute.search([
-                ('product_tmpl_ids', 'in', search_product.ids),
-                ('visibility', '=', 'visible'),
-            ]))
-        else:
-            attributes = lazy(lambda: ProductAttribute.browse(attributes_ids))
+            attributes_grouped = request.env['product.template.attribute.line']._read_group(
+                domain=[
+                    ('product_tmpl_id', 'in', search_product.ids),
+                    ('attribute_id.visibility', '=', 'visible'),
+                ],
+                groupby=['attribute_id']
+            )
+
+            attributes_ids = [attribute.id for attribute, *aggregates in attributes_grouped]
+        attributes = lazy(lambda: ProductAttribute.browse(attributes_ids))
 
         layout_mode = request.session.get('website_sale_shop_layout_mode')
         if not layout_mode:


### PR DESCRIPTION
### Description:

The default query to fetch attributes for searched products needs to join on the `product_tmpl_ids` Many2Many field. This can be slow, as it requires a join on an intermediate table. This change avoids that by directly querying the attribute lines and grouping by `attribute_id` to remove duplicates.

### Benchmark (in 18.0):

| N° of products | Before | After |
|----------------|--------|-------|
|           3708 |  400ms | 200ms |
|         128539 |  4 min | 800ms |
|         484798 |  6 min |    3s |

### Reference:

opw-4937361