### PR TITLE
[IMP] core: add a group containing all users

### DIFF
--- a/odoo/addons/base/security/base_groups.xml
+++ b/odoo/addons/base/security/base_groups.xml
@@ -71,23 +71,22 @@
             <field name="implied_by_ids" eval="[Command.link(ref('base.group_erp_manager'))]"/>
             <field name="privilege_id" ref="res_groups_privilege_contact"/>
         </record>
-        <!--
-            A group dedicated to the portal users, making groups
-            restrictions more convenient.
-        -->
+
         <record model="res.groups" id="group_portal">
             <field name="name">Role / Portal</field>
             <field name="comment">Portal members have specific access rights (such as record rules and restricted menus).
                 They usually do not belong to the usual Odoo groups.</field>
         </record>
-        <!--
-            A group dedicated to the public user only, making groups
-            restrictions more convenient.
-        -->
         <record model="res.groups" id="group_public">
             <field name="name">Role / Public</field>
             <field name="comment">Public users have specific access rights (such as record rules and restricted menus).
-                They usually do not belong to the usual Odoo groups.</field>
+                They usually do not belong to the usual Odoo groups.
+                This makes group restrictions more convenient.</field>
+        </record>
+        <record model="res.groups" id="group_everyone">
+            <field name="name">Role / Everyone</field>
+            <field name="implied_by_ids" eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_public')), Command.link(ref('base.group_user'))]"/>
+            <field name="comment">Includes all users. This makes group restrictions more convenient.</field>
         </record>
 
         <record id="public_user" model="res.users">

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -19,6 +19,17 @@
             <field name="domain_force">['|', '|', ('partner_share', '=', False), ('company_id', 'parent_of', company_ids), ('company_id', '=', False)]</field>
         </record>
 
+        <record id="res_partner_rule_user" model="ir.rule">
+            <field name="name">user read access</field>
+            <field name="model_id" ref="model_res_partner"/>
+            <field name="groups" eval="[Command.set([ref('base.group_user')])]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+
         <record id="res_partner_rule_edit_all" model="ir.rule">
             <field name="name">edit all</field>
             <field name="model_id" ref="model_res_partner"/>
@@ -45,7 +56,7 @@
             <field name="name">res_partner: portal/public: read access on my commercial partner</field>
             <field name="model_id" ref="base.model_res_partner"/>
             <field name="domain_force">[('id', 'child_of', user.commercial_partner_id.id)]</field>
-            <field name="groups" eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_public'))]"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
             <field name="perm_create" eval="False"/>
             <field name="perm_unlink" eval="False"/>
             <field name="perm_write" eval="False"/>
@@ -120,29 +131,15 @@
             <field name="name">ir.filter: portal/public</field>
             <field name="model_id" ref="model_ir_filters"/>
             <field name="domain_force">[('user_ids', 'in', user.ids)]</field>
-            <field name="groups" eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_public'))]"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
         </record>
 
         <!-- Record Rules For Company -->
-        <record id="res_company_rule_portal" model="ir.rule">
-            <field name="name">company rule portal</field>
-            <field name="model_id" ref="model_res_company"/>
-            <field eval="False" name="global"/>
-            <field name="groups" eval="[Command.set([ref('base.group_portal')])]"/>
-            <field name="domain_force">[('id','in', company_ids)]</field>
-        </record>
-        <record id="res_company_rule_employee" model="ir.rule">
-            <field name="name">company rule employee</field>
-            <field name="model_id" ref="model_res_company"/>
-            <field eval="False" name="global"/>
-            <field name="groups" eval="[Command.set([ref('base.group_user')])]"/>
-            <field name="domain_force">[('id','in', company_ids)]</field>
-        </record>
         <record id="res_company_rule_public" model="ir.rule">
             <field name="name">company rule public</field>
             <field name="model_id" ref="model_res_company"/>
             <field eval="False" name="global"/>
