### PR TITLE
[FIX] website_sale_stock: out of stock order validation using gift card

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1862,6 +1862,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         if order and not order.amount_total and not tx_sudo:
             if order.state != 'sale':
+                order._check_cart_is_ready_to_be_paid()
                 order.with_context(send_email=True).with_user(SUPERUSER_ID).action_confirm()
             request.website.sale_reset()
             return request.redirect(order.get_portal_url())

--- a/addons/website_sale_stock/tests/test_website_sale_stock_delivery.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_delivery.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.tests import tagged
 
 from odoo.addons.payment.tests.common import PaymentCommon
@@ -33,5 +34,35 @@ class TestWebsiteSaleStockDeliveryController(PaymentCommon, SaleCommon):
         with MockRequest(self.env, website=self.website):
             self.website.sale_get_order(force_create=True)
             self.Controller.cart_update_json(product_id=storable_product.id, add_qty=1)
+            with self.assertRaises(ValidationError):
+                self.Controller.shop_payment_validate()
+
+    def test_validate_order_out_of_stock_zero_price(self):
+        """
+        An error should be raised if you try to validate an order for
+        an out of stock product with 0 price
+        """
+        storable_product = self.env['product.product'].create({
+            'name': 'Storable Product',
+            'sale_ok': True,
+            'type': 'product',
+            'website_published': True,
+            'allow_out_of_stock_order': False,
+            'lst_price': 0,
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'product_id': storable_product.id,
+                'product_uom_qty': 12.0,
+            })]
+        })
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': storable_product.id,
+            'inventory_quantity': 10.0,
+            'location_id': self.env.user._get_default_warehouse_id().lot_stock_id.id,
+        }).action_apply_inventory()
+
+        with MockRequest(self.env, website=self.website, sale_order_id=sale_order.id):
             with self.assertRaises(ValidationError):
                 self.Controller.shop_payment_validate()


### PR DESCRIPTION
In this bug, when a order is out of stock, it can be validated if gift card is used as the sole method of payment. This happens when a product gets out of stock while it is on customer's cart. The other payment methods fail successfully but if gift card is used, the order can be validated.

To reproduce:
1- Create a product and add quantity on stock.
2- Uncheck `Conitnue Selling` in `Out-of-Stock`
3- Publish the product on the website
4- Create a gift card
5- Add the product to the cart using portal user
7- Using admin user, set the quantity to less than ordered quantity
8- Using portal user, proceed to payment, and use the gift card. Then checkout.
9- As you see, the order is validated

The issue is because `_check_cart_is_ready_to_be_paid()` which is supposed to check the stock, is only called inside `shop_payment_transaction()`.
However, when checking out with gift card, this method is not called.
To solve the issue, we can call `_check_cart_is_ready_to_be_paid()` also inside payment validate flow. However this only be called when a gift card is used solely. (The case `order.amount_total` is 0)

opw-4941658


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
