### PR TITLE
[FIX] point_of_sale, pos_*: Fix several issues related to self-ordering

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
@@ -372,4 +374,23 @@ export function shippingLaterHighlighted() {
         content: "Shipping later button is highlighted",
         trigger: ".button:contains('Ship Later').highlight",
     };
+}
+
+// This method is used to simulate payment with a payment terminal, before using terminal the order
+// is synced to ensure that the order is up-to-date and ready for payment.
+export function syncCurrentOrder() {
+    return [
+        {
+            content: "sync current order",
+            trigger: "body",
+            run: async () => {
+                const currentOrder = posmodel.getOrder();
+                const order = await posmodel.syncAllOrders({ orders: [currentOrder] });
+
+                if (typeof order[0].id !== "number") {
+                    throw new Error("Order ID is not a number after sync.");
+                }
+            },
+        },
+    ];
 }

--- a/addons/pos_online_payment_self_order/static/src/overrides/services/pos_store.js
+++ b/addons/pos_online_payment_self_order/static/src/overrides/services/pos_store.js
@@ -36,7 +36,7 @@ patch(PosStore.prototype, {
                 orderId,
             ]);
             const order = result["pos.order"][0];
-            this.printReceipt({ order });
+            await this.printReceipt({ order });
             await this.sendOrderInPreparation(order, { bypassPdis: true });
         } catch {
             console.info("Another instance is already printing the receipt");

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -66,6 +66,17 @@ patch(PosStore.prototype, {
 
         return order;
     },
+    async preSyncAllOrders(orders) {
+        if (this.config.module_pos_restaurant) {
+            for (const order of orders) {
+                // Avoid to block others devices on register screen when no table and name is set.
+                if (!order.table_id && !order.floating_order_name) {
+                    order.floating_order_name = order.pos_reference;
+                }
+            }
+        }
+        return super.preSyncAllOrders(...arguments);
+    },
     async setCustomerCount(o = false) {
         const currentOrder = o || this.getOrder();
         const count = await makeAwaitable(this.dialog, NumberPopup, {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -856,3 +856,42 @@ registry.category("web_tour.tours").add("test_transfering_orders", {
             TicketScreen.nbOrdersIs(1),
         ].flat(),
 });
+registry.category("web_tour.tours").add("test_direct_sales", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickNewOrder(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickDisplayedProduct("Water"),
+            ProductScreen.totalAmountIs("4.40"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.syncCurrentOrder(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.discardOrderWarningDialog(),
+
+            Chrome.clickPlanButton(),
+            FloorScreen.clickNewOrder(),
+            ProductScreen.setTab("Test"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickDisplayedProduct("Water"),
+            ProductScreen.totalAmountIs("4.40"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.syncCurrentOrder(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.discardOrderWarningDialog(),
+
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickDisplayedProduct("Water"),
+            ProductScreen.totalAmountIs("4.40"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.syncCurrentOrder(),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.discardOrderWarningDialog(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -617,3 +617,15 @@ class TestFrontend(TestFrontendCommon):
         We can now transfer order from one table to another and from floating order to another etc.
         """
         self.start_pos_tour('test_transfering_orders', login="pos_user")
+
+    def test_direct_sales(self):
+        """
+        Direct sales should not be synced without table_id or floating_order_name, if an order is
+        sync without one of them, we assign pos_reference in floating_order_name.
+        """
+        self.start_pos_tour('test_direct_sales', login="pos_user")
+        orders = self.env['pos.order'].search([], limit=3, order='id desc')
+        self.assertEqual(orders[2].floating_order_name, orders[2].pos_reference)
+        self.assertEqual(orders[1].floating_order_name, "Test")
+        self.assertEqual(orders[0].floating_order_name, False)
+        self.assertIsNotNone(orders[0].table_id)

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -54,12 +54,19 @@ class PosOrder(models.Model):
         self._send_notification(order_ids)
         return result
 
+    def action_pos_order_cancel(self):
+        orders = super().action_pos_order_cancel()
+        success_orders_ids = [o['id'] for o in orders['pos.order'] if o['state'] == 'cancel']
+        orders_ids = self.browse(success_orders_ids)
+        self._send_notification(orders_ids)
+        return orders
+
     def _send_notification(self, order_ids):
         config_ids = order_ids.config_id
         for config in config_ids:
             config.notify_synchronisation(config.current_session_id.id, self.env.context.get('login_number', 0))
             config._notify('ORDER_STATE_CHANGED', {})
-    
+
     def action_send_self_order_receipt(self, email, mail_template_id, ticket_image, basic_image):
         self.ensure_one()
         self.email = email

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -117,8 +117,8 @@ export class CartPage extends Component {
         ) {
             this.state.selectTable = true;
             return;
-        } else {
-            this.selfOrder.currentOrder.table_id = this.selfOrder.currentTable;
+        } else if (this.selfOrder.currentTable) {
+            this.selectTableDependingOnMode(this.selfOrder.currentTable);
         }
 
         this.selfOrder.rpcLoading = true;
@@ -162,9 +162,20 @@ export class CartPage extends Component {
         ]);
     }
 
+    selectTableDependingOnMode(table) {
+        if (this.selfOrder.config.self_ordering_pay_after === "each") {
+            this.selfOrder.currentOrder.floating_order_name = _t(
+                "Self-Order T %s",
+                table.table_number
+            );
+        } else {
+            this.selfOrder.currentOrder.table_id = table;
+        }
+    }
+
     selectTable(table) {
         if (table) {
-            this.selfOrder.currentOrder.table_id = table;
+            this.selectTableDependingOnMode(table);
             this.selfOrder.currentTable = table;
             this.router.addTableIdentifier(table);
             this.pay();

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -601,6 +601,7 @@ export class SelfOrder extends Reactive {
         }
 
         try {
+            const tableIdentifier = this.router.getTableIdentifier([]);
             let uuid = this.selectedOrderUuid;
             this.currentOrder.recomputeOrderData();
             const data = await rpc(
@@ -608,7 +609,7 @@ export class SelfOrder extends Reactive {
                 {
                     order: this.currentOrder.serializeForORM(),
                     access_token: this.access_token,
-                    table_identifier: this.currentOrder?.table_id?.identifier || false,
+                    table_identifier: this.currentOrder?.table_id?.identifier || tableIdentifier,
                 }
             );
             const result = this.models.connectNewData(data);

--- a/addons/pos_self_order/static/src/overrides/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_self_order/static/src/overrides/screens/ticket_screen/ticket_screen.js
@@ -1,0 +1,23 @@
+import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+
+patch(TicketScreen.prototype, {
+    getStatus(order) {
+        if (!(order.pos_reference || "").includes("Self")) {
+            return super.getStatus(order);
+        }
+
+        if (order.state === "cancel") {
+            return _t("Cancelled");
+        } else if (order.finalized) {
+            if (order.raw.account_move) {
+                return _t("Invoiced");
+            }
+
+            return _t("Paid");
+        } else {
+            return _t("Ongoing");
+        }
+    },
+});

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -354,3 +354,31 @@ registry.category("web_tour.tours").add("self_order_mobile_0_price_order", {
             Utils.clickBtn("My Order"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_order_table_assignement_each", {
+    steps: () =>
+        [
+            Utils.checkIsNoBtn("My Order"),
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Coca-Cola"),
+            Utils.clickBtn("Checkout"),
+            CartPage.checkProduct("Coca-Cola", "0.00", "1"),
+            Utils.clickBtn("Order"),
+            ...CartPage.selectTable("1"),
+            Utils.clickBtn("Ok"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_order_table_assignement_meal", {
+    steps: () =>
+        [
+            Utils.checkIsNoBtn("My Order"),
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Coca-Cola"),
+            Utils.clickBtn("Checkout"),
+            CartPage.checkProduct("Coca-Cola", "0.00", "1"),
+            Utils.clickBtn("Order"),
+            ...CartPage.selectTable("1"),
+            Utils.clickBtn("Ok"),
+        ].flat(),
+});


### PR DESCRIPTION
*: pos_restaurant, pos_online_payment_self_order, pos_self_order

When self-ordering is enabled and in pay after each mode, the table
selection was handled via table_id fields, which caused issues when a
customer had an issue with its payment and wanted to pay later. It was
blocking the table with its order, so if another customer wanted to
scan the same QR code, it would not be able to add anything to the cart.

Now in pay after each mode, the table selection is handled via
floating_order_name, which allows the order to be processed without
blocking the table. This way, the table can be reused for another
customer, and the order can be paid later.

---

Regarding direct sale in `point_of_sale`, when a customer wanted to pay
by card the order was synced with the server when the waiter clicked on
the payment method, if the direct sale had no table and no floating
order name, when synching on other devices the order was blocking them.

Now if no table and no floating order name is set, when synching the
order, the pos_reference is set to the floating_order_name, which
prevents the order from blocking other devices.

---

Regarding self order cancellation from a PoS, when the waiter was
cancelling an order it was not synced with the self-order app, which
caused the self-order app to keep the order in the cart, preventing the
customer from starting a new order.

---

Regarding self order ticket printing, when an order arrives on the PoS
to be printed, we were trying to print the preparation ticket and
the customer ticket at the same time, which caused issues with the
printing. Now we printing them one after the other.