### PR TITLE
[IMP] base: remove the footer-right option from wkhtmltopdf wrapper

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -508,7 +508,6 @@ class IrActionsReport(models.Model):
             report_ref=False,
             header=None,
             footer=None,
-            footer_right=None,
             landscape=False,
             specific_paperformat_args=None,
             set_viewport_size=False):
@@ -519,7 +518,6 @@ class IrActionsReport(models.Model):
         :param report_ref: report reference that is needed to get report paperformat.
         :param str header: The html header of the report containing all headers.
         :param str footer: The html footer of the report containing all footers.
-        :param str footer_right: String syntax for the --footer-right option (e.g: '[page]/[toPage]').
         :param landscape: Force the pdf to be rendered under a landscape format.
         :param specific_paperformat_args: dict of prioritized paperformat arguments.
         :param set_viewport_size: Enable a viewport sized '1024x1280' or '1280x1024' depending of landscape arg.
@@ -580,8 +578,6 @@ class IrActionsReport(models.Model):
                     foot_file.write(footer.encode())
                 stack.callback(delete_file, foot_file_path)
                 files_command_args.extend(['--footer-html', foot_file_path])
-            elif footer_right:
-                files_command_args.extend(['--footer-right', footer_right])
 
             paths = []
             body_idx = 0


### PR DESCRIPTION
This PR removes the `footer-right` option from the wkhtmltopdf wrapper. Previously, this option enabled easy insertion of page numbers in audit report PDFs using inline markup like `[page]/[toPage]`.

While convenient, this functionality introduced a non-standard extension to the wrapper, adding unnecessary complexity. To keep the wrapper aligned with upstream behavior and ensure maintainability, we're removing this custom option.

Going forward, audit reports will use the standard `footer` option, which accepts full HTML for rendering footers - providing greater flexibility without diverging from the core tool's capabilities.

ENT: odoo/enterprise#91906
Reference: odoo/odoo@7706e8d

Task-4989809

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
