### PR TITLE
[FIX] pos_online_payment: Fix payment provider widget

### DIFF
--- a/addons/pos_online_payment/models/pos_payment_method.py
+++ b/addons/pos_online_payment/models/pos_payment_method.py
@@ -129,3 +129,8 @@ class PosPaymentMethod(models.Model):
                         pos_config_id=pos_config_id,
                     ))
         return payment_method_id
+
+    @api.onchange('is_online_payment')
+    def _onchange_is_online_payment(self):
+        """Reset method to hide widget `pos_payment_provider_cards` in form view."""
+        self.payment_method_type = 'none'


### PR DESCRIPTION
Before this commit, when the `is_online_payment` field was set to `True` the widget `pos_payment_provider_cards` was not properly hidden in the form view of the POS payment method.

This commit ensures that the widget is correctly hidden when the field is set to `True` by resetting the `payment_method_type` to 'none'.

Thanks to @elierwclik for the report and initial PR #222142

