### PR TITLE
[IMP] hr_holidays: Batch time off improvements

### DIFF
--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard_views.xml
@@ -5,9 +5,9 @@
         <field name="arch" type="xml">
             <form string="Generate time off for multiple employees">
                 <group>
-                    <field name="holiday_status_id" domain="[('requires_allocation', '=', False)]" class="w-100"/>
+                    <field name="holiday_status_id" class="w-100"/>
                     <field name="allocation_mode" string="Mode" groups="hr_holidays.group_hr_holidays_user"/>
-                    <field name="employee_ids" invisible="allocation_mode != 'employee'" required="allocation_mode == 'employee'" 
+                    <field name="employee_ids" invisible="allocation_mode != 'employee'" 
                     widget="many2many_avatar_employee" placeholder="Everyone"/>
                     <field name="company_id" invisible="allocation_mode != 'company'"/>
                     <field name="department_id" invisible="allocation_mode != 'department'" required="allocation_mode == 'department'"/>
@@ -19,6 +19,17 @@
                         options="{'end_date_field': 'date_to'}"
                         class="w-50" nolabel="1"/>
                     <field name="date_to" invisible="1" />
+                    <!-- half day or custom hours-->
+                    <label for="date_from_period" invisible="leave_type_request_unit != 'half_day'" string="Day Period"/>
+                    <div class="o_row" invisible="leave_type_request_unit != 'half_day'">
+                        <field name="date_from_period" invisible="leave_type_request_unit != 'half_day'" required="leave_type_request_unit == 'half_day'" class="o_hr_narrow_field me-2"/>
+                        <field name="date_to_period" invisible="leave_type_request_unit != 'half_day'" required="leave_type_request_unit == 'half_day'" class="o_hr_narrow_field"/>
+                    </div>
+                    <label for="hour_from" invisible="leave_type_request_unit != 'hour'" string="Hours"/>
+                    <div class="o_row" invisible="leave_type_request_unit != 'hour'">
+                        <field name="hour_from" required="leave_type_request_unit != 'hour'" widget="float_time_selection" class="o_hr_narrow_field me-2"/>
+                        <field name="hour_to" required="leave_type_request_unit != 'hour'" widget="float_time_selection" class="o_hr_narrow_field"/>
+                    </div>
                 </group>
                 <field name="name" widget="text" placeholder="e.g. Extra recuperation, Company unavailability, ..."/>
                 <footer>


### PR DESCRIPTION
purpose: adding time off types that require allocation to the group time off and allowing to retrieve all employees when no employee is selected

Current behavior:
- allowed to load all time off types in the group time off
- removed the required selection of employees to allow to select everyone
- added error messages when some employees can't be added because of not enough allocation or having mandatory days
- made the wizard preserve the behavior of the single time off request for hourly and half day time off types (without creating zero duration leaves)
- added tests to check the behavior of the wizard for leaves of different types

task-id: 4985763

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
