### PR TITLE
[IMP] website: support multi-page popup display

### DIFF
--- a/addons/html_builder/static/src/core/builder_component_plugin.js
+++ b/addons/html_builder/static/src/core/builder_component_plugin.js
@@ -21,6 +21,7 @@ import { Plugin } from "@html_editor/plugin";
 import { Img } from "./img";
 import { BuilderUrlPicker } from "./building_blocks/builder_urlpicker";
 import { BuilderFontFamilyPicker } from "./building_blocks/builder_fontfamilypicker";
+import { BuilderMultiUrlPicker } from "./building_blocks/builder_multiurlpicker";
 
 export class BuilderComponentPlugin extends Plugin {
     static id = "builderComponents";
@@ -50,6 +51,7 @@ export class BuilderComponentPlugin extends Plugin {
             BuilderDateTimePicker,
             BuilderList,
             Img,
+            BuilderMultiUrlPicker,
         },
     };
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_multiurlpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_multiurlpicker.js
@@ -1,0 +1,104 @@
+import { BuilderComponent } from "@html_builder/core/building_blocks/builder_component";
+import {
+    BuilderTextInputBase,
+    textInputBasePassthroughProps,
+} from "@html_builder/core/building_blocks/builder_text_input_base";
+import {
+    basicContainerBuilderComponentProps,
+    useBuilderComponent,
+    useInputBuilderComponent,
+} from "@html_builder/core/utils";
+import { Component } from "@odoo/owl";
+import { useChildRef } from "@web/core/utils/hooks";
+import { pick } from "@web/core/utils/objects";
+
+export class BuilderMultiUrlPicker extends Component {
+    static template = "html_builder.BuilderMultiUrlPicker";
+    static props = {
+        ...basicContainerBuilderComponentProps,
+        ...textInputBasePassthroughProps,
+        default: { type: String, optional: true },
+    };
+    static components = {
+        BuilderComponent,
+        BuilderTextInputBase,
+    };
+
+    setup() {
+        this.inputRef = useChildRef();
+        useBuilderComponent();
+        const { state, commit } = useInputBuilderComponent({
+            id: this.props.id,
+            defaultValue: this.props.default,
+            formatRawValue: this.formatRawValue,
+            parseDisplayValue: this.parseDisplayValue,
+        });
+        this.commit = commit;
+        this.state = state;
+        this.unselectUrl = this.unselectUrl.bind(this);
+    }
+
+    /**
+     * @param {String} rawValue - Raw stringified list of URLs.
+     * @returns {String[]} Array of selected URLs.
+     */
+    formatRawValue(rawValue) {
+        return rawValue ? JSON.parse(rawValue) : [];
+    }
+
+    /**
+     * @param {String[]} displayValue - Array of URLs to stringify.
+     * @returns {String} JSON stringified representation of the URL list.
+     */
+    parseDisplayValue(displayValue) {
+        return JSON.stringify(displayValue);
+    }
+
+    /**
+     * Handles the Enter key event to trigger URL selection.
+     *
+     * @param {KeyboardEvent} ev - The keyboard event.
+     */
+    handleEnterKey(ev) {
+        if (ev.key === "Enter") {
+            this.select();
+        }
+    }
+
+    /**
+     * Handles the selection of a URL from the input field.
+     */
+    select() {
+        const url = this.inputRef.el.value;
+        const selectedUrls = this.urls;
+        this.inputRef.el.value = ""; // clear the input
+
+        if (!url || selectedUrls.includes(url)) {
+            return;
+        }
+
+        selectedUrls.push(url);
+        this.commit(selectedUrls);
+    }
+
+    /**
+     * Removes the given URL from the list and commits the updated value.
+     *
+     * @param {String} url - URL to remove.
+     */
+    unselectUrl(url) {
+        const updatedUrls = this.urls.filter((u) => u !== url);
+        this.commit(updatedUrls);
+    }
+
+    /**
+     * @returns {String[]} Array of URLs currently selected in the picker.
+     */
+    get urls() {
+        return this.formatRawValue(this.state.value);
+    }
+
+    get textInputBaseProps() {
+        return pick(this.props, ...Object.keys(textInputBasePassthroughProps));
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_multiurlpicker.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_multiurlpicker.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.BuilderMultiUrlPicker">
+    <BuilderComponent>
+        <div>
+            <table class="mb-1">
+                <tr t-foreach="urls" t-as="url" t-key="url">
+                    <td>
+                        <input type="text" class="o-hb-input-base" disabled="" t-att-data-name="url" t-att-value="url"/>
+                    </td>
+                    <td>
+                        <button class="mt-0 border-0 p-0 bg-transparent text-danger fa fa-fw fa-minus" title="Remove" t-on-click="() => unselectUrl(url)"/>
+                    </td>
+                </tr>
+            </table>
+            <BuilderTextInputBase
+                t-props="textInputBaseProps"
+                inputRef="inputRef"
+                commit="(inputValue) => inputValue"
+                preview="(inputValue) => inputValue"
+                onKeydown.bind="handleEnterKey"
+            />
+        </div>
+    </BuilderComponent>
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/options/popup_option.xml
+++ b/addons/website/static/src/builder/plugins/options/popup_option.xml
@@ -53,8 +53,14 @@
     <BuilderRow label.translate="Show on">
         <BuilderSelect action="'moveBlock'" preview="false">
             <BuilderSelectItem actionValue="'currentPage'">This page</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'specificPages'" id="'specific_pages'">These specific pages</BuilderSelectItem>
             <BuilderSelectItem actionValue="'allPages'">All pages</BuilderSelectItem>
         </BuilderSelect>
+    </BuilderRow>
+    <BuilderRow label.translate=" ">
+        <WebsiteMultiUrlPicker t-if="isActiveItem('specific_pages')"
+                placeholder.translate="e.g. /my-awesome-page"
+                dataAttributeAction="'selectedUrls'"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -74,12 +74,23 @@ export class MoveBlockAction extends BuilderAction {
     static id = "moveBlock";
     isApplied({ editingElement, value }) {
         return editingElement.closest("#o_shared_blocks")
-            ? value === "allPages"
+            ? editingElement.dataset.showOnSpecificPages === "true"
+                ? value === "specificPages"
+                : value === "allPages"
             : value === "currentPage";
     }
     apply({ editingElement, value }) {
         const selector =
-            value === "allPages" ? "#o_shared_blocks" : "main .oe_structure.o_editable";
+            value === "allPages" || value === "specificPages"
+                ? "#o_shared_blocks"
+                : "main .oe_structure.o_editable";
+        editingElement.dataset.showOnSpecificPages = value === "specificPages";
+
+        if (value === "specificPages" && !editingElement.dataset.selectedUrls) {
+            // Set the current page as selected URL initially.
+            editingElement.dataset.selectedUrls = `["${window.location.pathname}"]`;
+        }
+
         const whereEl = this.editable.querySelector(selector);
         const popupEl = editingElement.closest(".s_popup");
         whereEl.insertAdjacentElement("afterbegin", popupEl);

--- a/addons/website/static/src/builder/website_multiurlpicker.js
+++ b/addons/website/static/src/builder/website_multiurlpicker.js
@@ -1,0 +1,53 @@
+import { BuilderMultiUrlPicker } from "@html_builder/core/building_blocks/builder_multiurlpicker";
+import { Plugin } from "@html_editor/plugin";
+import { useEffect } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import wUtils from "@website/js/utils";
+
+export class WebsiteMultiUrlPicker extends BuilderMultiUrlPicker {
+    setup() {
+        super.setup();
+
+        useEffect(
+            (inputEl) => {
+                if (!inputEl) {
+                    return;
+                }
+                const unmountAutocompleteWithPages = wUtils.autocompleteWithPages(
+                    inputEl,
+                    {
+                        classes: {
+                            "ui-autocomplete": "o_website_ui_autocomplete",
+                        },
+                        body: this.env.getEditingElement().ownerDocument.body,
+                        urlChosen: this.select.bind(this),
+                    },
+                    this.env
+                );
+                return () => unmountAutocompleteWithPages();
+            },
+            () => [this.inputRef.el]
+        );
+    }
+
+    /**
+     * @override
+     */
+    handleEnterKey(ev) {
+        // It prevents double selection of URL when pressing Enter key
+        // to select an URL from the autocomplete list.
+        return;
+    }
+}
+
+class MultiUrlPickerPlugin extends Plugin {
+    static id = "multiUrlPickerPlugin";
+
+    resources = {
+        builder_components: {
+            WebsiteMultiUrlPicker,
+        },
+    };
+}
+
+registry.category("website-plugins").add(MultiUrlPickerPlugin.id, MultiUrlPickerPlugin);

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_multiurlpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_multiurlpicker.test.js
@@ -1,0 +1,104 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { xml } from "@odoo/owl";
+import { contains } from "@web/../tests/web_test_helpers";
+import { addOption, defineWebsiteModels, setupWebsiteBuilder } from "../../website_helpers";
+
+defineWebsiteModels();
+
+const inputSelector = ".we-bg-options-container input.o-hb-input-base:not(:disabled)";
+const selectedUrlsSelector = ".we-bg-options-container input.o-hb-input-base:disabled";
+const testOptionsTargetSelector = ":iframe .test-options-target";
+
+beforeEach(() => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderMultiUrlPicker dataAttributeAction="'urls'"/>`,
+    });
+});
+
+test("adds URL by typing and pressing Enter", async () => {
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await contains(testOptionsTargetSelector).click();
+
+    await contains(inputSelector).edit("/page");
+    await contains(inputSelector).press("Enter");
+    expect(inputSelector).toHaveValue("");
+    expect(selectedUrlsSelector).toHaveValue("/page");
+    expect(testOptionsTargetSelector).toHaveAttribute("data-urls", '["/page"]');
+});
+
+test("adding multiple URLs", async () => {
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await contains(testOptionsTargetSelector).click();
+
+    // Add first URL
+    await contains(inputSelector).edit("/page1");
+    await contains(inputSelector).press("Enter");
+
+    // Add second URL
+    await contains(inputSelector).edit("/page2");
+    await contains(inputSelector).press("Enter");
+
+    // Verify disabled inputs contain the added URLs
+    const selectedUrls = document.querySelectorAll(selectedUrlsSelector);
+    expect(selectedUrls).toHaveLength(2);
+    expect(selectedUrls[0].value).toBe("/page1");
+    expect(selectedUrls[1].value).toBe("/page2");
+
+    // Check data attribute is updated correctly
+    await expect(testOptionsTargetSelector).toHaveAttribute(
+        "data-urls",
+        JSON.stringify(["/page1", "/page2"])
+    );
+});
+
+test("does not add duplicate URLs", async () => {
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await contains(testOptionsTargetSelector).click();
+
+    // Add URL
+    await contains(inputSelector).edit("/page1");
+    await contains(inputSelector).press("Enter");
+    let selectedUrls = document.querySelectorAll(selectedUrlsSelector);
+    expect(selectedUrls[0].value).toBe("/page1");
+
+    // Try to add duplicate
+    await contains(inputSelector).edit("/page1");
+    await contains(inputSelector).press("Enter");
+    selectedUrls = document.querySelectorAll(selectedUrlsSelector);
+    expect(selectedUrls).toHaveLength(1);
+});
+
+test("can remove a URL", async () => {
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await contains(testOptionsTargetSelector).click();
+
+    // Add URLs
+    await contains(inputSelector).edit("/page1");
+    await contains(inputSelector).press("Enter");
+
+    await contains(inputSelector).edit("/page2");
+    await contains(inputSelector).press("Enter");
+
+    // Remove first URL
+    await contains(".we-bg-options-container button.fa-minus:nth-child(1)").click();
+    const selectedUrls = document.querySelectorAll(selectedUrlsSelector);
+    expect(selectedUrls).toHaveLength(1);
+    expect(selectedUrls[0].value).toBe("/page2");
+    await expect(testOptionsTargetSelector).toHaveAttribute(
+        "data-urls",
+        JSON.stringify(["/page2"])
+    );
+});
+
+test("previously selected URLs", async () => {
+    await setupWebsiteBuilder(
+        `<div class="test-options-target" data-urls='["/page1", "/page2"]'>b</div>`
+    );
+    await contains(testOptionsTargetSelector).click();
+
+    const selectedUrls = document.querySelectorAll(selectedUrlsSelector);
+    expect(selectedUrls).toHaveLength(2);
+    expect(selectedUrls[0].value).toBe("/page1");
+    expect(selectedUrls[1].value).toBe("/page2");
+});

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_urlpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_urlpicker.test.js
@@ -1,7 +1,12 @@
 import { after, before, expect, test } from "@odoo/hoot";
 import { xml } from "@odoo/owl";
-import { contains, onRpc } from "@web/../tests/web_test_helpers";
-import { addOption, defineWebsiteModels, setupWebsiteBuilder } from "../../website_helpers";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    addOption,
+    defineWebsiteModels,
+    mockGetSuggestedLinks,
+    setupWebsiteBuilder,
+} from "../../website_helpers";
 
 defineWebsiteModels();
 
@@ -14,44 +19,6 @@ function mockWindowOpen() {
 }
 function unmockWindowOpen() {
     window.open = originalWindowOpen;
-}
-function mockGetSuggestedLinks(callback = undefined) {
-    onRpc("/website/get_suggested_links", () => {
-        callback?.();
-        return {
-            matching_pages: [
-                {
-                    value: "/page1",
-                    label: "/page1 (Page 1)",
-                },
-                {
-                    value: "/page2",
-                    label: "/page2 (Page 2)",
-                },
-            ],
-            others: [
-                {
-                    title: "Last modified pages",
-                    values: [
-                        {
-                            value: "/page3",
-                            label: "/page3 (Page 3)",
-                        },
-                    ],
-                },
-                {
-                    title: "Apps url",
-                    values: [
-                        {
-                            value: "/app1",
-                            label: "/app1 (App 1)",
-                            icon: "app1_icon",
-                        },
-                    ],
-                },
-            ],
-        };
-    });
 }
 
 before(() => {

--- a/addons/website/static/tests/builder/website_builder/website_multiurlpicker.test.js
+++ b/addons/website/static/tests/builder/website_builder/website_multiurlpicker.test.js
@@ -1,0 +1,53 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { xml } from "@odoo/owl";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    addOption,
+    defineWebsiteModels,
+    mockGetSuggestedLinks,
+    setupWebsiteBuilder,
+} from "../website_helpers";
+
+defineWebsiteModels();
+
+const inputSelector = ".we-bg-options-container input.o-hb-input-base:not(:disabled)";
+const selectedUrlsSelector = ".we-bg-options-container input.o-hb-input-base:disabled";
+const testOptionsTargetSelector = ":iframe .test-options-target";
+
+beforeEach(async () => {
+    mockGetSuggestedLinks();
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<WebsiteMultiUrlPicker dataAttributeAction="'urls'"/>`,
+    });
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await contains(testOptionsTargetSelector).click();
+});
+
+test("opens dropdown when typing /", async () => {
+    await contains(inputSelector).edit("/");
+    await contains(inputSelector).click();
+    expect(document.querySelector(".o_website_ui_autocomplete")).toBeVisible();
+});
+
+test("selects URL from dropdown by clicking", async () => {
+    await contains(inputSelector).edit("/");
+    await contains(inputSelector).click();
+    await contains(document.querySelector(".o_website_ui_autocomplete > li:first-child a")).click();
+    expect(inputSelector).toHaveValue("");
+    expect(document.querySelector(".o_website_ui_autocomplete")).toBe(null);
+    expect(selectedUrlsSelector).toHaveValue("/page1");
+    expect(testOptionsTargetSelector).toHaveAttribute("data-urls", '["/page1"]');
+});
+
+test("selects URL from dropdown by pressing Enter", async () => {
+    await contains(inputSelector).edit("/");
+    await contains(inputSelector).click();
+    await contains(document.querySelector(".o_website_ui_autocomplete > li:first-child a")).press(
+        "Enter"
+    );
+    expect(inputSelector).toHaveValue("");
+    expect(document.querySelector(".o_website_ui_autocomplete")).toBe(null);
+    expect(selectedUrlsSelector).toHaveValue("/page1");
+    expect(testOptionsTargetSelector).toHaveAttribute("data-urls", '["/page1"]');
+});

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -571,3 +571,50 @@ export async function waitForEndOfOperation() {
     await waitForNone(":iframe .o_loading_screen", { timeout: 600 });
     await animationFrame();
 }
+
+/**
+ * Mocks the RPC call to "/website/get_suggested_links" and returns a set of
+ * suggested links for testing purposes. Optionally executes a callback
+ * after the mock is triggered.
+ *
+ * @param {Function} [callback] - Optional callback function to execute when
+ *                                the mock is triggered.
+ */
+export function mockGetSuggestedLinks(callback = undefined) {
+    onRpc("/website/get_suggested_links", () => {
+        callback?.();
+        return {
+            matching_pages: [
+                {
+                    value: "/page1",
+                    label: "/page1 (Page 1)",
+                },
+                {
+                    value: "/page2",
+                    label: "/page2 (Page 2)",
+                },
+            ],
+            others: [
+                {
+                    title: "Last modified pages",
+                    values: [
+                        {
+                            value: "/page3",
+                            label: "/page3 (Page 3)",
+                        },
+                    ],
+                },
+                {
+                    title: "Apps url",
+                    values: [
+                        {
+                            value: "/app1",
+                            label: "/app1 (App 1)",
+                            icon: "app1_icon",
+                        },
+                    ],
+                },
+            ],
+        };
+    });
+}

--- a/addons/website/static/tests/tours/snippet_popup_specific_pages.js
+++ b/addons/website/static/tests/tours/snippet_popup_specific_pages.js
@@ -1,0 +1,110 @@
+import { stepUtils } from "@web_tour/tour_utils";
+import {
+    changeOptionInPopover,
+    clickOnEditAndWaitEditMode,
+    clickOnSave,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+const selectPage = (page, url, position = 1) => [
+    {
+        content: `Enter '${page}' in dropdown.`,
+        trigger: '.we-bg-options-container [data-label=" "] input:not(:disabled)',
+        run: `edit ${page}`,
+    },
+    {
+        content: "Verify autocomplete popover is displayed.",
+        trigger: ".o_website_ui_autocomplete",
+    },
+    {
+        content: `Select '${page}' from dropdown.`,
+        trigger: `.o_website_ui_autocomplete > li.ui-autocomplete-item:nth-child(${position}) a`,
+        run: "click",
+    },
+    {
+        content: `Verify '${page}' is selected.`,
+        trigger: `.we-bg-options-container .o-hb-input-base:disabled[data-name='${url}']`,
+    },
+];
+
+const navigateAndVerify = (label, xmlid, triggerSelector = null) => [
+    {
+        content: `Go to ${label} page`,
+        trigger: triggerSelector || `:iframe .nav-item a:contains("${label}")`,
+        run: "click",
+    },
+    {
+        content: `Verify that we are on ${label} page`,
+        trigger: `:iframe [data-view-xmlid='website.${xmlid}']`,
+        timeout: 30000,
+    },
+];
+
+const checkPopup = (shouldExist, label) => ({
+    content: `Check popup ${shouldExist ? "exists" : "does not exist"} on ${label} page.`,
+    trigger: `:iframe #o_shared_blocks:${
+        shouldExist ? "has" : "not(:has"
+    }([data-snippet='s_popup']:not(:visible))`,
+});
+
+registerWebsitePreviewTour(
+    "snippet_popup_specific_pages",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({ name: "Popup", id: "s_popup", groupName: "Content" }),
+        {
+            content: "Click on the Popup snippet to edit it.",
+            trigger: ":iframe #wrap.o_editable [data-snippet='s_popup']:not(:visible)",
+            run: "click",
+        },
+        ...changeOptionInPopover("Popup", "Show on", "These specific pages"),
+        ...clickOnSave(),
+        checkPopup(true, "Home"),
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Toggle the visibility of the Popup",
+            trigger: '.o_we_invisible_el_panel .o_we_invisible_entry:contains("Popup")',
+            run: "click",
+        },
+        ...changeOptionInPopover("Popup", "Show on", "These specific pages"),
+        ...selectPage("contactus", "/contactus", 1),
+        ...clickOnSave(),
+        ...navigateAndVerify(
+            "Contact us",
+            "contactus",
+            ":iframe .navbar-nav a.btn-primary[href='/contactus']:nth-child(1)"
+        ),
+        checkPopup(true, "Contact us"),
+        ...navigateAndVerify("Home", "homepage"),
+        stepUtils.waitIframeIsReady(),
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Toggle the visibility of the Popup",
+            trigger: '.o_we_invisible_el_panel .o_we_invisible_entry:contains("Popup")',
+            run: "click",
+        },
+        {
+            content: "Remove Home page ('/') from the selection.",
+            trigger: ".we-bg-options-container button.fa-minus:nth-child(1)",
+            run: "click",
+        },
+        {
+            content: "Verify Home page ('/') is removed from the selection.",
+            trigger:
+                ".we-bg-options-container .o-hb-input-base:not(:has(:disabled[data-name='/']))",
+        },
+        ...clickOnSave(),
+        ...navigateAndVerify("Home", "homepage"),
+        checkPopup(false, "Home"),
+        ...navigateAndVerify(
+            "Contact us",
+            "contactus",
+            ":iframe .navbar-nav a.btn-primary[href='/contactus']:nth-child(1)"
+        ),
+        checkPopup(true, "Contact us"),
+    ]
+);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -152,3 +152,6 @@ class TestSnippets(HttpCase):
 
     def test_tabs_snippet(self):
         self.start_tour(self.env["website"].get_client_action_url("/"), "snippet_tabs", login="admin")
+
+    def test_snippet_popup_specific_pages(self):
+        self.start_tour(self.env["website"].get_client_action_url("/"), "snippet_popup_specific_pages", login="admin")


### PR DESCRIPTION
**Issue:**
Earlier, if a user wanted to display a pop-up on specific pages,
They need to manually add the pop-up to each page by saving
and reusing the snippet. This process is time-consuming and
not user-friendly, especially when managing multiple pages.

**Improvement:**
This functionality allows users to select multiple pages from an
autocomplete list easily. Popups can now be configured to appear on
specific pages without manual duplication. 

**NB:** If the user selects the `These specific pages` option and doesn't select any page, the popup will be shown on the current page only.

**Impact:**
This change improves the usability of popup, where it can now
be configured to appear on specific pages directly
from the snippet options.

task-[5016731](https://www.odoo.com/odoo/project/974/tasks/5016731)