### PR TITLE
[FIX] website: preserve the color filter on scroll effect change

### DIFF
--- a/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option_plugin.js
@@ -4,6 +4,7 @@ import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { WebsiteBackgroundOption } from "./background_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { withSequence } from "@html_editor/utils/resource";
 class WebsiteParallaxPlugin extends Plugin {
     static id = "websiteParallaxPlugin";
     static dependencies = ["builderActions", "backgroundImageOption"];
@@ -14,6 +15,7 @@ class WebsiteParallaxPlugin extends Plugin {
         },
         on_bg_image_hide_handlers: this.onBgImageHide.bind(this),
         force_not_editable_selector: ".s_parallax_bg, section.s_parallax > .oe_structure",
+        get_target_element_providers: withSequence(1, this.getTargetElement),
     };
     setup() {
         this.backgroundOptionSelectorParams = getSelectorParams(
@@ -85,6 +87,9 @@ class WebsiteParallaxPlugin extends Plugin {
                 value: "none",
             });
         }
+    }
+    getTargetElement(editingEl) {
+        return editingEl.classList.contains("s_parallax_bg") ? editingEl.parentElement : editingEl;
     }
 }
 export class SetParallaxTypeAction extends BuilderAction {

--- a/addons/website/static/tests/builder/website_builder/background.test.js
+++ b/addons/website/static/tests/builder/website_builder/background.test.js
@@ -57,7 +57,19 @@ test("remove parallax from block containing an inner block with parallax", async
     await contains("[data-action-value='none']").click();
     expect(":iframe section#section_a > .s_parallax_bg").not.toHaveCount();
     expect(":iframe section#section_b > .s_parallax_bg").toHaveCount();
-
+});
+test("parallax scroll effect 'none' doesn't remove the color filter", async () => {
+    const backgroundImageUrl = "url('/web/image/123/transparent.png')";
+    await setupWebsiteBuilder(`
+        <section>
+            <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
+            <div class="o_we_bg_filter" style="background-color: rgba(80, 80, 80, 50);" contenteditable="false"></div>
+        </section>`);
+    await contains(":iframe section").click();
+    expect(":iframe section .o_we_bg_filter").toHaveCount(1);
+    await contains("[data-label='Scroll Effect'] button.o-dropdown").click();
+    await contains("[data-action-value='none']").click();
+    expect(":iframe section .o_we_bg_filter").toHaveCount(1);
 });
 
 async function setupWebsiteAndOpenParallaxOptions({ editingElClasses = "" } = {}) {


### PR DESCRIPTION
After this [commit], we'd have an issue when we tried to remove the parallax (set the scroll effect to none) and had a color filter. To reproduce the problem:
- Open Website and start editing;
- Drop a `cover` snippet and click on it;
- Set the scroll effect to None

=> The color filter is removed.
This commit follows the [html_builder refactoring].

[commit]: https://github.com/odoo/odoo/commit/eea7216e5e366c2
[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb