### PR TITLE
[FIX] l10n_es_edi_verifactu: installation with missing taxes

### DIFF
--- a/addons/l10n_es_edi_verifactu/__init__.py
+++ b/addons/l10n_es_edi_verifactu/__init__.py
@@ -7,6 +7,14 @@ from . import wizard
 def _l10n_es_edi_verifactu_post_init_hook(env):
     for company in env['res.company'].search([('chart_template', 'like', r'es\_%'), ('parent_id', '=', False)]):
         Template = env['account.chart.template'].with_company(company)
+        # Filter out data for non-exsting taxes; else this function will raise.
+        # In case of data for a non-existing tax we would try to create that tax.
+        # This would fail because we don't supply enough information in this module (just `l10n_es_applicability`).
+        tax_data = {
+            xmlid: value
+            for xmlid, value in Template._get_es_verifactu_account_tax().items()
+            if Template.ref(xmlid, raise_if_not_found=False)
+        }
         Template._load_data({
-            'account.tax': Template._get_es_verifactu_account_tax(),
+            'account.tax': tax_data,
         })


### PR DESCRIPTION
In case some taxes for which we specify Applicability info (field `l10n_es_applicability`) do not exist the module can not be installed.
I.e. the `_l10n_es_edi_verifactu_post_init_hook` raises.

Reproduce
1. Install `l10n_es` without installing `l10n_es_edi_verifactu`
2. Delete tax with xmlid `account_tax_template_s_iva_e` (sales tax with description "VAT 0% export (services)")
3. Install `l10n_es_edi_verifactu`
4. A "Validation Error" appears
   ``` The operation cannot be completed:
   - Create/update: a mandatory field is not set.
   - Delete: another model requires the record being deleted. If possible, archive it instead.

   Model: Tax (account.tax)
   Field: Tax Name (name)
   ```
opw-5003231
opw-4996685
opw-4999922
