### PR TITLE
[FIX] html_editor: prevent `o_editable_media` class to add `o_dirty` + [FIX] html_builder: prevent drag and drop to add unwanted `o_dirty` 

### DIFF
--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -1,5 +1,6 @@
 import { isVisible } from "@html_builder/utils/utils";
 import { Plugin } from "@html_editor/plugin";
+import { isElement } from "@html_editor/utils/dom_info";
 import { _t } from "@web/core/l10n/translation";
 
 export class DropZonePlugin extends Plugin {
@@ -13,6 +14,18 @@ export class DropZonePlugin extends Plugin {
         "getSelectorChildren",
         "getSelectors",
     ];
+    resources = {
+        savable_mutation_record_predicates: (record) => {
+            if (record.type === "childList") {
+                const addedOrRemovedNode = record.addedNodes[0] || record.removedNodes[0];
+                // Do not record the addition/removal of the dropzones.
+                if (isElement(addedOrRemovedNode) && addedOrRemovedNode.matches(".oe_drop_zone")) {
+                    return false;
+                }
+            }
+            return true;
+        },
+    };
 
     setup() {
         this.snippetModel = this.config.snippetModel;

--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -6,7 +6,7 @@ import { uniqueId } from "@web/core/utils/functions";
 
 export class SavePlugin extends Plugin {
     static id = "savePlugin";
-    static shared = ["save", "isAlreadySaved", "saveView"];
+    static shared = ["save", "isAlreadySaved", "saveView", "ignoreDirty"];
     static dependencies = ["history"];
 
     resources = {
@@ -187,5 +187,18 @@ export class SavePlugin extends Plugin {
             }
             savableEl.classList.add("o_dirty");
         }
+    }
+
+    /**
+     * Prevents elements to be marked as dirty until it is reactivated with the
+     * returned callback.
+     *
+     * @returns {Function}
+     */
+    ignoreDirty() {
+        this.canObserve = false;
+        return () => {
+            this.canObserve = true;
+        };
     }
 }

--- a/addons/html_editor/static/src/core/content_editable_plugin.js
+++ b/addons/html_editor/static/src/core/content_editable_plugin.js
@@ -17,6 +17,7 @@ export class ContentEditablePlugin extends Plugin {
         normalize_handlers: withSequence(5, this.normalize.bind(this)),
         clean_for_save_handlers: withSequence(Infinity, this.cleanForSave.bind(this)),
         filter_contenteditable_handlers: this.filterContentEditable.bind(this),
+        system_classes: ["o_editable_media"],
     };
 
     normalize(root) {


### PR DESCRIPTION
[FIX] html_editor: prevent `o_editable_media` class to add `o_dirty`

Before this commit, when the `o_editable_media` class was added on an
element, its closest view was marked as dirty, because of the mutation
it was adding.

This commit fixes that by making this class a system class, so its
mutations are always filtered out.

Steps to reproduce:
- Go in edit mode with eCommerce installed.
- In the header, inspect the shopping cart button and see that its view
  does not have the `o_editable_media` and `o_dirty` classes.
- Change a header option and inspect the button again.
=> the `o_editable_media` class was added, as well as `o_dirty`, because
of that class addition.

task-4367641

---
[FIX] html_builder: prevent drag and drop to add unwanted `o_dirty`

Before this commit, drag and dropping elements from the sidebar or from
the page would add the `o_dirty` class on every views in which dropzones
appeared, creating many views in DB for no valid reason when saving.

This commit fixes this issue by:
- not observing the dropzones addition/removal anymore,
- preventing the drag mutations to mark elements as dirty until we
  finally drop the dragged element.

task-4367641