### PR TITLE
[FIX] l10n_id_efaktur_coretax: ByerDocument wrong value

### DIFF
--- a/addons/l10n_id_efaktur_coretax/models/account_move.py
+++ b/addons/l10n_id_efaktur_coretax/models/account_move.py
@@ -272,6 +272,13 @@ class AccountMove(models.Model):
         partner = self.commercial_partner_id
         trx_code = self.l10n_id_kode_transaksi
 
+        l10n_id_buyer_document_type_mapping_to_xml = {
+            'TIN': 'TIN',
+            'NIK': 'National ID',
+            'Passport': 'Passport',
+            'Other': 'Other ID'
+        }
+
         vals.update({
             "TIN": self.company_id.vat,
             "TaxInvoiceDate": self.invoice_date.strftime("%Y-%m-%d"),
@@ -283,7 +290,7 @@ class AccountMove(models.Model):
             "FacilityStamp": "",
             "RefDesc": self.name,
             "SellerIDTKU": self.company_id.vat + self.company_id.partner_id.l10n_id_tku,
-            "BuyerDocument": partner.l10n_id_buyer_document_type,
+            "BuyerDocument": l10n_id_buyer_document_type_mapping_to_xml.get(partner.l10n_id_buyer_document_type, partner.l10n_id_buyer_document_type),
             "BuyerTin": partner.vat if partner.l10n_id_buyer_document_type == "TIN" else "0000000000000000",
             "BuyerCountry": COUNTRY_CODE_MAP.get(partner.country_id.code),
             "BuyerDocumentNumber": partner.l10n_id_buyer_document_number if partner.l10n_id_buyer_document_type != "TIN" else "",


### PR DESCRIPTION
the byer document has a wrong value in others and NIT. so this commit change the values to `Other ID` and `National ID`

To check values:
go to fields and search for `l10n_id_buyer_document_type`

opw-4974469




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
