### PR TITLE
[FIX] mrp: operation state in next operations backorder

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -345,7 +345,7 @@ class MrpWorkorder(models.Model):
             delta_duration = new_order_duration - old_order_duration
 
             if delta_duration > 0:
-                if order.state not in ('progress', 'done'):
+                if order.state not in ('progress', 'done', 'cancel'):
                     order.state = 'progress'
                 enddate = fields.Datetime.now()
                 date_start = enddate - timedelta(seconds=_float_duration_to_second(delta_duration))

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -1001,7 +1001,10 @@ class TestMrpWorkorderBackorder(TransactionCase):
         op_6.button_start()
         op_6.button_finish()
         bo_2.button_mark_done()
-        self.assertRecordValues(op_6, [{'state': 'done', 'qty_remaining': 0.0}])
+        self.assertRecordValues(bo_2.workorder_ids, [
+            {'state': 'cancel', 'qty_remaining': 0.0},
+            {'state': 'done', 'qty_remaining': 0.0}
+        ])
 
     def test_kit_bom_order_splitting(self):
         self.env.ref('base.group_user').implied_ids += (


### PR DESCRIPTION
In this bug, in backorder created for later work opertions, the `state` of initial operation is changed to `progress` after, the backorder is `done`.

To produce the bug:
1- Create a Bill of Materials with at least two operations at two work centers
2- Create a manufacturing order and confirm it.
3- Complete the first operation and edit the quantity on the second operation so there is a backorder for the remaining quantity
4- In the second work order, the first operation initially appears as `Cancelled`. Once the second operation is completed, it will change to `In progress`.

opw-4931653

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
