### PR TITLE
[FIX] account: fix computation of the amount of the partial exchange diff

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2140,7 +2140,9 @@ class AccountMoveLine(models.Model):
                 and company_currency.compare_amounts(partial_credit_amount, partial_debit_amount_range[2]) <= 0
                 and company_currency.compare_amounts(partial_credit_amount, partial_debit_amount_range[0]) >= 0
             ):
-                if debit_fully_matched:
+                if debit_fully_matched and credit_fully_matched:
+                    partial_amount = min(remaining_debit_amount, -remaining_credit_amount)
+                elif debit_fully_matched:
                     partial_amount = remaining_debit_amount
                 else:
                     partial_amount = -remaining_credit_amount


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
(To easily reproduce, we need a company in a currency having no decimal: JP)
- Install l10n_jp

- Switch to a Japanese company (e.g. JP Company)
- Activate a foreign currency (e.g. USD)
- Set the following rate:
  * JPY per Unit: 936.29
  * Unit per JPY: 0.001068045157 (should be computed automatically)
- Go to "Accounting / Configuration / Accounting / Journals"
- Create a Bank journal in USD (e.g. Duplicate the existing Bank journal and set its currency to USD)

- Create a bill:
  * Currency: JPY
  * Vendor: [any] (e.g. Azure Interior)
  * Bill Date: [today]
  * Invoice Lines: [a line generating a total of 16345] (e.g. price of 16345 and no tax)
- Confirm the bill

- From Acocunting Dashboard, go to the USD Bank journal
- Create a statement:
  * Date: [today]
  * Label: [anything]
  * Partner: [the same than the bill] (e.g. Azure Interior)
  * Amount: $-17.46 (this is the rounded value of -16345 JPY converted in USD)
- Reconcile the statement with the default manual operation
(It should be an open balance for Azure Interior in the payable account)
=> As we are using exactly $-17.46, the debit/credit is 16348 JPY, which is a little more than the total from the bill (i.e. 16345 JPY)

- Go to the bill
- Pay the bill with the outstanding debit of 16348 JPY

**Issue:**
The bill is partially paid with an amount due of 3 JPY.
A currency exchange rate difference entry of 3 JPY is correctly created, but it is not reconciled with the bill of 16345 JPY and the outstanding debit of 16348 JPY.
Therefore, the bill and the outstanding debit are just partially reconciled, not fully.
The bill should be fully reconciled with the exchange difference as it is the case when following the same steps for an invoice.

**Cause:**
In `_prepare_reconciliation_single_partial` method, we first check if the debit fully matches.
If it is the case, we use the debit amount as partial amount to compute the exchange diff amount.
However, in this case, both debit and credit fully match and because debit is checked before, the debit amount of 16348 JPY is used as partial amount instead of the credit amount of 16345 JPY.

**Solution:**
When both debit and credit fully match, use the lowest value as partial amount.

opw-4929165




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
