### PR TITLE
[FIX] point_of_sale: fix pos inalterability check report memory error

### DIFF
--- a/addons/l10n_fr_pos_cert/models/res_company.py
+++ b/addons/l10n_fr_pos_cert/models/res_company.py
@@ -60,7 +60,7 @@ class ResCompany(models.Model):
         msg_alert = ''
         report_dict = {}
         if self._is_accounting_unalterable():
-            orders = self.env['pos.order'].search([('state', 'in', ['paid', 'done', 'invoiced']), ('company_id', '=', self.id),
+            orders = self.with_context(prefetch_fields=False).env['pos.order'].search([('state', 'in', ['paid', 'done', 'invoiced']), ('company_id', '=', self.id),
                                     ('l10n_fr_secure_sequence_number', '!=', 0)], order="l10n_fr_secure_sequence_number ASC")
 
             if not orders:


### PR DESCRIPTION
### Problem:
Following this pr https://github.com/odoo/odoo/pull/217348, field prefetching is unnecessary when fetching orders, as all required fields are already fetched explicitly. Keeping prefetching enabled causes excessive memory usage.

### Benchmark

| Orders | Before  | After  |
|--------|---------|--------|
| 1k     | 6MB     | 5.8MB  |
| 10k    | 42MB    | 27MB   |
| 100k   | 534MB   | 320MB  |
| 200K   | 1.1GB   | 646MB  |

opw-4901994
