### PR TITLE
[IMP] mail: squarish composer + slight discuss app top border

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -7,8 +7,7 @@
     <t t-set="compact" t-value="props.mode === 'compact'"/>
     <t t-set="normal" t-value="props.mode === 'normal'"/>
     <t t-set="extended" t-value="props.mode === 'extended'"/>
-    <t t-set="roundedClass" t-value="env.inChatter or props.composer.message ? 'o-rounded-bubble' : 'rounded-4'"/>
-    <t t-set="actionsContainerClass" t-value="'o-mail-Composer-actions d-flex ' + roundedClass"/>
+    <t t-set="actionsContainerClass" t-value="'o-mail-Composer-actions d-flex o-rounded-bubble'"/>
     <div t-ref="root">
         <div class="o-mail-Composer d-grid flex-shrink-0 pt-0"
                 t-att-class="{
@@ -42,9 +41,8 @@
                 <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => (props.composer.replyToMessage = undefined)"/>
             </div>
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended or props.composer.message }">
-                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border border-secondary shadow-sm"
+                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border border-secondary shadow-sm o-rounded-bubble"
                     t-att-class="{
-                        [roundedClass]: true,
                         'o-iosPwa': isIosPwa,
                         'align-self-stretch' : extended,
                         'w-100': props.composer.message,
@@ -61,8 +59,7 @@
                     </div>
                     <div class="position-relative flex-grow-1">
                         <t t-set="inputClasses" t-value="{
-                            [roundedClass]: true,
-                            'o-mail-Composer-inputStyle form-control border-0': true,
+                            'o-mail-Composer-inputStyle form-control border-0 o-rounded-bubble': true,
                             'ps-2': partitionedActions.other.length === 0
                         }"/>
                         <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto o-scrollbar-thin text-body user-select-auto"

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -21,6 +21,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     background-color: $body-bg !important;
 }
 
+.o-border-opacity-25 {
+    --border-opacity: 0.25;
+}
+
 .o-border-opacity-50 {
     --border-opacity: 0.5;
 }

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -90,5 +90,5 @@
 }
 
 .o_web_client:has(.o-mail-Discuss) .o_control_panel {
-    --ControlPanel-border-bottom: #{$border-width} solid #{rgba($border-color, .25)};
+    --ControlPanel-border-bottom: #{$border-width} solid #{rgba($border-color, .0)};
 }

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.Discuss">
     <t t-set="partitionedActions" t-value="threadActions.partition"/>
-    <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center': ui.isSmall }" t-att-data-active="store.discuss.isActive" t-ref="root">
+    <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center': ui.isSmall, 'border-top border-secondary o-border-opacity-25': !ui.isSmall }" t-att-data-active="store.discuss.isActive" t-ref="root">
         <DiscussSidebar t-if="!ui.isSmall and props.hasSidebar"/>
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto o-scrollbar-thin" t-ref="content">
             <div class="o-mail-Discuss-header px-2 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">


### PR DESCRIPTION
This commit makes composer in discuss app and chat window less rounded to match style with other inputs like "search conversations".

Discuss app had no top border due to having no control panel most of the time. This is fixed by managing the top border by discuss app itself and cancelling the control panel one all the time instead.

Before / After
<img width="904" height="480" alt="before" src="https://github.com/user-attachments/assets/c6cf7f46-00f2-4b01-ae55-82c3a05e11a3" /> <img width="906" height="479" alt="after" src="https://github.com/user-attachments/assets/d1452c57-97ce-430a-a82a-35d33e593ea7" />