-            <field name="groups" eval="[Command.set([ref('base.group_public')])]"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
             <field name="domain_force">[('id','in', company_ids)]</field>
         </record>
         <record id="res_company_rule_erp_manager" model="ir.rule">
@@ -237,12 +234,6 @@
         </record>
 
         <!-- rules for API token -->
-        <record id="api_key_public" model="ir.rule">
-            <field name="name">Public users can't interact with keys at all</field>
-            <field name="model_id" ref="model_res_users_apikeys"/>
-            <field name="domain_force">[(0, '=', 1)]</field>
-            <field name="groups" eval="[Command.link(ref('base.group_public'))]"/>
-        </record>
         <record id="api_key_user" model="ir.rule">
             <field name="name">Users can read and delete their own keys</field>
             <field name="model_id" ref="model_res_users_apikeys"/>

--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -40,38 +40,23 @@
 "access_ir_default_group_user","ir_default group_user","model_ir_default","group_user",1,1,1,1
 "access_ir_default_group_system","ir_default group_system","model_ir_default","group_system",1,1,1,1
 "access_res_company_group_erp_manager","res_company group_erp_manager","model_res_company","group_erp_manager",1,1,1,1
-"access_res_company_public","res_company group_user","model_res_company",base.group_public,1,0,0,0
-"access_res_company_portal","res_company group_user","model_res_company",base.group_portal,1,0,0,0
-"access_res_company_employee","res_company group_user","model_res_company",base.group_user,1,0,0,0
-"access_res_country_public","res_country group_user_all","model_res_country",base.group_public,1,0,0,0
-"access_res_country_portal","res_country group_user_all","model_res_country",base.group_portal,1,0,0,0
-"access_res_country_employee","res_country group_user_all","model_res_country",base.group_user,1,0,0,0
-"access_res_country_state_public","res_country_state group_user_all","model_res_country_state",base.group_public,1,0,0,0
-"access_res_country_state_portal","res_country_state group_user_all","model_res_country_state",base.group_portal,1,0,0,0
-"access_res_country_state_employee","res_country_state group_user_all","model_res_country_state",base.group_user,1,0,0,0
-"access_res_country_group_public","res_country_group group_user_all","model_res_country_group",base.group_public,1,0,0,0
-"access_res_country_group_portal","res_country_group group_user_all","model_res_country_group",base.group_portal,1,0,0,0
-"access_res_country_group_employee","res_country_group group_user_all","model_res_country_group",base.group_user,1,0,0,0
+"access_res_company_everyone","res_company group_everyone","model_res_company",base.group_everyone,1,0,0,0
+"access_res_country_public","res_country group_user_all","model_res_country",base.group_everyone,1,0,0,0
+"access_res_country_state_public","res_country_state group_user_all","model_res_country_state",base.group_everyone,1,0,0,0
+"access_res_country_group_all","res_country_group group_user_all","model_res_country_group",base.group_everyone,1,0,0,0
 "access_res_country_group_user","res_country group_user","model_res_country","group_partner_manager",1,0,0,0
 "access_res_country_group_system","res_country_group_system","model_res_country","group_system",1,1,1,1
 "access_res_country_state_group_user","res_country_state group_user","model_res_country_state","group_partner_manager",1,1,1,1
 "access_res_country_group_group_user","res_country_group group_user","model_res_country_group","group_partner_manager",1,1,1,1
