### PR TITLE
[IMP] point_of_sale: replace company details with shop name on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -121,7 +121,7 @@
             <div class="d-flex gap-2 pt-3">
                 <!-- Left: Company Address -->
                 <div class="w-50 text-break text-start" style="font-size: 75%;">
-                    <div t-out="company.name"/>
+                    <div class="pos-config-name" t-out="order.config.name"/>
                     <div>
                         <t t-if="company.street" t-out="company.street"/>
                         <t t-if="company.city" t-out="', ' + company.city"/>

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -112,6 +112,7 @@ registry.category("web_tour.tours").add("ChromeTour", {
             PaymentScreen.clickInvoiceButton(),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
+            { trigger: ".receipt-screen .pos-config-name:contains(Shop)" },
 
             // Cancelling a floating order should remove it from the floating orders list.
             ReceiptScreen.clickNextOrder(),


### PR DESCRIPTION
In this commit:
------------------
- Replaced the company name and address on receipts with the corresponding
shop name to reflect the actual selling point.

task: 5000272