### PR TITLE
[FIX] base: add unit test for traceback when adding tags on contact

### DIFF
--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -1056,3 +1056,13 @@ class TestPartnerRecursion(TransactionCase):
         self.p1.parent_id = self.p2
         with self.assertRaises(ValidationError):
             (self.p3|self.p2).write({'parent_id': self.p1.id})
+
+
+@tagged('res_partner')
+class TestPartnerCategory(TransactionCase):
+
+    def test_name_search(self):
+        category = self.env['res.partner.category'].create({'name': 'buggy_test'})
+        result = self.env['res.partner.category'].name_search('buggy_test')
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result, [(category.id, category.display_name)])


### PR DESCRIPTION
Add basic test case for PR  https://github.com/odoo/odoo/pull/221866 to ensure that the _search_display_name method 
on res.partner.category returns a list domain
