### PR TITLE
[FIX] website: indeterministic popup closing test

### DIFF
--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -92,7 +92,7 @@ describe("Popup options: popup in page before edit", () => {
         await contains(".o_we_invisible_entry .fa-eye-slash").click();
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         // Sometimes bootstrap.js takes a bit of time to display the popup
-        await waitFor(":iframe .s_popup div.js_close_popup", { timeout: 500, visible: true });
+        await waitFor(":iframe .s_popup div.js_close_popup", { timeout: 1000, visible: true });
         expect(":iframe .s_popup .modal").toBeVisible();
         await contains(":iframe .s_popup div.js_close_popup").click();
         expect(":iframe .s_popup .modal").not.toBeVisible();
@@ -109,8 +109,9 @@ describe("Popup options: popup in page before edit", () => {
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         expect(":iframe .s_popup .modal").toBeVisible();
         setSelection({ anchorNode: queryOne(":iframe .s_popup section p"), anchorOffset: 0 });
-        insertText(editor, "Other content");
-        await animationFrame();
+        await insertText(editor, "Other content");
+        // Sometimes bootstrap.js takes a bit of time to display the popup
+        await waitFor(":iframe .s_popup div.js_close_popup", { timeout: 1000, visible: true });
         await contains(":iframe .s_popup div.js_close_popup").click();
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");
         expect(":iframe .s_popup .modal").not.toBeVisible();


### PR DESCRIPTION
Before to this commit, the ‘closing s_popup with the X button updates the invisible elements panel’ test failed from sometimes on runbot. We think boostrap.js takes longer than normal to display the popup.

Solution:
We're going to increase the waiting timeout so that the crash doesn't recur. We've taken this decision because the problem is very specific and probably link to bootstrap.js.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
