### PR TITLE
[IMP] core: web is not a required server-wide module

### DIFF
--- a/odoo/addons/base/tests/test_configmanager.py
+++ b/odoo/addons/base/tests/test_configmanager.py
@@ -205,7 +205,7 @@ class TestConfigManager(TransactionCase):
             'addons_path': [],  # the path found in the config file is invalid
             'upgrade_path': [],  # the path found in the config file is invalid
             'pre_upgrade_scripts': [],  # the path found in the config file is invalid
-            'server_wide_modules': ['web', 'base', 'mail'],
+            'server_wide_modules': ['base', 'mail'],
             'data_dir': '/tmp/data-dir',
 
             # HTTP
@@ -502,7 +502,7 @@ class TestConfigManager(TransactionCase):
             'addons_path': [],
             'upgrade_path': [],
             'pre_upgrade_scripts': [],
-            'server_wide_modules': ['web', 'base', 'mail'],
+            'server_wide_modules': ['base', 'mail'],
             'data_dir': '/tmp/data-dir',
 
             # HTTP
@@ -628,7 +628,7 @@ class TestConfigManager(TransactionCase):
             'addons_path': [],
             'upgrade_path': [],
             'pre_upgrade_scripts': [],
-            'server_wide_modules': ['web', 'base', 'mail'],
+            'server_wide_modules': ['base', 'mail'],
             'data_dir': '/tmp/data-dir',
 
             # HTTP

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1466,6 +1466,8 @@ def load_server_wide_modules():
     The `web` module is provided by the addons found in the `openerp-web` project.
     Maybe you forgot to add those addons in your addons_path configuration."""
                 _logger.exception('Failed to load server-wide module `%s`.%s', m, msg)
+        if 'web' not in config['server_wide_modules'] and len(list_dbs(True)) > 1:
+            _logger.warning("web is not in server-wide modules, database selector will not work")
 
 
 def _reexec(updated_modules=None):

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -28,7 +28,6 @@ optparse._ = str  # disable gettext
 
 ALL_DEV_MODE = ['access', 'qweb', 'reload', 'xml']
 DEFAULT_SERVER_WIDE_MODULES = ['base', 'rpc', 'web']
-REQUIRED_SERVER_WIDE_MODULES = ['base', 'web']
 
 
 class _Empty:
@@ -657,10 +656,9 @@ class configmanager:
         # ensure default server wide modules are present
         if not self['server_wide_modules']:
             self._runtime_options['server_wide_modules'] = DEFAULT_SERVER_WIDE_MODULES
-        for mod in REQUIRED_SERVER_WIDE_MODULES:
-            if mod not in self['server_wide_modules']:
-                self._log(logging.INFO, "adding missing %r to %s", mod, self.options_index['server_wide_modules'])
-                self._runtime_options['server_wide_modules'] = [mod] + self['server_wide_modules']
+        if 'base' not in self['server_wide_modules']:
+            self._log(logging.INFO, "adding missing 'base' to %s", self.options_index['server_wide_modules'])
+            self._runtime_options['server_wide_modules'] = ['base', *self['server_wide_modules']]
 
         # accumulate all log_handlers
         self._runtime_options['log_handler'] = list(_deduplicate_loggers([


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Only **base** is required for Odoo to work. All other modules add functionality and we should be able to start without them. Things may not work properly if they are not server-wide.

Current behavior before PR:
web is always in required server-wide modules

Desired behavior after PR is merged:
only base is forced in required server-wide modules



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
