### PR TITLE
[ADD] l10n_ar: add ARCA activity model

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -86,6 +86,7 @@ Master Data:
         'data/res_partner_data.xml',
         'data/res.currency.csv',
         'data/res.country.csv',
+        'data/l10n_ar.arca.activity.csv',
         'views/account_move_view.xml',
         'views/res_partner_view.xml',
         'views/res_company_view.xml',
@@ -100,6 +101,8 @@ Master Data:
         'views/portal_address_templates.xml',
         'views/report_invoice.xml',
         'views/res_config_settings_view.xml',
+        'views/l10n_ar_arca_activity_view.xml',
+        'views/account_account_views.xml',
         'report/invoice_report_view.xml',
     ],
     'demo': [

--- a/addons/l10n_ar/data/l10n_ar.arca.activity.csv
+++ b/addons/l10n_ar/data/l10n_ar.arca.activity.csv
@@ -1,0 +1,959 @@
+code,name
+11111,Cultivo de arroz
+11112,Cultivo de trigo
+11119,"Cultivo de cereales n.c.p., excepto los de uso forrajero"
+11121,Cultivo de maíz
+11129,Cultivo de cereales de uso forrajero n.c.p.
+11130,Cultivo de pastos de uso forrajero
+11211,Cultivo de soja
+11291,Cultivo de girasol
+11299,Cultivo de oleaginosas n.c.p. excepto soja y girasol
+11310,"Cultivo de papa, batata y mandioca"
+11321,Cultivo de tomate
+11329,"Cultivo de bulbos, brotes, raíces y hortalizas de fruto n.c.p."
+11331,Cultivo de hortalizas de hoja y de otras hortalizas frescas
+11341,Cultivo de legumbres frescas
+11342,Cultivo de legumbres secas
+11400,Cultivo de tabaco
+11501,Cultivo de algodón
+11509,Cultivo de plantas para la obtención de fibras n.c.p.
+11911,Cultivo de flores
+11912,Cultivo de plantas ornamentales
+11990,Cultivos temporales n.c.p.
+12110,Cultivo de vid para vinificar
+12121,Cultivo de uva de mesa
+12200,Cultivo de frutas cítricas
+12311,Cultivo de manzana y pera
+12319,Cultivo de frutas de pepita n.c.p.
+12320,Cultivo de frutas de carozo
+12410,Cultivo de frutas tropicales y subtropicales
+12420,Cultivo de frutas secas
+12490,Cultivo de frutas n.c.p.
+12510,Cultivo de caña de azúcar
+12590,Cultivo de plantas sacaríferas n.c.p.
+12600,Cultivo de frutos oleaginosos
+12701,Cultivo de yerba mate
+12709,Cultivo de té y otras plantas cuyas hojas se utilizan para preparar infusiones
+12800,Cultivo de especias y de plantas aromáticas y medicinales
+12900,Cultivos perennes n.c.p.
+13011,Producción de semillas híbridas de cereales y oleaginosas
+13012,"Producción de semillas varietales o autofecundadas de cereales, oleaginosas, y forrajeras"
+13013,"Producción de semillas de hortalizas y legumbres, flores y plantas ornamentales y árboles frutales"
+13019,Producción de semillas de cultivos agrícolas n.c.p.
+13020,Producción de otras formas de propagación de cultivos agrícolas
+14113,"Cría de ganado bovino, excepto la realizada en cabañas y para la producción de leche"
+14114,Invernada  de ganado bovino excepto el engorde en corrales (Feed-Lot)
+14115,Engorde en corrales (Feed-Lot)
+14121,Cría de ganado bovino realizada en cabañas
+14211,"Cría de ganado equino, excepto la realizada en haras"
+14300,Cría de camélidos
+14410,Cría de ganado ovino -excepto en cabañas y para la  producción de lana y leche
+14420,Cría de ganado ovino realizada en cabañas
+14430,Cría de ganado caprino -excepto la realizada en cabañas y para producción de pelos y de leche
+14440,Cría de ganado caprino realizada en cabañas
+14510,"Cría de ganado porcino, excepto la realizada en cabañas"
+14520,Cría de ganado porcino realizado en cabañas
+14610,Producción de leche bovina
+14620,Producción de leche de oveja y de cabra
+14710,Producción de lana y pelo de oveja y cabra (cruda)
+14720,Producción de pelos de ganado n.c.p.
+14810,"Cría de aves de corral, excepto para la producción de huevos"
+14820,Producción de huevos
+14910,Apicultura
+14920,Cunicultura
+14930,"Cría de animales pelíferos, pilíferos y plumíferos, excepto de las especies ganaderas"
+14990,"Cría de animales y obtención de productos de origen animal, n.c.p."
+16111,"Servicios de labranza, siembra, transplante  y  cuidados culturales"
+16112,"Servicios de pulverización, desinfección y fumigación terrestre"
+16113,"Servicios de pulverización, desinfección y fumigación aérea"
+16119,"Servicios de maquinaria agrícola n.c.p., excepto los de cosecha mecánica"
+16120,Servicios de cosecha mecánica
+16130,Servicios de contratistas de mano de obra agrícola
+16140,Servicios de post cosecha
+16150,Servicios de procesamiento de semillas para su siembra
+16190,Servicios de apoyo agrícolas n.c.p
+16210,Inseminación artificial y servicios n.c.p. para mejorar la reproducción de los animales y el rendimiento de sus productos
+16220,Servicios de contratistas de mano de obra pecuaria
+16230,Servicios de esquila de animales
+16291,"Servicios para el control de plagas, baños parasiticidas, etc."
+16292,Albergue y cuidado de  animales de terceros
+16299,Servicios de apoyo pecuarios n.c.p.
+17010,Caza y repoblación  de animales de caza
+17020,Servicios de apoyo para la caza
+21010,Plantación de bosques
+21020,Repoblación y conservación de bosques nativos y zonas forestadas
+21030,Explotación de viveros forestales
+22010,Extracción de productos forestales de bosques cultivados
+22020,Extracción de productos forestales de bosques nativos
+24010,Servicios forestales para la extracción de madera
+24020,Servicios forestales excepto los servicios para la extracción de madera
+31110,"Pesca de organismos marinos, excepto cuando es realizada en buques procesadores"
+31120,Pesca y elaboración de productos marinos realizada a bordo de buques procesadores
+31130,"Recolección de organismos marinos excepto peces, crustáceos y moluscos"
+31200,Pesca continental: fluvial y lacustre
+31300,Servicios de apoyo para la pesca
+32000,"Explotación de criaderos de peces, granjas piscícolas y otros frutos acuáticos  (acuicultura)"
+51000,Extracción y aglomeración de carbón
+52000,Extracción y aglomeración de lignito
+61000,Extracción de petróleo crudo
+62000,Extracción de gas natural
+71000,Extracción de minerales de hierro
+72100,Extracción de minerales y concentrados de uranio y torio
+72910,Extracción de metales preciosos
+72990,"Extracción de minerales metalíferos no ferrosos n.c.p., excepto minerales de uranio y torio"
+81100,Extracción de rocas ornamentales
+81200,Extracción de piedra caliza y yeso
+81300,"Extracción de arenas, canto rodado y triturados pétreos"
+81400,Extracción de arcilla y caolín
+89110,Extracción de minerales para la fabricación de abonos excepto turba
+89120,Extracción de minerales para la fabricación de productos químicos
+89200,Extracción y aglomeración de turba
+89300,Extracción de sal
+89900,Explotación de minas y canteras n.c.p.
+91000,Servicios de apoyo para la extracción de petróleo y gas natural
+99000,"Servicios de apoyo para la minería, excepto para la extracción de petróleo y gas natual"
+101011,Matanza de ganado bovino
+101012,Procesamiento de carne de ganado bovino
+101013,Saladero y peladero de cueros de ganado bovino
+101020,Producción y procesamiento de carne de aves
+101030,Elaboración de fiambres y embutidos
+101040,Matanza de ganado excepto el bovino y procesamiento de su carne
+101091,Fabricación de aceites y grasas de origen animal
+101099,"Matanza de animales n.c.p. y procesamiento de su carne, elaboración de subproductos cárnicos n.c.p."
+102001,"Elaboración de pescados de mar, crustáceos y  productos marinos"
+102002,Elaboración de pescados de ríos y lagunas y otros productos fluviales y lacustres
+102003,"Fabricación de aceites, grasas, harinas y productos a base de pescados"
+103011,"Preparación de conservas de frutas, hortalizas y legumbres"
+103012,"Elaboración y envasado de dulces, mermeladas y jaleas"
+103020,"Elaboración de jugos naturales y sus concentrados, de frutas, hortalizas y legumbres"
+103030,"Elaboración de frutas, hortalizas y legumbres congeladas"
+103091,"Elaboración de hortalizas y legumbres deshidratadas o desecadas, preparación n.c.p. de hortalizas y legumbres"
+103099,"Elaboración de frutas deshidratadas o desecadas, preparación n.c.p. de frutas"
+104011,Elaboración de aceites y grasas vegetales  sin refinar
+104012,Elaboración de aceite de oliva
+104013,Elaboración de aceites y grasas vegetales refinados
+104020,Elaboración de margarinas y grasas vegetales comestibles similares
+105010,Elaboración de leches y productos lácteos deshidratados
+105020,Elaboración de quesos
+105030,Elaboración industrial de helados
+105090,Elaboración de productos lácteos n.c.p.
+106110,Molienda de trigo
+106120,Preparación de arroz
+106131,Elaboración de alimentos a base de cereales
+106139,"Preparación y molienda de legumbres y cereales n.c.p., excepto trigo y arroz y molienda húmeda de maíz"
+106200,"Elaboración de almidones y productos derivados del almidón, molienda húmeda de maíz"
+107110,Elaboración de galletitas y bizcochos
+107121,"Elaboración industrial de productos de panadería, excepto galletitas y bizcochos"
+107129,Elaboración de productos de panadería n.c.p.
+107200,Elaboración de azúcar
+107301,Elaboración de cacao y chocolate
+107309,Elaboración de productos de confitería n.c.p.
+107410,Elaboración de pastas alimentarias frescas
+107420,Elaboración de pastas alimentarias secas
+107500,Elaboración de comidas preparadas para reventa
+107911,"Tostado, torrado y molienda de café"
+107912,Elaboración y molienda de hierbas aromáticas y  especias
+107920,Preparación de hojas de té
+107930,Elaboración de yerba mate
+107991,"Elaboración de extractos, jarabes y concentrados"
+107992,Elaboración de vinagres
+107999,Elaboración de productos alimenticios n.c.p.
+108000,Elaboración de alimentos preparados para animales
+109000,Servicios industriales para la elaboración de alimentos y bebidas
+110100,"Destilación, rectificación y mezcla de bebidas espiritosas"
+110211,Elaboración de mosto
+110212,Elaboración de vinos
+110290,Elaboración de sidra y otras bebidas alcohólicas fermentadas
+110300,"Elaboración de cerveza, bebidas malteadas y malta"
+110411,Embotellado de aguas naturales y minerales
+110412,Fabricación de sodas
+110420,"Elaboración de bebidas gaseosas, excepto soda"
+110491,Elaboración de hielo
+110492,Elaboración de bebidas no alcohólicas n.c.p.
+120010,Preparación de hojas de tabaco
+120091,Elaboración de cigarrillos
+120099,Elaboración de productos de tabaco n.c.p.
+131110,"Preparación de fibras textiles vegetales, desmotado de algodón"
+131120,Preparación de fibras animales de uso textil
+131131,"Fabricación de hilados textiles de lana, pelos y sus mezclas"
+131132,Fabricación de hilados textiles de algodón y sus mezclas
+131139,"Fabricación de hilados textiles n.c.p., excepto de lana  y de algodón"
+131201,"Fabricación de tejidos (telas) planos de lana y sus mezclas, incluye hilanderías y tejedurías integradas"
+131202,"Fabricación de tejidos (telas) planos de algodón y sus mezclas, incluye hilanderías y tejedurías integradas"
+131209,"Fabricación de tejidos (telas) planos de fibras textiles n.c.p., incluye hilanderías y tejedurías integradas"
+131300,Acabado de productos textiles
+139100,Fabricación de tejidos de punto
+139201,"Fabricación de frazadas, mantas, ponchos, colchas, cobertores, etc."
+139202,Fabricación de ropa de cama y mantelería
+139203,Fabricación de artículos de lona y sucedáneos de lona
+139204,Fabricación de bolsas de materiales textiles para productos a granel
+139209,"Fabricación de artículos confeccionados de materiales textiles n.c.p., excepto prendas de vestir"
+139300,Fabricación de tapices y alfombras
+139400,"Fabricación de cuerdas, cordeles, bramantes y redes"
+139900,Fabricación de productos textiles n.c.p.
+141110,"Confección de ropa interior, prendas para dormir y para la playa"
+141120,"Confección de ropa de trabajo, uniformes y guardapolvos"
+141130,Confección de prendas de vestir para bebés y niños
+141140,Confección de prendas deportivas
+141191,Fabricación de accesorios de vestir excepto de cuero
+141199,"Confección de prendas de vestir n.c.p., excepto prendas de piel, cuero y de punto"
+141201,Fabricación de accesorios de vestir de cuero
+141202,Confección de prendas de vestir de cuero
+142000,"Terminación y teñido de pieles, fabricación de artículos de piel"
+143010,Fabricación de medias
+143020,Fabricación de prendas de vestir y artículos similares de punto
+149000,Servicios industriales para la industria confeccionista
+151100,Curtido y terminación de cueros
+151200,"Fabricación de maletas, bolsos de mano y similares, artículos de talabartería y artículos de cuero n.c.p."
+152011,"Fabricación de calzado de cuero, excepto calzado deportivo y ortopédico"
+152021,"Fabricación de calzado de materiales n.c.p., excepto calzado deportivo y ortopédico"
+152031,Fabricación de calzado deportivo
+152040,Fabricación de partes de calzado
+161001,Aserrado y cepillado de madera  nativa
+161002,Aserrado y cepillado de madera implantada
+162100,"Fabricación de hojas de madera para enchapado, fabricación de tableros contrachapados, tableros laminados, tableros de partículas y tableros y paneles n.c.p."
+162201,Fabricación de aberturas y estructuras de madera para la construcción
+162202,Fabricación de viviendas prefabricadas de madera
+162300,Fabricación de recipientes de madera
+162901,Fabricación de ataúdes
+162902,Fabricación de artículos de madera en tornerías
+162903,Fabricación de productos de corcho
+162909,"Fabricación de productos de madera n.c.p, fabricación de artículos de paja y materiales trenzables"
+170101,Fabricación de pasta de madera
+170102,Fabricación de papel y cartón excepto envases
+170201,Fabricación de papel ondulado y envases de papel
+170202,Fabricación de cartón ondulado y envases de cartón
+170910,Fabricación de artículos de papel y cartón de uso doméstico e higiénico sanitario
+170990,Fabricación de artículos de papel y cartón n.c.p.
+181101,Impresión de diarios y revistas
+181109,"Impresión n.c.p., excepto de diarios y revistas"
+181200,Servicios relacionados con la impresión
+182000,Reproducción de grabaciones
+191000,Fabricación de productos de hornos de coque
+192000,Fabricación de productos de la refinación del petróleo
+201110,Fabricación de gases industriales y medicinales comprimidos o licuados
+201120,Fabricación de curtientes naturales y sintéticos
+201130,"Fabricación de materias colorantes básicas, excepto pigmentos preparados"
+201140,"Fabricación de combustible nuclear, sustancias y materiales radiactivos"
+201180,Fabricación de materias químicas inorgánicas básicas n.c.p.
+201190,Fabricación de materias químicas orgánicas básicas n.c.p.
+201210,Fabricación de alcohol
+201220,Fabricación de biocombustibles excepto alcohol
+201300,Fabricación de abonos y compuestos de nitrógeno
+201401,Fabricación de resinas y cauchos sintéticos
+201409,Fabricación de materias plásticas en formas primarias n.c.p.
+202101,"Fabricación de insecticidas, plaguicidas y  productos químicos de uso agropecuario"
+202200,"Fabricación de pinturas, barnices y productos de revestimiento similares, tintas de imprenta y masillas"
+202311,"Fabricación de preparados para limpieza, pulido y saneamiento"
+202312,Fabricación de jabones y detergentes
+202320,"Fabricación de cosméticos, perfumes y  productos de higiene y tocador"
+202906,Fabricación de explosivos y productos de pirotecnia
+202907,"Fabricación de colas, adhesivos, aprestos y cementos excepto los odontológicos obtenidos de sustancias minerales y vegetales"
+202908,Fabricación de productos químicos n.c.p.
+203000,Fabricación de fibras manufacturadas
+204000,Servicios industriales para la fabricación de sustancias y productos químicos
+210010,Fabricación de medicamentos de uso humano y productos farmacéuticos
+210020,Fabricación de medicamentos de uso veterinario
+210030,Fabricación de sustancias químicas para la elaboración de medicamentos
+210090,Fabricación de productos de laboratorio y productos botánicos de uso farmaceútico n.c.p.
+221110,Fabricación de cubiertas y cámaras
+221120,Recauchutado y renovación de cubiertas
+221901,Fabricación de  autopartes de caucho excepto cámaras y cubiertas
+221909,Fabricación  de productos de caucho n.c.p.
+222010,Fabricación de envases plásticos
+222090,"Fabricación de productos plásticos en formas básicas y artículos de plástico n.c.p., excepto muebles"
+231010,Fabricación de envases de vidrio
+231020,Fabricación y elaboración de vidrio plano
+231090,Fabricación de productos de vidrio n.c.p.
+239100,Fabricación de productos de cerámica refractaria
+239201,Fabricación de ladrillos
+239202,Fabricación de revestimientos cerámicos
+239209,Fabricación de productos de arcilla y cerámica no refractaria para uso estructural n.c.p.
+239310,Fabricación de artículos sanitarios de cerámica
+239391,Fabricación de objetos cerámicos para uso doméstico excepto artefactos sanitarios
+239399,Fabricación de artículos de cerámica no refractaria para uso no estructural n.c.p.
+239410,Elaboración de cemento
+239421,Elaboración de  yeso
+239422,Elaboración de cal
+239510,Fabricación de mosaicos
+239591,Elaboración de hormigón
+239592,Fabricación de premoldeadas para la construcción
+239593,"Fabricación de artículos de cemento, fibrocemento y yeso excepto hormigón y mosaicos"
+239600,"Corte, tallado y acabado de la piedra"
+239900,Fabricación de productos minerales no metálicos n.c.p.
+241001,"Laminación y estirado. Producción de lingotes, planchas o barras fabricadas por operadores independientes"
+241009,Fabricación en industrias básicas de productos de hierro y acero n.c.p.
+242010,Elaboración de aluminio primario y semielaborados de aluminio
+242090,Fabricación de productos primarios de metales preciosos y metales no ferrosos n.c.p. y sus semielaborados
+243100,Fundición de hierro y acero
+243200,Fundición de metales no ferrosos
+251101,Fabricación de carpintería metálica
+251102,Fabricación de productos metálicos para uso estructural
+251200,"Fabricación de tanques, depósitos y recipientes de metal"
+251300,Fabricación de generadores de vapor
+252000,Fabricación de armas y municiones
+259100,"Forjado, prensado, estampado y laminado de metales, pulvimetalurgia"
+259200,Tratamiento y revestimiento de metales y trabajos de metales en general
+259301,Fabricación de herramientas manuales y sus accesorios
+259302,Fabricación de artículos de cuchillería y utensillos de mesa y de cocina
+259309,"Fabricación de cerraduras, herrajes y artículos de ferretería n.c.p."
+259910,Fabricación de envases metálicos
+259991,Fabricación de tejidos de alambre
+259992,Fabricación de cajas de seguridad
+259993,Fabricación de productos metálicos de tornería y/o matricería
+259999,Fabricación de productos elaborados de metal n.c.p.
+261000,Fabricación de componentes electrónicos
+262000,Fabricación de equipos y productos informáticos
+263000,Fabricación  de equipos de comunicaciones y transmisores de radio y televisión
+264000,"Fabricación de receptores de radio y televisión, aparatos de grabación y reproducción de sonido y video, y productos conexos"
+265101,"Fabricación de instrumentos y aparatos para medir, verificar, ensayar, navegar y otros fines, excepto el equipo de control de procesos industriales"
+265102,Fabricación de equipo de control de procesos industriales
+265200,Fabricación de relojes
+266010,Fabricación de equipo médico y quirúrgico y de aparatos ortopédicos principalmente electrónicos y/o eléctricos
+266090,Fabricación de equipo médico y quirúrgico y de aparatos ortopédicos n.c.p.
+267001,Fabricación de equipamiento e instrumentos ópticos y sus accesorios
+267002,"Fabricación de aparatos y accesorios para fotografía excepto películas, placas y papeles sensibles"
+268000,Fabricación de soportes ópticos y magnéticos
+271010,"Fabricación de motores, generadores y transformadores eléctricos"
+271020,Fabricación de aparatos de distribución y control de la energía eléctrica
+272000,"Fabricación de acumuladores, pilas y baterías primarias"
+273110,Fabricación de cables de fibra óptica
+273190,Fabricación de hilos y cables aislados n.c.p.
+274000,Fabricación de lámparas eléctricas y equipo de iluminación
+275010,"Fabricación de cocinas, calefones, estufas y calefactores no eléctricos"
+275020,"Fabricación de heladeras, ""freezers"", lavarropas y secarropas"
+275091,"Fabricación de ventiladores, extractores de aire, aspiradoras y similares"
+275092,"Fabricación de planchas, calefactores, hornos eléctricos, tostadoras y otros aparatos generadores de calor"
+275099,Fabricación de aparatos de uso doméstico n.c.p.
+279000,Fabricación  de equipo eléctrico n.c.p.
+281100,"Fabricación  de  motores  y  turbinas,  excepto  motores  para aeronaves, vehículos automotores   y motocicletas"
+281201,Fabricación de bombas
+281301,"Fabricación de compresores, grifos y válvulas"
+281400,"Fabricación de cojinetes, engranajes, trenes de engranaje y piezas de transmisión"
+281500,"Fabricación de hornos, hogares y quemadores"
+281600,Fabricación de maquinaria y equipo de elevación y manipulación
+281700,"Fabricación de maquinaria y equipo de oficina, excepto equipo informático"
+281900,Fabricación de  maquinaria y equipo de uso general n.c.p.
+282110,Fabricación de tractores
+282120,Fabricación de maquinaria y equipo de uso agropecuario y forestal
+282130,Fabricación de implementos de uso agropecuario
+282200,Fabricación de máquinas herramienta
+282300,Fabricación de maquinaria metalúrgica
+282400,Fabricación de maquinaria para la explotación de minas y canteras y para obras de construcción
+282500,"Fabricación de maquinaria para la elaboración de alimentos, bebidas y tabaco"
+282600,"Fabricación de maquinaria para la elaboración de productos textiles, prendas de vestir y cueros"
+282901,Fabricación de maquinaria para la industria del papel y las artes gráficas
+282909,Fabricación de maquinaria y equipo de uso especial n.c.p.
+291000,Fabricación de vehículos automotores
+292000,"Fabricación de carrocerías para vehículos automotores, fabricación de remolques y semirremolques"
+293011,Rectificación de motores
+293090,"Fabricación de partes, piezas y accesorios para vehículos automotores y sus motores n.c.p."
+301100,Construcción y reparación de buques
+301200,Construcción y reparación de embarcaciones de recreo y deporte
+302000,Fabricación y reparación de locomotoras y de material rodante para transporte ferroviario
+303000,Fabricación y reparación de aeronaves
+309100,Fabricación de motocicletas
+309200,Fabricación de bicicletas y de sillones de ruedas ortopédicos
+309900,Fabricación de equipo de transporte n.c.p.
+310010,"Fabricación de muebles y partes de muebles, principalmente de madera"
+310020,"Fabricación de muebles y partes de muebles, excepto los que son principalmente de madera (metal, plástico, etc.)"
+310030,Fabricación de somieres y colchones
+321011,Fabricación de joyas finas y artículos conexos
+321012,Fabricación de objetos de platería
+321020,Fabricación de bijouterie
+322001,Fabricación de instrumentos de música
+323001,Fabricación de artículos de deporte
+324000,Fabricación de juegos y juguetes
+329010,"Fabricación de lápices, lapiceras,  bolígrafos, sellos y artículos similares para oficinas y artistas"
+329020,"Fabricación de escobas, cepillos y pinceles"
+329030,"Fabricación de carteles, señales e indicadores  -eléctricos o no-"
+329040,"Fabricación de equipo de protección y seguridad, excepto calzado"
+329090,Industrias manufactureras n.c.p.
+331101,"Reparación y mantenimiento de productos de metal, excepto maquinaria y equipo"
+331210,Reparación y mantenimiento de maquinaria de uso general
+331220,Reparación y mantenimiento de maquinaria y equipo de uso agropecuario y forestal
+331290,Reparación y mantenimiento de maquinaria de uso especial n.c.p.
+331400,Reparación y mantenimiento de maquinaria y aparatos eléctricos
+331900,Reparación y mantenimiento de máquinas y equipo n.c.p.
+332000,Instalación de maquinaria y equipos industriales
+351110,Generación de energía térmica convencional
+351120,Generación de energía térmica nuclear
+351130,Generación de energía hidráulica
+351190,Generación de energía n.c.p.
+351201,Transporte de energía eléctrica
+351310,Comercio mayorista de energía eléctrica
+351320,Distribución de energía eléctrica
+352010,Fabricación de gas y procesamiento de gas natural
+352020,Distribución de combustibles gaseosos por tuberías
+353001,Suministro de vapor y aire acondicionado
+360010,"Captación, depuración y distribución de agua de fuentes subterráneas"
+360020,"Captación, depuración y distribución de agua de fuentes superficiales"
+370000,"Servicios de depuración de aguas residuales, alcantarillado y cloacas"
+381100,"Recolección, transporte, tratamiento y disposición final de residuos no peligrosos"
+381200,"Recolección, transporte, tratamiento y disposición final de residuos peligrosos"
+382010,Recuperación de materiales y desechos metálicos
+382020,Recuperación de materiales y desechos no metálicos
+390000,Descontaminación y otros servicios de gestión de residuos
+410011,"Construcción, reforma y reparación de edificios residenciales"
+410021,"Construcción, reforma y reparación de edificios no residenciales"
+421000,"Construcción, reforma y reparación de obras de infraestructura para el transporte"
+422100,Perforación de pozos de agua
+422200,"Construcción, reforma y reparación de redes distribución de electricidad, gas, agua, telecomunicaciones y de otros servicios públicos"
+429010,"Construcción, reforma y reparación de obras hidráulicas"
+429090,Construcción de obras de ingeniería civil n.c.p.
+431100,Demolición y voladura de edificios y de sus partes
+431210,Movimiento de suelos y preparación de terrenos para obras
+432110,"Instalación de sistemas de iluminación, control y señalización eléctrica para el transporte"
+432190,"Instalación, ejecución y mantenimiento de instalaciones eléctricas, electromecánicas y electrónicas n.c.p."
+432200,"Instalaciones de gas, agua, sanitarios y de climatización, con sus artefactos conexos"
+432910,"Instalaciones de ascensores, montacargas y  escaleras mecánicas"
+432920,"Aislamiento térmico, acústico, hídrico y antivibratorio"
+432990,Instalaciones para edificios y obras de ingeniería civil n.c.p.
+433010,"Instalaciones de carpintería, herrería de obra y artística"
+433020,Terminación y revestimiento de paredes y pisos
+433030,Colocación de cristales en obra
+433040,Pintura y trabajos de decoración
+433090,Terminación de edificios n.c.p.
+439100,Alquiler de equipo de construcción o demolición dotado de operarios
+439910,"Hincado de pilotes, cimentación y otros trabajos de hormigón armado"
+439990,Actividades especializadas de construcción n.c.p.
+451110,"Venta de autos, camionetas y utilitarios nuevos"
+451190,Venta de vehículos automotores nuevos n.c.p.
+451210,"Venta de autos, camionetas y utilitarios, usados"
+451290,Venta de vehículos automotores usados n.c.p.
+452101,Lavado automático y manual de vehículos automotores
+452210,Reparación de cámaras y cubiertas
+452220,"Reparación de amortiguadores,  alineación de dirección y balanceo de ruedas"
+452300,"Instalación y reparación de parabrisas, lunetas y ventanillas, cerraduras no eléctricas y grabado de cristales"
+452401,"Reparaciones eléctricas del tablero e instrumental, reparación y recarga de baterías, instalación de alarmas, radios, sistemas de climatización"
+452500,Tapizado y retapizado de automotores
+452600,"Reparación y pintura de carrocerías, colocación y reparación de guardabarros y protecciones exteriores"
+452700,Instalación y reparación de caños de escape y radiadores
+452800,Mantenimiento y reparación de frenos y embragues
+452910,Instalación y reparación de equipos de GNC
+452990,"Mantenimiento y reparación del motor n.c.p., mecánica integral"
+453100,"Venta al por mayor de partes, piezas y accesorios de vehículos automotores"
+453210,Venta al por menor de cámaras y cubiertas
+453220,Venta al por menor de baterías
+453291,"Venta al por menor de partes, piezas y accesorios nuevos n.c.p."
+453292,"Venta al por menor de partes, piezas y accesorios usados n.c.p."
+454010,"Venta de motocicletas y de sus partes, piezas y accesorios"
+454020,Mantenimiento y reparación de motocicletas
+461011,"Venta al por mayor en comisión o consignación de cereales (incluye arroz), oleaginosas y forrajeras excepto semillas"
+461012,Venta al por mayor en comisión o consignación de semillas
+461013,Venta al por mayor en comisión o consignación de frutas
+461014,"Acopio y acondicionamiento en comisión o consignación de cereales (incluye arroz), oleaginosas y forrajeras excepto semillas"
+461019,Venta al por mayor en comisión o consignación de productos agrícolas n.c.p.
+461021,Venta al por mayor en comisión o consignación de ganado bovino en pie
+461022,Venta al por mayor en comisión o consignación de ganado en pie excepto bovino
+461029,Venta al por mayor en comisión o consignación de productos pecuarios n.c.p.
+461031,Operaciones de intermediación de carne - consignatario directo -
+461032,Operaciones de intermediación de carne excepto consignatario directo
+461039,"Venta al por mayor en comisión o consignación de alimentos, bebidas y tabaco n.c.p."
+461040,Venta al por mayor en comisión o consignación de combustibles
+461092,Venta al por mayor en comisión o consignación de  madera y materiales para la construcción
+461093,"Venta al por mayor en comisión o consignación de minerales, metales y productos químicos industriales"
+461094,"Venta al por mayor en comisión o consignación de  maquinaria, equipo profesional industrial y comercial, embarcaciones y aeronaves"
+461095,"Venta al por mayor en comisión o consignación de papel, cartón, libros, revistas, diarios, materiales de embalaje y artículos de librería"
+461099,Venta al por mayor en comisión o consignación de  mercaderías n.c.p.
+462110,Acopio de algodón
+462120,Venta al por mayor de semillas y granos para forrajes
+462131,"Venta al por mayor de cereales (incluye arroz), oleaginosas y forrajeras excepto semillas"
+462132,"Acopio y acondicionamiento de cereales y semillas, excepto de algodón y semillas y granos para forrajes"
+462190,Venta al por mayor de materias primas agrícolas y de la silvicultura n.c.p.
+462201,"Venta al por mayor de lanas, cueros en bruto y productos afines"
+462209,Venta al por mayor de materias primas pecuarias n.c.p. incluso animales vivos
+463111,Venta al por mayor de productos lácteos
+463112,Venta al por mayor de fiambres y quesos
+463121,Venta al por mayor de carnes rojas y derivados
+463129,"Venta al por mayor de aves, huevos y productos de granja y de la caza n.c.p."
+463130,Venta al por mayor de pescado
+463140,"Venta al por mayor y empaque de frutas, de legumbres y hortalizas frescas"
+463151,"Venta al por mayor de pan, productos de confitería y pastas frescas"
+463152,Venta al por mayor de azúcar
+463153,Venta al por mayor de aceites y grasas
+463154,"Venta al por mayor de café, té, yerba mate y otras infusiones y especias y condimentos"
+463159,Venta al por mayor de productos y subproductos de molinería n.c.p.
+463160,"Venta al por mayor de chocolates, golosinas y productos para kioscos y polirrubros n.c.p., excepto cigarrillos"
+463170,Venta al por mayor de alimentos balanceados para animales
+463180,Venta al por mayor en supermercados mayoristas de alimentos
+463191,"Venta al por mayor de frutas, legumbres y cereales secos y en conserva"
+463199,Venta al por mayor de productos alimenticios n.c.p.
+463211,Venta al por mayor de vino
+463212,Venta al por mayor de bebidas espiritosas
+463219,Venta al por mayor de bebidas alcohólicas n.c.p.
+463220,Venta al por mayor de bebidas no alcohólicas
+463300,Venta al por mayor de cigarrillos y productos de tabaco
+464111,Venta al por mayor de tejidos (telas)
+464112,Venta al por mayor de artículos de mercería
+464113,"Venta al por mayor de mantelería, ropa de cama y artículos textiles para el hogar"
+464114,Venta al por mayor de tapices y alfombras de materiales textiles
+464119,Venta al por mayor de productos textiles n.c.p.
+464121,Venta al por mayor de prendas de vestir de cuero
+464122,Venta al por mayor de medias y prendas de punto
+464129,"Venta al por mayor de prendas y accesorios de vestir n.c.p., excepto uniformes y ropa de trabajo"
+464130,Venta al por mayor de calzado excepto el ortopédico
+464141,Venta al por mayor de pieles y cueros curtidos y salados
+464142,Venta al por mayor de suelas y afines
+464149,"Venta al por mayor de artículos de marroquinería,  paraguas y productos similares n.c.p."
+464150,Venta al por mayor de uniformes y ropa de trabajo
+464211,Venta al por mayor de libros y publicaciones
+464212,Venta al por mayor de diarios y revistas
+464221,Venta al por mayor de papel y productos de papel y cartón excepto envases
+464222,Venta al por mayor de envases de papel y cartón
+464223,Venta al por mayor de artículos de librería y papelería
+464310,Venta al por mayor de productos farmacéuticos
+464320,"Venta al por mayor de productos cosméticos, de tocador y de perfumería"
+464330,Venta al por mayor de instrumental médico y odontológico y artículos ortopédicos
+464340,Venta al por mayor de productos veterinarios
+464410,Venta al por mayor de artículos de óptica y de fotografía
+464420,"Venta al por mayor de artículos de relojería, joyería y fantasías"
+464501,Venta al por mayor de electrodomésticos y artefactos para el hogar excepto equipos de audio y video
+464502,"Venta al por mayor de equipos de audio, video y televisión"
+464610,"Venta al por mayor de muebles excepto de oficina, artículos de mimbre y corcho, colchones y somieres"
+464620,Venta al por mayor de artículos de iluminación
+464631,Venta al por mayor de artículos de vidrio
+464632,Venta al por mayor de artículos de bazar y menaje excepto de vidrio
+464920,Venta al por mayor de materiales y productos de limpieza
+464930,Venta al por mayor de juguetes
+464940,Venta al por mayor de bicicletas y rodados similares
+464950,Venta al por mayor de artículos de esparcimiento y deportes
+464991,Venta al por mayor de flores y plantas naturales y artificiales
+464999,Venta al por mayor de artículos de uso doméstico o personal n.c.p
+465100,"Venta al por mayor de equipos, periféricos, accesorios y programas informáticos"
+465210,Venta al por mayor de equipos de telefonía y comunicaciones
+465220,Venta al por mayor de componentes electrónicos
+465310,"Venta al por mayor de máquinas, equipos e implementos de uso en los sectores agropecuario, jardinería, silvicultura, pesca y caza"
+465320,"Venta al por mayor de máquinas, equipos e implementos de uso en la elaboración de alimentos, bebidas y tabaco"
+465330,"Venta al por mayor de máquinas, equipos e implementos de uso en la fabricación de textiles, prendas y accesorios de vestir, calzado, artículos de cuero y marroquinería"
+465340,"Venta al por mayor de máquinas, equipos e implementos de uso en imprentas, artes gráficas y actividades conexas"
+465350,"Venta al por mayor de máquinas, equipos e implementos de uso médico y paramédico"
+465360,"Venta al por mayor de máquinas, equipos e implementos de uso en la industria del plástico y del caucho"
+465390,"Venta al por mayor de máquinas, equipos e implementos de uso especial n.c.p."
+465400,Venta al por mayor de máquinas - herramienta de uso general
+465500,"Venta  al  por  mayor  de  vehículos,  equipos  y  máquinas  para  el transporte ferroviario, aéreo y de navegación"
+465610,Venta al por mayor de muebles e instalaciones para oficinas
+465690,"Venta al por mayor de muebles e instalaciones para la industria, el comercio y los servicios n.c.p."
+465910,Venta al por mayor de máquinas y equipo de control y seguridad
+465920,"Venta al por mayor de maquinaria y equipo de oficina, excepto equipo informático"
+465930,Venta al por mayor de equipo profesional y científico e instrumentos de medida y de control n.c.p.
+465990,"Venta al por mayor de máquinas, equipo y materiales conexos n.c.p."
+466110,Venta al por mayor de combustibles y lubricantes para automotores
+466121,Fraccionamiento y distribución de gas licuado
+466129,"Venta al por mayor de combustibles, lubricantes, leña y carbón, excepto gas licuado y combustibles y lubricantes para automotores"
+466200,Venta al por mayor de metales y minerales metalíferos
+466310,Venta al por mayor de aberturas
+466320,Venta al por mayor de productos de madera excepto muebles
+466330,Venta al por mayor de artículos de ferretería y materiales eléctricos
+466340,Venta al por mayor de pinturas y productos conexos
+466350,Venta al por mayor de cristales y espejos
+466360,"Venta al por mayor de artículos para plomería, instalación de gas y calefacción"
+466370,"Venta al por mayor de papeles para pared, revestimiento para pisos de goma, plástico y textiles,  y artículos similares para la decoración"
+466391,"Venta al por mayor de artículos de loza, cerámica y porcelana de uso en construcción"
+466399,Venta al por mayor de artículos para la construcción n.c.p.
+466910,"Venta al por mayor de productos intermedios n.c.p., desperdicios y desechos textiles"
+466920,"Venta al por mayor de productos intermedios n.c.p., desperdicios y desechos de papel y cartón"
+466931,Venta al por mayor de artículos de plástico
+466932,"Venta al por mayor de abonos, fertilizantes y plaguicidas"
+466939,"Venta al por mayor de productos intermedios, desperdicios y desechos de vidrio, caucho, goma y químicos n.c.p."
+466940,"Venta al por mayor de productos intermedios n.c.p., desperdicios y desechos metálicos"
+466990,"Venta al por mayor de productos intermedios, desperdicios y desechos n.c.p."
+469010,Venta al por mayor de insumos agropecuarios diversos
+469090,Venta al por mayor de mercancías n.c.p.
+471110,Venta al por menor en hipermercados
+471120,Venta al por menor en supermercados
+471130,Venta al por menor en minimercados
+471190,"Venta al por menor en kioscos, polirrubros y comercios no especializados n.c.p."
+471900,"Venta al por menor en comercios no especializados, sin predominio de productos alimenticios y bebidas"
+472111,Venta al por menor de productos lácteos
+472112,Venta al por menor de fiambres y embutidos
+472120,Venta al por menor de productos de almacén y dietética
+472130,"Venta al por menor de carnes rojas, menudencias y chacinados frescos"
+472140,"Venta al por menor de huevos, carne de aves y  productos de granja y de la caza"
+472150,Venta al por menor de pescados y  productos de la pesca
+472160,"Venta al por menor de frutas, legumbres y hortalizas frescas"
+472171,Venta al por menor de pan y productos de panadería
+472172,"Venta al por menor de bombones, golosinas y demás productos de confitería"
+472190,"Venta al por menor de productos alimenticios n.c.p., en comercios especializados"
+472200,Venta al por menor de bebidas en comercios especializados
+472300,Venta al por menor de tabaco en comercios especializados
+473000,Venta al por menor de combustible para vehículos automotores y motocicletas
+474010,"Venta al por menor de equipos, periféricos,  accesorios y programas informáticos"
+474020,Venta al por menor de aparatos de telefonía y comunicación
+475110,"Venta al por menor de hilados, tejidos y artículos de mercería"
+475120,Venta al por menor de confecciones para el hogar
+475190,Venta al por menor de artículos textiles n.c.p. excepto prendas de vestir
+475210,Venta al por menor de aberturas
+475220,"Venta al por menor de maderas y artículos de madera  y corcho, excepto muebles"
+475230,Venta al por menor de artículos de ferretería y materiales eléctricos
+475240,Venta al por menor de pinturas y productos conexos
+475250,Venta al por menor de artículos para plomería e instalación de gas
+475260,"Venta al por menor de cristales, espejos, mamparas y cerramientos"
+475270,"Venta al por menor de papeles para pared, revestimientos para pisos y artículos similares para la decoración"
+475290,Venta al por menor de materiales de construcción n.c.p.
+475300,"Venta al por menor  de electrodomésticos, artefactos para el hogar y equipos de audio y video"
+475410,"Venta al por menor de muebles para el hogar, artículos de mimbre y corcho"
+475420,Venta al por menor de colchones y somieres
+475430,Venta al por menor de artículos de iluminación
+475440,Venta al por menor de artículos de bazar y menaje
+475490,Venta al por menor de artículos para el hogar n.c.p.
+476110,Venta al por menor de libros
+476120,Venta al por menor de diarios y revistas
+476130,"Venta al por menor de papel, cartón, materiales de embalaje y artículos de librería"
+476310,Venta al por menor de equipos  y artículos deportivos
+476320,"Venta al por menor de armas, artículos para la caza y pesca"
+476400,"Venta al por menor de juguetes, artículos de cotillón y juegos de mesa"
+477110,"Venta al por menor de ropa interior, medias, prendas para dormir y para la playa"
+477120,Venta al por menor de uniformes escolares y guardapolvos
+477130,Venta al por menor de indumentaria para bebés y niños
+477140,Venta al por menor de indumentaria deportiva
+477150,Venta al por menor de prendas de cuero
+477190,Venta al por menor de prendas y accesorios de vestir n.c.p.
+477210,Venta al por menor de artículos de talabartería y artículos regionales
+477220,"Venta al por menor de calzado, excepto el ortopédico y el deportivo"
+477230,Venta al por menor de calzado deportivo
+477290,"Venta al por menor de artículos de marroquinería, paraguas y similares n.c.p."
+477310,Venta al por menor de productos farmacéuticos y de herboristería
+477320,"Venta al por menor de productos cosméticos, de tocador y de perfumería"
+477330,Venta al por menor de instrumental médico y odontológico y artículos ortopédicos
+477410,Venta al por menor de artículos de óptica y fotografía
+477420,Venta al por menor de artículos de relojería y joyería
+477430,Venta al por menor de bijouterie y fantasía
+477440,"Venta al por menor de flores, plantas, semillas, abonos, fertilizantes y otros productos de vivero"
+477450,Venta al por menor de materiales y productos de limpieza
+477460,"Venta al por menor de fuel oil, gas en garrafas, carbón y leña"
+477470,"Venta al por menor de productos veterinarios, animales domésticos y alimento balanceado para mascotas"
+477480,Venta al por menor de obras de arte
+477490,Venta al por menor de artículos nuevos n.c.p.
+477810,Venta al por menor de muebles usados
+477820,"Venta al por menor de libros, revistas y similares usados"
+477830,Venta al por menor de antigüedades
+477840,"Venta al por menor de oro, monedas, sellos y similares"
+477890,Venta al por menor de artículos usados n.c.p. excepto+E1155 automotores y motocicletas
+478010,"Venta al por menor de alimentos, bebidas y tabaco en puestos móviles y mercados"
+478090,Venta al por menor de productos n.c.p. en puestos móviles y mercados
+479101,Venta al por menor por internet
+479109,"Venta al por menor por correo, televisión y otros medios de comunicación n.c.p."
+479900,Venta al por menor no realizada en establecimientos  n.c.p.
+491110,Servicio de transporte ferroviario urbano y suburbano de pasajeros
+491120,Servicio de transporte ferroviario interurbano de pasajeros
+491200,Servicio de transporte ferroviario de cargas
+492110,Servicio de transporte automotor urbano y suburbano regular de pasajeros
+492120,"Servicios de transporte automotor de pasajeros mediante taxis y remises, alquiler de autos con chofer"
+492130,Servicio de transporte escolar
+492140,"Servicio de transporte automotor urbano y suburbano no regular de pasajeros de oferta libre,  excepto mediante taxis y remises, alquiler de autos con chofer y transporte escolar"
+492150,"Servicio de transporte automotor interurbano regular de pasajeros, E1203excepto transporte internacional"
+492160,Servicio de transporte automotor interurbano no regular de pasajeros
+492170,Servicio de transporte automotor internacional de pasajeros
+492180,Servicio de transporte automotor turístico de pasajeros
+492190,Servicio de transporte automotor de pasajeros n.c.p.
+492210,Servicios de mudanza
+492221,Servicio de transporte automotor de cereales
+492229,Servicio de transporte automotor de mercaderías a granel n.c.p.
+492230,Servicio de transporte automotor de animales
+492240,Servicio de transporte por camión cisterna
+492250,Servicio de transporte automotor de mercaderías y sustancias peligrosas
+492280,Servicio de transporte automotor urbano de carga n.c.p.
+492290,Servicio de transporte automotor de cargas n.c.p.
+493110,Servicio de transporte por oleoductos
+493120,Servicio de transporte por poliductos y fueloductos
+493200,Servicio de transporte por gasoductos
+501100,Servicio de transporte marítimo de pasajeros
+501200,Servicio de transporte marítimo de carga
+502101,Servicio de transporte fluvial y lacustre de pasajeros
+502200,Servicio de transporte fluvial y lacustre de carga
+511000,Servicio de transporte aéreo de pasajeros
+512000,Servicio de transporte aéreo de cargas
+521010,Servicios de manipulación de carga en el ámbito terrestre
+521020,Servicios de manipulación de carga en el ámbito portuario
+521030,Servicios de manipulación de carga en el ámbito aéreo
+522010,Servicios de almacenamiento y depósito en silos
+522020,Servicios de almacenamiento y depósito en cámaras frigoríficas
+522091,Servicios de usuarios directos de zona franca
+522092,Servicios de gestión de depósitos fiscales
+522099,Servicios de almacenamiento y depósito n.c.p.
+523011,Servicios de gestión aduanera realizados por despachantes de aduana
+523019,Servicios de gestión aduanera para el transporte de mercaderías n.c.p.
+523020,Servicios de agencias marítimas para el transporte de mercaderías
+523031,Servicios de gestión de agentes de transporte aduanero excepto agencias marítimas
+523032,Servicios de operadores logísticos seguros (OLS) en el ámbito aduanero
+523039,Servicios de operadores logísticos n.c.p.
+523090,Servicios de gestión y logística para el transporte de mercaderías n.c.p.
+524110,"Servicios de explotación de infraestructura para el transporte terrestre, peajes y otros derechos"
+524120,Servicios  de playas de estacionamiento y garajes
+524130,Servicios de estaciones terminales de ómnibus y ferroviárias
+524190,Servicios complementarios para el transporte terrestre n.c.p.
+524210,"Servicios de explotación de infraestructura para el transporte marítimo, derechos de puerto"
+524220,Servicios de guarderías náuticas
+524230,Servicios para la navegación
+524290,Servicios complementarios para el transporte marítimo n.c.p.
+524310,"Servicios de explotación de infraestructura para el transporte aéreo, derechos de aeropuerto"
+524320,Servicios de hangares y estacionamiento de aeronaves
+524330,Servicios para la aeronavegación
+524390,Servicios complementarios para el transporte aéreo n.c.p.
+530010,Servicio de correo postal
+530090,Servicios de mensajerías.
+551010,Servicios de alojamiento por hora
+551021,Servicios de alojamiento en pensiones
+551022,"Servicios de alojamiento en hoteles, hosterías y residenciales similares, excepto por hora, que incluyen servicio de restaurante al público"
+551023,"Servicios de alojamiento en hoteles, hosterías y residenciales similares, excepto por hora, que no incluyen servicio de restaurante al público"
+551090,Servicios de hospedaje temporal n.c.p.
+552000,Servicios de alojamiento en campings
+561011,Servicios de restaurantes y cantinas sin espectáculo
+561012,Servicios de restaurantes y cantinas con espectáculo
+561013,"Servicios de ""fast food"" y locales de venta de comidas y bebidas al paso"
+561014,Servicios de expendio de bebidas en bares
+561019,Servicios de expendio de comidas y bebidas en establecimientos con servicio de mesa y/o en mostrador n.c.p.
+561020,Servicios de preparación de comidas para llevar
+561030,Servicio de expendio de helados
+561040,Servicios de preparación de comidas realizadas por/para vendedores ambulantes.
+562010,Servicios de preparación de comidas para empresas y eventos
+562091,Servicios de cantinas con atención exclusiva  a los empleados o estudiantes dentro de empresas o establecimientos educativos.
+562099,Servicios de comidas n.c.p.
+581100,"Edición de libros, folletos, y otras publicaciones"
+581200,Edición de directorios y listas de correos
+581300,"Edición de periódicos, revistas y publicaciones periódicas"
+581900,Edición n.c.p.
+591110,Producción de filmes y videocintas
+591120,Postproducción de filmes y videocintas
+591200,Distribución de filmes y videocintas
+591300,Exhibición de filmes y videocintas
+592000,Servicios de grabación de sonido y edición de música
+601000,Emisión y retransmisión de radio
+602100,Emisión y retransmisión  de televisión abierta
+602200,Operadores de televisión por suscripción.
+602310,Emisión de señales de televisión por suscripción
+602320,Producción de programas de televisión
+602900,Servicios de televisión n.c.p
+611010,Servicios de locutorios
+611090,"Servicios de telefonía fija, excepto locutorios"
+612000,Servicios de telefonía móvil
+613000,"Servicios de telecomunicaciones vía satélite, excepto servicios de transmisión de televisión"
+614010,Servicios de proveedores de acceso a internet
+614090,Servicios de telecomunicación vía internet n.c.p.
+619000,Servicios de telecomunicaciones n.c.p.
+620100,Servicios de consultores en informática y suministros de programas de informática
+620200,Servicios de consultores en equipo de informática
+620300,Servicios de consultores en tecnología de la información
+620900,Servicios de informática n.c.p.
+631110,Procesamiento de datos
+631120,Hospedaje de datos
+631190,Actividades conexas al procesamiento y hospedaje de datos n.c.p.
+631200,Portales web
+639100,Agencias de noticias
+639900,Servicios de información n.c.p.
+641100,Servicios de la banca central
+641910,Servicios de la banca mayorista
+641920,Servicios de la banca de inversión
+641930,Servicios de la banca minorista
+641941,Servicios de intermediación financiera realizada por las compañías financieras
+641942,Servicios de intermediación financiera realizada por sociedades de ahorro y préstamo para la vivienda y otros inmuebles
+641943,Servicios de intermediación financiera realizada por cajas de crédito
+642000,Servicios de sociedades de cartera
+643001,Servicios de fideicomisos
+643009,Fondos y sociedades de inversión y entidades financieras similares n.c.p.
+649100,"Arrendamiento financiero, leasing"
+649210,Actividades de crédito para financiar otras actividades económicas
+649220,Servicios de entidades de tarjeta de compra y/o crédito
+649290,Servicios de crédito n.c.p.
+649910,"Servicios de agentes de mercado abierto ""puros"""
+649991,"Servicios de socios inversores en sociedades regulares según Ley 19.550 - S.R.L., S.C.A, etc, excepto socios inversores en sociedades anónimas incluidos en 649999 -"
+649999,Servicios de financiación y actividades financieras n.c.p.
+651110,Servicios de seguros de salud
+651120,Servicios de seguros de vida
+651130,Servicios de seguros personales excepto  los de salud y de vida
+651210,Servicios de aseguradoras de riesgo de trabajo (ART)
+651220,Servicios de seguros patrimoniales excepto los de las aseguradoras de riesgo de trabajo (ART)
+651310,Obras Sociales
+651320,Servicios de cajas de previsión social pertenecientes a asociaciones profesionales
+652000,Reaseguros
+653000,"Administración de fondos de pensiones, excepto la seguridad social obligatoria"
+661111,Servicios de mercados y cajas de valores
+661121,Servicios de mercados a término
+661131,Servicios de bolsas de comercio
+661910,Servicios bursátiles de mediación o por cuenta de terceros
+661920,Servicios de casas y agencias de cambio
+661930,Servicios de sociedades calificadoras de riesgos financieros
+661991,Servicios de envio y recepción de fondos desde y hacia el exterior
+661992,Servicios de administradoras de vales y tickets
+661999,Servicios auxiliares a la intermediación financiera n.c.p.
+662010,Servicios de evaluación de riesgos y daños
+662020,Servicios de productores  y asesores de seguros
+662090,Servicios auxiliares a los servicios de seguros n.c.p.
+663000,Servicios de gestión de fondos a cambio de una retribución o por contrata
+681010,"Servicios de alquiler y explotación de inmuebles para fiestas, convenciones y otros eventos similares"
+681020,Servicios de alquiler  de consultorios médicos
+681098,"Servicios inmobiliarios realizados por cuenta propia, con bienes urbanos propios o arrendados n.c.p."
+681099,"Servicios inmobiliarios realizados por cuenta propia, con bienes rurales propios o arrendados n.c.p."
+682010,Servicios de administración de consorcios de edificios
+682091,Servicios prestados por inmobiliarias
+682099,Servicios inmobiliarios realizados a cambio de una retribución o por contrata n.c.p.
+691001,Servicios jurídicos
+691002,Servicios  notariales
+692000,"Servicios de contabilidad, auditoría y asesoría fiscal"
+702010,"Servicios de gerenciamiento de empresas e instituciones de salud, servicios de auditoria y medicina legal, servicio de asesoramiento farmacéutico"
+702091,"Servicios de asesoramiento, dirección y gestión empresarial realizados por integrantes de los órganos de administración y/o fiscalización en sociedades anónimas"
+702092,"Servicios de asesoramiento, dirección y gestión empresarial realizados por integrantes de cuerpos de dirección en sociedades excepto las anónimas"
+702099,"Servicios de asesoramiento, dirección y gestión empresarial n.c.p."
+711001,Servicios relacionados con la construcción.
+711002,Servicios geológicos y de prospección
+711003,Servicios relacionados con la electrónica y las comunicaciones
+711009,Servicios de arquitectura e ingeniería y servicios conexos de asesoramiento técnico n.c.p.
+712000,Ensayos y análisis técnicos
+721010,Investigación  y desarrollo experimental en el campo de la ingeniería y la tecnología
+721020,Investigación  y desarrollo experimental en el campo de las ciencias médicas
+721030,Investigación  y desarrollo experimental en el campo de las ciencias agropecuarias
+721090,Investigación y desarrollo experimental en el campo de las ciencias exactas y naturales n.c.p.
+722010,Investigación  y desarrollo experimental en el campo de las ciencias sociales
+722020,Investigación  y desarrollo experimental en el campo de las ciencias humanas
+731001,Servicios de comercialización de tiempo y espacio publicitario
+731009,Servicios de publicidad n.c.p.
+732000,"Estudio de mercado, realización de encuestas de opinión pública"
+741000,Servicios de diseño especializado
+742000,Servicios de fotografía
+749001,Servicios de traducción e interpretación
+749002,Servicios de representación e intermediación de artistas y modelos
+749003,Servicios de representación e intermediación de deportistas profesionales
+749009,"Actividades profesionales, científicas y técnicas n.c.p."
+750000,Servicios veterinarios
+771110,Alquiler de automóviles sin conductor
+771190,"Alquiler de vehículos automotores n.c.p., sin conductor ni operarios"
+771210,"Alquiler de equipo de transporte para vía acuática, sin operarios ni tripulación"
+771220,"Alquiler de equipo de transporte para vía aérea, sin operarios ni tripulación"
+771290,Alquiler de equipo de transporte n.c.p. sin conductor ni operarios
+772010,Alquiler de videos y video juegos
+772091,Alquiler de prendas de vestir
+772099,Alquiler de efectos personales y enseres domésticos n.c.p.
+773010,"Alquiler de maquinaria y equipo agropecuario y forestal, sin operarios"
+773020,"Alquiler de maquinaria y equipo para la minería, sin operarios"
+773030,"Alquiler de maquinaria y equipo de construcción e ingeniería civil, sin operarios"
+773040,"Alquiler de maquinaria y equipo de oficina, incluso computadoras"
+773090,"Alquiler de maquinaria y equipo n.c.p., sin personal"
+774000,Arrendamiento y gestión de bienes intangibles no financieros
+780000,Obtención y dotación de personal
+791100,Servicios minoristas de agencias de viajes
+791200,Servicios mayoristas de agencias de viajes
+791901,Servicios de turismo aventura
+791909,Servicios complementarios de apoyo turístico n.c.p.
+801010,Servicios de transporte de caudales y objetos de valor
+801020,Servicios de sistemas de seguridad
+801090,Servicios de seguridad e investigación n.c.p.
+811000,Servicio combinado de apoyo a edificios
+812010,Servicios de limpieza general de edificios
+812020,Servicios de desinfección y exterminio de plagas en el ámbito urbano
+812090,Servicios de limpieza n.c.p.
+813000,Servicios de jardinería y mantenimiento de espacios verdes
+821100,Servicios combinados de gestión administrativa de oficinas
+821900,"Servicios de fotocopiado, preparación de documentos y otros servicios de apoyo de oficina"
+822000,Servicios de call center
+823000,"Servicios de organización de convenciones y exposiciones comerciales, excepto culturales y deportivos"
+829100,Servicios de agencias de cobro y calificación crediticia
+829200,Servicios de envase y empaque
+829900,Servicios empresariales n.c.p.
+841100,Servicios generales de la Administración Pública
+841200,"Servicios para la regulación de las actividades sanitarias, educativas, culturales, y restantes servicios sociales, excepto seguridad social obligatoria"
+841300,Servicios para la regulación de la actividad económica
+841900,Servicios auxiliares para los servicios generales de la Administración Pública
+842100,Servicios de asuntos exteriores
+842200,Servicios de defensa
+842300,Servicios para el orden público y la seguridad
+842400,Servicios de justicia
+842500,Servicios de protección civil
+843000,"Servicios de la seguridad social obligatoria, excepto obras sociales"
+851010,Guarderías y jardines maternales
+851020,"Enseñanza inicial, jardín de infantes y primaria"
+852100,Enseñanza secundaria de formación general
+852200,Enseñanza secundaria de formación técnica y profesional
+853100,Enseñanza  terciaria
+853201,Enseñanza universitaria excepto formación de posgrado
+853300,Formación de posgrado
+854910,Enseñanza de idiomas
+854920,Enseñanza de cursos relacionados con informática
+854930,"Enseñanza para adultos, excepto discapacitados"
+854940,Enseñanza especial y para discapacitados
+854950,"Enseñanza de gimnasia, deportes y actividades físicas"
+854960,Enseñanza artística
+854990,Servicios de enseñanza n.c.p.
+855000,Servicios de apoyo a la educación
+861010,Servicios de internación excepto instituciones relacionadas con la salud mental
+861020,Servicios de internación en instituciones relacionadas con la salud mental
+862110,Servicios de  consulta médica
+862120,Servicios de proveedores de atención médica domiciliaria
+862130,"Servicios de atención médica en dispensarios, salitas, vacunatorios y otros locales de atención primaria de la salud"
+862200,Servicios odontológicos
+863110,Servicios de prácticas de diagnóstico en laboratorios
+863120,Servicios de prácticas de diagnóstico por imágenes
+863190,Servicios de prácticas de diagnóstico n.c.p.
+863200,Servicios de tratamiento
+863300,"Servicio médico integrado de consulta, diagnóstico y tratamiento"
+864000,Servicios de emergencias y traslados
+869010,Servicios de rehabilitación física
+869090,Servicios relacionados con la salud humana n.c.p.
+870100,"Servicios de atención a personas con problemas de salud mental o de adicciones, con alojamiento"
+870210,Servicios de atención a ancianos con alojamiento
+870220,Servicios de atención a personas minusválidas con alojamiento
+870910,Servicios de atención a niños y adolescentes carenciados con alojamiento
+870920,Servicios de atención a mujeres con alojamiento
+870990,Servicios sociales con alojamiento n.c.p.
+880000,Servicios sociales sin alojamiento
+900011,Producción de espectáculos teatrales y musicales
+900021,"Composición y representación de obras teatrales, musicales y artísticas"
+900030,Servicios conexos a la producción de espectáculos teatrales y musicales
+900040,Servicios de agencias de ventas de entradas
+900091,Servicios de espectáculos artísticos n.c.p.
+910100,Servicios de bibliotecas y archivos
+910200,Servicios de museos y preservación de lugares y edificios históricos
+910300,"Servicios de jardines botánicos, zoológicos y de parques nacionales"
+910900,Servicios culturales n.c.p.
+920001,"Servicios de recepción de apuestas de quiniela, lotería y similares"
+920009,Servicios relacionados con juegos de azar y apuestas n.c.p.
+931010,"Servicios de organización, dirección y gestión de prácticas deportivas en clubes"
+931020,"Explotación de instalaciones deportivas, excepto clubes"
+931030,Promoción y producción de espectáculos deportivos
+931041,Servicios prestados por deportistas y atletas para la realización de prácticas deportivas
+931042,Servicios prestados por profesionales y técnicos para la realización de prácticas deportivas
+931050,Servicios de acondicionamiento físico
+931090,Servicios para la práctica deportiva n.c.p.
+939010,Servicios de parques de diversiones y parques temáticos
+939020,Servicios de salones de juegos
+939030,"Servicios de salones de baile, discotecas y similares"
+939090,Servicios de entretenimiento n.c.p.
+941100,Servicios de organizaciones empresariales y de empleadores
+941200,Servicios de organizaciones profesionales
+942000,Servicios de sindicatos
+949100,Servicios de organizaciones religiosas
+949200,Servicios de organizaciones políticas
+949910,"Servicios de mutuales, excepto mutuales de salud y financieras"
+949920,Servicios de consorcios de edificios
+949930,Servicios de cooperativas cuando realizan varias actividades
+949990,Servicios de asociaciones n.c.p.
+951100,Reparación y mantenimiento de equipos informáticos
+951200,Reparación y mantenimiento de equipos de telefonía y de comunicación
+952200,Reparación de calzado y artículos de marroquinería
+952300,Reparación de tapizados y muebles
+952910,"Reforma y reparación de cerraduras, duplicación de llaves. Cerrajerías"
+952920,Reparación de relojes y joyas. Relojerías
+952990,Reparación de efectos personales y enseres domésticos n.c.p.
+960101,Servicios de limpieza de prendas prestado por tintorerías rápidas
+960102,"Lavado y limpieza de artículos de tela, cuero y/o de piel, incluso la limpieza en seco"
+960201,Servicios de peluquería
+960202,"Servicios de tratamiento de belleza, excepto los de peluquería"
+960300,Pompas fúnebres y servicios conexos
+960910,"Servicios de centros de estética, spa y similares"
+960990,Servicios personales n.c.p.
+970000,Servicios de hogares privados que contratan servicio doméstico
+990000,Servicios de organizaciones y órganos extraterritoriales
+952100,Reparación de artículos eléctricos y electrónicos de uso doméstico
+476200,Venta al por menor de CD's y DVD's de audio y video grabados
+464910,Venta al por mayor de CD's y DVD's de audio y video grabados.
+461091,"Venta al por mayor en comisión o consignación de prod. textiles, prendas de vestir, calzado excepto el ortopédico, art.de marroquinería, paraguas y similares y prod.de cuero n.c.p"
+431220,"Perforación y sondeo, excepto perforación de pozos de petróleo, de gas, de minas e hidráulicos  y prospección de yacimientos de petróleo"
+331301,"Reparación y mantenimiento de instrumentos médicos,ópticos y de precisión,equipo fotográfico,aparatos para medir,ensayar o navegar,relojes,excepto para uso personal o doméstico"
+14221,Cría de ganado equino realizada en haras
+7,Jubilado
+8,Estudiante
+9,Ama de casa
+10,Ex - Agente de la Adm. Publica
+11,Trabajo Relac. Dependencia
+12,Sin Actividad Economica
+13,Agricultura Familiar

--- a/addons/l10n_ar/models/__init__.py
+++ b/addons/l10n_ar/models/__init__.py
@@ -17,3 +17,6 @@ from . import uom_uom
 from . import account_chart_template
 from . import account_move
 from . import account_move_line
+from . import l10n_ar_arca_activity
+from . import res_config_settings
+from . import account_account

--- a/addons/l10n_ar/models/account_account.py
+++ b/addons/l10n_ar/models/account_account.py
@@ -1,0 +1,13 @@
+from odoo import fields, models
+
+
+class AccountAccount(models.Model):
+    _inherit = 'account.account'
+
+    l10n_ar_arca_activity_id = fields.Many2one(
+        'l10n_ar.arca.activity',
+        string='Associated ARCA Activity',
+        help="Argentina: This field is to associate a specific activity to use with this account. "
+        "If not set, the company's default activity will be used."
+        "The activity will be used to when generating ARCA VAT reports."
+    )

--- a/addons/l10n_ar/models/l10n_ar_arca_activity.py
+++ b/addons/l10n_ar/models/l10n_ar_arca_activity.py
@@ -1,0 +1,18 @@
+from odoo import fields, models, api
+
+
+class ARCAActivity(models.Model):
+    _name = "l10n_ar.arca.activity"
+    _description = "ARCA Activity"
+    _order = "code"
+
+    code = fields.Char(required=True, help="Activity Code")
+    name = fields.Char(required=True, help="Activity Description")
+    display_name = fields.Char(compute="_compute_display_name", store=True)
+
+    @api.depends("code", "name")
+    def _compute_display_name(self):
+        """Recompute the display name for the activity model so it is more user-friendly.
+        Display name: Activity code + Activity description"""
+        for activity in self:
+            activity.display_name = "%s - %s" % (activity.code, activity.name)

--- a/addons/l10n_ar/models/res_company.py
+++ b/addons/l10n_ar/models/res_company.py
@@ -16,6 +16,9 @@ class ResCompany(models.Model):
         domain="[('code', 'in', [1, 4, 6])]", related='partner_id.l10n_ar_afip_responsibility_type_id', readonly=False)
     l10n_ar_company_requires_vat = fields.Boolean(compute='_compute_l10n_ar_company_requires_vat', string='Company Requires Vat?')
     l10n_ar_afip_start_date = fields.Date('Activities Start')
