### PR TITLE
[FIX] stock_account: ignore default tax for stock revaluation

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -247,6 +247,11 @@ class AccountMoveLine(models.Model):
 
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'account_move_line_id', string='Stock Valuation Layer')
 
+    def create(self, vals_list):
+        if self._context.get('is_price_change'):
+            vals_list = [val for val in vals_list if val.get('display_type') != 'tax']
+        return super().create(vals_list)
+
     def _compute_account_id(self):
         super()._compute_account_id()
         input_lines = self.filtered(lambda line: (

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -338,7 +338,7 @@ class ProductProduct(models.Model):
             }
             am_vals_list.append(move_vals)
 
-        account_moves = self.env['account.move'].sudo().with_context(clean_context(self._context)).create(am_vals_list)
+        account_moves = self.env['account.move'].sudo().with_context({**clean_context(self._context), 'is_price_change': True}).create(am_vals_list)
         if account_moves:
             account_moves._post()
 


### PR DESCRIPTION
Issue
-----
If the account on which stock revaluation is registered has a default tax, the account moves generated by changing the price of the product include the tax.

For context, the issue was reported because some l10n modules use accounts with default taxes (eg l10n_de).

Steps to reproduce
-----
- Install a localisation to have default accounts set up
- Create a product category (Cat1)
	- Set Inventory Valuation to "Automated"
	- Set a default tax on the Expense Account
- Create a product Prod1
	- Storable
	- Category set to Cat1
	- Cost set to 500
- Update the on hand quantity of Prod1 to 1
- Change the price of Prod1 to 300
- Go to Accounting > Accounting > Journal > Journal Entries

--> There is an AM for 200 + tax instead of just 200

Discussion
-----
When manually changing the cost of the product, we go through

https://github.com/odoo/odoo/blob/c1d3153ed564c0f47a201e5751740857a15d7db2/addons/stock_account/models/product.py#L110-L113

This calls the `_change_standard_price` method, which will create the AM

https://github.com/odoo/odoo/blob/c1d3153ed564c0f47a201e5751740857a15d7db2/addons/stock_account/models/product.py#L341

This creates the corresponding debit/credit AMLs. Afterwards, we go through

https://github.com/odoo/odoo/blob/c1d3153ed564c0f47a201e5751740857a15d7db2/addons/account/models/account_move.py#L2034

Where additional AMLs are created for the taxes

https://github.com/odoo/odoo/blob/c1d3153ed564c0f47a201e5751740857a15d7db2/addons/account/models/account_move.py#L2145-L2149

We don't want to make changes in `account` if we can avoid it since our problem is stock related. As such, what we can do is

1. Add a key in the context when creating the AM, since all of the AMLs are created further down the call stack so they inherit the context

2. Add an override of AML `create` in `stock_account` to filter out tax lines when the context key is present

-----
Ticket:
opw-4798231
