### PR TITLE
[REM] hr: removed Developer USA demo record in Contract Templates

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -816,16 +816,6 @@ If you have development competencies, we can propose you specific traineeships</
         </function>
 
         <!-- Contract Templates -->
-        <record id="contract_template_us_developer" model="hr.version">
-            <field name="name">Developer USA</field>
-            <field name="contract_type_id" ref="contract_type_permanent"/>
-            <field name="structure_type_id" ref="structure_type_employee"/>
-            <field name="wage">3000.00</field>
-            <field name="job_id" ref="hr.job_developer"/>
-            <field name="department_id" ref="hr.dep_rd_be"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
-        </record>
-
         <record id="contract_template_hr_manager" model="hr.version">
             <field name="name">HR Manager</field>
             <field name="contract_type_id" ref="contract_type_permanent"/>


### PR DESCRIPTION
Removed the record for the Developer USA in the demo in the hr module /hr_demo.xml as it was called before triggering the _default_salary_structure function in hr_version.py so the fields are not updated based on company_id

Task ID: 5003603