### PR TITLE
[FIX] pos_online_payment: hide 'pos_payment_provider_cards' when is_online_payment changes

### DIFF
--- a/addons/pos_online_payment/models/pos_payment_method.py
+++ b/addons/pos_online_payment/models/pos_payment_method.py
@@ -129,6 +129,7 @@ class PosPaymentMethod(models.Model):
                         pos_config_id=pos_config_id,
                     ))
         return payment_method_id
+
     @api.onchange('is_online_payment')
     def _onchange_is_online_payment(self):
         """Reset method to hide widget `pos_payment_provider_cards` in form view."""

--- a/addons/pos_online_payment/models/pos_payment_method.py
+++ b/addons/pos_online_payment/models/pos_payment_method.py
@@ -129,3 +129,7 @@ class PosPaymentMethod(models.Model):
                         pos_config_id=pos_config_id,
                     ))
         return payment_method_id
+    @api.onchange('is_online_payment')
+    def _onchange_is_online_payment(self):
+        """Reset method to hide widget `pos_payment_provider_cards` in form view."""
+        self.payment_method_type = 'none'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
`pos_payment_provider_cards` widget not hidden when is_online_payment is changed.

Current behavior before PR:
Widget remains visible after changing `is_online_payment`.

Desired behavior after PR is merged:
Widget is hidden and `payment_method_type` is reset.

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
