### PR TITLE
[FIX] html_editor: ensure editor defaultConfig before using the config

### DIFF
--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -96,7 +96,8 @@ export class Editor {
         }
         this.editable = editable;
         this.document = editable.ownerDocument;
-        if (this.config.content) {
+        this.preparePlugins();
+        if ("content" in this.config) {
             setElementContent(editable, fixInvalidHTML(this.config.content));
             if (isEmpty(editable)) {
                 const baseContainer = createBaseContainer(
@@ -107,7 +108,6 @@ export class Editor {
                 editable.replaceChildren(baseContainer);
             }
         }
-        this.preparePlugins();
         editable.setAttribute("contenteditable", true);
         initElementForEdition(editable, { allowInlineAtRoot: !!this.config.allowInlineAtRoot });
         editable.classList.add("odoo-editor-editable");

--- a/addons/html_editor/static/tests/initialization.test.js
+++ b/addons/html_editor/static/tests/initialization.test.js
@@ -328,3 +328,12 @@ describe("formatting normalization", () => {
         });
     });
 });
+
+describe("Editor config initialization", () => {
+    test("should replace empty content by a default baseContainer, even if not provided in the config", async () => {
+        await testEditor({
+            config: { content: "" },
+            contentAfter: "<p><br></p>",
+        });
+    });
+});


### PR DESCRIPTION
Issue:
There are configurations where the editor is used without a `HtmlField` and the editor config does not contain `baseContainer`.

The `baseContainer` plugin sets a value for `baseContainer` in the `defaultConfig`, but it is done in `preparePlugins`.

Solution:
Call `preparePlugins` before reading anything in the `config` so that `defaultConfig` can be properly initialized.
