### PR TITLE
[FIX] account: fix section line creation

### DIFF
--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -154,7 +154,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async addRowAfterSection(record, addSubSection) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }
@@ -170,7 +170,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async addNoteInSection(record) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }
@@ -186,7 +186,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async addRowInSection(record, addSubSection) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }
@@ -214,7 +214,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
 
     async deleteSection(record) {
         if (this.editedRecord && this.editedRecord !== record) {
-            const left = await this.props.list.leaveEditMode();
+            const left = await this.props.list.leaveEditMode({ canAbandon: false });
             if (!left) {
                 return;
             }
@@ -414,7 +414,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async moveSectionDown(record) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }
@@ -426,7 +426,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async moveSectionUp(record) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -12,7 +12,7 @@
         <xpath expr="//td[hasclass('o_list_record_remove')]" position="after">
             <td t-else="" class="o_list_section_options w-print-0 p-print-0 text-center">
                 <Dropdown position="'bottom-end'" t-if="!props.readonly">
-                    <button class="btn px-1">
+                    <button class="btn px-1 cursor-pointer">
                         <i class="fa fa-ellipsis-v"/>
                     </button>
                     <t t-set-slot="content">


### PR DESCRIPTION
With the new section widget, you are now able to create section and subsection lines. But there is an issue when you create multiple lines.

Step to reproduce:
- Create a section or a subsection line
- Create directly another section or subsection line, without adding a name on the first line
- You will have a traceback

This is because the first line is removed from the record list in the JS just before adding the new line, which lead to and undefined record.

Fix this behaviour by keeping the record in the list.

task-4966574