### PR TITLE
[IMP] project, _*: create separate model `project.project.template`

### DIFF
--- a/addons/hr_timesheet/__init__.py
+++ b/addons/hr_timesheet/__init__.py
@@ -36,7 +36,7 @@ def _uninstall_hook(env):
     def update_action_window(xmlid):
         act_window = env.ref(xmlid, raise_if_not_found=False)
         if act_window and act_window.domain and 'is_internal_project' in act_window.domain:
-            act_window.domain = [("is_template", "=", False)]
+            act_window.domain = []
 
     update_action_window('project.open_view_project_all')
     update_action_window('project.open_view_project_all_group_stage')

--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -27,6 +27,7 @@ up a management by affair.
         'data/digest_data.xml',
         'views/hr_timesheet_views.xml',
         'views/res_config_settings_views.xml',
+        'views/project_project_template_views.xml',
         'views/project_project_views.xml',
         'views/project_task_tempate_views.xml',
         'views/project_task_views.xml',

--- a/addons/hr_timesheet/models/__init__.py
+++ b/addons/hr_timesheet/models/__init__.py
@@ -9,6 +9,7 @@ from . import ir_http
 from . import ir_ui_menu
 from . import res_company
 from . import res_config_settings
+from . import project_project_template
 from . import project_project
 from . import project_task_template
 from . import project_task

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -48,7 +48,7 @@ class AccountAnalyticLine(models.Model):
         return result
 
     def _domain_project_id(self):
-        domain = Domain([('allow_timesheets', '=', True), ('is_template', '=', False)])
+        domain = Domain([('allow_timesheets', '=', True)])
         if not self.env.user.has_group('hr_timesheet.group_timesheet_manager'):
             domain &= Domain('privacy_visibility', 'in', ['employees', 'portal']) | Domain('message_partner_ids', 'in', [self.env.user.partner_id.id])
         return domain

--- a/addons/hr_timesheet/models/project_project_template.py
+++ b/addons/hr_timesheet/models/project_project_template.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+
+class ProjectProjectTemplate(models.Model):
+    _inherit = "project.project.template"
+
+    allow_timesheets = fields.Boolean("Timesheets", readonly=False, default=True)
+    allocated_hours = fields.Float(string='Allocated Time')

--- a/addons/hr_timesheet/models/project_task_template.py
+++ b/addons/hr_timesheet/models/project_task_template.py
@@ -26,10 +26,15 @@ class ProjectTaskTemplate(models.Model):
     def _compute_encode_uom_in_days(self):
         self.encode_uom_in_days = self._uom_in_days()
 
-    @api.depends('project_id.allow_timesheets')
+    @api.depends('project_id.allow_timesheets', 'project_template_id.allow_timesheets')
     def _compute_allow_timesheets(self):
