### PR TITLE
[FIX] point_of_sale, product: cloth shop demo data loading

### DIFF
--- a/addons/point_of_sale/data/scenarios/clothes_data.xml
+++ b/addons/point_of_sale/data/scenarios/clothes_data.xml
@@ -5,6 +5,38 @@
             <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
         </record>
 
+        <!-- Shoe Size -->
+        <record id="pa_shoe_size" model="product.attribute">
+            <field name="name">Shoes size</field>
+            <field name="create_variant">no_variant</field>
+            <field name="display_type">pills</field>
+        </record>
+
+        <record id="pav_shoe_size_39" model="product.attribute.value">
+            <field name="name">39</field>
+            <field name="attribute_id" ref="pa_shoe_size"/>
+        </record>
+
+        <record id="pav_shoe_size_40" model="product.attribute.value">
+            <field name="name">40</field>
+            <field name="attribute_id" ref="pa_shoe_size"/>
+        </record>
+
+        <record id="pav_shoe_size_41" model="product.attribute.value">
+            <field name="name">41</field>
+            <field name="attribute_id" ref="pa_shoe_size"/>
+        </record>
+
+        <record id="pav_shoe_size_42" model="product.attribute.value">
+            <field name="name">42</field>
+            <field name="attribute_id" ref="pa_shoe_size"/>
+        </record>
+
+        <record id="pav_shoe_size_43" model="product.attribute.value">
+            <field name="name">43</field>
+            <field name="attribute_id" ref="pa_shoe_size"/>
+        </record>
+
         <!-- Clothes products -->
         <record model="product.product" id="casual_t_shirt">
             <field name="name">Casual T-shirt</field>
@@ -384,15 +416,15 @@
 
         <record model="product.template.attribute.line" id="product_attribute_line_size_number">
             <field name="product_tmpl_id" ref="point_of_sale.product_odoo_sneakers_template"/>
-            <field name="attribute_id" ref="product.pa_shoe_size"/>
+            <field name="attribute_id" ref="pa_shoe_size"/>
             <field
                 name="value_ids"
                 eval="[Command.set([
-                    ref('product.pav_shoe_size_39'),
-                    ref('product.pav_shoe_size_40'),
-                    ref('product.pav_shoe_size_41'),
-                    ref('product.pav_shoe_size_42'),
-                    ref('product.pav_shoe_size_43'),
+                    ref('pav_shoe_size_39'),
+                    ref('pav_shoe_size_40'),
+                    ref('pav_shoe_size_41'),
+                    ref('pav_shoe_size_42'),
+                    ref('pav_shoe_size_43'),
             ])]" />
         </record>
 
@@ -561,15 +593,15 @@
 
         <record model="product.template.attribute.line" id="product_attribute_line_sport_shoes">
             <field name="product_tmpl_id" ref="point_of_sale.sport_shoes_template"/>
-            <field name="attribute_id" ref="product.pa_shoe_size"/>
+            <field name="attribute_id" ref="pa_shoe_size"/>
             <field
                 name="value_ids"
                 eval="[Command.set([
-                    ref('product.pav_shoe_size_39'),
-                    ref('product.pav_shoe_size_40'),
-                    ref('product.pav_shoe_size_41'),
-                    ref('product.pav_shoe_size_42'),
-                    ref('product.pav_shoe_size_43'),
+                    ref('pav_shoe_size_39'),
+                    ref('pav_shoe_size_40'),
+                    ref('pav_shoe_size_41'),
+                    ref('pav_shoe_size_42'),
+                    ref('pav_shoe_size_43'),
             ])]" />
         </record>
     </data>

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -941,6 +941,9 @@ class PosConfig(models.Model):
 
     def _load_onboarding_clothes_demo_data(self, with_demo_data=True):
         self.ensure_one()
+        product_module = self.env['ir.module.module'].search([('name', '=', 'product')])
+        if not product_module.demo:
+            convert.convert_file(self._env_with_clean_context(), 'product', 'data/product_attribute_demo.xml', idref=None, mode='init', noupdate=True)
         convert.convert_file(self._env_with_clean_context(), 'point_of_sale', 'data/scenarios/clothes_category_data.xml', idref=None, mode='init', noupdate=True)
         if with_demo_data:
             convert.convert_file(self._env_with_clean_context(), 'point_of_sale', 'data/scenarios/clothes_data.xml', idref=None, mode='init', noupdate=True)

--- a/addons/product/data/product_attribute_demo.xml
+++ b/addons/product/data/product_attribute_demo.xml
@@ -543,36 +543,4 @@
         <field name="is_custom">True</field>
     </record>
 
-    <!-- Shoe Size -->
-    <record id="pa_shoe_size" model="product.attribute">
-        <field name="name">Shoes size</field>
-        <field name="create_variant">no_variant</field>
-        <field name="display_type">pills</field>
-    </record>
-
-    <record id="pav_shoe_size_39" model="product.attribute.value">
-        <field name="name">39</field>
-        <field name="attribute_id" ref="pa_shoe_size"/>
-    </record>
-
-    <record id="pav_shoe_size_40" model="product.attribute.value">
-        <field name="name">40</field>
-        <field name="attribute_id" ref="pa_shoe_size"/>
-    </record>
-
-    <record id="pav_shoe_size_41" model="product.attribute.value">
-        <field name="name">41</field>
-        <field name="attribute_id" ref="pa_shoe_size"/>
-    </record>
-
-    <record id="pav_shoe_size_42" model="product.attribute.value">
-        <field name="name">42</field>
-        <field name="attribute_id" ref="pa_shoe_size"/>
-    </record>
-
-    <record id="pav_shoe_size_43" model="product.attribute.value">
-        <field name="name">43</field>
-        <field name="attribute_id" ref="pa_shoe_size"/>
-    </record>
-
 </odoo>

--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -21,9 +21,6 @@
             <field name="preview_variants">visible</field>
             <field name="is_thumbnail_visible" eval="True"/>
         </record>
-        <record id="product.pa_shoe_size" model="product.attribute">
-            <field name="visibility">hidden</field>
-        </record>
 
         <record id="product.product_product_24" model="product.product">
             <field name="is_published" eval="True"/>


### PR DESCRIPTION
Steps:
-------------------------------------------------
- Set up a database without demo data.
- Open Cloth Shop POS.
- Click on load sample data.

Issue:
-------------------------------------------------
Data doesn't load.
(Traceback in terminal for not found external ID)

Cause:
-------------------------------------------------
Commit https://github.com/odoo/odoo/commit/ffb976c3ed5fbcff2e5d06a3183bab2fbe0307ff moved demo data from point_of_sale to product. The issue is that point_of_sale uses a custom 'scenario' flow where demo data gets loaded for a specific scenario. As a consequence, any reference to demo data from the product will cause an error.

Solution:
-------------------------------------------------
- Move the shoe size attribute back to the pos cloth scenario from product.
- Load attribute from the product when we click on Load Sample Data in the cloth shop.

task - 5002430


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
