### PR TITLE
[FIX] account: fix traceback when onboarding company not having COA

### DIFF
--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -222,6 +222,7 @@ class ResConfigSettings(models.TransientModel):
         if self.env.company == self.company_id and self.chart_template \
         and self.chart_template != self.company_id.chart_template:
             self.env['account.chart.template'].try_loading(self.chart_template, company=self.company_id)
+            self.company_id._initiate_account_onboardings()
 
     def reload_template(self):
         self.env['account.chart.template'].try_loading(self.company_id.chart_template, company=self.company_id)


### PR DESCRIPTION
For companies that didn't have COA installed, they didn't have onboarding created leading to traceback when setting up fiscal year onboarding for Tax Returns.

Steps to reproduce:
* A company installed but don't have COA.
* Install COA from settings.
* In Accounting Dashboard -> Tax Returns
* Traceback when validating the return wizard.

task-4981853




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
