### PR TITLE
fix form dependency name

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -34,6 +34,7 @@ export class BuilderList extends Component {
         sortable: { optional: true },
         hiddenProperties: { type: Array, optional: true },
         records: { type: String, optional: true },
+        defaultNewValue: { type: Object, optional: true },
     };
     static defaultProps = {
         addItemTitle: _t("Add"),
@@ -42,6 +43,7 @@ export class BuilderList extends Component {
         sortable: true,
         hiddenProperties: [],
         mode: "button",
+        defaultNewValue: {},
     };
     static components = { BuilderComponent, Dropdown };
 
@@ -148,6 +150,7 @@ export class BuilderList extends Component {
 
     makeDefaultItem() {
         return {
+            ...this.props.defaultNewValue,
             ...this.props.default,
             _id: this.getNextAvailableItemId(),
         };

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -4,6 +4,7 @@ import {
     useBuilderComponent,
     useInputBuilderComponent,
 } from "@html_builder/core/utils";
+import { isSmallInteger } from "@html_builder/utils/utils";
 import { Component, onWillUpdateProps, useRef } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
@@ -183,6 +184,7 @@ export class BuilderList extends Component {
         }
         const item = items.find((item) => item._id === id);
         item[propertyName] = value;
+        item.id = isSmallInteger(value) ? parseInt(value) : value;
 
         if (commitToHistory) {
             this.commit(items);

--- a/addons/html_builder/static/src/utils/utils.js
+++ b/addons/html_builder/static/src/utils/utils.js
@@ -187,3 +187,12 @@ export function isEditable(node) {
 export function removePlugins(plugins, pluginsToRemove) {
     return plugins.filter((p) => !pluginsToRemove.includes(p.name));
 }
+
+/**
+ * Check if the given value is an integer smaller than 15 digits.
+ * @param {String} value
+ * @returns {Boolean}
+ */
+export function isSmallInteger(value) {
+    return /^-?[0-9]{1,15}$/.test(value);
+}

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -221,6 +221,7 @@
                 addItemTitle="state.valueList.addItemTitle"
                 itemShape="{ display_name: 'text', selected: state.valueList.checkType }"
                 default="{ display_name: state.valueList.defaultItemName, selected: false }"
+                defaultNewValue="{ id: state.valueList.defaultItemName }"
                 records="state.valueList.availableRecords" />
         </div>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -525,6 +525,27 @@ export class FormOptionPlugin extends Plugin {
                 field.id = targetEl.id;
             }
         }
+
+        // Synchronize the possible values with the fields whose visibility
+        // depends on the current field
+        const newValuesText = field.records.map((record) => record.id);
+        const inputEls = oldFieldEl.querySelectorAll(".s_website_form_input, option");
+        const inputName = oldFieldEl.querySelector(".s_website_form_input")?.name;
+        const formEl = oldFieldEl.closest(".s_website_form");
+        for (let i = 0; i < inputEls.length; i++) {
+            const input = inputEls[i];
+            if (newValuesText[i] && input.value && !newValuesText.includes(input.value)) {
+                for (const dependentEl of formEl.querySelectorAll(
+                    `[data-visibility-condition="${CSS.escape(
+                        input.value
+                    )}"][data-visibility-dependency="${CSS.escape(inputName)}"]`
+                )) {
+                    dependentEl.dataset.visibilityCondition = newValuesText[i];
+                }
+                break;
+            }
+        }
+
         const fieldEl = renderField(field);
         replaceFieldElement(oldFieldEl, fieldEl);
     }

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -40,6 +40,7 @@ import { renderToElement } from "@web/core/utils/render";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { FormOption } from "./form_option";
+import { isSmallInteger } from "@html_builder/utils/utils";
 
 const DEFAULT_EMAIL_TO_VALUE = "info@yourcompany.example.com";
 export class FormOptionPlugin extends Plugin {
@@ -683,7 +684,7 @@ export class FormOptionPlugin extends Plugin {
                 ? [_t("Radio"), "exclusive_boolean"]
                 : [_t("Checkbox"), "boolean"];
             const defaults = [...fieldEl.querySelectorAll("[checked], [selected]")].map((el) =>
-                /^-?[0-9]{1,15}$/.test(el.value) ? parseInt(el.value) : el.value
+                isSmallInteger(el.value) ? parseInt(el.value) : el.value
             );
             let availableRecords = undefined;
             if (!isFieldCustom(fieldEl)) {

--- a/addons/website/static/src/builder/plugins/form/utils.js
+++ b/addons/website/static/src/builder/plugins/form/utils.js
@@ -1,6 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { renderToElement } from "@web/core/utils/render";
 import { generateHTMLId } from "@html_builder/utils/utils_css";
+import { isSmallInteger } from "@html_builder/utils/utils";
 
 export const VISIBILITY_DATASET = [
     "visibilityDependency",
@@ -500,15 +501,10 @@ export function getListItems(fieldEl) {
     } else if (multipleInputsEl) {
         options = [...multipleInputsEl.querySelectorAll(".checkbox input, .radio input")];
     }
-    const isFieldElCustom = isFieldCustom(fieldEl);
     return options.map((opt) => {
         const name = selectEl ? opt : opt.nextElementSibling;
         return {
-            id: isFieldElCustom
-                ? opt.id
-                : /^-?[0-9]{1,15}$/.test(opt.value)
-                ? parseInt(opt.value)
-                : opt.value,
+            id: isSmallInteger(opt.value) ? parseInt(opt.value) : opt.value,
             display_name: name.textContent.trim(),
             selected: selectEl ? opt.selected : opt.checked,
         };

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_list.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_list.test.js
@@ -39,6 +39,7 @@ test("writes a list of numbers to a data attribute", async () => {
                 value: "35",
                 title: "a thing",
                 _id: "0",
+                id: "a thing",
             },
             ...defaultValueWithIds([1, 2]),
         ])
@@ -235,6 +236,7 @@ test("hides hiddenProperties from options", async () => {
                 c: "2",
                 d: "a thing",
                 _id: "0",
+                id: "a thing",
             },
             {
                 a: "4",

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -301,13 +301,28 @@ const formWithConditionOnChexbox = `
 </form></section>
 `;
 
-test("Correctly set field dependency name at field rename", async () => {
+const changeFieldAndCheckDependency = async (changeFieldAction) => {
     onRpc("get_authorized_fields", () => ({}));
     await setupWebsiteBuilder(formWithConditionOnChexbox);
     await contains(":iframe input[value='Option 2']").click();
-    await contains("input[data-id='1']").edit("newName");
+    await changeFieldAction();
     await contains(":iframe input[name='b']").click();
     await contains("#hidden_condition_no_text_opt:contains(Option 1)").click();
+};
+
+test("Correctly set field dependency name at field rename", async () => {
+    await changeFieldAndCheckDependency(
+        async () => await contains("input[data-id='1']").edit("newName")
+    );
     expect(".o-main-components-container  .o-dropdown-item:contains('Option 3')").toHaveCount(1);
     expect(".o-main-components-container  .o-dropdown-item:contains('newName')").toHaveCount(1);
+});
+
+test("Correctly set field dependency name at field addition", async () => {
+    await changeFieldAndCheckDependency(
+        async () => await contains("button.builder_list_add_item").click()
+    );
+    expect(".o-main-components-container  .o-dropdown-item:contains('Option 2')").toHaveCount(1);
+    expect(".o-main-components-container  .o-dropdown-item:contains('Option 3')").toHaveCount(1);
+    expect(".o-main-components-container  .o-dropdown-item:contains('Item')").toHaveCount(1);
 });

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -252,3 +252,62 @@ test("Remove visibility dependency on field unavailable (change second)", async 
     await contains("[data-label=Label] input").edit("a");
     expect(":iframe .s_website_form_field:not([data-visibility-dependency])").toHaveCount(2);
 });
+
+const formWithConditionOnChexbox = `
+<section class="s_website_form"><form data-model_name="mail.mail">
+    <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="one2many">
+        <div class="row s_col_no_resize s_col_no_bgcolor">
+            <label class="col-sm-auto s_website_form_label" style="width: 200px" for="ofwe8fyqws37">
+                <span class="s_website_form_label_content">Custom Text</span>
+            </label>
+            <div class="col-sm">
+                <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" data-name="Custom Text" data-display="horizontal">
+                    <div class="checkbox col-12 col-lg-4 col-md-6">
+                        <div class="form-check">
+                            <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws370" name="Custom Text" value="Option 1" data-fill-with="undefined">
+                            <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws370">Option 1</label>
+                        </div>
+                    </div>
+                    <div class="checkbox col-12 col-lg-4 col-md-6">
+                        <div class="form-check">
+                            <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws371" name="Custom Text" value="Option 2">
+                            <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws371">Option 2</label>
+                        </div>
+                    </div>
+                    <div class="checkbox col-12 col-lg-4 col-md-6">
+                        <div class="form-check">
+                            <input type="checkbox" class="s_website_form_input form-check-input" id="ofwe8fyqws372" name="Custom Text" value="Option 3">
+                            <label class="form-check-label s_website_form_check_label" for="ofwe8fyqws372">Option 3</label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+     <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom s_website_form_field_hidden_if d-none" data-type="char" data-visibility-dependency="Custom Text" data-visibility-condition="Option 1" data-visibility-comparator="selected">
+         <div class="row s_col_no_resize s_col_no_bgcolor">
+             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="second">
+                 <span class="s_website_form_label_content">b</span>
+             </label>
+             <div class="col-sm">
+                 <input class="form-control s_website_form_input" type="text" name="b" id="second"/>
+             </div>
+         </div>
+     </div>
+     <div class="s_website_form_submit">
+        <div class="s_website_form_label"/>
+        <a>Submit</a>
+    </div>
+</form></section>
+`;
+
+test("Correctly set field dependency name at field rename", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    await setupWebsiteBuilder(formWithConditionOnChexbox);
+    await contains(":iframe input[value='Option 2']").click();
+    await contains("input[data-id='1']").edit("newName");
+    await contains(":iframe input[name='b']").click();
+    await contains("#hidden_condition_no_text_opt:contains(Option 1)").click();
+    expect(".o-main-components-container  .o-dropdown-item:contains('Option 3')").toHaveCount(1);
+    expect(".o-main-components-container  .o-dropdown-item:contains('newName')").toHaveCount(1);
+});

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -301,13 +301,16 @@ const formWithConditionOnChexbox = `
 </form></section>
 `;
 
-const changeFieldAndCheckDependency = async (changeFieldAction) => {
+const changeFieldAndCheckDependency = async (
+    changeFieldAction,
+    fieldDependencyName = "Option 1"
+) => {
     onRpc("get_authorized_fields", () => ({}));
     await setupWebsiteBuilder(formWithConditionOnChexbox);
     await contains(":iframe input[value='Option 2']").click();
     await changeFieldAction();
     await contains(":iframe input[name='b']").click();
-    await contains("#hidden_condition_no_text_opt:contains(Option 1)").click();
+    await contains(`#hidden_condition_no_text_opt:contains(${fieldDependencyName})`).click();
 };
 
 test("Correctly set field dependency name at field rename", async () => {
@@ -325,4 +328,15 @@ test("Correctly set field dependency name at field addition", async () => {
     expect(".o-main-components-container  .o-dropdown-item:contains('Option 2')").toHaveCount(1);
     expect(".o-main-components-container  .o-dropdown-item:contains('Option 3')").toHaveCount(1);
     expect(".o-main-components-container  .o-dropdown-item:contains('Item')").toHaveCount(1);
+});
+
+test("Correctly set field dependency name at selected field rename", async () => {
+    const newName = "newName";
+    await changeFieldAndCheckDependency(
+        async () => await contains("input[data-id='0']").edit(newName),
+        newName
+    );
+    expect(".o-main-components-container  .o-dropdown-item:contains('Option 3')").toHaveCount(1);
+    expect(".o-main-components-container  .o-dropdown-item:contains('Option 2')").toHaveCount(1);
+    expect(`.o-main-components-container  .o-dropdown-item:contains('${newName}')`).toHaveCount(1);
 });


### PR DESCRIPTION
[FIX] html_builder, *: use name for multiple checkbox form field
*: website

Steps to reproduce the problem:
- Add a form snippet on the website.
- Add a "Multiple Checkboxes" field in the form and change the name of a
checkbox.
- Make the first field depend on the "Multiple Checkboxes".

-> The name of the checkboxes are not correct.

When the user changes the name of a checkbox, there is a re-redendering
of the entire field. The problem here is double:
- The template used for the re-redendering is based on the `id`
attribute given as parameter to correctly set the `value` attribute of
the `input` of the checkbox. Since the [website refactoring], the
parameter was not not correctly computed as an unexplainable
`isFieldElCustom` condition was introduced. Due to it, the `value`
attributes of all the `input` checkboxes were wrongly set.
- The system was not updating the `id` attribute with the new user
value. Due to it, the system failed at setting the correct `value`
attribute of the renamed field.

----------------------------------------------------------------------------------------------------------------------------------------------------------


[FIX] html_builder, *: update value list on multiple checkbox add option
*: website

Steps to reproduce the problem:
- Add a form snippet on the website.
- Add a "Multiple Checkboxes" field in the form and make the first field
depend on this one ("Visible only if", "Custom Text", "Is equal to",
"Option 1").
- Click on "Add new Checkbox".
- Click on the first field and open the dropdown to try to change
"Option 1" to "Item" (the new checkbox).

-> The new checkbox is not in the list.

When the user adds a new checkbox, there is a re-redendering of the
entire field. The problem is that the template used for the
re-redendering is based on the `id` attribute given as parameter to
correctly set the `value` attribute of the `input` of the checkbox. This
commit re-introduces this parameter as it was missing when adding a new
checkbox since the [website refactoring].


----------------------------------------------------------------------------------------------------------------------------------------------------------

[FIX] website: refresh visibility option names
Steps to reproduce the problem:
- Add a form field on the website
- Add a "Multiple Checkboxes" field in the form and make the first field
depend on this one ("Visible only if", "Custom Text", "Is equal to",
"Option 1").
- Select "Option 1" and change its name.
- Click on the first field.

-> The UI shows "Visible only if", "Custom Text", "Is equal to", "None".

The problem is that since the [website refactoring], the update of
dependencies done when a field was replaced was missing.

Related to task-4367641

[website refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
