### PR TITLE
[FIX] add payment_demo module check for payment token used in a test case

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -825,8 +825,11 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
         we shouldn't sent email notification automatically.
         '''
         self.env['ir.config_parameter'].set_param('sale.automatic_invoice', True)
-        payment_token = self._create_token(provider_id=self._prepare_provider(code='demo').id,
-                                           demo_simulated_state='done')
+        if self.env['ir.module.module']._get('payment_demo').state == 'installed':
+            payment_token = self._create_token(provider_id=self._prepare_provider(code='demo').id,
+                                               demo_simulated_state='done')
+        else:
+            payment_token = self._create_token()
         payment_register = self.env['account.payment.register']\
                                .with_context(active_model='account.move', active_ids=self.out_invoice_4.ids)\
                                .create({'payment_token_id': payment_token.id})


### PR DESCRIPTION
Add module installation check before using "demo" as payment provider to generate payment token for payment register test case.

Steps to reproduce:
1. Install single module (website_sale).
2. Run test case `TestAccountPaymentRegister.test_register_payment_doesnt_send_email`. 
You will get ValueError: Invalid field 'demo_simulated_state' on model 'payment.token'

build_error-230731