### PR TITLE
[IMP] mail: display partner emails in channel invite panel

### DIFF
--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
@@ -1,32 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="discuss.ChannelInvitation.main" t-inherit-mode="extension">
-        <xpath expr="//*[@name='selectablePartnerDetail']//*" position="inside">
+        <xpath expr="//*[@name='selectablePartnerName']" position="inside">
             <span t-if="props.thread?.channel_type === 'livechat' and selectablePartner.user_livechat_username" t-esc="selectablePartner.user_livechat_username" class="text-truncate text-muted smaller mx-2"/>
             <span t-if="props.thread?.channel_type === 'livechat' and selectablePartner.is_in_call" class="flex-shrink-0 opacity-75 smaller mx-2">
                 <i class="fa fa-volume-up o-discuss-inCallIconColor me-1"/>
                 <span class="o-discuss-ChannelInvitation-inCallTextColor">in a call</span>
             </span>
         </xpath>
-        <xpath expr="//*[@name='selectablePartnerDetail']" position="replace">
-            <t t-if="props.thread?.channel_type !== 'livechat' or !selectablePartner.lang_name">$0</t>
-            <div t-else="" class="d-flex flex-column flex-grow-1 overflow-hidden">
-                <t>$0</t>
-                <div class="d-flex flex-wrap align-items-center gap-1 ms-2">
-                    <span class="d-flex text-start fs-6 gap-1">
-                        <i class="fa fa-fw fa-comment-o" title="Language"/>
-                        <span class="badge rounded text-bg-primary" t-esc="selectablePartner.lang_name"/>
-                        <t t-foreach="selectablePartner.livechat_languages" t-as="language" t-key="language_index">
-                            <span class="badge rounded text-bg-primary" t-esc="language"/>
-                        </t>
-                    </span>
-                    <span class="d-flex text-start fs-6 gap-1">
-                        <i t-if="selectablePartner.livechat_expertise.length" class="fa fa-fw fa-graduation-cap" title="Expertise"/>
-                        <t t-foreach="selectablePartner.livechat_expertise" t-as="expertise" t-key="expertise_index">
-                            <span class="badge rounded text-bg-info bg-opacity-75 o-text-white" t-esc="expertise"/>
-                        </t>
-                    </span>
-                </div>
+        <xpath expr="//*[@name='selectablePartnerDetail']" position="inside">
+            <div t-if="props.thread?.channel_type === 'livechat' and selectablePartner.lang_name" class="d-flex flex-wrap align-items-center gap-1">
+                <span class="d-flex text-start fs-6 gap-1">
+                    <span class="badge rounded text-bg-primary" t-esc="selectablePartner.lang_name"/>
+                    <t t-foreach="selectablePartner.livechat_languages" t-as="language" t-key="language_index">
+                        <span class="badge rounded text-bg-primary" t-esc="language"/>
+                    </t>
+                </span>
+                <span class="d-flex text-start fs-6 gap-1">
+                    <i t-if="selectablePartner.livechat_expertise.length" class="fa fa-fw fa-graduation-cap" title="Expertise"/>
+                    <t t-foreach="selectablePartner.livechat_expertise" t-as="expertise" t-key="expertise_index">
+                        <span class="badge rounded text-bg-info bg-opacity-75 o-text-white" t-esc="expertise"/>
+                    </t>
+                </span>
             </div>
         </xpath>
     </t>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -17,20 +17,23 @@
                         <t t-if="props.thread">No user found that is not already a member of this channel.</t>
                         <t t-else="">No user found.</t>
                     </div>
-                    <div t-if="state.searchResultCount > selectablePartners.length" class="smaller text-muted mx-1 fst-italic" t-esc="showingResultNarrowText"/>
+                    <div t-if="state.searchResultCount > selectablePartners.length" class="smaller text-muted mx-1 mb-1 fst-italic" t-esc="showingResultNarrowText"/>
                     <t t-foreach="selectablePartners" t-as="selectablePartner" t-key="selectablePartner.id">
-                        <li class="o-discuss-ChannelInvitation-selectable object-fit-cover d-flex align-items-center px-1 py-0 btn list-group-item border-0 rounded-0" t-att-class="{ 'o-odd': selectablePartner_index % 2 === 1, 'o-selected': selectablePartner.in(selectedPartners) }" t-on-click="() => this.onClickSelectablePartner(selectablePartner)">
+                        <li class="o-discuss-ChannelInvitation-selectable object-fit-cover d-flex align-items-start px-1 py-0 btn list-group-item border-0 rounded-0" t-att-class="{ 'o-odd': selectablePartner_index % 2 === 1, 'o-selected': selectablePartner.in(selectedPartners) }" t-on-click="() => this.onClickSelectablePartner(selectablePartner)">
                             <div class="d-flex align-items-center p-1 bg-inherit">
                                 <div class="o-discuss-ChannelInvitation-avatar position-relative d-flex flex-shrink-0 bg-inherit">
                                     <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="selectablePartner.avatarUrl"/>
                                     <ImStatus persona="selectablePartner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
                                 </div>
                             </div>
-                            <t name="selectablePartnerDetail">
-                                <div class="d-flex flex-grow-1 mx-2 overflow-hidden align-items-baseline">
+                            <div class="d-flex flex-column mx-2 flex-grow-1 overflow-hidden o-mt-0_5">
+                                <div class="d-flex overflow-hidden align-items-baseline" name="selectablePartnerName">
                                     <span class="text-truncate" t-esc="selectablePartner.name"/>
                                 </div>
-                            </t>
+                                <div class="d-flex flex-column flex-grow-1 gap-1" name="selectablePartnerDetail">
+                                    <span t-if="selectablePartner.email" t-esc="selectablePartner.email" class="text-truncate text-start smaller text-600 fw-normal lh-1"/>
+                                </div>
+                            </div>
                             <input class="form-check-input flex-shrink-0 me-1" type="checkbox" t-att-checked="selectablePartner.in(selectedPartners) ? 'checked' : undefined"/>
                         </li>
                     </t>


### PR DESCRIPTION
The channel invite panel searches for partners whose name or email matches the search terms. However, it's not obvious from the UI why certain partners match the search, especially since their email addresses are not displayed.

Moreover, in [1], we aim to change the input placeholder to indicate that searches can be performed by either name or email, and that an email will be sent if the user is not known.

This commit prepares the ground for [1] by displaying the partner's email in the channel invitation panel.

[1]: https://www.odoo.com/odoo/1519/tasks/4967103

Before:
<img width="494" height="538" alt="image" src="https://github.com/user-attachments/assets/bee2ba51-45d6-4983-8a04-3a99b7daaffe" />

After:

<img width="496" height="535" alt="image" src="https://github.com/user-attachments/assets/7abda13a-afd8-4150-81e1-ff36ddbb6a08" />

