### PR TITLE
[FIX] html_builder: fix click redispatch

### DIFF
--- a/addons/html_builder/static/src/core/operation.js
+++ b/addons/html_builder/static/src/core/operation.js
@@ -129,12 +129,17 @@ export class Operation {
         let removeClickListener = () => {};
         if (shouldInterceptClick) {
             const onClick = (ev) => {
-                const trueTargetEl = this.editableDocument.elementsFromPoint(
+                const trueTargetEls = this.editableDocument.elementsFromPoint(
                     ev.clientX,
                     ev.clientY
-                )[1];
+                );
                 this.next(() => {
-                    trueTargetEl.click();
+                    for (const trueTargetEl of trueTargetEls) {
+                        if (trueTargetEl.isConnected) {
+                            trueTargetEl.click();
+                            break;
+                        }
+                    }
                 });
             };
             this.editableDocument.addEventListener("click", onClick);


### PR DESCRIPTION
[1] introduced a click redispatching in case a newly dropped element is being clicked upon too early. It just forwarded the click under the loading glasspane, but this is not ok in case elements of the block get redrawn before the click happens, as they will not be inside the DOM anymore.

This commit fixes this by clicking on the topmost remaining element of the initially clicked elements.

Steps to reproduce:
- Drop a "Form Info" block
- Very quickly click on a field

=> The field was not selected.

[1]: https://github.com/odoo/odoo/commit/0884b2c716366c872a977f84f8bbdb33ce13468d

task-4367641
