### PR TITLE
[FIX] point_of_sale: restore error sound on invalid barcode

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -71,6 +71,7 @@ export class ProductScreen extends Component {
         });
 
         this.barcodeReader = useService("barcode_reader");
+        this.sound = useService("mail.sound_effects");
 
         useBarcodeReader({
             product: this._barcodeProductAction,
@@ -237,6 +238,7 @@ export class ProductScreen extends Component {
         const product = await this._getProductByBarcode(code);
 
         if (!product) {
+            this.sound.play("error");
             this.barcodeReader.showNotFoundNotification(code);
             return;
         }


### PR DESCRIPTION
When scanning an unknown barcode, the error notification pop-up is displayed, but the error sound is not played.

Steps to reproduce:
-------------------
* Open PoS
* Scan an unknown barcode

> Expected:
Both the 'BIP' and the error sound should play.

Why this fix:
-------------
This feature was present in 16.0 and 17.0,
but was lost in 18.0 REF. It was reintroduced
in 18.3 with this [IMP](https://github.com/odoo/odoo/pull/209478).

opw-4987066


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
