### PR TITLE
[FIX] website_sale: make attribute accordions more consistent

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1529,12 +1529,12 @@
             <h6 t-if="not isMobile" class="accordion-header">
                 <button
                     t-attf-class="accordion-button px-0 bg-transparent shadow-none
-                        {{'collapsed' if visible_attributes &gt;= 4 else ''}}"
+                        {{'collapsed' if _status != 'active' and visible_attributes &gt;= 4 else ''}}"
                     type="button"
                     data-bs-toggle="collapse"
                     t-attf-data-bs-target="#o_products_attributes_{{a.id}}"
                     t-attf-aria-controls="o_products_attributes_{{a.id}}"
-                    t-att-aria-expanded="'false' if visible_attributes &gt;= 4 else 'true'"
+                    t-att-aria-expanded="'false' if _status != 'active' and visible_attributes &gt;= 4 else 'true'"
                 >
                     <b t-field="a.name"/>
                 </button>
@@ -1543,7 +1543,7 @@
         <xpath expr="//div[contains(@t-attf-id, 'o_products_attributes_')]" position="attributes">
             <attribute
                 name="t-attf-class"
-                add="accordion-collapse collapse {{'' if visible_attributes &gt;= 4 else 'show'}}"
+                add="accordion-collapse collapse {{'' if _status != 'active' and visible_attributes &gt;= 4 else 'show'}}"
                 separator=" "
             />
             <attribute name="data-bs-parent" add="wsale_products_attributes_collapse"/>


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Have 5 or more product attributes visible in eCommerce;
2. go to /shop;
3. select an attribute.

Issue
-----
The list we just selected an attribute value from collapsed.

Cause
-----
While some parts allow accordions to auto-expand if 4 or less attributes are visible, or if an attribute is selected, other parts only look at the number of visible attributes.

Solution
--------
In parts where it only checks whether more than 4 attributes are visible, also add a check on `_status` to improve consistency.

opw-4986032