### PR TITLE
[IMP] sale_project: exclude cancelled credit notes from project's dashboard

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -883,6 +883,7 @@ class ProjectProject(models.Model):
     def action_open_project_vendor_bills(self):
         move_lines = self.env['account.move.line'].search_fetch(
             [
+                ('parent_state', '!=', 'cancel'),
                 ('move_id.move_type', 'in', ['in_invoice', 'in_refund']),
                 ('analytic_distribution', 'in', self.account_id.ids),
             ],


### PR DESCRIPTION
**Steps to Reproduce:**
1. Sell a service that creates a project.
2. Create a purchase order and link it to the project’s analytic account.
3. Create a bill for that PO.
4. Create a credit note for the bill and cancel it.
5. Create a second credit note for the same bill.
6. Go to the project dashboard.

**Current Behavior:**
- The cost section correctly excludes cancelled credit notes.
- However, cancelled credit notes still appear in the vendor bill list view on the project dashboard, causing confusion.

**Expected Behavior:**
- Cancelled credit notes should be excluded from the vendor bill list view on the project dashboard.

task-4782222

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
