### PR TITLE
[FIX] website_sale: skip inactive custom footers in configurator

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -313,8 +313,10 @@ class Website(models.Model):
             ThemeUtils.enable_view(xml_id)
 
         for footer_id in ThemeUtils._footer_templates:
-            footer_view = self.env['website'].with_context(website_id=website.id).viewref(footer_id)
-
+            footer_view = self.with_context(website_id=website.id).viewref(
+                footer_id,
+                raise_if_not_found=False,  # don't raise on custom footers not installed on website
+            )
             if not footer_view.active:
                 continue
 


### PR DESCRIPTION
Versions
--------
- master

Steps
-----
1. Have `theme_test_custo` from `design-themes` installed;
2. create a new website;
3. in the configurator, select a theme other than `theme_test_custo`.

Issue
-----
> Missing Record
> Template not found: theme_test_custo.template_footer_custom

Cause
-----
Commit 11e46faae3350 added logic to the website configurator to customize footers installed on the current website. It does this by looping over `ThemeUtils._footer_templates`, and referencing the views.

`_footer_templates` is a property that can be overridden to add custom footers, which `theme_test_custo` does. As a consequence, there is no guarantee using `viewref` is able to return a record, as it only checks views that are active on the website in the current context.

Solution
--------
The `viewref` method has an optional `raise_if_not_found` argument, by passing it a `False` value, it will return an empty recordset, enabling us to skip the view the same way we skip footers that are installed but inactive.

opw-5003615