### PR TITLE
[FIX] website: remove theme tab for color filter (colorpicker)

### DIFF
--- a/addons/website/static/src/builder/plugins/options/map_option.xml
+++ b/addons/website/static/src/builder/plugins/options/map_option.xml
@@ -39,7 +39,7 @@
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Color Filter">
-        <BuilderColorPicker styleAction="'background-color'" applyTo="'.s_map_color_filter'"/>
+        <BuilderColorPicker styleAction="'background-color'" enabledTabs="['custom', 'gradient']" applyTo="'.s_map_color_filter'"/>
     </BuilderRow>
     <BuilderRow label.translate="Description">
         <BuilderCheckbox action="'mapDescription'"/>


### PR DESCRIPTION
The "theme" tab does not make any sense with the color filter option since it will generally apply an opaque color. Only the custom and gradient tabs are relevant.

This commit removes this tab for the s_map color filter option.

task-4367641