### PR TITLE
[IMP] hr_attendance: Extend absence management cron to cover last 30 days

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -646,33 +646,53 @@ class HrAttendance(models.Model):
         """
         Objective is to create technical attendances on absence days to have negative overtime created for that day
         """
-        yesterday = datetime.today().replace(hour=0, minute=0, second=0) - relativedelta(days=1)
+        today = datetime.today().replace(hour=0, minute=0, second=0)
+        date_from = today - relativedelta(days=1)
         companies = self.env['res.company'].search([('absence_management', '=', True)])
         if not companies:
             return
 
-        checked_in_employees = self.env['hr.attendance.overtime.line'].search([('date', '=', yesterday)]).employee_id
+        employees = self.env['hr.employee'].search([
+            ('company_id', 'in', companies.ids),
+            ('resource_calendar_id.flexible_hours', '=', False),
+        ])
+        if not employees:
+            return
+
+        domain = [
+            ('employee_id', 'in', employees.ids),
+            ('date', '>=', date_from),
+            ('date', '<', today),
+        ]
+        attendances = self.env['hr.attendance.overtime.line'].search(domain)
+
+        attendance_map = defaultdict(set)
+        for att in attendances:
+            att_date = att.date
+            attendance_map[att.employee_id.id].add(att_date)
 
         technical_attendances_vals = []
-        absent_employees = self.env['hr.employee'].search([('id', 'not in', checked_in_employees.ids),
-                                                           ('company_id', 'in', companies.ids),
-                                                           ('resource_calendar_id.flexible_hours', '=', False)])
 
-        for emp in absent_employees:
-            local_day_start = pytz.utc.localize(yesterday).astimezone(pytz.timezone(emp._get_tz()))
-            technical_attendances_vals.append({
-                'check_in': local_day_start.strftime('%Y-%m-%d %H:%M:%S'),
-                'check_out': (local_day_start + relativedelta(seconds=1)).strftime('%Y-%m-%d %H:%M:%S'),
-                'in_mode': 'technical',
-                'out_mode': 'technical',
-                'employee_id': emp.id
-            })
+        for employee in employees:
+            tz = pytz.timezone(employee._get_tz())
+            for i in range(1, 31):
+                current_date = today - relativedelta(days=i)
+                if current_date not in attendance_map[employee.id]:
+                    local_day_start = pytz.utc.localize(current_date).astimezone(tz)
+                    technical_attendances_vals.append({
+                        'check_in': local_day_start.strftime('%Y-%m-%d %H:%M:%S'),
+                        'check_out': (local_day_start + relativedelta(seconds=1)).strftime('%Y-%m-%d %H:%M:%S'),
+                        'in_mode': 'technical',
+                        'out_mode': 'technical',
+                        'employee_id': employee.id,
+                    })
 
-        technical_attendances = self.env['hr.attendance'].create(technical_attendances_vals)
-        to_unlink = technical_attendances.filtered(lambda a: a.overtime_hours == 0)
+        if technical_attendances_vals:
+            technical_attendances = self.env['hr.attendance'].create(technical_attendances_vals)
+            to_unlink = technical_attendances.filtered(lambda a: a.overtime_hours == 0)
 
-        body = _('This attendance was automatically created to cover an unjustified absence on that day.')
-        for technical_attendance in technical_attendances - to_unlink:
-            technical_attendance.message_post(body=body)
+            body = _('This attendance was automatically created to cover an unjustified absence on that day.')
+            for technical_attendance in technical_attendances - to_unlink:
+                technical_attendance.message_post(body=body)
 
-        to_unlink.unlink()
+            to_unlink.unlink()

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -83,6 +83,8 @@ class ResCompany(models.Model):
         res = super().write(vals)
         if not search_domain.is_false():
             self.env['hr.attendance'].search(search_domain)._update_overtime()
+        if vals.get('absence_management', False):
+            self.env['hr.attendance']._cron_absence_detection()
 
         return res
 

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -663,15 +663,17 @@ class TestHrAttendanceOvertime(TransactionCase):
     #     self.assertAlmostEqual(self.europe_employee.total_overtime, 0, 2)
     #     self.assertAlmostEqual(self.flexible_employee.total_overtime, 0, 2)
 
-    #     self.env['hr.attendance']._cron_absence_detection()
+    #     self.company.write({
+    #         'absence_management': True,
+    #     })
 
-    #     # Check that absences were correctly attributed
-    #     self.assertAlmostEqual(self.other_employee.total_overtime, -8, 2)
-    #     self.assertAlmostEqual(self.jpn_employee.total_overtime, -8, 2)
-    #     self.assertAlmostEqual(self.honolulu_employee.total_overtime, -8, 2)
+    #     # Check that absences were correctly attributed (Absences on the full month - 22 working days)
+    #     self.assertAlmostEqual(self.other_employee.total_overtime, -176, 2)
+    #     self.assertAlmostEqual(self.jpn_employee.total_overtime, -176, 2)
+    #     self.assertAlmostEqual(self.honolulu_employee.total_overtime, -176, 2)
 
-    #     # Employee Checked in yesterday, no absence found
-    #     self.assertAlmostEqual(self.employee.total_overtime, 0, 2)
+    #     # Employee Checked in yesterday, no absence found (Absences on the full month except one day - 21 working)
+    #     self.assertAlmostEqual(self.employee.total_overtime, -168, 2)
 
     #     # Flexible schedule employee, no absence found
     #     self.assertAlmostEqual(self.flexible_employee.total_overtime, 0, 2)


### PR DESCRIPTION
The absence detection cron now processes the last 30 days (D-30 to D-1) instead of only the previous day (D-1). This ensures that missing attendances are detected and technical attendances are created for up to 30 days of untracked absences. This also improves reporting accuracy, especially when the setting is enabled after a long inactive period. Related task: 5003559

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
