### PR TITLE
[FIX] mail: send correct access values in _thread_to_store

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4709,15 +4709,9 @@ class MailThread(models.AbstractModel):
                 load=False,
             )[0]
             if is_request:
-                res["hasReadAccess"] = True
-                res["hasWriteAccess"] = False
+                res["hasReadAccess"] = thread.sudo(False).has_access("read")
+                res["hasWriteAccess"] = thread.sudo(False).has_access("write")
                 res["canPostOnReadonly"] = self._mail_post_access == "read"
-            try:
-                thread.check_access("write")
-                if is_request:
-                    res["hasWriteAccess"] = True
-            except AccessError:
-                pass
             if (
                 request_list
                 and "activities" in request_list

--- a/addons/test_mail_full/controllers/portal.py
+++ b/addons/test_mail_full/controllers/portal.py
@@ -14,9 +14,9 @@ class PortalTest(http.Controller):
         record = request.env["mail.test.portal"]._get_thread_with_access(res_id, **kwargs)
         values = {
             "object": record,
-            "token": kwargs.get("access_token", None),
-            "hash": kwargs.get("hash", None),
-            "pid": kwargs.get("pid", None),
+            "token": kwargs.get("token"),
+            "hash": kwargs.get("hash"),
+            "pid": kwargs.get("pid"),
         }
         return request.render("test_mail_full.test_portal_template", values)
 

--- a/addons/test_mail_full/static/tests/tours/portal_copy_link_tour.js
+++ b/addons/test_mail_full/static/tests/tours/portal_copy_link_tour.js
@@ -1,0 +1,22 @@
+import { messageActionsRegistry } from "@mail/core/common/message_actions";
+import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
+
+registry.category("web_tour.tours").add("portal_copy_link_tour", {
+    steps: () => [
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message",
+            run: () => {
+                const copyLinkAction = messageActionsRegistry.get("copy-link");
+                patch(copyLinkAction, { sequence: 1 }); // make sure the action is visible without expanding
+            }
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Test Message)",
+            run: "hover && click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-actions [title='Copy Link']",
+        },
+    ],
+});

--- a/addons/test_mail_full/static/tests/tours/portal_no_copy_link_tour.js
+++ b/addons/test_mail_full/static/tests/tours/portal_no_copy_link_tour.js
@@ -1,0 +1,28 @@
+import { messageActionsRegistry } from "@mail/core/common/message_actions";
+import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
+
+registry.category("web_tour.tours").add("portal_no_copy_link_tour", {
+    steps: () => [
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message",
+            run: () => {
+                const copyLinkAction = messageActionsRegistry.get("copy-link");
+                patch(copyLinkAction, { sequence: 1 }); // make sure the action is visible without expanding
+            }
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Test Message)",
+            run: "hover && click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-actions",
+            run: async () => {
+                const copyLinkButton = document.querySelector('#chatterRoot').shadowRoot.querySelector("[title='Copy Link']");
+                if (copyLinkButton) {
+                    throw new Error("Users without read access should not be able to copy the link to a message");
+                }
+            },
+        },
+    ],
+});

--- a/addons/test_mail_full/tests/test_ui.py
+++ b/addons/test_mail_full/tests/test_ui.py
@@ -1,12 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from urllib.parse import urlencode
+
 from odoo import tests
 from odoo.addons.test_mail_full.tests.test_portal import TestPortal
 
 
 @tests.common.tagged("post_install", "-at_install")
 class TestUIPortal(TestPortal):
-    def test_star_message(self):
+
+    def setUp(self):
+        super().setUp()
         self.env["mail.message"].create(
             {
                 "author_id": self.user_employee.partner_id.id,
@@ -16,8 +20,26 @@ class TestUIPortal(TestPortal):
                 "subtype_id": self.ref("mail.mt_comment"),
             }
         )
+
+    def test_star_message(self):
         self.start_tour(
             f"/my/test_portal_records/{self.record_portal.id}",
             "star_message_tour",
+            login=self.user_employee.login,
+        )
+
+    def test_no_copy_link_for_non_readable_portal_record(self):
+        # mail.test.portal has read access only for base.group_user
+        self.start_tour(
+            f"/my/test_portal_records/{self.record_portal.id}?{urlencode({'token': self.record_portal.access_token})}",
+            "portal_no_copy_link_tour",
+            login=None,
+        )
+
+    def test_copy_link_for_readable_portal_record(self):
+        # mail.test.portal has read access only for base.group_user
+        self.start_tour(
+            f"/my/test_portal_records/{self.record_portal.id}?{urlencode({'token': self.record_portal.access_token})}",
+            "portal_copy_link_tour",
             login=self.user_employee.login,
         )


### PR DESCRIPTION
Before this commit, the `_thread_to_store` method would always set the `hasReadAccess` property to true. This was fine because the only flow that would add the values to the store would already check the existance and access to the thread.

However after change [1] the access values would be sent in more flows, one of which being portal chatter initialization. This causes the client to have incorrect access information to the thread (i.e. hasReadAccess would be true even when accessing portal document through token).

This commit fixes the issue by sending the correct access values.

[1] https://github.com/odoo/odoo/pull/220774
