### PR TITLE
[IMP] purchase: show end-customer address in portal for dropship PO

### DIFF
--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -249,6 +249,12 @@
                       <strong>Receipt Date:</strong><span class="ms-1" t-field="order.date_planned" t-options='{"widget": "date"}'/>
                     </div>
                   </div>
+                  <t t-if="order.dest_address_id">
+                    <div class="col-lg-6">
+                      <strong class="d-block mb-1">Shipping address:</strong>
+                      <address t-field="order.dest_address_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                    </div>
+                  </t>
               </div>
 
               <t t-set="invoices" t-value="[i for i in order.invoice_ids if i.state not in ['draft', 'cancel']]"/>


### PR DESCRIPTION
### **Purpose**:
Currently, vendors cannot see the end customer’s delivery address
directly from the portal when accessing a dropship Purchase Order (PO).
The only way to view this information is by opening or downloading the PDF.

### **What this Commit does:**
This Commit improves the vendor portal view by displaying the
dest_address_id (customer delivery address) on the PO page.
This is particularly useful for dropshipping workflows,
where the shipping destination is different from the vendor’s address.

Displaying the destination address on the portal ensures clarity
by showing where the order will actually be delivered or shipped.

task - 4939166

