### PR TITLE
[IMP] account: show journal field when 2+ journals are present

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -398,6 +398,7 @@ class AccountMove(models.Model):
     tax_calculation_rounding_method = fields.Selection(
         related='company_id.tax_calculation_rounding_method',
         string='Tax calculation rounding method', readonly=True)
+    show_journal = fields.Boolean(compute='_compute_show_journal')
     # === Partner fields === #
     partner_id = fields.Many2one(
         'res.partner',
@@ -1368,6 +1369,11 @@ class AccountMove(models.Model):
                         'balance': invoice.amount_total_signed,
                         'amount_currency': invoice.amount_total_in_currency_signed,
                     }
+
+    @api.depends('suitable_journal_ids')
+    def _compute_show_journal(self):
+        for move in self:
+            move.show_journal = len(move.suitable_journal_ids) > 1
 
     def _compute_payments_widget_to_reconcile_info(self):
 

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3277,6 +3277,14 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'company_id': self.company_data_2['company'].id,
         })
 
+        # Create an additional journal to ensure show_journal is True and avoid invisible journal_id constraint
+        self.env['account.journal'].create({
+            'name': 'abc',
+            'code': 'YYYYY',
+            'type': 'sale',
+            'company_id': self.company_data['company'].id,
+        })
+
         product.with_company(self.company_data['company']).write({
             'property_account_income_id': self.company_data['default_account_revenue'].id,
         })
@@ -3942,7 +3950,6 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertEqual(move.line_ids.currency_id, self.other_currency)
 
         with Form(self.env['account.move'].with_context(default_move_type='out_invoice')) as move_form:
-            move_form.journal_id = self.company_data['default_journal_sale']
             with move_form.invoice_line_ids.new() as line_form:
                 line_form.product_id = self.product_a
                 line_form.tax_ids.clear()

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -1171,12 +1171,12 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             'is_invoice_report': True,
         })
         self.company_data['default_journal_sale'].invoice_template_pdf_report_id = third_report
-        invoice2 = self.init_invoice('out_invoice', partner=self.partner_b, post=True, amounts=[1000], journal=self.company_data['default_journal_sale'])
+        invoice2 = self.init_invoice('out_invoice', partner=self.partner_b, post=True, amounts=[1000])
         wizard = self.create_send_and_print(invoice2)
         self.assertEqual(third_report, wizard.pdf_report_id)
 
         # Test with 3 reports, the second one is default for partner and the third one is default for journal
-        invoice3 = self.init_invoice('out_invoice', partner=self.partner_a, post=True, amounts=[300], journal=self.company_data['default_journal_sale'])
+        invoice3 = self.init_invoice('out_invoice', partner=self.partner_a, post=True, amounts=[300])
         wizard = self.create_send_and_print(invoice3)
         self.assertEqual(second_report, wizard.pdf_report_id)
 

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1065,13 +1065,12 @@
                                            options="{'no_quick_create':True}" readonly="state in ['cancel', 'posted']"/>
                                 </div>
                                 <field name="delivery_date" invisible="not show_delivery_date" readonly="state != 'draft'"/>
-                                <label for="journal_id" groups="account.group_account_readonly"/>
-                                <label for="currency_id" groups="!account.group_account_readonly,base.group_multi_currency"/>
+                                <label for="journal_id" invisible="not show_journal"/>
+                                <label for="currency_id" groups="base.group_multi_currency" invisible="show_journal"/>
                                 <div name="journal_div"
-                                     class="d-flex"
-                                     groups="account.group_account_readonly,base.group_multi_currency">
+                                     class="d-flex">
                                     <field name="journal_id"
-                                           groups="account.group_account_readonly"
+                                           invisible="not show_journal"
                                            options="{'no_create': True, 'no_open': True}"
                                            readonly="posted_before and name not in (False, '', '/')"/>
                                     <div name="in_and_refresh_button_div"

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -158,9 +158,10 @@ class TestManual(common.TestAr):
                 bill_form.partner_id = self.res_partner_adhoc
                 bill_form.invoice_payment_term_id = payment_term_id
                 bill_form.invoice_date = '2023-02-09'
-                bill_form.journal_id = purchase_not_pos_journal
                 bill_form.l10n_latam_document_type_id = doc_60_lp_a
             bill = bill_form.save()
+
+            self.assertEqual(bill.journal_id, purchase_not_pos_journal)
 
         # Create a new journal that is an AFIP POS
         purchase_pos_journal = self._create_journal('preprinted', data={'type': 'purchase', 'l10n_ar_is_pos': True})


### PR DESCRIPTION
Before this PR:
- The journal field was not visible to invoicing users because it was restricted to users in the `account.group_account_readonly` group only.

After this PR:
- Now the Journal field is visible to invoicing users when 2 or more journals of the same type exist even when only using `account` or `account_accountant`.
- for example,
  when more than one Sales journal exists, journal field is visible on Invoice and Credit Note; 
  when more than one Purchase    journal exists, journal field is visible on Vendor Bill and Vendor Refund.
  
Related PR: https://github.com/odoo/enterprise/pull/93906
  
Task : 4988183

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
