### PR TITLE
[FIX] calendar: correct selectivity in alarm query

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -25,7 +25,9 @@ class AlarmManager(models.AbstractModel):
         result = {}
         delta_request = """
             SELECT
-                rel.calendar_event_id, max(alarm.duration_minutes) AS max_delta,min(alarm.duration_minutes) AS min_delta
+                rel.calendar_event_id,
+                max(alarm.duration_minutes) AS max_delta,
+                min(alarm.duration_minutes) AS min_delta
             FROM
                 calendar_alarm_calendar_event_rel AS rel
             LEFT JOIN calendar_alarm AS alarm ON alarm.id = rel.calendar_alarm_id
@@ -33,30 +35,24 @@ class AlarmManager(models.AbstractModel):
             GROUP BY rel.calendar_event_id
         """
         base_request = """
-                    SELECT
-                        cal.id,
-                        cal.start - interval '1' minute  * calcul_delta.max_delta AS first_alarm,
-                        CASE
-                            WHEN cal.recurrency THEN rrule.until - interval '1' minute  * calcul_delta.min_delta
-                            ELSE cal.stop - interval '1' minute  * calcul_delta.min_delta
-                        END as last_alarm,
-                        cal.start as first_event_date,
-                        CASE
-                            WHEN cal.recurrency AND rrule.end_type = 'end_date' THEN rrule.until
-                            ELSE cal.stop
-                        END as last_event_date,
-                        calcul_delta.min_delta,
-                        calcul_delta.max_delta,
-                        rrule.rrule AS rule
-                    FROM
-                        calendar_event AS cal
-                    RIGHT JOIN calcul_delta ON calcul_delta.calendar_event_id = cal.id
-                    LEFT JOIN calendar_recurrence as rrule ON rrule.id = cal.recurrence_id
-             """
-
+            SELECT
+                cal.id,
+                cal.start - interval '1' minute * calcul_delta.max_delta AS first_alarm,
+                cal.stop - interval '1' minute * calcul_delta.min_delta AS last_alarm,
+                cal.start AS first_meeting,
+                cal.stop AS last_meeting,
+                calcul_delta.min_delta,
+                calcul_delta.max_delta
+            FROM
+                calendar_event AS cal
+            INNER JOIN calcul_delta ON calcul_delta.calendar_event_id = cal.id
+            WHERE cal.active = True
+        """
         filter_user = """
-                RIGHT JOIN calendar_event_res_partner_rel AS part_rel ON part_rel.calendar_event_id = cal.id
-                    AND part_rel.res_partner_id IN %s
+            INNER JOIN calendar_event_res_partner_rel AS part_rel
+                ON part_rel.calendar_event_id = cal.id
+                AND part_rel.res_partner_id IN %s
+            WHERE cal.active = True
         """
 
         # Add filter on alarm type
@@ -64,7 +60,7 @@ class AlarmManager(models.AbstractModel):
 
         # Add filter on partner_id
         if partners:
-            base_request += filter_user
+            base_request = base_request.replace("WHERE cal.active = True", filter_user)
             tuple_params += (tuple(partners.ids), )
 
         # Upper bound on first_alarm of requested events
@@ -86,12 +82,12 @@ class AlarmManager(models.AbstractModel):
         self._cr.execute("""
             WITH calcul_delta AS (%s)
             SELECT *
