### PR TITLE
[IMP] web: export Content-Disposition parser

### DIFF
--- a/addons/web/static/src/core/network/download.js
+++ b/addons/web/static/src/core/network/download.js
@@ -161,7 +161,7 @@ function decodefield(str) {
  * @return {ContentDisposition}
  * @public
  */
-function parse(string) {
+export function parse(string) {
     if (!string || typeof string !== "string") {
         throw new TypeError("argument string is required");
     }


### PR DESCRIPTION
Allow other modules to reuse the existing RFC 6266/5987-compliant parser for the
Content-Disposition header. This avoids duplicated parsing logic and prevents
subtle bugs when extracting filenames (quoted, escaped, or RFC 5987-encoded)
across custom XHR/Blob download flows.
This change only exports an already used function in the web download stack.
No behavior change, no performance impact, and fully backward compatible.
It centralizes fixes and makes testing easier while keeping modules consistent.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
