### PR TITLE
[FIX] hr_skills: fix crash in pivot view caused by incorrect access to group data

### DIFF
--- a/addons/hr_skills/static/src/views/pivot/skills_pivot_model.js
+++ b/addons/hr_skills/static/src/views/pivot/skills_pivot_model.js
@@ -22,7 +22,7 @@ export class SkillsPivotModel extends PivotModel {
 
         for (const [groupBy, data] of params.groupingSets.map((g, i) => [g, multiData[i]])) {
             if (groupBy.includes("department_id")) {
-                data.forEach((res) => {
+                data.subGroups.forEach((res) => {
                     res.department_id[1] = this.departmentNamesById[res.department_id[0]];
                 });
             }


### PR DESCRIPTION
#### Description of the bug
We are trying to access group data of employees' skills in pivot view by calling `forEach` on the global object instead of the nested array that contains data entries for the view.

#### Current behavior before PR
We get an `Odoo Client Error` as we are calling `forEach` on an object, not an array.

#### Desired behavior after PR is merged:
We get the pivot view of skills correctly without errors.