-"access_res_currency_public","res_currency group_all","model_res_currency",base.group_public,1,0,0,0
-"access_res_currency_portal","res_currency group_all","model_res_currency",base.group_portal,1,0,0,0
-"access_res_currency_employee","res_currency group_all","model_res_currency",base.group_user,1,0,0,0
-"access_res_currency_rate_public","res_currency_rate group_all","model_res_currency_rate",base.group_public,1,0,0,0
-"access_res_currency_rate_portal","res_currency_rate group_all","model_res_currency_rate",base.group_portal,1,0,0,0
-"access_res_currency_rate_employee","res_currency_rate group_all","model_res_currency_rate",base.group_user,1,0,0,0
+"access_res_currency_public","res_currency group_all","model_res_currency",base.group_everyone,1,0,0,0
+"access_res_currency_rate_public","res_currency_rate group_all","model_res_currency_rate",base.group_everyone,1,0,0,0
 "access_res_currency_group_system","res_currency group_system","model_res_currency","group_system",1,1,1,1
 "access_res_currency_rate_group_system","res_currency_rate group_system","model_res_currency_rate","group_system",1,1,1,1
 "access_res_groups_group_erp_manager","res_groups group_erp_manager","model_res_groups","group_erp_manager",1,1,1,1
 "access_res_groups_group_user","res_groups group_user","model_res_groups",group_user,1,0,0,0
-"access_res_lang_public","res_lang group_all","model_res_lang",base.group_public,1,0,0,0
-"access_res_lang_portal","res_lang group_all","model_res_lang",base.group_portal,1,0,0,0
-"access_res_lang_employee","res_lang group_all","model_res_lang",base.group_user,1,0,0,0
+"access_res_lang_public","res_lang group_all","model_res_lang",base.group_everyone,1,0,0,0
 "access_res_lang_group_system","res_lang group_user","model_res_lang","group_system",1,1,1,1
-"access_res_partner_public","res_partner group_public","model_res_partner","group_public",1,0,0,0
-"access_res_partner_portal","res_partner group_portal","model_res_partner","group_portal",1,0,0,0
+"access_res_partner_public","res_partner group_everyone","model_res_partner","group_everyone",1,0,0,0
 "access_res_partner_group_partner_manager","res_partner group_partner_manager","model_res_partner","group_partner_manager",1,1,1,1
 "access_res_partner_group_user","res_partner group_user","model_res_partner","group_user",1,1,0,0
 "access_res_partner_bank_group_user","res_partner_bank group_user","model_res_partner_bank","group_user",1,0,0,0
@@ -80,8 +65,7 @@
 "access_res_partner_category_group_partner_manager","res_partner_category group_partner_manager","model_res_partner_category","group_partner_manager",1,1,1,1
 "access_res_partner_industry_group_user","res_partner_industry group_user","model_res_partner_industry","group_user",1,0,0,0
 "access_res_partner_industry_group_system","res_partner_industry group_system","model_res_partner_industry","group_system",1,1,1,1
-"access_res_users_public","res_users all","model_res_users","base.group_public",1,0,0,0
-"access_res_users_portal","res_users all","model_res_users","base.group_portal",1,0,0,0
+"access_res_users_everyone","res_users all","model_res_users","base.group_everyone",1,0,0,0
 "access_res_users_employee","res_users all","model_res_users","base.group_user",1,1,0,0
 "access_res_users_group_erp_manager","res_users group_erp_manager","model_res_users","group_erp_manager",1,1,1,1
 "access_res_users_deletion_all","res_users_deletion all","model_res_users_deletion",,0,0,0,0
@@ -111,10 +95,7 @@ access_res_users_settings_user,res.users.settings,model_res_users_settings,group
 "access_res_bank_group_system","res_bank_group_system","model_res_bank","group_system",1,1,1,1
 "access_res_bank_group_partner_manager","res_bank_group_partner_manager","model_res_bank","group_partner_manager",1,1,1,1
 "access_res_bank_user","res_bank user","model_res_bank","group_user",1,0,0,0
