### PR TITLE
[FIX] website_profile: render website_description as HTML

### DIFF
--- a/addons/website_profile/static/src/components/profile_dialog/profile_dialog.js
+++ b/addons/website_profile/static/src/components/profile_dialog/profile_dialog.js
@@ -1,5 +1,5 @@
 import { Wysiwyg } from "@html_editor/wysiwyg";
-import { Component, onMounted, onWillStart, reactive, useRef, useState } from "@odoo/owl";
+import { Component, markup, onMounted, onWillStart, reactive, useRef, useState } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
@@ -66,6 +66,7 @@ export class ProfileDialog extends Component {
             ]);
             const userData = users[0];
             userData.country_id = userData.country_id && userData.country_id[0]; // keep only id
+            userData.website_description = markup(userData.website_description || "");
             this.user = reactive(userData, () => this.validate());
             this.countries = countries;
             const isInternalUser = await user.hasGroup("base.group_user");


### PR DESCRIPTION
Currently, when opening the dialog to edit the user profile in Forum,
the biography field is shown as raw text and displays the HTML tags
instead of rendering them.

Steps to reproduce the issue:
1. Open a forum
2. Click on your avatar to open your profile (/profile/user/<user_id>)
3. Click on the "EDIT PROFILE" button
=> The biography is displayed as text while it should be rendered as HTML

Since this [fix], the editor renders markup as HTML and strings as text.
To ensure that the profile dialog correctly renders the field, we now
convert the field value into markup so that the editor interprets and
renders the HTML properly.

[fix]: https://github.com/odoo/odoo/commit/560fca7e94b232a7e2c9ad452a9772367c34204b

task-5005880