### PR TITLE
[FIX] base: allow Markup content in server action

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -17,6 +17,7 @@ import requests
 import json
 import re
 import contextlib
+from markupsafe import Markup
 
 from pytz import timezone
 
@@ -144,6 +145,7 @@ class IrActions(models.Model):
             'b64encode': base64.b64encode,
             'b64decode': base64.b64decode,
             'Command': Command,
+            'Markup': Markup,
         }
 
     @api.model
@@ -519,6 +521,7 @@ class IrActionsServer(models.Model):
 #  - _logger: _logger.info(message): logger to emit messages in server logs
 #  - UserError: exception class for raising user-facing warning messages
 #  - Command: x2many commands namespace
+#  - Markup: wrap html content
 # To return an action, assign: action = {...}\n\n\n\n"""
 
     @api.model


### PR DESCRIPTION
Before this PR, for exemple a message post is not formated : record.message_post(body="<strong>Hello Word!</strong>")

now it is possible to use Markup in action server: record.message_post(body=Markup("<strong>Hello Word!</strong>"))

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
