### PR TITLE
[FIX] account: fix FEC imported entries not appearing in sale journal

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -1031,7 +1031,7 @@ class account_journal(models.Model):
             action['domain'] = ast.literal_eval(action['domain'] or '[]')
         if not self._context.get('action_name'):
             if self.type == 'sale':
-                action['domain'] = [(domain_type_field, 'in', ('out_invoice', 'out_refund', 'out_receipt'))]
+                action['domain'] = [(domain_type_field, 'in', ('out_invoice', 'out_refund', 'out_receipt', 'entry'))]
             elif self.type == 'purchase':
                 action['domain'] = [(domain_type_field, 'in', ('in_invoice', 'in_refund', 'in_receipt', 'entry'))]
 


### PR DESCRIPTION
**PROBLEM**
When importing a FEC files, moves are created with the `move_type` `entry`. They don't appear in the action of the journal of type `sale` when clicking on the dashboard.

**STEP TO REPRODUCE**
1. on a local database install `l10n_fr_fec_import` (you need to import a FEC file given by our client, dont do it on the runbot please !)
2. select the french demo company
3. import the FEC file (accounting/settings/import a file) (for file, see [ticket](https://www.odoo.com/odoo/project/49/tasks/4848763) )
4. goes in the dashboard, and click on the `Ventes Marchandises` journal.
5. notice the entries does not appear in the action.

**CAUSE**
When importing a FEC file, all moves are created with the `entry`. The domain for `sale` journal doesn't include the move of type `entry`.

**FIX**
Adding `entry` in the `sale` journal domain.

opw-4848763