### PR TITLE
[FIX] point_of_sale: random failure test_barcode_search_attributes_prese

### DIFF
--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -622,6 +622,7 @@ registry.category("web_tour.tours").add("test_barcode_search_attributes_preset",
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
 
+            // Step 1: Search and add first variant
             ProductScreen.searchProduct("12341357"),
             ProductScreen.clickDisplayedProduct("Product with Attributes"),
             {
@@ -634,6 +635,16 @@ registry.category("web_tour.tours").add("test_barcode_search_attributes_preset",
                 "1.0"
             ),
 
+            // Step 2: Search and add product without attributes (used to delay UI update)
+            ProductScreen.searchProduct("987654321"),
+            {
+                content: "Wait for the product without attributes to be visible",
+                trigger: '.product:contains("Product without Attributes")',
+            },
+            ProductScreen.clickDisplayedProduct("Product without Attributes"),
+            ProductScreen.selectedOrderlineHas("Product without Attributes", "1.0"),
+
+            // Step 3: Search and add second variant of the original product
             ProductScreen.searchProduct("12342468"),
             ProductScreen.clickDisplayedProduct("Product with Attributes"),
             {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1983,6 +1983,15 @@ class TestUi(TestPointOfSaleHttpCommon):
             'taxes_id': False,
         })
 
+        # Product template to force UI reset (acts as a delay)
+        self.env['product.template'].create({
+            'name': 'Product without Attributes',
+            'available_in_pos': True,
+            'list_price': 20,
+            'taxes_id': False,
+            'barcode': '987654321',
+        })
+
         attribute_1, attribute_2, attribute_3, attribute_4 = self.env['product.attribute'].create([{
             'name': 'Attribute 1',
             'create_variant': 'always',


### PR DESCRIPTION
This fixes a random runbot failure in the barcode
search test involving product variants.

The issue was caused by timing problems when selecting a second variant of a product with the same template name. Due to UI delays, the wrong variant could be selected.

The issue happened in this sequence:
- The test searched the first barcode (12341357), which correctly
  displayed the product template "Product with Attributes" with the
  variant (Value 1, 3, 5, 7) preselected.
- The product was added successfully.
- Then the second barcode (12342468) was searched. But before the UI
  had time to update
  and reflect the new variant (Value 2, 4, 6, 8), the test clicked
  again on the same product template — which still had the *first*
  variant preselected.
- As a result, the first variant was added twice, and the expected
  second variant was missing.

To prevent this, a distinct product template ("Product without Attributes") was introduced between the two variant searches to give the UI enough time to refresh. The tour was also updated to properly wait for the correct product to appear and to avoid triggering the configurator on products without attributes.

runbot-230339
