### PR TITLE
[FIX] website: fix test closing popup in builder

### DIFF
--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -47,20 +47,8 @@ describe("Popup options: popup in page before edit", () => {
                     //   modal, and verifies that it did not add mutations
                     // TODO: once the service website_edit runs during the
                     // tests, this plugin should be removed
-                    savable_mutation_record_predicates: (record) => {
-                        if (
-                            record.target.matches?.(".s_popup") &&
-                            record.attributeName === "class"
-                        ) {
-                            const oldValue = new Set(record.oldValue.split(" "));
-                            const newValue = new Set(record.target.className.split(" "));
-                            const union = oldValue.union(newValue);
-                            const intersection = oldValue.intersection(newValue);
-                            const difference = union.difference(intersection);
-                            return !(difference.size === 1 && difference.has("d-none"));
-                        }
-                        return true;
-                    },
+                    savable_mutation_record_predicates: (record) =>
+                        !(record.target.matches?.(".s_popup") && record.className === "d-none"),
                 };
             }
         );


### PR DESCRIPTION
The workaround to ignore the `d-none` mutations in test `closing s_popup with the X button updates the invisible elements panel` stopped working with the changes in the structure of the mutations passed to the resource made in a9e23b9139ad22040bd828222e10dbed570cbd34

task-4367641
