### PR TITLE
[FIX] base: improve alignment for address fields in partner form

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -170,11 +170,13 @@
                             <div class="o_address_format">
                                 <field name="street" placeholder="Street..." class="o_address_street"/>
                                 <field name="street2" placeholder="Street 2..." class="o_address_street"/>
-                                <field name="city" placeholder="City" class="o_address_city"/>
-                                <field name="state_id" placeholder="State" class="o_address_state"
-                                    options="{'no_open': True, 'no_quick_create': True}"
-                                    context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
-                                <field name="zip" placeholder="ZIP" class="o_address_zip"/>
+                                <div class="d-flex gap-2 align-items-end">
+                                    <field name="city" placeholder="City" class="o_address_city"/>
+                                    <field name="state_id" placeholder="State" class="o_address_state"
+                                        options="{'no_open': True, 'no_quick_create': True}"
+                                        context="{'country_id': country_id, 'default_country_id': country_id, 'zip': zip}"/>
+                                    <field name="zip" placeholder="ZIP" class="o_address_zip"/>
+                                </div>
                                 <div name="partner_address_country" class="d-flex justify-content-between">
                                     <field name="country_id" placeholder="Country" class="o_address_country"
                                         options='{"no_open": True, "no_create": True}'/>


### PR DESCRIPTION
Task ID: 5002920

Description of the issue/feature this PR addresses: Align state, city, and zip fields horizontally on employee form 

Current behavior before PR: Not alignment in tab Employee > Work address as per fields state, city, and zip

Desired behavior after PR is merged: Fields aligned

