### PR TITLE
[FIX] mail: prevent dropdown from closing when removing a follower in chatter

### DIFF
--- a/addons/mail/static/src/core/web/follower.xml
+++ b/addons/mail/static/src/core/web/follower.xml
@@ -11,7 +11,7 @@
                 <span class="o-mail-Follower-action btn btn-icon p-0 opacity-50 opacity-100-hover" title="Edit subscription" aria-label="Edit subscription" t-on-click="(ev) => this.onClickEdit(ev)">
                     <i class="fa fa-fw fa-pencil"/>
                 </span>
-                <span class="o-mail-Follower-action btn btn-icon p-0 opacity-50 opacity-100-hover" title="Remove this follower" aria-label="Remove this follower" t-on-click="(ev) => this.onClickRemove(ev)">
+                <span class="o-mail-Follower-action btn btn-icon p-0 opacity-50 opacity-100-hover" title="Remove this follower" aria-label="Remove this follower" t-on-click.stop="(ev) => this.onClickRemove(ev)">
                     <i class="oi fa-fw oi-close"/>
                 </span>
             </div>

--- a/addons/mail/static/src/core/web/follower_list.js
+++ b/addons/mail/static/src/core/web/follower_list.js
@@ -69,5 +69,6 @@ export class FollowerList extends Component {
             follower: this.props.thread.selfFollower,
             onFollowerChanged: () => this.props.onFollowerChanged?.(),
         });
+        this.props.dropdown.close();
     }
 }

--- a/addons/mail/static/tests/chatter/web/follow_button.test.js
+++ b/addons/mail/static/tests/chatter/web/follow_button.test.js
@@ -11,7 +11,7 @@ import { describe, test } from "@odoo/hoot";
 describe.current.tags("desktop");
 defineMailModels();
 
-test("base rendering follow and unfollow button", async () => {
+test("base rendering follow, edit subscription and unfollow button", async () => {
     const pyEnv = await startServer();
     const threadId = pyEnv["res.partner"].create({});
     await start();
@@ -23,7 +23,10 @@ test("base rendering follow and unfollow button", async () => {
     await contains(".o-mail-Followers-counter", { text: "1" });
     await contains("[title='Show Followers'] .fa-user");
     await click("[title='Show Followers']");
-    await contains("[title='Edit subscription']");
+    await contains(".o-mail-Followers-dropdown");
+    await click("[title='Edit subscription']");
+    await contains(".o-mail-Followers-dropdown", { count: 0 });
+    await click("[title='Show Followers']");
     await click(".o-dropdown-item", { text: "Unfollow" });
     await contains(".o-mail-Followers-counter", { text: "0" });
     await contains("[title='Show Followers'] .fa-user-o");

--- a/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
@@ -108,6 +108,7 @@ test("click on remove follower", async () => {
     await contains(".o-mail-Follower");
     await click("[title='Remove this follower']");
     await contains(".o-mail-Follower", { count: 0 });
+    await contains(".o-mail-Followers-dropdown");
 });
 
 test("Load 100 followers at once", async () => {


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------

Removing multiple followers from the chatter is cumbersome because the followers dropdown closes immediately after each removal.
Additionally, clicking 'Edit Subscription' next to 'Unfollow' did not close the dropdown, which was inconsistent with expected behavior.

**Current behavior before PR:**
---------------------------------

- Removing a follower from the chatter closes the followers dropdown immediately
- Clicking 'Edit Subscription' next to 'Unfollow' leaves the dropdown open

**Desired behavior after PR is merged:**
-----------------------------------------

- The followers dropdown remains open after removing a follower, allowing multiple removals without interruption
- Clicking 'Edit Subscription' next to 'Unfollow' closes the dropdown as expected

**Task:** 4943867