### PR TITLE
[IMP] l10n_*_pos: add all l10n tests

### DIFF
--- a/addons/l10n_ar_pos/tests/__init__.py
+++ b/addons/l10n_ar_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_ar_pos

--- a/addons/l10n_ar_pos/tests/test_ar_pos.py
+++ b/addons/l10n_ar_pos/tests/test_ar_pos.py
@@ -1,0 +1,12 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericAR(TestGenericLocalization):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('ar')
+    def setUpClass(cls):
+        super().setUpClass()

--- a/addons/l10n_ch_pos/tests/__init__.py
+++ b/addons/l10n_ch_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_ch_pos

--- a/addons/l10n_ch_pos/tests/test_ch_pos.py
+++ b/addons/l10n_ch_pos/tests/test_ch_pos.py
@@ -1,0 +1,12 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericCH(TestGenericLocalization):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('ch')
+    def setUpClass(cls):
+        super().setUpClass()

--- a/addons/l10n_co_pos/tests/__init__.py
+++ b/addons/l10n_co_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_co_pos

--- a/addons/l10n_co_pos/tests/test_co_pos.py
+++ b/addons/l10n_co_pos/tests/test_co_pos.py
@@ -1,0 +1,11 @@
+from odoo.addons.account_edi.tests.common import AccountTestInvoicingCommon
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericCO(TestGenericLocalization):
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('co')
+    def setUpClass(cls):
+        super().setUpClass()

--- a/addons/l10n_es_edi_tbai_pos/tests/__init__.py
+++ b/addons/l10n_es_edi_tbai_pos/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_tbai_pos
+from . import test_es_tbai_pos

--- a/addons/l10n_es_edi_tbai_pos/tests/test_es_tbai_pos.py
+++ b/addons/l10n_es_edi_tbai_pos/tests/test_es_tbai_pos.py
@@ -1,0 +1,12 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericESTbai(TestGenericLocalization):
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('es')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company.l10n_es_tbai_tax_agency = 'bizkaia'

--- a/addons/l10n_es_pos/tests/__init__.py
+++ b/addons/l10n_es_pos/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_frontend
+from . import test_es_pos

--- a/addons/l10n_es_pos/tests/test_es_pos.py
+++ b/addons/l10n_es_pos/tests/test_es_pos.py
@@ -1,0 +1,12 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericES(TestGenericLocalization):
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('es')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.main_pos_config.l10n_es_simplified_invoice_journal_id = cls.main_pos_config.journal_id

--- a/addons/l10n_fr_pos_cert/tests/__init__.py
+++ b/addons/l10n_fr_pos_cert/tests/__init__.py
@@ -1,1 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_fr_pos
 from . import test_string_to_hash

--- a/addons/l10n_fr_pos_cert/tests/test_fr_pos.py
+++ b/addons/l10n_fr_pos_cert/tests/test_fr_pos.py
@@ -1,0 +1,11 @@
+from odoo.addons.account_edi.tests.common import AccountTestInvoicingCommon
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericFR(TestGenericLocalization):
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('fr')
+    def setUpClass(cls):
+        super().setUpClass()

--- a/addons/l10n_gcc_pos/tests/__init__.py
+++ b/addons/l10n_gcc_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_gcc_pos

--- a/addons/l10n_gcc_pos/tests/test_gcc_pos.py
+++ b/addons/l10n_gcc_pos/tests/test_gcc_pos.py
@@ -1,0 +1,36 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericGCC(TestGenericLocalization):
+    @classmethod
+    @AccountEdiTestCommon.setup_edi_format('l10n_sa_edi.edi_sa_zatca')
+    @AccountTestInvoicingCommon.setup_country('sa')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.main_pos_config.company_id.name = 'Generic SA'
+        cls.main_pos_config.journal_id._l10n_sa_load_edi_demo_data()
+        cls.company.write({
+            'name': 'SA Company Test',
+            'email': 'info@company.saexample.com',
+            'phone': '+966 51 234 5678',
+            'street2': 'Testomania',
+            'vat': '311111111111113',
+            'state_id': cls.env['res.country.state'].create({
+                'name': 'Riyadh',
+                'code': 'RYA',
+                'country_id': cls.company.country_id.id
+            }),
+            'street': 'Al Amir Mohammed Bin Abdul Aziz Street',
+            'city': 'المدينة المنورة',
+            'zip': '42317',
+            'l10n_sa_edi_building_number': '1234',
+        })
+
+    def test_generic_localization(self):
+        if self.env['ir.module.module']._get('l10n_sa_edi').state != 'installed':
+            self.skipTest("l10n_sa_edi is not installed")
+        super().test_generic_localization()

--- a/addons/l10n_in_pos/tests/test_in_pos.py
+++ b/addons/l10n_in_pos/tests/test_in_pos.py
@@ -1,0 +1,22 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericIN(TestGenericLocalization):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('in')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.state_in_gj = cls.env.ref('base.state_in_gj')
+        cls.main_pos_config.company_id.write({
+            'name': "Default Company",
+            'state_id': cls.state_in_gj.id,
+            'vat': "24AAGCC7144L6ZE",
+            'street': "Khodiyar Chowk",
+            'street2': "Sala Number 3",
+            'city': "Amreli",
+            'zip': "365220",
+        })

--- a/addons/l10n_pe_pos/tests/__init__.py
+++ b/addons/l10n_pe_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_pe_pos

--- a/addons/l10n_pe_pos/tests/test_pe_pos.py
+++ b/addons/l10n_pe_pos/tests/test_pe_pos.py
@@ -1,0 +1,11 @@
+from odoo.addons.account_edi.tests.common import AccountTestInvoicingCommon
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericPE(TestGenericLocalization):
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('pe')
+    def setUpClass(cls):
+        super().setUpClass()

