### PR TITLE
[IMP] spreadsheet_dashboard: add mobile kanban view for dashboard_ids

### DIFF
--- a/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
+++ b/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
@@ -57,11 +57,26 @@
                 <group>
                     <field name="name"/>
                     <field name="dashboard_group_id"/>
-                    <field name="spreadsheet_binary_data"/>
-                    <field name="thumbnail"/>
+                    <field name="company_ids" options="{'no_create': True}" widget="many2many_tags" groups="base.group_multi_company" placeholder="Visible to all"/>
                     <field name="group_ids" widget="many2many_tags"/>
+                    <field name="spreadsheet_binary_data"/>
                 </group>
             </form>
         </field>
     </record>
+
+    <record id="spreadsheet_dashboard_view_kanban" model="ir.ui.view">
+        <field name="name">spreadsheet.dashboard.kanban</field>
+        <field name="model">spreadsheet.dashboard</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile">
+                <templates>
+                    <t t-name="card" class="d-flex flex-row align-items-center justify-content-between border">
+                        <field name="name"/>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- Currently, the mobile view of the kanban uses the default layout, which does not provide an 'Edit' button.

**Current behavior before PR:**

* No dedicated kanban view for mobile; default kanban is used.
* 'Edit' button is not available in the mobile kanban view.

**Desired behavior after PR is merged:**

* Introduces a dedicated kanban view for mobile in the community.
* Adds an 'Edit' button in the mobile kanban view (enterprise edition).
* Rearranges form view fields for improved usability.
* Includes the company field in the form view.


**Task:** [4965595](https://www.odoo.com/odoo/project/2328/tasks/4965595)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
