### PR TITLE
Add EDI proxy user timeout and demo data for Australian payroll

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -11,7 +11,7 @@ from .account_edi_proxy_auth import OdooEdiProxyAuth
 
 _logger = logging.getLogger(__name__)
 
-TIMEOUT = 30
+DEFAULT_TIMEOUT = 30
 
 
 class AccountEdiProxyError(Exception):
@@ -93,7 +93,7 @@ class Account_Edi_Proxy_ClientUser(models.Model):
         '''
         return False
 
-    def _make_request(self, url, params=False, auth_type: Literal['hmac', 'asymmetric'] = 'hmac'):
+    def _make_request(self, url, params=False, auth_type: Literal['hmac', 'asymmetric'] = 'hmac', request_timeout=DEFAULT_TIMEOUT):
         ''' Make a request to proxy and handle the generic elements of the reponse (errors, new refresh token).
         '''
         payload = {
@@ -111,7 +111,7 @@ class Account_Edi_Proxy_ClientUser(models.Model):
             response = requests.post(
                 url,
                 json=payload,
-                timeout=TIMEOUT,
+                timeout=request_timeout,
                 headers={'content-type': 'application/json'},
                 auth=OdooEdiProxyAuth(user=self, auth_type=auth_type)).json()
         except (ValueError, requests.exceptions.ConnectionError, requests.exceptions.MissingSchema, requests.exceptions.Timeout, requests.exceptions.HTTPError):
@@ -130,7 +130,7 @@ class Account_Edi_Proxy_ClientUser(models.Model):
             if error_code == 'refresh_token_expired':
                 self._renew_token()
                 self.env.cr.commit()  # We do not want to lose it if in the _make_request below something goes wrong
-                return self._make_request(url, params)
+                return self._make_request(url, params, request_timeout)
             if error_code == 'no_such_user':
                 # This error is also raised if the user didn't exchange data and someone else claimed the edi_identificaiton.
                 self.sudo().active = False

--- a/addons/l10n_au/__manifest__.py
+++ b/addons/l10n_au/__manifest__.py
@@ -31,6 +31,7 @@ Also:
     ],
     'demo': [
         'demo/demo_company.xml',
+        'demo/res_bank.xml',
     ],
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',

--- a/addons/l10n_au/demo/res_bank.xml
+++ b/addons/l10n_au/demo/res_bank.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="res.bank" id="au_res_bank_cba">
+        <field name="name">Commonwealth Bank of Australia</field>
+        <field name="bic">CTBAAU2S</field>
+    </record>
+
+</odoo>

--- a/addons/l10n_au/models/res_company.py
+++ b/addons/l10n_au/models/res_company.py
@@ -5,3 +5,4 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     l10n_au_is_gst_registered = fields.Boolean(string="Australia GST registered", help="Enable if your company is registered for GST.")
+    l10n_au_trading_name = fields.Char(string="Trading Name", help="The trading name of the company.")

--- a/addons/l10n_au/views/res_company_views.xml
+++ b/addons/l10n_au/views/res_company_views.xml
@@ -7,14 +7,15 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="attributes">
-                <attribute name="invisible" add="country_code == 'AU'" separator=" or "/> 
+                <attribute name="invisible" add="country_code == 'AU'" separator=" or "/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
+                <field name="l10n_au_trading_name" invisible="country_code != 'AU'"/>
                 <field name="vat" string="ABN" invisible="country_code != 'AU'"/>
                 <field name="l10n_au_is_gst_registered" string="GST registered" invisible="country_code != 'AU'"/>
             </xpath>
             <xpath expr="//field[@name='company_registry']" position="attributes">
-                <attribute name="invisible" add="country_code == 'AU'" separator=" or "/> 
+                <attribute name="invisible" add="country_code == 'AU'" separator=" or "/>
             </xpath>
             <xpath expr="//field[@name='company_registry']" position="after">
                 <field name="company_registry" string="ACN" invisible="country_code != 'AU'"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
[IMP] account_edi_proxy_client: add timeout argument to _make_request

Some requests may require a longer timeout than the default 30 seconds
when pinging the IAP server as they may need several external API calls.

This commit adds a `request_timeout` argument to the `_make_request` method
to allow specifying a custom timeout value for the request.

[FIX] l10n_au: Add Australian Bank for demo data


Tasks:
4201473
4201471

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
