### PR TITLE
[IMP] l10n_mx_edi: Add simple factoring

### DIFF
--- a/addons/l10n_mx/data/template/account.account-mx.csv
+++ b/addons/l10n_mx/data/template/account.account-mx.csv
@@ -31,6 +31,7 @@
 "cuenta173_01","Deferred expenses","173.01.01","asset_current","True","l10n_mx.tag_debit_balance_account","","Gastos diferidos"
 "cuenta201_01","National suppliers","201.01.01","liability_payable","True","l10n_mx.tag_credit_balance_account","","Proveedores nacionales"
 "cuenta201_01_02","Employee Reimbursement","201.01.02","liability_current","True","l10n_mx.tag_credit_balance_account","","Reembolso empleados"
+"cuenta203_09","National short-term prepaid financial factoring","203.09.01","liability_payable","True","l10n_mx.tag_credit_balance_account","","Factoraje financiero cobrados por anticipado a corto plazo nacional"
 "cuenta205_06_01","Goods Received - No Invoices","205.06.01","liability_current","True","l10n_mx.tag_credit_balance_account","","Mercancías Recibidas - No Facturas"
 "cuenta205_06_02","Other Various Short-Term Credits (Fonacot)","205.06.02","liability_current","True","l10n_mx.tag_credit_balance_account","","Otros acreedores diversos a corto plazo (Fonacot)"
 "cuenta206_01","Domestic customer advance","206.01.01","liability_current","True","l10n_mx.tag_credit_balance_account","","Anticipo de cliente nacional"

--- a/addons/l10n_mx/models/template_mx.py
+++ b/addons/l10n_mx/models/template_mx.py
@@ -37,6 +37,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_purchase_tax_id': 'tax14',
                 'expense_account_id': 'cuenta601_84',
                 'income_account_id': 'cuenta401_01',
+                'l10n_mx_edi_factoring_account_id': 'cuenta203_09', #TODO this should be in l10n_mx_edi, tho should I override this function?
                 'account_cash_basis_base_account_id': 'cuenta801_01_99',
                 'l10n_mx_income_return_discount_account_id': 'cuenta402_01',
                 'l10n_mx_income_re_invoicing_account_id': 'cuenta402_04',


### PR DESCRIPTION
A very common use case for mexican users is factoring. This lets a bank pay some of your provider's invoices, incurring some fees, so that you can have the money in advance. Once your provider finally pays his bills, the payments have to be properly reconciled, including the fees the bank charges you, which you have to deduct from the providers transaction into another move line.

