### PR TITLE
[FIX] stock_account: remove warning

### DIFF
--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -82,7 +82,7 @@ class StockLot(models.Model):
 
         :param new_price: new standard price
         """
-        if self.product_id.filtered(lambda p: p.valuation == 'real_time') and not self.env['stock.valuation.layer'].check_access_rights('read', raise_exception=False):
+        if self.product_id.filtered(lambda p: p.valuation == 'real_time') and not self.env['stock.valuation.layer'].has_access('read'):
             raise UserError(_("You cannot update the cost of a product in automated valuation as it leads to the creation of a journal entry, for which you don't have the access rights."))
 
         svl_vals_list = []


### PR DESCRIPTION
Before this commit a deprecated method is used and create a useless warning.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
