### PR TITLE
[FIX] html_builder: fix drag and drop when no siblings before and after

### DIFF
--- a/addons/html_builder/static/src/core/drag_and_drop_plugin.js
+++ b/addons/html_builder/static/src/core/drag_and_drop_plugin.js
@@ -358,9 +358,11 @@ export class DragAndDropPlugin extends Plugin {
                 } else {
                     const previousEl = this.overlayTarget.previousElementSibling;
                     const nextEl = this.overlayTarget.nextElementSibling;
-                    const { startPreviousEl, startNextEl } = this.dragState;
+                    const parentEl = this.overlayTarget.parentElement;
                     hasSamePositionAsStart =
-                        startPreviousEl === previousEl && startNextEl === nextEl;
+                        startPreviousEl === previousEl &&
+                        startNextEl === nextEl &&
+                        startParentEl === parentEl;
                 }
                 if (!hasSamePositionAsStart) {
                     this.dependencies.history.addStep();


### PR DESCRIPTION
Steps to reproduce:
- With eCommerce installed, go to the /shop page and go in edit mode.
- Drop a "Text - Image" snippet on the dropzone above the products.
- Drag this snippet and drop it on the dropzone under the products.
=> Nothing happens, the drag and drop was cancelled.

This happens because the code checking if a change happened (in order to
cancel the drag and drop if there is none) was only checking if the new
siblings are the same as the old ones. This check is wrong when the
dragged snippet had no siblings and is then dropped in an element where
it ends up with no siblings too, as both the old and the new ones are
`null`, making the condition `true` and cancelling the move.

This commit fixes that by also checking if the parent is the same as the
old one, making all possible situations covered.

task-4367641
