### PR TITLE
[FIX] privacy_lookup: make test resilient to extra partner links

### DIFF
--- a/addons/privacy_lookup/tests/test_privacy_wizard.py
+++ b/addons/privacy_lookup/tests/test_privacy_wizard.py
@@ -101,12 +101,8 @@ class TestPrivacyWizard(TransactionCase):
 
         # Lookup
         wizard.action_lookup()
-        self.assertEqual(len(wizard.line_ids), 2)
-        self.assertEqual(wizard.line_ids[0].res_id, self.partner.id)
-        self.assertEqual(wizard.line_ids[0].res_model, self.partner._name)
-
-        self.assertEqual(wizard.line_ids[1].res_id, self.env.company.id)
-        self.assertEqual(wizard.line_ids[1].res_model, self.env.company._name)
+        self.assertTrue(wizard.line_ids.filtered(lambda l: l.res_model == 'res.partner' and l.res_id == self.partner.id))
+        self.assertTrue(wizard.line_ids.filtered(lambda l: l.res_model == 'res.company' and l.res_id == self.env.company.id))
 
     def test_wizard_indirect_reference_cascade(self):
         # Don't retrieve ondelete cascade records


### PR DESCRIPTION
The test `test_wizard_indirect_reference` failed when modules like `l10n_gt_edi` were installed. This was due to additional Many2one fields (e.g., `l10n_gt_edi_consignatory_partner` on `account.move`) referencing `res.partner`, which were picked up by the privacy lookup wizard.

This commit updates the test to avoid assuming a fixed number of reference lines and instead asserts the presence of the expected ones (the partner and the company).

No change in functional behavior.

RB-[230449](https://runbot.odoo.com/odoo/error/230449)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
