### PR TITLE
[PERF] core: Environment kept longer

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -542,7 +542,7 @@ class MailThread(models.AbstractModel):
         :param iter fields_iter: iterable of fields names to potentially track
         """
         fnames = self._track_get_fields().intersection(fields_iter)
-        if not fnames:
+        if not self or not fnames:
             return
         self.env.cr.precommit.add(self._track_finalize)
         initial_values = self.env.cr.precommit.data.setdefault(f'mail.tracking.{self._name}', {})
@@ -563,7 +563,7 @@ class MailThread(models.AbstractModel):
 
     def _track_discard(self):
         """ Prevent any tracking of fields on ``self``. """
-        if not self._track_get_fields():
+        if not self or not self._track_get_fields():
             return
         self.env.cr.precommit.add(self._track_finalize)
         initial_values = self.env.cr.precommit.data.setdefault(f'mail.tracking.{self._name}', {})

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1141,6 +1141,7 @@ class ProjectTask(models.Model):
         # no track when the portal user create a task to avoid using during tracking
         # process since the portal does not have access to tracking models
         tasks = super(ProjectTask, self_ctx.with_context(mail_create_nosubscribe=True, mail_notrack=not self_ctx.env.su and self_ctx.env.user._is_portal())).create(vals_list)
+        tasks = tasks.with_env(self.env)  # reset the environment
         for task, computed_vals in zip(tasks.sudo(), additional_vals_list):
             if computed_vals:
                 task.write(computed_vals)

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -828,7 +828,7 @@ actual arch.
         err.context = {
             'view': self,
             'name': getattr(self, 'name', None),
-            'xmlid': self.env.context.get('install_xmlid') or self.xml_id,
+            'xmlid': self.xml_id,
             'view.model': self.model,
             'view.parent': self.inherit_id,
             'file': self.env.context.get('install_filename'),
@@ -846,7 +846,7 @@ actual arch.
         error_context = {
             'view': self,
             'name': getattr(self, 'name', None),
-            'xmlid': self.env.context.get('install_xmlid') or self.xml_id,
+            'xmlid': self.xml_id,
             'view.model': self.model,
             'view.parent': self.inherit_id,
             'file': self.env.context.get('install_filename'),

--- a/odoo/addons/base/tests/test_transactions.py
+++ b/odoo/addons/base/tests/test_transactions.py
@@ -1,4 +1,5 @@
 from odoo.tests.common import tagged, TransactionCase
+from unittest.mock import patch
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
@@ -7,9 +8,31 @@ class TestTransactionEnvs(TransactionCase):
         transaction = self.env.transaction
         starting_envs = set(transaction.envs)
         base_x = self.env['base'].with_context(test_stuff=False)
+        base_x_env_id = id(base_x.env)
         self.assertIn(base_x.env, transaction.envs)
         del base_x
+
+        base_x = self.env['base'].with_context(test_stuff=False)
+        self.assertEqual(id(base_x.env), base_x_env_id, "We should get the same environment")
+        del base_x
+
+        transaction.reset()
         self.assertEqual(set(transaction.envs), starting_envs)
+
+    def test_transaction_envs_many(self):
+        model = self.env['base']
+        counts = []
+        combinations = [(a, b) for a in range(100, 200) for b in range(200, 300)]
+        with patch.object(model.env.transaction.__class__, 'compactify_envs', side_effect=model.env.transaction.compactify_envs) as deref_func:
+            for ctx_val, uid in combinations:
+                # getting 2 environments per loop
+                model.with_user(uid).with_context(val=ctx_val)
+                env_count = sum(1 for _ in model.env.transaction.envs)
+                counts.append(env_count)
+                self.assertLess(env_count, 100, f"Make sure we never allocate too many environments at once: ...{counts[-10:]} at val={ctx_val}, uid={uid}")
+            deref_func.assert_called()
+            self.assertLess(deref_func.call_count / len(combinations), 0.1, "Cleaning too much")
+            self.assertGreater(max(counts), 30, "The test did not stress enough allocations (check key) or wrong assumptions")
 
     def do_stuff_with_env(self):
         base_test = self.env['base'].with_context(test_stuff=False)
@@ -21,12 +44,14 @@ class TestTransactionEnvs(TransactionCase):
         transaction = self.env.transaction
         starting_envs = set(transaction.envs)
         self.do_stuff_with_env()
+        transaction.reset()
         self.assertEqual(set(transaction.envs), starting_envs)
 
     def test_transation_envs_weakrefs_return(self):
         transaction = self.env.transaction
         starting_envs = set(transaction.envs)
         base_test = self.do_stuff_with_env()
+        transaction.reset()
         self.assertEqual(set(transaction.envs), starting_envs | {base_test.env})
 
     def test_transation_envs_ordered(self):
@@ -39,4 +64,5 @@ class TestTransactionEnvs(TransactionCase):
         env_items = [env.context['item'] for env in transaction.envs if env not in starting_envs]
         self.assertEqual(env_items, items)
         del envs
+        transaction.reset()
         self.assertEqual(set(transaction.envs), starting_envs)

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -424,6 +424,8 @@ class TestTranslation(TransactionCase):
         self.env['res.lang']._activate_lang('nl_NL')
         category.with_context(lang='nl_NL').name = 'Klanten'
         self.env.ref('base.lang_nl').active = False
+        self.env.flush_all()
+        self.env.transaction.reset()  # remove environments
 
         category.invalidate_recordset()
         self.assertEqual(category.with_context(lang=None).name, 'Customers')
@@ -657,6 +659,8 @@ class TestTranslationWrite(TransactionCase):
         self.env['res.lang']._activate_lang('nl_NL')
         self.category.with_context(lang='nl_NL').name = 'Reblochon nl_NL'
         self.env.ref('base.lang_nl').active = False
+        self.env.flush_all()
+        self.env.transaction.reset()  # remove environments
 
         # [inactive_lang, non_existing_lang, technical_lang, sql_injection_lang]
         langs = ['nl_NL', 'Dummy', '_en_US', "'', NOW("]

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -57,6 +57,7 @@ def load_data(env: Environment, idref: IdRef, mode: LoadMode, kind: LoadKind, pa
 
             _logger.info("loading %s/%s", package.name, filename)
             convert_file(env, package.name, filename, idref, mode, noupdate=kind == 'demo')
+            env.cr.flush()  # run precommit hooks
 
     return bool(files)
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1136,12 +1136,16 @@ class TransactionCase(BaseCase):
         self.addCleanup(_check_registry_lock)
         # restore environments after the test to avoid invoking flush() with an
         # invalid environment (inexistent user id) from another test
-        envs = self.env.transaction.envs
-        for env in list(envs):
+        for env in self.env.transaction.envs:
             self.addCleanup(env.clear)
+
         # restore the set of known environments as it was at setUp
-        self.addCleanup(envs.update, list(envs))
-        self.addCleanup(envs.clear)
+        def reset_env(transaction, envs):
+            transaction._recent_envs.clear()
+            transaction._weak_envs.clear()
+            transaction._weak_envs.extend(envs)
+
+        self.addCleanup(reset_env, self.env.transaction, list(self.env.transaction._weak_envs))
 
         self.addCleanup(self.muted_registry_logger(self.registry.clear_all_caches))
 

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -350,7 +350,6 @@ form: module.record_id""" % (xml_id,)
                 install_mode=True,
                 install_module=self.module,
                 install_filename=self.xml_filename,
