### PR TITLE
[FIX] pos_loyalty: prevent duplicate coupon count on confirmation

### DIFF
--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -56,7 +56,7 @@ class PosOrder(models.Model):
         id_mapping = {item['old_id']: int(item['id']) for item in coupon_updates}
         history_lines_create_vals = []
         for coupon in coupon_data:
-            card_id = id_mapping.get(int(coupon['card_id'], False)) or int(coupon['card_id'])
+            card_id = id_mapping.get(int(coupon['card_id']), False) or int(coupon['card_id'])
             if not self.env['loyalty.card'].browse(card_id).exists():
                 continue
             issued = coupon['won']
@@ -85,6 +85,7 @@ class PosOrder(models.Model):
         coupon_data = {int(k): v for k, v in coupon_data.items()}
 
         self._check_existing_loyalty_cards(coupon_data)
+        self._remove_duplicate_coupon_data(coupon_data)
         # Map negative id to newly created ids.
         coupon_new_id_map = {k: k for k in coupon_data.keys() if k > 0}
 
@@ -144,6 +145,26 @@ class PosOrder(models.Model):
                     filtered(lambda c: c.trigger == 'create').pos_report_print_id
             for report in report_per_program[coupon.program_id]:
                 coupon_per_report[report.id].append(coupon.id)