+    l10n_ar_arca_activity_id = fields.Many2one(
+        'l10n_ar.arca.activity', string='Principal Activity',
+        help="Principal registered activity of the company")
 
     @api.onchange('country_id')
     def onchange_country(self):

--- a/addons/l10n_ar/models/res_config_settings.py
+++ b/addons/l10n_ar/models/res_config_settings.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    l10n_ar_arca_activity_id = fields.Many2one(
+        'l10n_ar.arca.activity',
+        related='company_id.l10n_ar_arca_activity_id', readonly=False)

--- a/addons/l10n_ar/security/ir.model.access.csv
+++ b/addons/l10n_ar/security/ir.model.access.csv
@@ -2,3 +2,5 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_l10n_ar_afip_responsibility_type_all,l10n_ar.afip.responsibility.type.all,model_l10n_ar_afip_responsibility_type,base.group_user,1,0,0,0
 access_l10n_ar_afip_responsibility_type_portal,l10n_ar.afip.responsibility.type.portal,model_l10n_ar_afip_responsibility_type,base.group_portal,1,0,0,0
 access_l10n_ar_afip_responsibility_type_public,l10n_ar.afip.responsibility.type.public,model_l10n_ar_afip_responsibility_type,base.group_public,1,0,0,0
+access_l10n_ar_arca_activity_manager,l10n_ar.arca.activity.manager,model_l10n_ar_arca_activity,base.group_user,1,0,0,0
+access_l10n_ar_arca_activity_user,l10n_ar.arca.activity.user,model_l10n_ar_arca_activity,base.group_user,1,0,0,0

