### PR TITLE
[FIX] hr_attendance: fixed the traceback

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -96,7 +96,7 @@ class HrAttendance(http.Controller):
             domain = Domain([('barcode', '=', False), ('company_id', '=', company.id)])
             if name:
                 domain = Domain.AND([domain, [('name', 'ilike', name)]])
-            employee_list = request.env['hr.employee'].search_read(
+            employee_list = request.env['hr.employee'].sudo().search_read(
                 domain,
                 ['id', 'name'],
                 limit=limit,

--- a/addons/hr_attendance/static/src/components/new_employee_dialog/many2one/many2one.js
+++ b/addons/hr_attendance/static/src/components/new_employee_dialog/many2one/many2one.js
@@ -1,6 +1,7 @@
 import { rpc } from "@web/core/network/rpc";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { Component } from "@odoo/owl";
+import { useDebounced } from "@web/core/utils/timing";
 
 export class Many2One extends Component {
     static template = "hr_attendance.Many2One";
@@ -11,11 +12,17 @@ export class Many2One extends Component {
         value: String,
     };
 
+    setup() {
+        this.debouncedLoadOptions = useDebounced(this.loadOptionsSource.bind(this), 200);
+    }
+
     get sources() {
-        return [{
-            options: this.loadOptionsSource.bind(this),
-            optionSlot: "option",
-        }];
+        return [
+            {
+                options: this.debouncedLoadOptions,
+                optionSlot: "option",
+            },
+        ];
     }
 
     async loadOptionsSource(input) {


### PR DESCRIPTION
**Steps to Reproduce:**

1. Log in with a user who has only the "Attendance: Administrator" right,
with no other rights.
2. Open the Attendance app in Gantt view and search for a random term.
A helper message will appear.
3. Click on "Try the Kiosk" and select the RFID Token option, then click
on "New Setup."
4. Try to select an employee from the selection field.
5. An error traceback will occur.

**Cause:**
The issue occurs because the domain is evaluated on the `hr.employee.public`
model instead of `hr.employee`, which lacks a barcode field.
This occurs in search_read when users don’t have access to `hr.employee`

**Fix:**
We want to add a barcode only for items that don't already have one,
so we need to search for existing barcodes. The best way to solve
this is to apply sudo as we will only return the name and ID to the frontend.

Task-5003435