--- a/addons/l10n_sa_edi_pos/tests/__init__.py
+++ b/addons/l10n_sa_edi_pos/tests/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_in_pos
-from . import test_hsn_summary
+from . import test_sa_edi_pos

--- a/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
+++ b/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
@@ -1,0 +1,30 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.l10n_sa_edi.tests.common import AccountEdiTestCommon
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericSAEdi(TestGenericLocalization):
+    @classmethod
+    @AccountEdiTestCommon.setup_edi_format('l10n_sa_edi.edi_sa_zatca')
+    @AccountTestInvoicingCommon.setup_country('sa')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.main_pos_config.journal_id._l10n_sa_load_edi_demo_data()
+        cls.company.write({
+            'name': 'SA Company Test',
+            'email': 'info@company.saexample.com',
+            'phone': '+966 51 234 5678',
+            'street2': 'Testomania',
+            'vat': '311111111111113',
+            'state_id': cls.env['res.country.state'].create({
+                'name': 'Riyadh',
+                'code': 'RYA',
+                'country_id': cls.company.country_id.id
+            }),
+            'street': 'Al Amir Mohammed Bin Abdul Aziz Street',
+            'city': 'المدينة المنورة',
+            'zip': '42317',
+            'l10n_sa_edi_building_number': '1234',
+        })

--- a/addons/l10n_sa_pos/tests/test_sa_pos.py
+++ b/addons/l10n_sa_pos/tests/test_sa_pos.py
@@ -1,8 +1,41 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.l10n_sa_edi.tests.common import TestSaEdiCommon
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.addons.account_edi.tests.common import AccountEdiTestCommon
-from odoo.tests.common import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericSA(TestGenericLocalization, TestSaEdiCommon):
+    @classmethod
+    @AccountEdiTestCommon.setup_edi_format('l10n_sa_edi.edi_sa_zatca')
+    @AccountTestInvoicingCommon.setup_country('sa')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.main_pos_config.company_id.name = 'Generic SA'
+        cls.main_pos_config.journal_id._l10n_sa_load_edi_demo_data()
+        cls.company.write({
+            'name': 'SA Company Test',
+            'email': 'info@company.saexample.com',
+            'phone': '+966 51 234 5678',
+            'street2': 'Testomania',
+            'vat': '311111111111113',
+            'state_id': cls.env['res.country.state'].create({
+                'name': 'Riyadh',
+                'code': 'RYA',
+                'country_id': cls.company.country_id.id
+            }),
+            'street': 'Al Amir Mohammed Bin Abdul Aziz Street',
+            'city': 'المدينة المنورة',
+            'zip': '42317',
+            'l10n_sa_edi_building_number': '1234',
+        })
+
+    def test_generic_localization(self):
+        if self.env['ir.module.module']._get('l10n_sa_edi').state != 'installed':
+            self.skipTest("l10n_sa_edi is not installed")
+        super().test_generic_localization()
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')

--- a/addons/point_of_sale/static/tests/tours/generic_tour.js
+++ b/addons/point_of_sale/static/tests/tours/generic_tour.js
@@ -1,0 +1,31 @@
+import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
+import { GenericHooks } from "@point_of_sale/../tests/tours/utils/generic_hooks";
+import { registry } from "@web/core/registry";
+
+//This tour is meant to be run on all localizations
+registry.category("web_tour.tours").add("generic_localization_tour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAAA Generic Partner"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            ProductScreen.clickDisplayedProduct("Wall Shelf Unit"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            GenericHooks.afterValidateHook(),
+            ProductScreen.closePos(),
+            Dialog.confirm("Close Register"),
+            {
+                trigger: "button:contains(backend)",
+                run: "click",
+                expectUnloadPage: true,
+            },
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/utils/generic_hooks.js
+++ b/addons/point_of_sale/static/tests/tours/utils/generic_hooks.js
@@ -1,0 +1,6 @@
+export class GenericHooks {
+    static afterValidateHook() {
+        // This function can be overridden in the localization to add steps after payment validation
+        return [];
+    }
+}

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -22,4 +22,5 @@ from . import test_pos_stock_account
 from . import test_report_pos_order
 from . import test_report_session
 from . import test_res_config_settings
+from . import test_generic_localization
 from . import test_stock_product_updates

--- a/addons/point_of_sale/tests/test_generic_localization.py
+++ b/addons/point_of_sale/tests/test_generic_localization.py
@@ -1,0 +1,29 @@
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo.tests import tagged
+from odoo.fields import Command
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericLocalization(TestPointOfSaleHttpCommon):
+    allow_inherited_tests_method = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_a.name = "AAAA Generic Partner"
+        cls.partner_a.vat = "32345678"
+        cls.whiteboard_pen.write({
+            'standard_price': 10.0,
+            'taxes_id': [Command.link(cls.tax_sale_a.id)]
+        })
+
+        cls.wall_shelf.write({
+            'standard_price': 10.0,
+            'taxes_id': [Command.link(cls.tax_sale_a.id)]
+        })
+
+    def test_generic_localization(self):
+        self.main_pos_config.open_ui()
+        current_session = self.main_pos_config.current_session_id
+        self.start_pos_tour("generic_localization_tour", login="accountman")
+        self.assertEqual(current_session.state, 'closed')


### PR DESCRIPTION
Thi commit add a generic tour that can be run in all pos l10n_modules. In some cases it requires some extra steps, this can be done with hooks. The hooks will execute different steps depending on the country the tour is run in.

opw-4606788