### PR TITLE
[IMP] mail: add 'Mark as Unread' action for messages

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -377,6 +377,27 @@ export class Message extends Component {
         );
     }
 
+    get onRightSwipe() {
+        if (this.props.thread?.eq(this.store.inbox)) {
+            return {
+                action: () => this.message.setDone(),
+                bgColor: "bg-success",
+                icon: "fa-check-circle",
+            };
+        }
+        if (
+            this.props.thread?.eq(this.store.history) &&
+            this.message.canMarkAsUnread(this.props.thread)
+        ) {
+            return {
+                action: () => this.message.markAsUnread(this.props.thread),
+                bgColor: "bg-secondary",
+                icon: "fa-eye-slash",
+            };
+        }
+        return undefined;
+    }
+
     get translatedFromText() {
         return _t("(Translated from: %(language)s)", { language: this.message.translationSource });
     }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.Message">
-        <ActionSwiper onRightSwipe="props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
+        <ActionSwiper onRightSwipe="onRightSwipe">
             <t t-set="dummy" t-value="computeActions()"/>
             <div class="o-mail-Message position-relative rounded-0 bg-inherit"
                 t-att-data-starred="message.starred"

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -112,6 +112,13 @@ registerMessageAction("mark-as-read", {
     onSelected: ({ message }) => message.setDone(),
     sequence: 40,
 });
+registerMessageAction("mark-as-unread", {
+    condition: ({ message, thread }) => message.canMarkAsUnread(thread),
+    icon: "fa fa-eye-slash",
+    name: _t("Mark as Unread"),
+    onSelected: ({ message, thread }) => message.markAsUnread(thread),
+    sequence: 40,
+});
 registerMessageAction("reactions", {
     condition: ({ message }) => message.reactions.length,
     icon: "fa fa-smile-o",

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -26,6 +26,13 @@ patch(Message.prototype, {
         this.action = useService("action");
         this.avatarCard = usePopover(AvatarCardPopover);
     },
+    get attClass() {
+        return {
+            ...super.attClass,
+            "o-needaction-message o-rounded-bubble bg-view shadow-sm border pb-1 pt-sm-2":
+                this.message.needaction && this.env.inChatter,
+        };
+    },
     get authorAvatarAttClass() {
         return {
             ...super.authorAvatarAttClass,

--- a/addons/mail/static/src/core/web/message_patch.scss
+++ b/addons/mail/static/src/core/web/message_patch.scss
@@ -1,0 +1,4 @@
+.o-needaction-message {
+    --border-opacity: .25;
+    border-color: rgba($o-action, var(--border-opacity)) !important;
+}

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -749,3 +749,29 @@ test("Update primary email in recipient without saving", async () => {
     document.querySelector("div[name='email_cc'] input").blur();
     await contains(".o-mail-RecipientsInput .o_tag_badge_text", { text: "test@test.be" });
 });
+
+test("can mark message as unread from chatter", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
+    const messageId = pyEnv["mail.message"].create({
+        author_id: partnerId,
+        body: "lorem ipsum",
+        model: "res.partner",
+        needaction: false,
+        res_id: partnerId,
+    });
+    pyEnv["mail.notification"].create({
+        is_read: true,
+        mail_message_id: messageId,
+        notification_status: "sent",
+        notification_type: "inbox",
+        res_partner_id: serverState.partnerId,
+    });
+    await start();
+    await openFormView("res.partner", partnerId);
+    await contains(".o-mail-Message-body:text(lorem ipsum)");
+    await click("button[title='Mark as Unread']");
+    await contains(".o_notification:text(Marked as unread)");
+    await click(".o-mail-MessagingMenu-counter:text(1)");
+    await contains(".o-mail-NotificationItem-text:text(John Doe: lorem ipsum)");
+});

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -899,7 +899,8 @@ test("composer: add an attachment in reply to message in history", async () => {
     });
     await start();
     await openDiscuss("mail.box_history");
-    await click("[title='Reply']");
+    await click("[title='Expand']");
+    await click(".o-dropdown-item:contains('Reply')");
     await inputFiles(".o-mail-Composer .o_input_file", [text]);
     await contains(".o-mail-AttachmentContainer:not(.o-isUploading):contains(text.txt) .fa-check");
     await contains(".o-mail-Composer-footer .o-mail-AttachmentList");

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -754,3 +754,33 @@ test("can reply to email message", async () => {
     await click(".o-dropdown-item:contains('Reply')");
     await contains(".o-mail-Composer", { text: "Replying to md@oilcompany.fr" });
 });
+
+test("can mark message as unread from history", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write([serverState.userId], { notification_type: "inbox" });
+    const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
+    const messageId = pyEnv["mail.message"].create({
+        author_id: partnerId,
+        body: "lorem ipsum",
+        model: "res.partner",
+        needaction: false,
+        res_id: partnerId,
+    });
+    pyEnv["mail.notification"].create({
+        is_read: true,
+        mail_message_id: messageId,
+        notification_status: "sent",
+        notification_type: "inbox",
+        res_partner_id: serverState.partnerId,
+    });
+    await start();
+    await openDiscuss("mail.box_history");
+    await contains(".o-mail-Message-body:text(lorem ipsum)");
+    await click("[title='Expand']");
+    await click(".o-dropdown-item:contains(Mark as Unread)");
+    await contains(".o-mail-Message-body:text(lorem ipsum)", { count: 0 });
+    await click(".o-mail-Mailbox[data-mailbox-id='inbox'] .badge:text(1)");
+    await contains(".o-mail-Message-body:text(lorem ipsum)");
+    await click(".o-mail-MessagingMenu-counter:text(1)");
+    await contains(".o-mail-NotificationItem-text:text(John Doe: lorem ipsum)");
+});


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Users have no way to mark messages as unread, which makes it difficult to revisit important conversations later.

**Desired behaviour after PR is merged:**
- Users can mark messages as unread via a message action in history and in the chatter of a record.
- On mobile devices, swiping right on a message marks it as unread.
- The action is only visible when the user’s notification preference is set to handle in Odoo.
- If the user was not initially notified, a new notification is created.

task-[4592279](https://www.odoo.com/odoo/project/1519/tasks/4592279)