### PR TITLE
[FIX] hr_holidays: fix date mismatch in hebrew language

### DIFF
--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -106,3 +106,26 @@ registry.category("web_tour.tours").add('hr_holidays_launch', {
         },
     ]
 });
+
+registry.category("web_tour.tours").add("hr_leave_mandatory_days_hebrew_tour", {
+    url: "/web",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="hr_holidays.menu_hr_holidays_root"]',
+            run: "click",
+        },
+        {
+            trigger: 'td[data-date="2025-11-11"]',
+            content: "Verify that the date has the hr_mandatory_day class.",
+            run: () => {
+                const td = document.querySelector('td[data-date="2025-11-11"]');
+                if (!td?.classList.contains("hr_mandatory_day")) {
+                    console.error(
+                        "The date 2025-11-11 does not have the hr_mandatory_day class."
+                    );
+                }
+            },
+        },
+    ],
+});

--- a/addons/hr_holidays/static/src/views/hooks.js
+++ b/addons/hr_holidays/static/src/views/hooks.js
@@ -19,10 +19,10 @@ export function useMandatoryDays(props) {
         const mandatoryDay = props.model.mandatoryDays[date];
         if (mandatoryDay) {
             const dayNumberElTop = info.view.el.querySelector(
-                `.fc-day-top[data-date="${info.el.dataset.date}"]`
+                `.fc-day-top[data-date="${date}"]`
             );
             const dayNumberEl = info.view.el.querySelector(
-                `.fc-day[data-date="${info.el.dataset.date}"]`
+                `.fc-day[data-date="${date}"]`
             );
             if (dayNumberElTop) {
                 dayNumberElTop.classList.add('hr_mandatory_day', `hr_mandatory_day_top_${mandatoryDay}`);

--- a/addons/hr_holidays/tests/test_hr_holidays_tour.py
+++ b/addons/hr_holidays/tests/test_hr_holidays_tour.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
 from freezegun import freeze_time
 
 from odoo.tests import HttpCase
@@ -49,3 +50,23 @@ class TestHrHolidaysTour(HttpCase):
         self.env.ref("base.lang_sr@latin").active = True
         admin_user.lang = "sr@latin"
         self.start_tour("/web", "hr_holidays_launch", login="admin")
+
+    @freeze_time('2025-11-11')
+    def test_tour_mandatory_days_in_hebrew(self):
+        """Run the UI tour in Hebrew to check mandatory days display."""
+        # Force Hebrew language for the user
+        admin_user = self.env.ref("base.user_admin")
+        self.env.ref("base.lang_he_IL").active = True
+        admin_user.lang = "he_IL"
+
+        self.env['hr.leave.mandatory.day'].create({
+            'name': 'Madatory Day',
+            'start_date': datetime(2025, 11, 11),
+            'end_date': datetime(2025, 11, 11),
+            'color': 1,
+        })
+        self.start_tour(
+            "/web",
+            'hr_leave_mandatory_days_hebrew_tour',
+            login="admin",
+        )


### PR DESCRIPTION
Steps to reproduce:
1. Install Time Off (hr_holidays).
2. Go to Time Off → Configuration → Mandatory Days.
3. Create a mandatory day.
4. Open the user profile (top right corner) and change the language to Hebrew.
5. Open Time Off and view the calendar.

Issue:
The mandatory day marker is displayed on the incorrect date when the interface is in Hebrew.

Cause:
https://github.com/odoo/odoo/blob/ea9cd8357e148654458e3505963ae847d181776e/addons/hr_holidays/static/src/views/hooks.js#L18-L32
This is because the code was using 'info.el.dataset.date' directly which is based on the rendered DOM element and can be influenced by locale formatting, instead of the canonical ISO date, leading to incorrect selectors when trying to add the hr_mandatory_day CSS classes to the date.

solution:
Use the correct date value derived from info.date via Luxon’s toISODate() method Replaced info.el.dataset.date in the DOM selectors with the normalized ISO date to ensure that the correct element is targeted
regardless of the current language or locale.

opw-4979274