### PR TITLE
[FIX] repair: correct field and apply OR logic in search

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -346,7 +346,10 @@ class RepairOrder(models.Model):
     def _search_date_category(self, operator, value):
         if operator != 'in':
             return NotImplemented
-        return self.env['stock.picking'].date_category_to_domain('scheduled_date', value)
+        return expression.OR(
+            self.env['stock.picking'].date_category_to_domain('schedule_date', item)
+            for item in value
+        )
 
     @api.onchange('product_uom')
     def onchange_product_uom(self):

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import tagged, common, Form
 from odoo.tools import float_compare, float_is_zero
@@ -907,3 +907,17 @@ class TestRepair(common.TransactionCase):
         self.assertEqual(self.product_product_11.type, 'consu')
         self.assertTrue(self.product_product_11.filtered_domain(domain))
         self.assertFalse(self.product_order_repair.filtered_domain(domain))
+
+    def test_search_date_category(self):
+        """
+        Test that the search_date_category field search functionality works correctly.
+        """
+        self.env['repair.order'].search([]).unlink()
+        repair_order = self.env['repair.order'].create({
+            'partner_id': self.res_partner_1.id,
+            'schedule_date': fields.Datetime.now(),
+            'picking_type_id': self.stock_warehouse.repair_type_id.id,
+        })
+        repair_order.action_validate()
+        repairs = self.env['repair.order'].search([('search_date_category', 'in', ['yesterday', 'today'])])
+        self.assertEqual(len(repairs), 1)


### PR DESCRIPTION
The _search_date_category method was using the incorrect field 'scheduled_date' instead of 'schedule_date', which broke the domain logic. This commit also wraps individual domain clauses in an expression.OR(...) to ensure proper filtering across multiple date categories, in line with the updated ORM search behavior (task-4150178).

Caused by:
https://github.com/odoo/odoo/commit/92301a5b300dec1ddfca44dc35318b83d67c56fa

This fix aligns `_search_date_category` logic in repair to match what is done in mrp & stock.

https://github.com/user-attachments/assets/e45791c3-feaf-4d52-9f63-6ff43fb84ca8

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