-        for task in self:
-            task.allow_timesheets = task.project_id.allow_timesheets
+        for task_template in self:
+            if task_template.project_template_id:
+                task_template.allow_timesheets = task_template.project_template_id.allow_timesheets
+            elif task_template.project_id:
+                task_template.allow_timesheets = task_template.project_id.allow_timesheets
+            else:
+                task_template.allow_timesheets = False
 
     def _search_allow_timesheets(self, operator, value):
         query = self.env['project.project'].sudo()._search([

--- a/addons/hr_timesheet/models/res_company.py
+++ b/addons/hr_timesheet/models/res_company.py
@@ -25,7 +25,6 @@ class ResCompany(models.Model):
         default=_default_timesheet_encode_uom_id)
     internal_project_id = fields.Many2one(
         "project.project", string="Internal Project",
-        domain=[("is_template", "=", False)],
         help="Default project value for timesheet generated from time off type.",
     )
 

--- a/addons/hr_timesheet/tests/test_project_template.py
+++ b/addons/hr_timesheet/tests/test_project_template.py
@@ -3,36 +3,14 @@ from odoo.tests import TransactionCase, tagged
 
 @tagged('post_install', '-at_install')
 class TestProjectProjectTemplate(TransactionCase):
-
-    def test_template_created_not_having_analytic_account(self):
-        template_project, normal_project = self.env["project.project"].create(
-            [
-                {
-                    "name": "Template Project",
-                    "is_template": True,
-                    "allow_timesheets": True,
-                },
-                {
-                    "name": "Normal Project",
-                    "is_template": False,
-                    "allow_timesheets": True,
-                },
-            ]
-        )
-
-        self.assertFalse(template_project.account_id, "The template project shouldn't have analytic account")
-        self.assertTrue(normal_project.account_id, "A normal project should have a analytic account")
-
     def test_project_created_from_template_to_have_analytic_account(self):
-        template_project_timesheet, template_project_no_timesheet = self.env['project.project'].create([
+        template_project_timesheet, template_project_no_timesheet = self.env['project.project.template'].create([
             {
                 "name": "Template Project Timesheet",
-                "is_template": True,
                 "allow_timesheets": True,
             },
             {
                 "name": "Template Project No Timesheet",
-                "is_template": True,
                 "allow_timesheets": False,
             },
         ])
@@ -41,16 +19,3 @@ class TestProjectProjectTemplate(TransactionCase):
         self.assertTrue(new_project_1.account_id, "A project created from template allowing timesheet should have an analytic account")
         new_project_2 = template_project_no_timesheet.action_create_from_template()
         self.assertFalse(new_project_2.account_id, "A project created from template disabling timesheet should not have an analytic account")
-
-    def test_convert_project_template_into_regular_project_analytics(self):
-        template_project = self.env["project.project"].create(
-            {
-                "name": "Template Project Timesheet",
-                "is_template": True,
-                "allow_timesheets": True,
-            }
-        )
-        self.assertFalse(template_project.account_id, "The template project shouldn't have analytic account before conversion")
-        template_project.action_undo_convert_to_template()
-        self.assertFalse(template_project.is_template, "The project should not be a template anymore after conversion")
-        self.assertTrue(template_project.account_id, "Converting a template project with timesheets enabled into a regular project should create an analytic account")

--- a/addons/hr_timesheet/views/project_project_template_views.xml
+++ b/addons/hr_timesheet/views/project_project_template_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="project_template_view_form_inherit" model="ir.ui.view">
+            <field name="model">project.project.template</field>
+            <field name="inherit_id" ref="project.project_template_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='date']" position="after">
+                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user"/>
+                </xpath>
+                <xpath expr="//group[@name='group_time_managment']" position="attributes">
+                    <attribute name="invisible">0</attribute>
+                </xpath>
+                <xpath expr="//group[@name='group_time_managment']" position="inside">
+                    <setting class="col-lg-12" id="timesheet_settings" string="Timesheets" help="Log time on tasks">
+                        <field name="allow_timesheets"/>
+                    </setting>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -23,7 +23,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//header" position="after">
                     <field name="analytic_account_active" invisible="1"/>
-                    <t name="timesheet_error" invisible="not allow_timesheets or is_template">
+                    <t name="timesheet_error" invisible="not allow_timesheets">
                         <div class="alert alert-warning mb-1 text-center" role="alert" colspan="2" invisible="not account_id or analytic_account_active">
                             You cannot log timesheets on this project since it is linked to an inactive analytic account.<br/>
                             Please switch to another account, or reactivate the current one to timesheet on the project.
@@ -77,7 +77,7 @@
                     <field name="allocated_hours"/>
                 </xpath>
                 <xpath expr="//div[@name='card_menu_view']" position="inside">
-                    <div role="menuitem" t-if="record.allow_timesheets.raw_value and !record.is_template.raw_value" groups="hr_timesheet.group_hr_timesheet_user">
+                    <div role="menuitem" t-if="record.allow_timesheets.raw_value" groups="hr_timesheet.group_hr_timesheet_user">
                         <a name="action_project_timesheets" type="object">Timesheets</a>
                     </div>
                 </xpath>
@@ -86,7 +86,7 @@
                     <t t-set="badgeColor" t-value="'border-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
                     <t t-set="title" t-if="record.encode_uom_in_days.raw_value">Days Remaining</t>
                     <t t-set="title" t-else="">Time Remaining</t>
-                    <div t-if="!record.is_template.raw_value and  record.allow_timesheets.raw_value and record.allocated_hours.raw_value &gt; 0"
+                    <div t-if="record.allow_timesheets.raw_value and record.allocated_hours.raw_value &gt; 0"
                         t-attf-class="me-1 ms-1 bg-transparent badge border {{ badgeColor }}" t-att-title="title" groups="hr_timesheet.group_hr_timesheet_user">
                         <field name="remaining_hours" widget="timesheet_uom" class="p-0"/>
                     </div>
@@ -106,22 +106,11 @@
         </record>
 
         <record id="project.open_view_project_all" model="ir.actions.act_window">
-            <field name="domain">[('is_internal_project', '=', False), ("is_template", "=", False)]</field>
+            <field name="domain">[('is_internal_project', '=', False)]</field>
         </record>
 
         <record id="project.open_view_project_all_group_stage" model="ir.actions.act_window">
-            <field name="domain">[('is_internal_project', '=', False), ("is_template", "=", False)]</field>
-        </record>
-
-        <!-- Project Template  -->
-        <record id="project_templates_view_list_inherit_timesheet" model="ir.ui.view">
-            <field name="name">project.project.template.list.inherit.timesheet</field>
-            <field name="model">project.project</field>
-            <field name="inherit_id" ref="project.project_templates_view_list"/>
-            <field name="arch" type="xml">
-                <field name="effective_hours" position="replace"/>
-                <field name="remaining_hours" position="replace"/>
-            </field>
+            <field name="domain">[('is_internal_project', '=', False)]</field>
         </record>
     </data>
 </odoo>

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -34,6 +34,7 @@
         'wizard/project_share_wizard_views.xml',
         'views/project_task_type_views.xml',
         'views/project_project_views.xml',
+        'views/project_project_template_views.xml',
         'views/project_task_views.xml',
         'views/project_task_template_views.xml',
         'views/project_role_views.xml',

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -58,7 +58,7 @@ class ProjectCustomerPortal(CustomerPortal):
         return self._get_page_view_values(project, access_token, values, 'my_projects_history', False, **kwargs)
 
     def _prepare_project_domain(self):
-        return [('is_template', '=', False)]
+        return []
 
     def _prepare_searchbar_sortings(self):
         return {
@@ -111,8 +111,6 @@ class ProjectCustomerPortal(CustomerPortal):
     def portal_my_project(self, project_id=None, access_token=None, page=1, date_begin=None, date_end=None, sortby=None, search=None, search_in='content', groupby=None, task_id=None, **kw):
         try:
             project_sudo = self._document_check_access('project.project', project_id, access_token)
-            if project_sudo.is_template:
-                return request.redirect('/my')
         except (AccessError, MissingError):
             return request.redirect('/my')
         if project_sudo.collaborator_count and project_sudo.with_user(request.env.user)._check_project_sharing_access():
@@ -501,7 +499,7 @@ class ProjectCustomerPortal(CustomerPortal):
 
     @http.route(['/my/tasks', '/my/tasks/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_tasks(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, search=None, search_in='name', groupby=None, **kw):
-        searchbar_filters = self._get_my_tasks_searchbar_filters([('is_template', '=', False)])
+        searchbar_filters = self._get_my_tasks_searchbar_filters()
 
         if not filterby:
             filterby = 'all'

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -216,9 +216,8 @@
         </record>
 
         <!-- Project Template -->
-        <record id="project_template_1" model="project.project">
+        <record id="project_template_1" model="project.project.template">
             <field name="name">Product Launch Campaign</field>
-            <field name="is_template" eval="True"/>
             <field name="date_start">2025-06-01 09:00:00</field>
             <field name="date">2025-06-30 18:00:00</field>
             <field name="user_id" ref="base.user_admin"/>
@@ -232,54 +231,54 @@
 
         <record id="project_template_1_task_1" model="project.task">
             <field name="name">Market Analysis</field>
-            <field name="project_id" ref="project_template_1"/>
+            <field name="project_template_id" ref="project_template_1"/>
         </record>
 
         <record id="project_template_1_task_2" model="project.task">
             <field name="name">Define Target Audience</field>
-            <field name="project_id" ref="project_template_1"/>
+            <field name="project_template_id" ref="project_template_1"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_1'))]"/>
         </record>
 
         <record id="project_template_1_task_3" model="project.task">
             <field name="name">Write Press Release</field>
-            <field name="project_id" ref="project_template_1"/>
+            <field name="project_template_id" ref="project_template_1"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_2'))]"/>
         </record>
 
         <record id="project_template_1_task_4" model="project.task">
             <field name="name">Design Visual Assets</field>
-            <field name="project_id" ref="project_template_1"/>
+            <field name="project_template_id" ref="project_template_1"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_2'))]"/>
         </record>
 
         <record id="project_template_1_task_5" model="project.task">
             <field name="name">Publish Landing Page</field>
-            <field name="project_id" ref="project_template_1"/>
+            <field name="project_template_id" ref="project_template_1"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_4'))]"/>
         </record>
 
         <record id="project_template_1_task_6" model="project.task">
             <field name="name">Send Press Kit</field>
-            <field name="project_id" ref="project_template_1"/>
+            <field name="project_template_id" ref="project_template_1"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_3'))]"/>
         </record>
 
         <record id="project_template_1_task_7" model="project.task">
             <field name="name">Social Media Follow-up</field>
-            <field name="project_id" ref="project_template_1"/>
+            <field name="project_template_id" ref="project_template_1"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_6'))]"/>
         </record>
 
         <record id="project_template_1_task_8" model="project.task">
             <field name="name">Collect Customer Feedback</field>
-            <field name="project_id" ref="project_template_1"/>
+            <field name="project_template_id" ref="project_template_1"/>
             <field name="depend_on_ids" eval="[Command.link(ref('project_template_1_task_5'))]"/>
         </record>
 
         <record id="project_template_1_task_9" model="project.task">
             <field name="name">Campaign Performance Review</field>
-            <field name="project_id" ref="project_template_1"/>
+            <field name="project_template_id" ref="project_template_1"/>
             <field name="depend_on_ids" eval="[
                 Command.link(ref('project_template_1_task_7')),
                 Command.link(ref('project_template_1_task_8'))

--- a/addons/project/models/__init__.py
+++ b/addons/project/models/__init__.py
@@ -9,6 +9,7 @@ from . import project_task_recurrence
 # `project_task_stage_personal` has to be loaded before `project_project` and `project_milestone`
 from . import project_task_stage_personal
 from . import project_milestone
+from . import project_project_template
 from . import project_project
 from . import project_role
 from . import project_task

--- a/addons/project/models/project_collaborator.py
+++ b/addons/project/models/project_collaborator.py
@@ -7,7 +7,7 @@ class ProjectCollaborator(models.Model):
     _name = 'project.collaborator'
     _description = 'Collaborators in project shared'
 
-    project_id = fields.Many2one('project.project', 'Project Shared', domain=[('privacy_visibility', '=', 'portal'), ('is_template', '=', False)], required=True, readonly=True, export_string_translation=False)
+    project_id = fields.Many2one('project.project', 'Project Shared', domain=[('privacy_visibility', '=', 'portal')], required=True, readonly=True, export_string_translation=False)
     partner_id = fields.Many2one('res.partner', 'Collaborator', required=True, readonly=True, export_string_translation=False)
     partner_email = fields.Char(related='partner_id.email', export_string_translation=False)
     limited_access = fields.Boolean('Limited Access', default=False, export_string_translation=False)

--- a/addons/project/models/project_project_template.py
+++ b/addons/project/models/project_project_template.py
@@ -1,0 +1,349 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import ast
+
+from odoo import api, fields, models
+from odoo.fields import Domain
+from odoo.tools import LazyTranslate
+
+_lt = LazyTranslate(__name__)
+
+
+class ProjectProjectTemplate(models.Model):
+    _name = 'project.project.template'
+    _description = "Project Template"
+
+    def __compute_task_temp_count(self, count_field='task_count'):
+        count_fields = {fname for fname in self._fields if 'count' in fname}
+        if count_field not in count_fields:
+            raise ValueError(f"Parameter 'count_field' can only be one of {count_fields}, got {count_field} instead.")
+        domain = Domain('project_template_id', 'in', self.ids)
+        ProjectTask = self.env['project.task.template'].with_context(active_test=any(project_template.active for project_template in self))
+        templates_count_by_project = dict(ProjectTask._read_group(domain, ['project_template_id'], ['__count']))
+        for project_template in self:
+            templates_count_by_project.get(project_template, 0)
+            project_template.update({count_field: templates_count_by_project.get(project_template, 0)})
+
+    def _compute_task_count(self):
+        self.__compute_task_temp_count()
+
+    def _default_stage_id(self):
+        # Since project stages are order by sequence first, this should fetch the one with the lowest sequence number.
+        return self.env['project.project.stage'].search([], limit=1)
+
+    @api.model
+    def _search_is_favorite(self, operator, value):
+        if operator != 'in':
+            return NotImplemented
+        return [('favorite_user_ids', 'in', [self.env.uid])]
+
+    name = fields.Char("Name", index='trigram', required=True, translate=True, default_export_compatible=True)
+    description = fields.Html(help="Description to provide more information and context about this project")
+    active = fields.Boolean(default=True, copy=False, export_string_translation=False)
+    sequence = fields.Integer(default=10, export_string_translation=False)
+    company_id = fields.Many2one('res.company', string='Company', store=True, readonly=False)
+
+    resource_calendar_id = fields.Many2one(
+        'resource.calendar', string='Working Time', compute='_compute_resource_calendar_id', export_string_translation=False)
+    label_tasks = fields.Char(string='Use Tasks as', default=lambda s: s.env._('Tasks'), translate=True,
+        help="Name used to refer to the tasks of your project e.g. tasks, tickets, sprints, etc...")
+    type_ids = fields.Many2many('project.task.type', string='Tasks Stages in Template', export_string_translation=False)
+    task_count = fields.Integer(compute='_compute_task_count', string="Task Count", export_string_translation=False)
+    task_template_ids = fields.One2many('project.task.template', 'project_template_id', string='Task Templates', export_string_translation=False,
+                               domain="[('is_closed', '=', False)]", copy=False)
+    color = fields.Integer(string='Color Index', export_string_translation=False)
+    user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, falsy_value_label=_lt("👤 Unassigned"))
+    privacy_visibility = fields.Selection([
+            ('followers', 'Invited internal users'),
+            ('invited_users', 'Invited internal and portal users'),
+            ('employees', 'All internal users'),
+            ('portal', ' All internal users and invited portal users'),
+        ],
+        string='Visibility', required=True,
+        default='portal',
+        help="Project and Task Visibility:\n"
+            "- Invited internal users: Can access only the project or tasks they follow. Assignees automatically get access.\n"
+            "- Invited internal and portal users: Same as above, extended to portal users.\n"
+            "- All internal users: Full access to the project and all its tasks.\n"
+            "- All internal and invited portal users: Internal users get full access. Portal users can access only the project or tasks they follow.\n\n"
+            "Portal Access Levels:\n"
+            "- Read-only: Portal users see tasks via their portal but can’t edit them.\n"
+            "- Edit (limited): Portal users access kanban/list views and can edit limited fields on followed tasks.\n"
+            "- Edit: Same as above, with access to all tasks.\n\n"
+            "Other Rules:\n"
+            "- Internal users can open a task from a direct link, even without project access.\n"
+            "- Project admins have access to private projects, even if not followers.\n")
+    privacy_visibility_warning = fields.Char('Privacy Visibility Warning', compute='_compute_privacy_visibility_warning', export_string_translation=False)
+    access_instruction_message = fields.Char('Access Instruction Message', compute='_compute_access_instruction_message', export_string_translation=False)
+    date_start = fields.Date(string='Start Date', copy=False)
+    date = fields.Date(string='Expiration Date', copy=False, index=True,
+        help="Date on which this project ends. The timeframe defined on the project is taken into account when viewing its planning.")
+    allow_task_dependencies = fields.Boolean('Task Dependencies', default=lambda self: self.env.user.has_group('project.group_project_task_dependencies'), inverse='_inverse_allow_task_dependencies')
+    allow_milestones = fields.Boolean('Milestones', default=lambda self: self.env.user.has_group('project.group_project_milestone'))
+    tag_ids = fields.Many2many('project.tags', string='Tags')
+    task_properties_definition = fields.PropertiesDefinition('Task Properties')
+
+    # rating fields
+    rating_active = fields.Boolean('Customer Ratings', default=lambda self: self.env.user.has_group('project.group_project_rating'))
+    rating_status = fields.Selection(
+        [('stage', 'when reaching a given stage'),
+         ('periodic', 'on a periodic basis')
+        ], 'Customer Ratings Status', default="stage", required=True,
+        help="Collect feedback from your customers by sending them a rating request when a task enters a certain stage. To do so, define a rating email template on the corresponding stages.\n"
+             "Rating when changing stage: an email will be automatically sent when the task reaches the stage on which the rating email template is set.\n"
+             "Periodic rating: an email will be automatically sent at regular intervals as long as the task remains in the stage in which the rating email template is set.")
+    rating_status_period = fields.Selection([
+        ('daily', 'Daily'),
+        ('weekly', 'Weekly'),
+        ('bimonthly', 'Twice a Month'),
+        ('monthly', 'Once a Month'),
+        ('quarterly', 'Quarterly'),
+        ('yearly', 'Yearly')], 'Rating Frequency', required=True, default='monthly')
+
+    # Not `required` since this is an option to enable in project settings.
+    stage_id = fields.Many2one('project.project.stage', string='Stage', ondelete='restrict', groups="project.group_project_stages",
+        index=True, copy=False, default=_default_stage_id, group_expand='_read_group_expand_full')
+    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
+
+    milestone_ids = fields.One2many('project.milestone', 'project_template_id', copy=True, export_string_translation=False)
+    milestone_count = fields.Integer(compute='_compute_milestone_count', groups='project.group_project_milestone', export_string_translation=False)
+
+    _project_date_greater = models.Constraint(
+        'check(date >= date_start)',
+        "The project's start date must be before its end date.",
+    )
+
+    @api.onchange('company_id')
+    def _onchange_company_id(self):
+        if (self.env.user.has_group('project.group_project_stages') and self.stage_id.company_id
+                and self.stage_id.company_id != self.company_id):
+            self.stage_id = self.env['project.project.stage'].search(
+                [('company_id', 'in', [self.company_id.id, False])],
+                order=f"sequence asc, {self.env['project.project.stage']._order}",
+                limit=1,
+            ).id
+
+    @api.depends_context('company')
+    @api.depends('company_id', 'company_id.resource_calendar_id')
+    def _compute_resource_calendar_id(self):
+        for template in self:
+            template.resource_calendar_id = template.company_id.resource_calendar_id or self.env.company.resource_calendar_id
+
+    @api.depends('privacy_visibility')
+    def _compute_privacy_visibility_warning(self):
+        _ = self.env._
+        for project_template in self:
+            if not project_template.ids:
+                project_template.privacy_visibility_warning = ''
+            elif project_template.privacy_visibility in ['invited_users', 'portal'] and project_template._origin.privacy_visibility not in ['invited_users', 'portal']:
+                project_template.privacy_visibility_warning = _('Customers will be added to the followers of their project and tasks.')
+            elif project_template.privacy_visibility not in ['invited_users', 'portal'] and project_template._origin.privacy_visibility in ['invited_users', 'portal']:
+                project_template.privacy_visibility_warning = _('Portal users will be removed from the followers of the project and its tasks.')
+            else:
+                project_template.privacy_visibility_warning = ''
+
+    @api.depends('privacy_visibility')
+    def _compute_access_instruction_message(self):
+        _ = self.env._
+        for project_template in self:
+            if project_template.privacy_visibility == 'portal':
+                project_template.access_instruction_message = _('To give portal users access to your project, add them as followers. For task access, add them as followers for each task.')
+            elif project_template.privacy_visibility == 'followers':
+                project_template.access_instruction_message = _('Grant employees access to your project or tasks by adding them as followers. Employees automatically get access to the tasks they are assigned to.')
+            elif project_template.privacy_visibility == 'invited_users':
+                project_template.access_instruction_message = _("Grant users access by adding them as followers — either to the project or individual tasks. Internal users automatically gain access to tasks they are assigned to.")
+            else:
+                project_template.access_instruction_message = ''
+
+    def _inverse_allow_task_dependencies(self):
+        """ Reset state for waiting tasks in the project if the feature is disabled
+            or recompute the tasks with dependencies if the project has the feature enabled again
+        """
+        project_with_task_dependencies_feature = self.filtered('allow_task_dependencies')
+        projects_without_task_dependencies_feature = self - project_with_task_dependencies_feature
+        ProjectTask = self.env['project.task']
+        if (
+            project_with_task_dependencies_feature
+            and (
+                open_tasks_with_dependencies := ProjectTask.search([
+                    ('project_id', 'in', project_with_task_dependencies_feature.ids),
+                    ('depend_on_ids.state', 'in', ProjectTask.OPEN_STATES),
+                    ('state', 'in', ProjectTask.OPEN_STATES),
+                ])
+            )
+        ):
+            open_tasks_with_dependencies.state = '04_waiting_normal'
+        if (
+            projects_without_task_dependencies_feature
+            and (
+                waiting_tasks := ProjectTask.search([
+                    ('project_id', 'in', projects_without_task_dependencies_feature.ids),
+                    ('state', '=', '04_waiting_normal'),
+                ])
+            )
+        ):
+            waiting_tasks.state = '01_in_progress'
+
+    @api.depends('milestone_ids')
+    def _compute_milestone_count(self):
+        read_group = self.env['project.milestone']._read_group([('project_template_id', 'in', self.ids)], ['project_template_id'], ['__count'])
+        mapped_count = {template.id: count for template, count in read_group}
+        for template in self:
+            template.milestone_count = mapped_count.get(template.id, 0)
+
+    @api.model
+    def _map_tasks_default_values(self, project):
+        """ get the default value for the copied task on project duplication.
+        The stage_id, name field will be set for each task in the overwritten copy_data function in project.task """
+        return {
+            'state': '01_in_progress',
+            'company_id': project.company_id.id,
+            'project_template_id': project.id,
+        }
+
+    def map_tasks(self, new_project_id):
+        """ copy and map tasks from old to new project Template"""
+        template = self.browse(new_project_id)
+        # We want to copy archived task, but do not propagate an active_test context key
+        task_templates = self.env['project.task.template'].with_context(active_test=False).search([('project_template_id', '=', self.id), ('parent_id', '=', False)])
+        self_ctx = self.with_context(self.env.context)
+        if self.allow_task_dependencies and 'task_mapping' not in self.env.context:
+            self_ctx = self.with_context(task_mapping=dict())
+        # preserve task name and stage, normally altered during copy
+        defaults = self_ctx._map_tasks_default_values(template)
+        new_tasks = task_templates.with_context(copy_project=True).copy(defaults)
+        all_subtasks = new_tasks._get_all_subtasks()
+        all_subtasks.filtered(
+            lambda child: child.project_template_id == self_ctx,
+        ).write({
+            'project_template_id': template.id,
+        })
+        return True
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Prevent double project creation
+        if any('label_tasks' in vals and not vals['label_tasks'] for vals in vals_list):
+            task_label = self.env._("Tasks")
+            for vals in vals_list:
+                if 'label_tasks' in vals and not vals['label_tasks']:
+                    vals['label_tasks'] = task_label
+        if self.env.user.has_group('project.group_project_stages'):
+            if 'default_stage_id' in self.env.context:
+                stage = self.env['project.project.stage'].browse(self.env.context['default_stage_id'])
+                # The project's company_id must be the same as the stage's company_id
+                if stage.company_id:
+                    for vals in vals_list:
+                        if vals.get('stage_id'):
+                            continue
+                        vals['company_id'] = stage.company_id.id
+            else:
+                companies_ids = [vals.get('company_id', False) for vals in vals_list] + [False]
+                stages = self.env['project.project.stage'].search([('company_id', 'in', companies_ids)])
+                for vals in vals_list:
+                    if vals.get('stage_id'):
+                        continue
+                    # Pick the stage with the lowest sequence with no company or project's company
+                    stage_domain = [False] if 'company_id' not in vals else [False, vals.get('company_id')]
+                    stage = stages.filtered(lambda s: s.company_id.id in stage_domain)[:1]
+                    vals['stage_id'] = stage.id
+
+        for vals in vals_list:
+            if vals.pop('is_favorite', False):
+                vals['favorite_user_ids'] = [self.env.uid]
+        projects = super().create(vals_list)
+        return projects
+
+    def copy(self, default=None):
+        if self.env.context.get("from_project"):
+            return super().copy(default=default)
+        default = dict(default or {})
+        # Since we dont want to copy the milestones if the original project has the feature disabled, we set the milestones to False by default.
+        default['milestone_ids'] = False
+        copy_context = dict(
+             self.env.context,
+             mail_auto_subscribe_no_notify=True,
+             mail_create_nosubscribe=True,
+         )
+        copy_context.pop("default_stage_id", None)
+        new_projects = super(ProjectProjectTemplate, self.with_context(copy_context)).copy(default=default)
+        self_ctx = self.env.context
+        if 'milestone_mapping' not in self_ctx:
+            self_ctx = self.with_context(milestone_mapping={})
+        for old_project, new_project in zip(self, new_projects):
+            if old_project.allow_milestones:
+                new_project.milestone_ids = self_ctx.milestone_ids.copy().ids
+            if 'tasks' not in default:
+                old_project.map_tasks(new_project.id)
+            if not old_project.active:
+                new_project.with_context(active_test=False).tasks.active = True
+        return new_projects
+
+    def copy_data(self, default=None):
+        vals_list = super().copy_data(default=default)
+        if self.env.context.get('copy_from_template') or 'name' in (default or {}):
+            return vals_list
+        return [dict(vals, name=self.env._("%s (copy)", project.name)) for project, vals in zip(self, vals_list)]
+
+    def action_view_tasks(self):
+        action = self.env['ir.actions.act_window'].with_context(active_id=self.id)._for_xml_id('project.act_project_template_2_task_template_all')
+        action['display_name'] = self.name
+        context = action['context'].replace('active_id', str(self.id))
+        context = ast.literal_eval(context)
+        context.update({
+            'create': self.active,
+            'active_test': self.active,
+            'active_id': self.id,
+        })
+        action['context'] = context
+        action['domain'] = action['domain'].replace('active_id', str(self.id))
+        view_id_per_view_type = {
+            'kanban': self.env.ref("project.view_task_template_kanban_default_groupby_stage_id").id,
+            'list': self.env.ref("project.view_task_template_list_default_groupby_stage_id").id,
+        }
+        action["views"] = [
+            (view_id_per_view_type.get(v_type, v_id), v_type)
+            for v_id, v_type in action["views"]
+        ]
+        return action
+
+    def action_get_list_view(self):
+        action = self.env['ir.actions.act_window']._for_xml_id('project.project_milestone_action')
+        action['display_name'] = self.env._("%(name)s's Milestones", name=self.name)
+        return action
+
+    def action_create_from_template(self, values=None, role_to_users_mapping=None):
+        self.ensure_one()
+        values = values or {}
+        if self.date_start and self.date:
+            if not values.get("date_start"):
+                values["date_start"] = fields.Date.today()
+            if not values.get("date"):
+                values["date"] = values["date_start"] + (self.date - self.date_start)
+        project_template_data = self.with_context(copy_from_template=True, copy_from_project_template=True).copy_data(default=values)
+        project = self.env['project.project'].with_context(
+            mail_create_nosubscribe=True,
+            mail_create_nolog=True,
+        ).sudo().create(project_template_data)
+        self.task_template_ids.filtered(lambda t: t.is_task_template).\
+            with_context(copy_from_template=True, is_copy_depend_task=True).\
+            copy({'project_id': project.id, 'project_template_id': False})
+        temp_converted_to_tasks = self.task_template_ids.filtered(lambda t: not t.is_task_template)
+        if temp_converted_to_tasks:
+            task_data = temp_converted_to_tasks.with_context(copy_from_project_template=True, copy_from_template=True, is_copy_depend_task=True).\
+                copy_data({'project_id': project.id, 'project_template_id': False})
+            created_tasks = self.env['project.task'].create(task_data)
+            template_to_new = dict(zip(temp_converted_to_tasks, created_tasks))
+            for template, new_task in template_to_new.items():
+                if template.parent_id:
+                    new_task.parent_id = template_to_new[template.parent_id]
+        project.message_post(body=self.env._("Project created from template %(name)s.", name=self.name))
+
+        # Tasks dispatching using project roles
+        project.task_ids.role_ids = False
+        if role_to_users_mapping and (mapping := role_to_users_mapping.filtered(lambda entry: entry.user_ids)):
+            for template_task, new_task in zip(self.task_template_ids, project.task_ids):
+                for entry in mapping:
+                    if entry.role_id in template_task.role_ids:
+                        new_task.user_ids |= entry.user_ids
+        return project

--- a/addons/project/models/project_task_type.py
+++ b/addons/project/models/project_task_type.py
@@ -16,6 +16,10 @@ class ProjectTaskType(models.Model):
         default_project_id = self.env.context.get('default_project_id')
         return [default_project_id] if default_project_id else None
 
+    def _get_default_project_template_ids(self):
+        default_project_template_id = self.env.context.get('default_project_template_id')
+        return [default_project_template_id] if default_project_template_id else None
+
     def _default_user_id(self):
         return not self.env.context.get('default_project_id', False) and self.env.uid
 
@@ -26,6 +30,8 @@ class ProjectTaskType(models.Model):
         default=lambda self: self._get_default_project_ids(),
         help="Projects in which this stage is present. If you follow a similar workflow in several projects,"
             " you can share this stage among them and get consolidated information this way.")
+    project_template_ids = fields.Many2many('project.project.template', string='Project Templates',
+        default=lambda self: self._get_default_project_template_ids())
     mail_template_id = fields.Many2one(
         'mail.template',
         string='Email Template',

--- a/addons/project/models/project_update.py
+++ b/addons/project/models/project_update.py
@@ -55,7 +55,7 @@ class ProjectUpdate(models.Model):
     user_id = fields.Many2one('res.users', string='Author', required=True, default=lambda self: self.env.user)
     description = fields.Html()
     date = fields.Date(default=fields.Date.context_today, tracking=True)
-    project_id = fields.Many2one('project.project', required=True, domain=[('is_template', '=', False)], index=True, export_string_translation=False)
+    project_id = fields.Many2one('project.project', required=True, index=True, export_string_translation=False)
     name_cropped = fields.Char(compute="_compute_name_cropped", export_string_translation=False)
     task_count = fields.Integer("Task Count", readonly=True, export_string_translation=False)
     closed_task_count = fields.Integer("Closed Task Count", readonly=True, export_string_translation=False)

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -1,6 +1,8 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_project_project,project.project,model_project_project,project.group_project_user,1,0,0,0
 access_project_project_manager,project.project,model_project_project,project.group_project_manager,1,1,1,1
+access_project_template_project_user,project.project_template,model_project_project_template,project.group_project_user,1,1,1,1
+access_project_template_user,project.project_template_user,model_project_project_template,base.group_user,1,0,0,0
 access_project_project_stage,project.project_stage,model_project_project_stage,base.group_user,1,0,0,0
 access_project_project_stage_manager,project.project_stage.manager,model_project_project_stage,project.group_project_manager,1,1,1,1
 access_project_task_type_user,project.task.type.user,model_project_task_type,base.group_user,1,0,0,0

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -53,6 +53,12 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
+    <record model="ir.rule" id="project_template_comp_rule">
+        <field name="name">Project Template: multi-company</field>
+        <field name="model_id" ref="model_project_project_template"/>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+    </record>
+
     <record model="ir.rule" id="project_project_stage_rule">
         <field name="name">Project Stage: multi-company</field>
         <field name="model_id" ref="model_project_project_stage"/>

--- a/addons/project/static/src/actions/client_actions.js
+++ b/addons/project/static/src/actions/client_actions.js
@@ -1,15 +1,5 @@
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
-
-export async function openFormView(env, { resModel, resId }) {
-    await env.services.action.doAction({
-        type: "ir.actions.act_window",
-        res_model: resModel,
-        views: [[false, "form"]],
-        res_id: resId,
-    });
-}
 
 export function showTemplateUndoNotification(
     env,
@@ -17,11 +7,8 @@ export function showTemplateUndoNotification(
         model,
         recordId,
         message,
-        undoMethod = "action_undo_convert_to_template",
+        undoMethod = "unlink",
         actionType = "success",
-        undoCallback,
-        templateResId,
-        templateResModel,
     }
 ) {
     const undoNotification = env.services.notification.add(_t(message), {
@@ -31,14 +18,8 @@ export function showTemplateUndoNotification(
                 name: _t("Undo"),
                 icon: "fa-undo",
                 onClick: async () => {
-                    const res = await env.services.orm.call(model, undoMethod, [recordId]);
-                    if (undoCallback) {
-                        await env.services.orm.call(model, undoCallback.method, undoCallback.args);
-                    }
-                    if (res && undoMethod !== "unlink") {
-                        env.services.action.doAction(res);
-                    } else if (undoMethod === "unlink") {
-                        if (model === 'project.task.template') {
+                    await env.services.orm.call(model, undoMethod, [recordId])
+                    if (undoMethod === "unlink") {
                             env.services.notification.add(_t('Removed from templates'), {
                                 type: "success",
                             });
@@ -46,12 +27,6 @@ export function showTemplateUndoNotification(
                                 type: "ir.actions.client",
                                 tag: "soft_reload",
                             });
-                        } else {
-                            // Taking out the controller to be restored after unlinking the record
-                            const restoreController =
-                                env.services.action.currentController.config.breadcrumbs?.at(-2);
-                            restoreController?.onSelected();
-                        }
                     }
                     undoNotification();
                 },
@@ -60,95 +35,14 @@ export function showTemplateUndoNotification(
     });
 }
 
-export function showTemplateUndoConfirmationDialog(
-    env,
-    {
-        model,
-        recordId,
-        bodyMessage,
-        confirmLabel,
-        undoMethod = "action_undo_convert_to_template",
-        confirmationCallback,
-    }
-) {
-    env.services.dialog.add(ConfirmationDialog, {
-        body: bodyMessage,
-        confirmLabel: confirmLabel,
-        confirm: async () => {
-            const action = await env.services.orm.call(model, undoMethod, [recordId]);
-            await env.services.action.doAction(action);
-            if (action.params.type == 'success') {
-                const { res_id, res_model } = action.params;
-                await openFormView(env, { resModel: res_model, resId: res_id });
-                env.services.action.currentController.config.breadcrumbs?.pop()
-            }
-            if (confirmationCallback) {
-                await env.services.orm.call(
-                    model,
-                    confirmationCallback.method,
-                    confirmationCallback.args
-                );
-            }
-        },
-        cancelLabel: _t("Discard"),
-        cancel: () => {},
-    });
-}
-
-export async function showTemplateFormView(
-    env,
-    { model, recordId, method = "action_create_template_from_project" }
-) {
-    const action = await env.services.orm.call(model, method, [recordId]);
-    await openFormView(env, { resModel: model, resId: action.params.project_id });
-    await env.services.action.doAction(action);
-}
-
-// Task → Template Notification
+// Project and Task → Template Notification
 registry.category("actions").add("project_show_template_notification", (env, action) => {
     const params = action.params || {};
     showTemplateUndoNotification(env, {
-        model: "project.task.template",
+        model: params.res_model,
         recordId: params.res_id,
         undoMethod: params.undo_method,
         message: _t("Saved as template"),
     });
     return params.next;
 });
-
-// Project → Template Create Redirection
-registry.category("actions").add("project_to_template_redirection_action", (env, action) => {
-    const params = action.params || {};
-    return showTemplateFormView(env, {
-        model: "project.project",
-        recordId: params.project_id,
-    });
-});
-
-// Project → Template Notification
-registry.category("actions").add("project_template_show_notification", (env, action) => {
-    const params = action.params || {};
-    showTemplateUndoNotification(env, {
-        model: "project.project",
-        recordId: params.project_id,
-        message: params.message || _t("Project converted to template."),
-        undoMethod: params.undo_method,
-        undoCallback: params.callback_data || null,
-    });
-    return params.next;
-});
-
-// Project → Template Undo Confirmation Dialog
-registry
-    .category("actions")
-    .add("project_template_show_undo_confirmation_dialog", (env, action) => {
-        const params = action.params || {};
-        showTemplateUndoConfirmationDialog(env, {
-            model: "project.project",
-            recordId: params.project_id,
-            bodyMessage: params.message,
-            confirmLabel: _t("Revert to Project"),
-            confirmationCallback: params.callback_data || null,
-        });
-        return params.next;
-    });

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
@@ -117,7 +117,7 @@ export class ProjectTaskStateSelection extends StateSelectionField {
      * Either the isToggleMode is active on the record OR the task is_private
      */
     get isToggleMode() {
-        return this.props.isToggleMode || !this.props.record.data.project_id;
+        return (this.props.isToggleMode || !this.props.record.data.project_template_id);
     }
 
     isView(viewNames) {
@@ -187,4 +187,25 @@ export const projectTaskStateSelection = {
     },
 }
 
+export class ProjectTaskTemplateStateSelection extends StateSelectionField {
+    get isToggleMode() {
+        return (
+            this.props.isToggleMode ||
+            !(this.props.record.data.project_id || this.props.record.data.project_template_id)
+        );
+    }
+}
+
+export const projectTaskTemplateStateSelection = {
+    ...projectTaskStateSelection,
+    component: ProjectTaskTemplateStateSelection,
+    fieldDependencies: [
+        { name: "project_id", type: "many2one" },
+        { name: "project_template_id", type: "many2one" },
+    ],
+};
+
 registry.category("fields").add("project_task_state_selection", projectTaskStateSelection);
+registry
+    .category("fields")
+    .add("project_task_template_state_selection", projectTaskTemplateStateSelection);

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
@@ -100,6 +100,7 @@ export class SubtaskKanbanList extends Component {
                 display_name: name,
                 parent_id: this.props.record.resId,
                 project_id: this.props.record.data.project_id.id,
+                project_template_id: this.props.record.data.project_template_id.id,
                 user_ids: this.props.record.data.user_ids.resIds,
                 sequence: nextSequence,
             }]);

--- a/addons/project/static/src/views/components/project_task_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.js
@@ -41,7 +41,7 @@ export class ProjectTaskTemplateDropdown extends Component {
     }
 
     async onWillStart() {
-        if (this.props.projectId && !this.props.context.default_is_template) {
+        if (this.props.projectId) {
             this.state.taskTemplates = await this.orm
                 .cache({
                     type: "disk",

--- a/addons/project/static/src/views/components/project_template_dropdown.js
+++ b/addons/project/static/src/views/components/project_template_dropdown.js
@@ -44,7 +44,7 @@ export class ProjectTemplateDropdown extends Component {
     }
 
     get projectTemplatesDomain() {
-        return [["is_template", "=", true]];
+        return [];
     }
 
     async onWillStart() {
@@ -58,7 +58,7 @@ export class ProjectTemplateDropdown extends Component {
                     }
                 },
             })
-            .searchRead("project.project", this.projectTemplatesDomain, this.readFields);
+            .searchRead("project.project.template", this.projectTemplatesDomain, this.readFields);
     }
 
     contextPreprocess(templateId) {

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
@@ -28,7 +28,7 @@ export class ProjectTaskKanbanRenderer extends KanbanRenderer {
         // This restrict the creation of project stages to the kanban view of a given project
         return (
             super.canCreateGroup() &&
-            ((!!this.props.list.context.default_project_id == this.props.list.isGroupedByStage &&
+            ((!!(this.props.list.context.default_project_id || this.props.list.context.default_project_template_id) == this.props.list.isGroupedByStage &&
                 this.isProjectManager) ||
                 this.props.list.groupByField.name === "personal_stage_type_id")
         );

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -1,12 +1,17 @@
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { defineModels, fields, models } from "@web/../tests/web_test_helpers";
 
+export class ProjectProjectTemplate extends models.Model {
+    _name = "project.project.template";
+
+    name = fields.Char();
+}
+
 export class ProjectProject extends models.Model {
     _name = "project.project";
 
     name = fields.Char();
     is_favorite = fields.Boolean();
-    is_template = fields.Boolean();
     active = fields.Boolean({ default: true });
     stage_id = fields.Many2one({ relation: "project.project.stage" });
     date = fields.Date({ string: "Expiration Date" });
@@ -163,6 +168,7 @@ export function defineProjectModels() {
 }
 
 export const projectModels = {
+    ProjectProjectTemplate,
     ProjectProject,
     ProjectProjectStage,
     ProjectTask,

--- a/addons/project/static/tests/project_task_kanban_view.test.js
+++ b/addons/project/static/tests/project_task_kanban_view.test.js
@@ -91,3 +91,17 @@ test("project.task (kanban): toggle sub-tasks", async () => {
     await animationFrame();
     expect(".o_kanban_record").toHaveCount(2);
 });
+
+test("stages nocontent helper should be displayed in the task template Kanban", async () => {
+    ProjectTask._records = [];
+
+    await mountView({
+        ...viewParams,
+        context: {
+            default_project_template_id: 1,
+        },
+    });
+
+    expect(".o_kanban_header").toHaveCount(1);
+    expect(".o_kanban_stages_nocontent").toHaveCount(1);
+});

--- a/addons/project/tests/test_project_template_ui.py
+++ b/addons/project/tests/test_project_template_ui.py
@@ -6,13 +6,12 @@ class TestProjectTemplatesTour(HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.project_template = cls.env["project.project"].create({
+        cls.project_template = cls.env["project.project.template"].create({
             "name": "Project Template",
-            "is_template": True,
         })
         cls.task_inside_template = cls.env["project.task"].create({
             "name": "Task in Project Template",
-            "project_id": cls.project_template.id,
+            "project_template_id": cls.project_template.id,
         })
 
     def test_project_templates_tour(self):

--- a/addons/project/views/project_project_template_views.xml
+++ b/addons/project/views/project_project_template_views.xml
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="project_template_view_form" model="ir.ui.view">
+        <field name="name">project.project.template.form</field>
+        <field name="model">project.project.template</field>
+        <field name="arch" type="xml">
+            <form string="Project Template" class="o_form_project_project">
+                <field name="company_id" invisible="1"/>
+                <header>
+                    <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}"
+                        groups="project.group_project_stages" domain="[('company_id', 'in', (company_id, False))]"/>
+                </header>
+                <sheet string="Project Template">
+                    <div class="oe_button_box" name="button_box" groups="base.group_user">
+                        <button class="oe_stat_button" type="object" name="action_view_tasks" icon="fa-check">
+                            <div class="o_field_widget o_stat_info">
+                                <field name="label_tasks" readonly="1"/>
+                                <span class="o_stat_value">
+                                    <field name="task_count"/>
+                                </span>
+                            </div>
+                        </button>
+                    </div>
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                    <widget name="web_ribbon" title="Template" bg_color="text-bg-info" invisible="not active"/>
+
+                    <div class="oe_title">
+                        <h1 class="d-flex flex-row">
+                            <field name="name" options="{'line_breaks': False}" widget="text" class="o_text_overflow" placeholder="e.g. Office Party"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="label_tasks" string="Name of the Tasks" placeholder="e.g. Tasks"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" placeholder="Visible to all"/>
+                        </group>
+                        <group>
+                            <field name="active" invisible="1"/>
+                            <field name="user_id" string="Project Manager" widget="many2one_avatar_user" readonly="not active" domain="[('share', '=', False)]" options="{'no_quick_create': True}"/>
+                            <field name="date_start" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": "1"}' required="date_start or date" />
+                            <field name="date" invisible="1" required="date_start"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page name="description" string="Description">
+                            <field name="description" options="{'resizable': false}" placeholder="Project description..."/>
+                        </page>
+                        <page name="settings" string="Settings">
+                            <group>
+                                <group>
+                                    <field name="privacy_visibility" widget="radio"/>
+                                    <span colspan="2" class="text-muted o_row ps-1" invisible="access_instruction_message == ''">
+                                        <i class="fa fa-lightbulb-o pe-2" title="Info"/><field class="d-inline" name="access_instruction_message" nolabel="1"/>
+                                    </span>
+                                    <span colspan="2" class="text-muted o_row ps-1" invisible="privacy_visibility_warning == ''">
+                                        <i class="fa fa-warning pe-2" title="Warning"/><field class="d-inline" name="privacy_visibility_warning" nolabel="1"/>
+                                    </span>
+                                </group>
+                                <group name="extra_settings">
+                                </group>
+                            </group>
+                            <group>
+                                <group name="group_tasks_managment" string="Tasks Management" col="1" class="row mt16 o_settings_container" groups="project.group_project_task_dependencies,project.group_project_milestone">
+                                    <div>
+                                        <setting class="col-lg-12" id="task_dependencies_setting" help="Determine the order in which to perform tasks" groups="project.group_project_task_dependencies">
+                                            <field name="allow_task_dependencies"/>
+                                        </setting>
+                                        <setting class="col-lg-12" id="project_milestone_setting" help="Track major progress points that must be reached to achieve success" groups="project.group_project_milestone">
+                                            <field name="allow_milestones"/>
+                                        </setting>
+                                    </div>
+                                </group>
+                                <group name="group_time_managment" string="Time Management" invisible="1" col="1" class="row mt16 o_settings_container"/>
+                                <group name="group_documents_analytics" string="Analytics" col="1" class="row mt16 o_settings_container" groups="project.group_project_rating">
+                                    <div>
+                                        <field name="rating_active" invisible="1"/>
+                                        <setting class="col-lg-12" name="analytic_div" help="Get customer feedback and evaluate the performance of your employees" groups="project.group_project_rating">
+                                            <field name="rating_active"/>
+                                            <div class="mt16" invisible="not rating_active">
+                                                <span class="text-muted o_row ps-1 pb-3">Send a rating request:</span>
+                                                <field name="rating_status" widget="radio" class="o_row"/>
+                                                <div  invisible="rating_status != 'periodic'"  required="rating_status == 'periodic'">
+                                                    <label for="rating_status_period" string="Frequency"/>
+                                                    <field class="mx-3 w-auto" name="rating_status_period"/>
+                                                </div>
+                                                <span colspan="2" class="text-muted o_row ps-1">
+                                                    <i class="fa fa-lightbulb-o pe-2"/>
+                                                    <span invisible="rating_status == 'periodic'">A rating request will be sent as soon as the task reaches a stage on which a Rating Email Template is defined.</span>
+                                                    <span invisible="rating_status == 'stage'">Rating requests will be sent as long as the task remains in a stage on which a Rating Email Template is defined.</span>
+                                                </span>
+                                                <div class="content-group">
+                                                    <div class="mt8">
+                                                        <button name="%(project.open_task_type_form_domain)d" context="{'project_id':id}" icon="oi-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link" groups="project.group_project_manager"/>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </setting>
+                                    </div>
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="project_template_view_list" model="ir.ui.view">
+        <field name="name">project.project.template.list</field>
+        <field name="model">project.project.template</field>
+        <field name="arch" type="xml">
+            <list decoration-muted="active == False" string="Project Templates" multi_edit="1" sample="1" default_order="sequence, name, id">
+                <field name="sequence" widget="handle"/>
+                <field name="active" column_invisible="True"/>
+                <field name="allow_milestones" column_invisible="True"/>
+                <field name="name" class="fw-bold"/>
+                <field name="company_id" optional="show" groups="base.group_multi_company" options="{'no_create': True, 'no_open': True}"/>
+                <field name="company_id" column_invisible="True"/>
+                <field name="date_start" string="Planned Date" widget="daterange" options="{'end_date_field': 'date', 'always_range': '1'}" optional="hide"/>
+                <field name="date" column_invisible="True" />
+                <field name="user_id" optional="show" string="Project Manager" widget="many2one_avatar_user" options="{'no_open':True, 'no_create': True, 'no_create_edit': True}"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                <field name="stage_id_color" column_invisible="1"/>
+                <field name="stage_id" domain="[('company_id', 'in', (company_id, False))]" optional="show" widget="badge" options="{'no_open': True, 'color_field': 'stage_id_color'}" />
+                <button string="View Tasks" name="action_view_tasks" type="object"/>
+            </list>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="project_template_view_kanban">
+        <field name="name">project.project.template.kanban</field>
+        <field name="model">project.project.template</field>
+        <field name="arch" type="xml">
+            <kanban highlight_color="color"
+                class="o_project_kanban"
+                action="action_view_tasks" type="object"
+                sample="1"
+                default_order="sequence, name, id"
+            >
+                <field name="allow_milestones"/>
+                <field name="rating_active" />
+                <field name="privacy_visibility"/>
+                <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info", "done": "purple"}'/>
+                <field name="sequence" widget="handle"/>
+                <templates>
+                    <t t-name="menu" groups="base.group_user">
+                        <div class="container">
+                            <div class="row">
+                                <div name="card_menu_view" class="col-6">
+                                    <h5 role="menuitem" class="o_kanban_card_manage_title">
+                                        <span>View</span>
+                                    </h5>
+                                    <div role="menuitem">
+                                        <a name="action_view_tasks" type="object">Tasks</a>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="o_kanban_card_manage_settings row">
+                                <div role="menuitem" aria-haspopup="true" class="col-6" groups="project.group_project_manager">
+                                    <field name="color" widget="kanban_color_picker"/>
+                                </div>
+                                <div role="menuitem" class="col-6" groups="project.group_project_manager">
+
+                                    <a class="dropdown-item" role="menuitem" name="copy" type="object">Duplicate</a>
+                                    <a class="dropdown-item" role="menuitem" type="open">Settings</a>
+                                </div>
+                                <div class="col-12 ps-0" groups="!project.group_project_manager">
+                                    <div role="menuitem" class="w-100">
+                                        <a class="dropdown-item mx-0" role="menuitem" type="open">View</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                    <t t-name="card">
+                        <main class="o_project_kanban_main">
+                            <div class="d-flex align-items-baseline gap-1">
+                                <span class="text-truncate d-block fs-4 fw-bold" t-att-title="record.display_name.value"><field name="display_name"/></span>
+                            </div>
+                            <div class="o_project_kanban_body min-w-0 pb-4 me-2">
+                                <div t-if="record.date.raw_value or record.date_start.raw_value" class="text-muted d-flex align-items-baseline">
+                                    <span class="fa fa-clock-o me-2" title="Dates"/>
+                                    <field name="date_start" widget="daterange" options="{'end_date_field': 'date'}"/>
+                                </div>
+                                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
+                            </div>
+                        </main>
+                        <footer class="mt-auto pt-0">
+                            <div class="d-flex align-items-center">
+                                <div class="o_project_kanban_boxes d-flex align-items-baseline">
+                                    <a class="o_project_kanban_box me-1" name="action_view_tasks" type="object">
+                                        <div>
+                                            <field name="task_count" class="o_value"/>
+                                            <field name="label_tasks" class="ms-1"/>
+                                        </div>
+                                    </a>
+                                    <a groups='project.group_project_milestone' t-if="record.allow_milestones and record.allow_milestones.raw_value and record.milestone_count.raw_value &gt; 0"
+                                        role="button"
+                                        class="text-muted"
+                                        name="action_get_list_view"
+                                        type="object"
+                                        t-attf-title="#{record.milestone_count.value} Milestones"
+                                    >
+                                        <span class="fa fa-flag me-1"/>
+                                        <field name="milestone_count"/>
+                                    </a>
+                                </div>
+                            </div>
+                            <div class="d-flex ms-auto align-items-center">
+                                <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" class="me-1"/>
+                            </div>
+                        </footer>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="project_templates_action" model="ir.actions.act_window">
+        <field name="name">Project Templates</field>
+        <field name="res_model">project.project.template</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="view_id" ref="project_template_view_kanban"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No project templates found. Let's create one!
+            </p>
+            <p>
+                Save time by using project templates with pre-filled details.<br/>
+                Standardize workflows and ensure consistency across projects.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -36,7 +36,7 @@
                     <field name="company_id" invisible="1"/>
                     <header>
                         <button name="action_open_share_project_wizard" string="Share Project" type="object" class="oe_highlight" groups="project.group_project_manager"
-                        invisible="privacy_visibility in ['followers', 'employees'] or is_template" context="{'default_access_mode': 'read'}" data-hotkey="r"/>
+                        invisible="privacy_visibility in ['followers', 'employees']" context="{'default_access_mode': 'read'}" data-hotkey="r"/>
                         <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" groups="project.group_project_stages" domain="[('company_id', 'in', (company_id, False))]"/>
                     </header>
                 <sheet string="Project">
@@ -50,7 +50,7 @@
                                 </span>
                             </div>
                         </button>
-                        <button class="oe_stat_button" name="project_update_all_action" type="object" groups="project.group_project_user" context="{'active_id': id}" invisible="is_template">
+                        <button class="oe_stat_button" name="project_update_all_action" type="object" groups="project.group_project_user" context="{'active_id': id}">
                             <field name="last_update_color" invisible="1"/>
                             <div class="o_stat_info">
                                 <field name="update_count" invisible="1"/>
@@ -59,7 +59,6 @@
                         </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                    <widget name="web_ribbon" title="Template" bg_color="text-bg-info" invisible="not (is_template and active)"/>
 
                     <div class="oe_title">
                         <h1 class="d-flex flex-row">
@@ -91,9 +90,9 @@
                                     <!-- Always display the whole alias in edit mode. It depends in read only -->
                                     <!-- Need to add alias_id in view for getting alias_domain_id by default -->
                                     <field name="alias_id" invisible="1"/>
-                                    <label for="alias_name" string="Email Alias" invisible="is_template"/>
-                                    <field name="alias_email" widget="email" readonly="1" nolabel="1" groups="!project.group_project_manager" invisible="is_template"/>
-                                    <div class="d-inline-flex" groups="project.group_project_manager" invisible="is_template">
+                                    <label for="alias_name" string="Email Alias"/>
+                                    <field name="alias_email" widget="email" readonly="1" nolabel="1" groups="!project.group_project_manager"/>
+                                    <div class="d-inline-flex" groups="project.group_project_manager">
                                         <field name="alias_name" placeholder="alias"/>@
                                         <field name="alias_domain_id" placeholder="e.g. mycompany.com"
                                             options="{'no_create': True, 'no_open': True}"/>
@@ -173,15 +172,15 @@
                     <field name="tag_ids"/>
                     <field name="user_id" string="Project Manager"/>
                     <field name="stage_id" groups="project.group_project_stages"/>
-                    <field name="partner_id" string="Customer" filter_domain="[('partner_id', 'child_of', self)]" invisible="context.get('default_is_template')"/>
+                    <field name="partner_id" string="Customer" filter_domain="[('partner_id', 'child_of', self)]"/>
                     <field name="activity_user_id" string="Activities of"/>
                     <field name="activity_type_id" string="Activity type"/>
-                    <filter string="My Projects" name="own_projects" domain="[('user_id', '=', uid)]" invisible="context.get('default_is_template')"/>
+                    <filter string="My Projects" name="own_projects" domain="[('user_id', '=', uid)]"/>
                     <filter string="My Favorites" name="my_projects" domain="[('favorite_user_ids', 'in', uid)]"/>
                     <filter string="Unassigned" name="unassigned_projects" domain="[('user_id', '=', False)]"/>
-                    <separator invisible="context.get('default_is_template')"/>
-                    <filter string="Late Milestones" name="late_milestones" domain="[('is_milestone_exceeded', '=', True)]" groups="project.group_project_milestone" invisible="context.get('default_is_template')"/>
-                    <separator invisible="context.get('default_is_template')"/>
+                    <separator/>
+                    <filter string="Late Milestones" name="late_milestones" domain="[('is_milestone_exceeded', '=', True)]" groups="project.group_project_milestone"/>
+                    <separator/>
                     <filter string="Start Date" name="start_date" date="date_start" end_month="1" end_year="1"/>
                     <filter string="End Date" name="end_date" date="date" end_month="1" end_year="1"/>
                     <separator/>
@@ -200,7 +199,7 @@
                     <group>
                         <filter string="Project Manager" name="Manager" context="{'group_by': 'user_id'}"/>
                         <filter string="Stage" name="groupby_stage" context="{'group_by': 'stage_id'}" groups="project.group_project_stages"/>
-                        <filter string="Status" name="status" context="{'group_by': 'last_update_status'}" invisible="context.get('default_is_template')"/>
+                        <filter string="Status" name="status" context="{'group_by': 'last_update_status'}"/>
                         <filter string="Tags" name="tags" context="{'group_by': 'tag_ids'}"/>
                         <filter string="Company" name="company" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                     </group>
@@ -222,24 +221,24 @@
                     <field name="allow_milestones" column_invisible="True"/>
                     <field name="is_favorite" string="Favorite" nolabel="1" widget="project_is_favorite" optional="hide"/>
                     <field name="name" class="fw-bold"/>
-                    <field name="partner_id" optional="show" string="Customer" invisible="is_template"/>
+                    <field name="partner_id" optional="show" string="Customer"/>
                     <field name="company_id" optional="show" groups="base.group_multi_company" options="{'no_create': True, 'no_open': True}"/>
                     <field name="company_id" column_invisible="True"/>
                     <field name="date_start" string="Planned Date" widget="daterange" options="{'end_date_field': 'date', 'always_range': '1'}" optional="hide"/>
                     <field name="date" column_invisible="True" />
                     <field name="milestone_progress" widget="progressbar"
-                        invisible="milestone_progress == 0 or not allow_milestones or is_template"
+                        invisible="milestone_progress == 0 or not allow_milestones"
                         optional="hide"
                     />
                     <field name="next_milestone_id"
                         decoration-danger="is_milestone_deadline_exceeded" decoration-success="can_mark_milestone_as_done"
                         optional="hide"
-                        invisible="not allow_milestones or is_template"
+                        invisible="not allow_milestones"
                     />
                     <field name="user_id" optional="show" string="Project Manager" widget="many2one_avatar_user" options="{'no_open':True, 'no_create': True}"/>
                     <field name="last_update_color" column_invisible="True"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
-                    <field name="last_update_status" string="Status" nolabel="1" width="20px" optional="show" widget="project_state_selection" invisible="is_template"/>
+                    <field name="last_update_status" string="Status" nolabel="1" width="20px" optional="show" widget="project_state_selection"/>
                     <field name="stage_id_color" column_invisible="1"/>
                     <field name="stage_id" domain="[('company_id', 'in', (company_id, False))]" optional="show" widget="badge" options="{'no_open': True, 'color_field': 'stage_id_color'}" />
                     <button string="View Tasks" name="action_view_tasks" type="object"/>
@@ -388,7 +387,6 @@
                     <field name="last_update_color"/>
                     <field name="is_milestone_deadline_exceeded"/>
                     <field name="can_mark_milestone_as_done"/>
-                    <field name="is_template"/>
                     <progressbar field="last_update_status" colors='{"on_track": "success", "at_risk": "warning", "off_track": "danger", "on_hold": "info", "done": "purple"}'/>
                     <field name="sequence" widget="handle"/>
                     <templates>
@@ -402,11 +400,11 @@
                                         <div role="menuitem">
                                             <a name="action_view_tasks" type="object">Tasks</a>
                                         </div>
-                                        <div role="menuitem" groups="project.group_project_milestone" t-if="record.allow_milestones.raw_value and !record.is_template.raw_value">
+                                        <div role="menuitem" groups="project.group_project_milestone" t-if="record.allow_milestones.raw_value">
                                             <a name="action_get_list_view" type="object">Milestones</a>
                                         </div>
                                     </div>
-                                    <div class="col-6 o_kanban_manage_reporting" t-if="!record.is_template.raw_value">
+                                    <div class="col-6 o_kanban_manage_reporting">
                                         <h5 role="menuitem" class="o_kanban_card_manage_title" groups="project.group_project_user">
                                             <span>Reporting</span>
                                         </h5>
@@ -424,7 +422,7 @@
                                     </div>
                                     <div role="menuitem" class="col-6" groups="project.group_project_manager">
 
-                                        <a t-if="['portal', 'invited_users'].includes(record.privacy_visibility.raw_value) and !record.is_template.raw_value" class="dropdown-item" role="menuitem" name="action_open_share_project_wizard" type="object">Share Project</a>
+                                        <a t-if="['portal', 'invited_users'].includes(record.privacy_visibility.raw_value)" class="dropdown-item" role="menuitem" name="action_open_share_project_wizard" type="object">Share Project</a>
 
                                         <a class="dropdown-item" role="menuitem" name="copy" type="object">Duplicate</a>
                                         <a class="dropdown-item" role="menuitem" type="open">Settings</a>
@@ -494,7 +492,7 @@
                                 </div>
                                 <div class="d-flex ms-auto align-items-center">
                                     <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" class="me-1"/>
-                                    <field t-if="record.last_update_status.value &amp;&amp; widget.editable &amp;&amp; !record.is_template.raw_value" name="last_update_status" widget="project_state_selection"/>
+                                    <field t-if="record.last_update_status.value &amp;&amp; widget.editable" name="last_update_status" widget="project_state_selection"/>
                                     <span t-if="record.last_update_status.value &amp;&amp; !widget.editable" t-att-class="'o_status_bubble mx-0 o_color_bubble_' + record.last_update_color.value" t-att-title="record.last_update_status.value"></span>
                                 </div>
                             </footer>
@@ -571,7 +569,7 @@
             <field name="name">Projects</field>
             <field name="path">project</field>
             <field name="res_model">project.project</field>
-            <field name="domain">[("is_template", "=", False)]</field>
+            <field name="domain">[]</field>
             <field name="context">{'display_milestone_deadline': True}</field>
             <field name="view_mode">kanban,list,form</field>
             <field name="view_id" ref="view_project_kanban"/>
@@ -591,7 +589,7 @@
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
             <field name="context">{'display_milestone_deadline': True}</field>
-            <field name="domain">[("is_template", "=", False)]</field>
+            <field name="domain">[]</field>
             <field name="view_mode">kanban,list,form,calendar,activity</field>
             <field name="view_id" ref="view_project_kanban"/>
             <field name="search_view_id" ref="view_project_project_filter"/>
@@ -624,7 +622,7 @@
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
             <field name="path">project-configuration</field>
-            <field name="domain">[('is_template', '=', False)]</field>
+            <field name="domain">[]</field>
             <field name="view_mode">list,kanban,form</field>
             <field name="view_ids" eval="[(5, 0, 0),
                 (0, 0, {'view_mode': 'list', 'view_id': ref('view_project_config')}),
@@ -645,7 +643,7 @@
         <record id="open_view_project_all_config_group_stage" model="ir.actions.act_window">
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
-            <field name="domain">[('is_template', '=', False)]</field>
+            <field name="domain">[]</field>
             <field name="view_mode">list,kanban,form,calendar,activity</field>
             <field name="search_view_id" ref="view_project_project_filter"/>
             <field name="context">{'display_milestone_deadline': True}</field>
@@ -689,96 +687,15 @@
             </field>
         </record>
 
-        <record id="project_templates_view_form" model="ir.ui.view">
-            <field name="name">project.project.template.form</field>
-            <field name="model">project.project</field>
-            <field name="inherit_id" ref="project.edit_project"/>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <form position="attributes">
-                    <attribute name="js_class"></attribute>
-                </form>
-            </field>
-        </record>
-
-        <record id="project_templates_view_list" model="ir.ui.view">
-            <field name="name">project.project.template.list</field>
-            <field name="model">project.project</field>
-            <field name="inherit_id" ref="project.view_project"/>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <list position="attributes">
-                    <attribute name="js_class"></attribute>
-                    <attribute name="default_order">sequence, is_favorite desc, name, id</attribute>
-                </list>
-                <field name="sequence" position="attributes">
-                    <attribute name="column_invisible">False</attribute>
-                    <attribute name="widget">handle</attribute>
-                </field>
-                <field name="partner_id" position="replace"/>
-                <field name="next_milestone_id" position="replace"/>
-                <field name="milestone_progress" position="replace"/>
-            </field>
-        </record>
-
-        <record id="project_templates_view_kanban" model="ir.ui.view">
-            <field name="name">project.project.template.kanban</field>
-            <field name="model">project.project</field>
-            <field name="inherit_id" ref="project.view_project_kanban"/>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <kanban position="attributes">
-                    <attribute name="js_class"></attribute>
-                </kanban>
-                <span name="partner_name" position="replace"/>
-            </field>
-        </record>
-
-        <record id="project_templates_action" model="ir.actions.act_window">
-            <field name="name">Project Templates</field>
-            <field name="res_model">project.project</field>
-            <field name="view_mode">list,kanban,form</field>
-            <field name="domain">[('is_template', '=', True)]</field>
-            <field name="context">{'default_is_template': True}</field>
-            <field name="view_id" ref="view_project_kanban"/>
-            <field name="help" type="html">
-                <p class="o_view_nocontent_smiling_face">
-                    No project templates found. Let's create one!
-                </p>
-                <p>
-                    Save time by using project templates with pre-filled details.<br/>
-                    Standardize workflows and ensure consistency across projects.
-                </p>
-            </field>
-        </record>
-
-        <record id="project_templates_action_list" model="ir.actions.act_window.view">
-            <field name="act_window_id" ref="project_templates_action"/>
-            <field name="view_mode">list</field>
-            <field name="view_id" ref="project.project_templates_view_list"/>
-        </record>
-
-        <record id="project_templates_action_kanban" model="ir.actions.act_window.view">
-            <field name="act_window_id" ref="project_templates_action"/>
-            <field name="view_mode">kanban</field>
-            <field name="view_id" ref="project.project_templates_view_kanban"/>
-        </record>
-
-         <record id="project_templates_action_form" model="ir.actions.act_window.view">
-            <field name="act_window_id" ref="project_templates_action"/>
-            <field name="view_mode">form</field>
-            <field name="view_id" ref="project.project_templates_view_form"/>
-        </record>
-
         <record id="action_server_convert_project_to_template" model="ir.actions.server">
-            <field name="name">Convert to Template</field>
+            <field name="name">Save as Template</field>
             <field name="model_id" ref="project.model_project_project"/>
             <field name="binding_model_id" ref="project.model_project_project"/>
             <field name="binding_view_types">form</field>
             <field name="group_ids" eval="[Command.link(ref('project.group_project_manager'))]"/>
             <field name="state">code</field>
             <field name="code">
-                action = record.action_toggle_project_template_mode()
+                action = record.action_create_template_from_project()
             </field>
         </record>
 

--- a/addons/project/views/project_task_template_views.xml
+++ b/addons/project/views/project_task_template_views.xml
@@ -13,7 +13,9 @@
                 <field name="id" optional="hide" options="{'enable_formatting': False}"/>
                 <field name="name" string="Title" widget="name_with_subtask_count"/>
                 <field name="project_id" widget="project" optional="show"
-                    options="{'no_open': 1}" column_invisible="context.get('default_project_id')" required="1"/>
+                    options="{'no_open': 1}" column_invisible="context.get('default_project_template_id')" required="1"/>
+                <field name="project_template_id" optional="show"
+                    options="{'no_open': 1}" column_invisible="not context.get('default_project_template_id')" required="1"/>
                 <field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}"
                     groups="project.group_project_milestone" optional="hide"/>
                 <field name="parent_id" optional="hide"/>
@@ -27,7 +29,7 @@
                 <field name="priority" widget="priority" optional="hide" width="70px"/>
                 <field name="tag_ids" widget="many2many_tags"
                     options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
-                <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"
+                <field name="state" widget="project_task_template_state_selection" nolabel="1" width="20px"
                     options="{'is_toggle_mode': false}"/>
                 <field name="stage_id_color" column_invisible="1"/>
                 <field name="stage_id" column_invisible="context.get('set_visible', False)"
@@ -72,7 +74,7 @@
         <field name="view_mode">list,kanban,form</field>
         <field name="search_view_id" ref="project.view_project_task_template_search"/>
         <field name="domain">[('id', 'child_of', active_id), ('id', '!=', active_id)]</field>
-        <field name="context">{'default_parent_id': active_id, 'search_default_stage': 1, 'default_is_template': True}</field>
+        <field name="context">{'default_parent_id': active_id, 'search_default_stage': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No tasks found. Let's create one!
@@ -96,7 +98,8 @@
                 <field name="is_closed" invisible="1"/>
                 <field name="html_field_history_metadata" invisible="1"/>
                 <header>
-                    <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not project_id and not stage_id" col="6"/>
+                    <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" domain="[('project_template_ids', '=', project_template_id)]" invisible="not project_template_id or not stage_id" col="6"/>
+                    <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="project_template_id or not stage_id" col="6"/>
                     <field name="state" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="1"/>
                 </header>
                 <sheet string="Task Templates">
@@ -137,37 +140,40 @@
                     <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25"
                         invisible="not active" style="margin-right: 96px">
                         <field name="priority" class="h3 pe-2" widget="priority_switch"/>
-                        <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
+                        <field name="state" widget="project_task_template_state_selection" class="o_task_state_widget" />
                     </div>
                     <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active">
                         <field name="priority" class="h3 pe-2" widget="priority_switch"/>
-                        <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
+                        <field name="state" widget="project_task_template_state_selection" class="o_task_state_widget" />
                     </div>
                 </div>
                 <group>
                     <group>
                         <field name="project_id"
                             domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
-                            required="1"
+                            invisible="context.get('default_project_id', False) or project_template_id"
                             widget="project"/>
+                        <field name="project_template_id"
+                            invisible="context.get('default_project_template_id', False) or project_id"
+                            domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"/>
                         <field name="milestone_id"
                             placeholder="e.g. Product Launch"
                             context="{'default_project_id': project_id}"
-                            invisible="not project_id or not allow_milestones"/>
+                            invisible="not(project_id or project_template_id) or not allow_milestones"/>
                         <field name="user_ids"
                             class="o_task_user_field"
                             options="{'no_open': True}"
                             widget="many2many_avatar_user"/>
                         <field name="role_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"
-                            placeholder="Assign at project creation" invisible="not has_project_template"/>
+                            placeholder="Assign at project creation" invisible="not project_template_id"/>
                     </group>
                     <group>
                         <field name="active" invisible="1"/>
                         <field name="tag_ids" widget="many2many_tags"
                             options="{'color_field': 'color', 'no_create_edit': True}"
                             context="{'project_id': project_id}"/>
-                        <label for="date_deadline" invisible="not has_project_template"/>
-                        <div id="date_deadline_and_recurring_task" class="d-inline-flex w-100" invisible="not has_project_template">
+                        <label for="date_deadline" invisible="not project_template_id"/>
+                        <div id="date_deadline_and_recurring_task" class="d-inline-flex w-100" invisible="not project_template_id">
                             <field name="date_deadline" nolabel="1" decoration-danger="date_deadline and date_deadline &lt; current_date and state not in ['1_done', '1_canceled']"/>
                             <field name="recurring_task" nolabel="1" class="ms-0" style="width: fit-content; margin-right: 54px;"
                                    widget="boolean_icon" options="{'icon': 'fa-repeat'}"
@@ -175,9 +181,9 @@
                                    groups="project.group_project_recurring_tasks"/>
                         </div>
                         <label for="repeat_interval" groups="project.group_project_recurring_tasks"
-                            invisible="has_project_template and not recurring_task"/>
+                            invisible="project_template_id and not recurring_task"/>
                         <div class="d-flex" groups="project.group_project_recurring_tasks" name="repeat_intervals"
-                            invisible="has_project_template and not recurring_task">
+                            invisible="project_template_id and not recurring_task">
                             <field name="repeat_interval" required="recurring_task"
                                    class="me-2" style="max-width: 2rem !important;" />
                             <field name="repeat_unit" required="recurring_task"
@@ -194,11 +200,12 @@
                         <field name="description" type="html" options="{'collaborative': true, 'resizable': false}"
                             placeholder="Add details about this Template task..."/>
                     </page>
-                   <page name="sub_tasks_page" string="Sub-tasks" invisible="not project_id">
+                   <page name="sub_tasks_page" string="Sub-tasks">
                         <field name="child_ids"
                                mode="list,kanban"
                                context="{
                                     'default_project_id': project_id,
+                                    'default_project_template_id': project_template_id,
                                     'default_user_ids': user_ids,
                                     'default_parent_id': id,
                                     'default_milestone_id': allow_milestones and milestone_id,
@@ -214,11 +221,12 @@
                                 <field name="sequence" widget="handle"/>
                                 <field name="id" optional="hide" options="{'enable_formatting': False}"/>
                                 <field name="parent_id" column_invisible="True"/>
-                                <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
+                                <field name="state" widget="project_task_template_state_selection" nolabel="1" width="20px"/>
                                 <field name="name" widget="name_with_subtask_count"/>
                                 <field name="subtask_count" column_invisible="True"/>
                                 <field name="closed_subtask_count" column_invisible="True"/>
-                                <field name="project_id" string="Project" optional="hide" required="1" options="{'no_open': 1}" widget="project"/>
+                                <field name="project_id" string="Project" optional="hide" required="context.get('default_project_id', False)" column_invisible="parent.project_template_id" options="{'no_open': 1}" widget="project"/>
+                                <field name="project_template_id" string="Project Template" optional="hide" required="context.get('default_project_template_id', False)" column_invisible="parent.project_id" options="{'no_open': 1}" widget="project"/>
                                 <field name="milestone_id"
                                     optional="hide"
                                     context="{'default_project_id': project_id}"
@@ -256,7 +264,7 @@
                                 <field name="subtask_count" column_invisible="True"/>
                                 <field name="closed_subtask_count" column_invisible="True"/>
                                 <field name="id" optional="hide" options="{'enable_formatting': False}"/>
-                                <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
+                                <field name="state" widget="project_task_template_state_selection" nolabel="1" width="20px"/>
                                 <field name="name" widget="name_with_subtask_count"/>
                                 <field name="project_id" optional="hide" options="{'no_open': 1}" />
                                 <field name="milestone_id"
@@ -302,8 +310,13 @@
                     <field name="display_name" string= "Task Template Title" placeholder="e.g. Send Invitations" required="1"/>
                     <field name="project_id"
                            widget="project"
-                           invisible="context.get('default_project_id', False)"
-                           required="1"
+                           required="not project_template_id"
+                           invisible="context.get('default_project_template_id', False)"
+                           class="o_project_task_project_field"
+                    />
+                    <field name="project_template_id"
+                           invisible="context.get('default_project_template_id', False)"
+                           required="not project_id"
                            class="o_project_task_project_field"
                     />
                     <field name="user_ids" options="{'no_open': True, 'no_quick_create': True}"
@@ -348,7 +361,8 @@
                             <field name="name" class="fw-bold fs-5"/>
                             <div class="text-muted d-flex flex-column">
                                 <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
-                                <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
+                                <field invisible="context.get('default_project_id', False) or project_template_id" name="project_id" options="{'no_open': True}"/>
+                                <field invisible="context.get('default_project_template_id', False) or project_id" name="project_template_id" options="{'no_open': True}"/>
                                 <field t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value"
                                     t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''"
                                     name="milestone_id" options="{'no_open': True}"/>
@@ -360,17 +374,14 @@
                             <field name="displayed_image_id" widget="attachment_image"/>
                             <footer t-if="!selection_mode" class="pt-1">
                                 <div class="d-flex align-items-center gap-1">
-                                    <a t-if="!record.project_id.raw_value" class="text-muted" style="font-size: 17px; margin-left: 1.5px">
-                                        <i title="Private Task" class="fa fa-lock"/>
-                                    </a>
-                                    <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
+                                    <t t-if="(record.project_id.raw_value or record.project_template_id.raw_value) and record.subtask_count.raw_value">
                                         <widget name="subtask_counter" class="me-1"/>
                                     </t>
                                     <field name="priority" class="pt-1" widget="priority"/>
                                 </div>
                                 <div class="d-flex ms-auto">
                                     <field name="user_ids" widget="many2many_avatar_user"/>
-                                    <field name="state" class="ms-1" widget="project_task_state_selection" options="{'is_toggle_mode': false}"/>
+                                    <field name="state" class="ms-1" widget="project_task_template_state_selection" options="{'is_toggle_mode': false}"/>
                                 </div>
                             </footer>
                         </main>
@@ -410,7 +421,6 @@
         <field name="res_model">project.task.template</field>
         <field name="view_mode">list,kanban,form</field>
         <field name="domain">[('project_id', '!=', False)]</field>
-        <field name="context">{'default_is_template': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No task templates found. Let's create one!
@@ -421,4 +431,26 @@
             </p>
         </field>
     </record>
+
+    <record id="act_project_template_2_task_template_all" model="ir.actions.act_window">
+            <field name="name">Task Templates</field>
+            <field name="path">task-templates</field>
+            <field name="res_model">project.task.template</field>
+            <field name="view_mode">kanban,list,form</field>
+            <field name="domain">[('project_template_id', '=', active_id)]</field>
+            <field name="context">{
+                'default_project_template_id': active_id,
+                'search_default_open_tasks': 1,
+            }</field>
+            <field name="search_view_id" ref="view_project_task_template_search"/>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No task templates found. Let's create one!
+                </p>
+                <p>
+                    Save time by using task templates with pre-filled details.<br/>
+                    Standardize workflows and ensure consistency across tasks.
+                </p>
+            </field>
+        </record>
 </odoo>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -336,7 +336,7 @@
                     <header>
                         <field name="stage_id" widget="rotting_statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not project_id and not stage_id"/>
                         <field name="state" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="1"/>
-                        <field name="personal_stage_type_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="project_id" domain="[('user_id', '=', uid)]" string="Personal Stage"/>
+                        <field name="personal_stage_type_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="project_id or project_template_id" domain="[('user_id', '=', uid)]" string="Personal Stage"/>
                     </header>
                     <!-- Used in inherited views to display the eventual warnings -->
                     <t name="warning_section"/>
@@ -398,6 +398,8 @@
                         </h1>
                         <div class="d-flex justify-content-end align-items-center px-1" invisible="not active">
                             <field name="priority" class="h3 pe-2" widget="priority_switch"/>
+                        </div>
+                        <div class="d-flex justify-content-end o_state_container" invisible="not active">
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>
                         <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active">
@@ -419,6 +421,7 @@
                                 class="o_task_user_field"
                                 options="{'no_open': True}"
                                 widget="many2many_avatar_user"/>
+                            <field name="role_ids" invisible="not project_template_id" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" placeholder="Assign at project creation"/>
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
@@ -452,11 +455,12 @@
                         <page name="description_page" string="Description">
                             <field name="description" type="html" options="{'collaborative': true, 'resizable': false}" placeholder="Add details about this task..."/>
                         </page>
-                        <page name="sub_tasks_page" string="Sub-tasks" invisible="not project_id">
+                        <page name="sub_tasks_page" string="Sub-tasks" invisible="not (project_id or project_template_id)">
                             <field name="child_ids"
                                    mode="list,kanban"
                                    context="{
                                         'default_project_id': project_id,
+                                        'default_project_template_id': project_template_id,
                                         'default_user_ids': user_ids,
                                         'default_parent_id': id,
                                         'default_partner_id': partner_id,
@@ -607,7 +611,8 @@
                                invisible="context.get('default_project_id', False)"
                                placeholder="Private"
                                class="o_project_task_project_field"
-                               domain="[('type_ids', 'in', context.get('default_stage_id'))] if context.get('default_stage_id') else []"
+                               domain="[('type_ids', 'in', context['default_stage_id'])] if context.get('default_stage_id') else []"
+                               required="(parent_id or child_ids) and not project_template_id"
                         />
                         <field name="user_ids" options="{'no_open': True}"
                             widget="many2many_avatar_user"/>
@@ -676,7 +681,8 @@
                                 <field name="name" class="fw-bold fs-5"/>
                                 <div class="text-muted d-flex flex-column">
                                     <field t-if="record.parent_id.raw_value" invisible="context.get('default_parent_id', False)" name="parent_id"/>
-                                    <field invisible="context.get('default_project_id', False)" name="project_id" options="{'no_open': True}"/>
+                                    <field invisible="context.get('default_project_id', False) or context.get('default_project_template_id', False)" name="project_id" options="{'no_open': True}"/>
+                                    <field invisible="1" name="project_template_id" options="{'no_open': True}"/>
                                     <field name="partner_id"/>
                                     <field t-if="record.allow_milestones.raw_value and record.milestone_id.raw_value" t-att-class="record.has_late_and_unreached_milestone.raw_value and !record.state.raw_value.startsWith('1_') ? 'text-danger' : ''" name="milestone_id" options="{'no_open': True}"/>
                                 </div>
@@ -692,10 +698,10 @@
                                             <span class="fa fa-fw fa-meh-o text-warning rating_face" t-elif="record.rating_avg.raw_value &gt;= 2.33" title="Average Rating: Neutral" role="img" aria-label="Neutral face"/>
                                             <span class="fa fa-fw fa-frown-o text-danger rating_face" t-else="" title="Average Rating: Unhappy" role="img" aria-label="Unhappy face"/>
                                         </b>
-                                        <a t-if="!record.project_id.raw_value" class="text-muted" style="font-size: 17px; margin-left: 1.5px">
+                                        <a t-if="!(record.project_id.raw_value or record.project_template_id.raw_value)" class="text-muted" style="font-size: 17px; margin-left: 1.5px">
                                             <i title="Private Task" class="fa fa-lock"/>
                                         </a>
-                                        <t t-if="record.project_id.raw_value and record.subtask_count.raw_value">
+                                        <t t-if="(record.project_id.raw_value or record.project_template_id) and record.subtask_count.raw_value">
                                             <widget name="subtask_counter" class="me-1"/>
                                         </t>
                                         <field name="priority" class="pt-1" widget="priority"/>
@@ -1295,6 +1301,40 @@
             <field name="sequence" eval="70"/>
             <field name="view_mode">graph</field>
             <field name="view_id" ref="project_task_graph_view_project_milestone"/>
+        </record>
+
+        <record id="project_task_templates_kanban" model="ir.ui.view">
+            <field name="name">project.task.templates.list</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="view_task_kanban"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <kanban position="attributes">
+                    <attribute name="default_group_by">project_template_id</attribute>
+                </kanban>
+                <xpath expr="//templates//field[@name='partner_id']" position="replace"/>
+                <xpath expr="//templates//field[@name='project_id']" position="replace">
+                    <field name="project_template_id" options="{'no_open': True}"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_task_template_search_form" model="ir.ui.view">
+            <field name="name">project.task.search.form</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="view_task_search_form"></field>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <filter name="private_tasks" position="replace"/>
+                <filter name="closed_on" position="replace"/>
+                <filter name="customer" position="replace"/>
+                <filter name="unassigned" position="after">
+                    <filter name="task_templates" string="Task Templates" domain="[('project_template_id', '=', False)]" invisible="1"/>
+                </filter>
+                <field name="user_ids" position="after">
+                   <field name="role_ids"/>
+                </field>
+            </field>
         </record>
 
 </odoo>

--- a/addons/project/wizard/project_template_create_wizard.py
+++ b/addons/project/wizard/project_template_create_wizard.py
@@ -7,7 +7,7 @@ class ProjectTemplateCreateWizard(models.TransientModel):
 
     def _default_role_to_users_ids(self):
         res = []
-        template = self.env['project.project'].browse(self.env.context.get('template_id'))
+        template = self.env['project.project.template'].browse(self.env.context.get('template_id'))
         if template:
             res = [Command.create({'role_id': role.id}) for role in template.task_template_ids.role_ids]
         return res
@@ -17,8 +17,8 @@ class ProjectTemplateCreateWizard(models.TransientModel):
     date = fields.Date(string='Expiration Date')
     alias_name = fields.Char(string="Alias Name")
     alias_domain_id = fields.Many2one("mail.alias.domain", string="Alias Domain")
-    template_id = fields.Many2one("project.project", default=lambda self: self.env.context.get('template_id'))
     template_has_dates = fields.Boolean(compute="_compute_template_has_dates")
+    template_id = fields.Many2one("project.project.template", default=lambda self: self.env.context.get('template_id'))
     role_to_users_ids = fields.One2many('project.template.role.to.users.map', 'wizard_id', default=_default_role_to_users_ids)
 
     @api.depends("template_id")

--- a/addons/project_mrp/models/mrp_bom.py
+++ b/addons/project_mrp/models/mrp_bom.py
@@ -6,4 +6,4 @@ from odoo import fields, models
 class MrpBom(models.Model):
     _inherit = 'mrp.bom'
 
-    project_id = fields.Many2one('project.project', domain=[('is_template', '=', False)])
+    project_id = fields.Many2one('project.project')

--- a/addons/project_mrp/models/mrp_production.py
+++ b/addons/project_mrp/models/mrp_production.py
@@ -6,7 +6,7 @@ from odoo import api, fields, models
 class MrpProduction(models.Model):
     _inherit = 'mrp.production'
 
-    project_id = fields.Many2one('project.project', compute='_compute_project_id', domain=[('is_template', '=', False)], readonly=False, store=True)
+    project_id = fields.Many2one('project.project', compute='_compute_project_id', readonly=False, store=True)
 
     @api.depends('bom_id')
     def _compute_project_id(self):

--- a/addons/project_purchase/models/purchase_order.py
+++ b/addons/project_purchase/models/purchase_order.py
@@ -6,4 +6,4 @@ from odoo import fields, models
 class PurchaseOrder(models.Model):
     _inherit = 'purchase.order'
 
-    project_id = fields.Many2one('project.project', domain=[('is_template', '=', False)])
+    project_id = fields.Many2one('project.project')

--- a/addons/project_stock/models/stock_picking.py
+++ b/addons/project_stock/models/stock_picking.py
@@ -6,4 +6,4 @@ from odoo import fields, models
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
-    project_id = fields.Many2one('project.project', domain=[('is_template', '=', False)])
+    project_id = fields.Many2one('project.project')

--- a/addons/project_timesheet_holidays/models/res_config_settings.py
+++ b/addons/project_timesheet_holidays/models/res_config_settings.py
@@ -9,7 +9,7 @@ class ResConfigSettings(models.TransientModel):
 
     internal_project_id = fields.Many2one(
         related='company_id.internal_project_id', required=True, string="Internal Project",
-        domain="[('company_id', '=', company_id), ('is_template', '=', False)]", readonly=False,
+        domain="[('company_id', '=', company_id)]", readonly=False,
         help="The default project used when automatically generating timesheets via time off requests."
              " You can specify another project on each time off type individually.")
     leave_timesheet_task_id = fields.Many2one(

--- a/addons/sale_project/__manifest__.py
+++ b/addons/sale_project/__manifest__.py
@@ -21,6 +21,7 @@ This module allows to generate a project/task from sales orders.
         'views/sale_project_portal_templates.xml',
         'views/project_update_template.xml',
         'views/project_sharing_views.xml',
+        'views/project_project_template_views.xml',
         'views/project_views.xml',
         'data/sale_project_data.xml',
         'wizard/project_template_create_wizard.xml',

--- a/addons/sale_project/data/sale_project_demo.xml
+++ b/addons/sale_project/data/sale_project_demo.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <!-- Project Template -->
-        <record id="so_template_project" model="project.project">
+        <record id="so_template_project" model="project.project.template">
             <field name="name">Sales Order</field>
             <field name="active">False</field>
             <field name="type_ids" eval="[Command.link(ref('project.project_stage_0')), Command.link(ref('project.project_stage_1')), Command.link(ref('project.project_stage_2'))]"/>

--- a/addons/sale_project/models/__init__.py
+++ b/addons/sale_project/models/__init__.py
@@ -4,6 +4,7 @@ from . import product_product
 from . import product_template
 from . import project_milestone
 from . import project_project
+from . import project_project_template
 from . import project_task_recurrence
 from . import project_task
 from . import project_update

--- a/addons/sale_project/models/product_template.py
+++ b/addons/sale_project/models/product_template.py
@@ -31,11 +31,10 @@ class ProductTemplate(models.Model):
         },
     )
     project_id = fields.Many2one(
-        'project.project', 'Project', company_dependent=True, copy=True, domain='[("is_template", "=", False)]'
+        'project.project', 'Project', company_dependent=True, copy=True,
     )
     project_template_id = fields.Many2one(
-        'project.project', 'Project Template', company_dependent=True, copy=True,
-        domain='[("is_template", "=", True)]',
+        'project.project.template', 'Project Template', company_dependent=True, copy=True,
     )
     task_template_id = fields.Many2one('project.task.template', 'Task Template',
         domain="[('project_id', '=', project_id)]",

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -24,7 +24,6 @@ class ProjectProject(models.Model):
         ])
         return domain
 
-    allow_billable = fields.Boolean("Billable")
     sale_line_id = fields.Many2one(
         'sale.order.line', 'Sales Order Item', copy=False,
         compute="_compute_sale_line_id", store=True, readonly=False, index='btree_not_null',
@@ -900,27 +899,3 @@ class ProjectProject(models.Model):
     def _fetch_products_linked_to_template(self, limit=None):
         self.ensure_one()
         return self.env['product.template'].search([('project_template_id', '=', self.id)], limit=limit)
-
-    def template_to_project_confirmation_callback(self, callbacks):
-        super().template_to_project_confirmation_callback(callbacks)
-        if callbacks.get('unlink_template_products'):
-            self._fetch_products_linked_to_template().project_template_id = False
-
-    def _get_template_to_project_confirmation_callbacks(self):
-        callbacks = super()._get_template_to_project_confirmation_callbacks()
-        if self._fetch_products_linked_to_template(limit=1):
-            callbacks['unlink_template_products'] = True
-        return callbacks
-
-    def _get_template_to_project_warnings(self):
-        self.ensure_one()
-        res = super()._get_template_to_project_warnings()
-        if self.is_template and self._fetch_products_linked_to_template(limit=1):
-            res.append(self.env._('Converting this template to a regular project will unlink it from its associated products.'))
-        return res
-
-    def _get_template_default_context_whitelist(self):
-        return [
-            *super()._get_template_default_context_whitelist(),
-            'allow_billable',
-        ]

--- a/addons/sale_project/models/project_project_template.py
+++ b/addons/sale_project/models/project_project_template.py
@@ -1,0 +1,7 @@
+from odoo import models, fields
+
+
+class ProjectProjectTemplate(models.Model):
+    _inherit = "project.project.template"
+
+    allow_billable = fields.Boolean("Billable")

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -194,10 +194,7 @@ class SaleOrderLine(models.Model):
         project_template = self.product_id.project_template_id
         if project_template:
             values['name'] = "%s - %s" % (values['name'], project_template.name)
-            if project_template.is_template:
-                project = project_template.action_create_from_template(values)
-            else:
-                project = project_template.copy(values)
+            project = project_template.action_create_from_template(values)
             project.tasks.write({
                 'sale_line_id': self.id,
                 'partner_id': self.order_id.partner_id.id,

--- a/addons/sale_project/tests/common.py
+++ b/addons/sale_project/tests/common.py
@@ -30,13 +30,13 @@ class TestSaleProjectCommon(TestSaleCommon):
             'account_id': cls.analytic_account_sale.id,
             'allow_billable': True,
         })
-        cls.project_template = Project.create({
+        cls.project_template = cls.env['project.project.template'].create({
             'name': 'Project TEMPLATE for services',
         })
         cls.project_template_state = cls.env['project.task.type'].create({
             'name': 'Only stage in project template',
             'sequence': 1,
-            'project_ids': [(4, cls.project_template.id)]
+            'project_template_ids': [(4, cls.project_template.id)]
         })
 
         # -- manual (delivered, manual)

--- a/addons/sale_project/tests/test_child_tasks.py
+++ b/addons/sale_project/tests/test_child_tasks.py
@@ -263,9 +263,9 @@ class TestNestedTaskUpdate(TransactionCase):
             check that the copied task and subtask are correctly assigned to the copied
             project rather than its template.
         """
-        project_tempalte = self.env['project.project'].create({'name': 'Super Project'})
-        parent = self.env['project.task'].create({'name': 'parent task', 'project_id': project_tempalte.id})
-        child = self.env['project.task'].create({'name': 'child task', 'parent_id': parent.id, 'project_id': project_tempalte.id})
+        project_tempalte = self.env['project.project.template'].create({'name': 'Super Project'})
+        parent = self.env['project.task.template'].create({'name': 'parent task', 'project_template_id': project_tempalte.id})
+        child = self.env['project.task.template'].create({'name': 'child task', 'parent_id': parent.id, 'project_template_id': project_tempalte.id})
         super_product = self.env['product.product'].create({
             'name': 'Super product',
             'type': 'service',
@@ -284,8 +284,7 @@ class TestNestedTaskUpdate(TransactionCase):
             ]
         })
         sale_order.action_confirm()
-        self.assertEqual(project_tempalte.tasks, parent | child)
+        self.assertEqual(project_tempalte.task_template_ids, parent | child)
         super_project = sale_order.order_line.project_id
-        self.assertFalse(super_project.tasks & project_tempalte.tasks)
         self.assertEqual(len(super_project.tasks), 2)
         self.assertEqual(super_project.tasks.parent_id, super_project.tasks.child_ids.parent_id)

--- a/addons/sale_project/tests/test_so_line_milestones.py
+++ b/addons/sale_project/tests/test_so_line_milestones.py
@@ -214,11 +214,11 @@ class TestSoLineMilestones(TestSaleCommon):
         If a milestone product has a project template with configured milestones, use those instead of creating
         a new milestone and set a quantity equal to the quantity of the SOL divided by the number of milestones.
         """
-        project_template = self.env['project.project'].create({
+        project_template = self.env['project.project.template'].create({
             'name': 'Project Template',
         })
-        self.env['project.milestone'].create([{
-            'project_id': project_template.id,
+        self.env['project.milestone'].sudo().create([{
+            'project_template_id': project_template.id,
             'name': str(i),
         } for i in range(4)])
         self.product_delivery_milestones1.project_template_id = project_template.id
@@ -242,11 +242,11 @@ class TestSoLineMilestones(TestSaleCommon):
         If multiple products use the same project template, which has configured milestones, use the first product
         on those milestones, but generate the other default milestones as normal
         """
-        project_template = self.env['project.project'].create({
+        project_template = self.env['project.project.template'].create({
             'name': 'Project Template',
         })
-        self.env['project.milestone'].create([{
-            'project_id': project_template.id,
+        self.env['project.milestone'].sudo().create([{
+            'project_template_id': project_template.id,
             'name': str(i),
         } for i in range(4)])
         products = self.product_delivery_milestones1 | self.product_delivery_milestones2

--- a/addons/sale_project/views/project_project_template_views.xml
+++ b/addons/sale_project/views/project_project_template_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="project_template_view_form_inherit" model="ir.ui.view">
+        <field name="name">project.project.template.view.inherit</field>
+        <field name="model">project.project.template</field>
+        <field name="inherit_id" ref="project.project_template_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_time_managment']" position="after">
+                 <group name="group_sales_invoicing" string="Sales &amp; Invoicing" col="1" class="row mt16 o_settings_container col-lg-6">
+                    <div>
+                        <setting class="col-lg-12" help="Invoice your time and material to customers" id="allow_billable_container">
+                            <field name="allow_billable"/>
+                        </setting>
+                    </div>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -39,7 +39,7 @@
                 <field name="allow_billable" column_invisible="True"/>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
-                <attribute name="invisible">not allow_billable or is_template</attribute>
+                <attribute name="invisible">not allow_billable</attribute>
             </xpath>
         </field>
     </record>
@@ -53,7 +53,7 @@
                 <field name="display_sales_stat_buttons" invisible="1"/>
                 <field name="allow_billable" invisible="1" />
                 <field name="privacy_visibility" invisible="1" />
-                <button class="oe_stat_button" type="object" name="action_customer_preview" icon="fa-globe icon" invisible="not partner_id or not allow_billable or privacy_visibility not in ['invited_users', 'portal'] or is_template">
+                <button class="oe_stat_button" type="object" name="action_customer_preview" icon="fa-globe icon" invisible="not partner_id or not allow_billable or privacy_visibility not in ['invited_users', 'portal']">
                     <div class="o_field_widget o_stat_info">
                         <span class="o_stat_text">Preview</span>
                     </div>
@@ -63,7 +63,7 @@
                     type="object"
                     name="action_view_sos"
                     icon="fa-dollar"
-                    invisible="not display_sales_stat_buttons or sale_order_count == 0 or is_template"
+                    invisible="not display_sales_stat_buttons or sale_order_count == 0"
                     groups="sales_team.group_sale_salesman_all_leads"
                     context="{
                         'create_for_project_id': id,
@@ -84,7 +84,7 @@
                     type="object"
                     name="action_view_sos"
                     icon="fa-dollar"
-                    invisible="not display_sales_stat_buttons or sale_order_count != 0 or is_template"
+                    invisible="not display_sales_stat_buttons or sale_order_count != 0 "
                     groups="sales_team.group_sale_salesman_all_leads"
                     context="{
                         'create_for_project_id': id,
@@ -106,7 +106,7 @@
                 <field name="has_any_so_with_nothing_to_invoice" invisible="1"/>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
-                <attribute name="invisible">not allow_billable or is_template</attribute>
+                <attribute name="invisible">not allow_billable</attribute>
             </xpath>
             <xpath expr="//group[@name='group_time_managment']" position="after">
                  <group name="group_sales_invoicing" string="Sales &amp; Invoicing" col="1" class="row mt16 o_settings_container col-lg-6">
@@ -118,11 +118,11 @@
                 </group>
             </xpath>
             <xpath expr="//page[@name='settings']//field[@name='privacy_visibility']" position="after">
-                <field name="reinvoiced_sale_order_id" invisible="not allow_billable or not partner_id or is_template"  context="{'default_partner_id': partner_id}"/>
-                <label for="sale_line_id" invisible="not allow_billable or not partner_id or is_template"/>
+                <field name="reinvoiced_sale_order_id" invisible="not allow_billable or not partner_id"  context="{'default_partner_id': partner_id}"/>
+                <label for="sale_line_id" invisible="not allow_billable or not partner_id"/>
                 <div 
                     class="o_row" 
-                    invisible="not allow_billable or not partner_id or is_template">
+                    invisible="not allow_billable or not partner_id">
                     <field name="sale_line_id"
                         groups="!sales_team.group_sale_salesman"
                         options="{'no_create': True, 'no_edit': True, 'delete': False, 'no_open': True}"/>

--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -98,13 +98,4 @@
     <record id="project.open_view_project_all_group_stage" model="ir.actions.act_window">
         <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True}</field>
     </record>
-
-    <record id="project_templates_view_list" model="ir.ui.view">
-        <field name="name">project.project.template.list</field>
-        <field name="model">project.project</field>
-        <field name="inherit_id" ref="project.project_templates_view_list"/>
-        <field name="arch" type="xml">
-            <field name="sale_line_id" position="replace"/>
-        </field>
-    </record>
 </odoo>

--- a/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
+++ b/addons/sale_project_stock/tests/test_sale_project_stock_profitability.py
@@ -12,9 +12,8 @@ class TestSaleProjectStockProfitability(TestProjectProfitabilityCommon, Valuatio
     def setUpClass(cls):
         super().setUpClass()
 
-        project_template = cls.env['project.project'].create({
+        project_template = cls.env['project.project.template'].create({
             'name': 'sale_project_stock project template',
-            'account_id': cls.analytic_account.id,
         })
         cls.cogs_account = cls.env['account.account'].search([
             ('name', '=', 'Cost of Goods Sold'),

--- a/addons/sale_timesheet/models/__init__.py
+++ b/addons/sale_timesheet/models/__init__.py
@@ -7,6 +7,7 @@ from . import hr_employee
 from . import hr_timesheet
 from . import product_product
 from . import product_template
+from . import project_project_template
 from . import project_project
 from . import project_sale_line_employee_map
 from . import project_task

--- a/addons/sale_timesheet/models/product_template.py
+++ b/addons/sale_timesheet/models/product_template.py
@@ -18,8 +18,8 @@ class ProductTemplate(models.Model):
         ('timesheet', 'Timesheets on project (one fare per SO/Project)'),
     ], ondelete={'timesheet': 'set manual'})
     # override domain
-    project_id = fields.Many2one(domain="['|', ('company_id', '=', False), '&', ('company_id', '=?', company_id), ('company_id', '=', current_company_id), ('allow_billable', '=', True), ('pricing_type', '=', 'task_rate'), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet', True]), ('is_template', '=', False)]")
-    project_template_id = fields.Many2one(domain="['|', ('company_id', '=', False), '&', ('company_id', '=?', company_id), ('company_id', '=', current_company_id), ('allow_billable', '=', True), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet', True]), ('is_template', '=', True)]")
+    project_id = fields.Many2one(domain="['|', ('company_id', '=', False), '&', ('company_id', '=?', company_id), ('company_id', '=', current_company_id), ('allow_billable', '=', True), ('pricing_type', '=', 'task_rate'), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet', True])]")
+    project_template_id = fields.Many2one(domain="['|', ('company_id', '=', False), '&', ('company_id', '=?', company_id), ('company_id', '=', current_company_id), ('allow_billable', '=', True), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet', True])]")
     service_upsell_threshold = fields.Float('Threshold', default=1, help="Percentage of time delivered compared to the prepaid amount that must be reached for the upselling opportunity activity to be triggered.")
     service_upsell_threshold_ratio = fields.Char(compute='_compute_service_upsell_threshold_ratio', export_string_translation=False)
 

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -58,17 +58,6 @@ class ProjectProject(models.Model):
     partner_id = fields.Many2one(
         compute='_compute_partner_id', store=True, readonly=False)
     allocated_hours = fields.Float()
-    billing_type = fields.Selection(
-        compute="_compute_billing_type",
-        selection=[
-            ('not_billable', 'not billable'),
-            ('manually', 'billed manually'),
-        ],
-        default='not_billable',
-        required=True,
-        readonly=False,
-        store=True,
-    )
 
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):
@@ -167,10 +156,6 @@ class ProjectProject(models.Model):
         non_billable_projects = self - billable_projects
         non_billable_projects.sale_order_line_count = 0
         non_billable_projects.sale_order_count = 0
-
-    @api.depends('allow_billable', 'allow_timesheets')
-    def _compute_billing_type(self):
-        self.filtered(lambda project: (not project.allow_billable or not project.allow_timesheets) and project.billing_type == 'manually').billing_type = 'not_billable'
 
     @api.constrains('sale_line_id')
     def _check_sale_line_type(self):
@@ -525,8 +510,3 @@ class ProjectProject(models.Model):
             res.append(self.env._("This project is current linked to timesheet."))
         return res
 
-    def _get_template_default_context_whitelist(self):
-        return [
-            *super()._get_template_default_context_whitelist(),
-            "allow_timesheets",
-        ]

--- a/addons/sale_timesheet/models/project_project_template.py
+++ b/addons/sale_timesheet/models/project_project_template.py
@@ -1,0 +1,23 @@
+
+from odoo import models, fields, api
+
+
+class ProjectProjectTemplate(models.Model):
+    _inherit = "project.project.template"
+
+    allow_billable = fields.Boolean("Billable")
+    billing_type = fields.Selection(
+        compute="_compute_billing_type",
+        selection=[
+            ('not_billable', 'not billable'),
+            ('manually', 'billed manually'),
+        ],
+        default='not_billable',
+        required=True,
+        readonly=False,
+        store=True,
+    )
+
+    @api.depends('allow_billable', 'allow_timesheets')
+    def _compute_billing_type(self):
+        self.filtered(lambda project: (not project.allow_billable or not project.allow_timesheets) and project.billing_type == 'manually').billing_type = 'not_billable'

--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -19,7 +19,7 @@ class ProjectSaleLineEmployeeMap(models.Model):
         ])
         return domain
 
-    project_id = fields.Many2one('project.project', "Project", domain=[('is_template', '=', False)], required=True, index=True)
+    project_id = fields.Many2one('project.project', "Project", required=True, index=True)
     employee_id = fields.Many2one('hr.employee', "Employee", required=True, domain="[('id', 'not in', existing_employee_ids)]")
     existing_employee_ids = fields.Many2many('hr.employee', compute="_compute_existing_employee_ids", export_string_translation=False, compute_sudo=True)
     sale_line_id = fields.Many2one(

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -260,19 +260,21 @@ class TestSaleService(TestCommonSaleTimesheet):
                 Line 5 : Service 5 create project with Template B ===> project created with template B
         """
         # second project template and its associated product
-        project_template2 = self.env['project.project'].create({
+        project_template2 = self.env['project.project.template'].create({
             'name': 'Second Project TEMPLATE for services',
             'allow_timesheets': True,
             'active': False,  # this template is archived
         })
-        Stage = self.env['project.task.type'].with_context(default_project_id=project_template2.id)
+        Stage = self.env['project.task.type']
         stage1_tmpl2 = Stage.create({
             'name': 'Stage 1',
-            'sequence': 1
+            'sequence': 1,
+            'project_template_ids': [(4, project_template2.id)],
         })
         stage2_tmpl2 = Stage.create({
             'name': 'Stage 2',
-            'sequence': 2
+            'sequence': 2,
+            'project_template_ids': [(4, project_template2.id)],
         })
         product_deli_ts_tmpl = self.env['product.product'].create({
             'name': "Service delivered, create project only based on template B",

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -548,12 +548,15 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
     def test_transfert_project(self):
         """ Transfert task with timesheet to another project. """
+        project = self.env['project.project'].create({
+            'name': 'Project',
+        })
         self.env.user.employee_id = self.env['hr.employee'].create({'user_id': self.env.uid})
         Timesheet = self.env['account.analytic.line']
         Task = self.env['project.task']
         today = Date.context_today(self.env.user)
 
-        task = Task.with_context(default_project_id=self.project_template.id).create({
+        task = Task.with_context(default_project_id=project.id).create({
             'name': 'first task',
             'partner_id': self.partner_b.id,
             'allocated_hours': 10,
@@ -561,14 +564,14 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         })
 
         Timesheet.create({
-            'project_id': self.project_template.id,
+            'project_id': project.id,
             'task_id': task.id,
             'name': 'my first timesheet',
             'unit_amount': 4,
         })
 
         timesheet_count1 = Timesheet.search_count([('project_id', '=', self.project_global.id)])
-        timesheet_count2 = Timesheet.search_count([('project_id', '=', self.project_template.id)])
+        timesheet_count2 = Timesheet.search_count([('project_id', '=', project.id)])
         self.assertEqual(timesheet_count1, 0, "No timesheet in project_global")
         self.assertEqual(timesheet_count2, 1, "One timesheet in project_template")
         self.assertEqual(len(task.timesheet_ids), 1, "The timesheet should be linked to task")
@@ -609,11 +612,11 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
         # change project of task, only the timesheet not billed gets its project changed
         task.write({
-            'project_id': self.project_template.id
+            'project_id': project.id
         })
 
         timesheet_count1 = Timesheet.search_count([('project_id', '=', self.project_global.id)])
-        timesheet_count2 = Timesheet.search_count([('project_id', '=', self.project_template.id)])
+        timesheet_count2 = Timesheet.search_count([('project_id', '=', project.id)])
         self.assertEqual(timesheet_count1, 1, "One timesheet in project_global")
         self.assertEqual(timesheet_count2, 1, "One timesheet in project_template")
         self.assertEqual(len(task.timesheet_ids), 2, "The 2 timesheets still should be linked to task")
@@ -926,7 +929,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             'partner_shipping_id': self.partner_a.id,
         })
 
-        project_template_1, project_template_2 = self.env['project.project'].create([
+        project_template_1, project_template_2 = self.env['project.project.template'].create([
             {'name': 'Template 1'},
             {'name': 'Template 1'},
         ])
@@ -1017,7 +1020,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
     def test_allocated_hours_copy(self):
         """ This test ensures that the generated project's allocated_hours field is copied from the project template when it is set."""
-        project_template = self.env['project.project'].create({
+        project_template = self.env['project.project.template'].create({
             'name': 'Template',
             'allocated_hours': 65,
         })

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <record id="project_project_template_view_form" model="ir.ui.view">
+        <field name="name">project.project.template.form.inherit</field>
+        <field name="model">project.project.template</field>
+        <field name="inherit_id" ref="sale_project.project_template_view_form_inherit"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='settings']//field[@name='allow_billable']" position="after">
+                <div invisible="not allow_billable or not allow_timesheets" class="text-muted">
+                    Timesheets without a sales order item are reported as
+                    <field name="billing_type" nolabel="1" class="w-auto"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
 
     <record id="project_project_view_form" model="ir.ui.view">
         <field name="name">project.project.form.inherit</field>
@@ -13,7 +26,7 @@
                 <attribute name="context">{'create_for_project_id': id, 'default_project_id': id, 'default_partner_id': partner_id}</attribute>
             </xpath>
             <xpath expr="//page[@name='settings']" position="after">
-                <page name="billing_employee_rate" string="Invoicing" invisible="not allow_billable or not partner_id or is_template">
+                <page name="billing_employee_rate" string="Invoicing" invisible="not allow_billable or not partner_id">
                     <field name="sale_line_employee_ids" mode="list,kanban" context="{'default_sale_line_id': sale_line_id}">
                         <list editable="bottom">
                             <field name="company_id" column_invisible="True"/>

--- a/addons/spreadsheet_dashboard_hr_timesheet/data/files/tasks_dashboard.json
+++ b/addons/spreadsheet_dashboard_hr_timesheet/data/files/tasks_dashboard.json
@@ -829,7 +829,6 @@
       "type": "relation",
       "label": "Project",
       "modelName": "project.project",
-      "domainOfAllowedValues": "[['is_template', '=', False]]",
       "defaultValueDisplayNames": []
     },
     {

--- a/addons/website_project/static/src/js/website_project_editor.js
+++ b/addons/website_project/static/src/js/website_project_editor.js
@@ -46,7 +46,6 @@ registry.category("website.form_editor_actions").add('create_task', {
         required: true,
         relation: 'project.project',
         string: _t('Project'),
-        domain: [["is_template", "=", false]],
         createAction: 'project.open_view_project_all',
     }],
     successPage: '/your-task-has-been-submitted',


### PR DESCRIPTION
_*= hr_timesheet, project_mrp, project_purchase, project_stock, project_timesheet_holidays, sale_project, sale_project_stock, sale_timesheet, spreadsheet_dashboard_hr_timesheet, website_project

- Templates were previously stored in the same model as regular projects (project.project), distinguished by an is_template boolean field. This approach required frequent domain filtering and added unnecessary complexity to logic and views.

Overview (`project.project.template`)
Includes the following fields:
- task_ids, type_ids, task_properties_definition
- milestone_ids, milestone_count, milestone_progress
- label_tasks, tag_ids, user_id, company_id
- privacy_visibility, collaborator_ids, favorite_user_ids
- allow_task_dependencies, allow_milestones, rating_active, stage_id
- Chatter and activity tracking are removed.

Before (in project.project)
| Name        | Template | Task Count | Milestones |
|-------------|----------|------------|------------|
| Project A   | False    | 4          | 2          |
| Template: A | True     | 5          | 3          |

After
Model: project.project
| Name      | Task Count | Milestones |
|-----------|------------|------------|
| Project A | 4          | 2          |

Model: project.project.template
| Name        | Task Count | Milestones |
|-------------|------------|------------|
| Template: A | 5          | 3          |


- Provides a clean separation of templates from regular projects without relying on `is_template` filters.

task-4919975


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
