### PR TITLE
[FIX] pos_online_payment: display correct order name in QR popup

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -121,7 +121,7 @@ patch(PaymentScreen.prototype, {
                         qrCode: qrCodeSrc(
                             `${this.pos.session._base_url}/pos/pay/${this.currentOrder.id}?access_token=${this.currentOrder.access_token}`
                         ),
-                        orderName: this.currentOrder.name,
+                        orderName: this.currentOrder.pos_reference,
                     };
                     this.currentOrder.onlinePaymentData = onlinePaymentData;
                     const qrCodePopupCloser = this.dialog.add(


### PR DESCRIPTION
When using the `POS Online Payment` method, the QR popup was displaying
an incorrect order reference (e.g., `/`) instead of the actual order name.

Steps to reproduce:
1. Activate a payment method for a `Point of Sale` and set it as `POS Online Payment`.
2. Create an order in the POS and select the configured payment method.
3. When the QR popup appears, the amount is correct but the order name shows `/` instead of the real reference.

This fix ensures the correct order name is displayed in the QR popup.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
