### PR TITLE
[FIX] html_builder, website: preview let o_dirty

### DIFF
--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -560,16 +560,21 @@ describe("shortcut", () => {
             content_updated_handlers: () => {
                 expect.step("contentUpdated");
             },
+            normalize_handlers: (root) => {
+                expect.step("normalize");
+                root.classList.add("test");
+            },
         };
         const { editor } = await setupEditor(`<p>[]</p>`, {
             config: { onChange, resources },
         });
-        expect.verifySteps([]);
+        expect.verifySteps(["normalize"]);
         await insertText(editor, "a");
         expect.verifySteps([
             // mutations for "a" insertion register new records for the current step
             "handleNewRecords",
             "contentUpdated",
+            "normalize",
             // mutations for the hint removal are filtered out (no registered record)
             "contentUpdated",
             "onchange",


### PR DESCRIPTION
Before this commit, in the website builder, previewing an option could
ley the o_dirty class, which caused an unaffected view to be saved.

Why:
===
When the preview is removed, normalise is called, which can add
mutations to the DOM, and handleNewRecords was called afterwards,
which caused the addition of o_dirty.

Solution:
========
We believe that o_dirty should only be added to views that have been
modified by the user and not by normalise. handleNewRecords should ignore
mutations created by normalise.

How to reproduce:
================
- Go to the website builder.
- Preview an action.
- When you unpreview, normalise should modify the DOM.

Before this commit:
    The o_dirty class is present.

After this commit:
    The o_dirty class is not present because no user modifications have taken place.

This commit will fix the same type of problem in the report editor.