### PR TITLE
[FIX] point_of_sale: fix undefined base URL in customer display

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -152,7 +152,7 @@ export class Navbar extends Component {
 
         if (this.ui.isSmall) {
             this.dialog.add(QrCodeCustomerDisplay, {
-                customerDisplayURL: `${this.pos.session._base_url}${customer_display_url}`,
+                customerDisplayURL: `${this.pos.config._base_url}${customer_display_url}`,
             });
             return;
         }


### PR DESCRIPTION
**Steps to reproduce:**

1. Open a Point of Sale on a medium or mobile device (responsive view).  
2. Open the Customer Display.  
3. Notice the QR is generated, but the base URL shows as `undefined`.

**Reason:**  
Previously, the base URL was read from `this.pos.session`, which is no longer correct.  
Now, it should be obtained from `this.pos.config`.

**Fix:**  
Changed the base URL reference to use `this.pos.config._base_url`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr