### PR TITLE
[16.0][17.0][18.0] Unable to reconcile bank entries in edge case

### DIFF
--- a/doc/cla/corporate/rooteam.md
+++ b/doc/cla/corporate/rooteam.md
@@ -1,0 +1,16 @@
+United States of America, 2025-01-28
+
+Rooteam agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Gabriel Grinspan gabriel@rooteam.net https://github.com/gabe-grinspan
+
+List of contributors:
+
+Gabriel Grinspan gabriel@rooteam.net https://github.com/gabe-grinspan
+Gabriel Grinspan grinspan.gabriel@gmail.com https://github.com/gabe-grinspan


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There is an edge case that is preventing the user from successfully reconciling their bank entries. it seems that using the `.write()` method instead of direct `=` fixes the issue.

Current behavior before PR:
User experiences a Traceback error popup.

Desired behavior after PR is merged:
User does not experience a Traceback error popup. Instead they are greeted with success and rainbows...minus the rainbows, let's be real this is accounting.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