-                install_xmlid=rec_id,
             )
 
         self._test_xml_id(rec_id)
@@ -458,6 +457,8 @@ form: module.record_id""" % (xml_id,)
             sequence = self.next_sequence()
             if sequence:
                 res['sequence'] = sequence
+        if 'xmlid' not in res and 'xmlid' in model._fields:
+            res['xmlid'] = xid
 
         data = dict(xml_id=xid, values=res, noupdate=self.noupdate)
         if foreign_record_to_create:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Keep environments using hard references instead of weak references so that they can be reused later.

On the performance side, lookup of an environment costs ~30% of the time it takes to look it up and create a new one. This is not a huge gain, however we keep all other lazy properties that were already computed: like the user, accessed fields, etc.

Since there is quite some code that would just create an environment for a single operation (think of `active_test=False`), it is not uncommon that there will soon be another similar operation.

In order to avoid keeping too many Environments, we add a method `_dereference_envs` which removes environments that are no longer accessible through the transaction. It is called during cleanup of the transaction or when a lot of environments exist. Most simple transactions use less than 8 environments, but can double when using multiple languages.

<details><summary>Performance</summary>
<p>

```py
env = Environment(Registry("odoo").cursor(), 1, {})
uenv = env(user=55)

%timeit env(user=1)  # no change
%timeit env(user=4)
%timeit uenv(su=True)
%timeit uenv(su=True, context={'hello': 5})
%timeit env(su=True, context={'active_test': False})

%timeit for a in "hello": env(context={'x': a})
%timeit for a in "hello world ABCDEF": env(context={'y': a})
%timeit for a in range(1000): env(user=a)

%timeit uenv(context={'active_test': False}).user
%timeit uenv(context={'active_test': False}).companies

tmp = [env(user=a) for a in range(10)]
%timeit [env(user=a) for a in range(10)]
%timeit env(user=6)
tmp = [env(user=a) for a in range(1000)]
%timeit [env(user=a) for a in range(1000)]
del tmp
```

```
OLD:

1.41 μs ± 15.5 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
2.82 μs ± 54 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.97 μs ± 75.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.92 μs ± 54.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.85 μs ± 33.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

14.3 μs ± 84.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
51.2 μs ± 359 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
2.81 ms ± 19 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

1.62 μs ± 34.1 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
1.61 μs ± 12.6 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

18.1 μs ± 180 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
1.88 μs ± 12 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
33 ms ± 125 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

NEW:

463 ns ± 11 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
442 ns ± 1.5 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
555 ns ± 2.32 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
481 ns ± 4.07 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
477 ns ± 2.57 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

3.5 μs ± 16.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
24.7 μs ± 141 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
3.68 ms ± 17.8 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

457 ns ± 5.37 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
443 ns ± 2.87 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

7.5 μs ± 114 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
424 ns ± 4.52 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
4.83 ms ± 76 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

INFO: I tried using a list or a dict for the implementation, but both are slightly slower.
</p>
</details> 

<details><summary>Environments created count</summary>
<p>
Counting how many environments and transactions (tx) are created. Before and after numbers. Tx numbers may be slightly different because another request may have happened.

Install contacts:
envs 22070 tx 1
envs 5837 tx 1

Run: open contacts, browse one by one until "Deco" and rename it
envs 7150 tx 99
envs 1372 tx 106

Install and switch to fr lang.
envs 1692 tx 40
envs 416 tx 41

Run: open contacts, browse one by one until "Deco" and rename it
envs 3711 tx 39
envs 449 tx 34

Configuration, rename any etiquette.
envs 389 tx 12
envs 65 tx 10

</p>
</details> 

We go from about 50+ environments created per transaction to 10+ for normal browsing.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