--- a/addons/l10n_ar/views/account_account_views.xml
+++ b/addons/l10n_ar/views/account_account_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_account_list" model="ir.ui.view">
+        <field name="name">account.account.tds.tcs.view.list.inherit</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_list"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='account_type']" position="after">
+                <field name="l10n_ar_arca_activity_id" invisible="company_fiscal_country_code != 'AR' or account_type in ('asset_receivable', 'liability_payable', 'off_balance')" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_account_account_form" model="ir.ui.view">
+        <field name="name">account.account.form.inherit</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='tag_ids']" position="after">
+                <field name="l10n_ar_arca_activity_id" invisible="company_fiscal_country_code != 'AR' or account_type in ('asset_receivable', 'liability_payable', 'off_balance')"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ar/views/l10n_ar_arca_activity_view.xml
+++ b/addons/l10n_ar/views/l10n_ar_arca_activity_view.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_arca_activity_form" model="ir.ui.view">
+        <field name="name">l10n_ar.arca.activity.form</field>
+        <field name="model">l10n_ar.arca.activity</field>
+        <field name="arch" type="xml">
+            <form string="Activity">
+                <group>
+                    <group>
+                        <group>
+                            <field name="code" placeholder="e.g. 011111"/>
+                        </group>
+                        <group>
+                            <field name="name" placeholder="Activity description"/>
+                        </group>
+                    </group>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_arca_activity_list" model="ir.ui.view">
+        <field name="name">l10n_ar.arca.activity.list</field>
+        <field name="model">l10n_ar.arca.activity</field>
+        <field name="arch" type="xml">
+            <list string="Activities" default_order="code" create="true" edit="true" delete="true">
+                <field name="code"/>
+                <field name="name"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_arca_activity_search" model="ir.ui.view">
+        <field name="name">l10n_ar.arca.activity.search</field>
+        <field name="model">l10n_ar.arca.activity</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="code"/>
+                <field name="name"/>
+            </search>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="act_arca_activity">
+        <field name="name">Activities</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">l10n_ar.arca.activity</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="view_arca_activity_search"/>
+    </record>
+
+    <menuitem name="Activities" action="act_arca_activity" id="menu_action_arca_activity" sequence="30" parent="l10n_ar.menu_afip_config"/>
+
+</odoo>

