### PR TITLE
[FIX] stock: fix error when opening Receipt

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -707,7 +707,7 @@ Please change the quantity done or the rounding precision in your settings.""",
             if move.description_picking_manual:
                 move.description_picking = move.description_picking_manual
             elif move.product_id:
-                product = move.product_id.with_context(lang=self._get_lang())
+                product = move.product_id.with_context(lang=move._get_lang())
                 move.description_picking = product._get_picking_description(move.picking_type_id) or move._get_description()
             else:
                 move.description_picking = ""


### PR DESCRIPTION
When opening a Receipt containing stock moves linked to different partners,
A traceback will appear.

Steps to reproduce the error:
- Install ``stock`` module with demo data
- Go to Inventory > Operations > Receipts
- Import this [file](https://docs.google.com/spreadsheets/d/1LkplPQqWdUGOUHaTuJ1khXdvB6kGDVwb/edit?usp=sharing&ouid=106663959141116380430&rtpof=true&sd=true)
- Open the imported record

Traceback:
``ValueError: Expected singleton: res.partner(1, 2)``

https://github.com/odoo/odoo/blob/ac2b182f55a632f4e8a869cbf61613ebc93d8ae2/addons/stock/models/stock_move.py#L710 Here, ``_get_lang`` method is called on self containing multiple stock moves.
So, it will give the traceback from below line because it will have multiple partners.

https://github.com/odoo/odoo/blob/ac2b182f55a632f4e8a869cbf61613ebc93d8ae2/addons/stock/models/stock_move.py#L2214-L2216

sentry-6798363441

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