-"access_ir_filter_erp_manager","ir_filters all","model_ir_filters","group_erp_manager",1,1,1,1
-"access_ir_filter_user","ir_filters all","model_ir_filters","group_user",1,1,1,1
-"access_ir_filter_portal","ir_filters all","model_ir_filters","group_portal",1,1,1,1
-"access_ir_filter_public","ir_filters all","model_ir_filters","group_public",1,1,1,1
+"access_ir_filter_everyone","ir_filters all","model_ir_filters","group_everyone",1,1,1,1
 "access_ir_config_parameter_system","ir_config_parameter_system","model_ir_config_parameter","group_system",1,1,1,1
 "access_ir_mail_server","ir_mail_server","model_ir_mail_server","group_system",1,1,1,1
 "access_ir_logging","ir_logging admin","model_ir_logging","group_erp_manager",1,1,1,1

--- a/odoo/addons/base/tests/test_acl.py
+++ b/odoo/addons/base/tests/test_acl.py
@@ -263,7 +263,7 @@ class TestIrRule(TransactionCaseWithUserDemo):
 
         # modify the global rule on res_company which triggers a recursive check
         # of the rules on company
-        global_rule = self.env.ref('base.res_company_rule_employee')
+        global_rule = self.env.ref('base.res_company_rule_public')
         global_rule.domain_force = "[('id','in', company_ids)]"
 
         # read as demo user (exercising the global company rule)

--- a/odoo/addons/base/tests/test_groups.py
+++ b/odoo/addons/base/tests/test_groups.py
@@ -701,13 +701,13 @@ class TestGroupsOdoo(common.TransactionCase):
 
         user.group_ids = self.env.ref('base.group_user') + self.test_group
 
-        self.assertEqual(set(self.test_group.all_implied_ids.get_external_id().values()), {'base.base_test_group', 'base.group_user', 'base.group_no_one'})
+        self.assertEqual(set(self.test_group.all_implied_ids.get_external_id().values()), {'base.base_test_group', 'base.group_user', 'base.group_no_one', 'base.group_everyone'})
 
         # update res.group implied_ids having the effect that users have distinct groups
         with self.assertRaises(ValidationError, msg="The user cannot have more than one user types."):
             self.test_group.implied_ids += self.env.ref('base.group_public')
 
-        self.assertEqual(set(self.test_group.all_implied_ids.get_external_id().values()), {'base.base_test_group', 'base.group_user', 'base.group_no_one'})
+        self.assertEqual(set(self.test_group.all_implied_ids.get_external_id().values()), {'base.base_test_group', 'base.group_user', 'base.group_no_one', 'base.group_everyone'})
 
         with self.assertRaises(ValidationError, msg="The user cannot have more than one user types."):
             self.env.ref('base.group_public').implied_by_ids = self.test_group
@@ -717,7 +717,7 @@ class TestGroupsOdoo(common.TransactionCase):
         with self.assertRaises(ValidationError, msg="This makes a group imply two disjoint groups."):
             self.env.ref('base.group_public').implied_ids += self.test_group
 
-        self.assertEqual(set(self.env.ref('base.group_public').all_implied_ids.get_external_id().values()), {'base.group_public'})
+        self.assertEqual(set(self.env.ref('base.group_public').all_implied_ids.get_external_id().values()), {'base.group_public', 'base.group_everyone'})
 
         new_group = self.env['res.groups'].create({
             'name': 'test group',
@@ -729,7 +729,7 @@ class TestGroupsOdoo(common.TransactionCase):
             "res_id": new_group.id,
         })
         self.env.ref('base.group_public').implied_ids += new_group
-        self.assertEqual(set(self.env.ref('base.group_public').all_implied_ids.get_external_id().values()), {'base.group_public', 'base.new_group'})
+        self.assertEqual(set(self.env.ref('base.group_public').all_implied_ids.get_external_id().values()), {'base.group_public', 'base.new_group', 'base.group_everyone'})
 
     def test_groups_7_distinct(self):
         def create(name, implied_by_ids=[]):


### PR DESCRIPTION
Group to ease defining access rights.
Use that group in the base module to simplify access.

After a discussion, a second commit is added to use everyone instead of public to avoid permission inconsistencies. This will be done in a separate PR.

https://github.com/odoo/enterprise/pull/94567


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
