### PR TITLE
[FIX] sale_(*): fix broken tours in automatic mode

### DIFF
--- a/addons/sale_project/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/project_create_sol_tour.js
@@ -30,17 +30,38 @@ registry.category("web_tour.tours").add('project_create_sol_tour', {
         trigger: 'div.o_notebook_headers',
     },
     {
+        id: "project_sale_timesheet_start",
         trigger: 'a.nav-link[name="settings"]',
         content: 'Click on Settings tab to configure this project.',
         run: "click",
     }, {
-        id: "project_sale_timesheet_start",
+        isActive: ["div[name='sale_line_id'] input:empty"],
         trigger: "div[name='sale_line_id'] input",
         content: 'Add the Sales Order Item',
         run: "fill New Sale order line",
-    }, {
+    },
+    {
+        isActive: [".o-autocomplete--dropdown-menu"],
         trigger: ".o_field_widget[name=sale_line_id] .o-autocomplete--dropdown-menu .o_m2o_dropdown_option_create a",
         content: "Create an Sales Order Item in the autocomplete dropdown.",
+        run: "click"
+    },
+    {
+        isActive: ["body:has(.modal)"],
+        trigger: ".modal div[name='product_id'] input",
+        content: "Select a product for the Sales Order Line",
+        run: "click",
+    },
+    {
+        isActive: ["body:has(.modal)"],
+        trigger: ".modal .ui-autocomplete > li > a:not(:has(i.fa))",
+        content: "Select the product in the autocomplete dropdown",
+        run: "click",
+    },
+    {
+        isActive: ["body:has(.modal)"],
+        trigger: ".modal .o_form_button_save:enabled",
+        content: "Save the Sale Order Line to be created",
         run: "click",
     },
     {

--- a/addons/sale_timesheet/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/project_create_sol_tour.js
@@ -6,7 +6,7 @@ patch(registry.category("web_tour.tours").get("project_create_sol_tour"), {
     steps() {
         const originalSteps = super.steps();
         const saleTimesheet = originalSteps.findIndex((step) => step.id === "project_sale_timesheet_start");
-        originalSteps.splice(saleTimesheet  + 1, 1, {
+        originalSteps.splice(saleTimesheet - 1, 0, {
             trigger: 'a.nav-link:contains(Invoicing)',
             content: 'Click on Invoicing tab to configure the invoicing of this project.',
             run: "click",
@@ -39,7 +39,7 @@ patch(registry.category("web_tour.tours").get("project_create_sol_tour"), {
             content: "Select the customer in the autocomplete dropdown",
             run: "click",
         }, {
-            trigger: ".modal:not(.o_inactive_modal) button:contains(save & close)",
+            trigger: ".modal .o_form_button_save:enabled",
             content: "Save project",
             run: "click",
         });


### PR DESCRIPTION
Issue:

- This tour is broken because it works fine when run if sale_timesheet is installed, in standalone sale_project it fails.

Reason:

- Due to  commit - https://github.com/odoo/odoo/commit/b2b35e74188b1f7d201e9cf3c467aebfe6546543
- From this commit we open a create dialog when we dont have a product in SOL.
- This tour was not adapted after the changes thus breaks in sale_project.

Fix:

- We check if we already have a SOL in task which happens when we have sale_timesheet as we create a SOL mapping through which we create a SOL, thus runnig this steps may cause a regression.
- So we check if we have a SOL and then proceed to create one if we dont have it.
- Also when sale_timesheet is installed we proiritize it business logic as it covers the sale_project too.
