### PR TITLE
[IMP] point_of_sale: add cash move `type`

### DIFF
--- a/addons/point_of_sale/models/account_bank_statement.py
+++ b/addons/point_of_sale/models/account_bank_statement.py
@@ -9,3 +9,4 @@ class AccountBankStatementLine(models.Model):
     _inherit = 'account.bank.statement.line'
 
     pos_session_id = fields.Many2one('pos.session', string="Session", copy=False, index='btree_not_null')
+    cash_move_type = fields.Char(string='Cash move type')

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -747,6 +747,7 @@ class PosSession(models.Model):
                 'id': cash_move.id,
                 'date': cash_move.create_date,
                 'cashier_name': cash_move.partner_id.name,
+                'cash_move_type': cash_move.cash_move_type
             })
         return cash_in_out_list
 
@@ -1806,7 +1807,7 @@ class PosSession(models.Model):
             ))
         return True
 
-    def _prepare_account_bank_statement_line_vals(self, session, sign, amount, reason, partner_id, extras):
+    def _prepare_account_bank_statement_line_vals(self, session, sign, amount, reason, cash_type, partner_id, extras):
         return {
             'pos_session_id': session.id,
             'journal_id': session.cash_journal_id.id,
@@ -1814,16 +1815,17 @@ class PosSession(models.Model):
             'date': fields.Date.context_today(self),
             'payment_ref': '-'.join([session.name, extras['translatedType'], reason]),
             'partner_id': partner_id,
+            'cash_move_type': cash_type
         }
 
-    def try_cash_in_out(self, _type, amount, reason, partner_id, extras):
+    def try_cash_in_out(self, _type, amount, reason, cash_type, partner_id, extras):
         sign = 1 if _type == 'in' else -1
         sessions = self.filtered('cash_journal_id')
         if not sessions:
             raise UserError(_("There is no cash payment method for this PoS Session"))
 
         vals_list = [
-            self._prepare_account_bank_statement_line_vals(session, sign, amount, reason, partner_id, extras)
+            self._prepare_account_bank_statement_line_vals(session, sign, amount, reason, cash_type, partner_id, extras)
             for session in sessions
         ]
 

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup.xml
@@ -13,8 +13,11 @@
                                         <div class="cash-move-date fs-6 fw-bolder"><t t-esc="this.pos.getDate(cm.date)"></t></div>
                                         <div class="cash-move-time small text-muted"><t t-esc="this.pos.getTime(cm.date)"></t></div>
                                     </td>
-                                    <td>
+                                    <td class="align-middle">
                                         <t t-if="cm.cashier_name" t-esc="cm.cashier_name"/>
