### PR TITLE
[FIX] l10n_it_edi: added missing translations of invoice fields

### DIFF
--- a/addons/l10n_it_edi/i18n/it.po
+++ b/addons/l10n_it_edi/i18n/it.po
@@ -133,7 +133,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_cig
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_cig
 msgid "CIG"
-msgstr ""
+msgstr "CIG"
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -147,7 +147,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_cup
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_cup
 msgid "CUP"
-msgstr ""
+msgstr "CUP"
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -314,7 +314,7 @@ msgstr "Nome visualizzato"
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_form_l10n_it
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.l10n_it_document_type_tree
 msgid "Document Type"
-msgstr ""
+msgstr "Tipo di documento"
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -343,7 +343,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_form_l10n_it
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_company_form_l10n_it
 msgid "Electronic Invoicing"
-msgstr ""
+msgstr "Fatturazione Elettronica"
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -373,13 +373,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_edi_attachment_id
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_edi_attachment_id
 msgid "FatturaPA Attachment"
-msgstr ""
+msgstr "Allegato FatturaPA"
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_edi_transaction
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_edi_transaction
 msgid "FatturaPA Transaction"
-msgstr ""
+msgstr "Transazione FatturaPA"
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,help:l10n_it_edi.field_res_company__l10n_it_codice_fiscale
@@ -740,19 +740,19 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_origin_document_date
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_origin_document_date
 msgid "Origin Document Date"
-msgstr ""
+msgstr "Data Documento Origine"
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_origin_document_name
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_origin_document_name
 msgid "Origin Document Name"
-msgstr ""
+msgstr "Nome Documento Origine"
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_bank_statement_line__l10n_it_origin_document_type
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move__l10n_it_origin_document_type
 msgid "Origin Document Type"
-msgstr ""
+msgstr "Tipo Documento Origine"
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_res_partner__l10n_it_pec_email
@@ -808,7 +808,7 @@ msgstr ""
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_invoice_form_l10n_it
 msgid "Payment Method"
-msgstr ""
+msgstr "Metodo di pagamento"
 
 #. module: l10n_it_edi
 #: model:ir.model,name:l10n_it_edi.model_account_payment_method_line
@@ -853,7 +853,7 @@ msgstr "Tipo di proxy"
 #: model:ir.model.fields,help:l10n_it_edi.field_account_bank_statement_line__l10n_it_cup
 #: model:ir.model.fields,help:l10n_it_edi.field_account_move__l10n_it_cup
 msgid "Public Investment Unique Identifier"
-msgstr ""
+msgstr "Codice Unico di Progetto"
 
 #. module: l10n_it_edi
 #: model:ir.model.fields.selection,name:l10n_it_edi.selection__l10n_it_document_type__type__purchase
@@ -1026,7 +1026,7 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_edi.field_account_bank_statement_line__l10n_it_cig
 #: model:ir.model.fields,help:l10n_it_edi.field_account_move__l10n_it_cig
 msgid "Tender Unique Identifier"
-msgstr ""
+msgstr "Codice Identificativo Gara"
 
 #. module: l10n_it_edi
 #. odoo-python


### PR DESCRIPTION
Steps to reproduce:
1. Install 'l10n_it' and 'accounting' from apps.
2. Enable debug mode.
3. Activate the Italian language and set it for the current user.
4. Go to Accounting > Customers / Vendors > Invoice / Bill > Electronic Invoicing tab

Observation:
When the Italian language is active, the 'Electronic Invoicing' tab and the fields within it are not translated.

Issue:
Missing translations in the PO file.

Solution:
Added the missing translations for the fields in the PO file.

opw-4937464