+
+        # Adding loyalty history lines
+        loyalty_points = [
+            {
+                'order_id': self.id,
+                'card_id': coupon_id,
+                'spent': -coupon_vals['points'] if coupon_vals['points'] < 0 else 0,
+                'won': coupon_vals['points'] if coupon_vals['points'] > 0 else 0,
+            }
+            for coupon_id, coupon_vals in coupon_data.items()
+        ]
+        coupon_updates = [
+            {
+                'id': coupon.id,
+                'old_id': coupon_new_id_map[coupon.id],
+            }
+            for coupon in all_coupons
+        ]
+        self.add_loyalty_history_lines(loyalty_points, coupon_updates)
+
         return {
             'coupon_updates': [{
                 'old_id': coupon_new_id_map[coupon.id],
@@ -175,14 +196,27 @@ class PosOrder(models.Model):
         for coupon_id, coupon_vals in coupon_data.items():
             partner_id = coupon_vals.get('partner_id', False)
             if partner_id:
-                partner_coupons = self.env['loyalty.card'].search(
-                    [('partner_id', '=', partner_id), ('program_type', '=', 'loyalty')])
-                existing_coupon_for_program = partner_coupons.filtered(lambda c: c.program_id.id == coupon_vals['program_id'])
+                existing_coupon_for_program = self.env['loyalty.card'].search(
+                    [('partner_id', '=', partner_id), ('program_type', 'in', ['loyalty', 'ewallet']), ('program_id', '=', coupon_vals['program_id'])])
                 if existing_coupon_for_program:
                     coupon_vals['coupon_id'] = existing_coupon_for_program[0].id
                     coupon_key_to_modify.append([coupon_id, existing_coupon_for_program[0].id])
         for old_key, new_key in coupon_key_to_modify:
             coupon_data[new_key] = coupon_data.pop(old_key)
+
+    def _remove_duplicate_coupon_data(self, coupon_data):
+        # to prevent duplicates, it is necessary to check if the history line already exists
+        items_to_remove = []
+        for coupon_id, coupon_vals in coupon_data.items():
+            existing_history = self.env['loyalty.history'].search_count([
+                ('card_id.program_id', '=', coupon_vals['program_id']),
+                ('order_model', '=', self._name),
+                ('order_id', '=', self.id),
+            ])
+            if existing_history:
+                items_to_remove.append(coupon_id)
+        for item in items_to_remove:
+            coupon_data.pop(item)
 
     def _get_fields_for_order_line(self):
         fields = super(PosOrder, self)._get_fields_for_order_line()

--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -185,23 +185,6 @@ patch(PaymentScreen.prototype, {
                     }
                 }
             }
-
-            const loyaltyPoints = Object.keys(couponData).map((coupon_id) => ({
-                order_id: order.id,
-                card_id: coupon_id,
-                spent: couponData[coupon_id].points < 0 ? -couponData[coupon_id].points : 0,
-                won: couponData[coupon_id].points > 0 ? couponData[coupon_id].points : 0,
-            }));
-
-            const couponUpdates = payload.coupon_updates.map((item) => ({
-                id: item.id,
-                old_id: item.old_id,
-            }));
-            this.pos.data.call("pos.order", "add_loyalty_history_lines", [
-                [this.currentOrder.id],
-                loyaltyPoints,
-                couponUpdates,
-            ]);
             // Update the usage count since it is checked based on local data
             if (payload.program_updates) {
                 for (const programUpdate of payload.program_updates) {

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -521,6 +521,8 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_pos_tour("GiftCardProgramTour1")
         # Check that gift cards are created
         self.assertEqual(len(gift_card_program.coupon_ids), 1)
+        gift_card_creation_history = self.env['loyalty.history'].search([('card_id', '=', gift_card_program.coupon_ids.id)])
+        self.assertEqual(gift_card_creation_history.issued, 50.0, "The gift card should have 50 points issued.")
         # Change the code to 044123456 so that we can use it in the next tour.
         # Make sure it starts with 044 because it's the prefix of the loyalty cards.
         gift_card_program.coupon_ids.code = '044123456'
@@ -528,7 +530,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_pos_tour("GiftCardProgramTour2")
         # Check that gift cards are used
         self.assertEqual(gift_card_program.coupon_ids.points, 46.8)
-        loyalty_history = self.env['loyalty.history'].search([('card_id','=',gift_card_program.coupon_ids.id)])
+        loyalty_history = self.env['loyalty.history'].search([('card_id', '=', gift_card_program.coupon_ids.id), ('id', '!=', gift_card_creation_history.id)])
         self.assertEqual(loyalty_history.used, 3.2)
 
     def test_ewallet_program(self):

--- a/addons/pos_loyalty/tests/test_loyalty_history.py
+++ b/addons/pos_loyalty/tests/test_loyalty_history.py
@@ -38,3 +38,84 @@ class TestPOSLoyaltyHistory(TestPointOfSaleHttpCommon):
         loyalty_card = loyalty_program.coupon_ids.filtered(lambda coupon: coupon.partner_id.id == partner_aaa.id)
         self.assertEqual(len(loyalty_card.history_ids), 1,
                         "Loyalty History line should be created on pos oder confirmation")
+
+    def test_duplicate_coupon_confirm(self):
+        """ Test that duplicate coupon confirm calls do not affect the coupon."""
+        test_partner = self.env['res.partner'].create({'name': 'Test Partner'})
+        ewallet_program = self.env['loyalty.program'].create({
+            'name': 'eWallet Program',
+            'program_type': 'ewallet',
+            'trigger': 'auto',
+            'applies_on': 'future',
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount_mode': 'per_point',
+                'discount': 1,
+            })],
+            'rule_ids': [Command.create({
+                'reward_point_amount': '1',
+                'reward_point_mode': 'money',
+                'product_ids': self.env.ref('loyalty.ewallet_product_50'),
+            })],
+            'trigger_product_ids': self.env.ref('loyalty.ewallet_product_50'),
+        })
+
+        self.main_pos_config.open_ui()
+        pos_order = self.env['pos.order'].create({
+            'config_id': self.main_pos_config.id,
+            'session_id': self.main_pos_config.current_session_id.id,
+            'partner_id': test_partner.id,
+            'amount_paid': 50,
+            'amount_return': 0,
+            'amount_tax': 0,
+            'amount_total': 50,
+        })
+
+        coupon_data = {
+            -1: {
+                'points': 50,
+                'program_id': ewallet_program.id,
+                'coupon_id': -1,
+                'barcode': '',
+                'partner_id': test_partner.id,
+            }
+        }
+        pos_order.confirm_coupon_programs(coupon_data)
+
+        def check_coupon(points, history_count):
+            created_card = self.env['loyalty.card'].search([('program_id', '=', ewallet_program.id), ('partner_id', '=', test_partner.id)])
+            self.assertEqual(created_card.points, points, "The coupon should have 50 points after the first confirmation.")
+            self.assertEqual(len(created_card.history_ids), history_count, "The history should have one entry after the first confirmation.")
+
+        check_coupon(50, 1)
+        # Confirm the coupon again
+        pos_order.confirm_coupon_programs(coupon_data)
+        check_coupon(50, 1)
+
+        new_pos_order = self.env['pos.order'].create({
+            'config_id': self.main_pos_config.id,
+            'session_id': self.main_pos_config.current_session_id.id,
+            'partner_id': test_partner.id,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'amount_tax': 0,
+            'amount_total': 0,
+        })
+
+        loyalty_card = self.env['loyalty.card'].search([('program_id', '=', ewallet_program.id), ('partner_id', '=', test_partner.id)])
+        coupon_data = {
+            loyalty_card.id: {
+                'points': -10,
+                'program_id': ewallet_program.id,
+                'coupon_id': loyalty_card.id,
+                'barcode': '',
+                'partner_id': test_partner.id,
+            }
+        }
+
+        new_pos_order.confirm_coupon_programs(coupon_data)
+        # Check that the coupon points are reduced correctly
+        check_coupon(40, 2)
+        # Confirm the coupon again
+        new_pos_order.confirm_coupon_programs(coupon_data)
+        check_coupon(40, 2)


### PR DESCRIPTION
Before this commit, if the `confirm_coupon_programs` method was called twice (e.g., due to an internet issue), the loyalty points were calculated incorrectly.

This commit fixes the issue by checking the existing loyalty history to prevent duplicate point calculations. To enable this, the creation of oyalty history records has been moved into the
`confirm_coupon_programs` function.

opw-4877599

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
