### PR TITLE
[FIX] hr{_skills}: prevent error while load demo data

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -824,7 +824,7 @@ class HrEmployee(models.Model):
         demo_tag = self.env.ref('hr.employee_category_demo', raise_if_not_found=False)
         if demo_tag:
             return
-        convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
+        convert.convert_file(self.sudo().env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
 
     # ---------------------------------------------------------
     # Business Methods

--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -46,5 +46,5 @@ class HrEmployee(models.Model):
         demo_tag = self.env.ref('hr_skills.employee_resume_line_emp_eg_1', raise_if_not_found=False)
         if demo_tag:
             return
-        convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
+        convert.convert_file(self.sudo().env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
         convert.convert_file(self.env, 'hr_skills', 'data/scenarios/hr_skills_scenario.xml', None, mode='init', kind='data')


### PR DESCRIPTION
The system will crash when user try to load sample data in appraisal.

**Steps to produce:-**
- Install `Appraisals` and `Recruitment` module.
- Make a new user with access right of administrator to `only Appraisals`.
- Login with new user.
- `Appraisals > Load sample data`.

**Error:-**
```py
AccessError: You are not allowed to create 'Job Position' (hr.job) records.

This operation is allowed for the following groups:
	- Recruitment/Officer: Manage all applicants

ParseError: while parsing /home/odoo/src/odoo/saas-18.4/addons/hr/data/scenarios/hr_scenario.xml:21, somewhere inside <record id="job_consultant" model="hr.job" forcecreate="1">
            <field name="name">Consultant</field>
            <field name="no_of_recruitment">5</field>
            <field name="contract_type_id" ref="hr.contract_type_interim"/>
            <field name="description">We are currently looking for someone like that to join our Consultant team.</field>
        </record>

ValueError: ParseError('while parsing /home/odoo/src/odoo/saas-18.4/addons/hr/data/scenarios/hr_scenario.xml:21, somewhere inside\n<record id="job_consultant" model="hr.job" forcecreate="1">\n            <field name="name">Consultant</field>\n            <field name="no_of_recruitment">5</field>\n            <field name="contract_type_id" ref="hr.contract_type_interim"/>\n            <field name="description">We are currently looking for someone like that to join our Consultant team.</field>\n        </record>') while evaluating
'action = model._load_demo_data()'
```

**Root Cause:-**
- When a user is granted access rights only for the Appraisal module and attempts to load sample data for it, an error occurs. This happens because the sample data at [1] includes the `creation of records` related to the `Recruitment module`. Since the user does not have the required access rights for Recruitment, the system raises a permission error.

**Solution:-**
- In this commit, we resolve the issue by using `sudo()` while loading the data.

[1]: https://github.com/odoo/odoo/blob/fabfeb55c56fbc7136bd1c3a72e9d6ee99f39714/addons/hr/data/scenarios/hr_scenario.xml#L21-L26

**sentry-6795776877**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
