### PR TITLE
[FIX] tools: prevent error on signed document with an invalid certifiacte

### DIFF
--- a/odoo/tools/pdf/signature.py
+++ b/odoo/tools/pdf/signature.py
@@ -78,7 +78,8 @@ class PdfSigner:
         Returns:
             Optional[PrivateKeyTypes]: a private key object, or None if the key couldn't be loaded.
         """
-        if "signing_certificate_id" not in self.company or not self.company.signing_certificate_id:
+        if "signing_certificate_id" not in self.company._fields \
+            or not self.company.signing_certificate_id.pem_certificate:
             return None, None
 
         certificate = self.company.signing_certificate_id


### PR DESCRIPTION
Currently, an error occurs when a user sign the document and tries to validate and send the completed document.

**Steps to reproduce:**

- Install the `sign` module.
- Go to: `Sign Settings > Cryptographic Signature` > Create a 'Signing certificate' and upload any random PDF (Observe: A warning appears `'This certificate could not be loaded. Either the content or the password is erroneous.'`).
- In the Sign app, upload any document, drag and drop a `Signature` field, and sign the document.
- Click `Validate & Send Completed Document`.

**Note:**
- [1] Make sure your system has cryptography version `41.0.7 or above`.
- Refer to [2] for steps to reproduce.

**Error:**
`TypeError: expected bytes-like object, not bool`

**Root Cause:**
At [3], when the certificate is not correctly created, `certificate.pem_certificate` is `False`, which leads to an error.

This commit allows validating and sending a signed document, when the certificate is invalid.

[1]:
https://github.com/odoo/odoo/blob/d730518fa6a1fba3b3edba6f3b65bcc88ed992fe/odoo/tools/pdf/signature.py#L16

[2]:
https://drive.google.com/file/d/19fd82TdGzVPRUVW3PDMGEhyaQLTwL41h/view?usp=sharing

[3]:
https://github.com/odoo/odoo/blob/a6fa3784b20f75490e405e3728d5a335f2104fa0/odoo/tools/pdf/signature.py#L85

sentry-6796501254