### PR TITLE
[REF] web_tour: remove waitForStable

### DIFF
--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -42,25 +42,6 @@ async function performAction(trigger, action) {
     }
 }
 
-export async function waitForStable(target = document, timeout = 1000 / 16) {
-    return new Promise((resolve) => {
-        let observer;
-        let timer;
-        const mutationList = [];
-        function onMutation(mutations) {
-            mutationList.push(...(mutations || []));
-            clearTimeout(timer);
-            timer = setTimeout(() => {
-                observer.disconnect();
-                resolve(mutationList);
-            }, timeout);
-        }
-        observer = new MacroMutationObserver(onMutation);
-        observer.observe(target);
-        onMutation([]);
-    });
-}
-
 async function waitForTrigger(trigger) {
     if (!trigger) {
         return;

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -4,7 +4,6 @@ import { cookie } from "@web/core/browser/cookie";
 
 import { markup } from "@odoo/owl";
 import { omit } from "@web/core/utils/objects";
-import { waitForStable } from "@web/core/macro";
 import { stepUtils } from "@web_tour/tour_utils";
 
 export function addMedia(position = "right") {
@@ -305,20 +304,9 @@ export function clickOnSave(position = "bottom", timeout = 50000) {
         },
         {
             trigger: "button[data-action=save]:enabled:contains(save)",
-            // TODO this should not be needed but for now it better simulates what
-            // an human does. By the time this was added, it's technically possible
-            // to drag and drop a snippet then immediately click on save and have
-            // some problem. Worst case probably is a traceback during the redirect
-            // after save though so it's not that big of an issue. The problem will
-            // of course be solved (or at least prevented in stable). More details
-            // in related commit message.
         content: markup(_t("Good job! It's time to <b>Save</b> your work.")),
             tooltipPosition: position,
-            async run(actions) {
-                await waitForStable(document, 1000);
-                // Somehow the anchor is not the right element at this point.
-                await actions.click("button[data-action=save]:enabled");
-            },
+            run: "click",
             timeout,
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -1,5 +1,4 @@
 import { queryAll } from "@odoo/hoot-dom";
-import { waitForStable } from "@web/core/macro";
 
 /*******************************
  *         Common Steps
@@ -43,9 +42,6 @@ export const start = [
     {
         content: "Is your message correctly sent ?",
         trigger: "body.no_duplicated_message",
-        async run() {
-            await waitForStable(document.body, 1000);
-        },
     },
     {
         trigger:

--- a/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { contains, click } from "@web/../tests/utils";
-import { waitForStable } from "@web/core/macro";
 
 const sendFirstMessageSteps = [
     {
@@ -14,10 +13,6 @@ const sendFirstMessageSteps = [
     {
         trigger:
             ".o-livechat-root:shadow .o-mail-Thread:not([data-transient]) .o-mail-Message:contains('Hello, I need help!')",
-        async run() {
-            //Livechat is rerendered after sending a message
-            await waitForStable(document.body, 1000);
-        },
     },
 ];
 registry.category("web_tour.tours").add("website_livechat_no_session_with_hide_rule", {

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -1,6 +1,8 @@
-import slidesTourTools from '@website_slides/../tests/tours/slides_tour_tools';
-import { clickOnEditAndWaitEditMode, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
-import { waitForStable } from '@web/core/macro';
+import slidesTourTools from "@website_slides/../tests/tours/slides_tour_tools";
+import {
+    clickOnEditAndWaitEditMode,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
 
 /**
  * Global use case:
@@ -9,117 +11,136 @@ import { waitForStable } from '@web/core/macro';
  * they create some lessons in it;
  * they publish it;
  */
-registerWebsitePreviewTour('course_publisher_standard', {
-    url: '/slides',
-}, () => [{
-    content: 'eLearning: click on New (top-menu)',
-    trigger: 'div.o_new_content_container a',
-    run: "click",
-}, {
-    content: 'eLearning: click on New Course',
-    trigger: '#o_new_content_menu_choices a:contains("Course")',
-    run: "click",
-}, {
-    content: 'eLearning: set name',
-    trigger: 'div[name="name"] input',
-    run: "edit How to Déboulonnate",
-}, {
-    content: 'eLearning: click on tags',
-    trigger: '.o_field_many2many_tags input',
-    run: "edit Gard",
-}, {
-    content: 'eLearning: select Gardening tag',
-    trigger: '.ui-autocomplete a:contains("Gardening")',
-    run: "click",
-}, {
-    content: 'eLearning: set description',
-    trigger: '.o_field_html[name="description"] .odoo-editor-editable div.o-paragraph',
-    run: "editor Déboulonnate is very common at Fleurus",
-}, {
-    content: 'eLearning: we want reviews',
-    trigger: '.o_field_boolean[name="allow_comment"] input',
-    run: "click",
-}, {
-    content: 'eLearning: seems cool, create it',
-    trigger: '.modal button:contains("Save")',
-    run: "click",
-},
-{
-    trigger: "body:not(:has(.modal))",
-},
-...clickOnEditAndWaitEditMode(),
-{
-    content: 'eLearning: double click image to edit it',
-    trigger: ':iframe img.o_wslides_course_pict',
-    run: 'dblclick',
-}, {
-    content: 'eLearning: click "Add URL" to trigger URL box',
-    trigger: '.o_upload_media_url_button',
-    run: "click",
-}, {
-    content: 'eLearning: add a bioutifoul URL',
-    trigger: 'input.o_we_url_input',
-    run: "edit https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg/800px-ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg",
-},
-{
-    trigger: ".o_we_url_success",
-},
-{
-    content: 'eLearning: click "Add URL" really adding image',
-    trigger: '.o_upload_media_url_button',
-    run: "click",
-}, {
-    content: 'eLearning: is the Corgi set ?',
-    trigger: ':iframe img.o_wslides_course_pict.o_modified_image_to_save[data-original-src$="GoldWinnerPembrookeWelshCorgi.jpg"][src^="data:image"]',
-    run: "click",
-}, {
-    content: 'eLearning: save course edition',
-    trigger: 'button[data-action="save"]',
-    run: "click",
-},
-{
-    trigger: ":iframe body:not(.editor_enable)", // wait for editor to close
-},
-{
-    content: 'eLearning: course create with current member',
-    trigger: ':iframe .o_wslides_js_course_join:contains("You\'re enrolled")',
-}
-].concat(
-    slidesTourTools.addExistingCourseTag(true),
-    slidesTourTools.addNewCourseTag('The Most Awesome Course', true),
-    slidesTourTools.addSection('Introduction', true),
-    slidesTourTools.addArticleToSection('Introduction', 'MyArticle', true),
-    [{
-    content: "eLearning: check editor is loaded for article",
-    trigger: ':iframe body.editor_enable',
-    timeout: 30000,
-}, {
-    content: "eLearning: save article",
-    trigger: '.o_we_website_top_actions button.btn-primary:contains("Save")',
-    run: "click",
-},
-{
-    trigger: ":iframe body[is-ready=true]:not(.editor_enable)",
-},
-{
-    trigger:
-        ":iframe main:has(.o_wslides_course_nav a:contains(Déboulonnate)):has(.o_wslides_lesson_header_container:contains(completed)):has(.o_wslides_lesson_content:contains(screen to edit))",
-},
-{
-    content: "eLearning: use breadcrumb to go back to channel",
-    trigger: ':iframe .o_wslides_course_nav a:contains("Déboulonnate")[href^="/slides/how-to-deboulonnate"]',
-    async run(actions) {
-        await waitForStable(document, 2000);
-        await actions.click();
-    }
-}],
-    slidesTourTools.addImageToSection('Introduction', 'Overview', true),
-    slidesTourTools.addPdfToSection('Introduction', 'Exercise', true),
-//     [
-// {
-//     content: 'eLearning: move new course inside introduction',
-//     trigger: 'div.o_wslides_slides_list_drag',
-//     // run: 'drag_and_drop div.o_wslides_slides_list_drag ul.ui-sortable:first',
-//     run: 'drag_and_drop div.o_wslides_slides_list_drag a.o_wslides_js_slide_section_add',
-// }]
-));
+registerWebsitePreviewTour(
+    "course_publisher_standard",
+    {
+        url: "/slides",
+    },
+    () =>
+        [
+            {
+                content: "eLearning: click on New (top-menu)",
+                trigger: "div.o_new_content_container a",
+                run: "click",
+            },
+            {
+                content: "eLearning: click on New Course",
+                trigger: '#o_new_content_menu_choices a:contains("Course")',
+                run: "click",
+            },
+            {
+                content: "eLearning: set name",
+                trigger: 'div[name="name"] input',
+                run: "edit How to Déboulonnate",
+            },
+            {
+                content: "eLearning: click on tags",
+                trigger: ".o_field_many2many_tags input",
+                run: "edit Gard",
+            },
+            {
+                content: "eLearning: select Gardening tag",
+                trigger: '.ui-autocomplete a:contains("Gardening")',
+                run: "click",
+            },
+            {
+                content: "eLearning: set description",
+                trigger: '.o_field_html[name="description"] .odoo-editor-editable div.o-paragraph',
+                run: "editor Déboulonnate is very common at Fleurus",
+            },
+            {
+                content: "eLearning: we want reviews",
+                trigger: '.o_field_boolean[name="allow_comment"] input',
+                run: "click",
+            },
+            {
+                content: "eLearning: seems cool, create it",
+                trigger: '.modal button:contains("Save")',
+                run: "click",
+            },
+            {
+                trigger: "body:not(:has(.modal))",
+            },
+            ...clickOnEditAndWaitEditMode(),
+            {
+                content: "eLearning: double click image to edit it",
+                trigger: ":iframe img.o_wslides_course_pict",
+                run: "dblclick",
+            },
+            {
+                content: 'eLearning: click "Add URL" to trigger URL box',
+                trigger: ".o_upload_media_url_button",
+                run: "click",
+            },
+            {
+                content: "eLearning: add a bioutifoul URL",
+                trigger: "input.o_we_url_input",
+                run: "edit https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg/800px-ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg",
+            },
+            {
+                trigger: ".o_we_url_success",
+            },
+            {
+                content: 'eLearning: click "Add URL" really adding image',
+                trigger: ".o_upload_media_url_button",
+                run: "click",
+            },
+            {
+                content: "eLearning: is the Corgi set ?",
+                trigger:
+                    ':iframe img.o_wslides_course_pict.o_modified_image_to_save[data-original-src$="GoldWinnerPembrookeWelshCorgi.jpg"][src^="data:image"]',
+                run: "click",
+            },
+            {
+                content: "eLearning: save course edition",
+                trigger: 'button[data-action="save"]',
+                run: "click",
+            },
+            {
+                trigger: ":iframe body:not(.editor_enable)", // wait for editor to close
+            },
+            {
+                content: "eLearning: course create with current member",
+                trigger: ':iframe .o_wslides_js_course_join:contains("You\'re enrolled")',
+            },
+        ].concat(
+            slidesTourTools.addExistingCourseTag(true),
+            slidesTourTools.addNewCourseTag("The Most Awesome Course", true),
+            slidesTourTools.addSection("Introduction", true),
+            slidesTourTools.addArticleToSection("Introduction", "MyArticle", true),
+            [
+                {
+                    content: "eLearning: check editor is loaded for article",
+                    trigger: ":iframe body.editor_enable",
+                    timeout: 30000,
+                },
+                {
+                    content: "eLearning: save article",
+                    trigger: '.o_we_website_top_actions button.btn-primary:contains("Save")',
+                    run: "click",
+                },
+                {
+                    trigger: ":iframe body[is-ready=true]:not(.editor_enable)",
+                },
+                {
+                    trigger:
+                        ":iframe main:has(.o_wslides_course_nav a:contains(Déboulonnate)):has(.o_wslides_lesson_header_container:contains(completed)):has(.o_wslides_lesson_content:contains(screen to edit))",
+                },
+                {
+                    content: "eLearning: use breadcrumb to go back to channel",
+                    trigger:
+                        ':iframe .o_wslides_course_nav a:contains("Déboulonnate")[href^="/slides/how-to-deboulonnate"]',
+                    run: "click",
+                },
+            ],
+            slidesTourTools.addImageToSection("Introduction", "Overview", true),
+            slidesTourTools.addPdfToSection("Introduction", "Exercise", true)
+            //     [
+            // {
+            //     content: 'eLearning: move new course inside introduction',
+            //     trigger: 'div.o_wslides_slides_list_drag',
+            //     // run: 'drag_and_drop div.o_wslides_slides_list_drag ul.ui-sortable:first',
+            //     run: 'drag_and_drop div.o_wslides_slides_list_drag a.o_wslides_js_slide_section_add',
+            // }]
+        )
+);


### PR DESCRIPTION
In this commit, we remove exported function waitForStable from macro.js. This function is not useful yet for automatic tour engine. We just need it to detect possible undeterminisms. So we remove it from macro and put it only where it's used.
We take advantages of this commit to remove uses of waitForStable in tours.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
