### PR TITLE
[FIX] website: remove warning when changing non-overridden palette

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -271,15 +271,20 @@ export class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
         this.dependencies.customizeWebsite.withCustomHistory(this);
     }
     async load() {
-        return new Promise((resolve) => {
-            this.services.dialog.add(ConfirmationDialog, {
-                body: _t(
-                    "Changing the color palette will reset all your color customizations, are you sure you want to proceed?"
-                ),
-                confirm: () => resolve(true),
-                cancel: () => resolve(false),
+        const style = this.window.getComputedStyle(this.document.body);
+        const hasCustomizedColors = getCSSVariableValue("has-customized-colors", style);
+        if (hasCustomizedColors && hasCustomizedColors !== "false") {
+            return new Promise((resolve) => {
+                this.services.dialog.add(ConfirmationDialog, {
+                    body: _t(
+                        "Changing the color palette will reset all your color customizations, are you sure you want to proceed?"
+                    ),
+                    confirm: () => resolve(true),
+                    cancel: () => resolve(false),
+                });
             });
-        });
+        }
+        return true;
     }
     async apply(context) {
         if (!context.loadResult) {

--- a/addons/website/static/tests/builder/theme_tab/palette.test.js
+++ b/addons/website/static/tests/builder/theme_tab/palette.test.js
@@ -1,0 +1,71 @@
+import { expect, test } from "@odoo/hoot";
+import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_helpers";
+import { Deferred } from "@odoo/hoot-dom";
+
+defineWebsiteModels();
+
+test("theme tab: warning on palette change", async () => {
+    class WebEditorAssets extends models.Model {
+        _name = "web_editor.assets";
+        make_scss_customization(location, changes) {
+            expect.step(`${location} ${JSON.stringify(changes)}`);
+        }
+    }
+    defineModels([WebEditorAssets]);
+    const def = new Deferred();
+    onRpc("/website/theme_customize_bundle_reload", async (request) => {
+        expect.step("asset reload");
+        def.resolve();
+        return "";
+    });
+
+    await setupWebsiteBuilder("", {
+        styleContent: 'body { --has-customized-colors: "true"; }',
+    });
+    await contains(".o-snippets-tabs button[data-name=theme]").click();
+    await contains(
+        ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
+    ).click();
+    await contains("[data-action-value='default-light-1'] .o-color-palette-pill span").click();
+    expect(".o_dialog").toHaveCount(1);
+    await contains(".o_dialog .btn-secondary").click();
+    expect(".o_dialog").toHaveCount(0);
+    expect.verifySteps([]);
+    await contains(
+        ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
+    ).click();
+    await contains("[data-action-value='default-light-1'] .o-color-palette-pill span").click();
+    expect(".o_dialog").toHaveCount(1);
+    await contains(".o_dialog .btn-primary").click();
+    expect.verifySteps([
+        '/website/static/src/scss/options/user_values.scss {"color-palettes-name":"default-light-1"}',
+    ]);
+});
+
+test("theme tab: no warning on palette change", async () => {
+    class WebEditorAssets extends models.Model {
+        _name = "web_editor.assets";
+        make_scss_customization(location, changes) {
+            expect.step(`${location} ${JSON.stringify(changes)}`);
+        }
+    }
+    defineModels([WebEditorAssets]);
+    const def = new Deferred();
+    onRpc("/website/theme_customize_bundle_reload", async (request) => {
+        expect.step("asset reload");
+        def.resolve();
+        return "";
+    });
+
+    await setupWebsiteBuilder("");
+    await contains(".o-snippets-tabs button[data-name=theme]").click();
+    await contains(
+        ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
+    ).click();
+    await contains("[data-action-value='default-light-1'] .o-color-palette-pill span").click();
+    expect(".o_dialog").toHaveCount(0);
+    expect.verifySteps([
+        '/website/static/src/scss/options/user_values.scss {"color-palettes-name":"default-light-1"}',
+    ]);
+});


### PR DESCRIPTION
Since `html_builder`, when changing the color palette, the warning about losing color customizations is displayed even when there were no such customization to lose.

This commit restores the condition around this warning.

Steps to reproduce:
- Go to "Theme" tab
- Pick a color palette

=> A confirmation warning was displayed even though no color customization could be lost.

task-4367641
