### PR TITLE
[IMP] hr: improve UX for employee's adress state selection

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -393,6 +393,11 @@ class HrEmployee(models.Model):
         if not self.contract_date_start:
             self.contract_date_end = False
 
+    @api.onchange("private_state_id")
+    def _onchange_private_state_id(self):
+        if self.private_state_id:
+            self.private_country_id = self.private_state_id.country_id
+
     @api.onchange('work_phone', 'mobile_phone', 'company_country_id', 'company_id')
     def _onchange_phone_validation_employee(self):
         if self.work_phone:

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -123,6 +123,11 @@ class ResUsers(models.Model):
     def SELF_WRITEABLE_FIELDS(self):
         return super().SELF_WRITEABLE_FIELDS + HR_WRITABLE_FIELDS
 
+    @api.onchange("private_state_id")
+    def _onchange_private_state_id(self):
+        if self.private_state_id:
+            self.private_country_id = self.private_state_id.country_id
+
     @api.model
     def get_views(self, views, options=None):
         # Requests the My Preferences form view as last.

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -296,8 +296,8 @@
                                             <field name="private_street2" placeholder="Street 2..." class="o_address_street"/>
                                             <field name="private_city" placeholder="City" class="o_address_city"/>
                                             <field name="private_state_id" class="o_address_state" placeholder="State" 
-                                                options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}"
-                                                domain="[('country_id', '=', private_country_id)]"/>
+                                                options='{"no_open": True, "no_create": True}' context="{'default_country_id': private_country_id}"
+                                                domain="[('id', 'in', allowed_country_state_ids)]"/>
                                             <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
                                             <field name="private_country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                         </div>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -88,7 +88,7 @@
                                     <field name="private_street" placeholder="Street..." class="o_address_street"/>
                                     <field name="private_street2" placeholder="Street 2..." class="o_address_street"/>
                                     <field name="private_city" placeholder="City" class="o_address_city"/>
-                                    <field name="private_state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}"/>
+                                    <field name="private_state_id" class="o_address_state" placeholder="State" options="{'no_open': True, 'no_create': True}" context="{'default_country_id': private_country_id}"/>
                                     <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
                                     <field name="private_country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                 </div>


### PR DESCRIPTION
If the country is not set and you try to put a state, you won't see anything and if you type in some state name, you will create a new record which is not ideal (some locations have logic based on the state).
Thus, a change has been made to allow to select a state from the whole record of states which will select the country.
Having a country selected (whether automatically or manually) will filter the states according to the country.
