### PR TITLE
[IMP] account: avoid redundant analytic item at import

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1552,6 +1552,8 @@ class AccountMoveLine(models.Model):
 
         lines.move_id._synchronize_business_models(['line_ids'])
         lines._check_constrains_account_id_journal_id()
+        # Remove analytic lines created for draft AMLs, after analytic_distribution has been updated
+        lines.filtered(lambda l: l.parent_state == 'draft').analytic_line_ids.with_context(skip_analytic_sync=True).unlink()
         return lines
 
     def write(self, vals):
@@ -1657,6 +1659,8 @@ class AccountMoveLine(models.Model):
                                 body=msg,
                                 tracking_value_ids=tracking_value_ids
                             )
+            if not self.env.context.get('skip_analytic_sync'):
+                self.filtered(lambda l: l.parent_state == 'draft').analytic_line_ids.with_context(skip_analytic_sync=True).unlink()
 
         return result
 


### PR DESCRIPTION
When importing an account move with analytic distribution, two analytic items are created, one at the creation of the move, and another when the move is posted. This happens because, when creating the move from an import, the line values passed include Commands to create analytic_line_ids, and not analytic distributions.

Desired behavior:
Only one analytic item should be created, and only when the move is posted. When the move is created, its lines' analytic distribution should be correctly filled based on the data imported.

Solution:
This commit unlinks the Analytic Lines created at move imports (removing the analytic_line_ids from moves at create/write), after the analytic distribution is set on the corresponding move line.

task-4987799

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
