### PR TITLE
 [IMP] stock: add sys param to picking print behavior

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -910,7 +910,8 @@ class Picking(models.Model):
         picking_operations_report = self.env.ref('stock.action_report_picking',raise_if_not_found=False)
         if not picking_operations_report:
             raise UserError(_("The Picking Operations report has been deleted so you cannot print at this time unless the report is restored."))
-        self.write({'printed': True})
+        if not self.env['ir.config_parameter'].sudo().get_param('stock.prevent_picking_print_flag'):
+            self.write({'printed': True})
         return picking_operations_report.report_action(self)
 
     def should_print_delivery_address(self):


### PR DESCRIPTION
Add optional system parameter 'stock.prevent_picking_print_flag' to control whether the do_print_picking() method sets the printed field to True. When param is set to True, the printed field remains False, preventing automatic marking of pickings as printed and allowing subsequent quantity changes to modify existing pickings instead of creating new ones.

This addresses support tickets where customers are confused by new pickings being generated after printing, as the system currently creates new pickings for any changes made to orders after the original picking has been printed. This provides a configurable workaround for cases where the default behavior is not desired.

_Current behavior before PR:_
**Print Action:**
When you print the picking, def do_print_picking() sets printed = True
**New Moves Created:**
Later, when new stock moves are created (e.g., from sales order line updates)
**Assignment Process:**
The system tries to assign these new moves to existing pickings using def _assign_picking()​
**Search Filter:** 
_search_picking_for_assignation() looks for pickings with printed = False
**No Match Found:** 
Since the picking now has printed = True, it's excluded from the search
**New Picking Created:** 
Since no suitable existing picking is found, a new picking is created for the new moves

_Desired behavior after PR is merged:_
An optional param to prevent printed being set to True.

opw-4688679

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
