### PR TITLE
[FIX] html_editor: fix html properties

### DIFF
--- a/addons/html_editor/static/src/fields/property_value.js
+++ b/addons/html_editor/static/src/fields/property_value.js
@@ -69,6 +69,7 @@ patch(PropertyValue.prototype, {
         }
 
         return {
+            baseContainers: ["DIV"],
             content: this.propertyValue,
             debug: !!this.env.debug,
             direction: localization.direction || "ltr",

--- a/addons/html_editor/static/tests/properties.test.js
+++ b/addons/html_editor/static/tests/properties.test.js
@@ -110,6 +110,34 @@ test("properties: html", async () => {
     );
 });
 
+test("properties: hmtl (empty)", async () => {
+    patchWithCleanup(user, { hasGroup: (group) => false });
+    let editor;
+    patchWithCleanup(PropertyValue.prototype, {
+        onEditorLoad(ed) {
+            super.onEditorLoad(ed);
+            editor = ed;
+        },
+    });
+    await mountView({
+        type: "form",
+        resId: 3,
+        resModel: "res.partner",
+        arch: `
+            <form>
+                <field name="user_id"/>
+                <field name="properties"/>
+            </form>`,
+    });
+    expect(`[name="properties"] .odoo-editor-editable`).toHaveCount(1);
+    setSelection({
+        anchorNode: queryOne(`[name="properties"] .odoo-editor-editable .o-paragraph`),
+        anchorOffset: 0,
+    });
+    await insertText(editor, " foo");
+    expect(`[name="properties"] .odoo-editor-editable .o-paragraph`).toHaveText("foo");
+});
+
 test("properties: html migration", async () => {
     patchWithCleanup(user, { hasGroup: (group) => false });
     let component;


### PR DESCRIPTION
Purpose:
--------
Inserting a new html property crashes.

Since f6bae187fbef6e7b87e10c057f721b36b551a72a , the baseContainers must be added in the config.

Task-4997296
