### PR TITLE
[FIX] l10n_sa: Fixed Phase 1 QR code disappearing

### DIFF
--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -80,3 +80,8 @@ class AccountMove(models.Model):
             'total_amount': self.amount_total_signed,
             'total_tax': self.amount_tax_signed,
         }
+
+    def _l10n_sa_is_legal(self):
+        # Check if the document is legal in Saudi
+        self.ensure_one()
+        return self.company_id.country_id.code == 'SA' and self.state == 'posted' and self.l10n_sa_qr_code_str

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -2,14 +2,7 @@
 <odoo>
     <template id="arabic_english_invoice" inherit_id="l10n_gcc_invoice.arabic_english_invoice">
         <xpath expr="//div[@name='due_date']" position="after">
-            <t t-if="o.company_id.country_id.code == 'SA' and o.edi_state != 'sent' and o.move_type in ('out_invoice', 'out_refund')" t-set="custom_header">
-                <div class="fw-bold text-center mt-2">
-                    <h5>THIS IS NOT A LEGAL DOCUMENT</h5>
-                    <h5>هذا المستند ليس مستنداً قانونياً</h5>
-                </div>
-                <!-- To help with centering the previous div in flex justify between-->
-                <div t-if="is_html_empty(o.company_id.report_header)" class="col-1"/>
-            </t>
+
             <div class="row" t-if="o.delivery_date" name="delivery_date">
                 <div class="col-6"></div>
                 <div class="col-2">
@@ -27,10 +20,18 @@
             </div>
         </xpath>
         <xpath expr="//t[@t-set='address']" position="after">
+            <t t-if="o.company_id.country_id.code == 'SA' and not o._l10n_sa_is_legal() " t-set="custom_header">
+                <div class="fw-bold text-center mt-2">
+                    <h5>THIS IS NOT A LEGAL DOCUMENT</h5>
+                    <h5>هذا المستند ليس مستنداً قانونياً</h5>
+                </div>
+                <!-- To help with centering the previous div in flex justify between-->
+                <div t-if="is_html_empty(o.company_id.report_header)" class="col-1"/>
+            </t>
             <t t-set="information_block">
                 <div class="row">
                     <p class="col-6 me-3">
-                        <img t-if="o.l10n_sa_qr_code_str and o.edi_state == 'sent'"
+                        <img t-if="o._l10n_sa_is_legal() and o.l10n_sa_qr_code_str"
                              class="d-block"
                              t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 200, 200)"/>
                     </p>

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -226,6 +226,16 @@ class AccountMove(models.Model):
         self.ensure_one()
         return self.is_invoice() and self.l10n_sa_confirmation_datetime and self.country_code == 'SA'
 
+    def _l10n_sa_is_legal(self):
+        # Extends l10n_sa
+        # Accounts for both ZATCA phases
+        # Phase 1: no documents
+        # Phase 2: checks the state of documents
+        self.ensure_one()
+        result = super()._l10n_sa_is_legal()
+        zatca_document = self.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'sa_zatca')
+        return result or (self.company_id.country_id.code == 'SA' and zatca_document and self.edi_state == "sent")
+
     def _get_report_base_filename(self):
         """
             Generate the name of the invoice PDF file according to ZATCA business rules:


### PR DESCRIPTION
Phase 1 ZATCA QR codes disappear when l10n_sa_edi is installed, there is a check for document submission to display the QR code for Phase 2 which older Phase 1 invoices will not pass as it doesn't use edi.

Description of the issue/feature this PR addresses:
Phase 1 ZATCA QR Code disappears once l10n_sa_edi is installed

Current behavior before PR:
Always hide Phase 1 ZATCA QR Code

Desired behaviour after PR is merged:
Showing Phase 1 and Phase 2 ZATCA QR codes based on the invoice

task-5005304
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
