### PR TITLE
[FIX] pos_self_order: sort the select table popup by table numbers

### DIFF
--- a/addons/pos_self_order/static/src/app/components/popup_table/popup_table.xml
+++ b/addons/pos_self_order/static/src/app/components/popup_table/popup_table.xml
@@ -18,7 +18,7 @@
                     <option value="floor" disabled="true">
                         <t t-esc="floor.name" />
                     </option>
-                    <option t-foreach="floor.table_ids" t-as="table" t-key="table.id" t-att-value="table.id">
+                    <option t-foreach="floor.sortedTable" t-as="table" t-key="table.id" t-att-value="table.id">
                         <t t-esc="table.table_number" />
                     </option>
                 </t>

--- a/addons/pos_self_order/static/src/app/models/restaurant_floor.js
+++ b/addons/pos_self_order/static/src/app/models/restaurant_floor.js
@@ -1,0 +1,12 @@
+import { registry } from "@web/core/registry";
+import { Base } from "@point_of_sale/app/models/related_models";
+
+export class RestaurantFloor extends Base {
+    static pythonModel = "restaurant.floor";
+
+    get sortedTable() {
+        return this.table_ids.sort((a, b) => a.table_number - b.table_number);
+    }
+}
+
+registry.category("pos_available_models").add(RestaurantFloor.pythonModel, RestaurantFloor);


### PR DESCRIPTION
Task [#4991803](https://www.odoo.com/odoo/my-tasks/4991803)
Runbot: https://runbot.odoo.com/runbot/bundle/18-0-incremental-order-table-pop-pos-self-order-ltra-391429

---
When selecting a table in the POS self-order, we sort the tables by `floor_id` and then by `table_number` in ascending order. This ensures a consistent and user-friendly experience when choosing a table.