--- a/addons/l10n_ar/views/res_config_settings_view.xml
+++ b/addons/l10n_ar/views/res_config_settings_view.xml
@@ -7,8 +7,14 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//app[@name='account']/block" position="after">
-                <div  id="argentina_localization_section" invisible="1">
+                <div id="argentina_localization_section" invisible="1">
                     <block title="Argentinean Localization" id="argentina_localization" invisible="country_code != 'AR'">
+                        <setting string="ARCA Activity" company_dependent="1" help="Principal registered activity of the company"> 
+                            <div class="content-group mt16">
+                                <label for="l10n_ar_arca_activity_id" class="o_form_label col-lg-3" string="Principal Activity"/>
+                                <field name="l10n_ar_arca_activity_id" options="{'no_open': True}"/>
+                            </div>
+                        </setting>
                     </block>
                 </div>
             </xpath>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses

This pull request introduces the **ARCA Activity** model to the Argentinean localization module (`l10n_ar`). It enables the management and association of economic activities declared in ARCA with companies and accounts, laying the foundation for future VAT reporting requirements.

### Current behavior before PR

- No support for ARCA-declared activities in the Argentinean localization.

### Desired behavior after PR is merged

- Adds a new model: `l10n_ar.arca.activity`, which stores economic activities declared in ARCA.
- Loads initial ARCA activity data from `data/l10n_ar.arca.activity.csv`, sourced from the official [ARCA website](https://serviciosweb.afip.gob.ar/genericos/nomencladoractividades/index.aspx).
- Allows associating activities with companies and accounts.
- Integrates activity selection into company and account settings views.

### Technical purpose

This is a preparatory step for future support of the **"IVA Simple"** regime, which requires VAT declarations to be segmented by economic activity. The logic introduced here will make it possible to determine the applicable activity for each invoice based on the account used, defaulting to the company's primary activity when no specific one is set.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
