### PR TITLE
[FIX] hr_attendance: handle users without `hr.employee` rights

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -657,14 +657,14 @@ class HrAttendance(models.Model):
         if not self.env.user.has_group('hr_attendance.group_hr_attendance_manager'):
             employee_domain &= Domain('attendance_manager_id', '=', self.env.user.id)
         if user_domain.is_true():
-            return self.env['hr.employee'].search(employee_domain)
+            return self.env['hr.employee'].sudo().search(employee_domain).sudo(False)
         else:
             employee_name_domain = Domain.OR(
                 Domain('name', condition.operator, condition.value)
                 for condition in user_domain.iter_conditions()
                 if condition.field_expr == 'employee_id'
             )
-            return resources | self.env['hr.employee'].search(employee_name_domain & employee_domain)
+            return resources | self.env['hr.employee'].sudo().search(employee_name_domain & employee_domain).sudo(False)
 
     def action_approve_overtime(self):
         self.write({


### PR DESCRIPTION
Non-HR users who lack access to *Employees* triggered a crash when the
Gantt (and any other grouped) view tried to expand the employees list
field.

task-4984211