### PR TITLE
[IMP] l10n_sa_edi: separate private key for branch from parent

### DIFF
--- a/addons/l10n_sa_edi/models/res_company.py
+++ b/addons/l10n_sa_edi/models/res_company.py
@@ -44,12 +44,6 @@ class ResCompany(models.Model):
     l10n_sa_additional_identification_number = fields.Char(
         related='partner_id.l10n_sa_additional_identification_number', readonly=False)
 
-    def _get_company_root_delegated_field_names(self):
-        return super()._get_company_root_delegated_field_names() + [
-            'l10n_sa_api_mode',
-            'l10n_sa_private_key',
-        ]
-
     def write(self, vals):
         for company in self:
             if 'l10n_sa_api_mode' in vals:


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
When a branch is created for a company it inherits the `l10n_sa_private_key` and `l10n_sa_api_mode` of the parent company, which is which is incorrect and non-compliant from both an Odoo workflow and ZATCA's perspective

Current behavior before PR:
When you try to create a branch, it automatically inherits the `l10n_sa_api_mode` and `l10n_sa_private_key` of the parent company.

Desired behavior after PR is merged:
When you try to create a branch, its `l10n_sa_api_mode` and `l10n_sa_private_key` will be independent from the parent company.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