+                                    </td>
+                                    <td class="align-middle">
+                                        <div><t t-esc="cm.cash_move_type"></t></div>
                                     </td>
                                     <td class="align-middle text-end">
                                         <t t-set="status" t-value="getStatus(cm)" />

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.scss
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.scss
@@ -1,0 +1,7 @@
+.input-cash-amount .form-control-lg {
+    font-size: 0.875rem;
+    input {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.xml
@@ -2,28 +2,46 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.CashMovePopup">
-        <Dialog header="false">
-            <div class="input-amount d-flex mb-2 gap-2">
-                <div class="input-group" t-att-class="{ 'w-50' : this.ui.isSmall }">
-                    <button t-on-click="() => this.onClickButton('in')" t-attf-class="input-type btn lh-lg #{this.ui.isSmall ? 'btn-md' : 'btn-lg'} #{state.type === 'in' ? 'highlight btn-success' : 'btn-secondary' }">
-                        Cash In
-                    </button>
-                    <button t-on-click="() => this.onClickButton('out')" t-attf-class="input-type btn lh-lg #{this.ui.isSmall ? 'btn-md' : 'btn-lg'} #{state.type === 'out' ? 'red-highlight btn-danger' : 'btn-secondary' }">
-                        Cash Out
-                    </button>
-                </div>
-                <div t-attf-class="{{this.ui.isSmall ? 'mw-50 h-50' : 'w-25'}}">
+        <Dialog title.translate="Cash In / Out">
+            <div class="d-flex gap-2 mb-3">
+                <label class="form-check-label me-5">
+                    <input type="radio" class="form-check-input" value="in" t-model="state.type"/>
+                    Cash In
+                </label>
+                <label class="form-check-label me-5">
+                    <input type="radio" class="form-check-input" value="out" t-model="state.type"/>
+                    Cash Out
+                </label>
+            </div>
+            <div t-attf-class="{{ this.ui.isSmall ? 'd-flex flex-column' : 'd-flex flex-row align-items-end gap-3' }}" class="mb-3">
+                <div class="input-amount" t-attf-class="{{this.ui.isSmall ? 'w-100' : 'w-25'}}">
+                    <label class="form-label fw-bold mb-1" style="font-size: 110%">Amount</label>
                     <Input tModel="[state, 'amount']"
                         icon="{type: 'string', value: pos.currency.symbol}"
                         iconOnLeftSide="pos.currency.position === 'before'"
                         isValid.bind="env.utils.isValidFloat"
                         autofocus="true"
+                        class="'input-cash-amount'"
                         getRef="(ref) => this.inputRef = ref" />
                 </div>
-            </div> 
+
+                <div t-attf-class="{{ this.ui.isSmall ? 'w-100 mt-3' : 'w-25 mt-0' }}">
+                    <label class="form-label fw-bold mb-1" style="font-size: 110%">Type</label>
+                    <select class="form-select form-control form-control-lg select-cash-type"
+                            t-model="state.cashType">
+                        <option value=""></option>
+                        <t t-foreach="getCashTypeOptions()" t-as="option" t-key="option_index">
+                            <option t-att-value="option" t-esc="option" />
+                        </t>
+                    </select>
+                </div>
+            </div>
             <div class="form-floating">
                 <textarea class="form-control cash-reason" placeholder="Leave a reason here" name="reason" id="reason" t-model="state.reason" style="height:100px;" />
                 <label for="reason">Reason</label>
+            </div>
+            <div class="text-end mt-2 fw-bold" style="font-size: 120%">
+                <span>Current cash: <t t-esc="env.utils.formatCurrency(props.cashAmount)" /></span>
             </div>
             <t t-set-slot="footer">
                 <div class="w-100 d-flex flex-wrap justify-content-between gap-2">

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -431,9 +431,14 @@ export class PosStore extends WithLazyGetterTrap {
 
         await this.processProductAttributes();
     }
-    cashMove() {
+    async cashMove() {
         this.hardwareProxy.openCashbox(_t("Cash in / out"));
-        return makeAwaitable(this.dialog, CashMovePopup);
+        const closingData = await this.data.call("pos.session", "get_closing_control_data", [
+            [this.session.id],
+        ]);
+        return makeAwaitable(this.dialog, CashMovePopup, {
+            cashAmount: closingData.default_cash_details.amount,
+        });
     }
     async closeSession() {
         const info = await this.getClosePosInfo();

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -198,7 +198,7 @@ registry.category("web_tour.tours").add("test_cash_in_out", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             Chrome.freezeDateTime(1749965940000),
-            Chrome.doCashMove("10", "MOBT in"),
+            Chrome.doCashMove("10", "MOBT in", "in", "Cash flow adjustment"),
             Chrome.doCashMove("5", "MOBT out"),
             Chrome.clickMenuOption("Close Register"),
             Utils.selectButton("Cash In/Out"),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -31,13 +31,21 @@ export function isCashMoveButtonHidden() {
         },
     ];
 }
-export function doCashMove(amount, reason) {
+export function doCashMove(amount, reason, cashSign = "out", cashType = "") {
     return [
         ...clickMenuOption("Cash In/Out"),
         fillTextArea(".cash-reason", reason),
         {
+            trigger: `input[type="radio"][value="${cashSign}"]`,
+            run: "click",
+        },
+        {
             trigger: ".modal .input-amount input",
             run: "edit " + amount,
+        },
+        {
+            trigger: ".form-select",
+            run: "select " + cashType,
         },
         Dialog.confirm(),
     ];

--- a/addons/pos_hr/models/pos_session.py
+++ b/addons/pos_hr/models/pos_session.py
@@ -86,8 +86,8 @@ class PosSession(models.Model):
 
         return data
 
-    def _prepare_account_bank_statement_line_vals(self, session, sign, amount, reason, partner_id, extras):
-        vals = super()._prepare_account_bank_statement_line_vals(session, sign, amount, reason, partner_id, extras)
+    def _prepare_account_bank_statement_line_vals(self, session, sign, amount, reason, cash_type, partner_id, extras):
+        vals = super()._prepare_account_bank_statement_line_vals(session, sign, amount, reason, cash_type, partner_id, extras)
         if extras.get('employee_id'):
             vals['employee_id'] = extras['employee_id']
         return vals


### PR DESCRIPTION
- Add a `type` selection when doing a cash in/out in point_of_sale.
- Display current cash amount in the cash in/out popup.
- Change cash in/out selection form to use radio buttons.

task-id: 4982915




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