-                FROM ( %s WHERE cal.active = True ) AS ALL_EVENTS
-               WHERE ALL_EVENTS.first_alarm < %s
-                 AND ALL_EVENTS.last_event_date > (now() at time zone 'utc')
+                FROM ( %s ) AS ALL_EVENTS
+            WHERE ALL_EVENTS.first_alarm < %s
+                AND ALL_EVENTS.last_alarm > (now() at time zone 'utc')
         """ % (delta_request, base_request, first_alarm_max_value), tuple_params)
 
-        for event_id, first_alarm, last_alarm, first_meeting, last_meeting, min_duration, max_duration, rule in self._cr.fetchall():
+        for event_id, first_alarm, last_alarm, first_meeting, last_meeting, min_duration, max_duration in self._cr.fetchall():
             result[event_id] = {
                 'event_id': event_id,
                 'first_alarm': first_alarm,
@@ -100,7 +96,6 @@ class AlarmManager(models.AbstractModel):
                 'last_meeting': last_meeting,
                 'min_duration': min_duration,
                 'max_duration': max_duration,
-                'rrule': rule
             }
 
         # determine accessible events

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -461,3 +461,76 @@ class TestEventNotifications(TransactionCase, MailCase, CronMixinCase):
                     'partner_ids': [(4, self.partner.id)],
                     'alarm_ids': [(4, alarm.id)]
                 })
+
+    def test_get_next_potential_limit_alarm(self):
+        """
+            Test that the next potential limit alarm is correctly computed for notification alarms.
+        """
+        now = fields.Datetime.now()
+        start = now - relativedelta(days=1)
+        while start.weekday() > 4:
+            start -= relativedelta(days=1)
+        stop = start + relativedelta(hours=1)
+        next_month = now + relativedelta(days=30)
+        weekday_flags = ['mon', 'tue', 'wed', 'thu', 'fri']
+        weekday_flag = weekday_flags[start.weekday()]
+        weekday_dict = {flag: False for flag in weekday_flags}
+        weekday_dict[weekday_flag] = True
+
+        partner = self.user.partner_id
+        # until_date event first alarm
+        alarm = self.env['calendar.alarm'].create({
+            'name': 'Alarm',
+            'alarm_type': 'notification',
+            'interval': 'minutes',
+            'duration': 15,
+        })
+
+        event_vals = {
+            'start': start,
+            'stop': stop,
+            'name': 'Weekly Sales Meeting',
+            'alarm_ids': [[6, 0, [alarm.id]]],
+            'partner_ids': [(4, self.partner.id)],
+        }
+        self.event.write(event_vals)
+        self.event._apply_recurrence_values({
+            'interval': 1,
+            'rrule_type': 'weekly',
+            'end_type': 'end_date',
+            'until': next_month.date().isoformat(),
+            **weekday_dict,
+        })
+        events = self.env['calendar.event'].search([('name', '=', 'Weekly Sales Meeting')])
+        self.env.flush_all()
+        result = self.env['calendar.alarm_manager']._get_next_potential_limit_alarm('notification', partners=partner)
+        for alarm_data in result.values():
+            first_alarm = alarm_data.get('first_alarm')
+            self.assertLess(now, first_alarm)
+        events.unlink()
+
+        # count event last alarm
+        recurrence_count = 5
+        start = now - relativedelta(days=1)
+        stop = start + relativedelta(hours=1)
+        event_vals = {
+            'start': start,
+            'stop': stop,
+            'name': 'Daily Sales Meeting',
+            'alarm_ids': [[6, 0, [alarm.id]]],
+            'partner_ids': [(4, self.partner.id)],
+        }
+        self.event = self.env['calendar.event'].create(event_vals)
+        self.event._apply_recurrence_values({
+            'interval': 1,
+            'rrule_type': 'daily',
+            'end_type': 'count',
+            'count': recurrence_count
+        })
+        self.env.flush_all()
+        result = self.env['calendar.alarm_manager']._get_next_potential_limit_alarm('notification', partners=partner)
+        expected_alarms = sorted([stop + relativedelta(days=offset) - relativedelta(minutes=15) for offset in range(1, recurrence_count)])
+        actual_alarms = sorted([data.get('last_alarm') for data in result.values()])
+
+        for expected, actual in zip(expected_alarms, actual_alarms):
+            self.assertEqual(actual, expected)


### PR DESCRIPTION
Steps to reproduce the issue:

1. Create a calendar event (meeting, for example)

2. Set the start date as yesterday and in 30 minutes from now.

3. Set it to be recurrent every week with end_type set to end_date and in the future(1 month from now).

4. Add a reminder to the event (30 mins, for example) and ensure that calendar_last_notif_ack is set before the alarm window for your user's res.partner.

5. Save the event and observe an alarm notification made for an event in the past.

After the fix, the calendar alarms will only trigger for events in the future and in their designated time windows. The recurrence logic was also removed from the query to align with this [[REF]](https://github.com/odoo/odoo/pull/42031/commits/a27afdb5434166c3ea48c18ccfba9e8245d18e62) since
recurring events are all persistent records in the database.

opw-4776638
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr