### PR TITLE
[FIX] account: allow sorting of invoices by Status and Sent fields

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1234,6 +1234,24 @@ class AccountMove(models.Model):
         for move in self:
             move.status_in_payment = move.state if move.state in ('draft', 'cancel') else move.payment_state
 
+    def _field_to_sql(self, alias: str, fname: str, query=None, flush: bool = True) -> SQL:
+        if fname == 'status_in_payment':
+            return SQL(
+                "CASE "
+                f"WHEN {alias}.state = 'draft' THEN 'draft' "
+                f"WHEN {alias}.state = 'cancel' THEN 'cancel' "
+                f"ELSE {alias}.payment_state "
+                "END"
+            )
+        elif fname == 'move_sent_values':
+            return SQL(
+                "CASE "
+                f"WHEN {alias}.is_move_sent THEN 'sent' "
+                f"ELSE 'not_sent' "
+                "END"
+            )
+        return super()._field_to_sql(alias, fname, query=query, flush=flush)
+
     @api.depends('matched_payment_ids')
     def _compute_payment_count(self):
         for invoice in self:


### PR DESCRIPTION
**Issue**
Users were unable to sort invoices by the "Status" and "Sent" columns in the customer invoices list view.

**Steps to Reproduce**
1. Go to Accounting > Customers > Invoices
2. Try sorting by the "Status" or "Sent" columns
3. Observe that sorting is not functional for these fields

**Root Cause**
Both `status_in_payment` and `move_sent_values` are computed (non-stored) fields. Odoo cannot sort by non-stored fields unless a SQL representation is provided using the `_field_to_sql` method.

Opw-4976838
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
