### PR TITLE
[FIX] website_sale_collect: change "Pay now" button when paying on site

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -43,6 +43,9 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
         } else {
             this._setPaymentFlow(); // Initialize the payment flow to let providers overwrite it.
         }
+        this.defaultSubmitButtonLabel = document.querySelector(
+            'button[name="o_payment_submit_button"]'
+        )?.textContent;
 
         this.$('[data-bs-toggle="tooltip"]').tooltip();
     },
@@ -237,6 +240,12 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
         const paymentOptionId = this._getPaymentOptionId(radio);
         const paymentMethodCode = this._getPaymentMethodCode(radio);
         const flow = this._getPaymentFlow(radio);
+        const btnLabel = this._isPayLaterMethod(paymentMethodCode)
+            ? _t("Confirm")
+            : this.defaultSubmitButtonLabel;
+        for (const btn of document.querySelectorAll('button[name="o_payment_submit_button"]')) {
+            btn.textContent = btnLabel;
+        }
         await this._prepareInlineForm(
             providerId, providerCode, paymentOptionId, paymentMethodCode, flow
         );
@@ -263,6 +272,19 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
      * @return {void}
      */
     async _prepareInlineForm(providerId, providerCode, paymentOptionId, paymentMethodCode, flow) {},
+
+    /**
+     * Check whether or not the given payment method expects immediate payment.
+     *
+     * Override this method to change the submit button label from the default to "Confirm".
+     *
+     * @private
+     * @param {string} paymentMethodCode - The code of the selected payment method, if any.
+     * @return {boolean}
+     */
+    _isPayLaterMethod(paymentMethodCode) {
+        return false;
+    },
 
     /**
      * Collapse all inline forms of the current widget.

--- a/addons/website_sale_collect/static/src/js/payment_form.js
+++ b/addons/website_sale_collect/static/src/js/payment_form.js
@@ -3,12 +3,12 @@ import PaymentForm from '@payment/js/payment_form';
 PaymentForm.include({
 
     /**
-     * Configure 'cash_on_delivery' as a pay-later method.
+     * Configure 'pay_on_site' as a pay-later method.
      *
      * @override
      */
     _isPayLaterMethod(paymentMethodCode) {
-        return paymentMethodCode === 'cash_on_delivery' || this._super(...arguments);
+        return paymentMethodCode === 'pay_on_site' || this._super(...arguments);
     }
 
 });


### PR DESCRIPTION
Steps
-----
1. Enable the "Pay on site" payment method;
2. in eCommerce, add a product to your cart you can pick up in store;
3. go to payment;
4. select "Pay on site".

Issue
-----
The payment button displays "Pay now", even though we're paying later.

Solution
--------
Add a `_isPayLaterMethod` hook, which returns `true` for `pay_on_site` and `cash_on_delivery`, changing the label from the default to "Confirm".

opw-4986791