### PR TITLE
[FIX] point_of_sale: allow hardware proxy prints

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/pos_printer_service.js
@@ -21,6 +21,10 @@ export class PosPrinterService extends PrinterService {
         this.dialog = dialog;
         this.device = hardware_proxy.printer;
     }
+    async print() {
+        this.setPrinter(this.hardware_proxy.printer);
+        return super.print(...arguments);
+    }
     printWeb() {
         try {
             return super.printWeb(...arguments);


### PR DESCRIPTION
When the printer comes form the hardware_proxy, the receipt was not printing for a cash out.

Steps to reproduce:
-------------------
* Connect an ePos printer
* Open pos
* Create and validate a cash out

> Observation:
Notification says 'Succesfully...'
Console log says 'No printer device available...'

Why the fix:
------------
Introduced by this pr: https://github.com/odoo/odoo/pull/209274 This protection wasn't working for our usecase where the device is set after this check in this call `this.printHtml(el, options)`.

A hoot test will be added during fw-port in 18.3

opw-4841441


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
