### PR TITLE
[IMP] payment: allow hiding 'Secured by <provider>' label in payment form

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -128,6 +128,10 @@ class PaymentProvider(models.Model):
              "to make it available for any payment amount.",
         currency_field='main_currency_id',
     )
+    hide_secured_by = fields.Boolean(
+        string="Hide Secured By",
+        help="Enable this option to remove the 'Secured by <provider>' label from the payment form."
+    )
 
     # Message fields
     pre_msg = fields.Html(

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -209,7 +209,7 @@
                     />
                 </div>
                 <!-- === Provider name (only for desktop and tablet) === -->
-                <t t-set="hide_secured_by" t-value="False"/>
+                <t t-set="hide_secured_by" t-value="provider_sudo.hide_secured_by"/>
                 <div class="col d-none d-md-block">
                     <p name="o_payment_secured_by_desktop" t-att-class="'mb-0 small text-600'
                                     + (' ms-4 ms-md-0' if allow_token_selection else '')
@@ -348,7 +348,7 @@
                     </label>
                 </div>
                 <!-- === Provider name === -->
-                <t t-set="hide_secured_by" t-value="False"/>
+                <t t-set="hide_secured_by" t-value="provider_sudo.hide_secured_by"/>
                 <p name="o_payment_secured_by"
                    t-att-class="'align-self-end mb-0 ms-auto small text-600'
                                 + (' d-none' if hide_secured_by else '')"

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -81,6 +81,7 @@
                                     <field name="allow_tokenization" invisible="not support_tokenization"/>
                                     <field name="capture_manually" invisible="not support_manual_capture"/>
                                     <field name="allow_express_checkout" invisible="not support_express_checkout"/>
+                                    <field name="hide_secured_by"/>
                                 </group>
                                 <group string="Availability" name="availability">
                                     <field name="maximum_amount"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Merchants can't hide the 'Secured by <provider>' label in the payment form.

Current behavior before PR:
The label is always shown.

Desired behavior after PR is merged:
Merchants can choose to hide the label via a new option.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
