### PR TITLE
[FIX] pos_restaurant: combo products transfer course

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -922,14 +922,19 @@ patch(PosStore.prototype, {
         if (!destCourse) {
             return;
         }
+        const lines = [];
         if (selectedLine) {
-            selectedLine.course_id = destCourse.id;
+            const mainLine = selectedLine.combo_parent_id || selectedLine;
+            lines.push(mainLine);
+            if (mainLine.combo_line_ids?.length) {
+                lines.push(...mainLine.combo_line_ids);
+            }
         } else {
-            const lines = [...selectedCourse.lines];
-            lines.forEach((line) => {
-                line.course_id = destCourse.id;
-            });
+            lines.push(...selectedCourse.lines);
         }
+        lines.forEach((line) => {
+            line.course_id = destCourse.id;
+        });
         order.selectCourse(destCourse);
         order.recomputeOrderData();
     },

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -863,5 +863,21 @@ registry.category("web_tour.tours").add("test_combo_synchronisation", {
                 content: "Check if there still has combo lines",
                 trigger: ".orderline-combo",
             },
+            ProductScreen.addCourse(),
+            ProductScreen.clickOrderline("Combo Product 2"),
+            ProductScreen.transferCourseTo("Course 2"),
+            {
+                content: "Check if entire combo is transfered to course 2",
+                trigger: ".pos", // dummy trigger
+                run: function () {
+                    const onlyCourse2 = window.posmodel
+                        .getOrder()
+                        .lines.every((x) => x.course_id.name === "Course 2");
+
+                    if (!onlyCourse2) {
+                        throw new Error("The entire combo must be transferred to Course 2.");
+                    }
+                },
+            },
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -89,3 +89,22 @@ export function releaseTable() {
         },
     ];
 }
+
+export function addCourse() {
+    return {
+        content: `click Course button`,
+        trigger: ProductScreen.controlButtonTrigger("Course"),
+        run: "click",
+    };
+}
+
+export function transferCourseTo(destCourse) {
+    return [
+        ...ProductScreen.clickControlButton("Transfer course"),
+        {
+            content: `click ${destCourse} from available courses`,
+            trigger: `.modal-body button:contains(${destCourse})`,
+            run: "click",
+        },
+    ];
+}


### PR DESCRIPTION
Steps to reproduce:
-------------------------
- Install POS restaurant & create order with multiple courses
- Add a combo product in one of the course
- Select a combo child line and try to transfer course

Issue:
-------
- Only the selected child line is transferred to the new course instead of the entire combo.

Cause:
---------
- The system currently transfers only the selected order line without checking whether it belongs to a combo.

Fix:
----
- Updated the logic to check if the selected order line is part of a combo. If so, the entire combo (parent and child lines) will now be moved to the new course together.

task: 5005141