### PR TITLE
[FIX] website: make img gallery work fine when imgs have links

### DIFF
--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -346,10 +346,11 @@ class ImageGalleryOption extends Plugin {
             // and not correctly loaded from cache, we use a clone of the
             // image to force the loading.
             const newImg = image.cloneNode(true);
-            newImg.loading = "eager";
+            const imgEl = newImg.tagName === "IMG" ? newImg : newImg.querySelector(":scope > img");
+            imgEl.loading = "eager";
             imgLoaded.push(
-                newImg.decode().then(() => {
-                    newImg.loading = "lazy";
+                imgEl.decode().then(() => {
+                    imgEl.loading = "lazy";
                 })
             );
             if (currentContainers.at(-1)?.element === image) {

--- a/addons/website/static/tests/builder/website_builder/image_gallery.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_gallery.test.js
@@ -184,6 +184,37 @@ test("Change gallery restore the container to the cloned equivalent image", asyn
     expectOptionContainerToInclude(queryOne(":iframe .first_img"));
 });
 
+test("Change gallery layout when images have a link", async () => {
+    await setupWebsiteBuilder(
+        `
+        <section class="s_image_gallery o_masonry" data-columns="2">
+            <div class="container">
+                <div class="o_masonry_col col-lg-6">
+                    <img class="first_img img img-fluid d-block rounded" data-index="1" src='${dummyBase64Img}'>
+                </div>
+                <div class="o_masonry_col col-lg-6">
+                    <img class="a_nice_img img img-fluid d-block rounded" data-index="5"  src='${dummyBase64Img}'>
+                </div>
+            </div>
+        </section>
+        `
+    );
+    await contains(":iframe .first_img").click();
+    await waitFor("[data-label='Mode']");
+    await contains("[data-label='Media'] button[data-action-id='setLink']").click();
+
+    await contains("[data-label='Your URL'] [data-action-id='setUrl'] > input").fill(
+        "http://odoo.com"
+    );
+    expect(":iframe section a[href='http://odoo.com'] > img.first_img").toHaveCount(1);
+
+    await contains("[data-label='Mode'] .dropdown-toggle").click();
+    await contains("[data-action-param='grid']").click();
+    await waitFor(":iframe .o_grid");
+
+    expect(":iframe .o_grid").toHaveCount(1);
+});
+
 test("Dropping multiple image galleries should produce unique IDs", async () => {
     await setupWebsiteBuilder("");
     patchWithCleanup(uniqueId, { nextId: 0 });


### PR DESCRIPTION
When at least one of the images in the image wall has a link, the editor will crash when trying to change the mode of the Image Wall, i.e. from Masonry to Grid.
Steps to reproduce the issue:
- Drag and drop an images wall
- Click on any of the images
- Add a link (Click on the chain icon in the `Media` option and then add a URL)
- Click on 'Mode'
- Try to change to Grid for example.

=> We have a traceback.
This commit follows the [html_builder refactoring]. Task-5005626

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2