### PR TITLE
[FIX] point_of_sale: only display `tracking_number` for restaurant

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_config.js
+++ b/addons/point_of_sale/static/src/app/models/pos_config.js
@@ -45,6 +45,10 @@ export class PosConfig extends Base {
         }
         return new Set();
     }
+
+    get displayTrackingNumber() {
+        return this.module_pos_restaurant;
+    }
 }
 
 registry.category("pos_available_models").add(PosConfig.pythonModel, PosConfig);

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -31,7 +31,7 @@
                     <t t-if="order.presetDateTime" t-out="order.presetDateTime" />
                 </div>
             </div>
-            <div t-if="order.tracking_number">
+            <div t-if="order.tracking_number and order.config.displayTrackingNumber">
                 <span class="tracking-number fs-1" t-esc="order.tracking_number" />
             </div>
         </div>

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
+import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
 
 registry.category("web_tour.tours").add("self_combo_selector", {
     steps: () => [
@@ -47,6 +48,8 @@ registry.category("web_tour.tours").add("self_combo_selector", {
             },
         ]),
         Utils.clickBtn("Pay"),
+        ConfirmationPage.orderNumberShown(),
+        ConfirmationPage.orderNumberIs("S", "1"),
         Utils.clickBtn("Ok"),
         Utils.checkIsNoBtn("Order Now"),
     ],

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -17,6 +17,8 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
         Utils.clickBtn("Pay"),
         Numpad.click("3"),
         Utils.clickBtn("Pay"),
+        ConfirmationPage.orderNumberShown(),
+        ConfirmationPage.orderNumberIs("K", "3"),
         Utils.clickBtn("Close"),
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),

--- a/addons/pos_self_order/static/tests/tours/utils/confirmation_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/confirmation_page_util.js
@@ -11,3 +11,19 @@ export function orderNumberShown() {
         trigger: ".number",
     };
 }
+
+export function orderNumberIs(trackingPrefix, trackingNumber) {
+    return {
+        content: `Check that the order number start with '${trackingPrefix}', and end with number '${trackingNumber}'.`,
+        trigger: `span.number`,
+        run: function () {
+            const span = document.querySelector("span.number");
+            const text = span.textContent || "";
+            if (!text.startsWith(trackingPrefix) || !text.endsWith(trackingNumber)) {
+                throw new Error(
+                    `Order number '${text}' does not start with '${trackingPrefix}' and end with '${trackingNumber}'`
+                );
+            }
+        },
+    };
+}


### PR DESCRIPTION
- Fix issue where `tracking_number` was displayed for all config. We want to display this number only for `pos_restaurant` configurations. We also want to display it for POS config which have a preparation display configured (see enterprise linked PR).
- Ensure Kiosk & Self orders correctly contains a prefix (S or K) inside their `tracking_number` to avoid regression.

task-id: 4922308

enterprise PR: https://github.com/odoo/enterprise/pull/91833





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
