### PR TITLE
[IMP] website_sale: set `shop_ppg` default value to `21`

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -314,7 +314,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         website = request.env['website'].get_current_website()
         website_domain = website.website_domain()
 
-        ppg = website.shop_ppg or 20
+        ppg = website.shop_ppg or 21
         ppr = website.shop_ppr or 4
         gap = website.shop_gap or "16px"
 

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -109,7 +109,7 @@ class Website(models.Model):
         store=True,
     )
     shop_ppg = fields.Integer(
-        string="Number of products in the grid on the shop", default=20,
+        string="Number of products in the grid on the shop", default=21,
     )
     shop_ppr = fields.Integer(string="Number of grid columns on the shop", default=3)
 


### PR DESCRIPTION
This PR sets the default value for `shop_ppg` to 21 in order to fill the whole products grid.

| Master | This PR |
|--------|--------|
| <img width="1154" height="771" alt="image" src="https://github.com/user-attachments/assets/cda263fb-4028-4c73-93b8-695ca22e44da" /> | <img width="1117" height="789" alt="image" src="https://github.com/user-attachments/assets/4e125dae-d03b-4446-8f27-8a86a8e7e71d" /> | 

Prior to the `website_sale` `/shop` redesign introduced in Commit[^1], the default number of product per row was set to `four`, which required the value of product per row to be an even number. As the linked commit changes this value to 3, we need the number of products per grid to be odd.

To do so, we simply set the `shop_ppg` default value to `21`

task-5002406
part of task-4252024

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
[^1]: a350af08b4120e88c1c4730020079a9eacb7b057
