### PR TITLE
[FIX] point_of_sale: prevent crash when preset missing during customer selection

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -865,11 +865,11 @@ export class PosOrder extends Base {
             newPartnerPricelist = this.config.pricelist_id;
         }
 
-        if (!this.config.use_presets || !this.preset_id.fiscal_position_id) {
+        if (!this.config.use_presets || !this.preset_id?.fiscal_position_id) {
             this.fiscal_position_id = newPartnerFiscalPosition;
         }
 
-        if (!this.config.use_presets || !this.preset_id.pricelist_id) {
+        if (!this.config.use_presets || !this.preset_id?.pricelist_id) {
             this.setPricelist(newPartnerPricelist);
         }
     }

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -149,4 +149,20 @@ describe("pos.order", () => {
         expect(taxTotalsWDiscount.total_amount).toBe(12.03);
         expect(taxTotalsWDiscount.tax_amount_currency).toBe(1.83);
     });
+
+    test("updatePricelistAndFiscalPosition", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const partner = models["res.partner"].get(3);
+
+        partner.fiscal_position_id = models["account.fiscal.position"].get(1);
+        partner.property_product_pricelist = models["product.pricelist"].get(1);
+
+        const order = store.addNewOrder();
+        order.preset_id = null;
+        order.updatePricelistAndFiscalPosition(partner);
+
+        expect(order.fiscal_position_id.id).toBe(partner.fiscal_position_id.id);
+        expect(order.pricelist_id.id).toBe(partner.property_product_pricelist.id);
+    });
 });


### PR DESCRIPTION
STEPS TO REPRODUCE:
----------------
- Open Point of sale
- Create preset in the backend with Identification = Address (make it Default).
- Open Register 
- Try to new order and select a customer.

ISSUE:
------------------
- Crash occurs if the order has no preset set yet (e.g., during customer
  selection or initial load).

CAUSE:
-------------------
- Accessing the preset’s fiscal position and pricelist even when no preset is 
  set.

FIX:
---------------------------
- Used optional chaining (?.) to safely access preset fields.

TASK-5005015