### PR TITLE
[IMP] web: visually indicate invalid fields in notebook tabs

### DIFF
--- a/addons/web/static/src/core/notebook/notebook.scss
+++ b/addons/web/static/src/core/notebook/notebook.scss
@@ -56,6 +56,11 @@
         &:hover {
             border-color: var(--Notebook__link-border-color--hover);
         }
+
+        &.o_page_invalid {
+            color: o-text-color('danger') !important;
+            background-color: #{$o-input-invalid-bg} !important;
+        }
     }
 
     .tab-pane:not(.show) {

--- a/addons/web/static/src/core/notebook/notebook.xml
+++ b/addons/web/static/src/core/notebook/notebook.xml
@@ -6,7 +6,7 @@
             <div class="o_notebook_headers" t-att-class="{ 'm-0': props.orientation === 'vertical' }">
                 <ul t-attf-class="nav nav-tabs {{ props.orientation === 'horizontal' ? 'flex-row flex-nowrap' : 'flex-column p-0' }}">
                     <li t-foreach="navItems" t-as="navItem" t-key="navItem[0]" class="nav-item flex-nowrap" t-if="navItem[1].isVisible" t-attf-class="{{ navItem[1].isDisabled ? 'disabled' : '' }}">
-                        <a class="nav-link" t-attf-class="{{ navItem[0] === state.currentPage ? 'active position-relative cursor-default z-1' : '' }} {{ props.orientation === 'vertical' ? 'p-3 rounded-0' : '' }} {{ navItem[1].className || '' }}" t-att-name="navItem[1].name" t-on-click.prevent="() => this.activatePage(navItem[0])" href="#" role="tab" tabindex="0">
+                        <a class="nav-link" t-att-class="{'active position-relative cursor-default z-1': navItem[0] === state.currentPage, 'p-3 rounded-0': props.orientation === 'vertical', 'o_page_invalid': invalidPages.has(navItem[0])}" t-attf-class="{{ navItem[1].className || '' }}" t-att-name="navItem[1].name" t-on-click.prevent="() => this.activatePage(navItem[0])" href="#" role="tab" tabindex="0">
                             <i t-if="props.icons and props.icons[navItem[0]]" t-attf-class="fa {{ props.icons[navItem[0]] }} me-2" />
                             <t t-esc="navItem[1].title" />
                         </a>

--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -183,6 +183,7 @@ export class FormCompiler extends ViewCompiler {
         const field = super.compileField(el, params);
 
         const fieldName = el.getAttribute("name");
+        params.notebookPageFields?.push(fieldName);
         const fieldString = el.getAttribute("string");
         const fieldId = el.getAttribute("field_id");
         const labelsForAttr = el.getAttribute("id") || fieldName;
@@ -572,9 +573,11 @@ export class FormCompiler extends ViewCompiler {
             }
             pageSlot.setAttribute("isVisible", isVisibleExpr);
 
+            params.notebookPageFields = [];
             for (const contents of child.children) {
                 append(pageSlot, this.compileNode(contents, { ...params, currentSlot: pageSlot }));
             }
+            pageSlot.setAttribute("fieldNames", `${JSON.stringify(params.notebookPageFields)}`);
         }
 
         return noteBook;

--- a/addons/web/static/tests/views/form/form_compiler.test.js
+++ b/addons/web/static/tests/views/form/form_compiler.test.js
@@ -134,10 +134,10 @@ test("properly compile notebook", () => {
         <t t-translation="off">
             <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
                 <Notebook defaultPage="__comp__.props.record.isNew ? undefined : __comp__.props.activeNotebookPages[0]" onPageUpdate="(page) =&gt; __comp__.props.onNotebookPageChange(0, page)">
-                    <t t-set-slot="page_1" title="\`Page1\`" name="\`p1\`" isVisible="true">
+                    <t t-set-slot="page_1" title="\`Page1\`" name="\`p1\`" isVisible="true" fieldnames="[&quot;charfield&quot;]">
                         <Field id="'charfield'" name="'charfield'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['charfield']" readonly="__comp__.props.readonly"/>
                     </t>
-                    <t t-set-slot="page_2" title="\`Page2\`" name="\`p2\`" isVisible="true">
+                    <t t-set-slot="page_2" title="\`Page2\`" name="\`p2\`" isVisible="true" fieldnames="[&quot;display_name&quot;]">
                         <Field id="'display_name'" name="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name']" readonly="__comp__.props.readonly"/>
                     </t>
                 </Notebook>


### PR DESCRIPTION
This commit improves the user experience in notebook views by highlighting tabs as invalid when they contain invalid fields. This ensures that users are no longer confused when a form cannot be saved due to a field error hidden within an inactive tab — the tab now visually indicates where the problem lies.

task-4991643
