### PR TITLE
[FIX] mail: prevent error when creating a channel with guest members

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -232,7 +232,7 @@ class Channel(models.Model):
                                 field_name=field_name,
                             )
                         )
-            membership_pids = [cmd[2]['partner_id'] for cmd in membership_ids_cmd if cmd[0] == 0]
+            membership_pids = [cmd[2]['partner_id'] for cmd in membership_ids_cmd if cmd[0] == 0 and 'partner_id' in cmd[2]]
 
             partner_ids_to_add = partner_ids
             # always add current user to new channel to have right values for

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -524,3 +524,15 @@ class TestChannelInternals(MailCommon):
             ],
         ):
             test_group.execute_command_help()
+
+    def test_create_channel_with_partners_and_guests(self):
+        channel = self.env['discuss.channel'].create({
+            'name': 'test channel',
+            'channel_member_ids': [
+                (0, 0, {'guest_id': self.guest.id}),
+                (0, 0, {'partner_id': self.partner_employee.id})
+            ]
+        })
+        actual_member_ids = [m.partner_id.id if m.partner_id else m.guest_id.id for m in channel.channel_member_ids]
+        expected_member_ids = [self.partner_employee.id, self.guest.id, self.env.user.partner_id.id]
+        self.assertCountEqual(actual_member_ids, expected_member_ids)


### PR DESCRIPTION
Currently, an error occurs when creating a channel that includes guest members.

Steps to Reproduce:
 - Install the `mail` module.
 - Go to `Channels > New`.
 - Fill in the `channel name` and `Under Members`, add a member with a `guest`, and `save`.

`KeyError: 'partner_id'`

This error occurs when a user creates a channel and adds a guest in the Members section. This error occurs after [this commit]( https://github.com/odoo/odoo/commit/ad612321bcafe6dfdaabf3aa37f26af364185a69), where the partner_id and guest_id fields dynamically become readonly [1], so that if only the guest is entered, the partner becomes readonly, and when the record is created, the partner_id key does not exist, and raises the error [2].

This commit ensures that the partner_id is accessed only if it is present in the record.

[1]- https://github.com/odoo/odoo/blob/5bddf9bfb634d09d3264e4fe4734d75f1083775a/addons/mail/views/discuss_channel_views.xml#L87-L88

[2]- https://github.com/odoo/odoo/blob/5bddf9bfb634d09d3264e4fe4734d75f1083775a/addons/mail/models/discuss/discuss_channel.py#L235

sentry-6791956423

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
