### PR TITLE
[FIX] website: restore the carousels to their first slide manually

### DIFF
--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -71,22 +71,29 @@ export class CarouselOptionPlugin extends Plugin {
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         get_gallery_items_handlers: this.getGalleryItems.bind(this),
         reorder_items_handlers: this.reorderCarouselItems.bind(this),
-        before_save_handlers: () => {
-            const proms = [];
-            // Restore all the carousels so their first slide is the active one.
-            for (const carouselEl of this.editable.querySelectorAll(".carousel")) {
-                const firstItemEl = carouselEl.querySelector(".carousel-item");
-                if (firstItemEl) {
-                    if (firstItemEl.classList.contains("active")) {
-                        continue;
-                    }
-                    proms.push(this.slide(carouselEl, 0));
-                }
-            }
-            return Promise.all(proms);
-        },
+        before_save_handlers: this.restoreCarousels.bind(this),
         is_unremovable_selector: carouselItemOptionSelector,
     };
+
+    /**
+     * Restores all the carousels so their first slide is the active one.
+     */
+    restoreCarousels() {
+        // Set the first slide as the active one.
+        for (const carouselEl of this.editable.querySelectorAll(".carousel")) {
+            carouselEl.querySelectorAll(".carousel-item").forEach((itemEl, i) => {
+                itemEl.classList.remove("next", "prev", "left", "right");
+                itemEl.classList.toggle("active", i === 0);
+            });
+            carouselEl.querySelectorAll(".carousel-indicators > *").forEach((indicatorEl, i) => {
+                indicatorEl.classList.toggle("active", i === 0);
+                indicatorEl.removeAttribute("aria-current");
+                if (i === 0) {
+                    indicatorEl.setAttribute("aria-current", "true");
+                }
+            });
+        }
+    }
 
     getTitleExtraInfo(editingElement) {
         const itemEls = [...editingElement.parentElement.children];


### PR DESCRIPTION
When saving the editor, the carousels are restored so they all have their first slide as the active one.

Before the refactoring, it was done manually (so the attributes and classes were adapted explicitely). But with the refactoring, it is now done automatically by sliding the carousels to the first slide. This causes a traceback when saving the "Products" snippets, because it has no control indicators.

Note that the traceback does not appear since commit [1], but it was only fixed by chance.

[1]: 80b5db99a3c26c3dd4fb5c55e04b8813dddb5b8d

task-4367641