### PR TITLE
[FIX] account: fix resequence payment test

### DIFF
--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -791,16 +791,17 @@ class TestAccountPayment(AccountTestInvoicingCommon, MailCommon):
 
         payment.action_post()
 
+        year = fields.Date.today().year
         wizard = self.env['account.resequence.wizard'].with_context({
             'active_ids': payment.move_id.ids,
             'active_model': 'account.move',
         }).create({
-            'first_name': 'PBNK1/2025/00002',
+            'first_name': f'PBNK1/{year}/00002',
         })
         wizard.resequence()
 
-        self.assertEqual(payment.move_id.name, 'PBNK1/2025/00002')
-        self.assertEqual(payment.name, 'PBNK1/2025/00002')
+        self.assertEqual(payment.move_id.name, f'PBNK1/{year}/00002')
+        self.assertEqual(payment.name, f'PBNK1/{year}/00002')
 
     def test_vendor_payment_save_user_selected_journal_id(self):
         journal_bank = self.env['account.journal'].search([('name', '=', 'Bank')])


### PR DESCRIPTION
The test test_resequence_change_payment_name had hardcoded 2025 in the sequence name, meaning that the test will fail in 2026.

opw-4437481

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
