### PR TITLE
[FIX] product: sync pricelist when adding company to a partner

### DIFF
--- a/addons/product/models/res_partner.py
+++ b/addons/product/models/res_partner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
@@ -48,10 +47,7 @@ class ResPartner(models.Model):
                 partner.specific_property_product_pricelist = False if partner.property_product_pricelist.id == default_for_country.id else partner.property_product_pricelist.id
 
     def _commercial_fields(self):
-        return super()._commercial_fields() + ['property_product_pricelist']
-
-    def _company_dependent_commercial_fields(self):
         return [
-            *super()._company_dependent_commercial_fields(),
-            'specific_property_product_pricelist'
+            *super()._commercial_fields(),
+            'specific_property_product_pricelist',
         ]


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Create an individual partner;
2. assign them a pricelist A;
3. create a new company partner for them;
4. create a new pricelist A & sort it on top;
5. open a new quotation;
6. set new company as customer;
7. change customer to the individual partner.

Issue
-----
The quotation's pricelist changed from B to A. The pricelist used for the individual should be identical to the one used for their company.

Cause
-----
Commit de302c2d36305 added the `specific_property_product_pricelist` field to `res.partner`, as the way company-dependent fields are managed was changed on the database-level.

Commit 67cf577cd0a0 added the `_company_dependent_commercial_fields` method to enable syncing company-dependent commercial fields. The base method fetches all fields retrieved via `_commercial_fields`, and selects those whose `company_dependent` attribute is `True`.

In previous versions, the `_company_dependent_commercial_fields` override in `product` adds `property_product_pricelist`, as this field does not have the `company_dependent` attribute set, but it behaves as a company-dependent field. Starting from 18.0, the override adds `specific_property_product_pricelist` instead, which does have the `company_dependent` property set.

As a consequence, when `_company_dependent_commercial_sync` gets called, it does not sync the `specific_property_product_pricelist` as it's not included in the `_commercial_fields` override, nor does it sync when retrieving it from `_company_dependent_commercial_fields`, as it skips the current company, assuming the field was already handled by `_commercial_sync_from_company`: https://github.com/odoo/odoo/blob/c40760244d128cb57e11a233e89a93dd92b8fb56/odoo/addons/base/models/res_partner.py#L667-L668

Solution
--------
- Move `specific_property_product_pricelist` to `_commercial_fields`
    - This enables it to sync in `_commercial_sync_from_company`
- Remove the `_company_dependent_commercial_fields` override
    - `property_product_pricelist` shouldn't get synced by itself
    - `specific_property_product_pricelist` is already included by the base method

opw-4988736