### PR TITLE
[IMP] template_inheritance: replace inner allow moving nodes

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -690,6 +690,28 @@ class TestApplyInheritanceSpecs(ViewCase):
         self.View.apply_inheritance_specs(self.adv_arch, spec)
         self.assertEqual(self.adv_arch, expected)
 
+    def test_replace_inner_2(self):
+        spec = E.field(
+            "TEXT 4",
+            E.xpath(position="move", expr="//field[2]"),
+            "TEXT 5",
+            E.xpath(expr="//field[@name='subtarget']", position="move"),
+            "TEXT 6",
+            name="target", position="replace", mode="inner")
+
+        expected = E.form(
+            E.field(
+                "TEXT 4",
+                E.field(name="anothersubtarget"),
+                "TEXT 5",
+                E.field(name="subtarget"),
+                "TEXT 6",
+                name="target"),
+            string="Title")
+
+        self.View.apply_inheritance_specs(self.adv_arch, spec)
+        self.assertEqual(self.adv_arch, expected)
+
     def test_unpack_data(self):
         spec = E.data(
                 E.field(E.field(name="inserted 0"), name="target"),


### PR DESCRIPTION

Before this commit, the xpath instruction `(position=replace, mode=inner)`
wiped the content of the targetted node, and put the content of the instruction instead.

This was a bit frustrating, and frankly was a great limitation on how we could programmtically build
xpath archs (for the Studio ReportEditor).

Indeed, replace inner would be the main way to handle text changes within a node.

This commit implements, in a fully retrocompatible way, the support
of xpath instructions `(position=move)` within a xpath `(position=replace, mode=inner)`