### PR TITLE
[FIX] base: Use mimetype of fixed file name.

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -18,7 +18,7 @@ from odoo import api, fields, models, SUPERUSER_ID, tools, _
 from odoo.exceptions import AccessError, ValidationError, UserError
 from odoo.http import Stream, root, request
 from odoo.tools import config, human_size, image, str2bool, consteq
-from odoo.tools.mimetypes import guess_mimetype, fix_filename_extension
+from odoo.tools.mimetypes import guess_mimetype, fix_filename_extension, _olecf_mimetypes
 from odoo.osv import expression
 
 _logger = logging.getLogger(__name__)
@@ -770,6 +770,8 @@ class IrAttachment(models.Model):
             file.seek(-len(head), 1)  # rewind
             mimetype = guess_mimetype(head)
             filename = fix_filename_extension(file.filename, mimetype)
+            if mimetype in ('application/zip', *_olecf_mimetypes):
+                mimetype = mimetypes.guess_type(filename)[0]
         elif all(mimetype.partition('/')):
             filename = fix_filename_extension(file.filename, mimetype)
         else:


### PR DESCRIPTION
Issue: Inconsistent mimetype vs filename for documents shared by portal users.

1. Share a ms office document logged in as a portal user.
2. filename is correct, but mimetype is `application/zip`.
3. User can't interact with the file to open the file in the Odoo spreadsheet because the mimetype is zip.

<img width="387" height="192" alt="image" src="https://github.com/user-attachments/assets/be31f05f-e4e3-44d9-b12a-66f96feba950" />

<img width="274" height="67" alt="image" src="https://github.com/user-attachments/assets/93064e5c-c028-41ce-8e79-1b9c9447c018" />


With `fix_filename_extension()`, the following two commits fixed the issue of Odoo's `guess_mimetype` function incorrectly guessing extensions such as `.xlsx` as `.zip` extension.
https://github.com/odoo/odoo/commit/8842b6b43e7c3d1cc67d7d399bb210e4009e23b2 https://github.com/odoo/odoo/commit/34d9375e2efb604f8e7036cb710f44b01f9ccaee

However, the `_from_request_file()` still uses the incorrectly guessed mimetype to create an attachment, leading to inconsistent extension from the filename (.xlsx) vs attachment record's mimetype (.zip).

This commit fixes the issue by using the mimetype from the filename's extension.

This is safe if the following assumption is correct:

At the point where the `from_request_file()` attempts to create the attachment record, the `filename` contains correct extension name, presumably fixed by the `fix_filename_extension()`.

Commit message to be changed after with Julien's confirmation;

opw-4753670


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
