### PR TITLE
[FIX] bus: skip bus test that doesn't work with faketime

### DIFF
--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -2,10 +2,12 @@
 
 import gc
 import json
+import os
 from collections import defaultdict
 from datetime import timedelta
 from freezegun import freeze_time
 from threading import Event
+from unittest import skipIf
 from unittest.mock import patch
 try:
     from websocket._exceptions import WebSocketBadStatusException
@@ -130,6 +132,7 @@ class TestWebsocketCaryall(WebsocketCase):
         websocket.send(json.dumps({'event_name': 'subscribe'}))
         self.assert_close_with_code(websocket, CloseCode.SESSION_EXPIRED)
 
+    @skipIf(os.getenv("ODOO_FAKETIME_TEST_MODE"), 'This test times out when faketime is used')
     def test_user_logout_outgoing_message(self):
         odoo_ws = None
 


### PR DESCRIPTION
In 16.0 only, this test never stops in faketime mode.

