### PR TITLE
[FIX] hr_appraisal_skills: Fields not visible on mobile

### DIFF
--- a/addons/hr_skills/static/src/scss/hr_employee.scss
+++ b/addons/hr_skills/static/src/scss/hr_employee.scss
@@ -6,9 +6,6 @@
     &:last-child {
         padding-right: calc(var(--gutter-x) * .5)!important;
     }
-    .o_list_renderer {
-        overflow-x: hidden!important;
-    }
 }
 
 .o_hr_skill_type_form {


### PR DESCRIPTION
Horizontal scrolling has been disabled on the appraisal skills list. An unwanted side effect of that is that the justification field along with the add and remove buttons are not visible on mobile. This PR re-enables the scrolling and removes some dead css.

task-5001344

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
