### PR TITLE
[FIX] l10n_es_edi_facturae: Allow internal users to send invoices with facturae

### DIFF
--- a/addons/l10n_es_edi_facturae/models/res_company.py
+++ b/addons/l10n_es_edi_facturae/models/res_company.py
@@ -25,7 +25,7 @@ class Company(models.Model):
                         'action_text': _("View Company(s)"),
                         'action': invalid_records._get_records_action(name=_("Check Company Data")),
                     }
-        if invalid_records := self.filtered(lambda company: not company.l10n_es_edi_facturae_certificate_ids):
+        if invalid_records := self.filtered(lambda company: not company.sudo().l10n_es_edi_facturae_certificate_ids):
             errors["l10n_es_edi_company_facturae_certificate_check"] = {
                 'level': 'danger',
                 'message': _("Company must have a valid Factura-e certificate configured."),


### PR DESCRIPTION
Non-admin users were hitting an “Access Error” when sending an invoice in facturae format, the onchange reads `company.l10n_es_edi_facturae_certificate_ids`, which reads certificate.certificate records , resulting in an “Access Error” popup. This changes Wrap the certificate lookup in company.sudo().

It's handled the same in
https://github.com/odoo/odoo/blob/18.0/addons/l10n_es_edi_facturae/models/account_move.py#L140 https://github.com/odoo/odoo/blob/18.0/addons/l10n_es_edi_facturae/models/account_move.py#L770

install l10n_es_edi_facturae
Go to Contacts and create an new contact with Spain as country in the same page (creating contact page) click on Accounting scroll down and set eInvoice format as facturaE
Go to Accountant and create an invoice with that client pay the invoice
log out and log in with a user with no administration (e.g. Marc demo) try to send the create invoice

OPW:4989007



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
