### PR TITLE
[FIX] web_editor: force display of custom snippets

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2991,6 +2991,16 @@ we-select.o_grid we-toggler {
                         }
                     }
                 }
+                //custom snippet might have visibility options preventing the display of the snippet
+                &.s_custom_snippet {
+                    &.o_snippet_desktop_invisible, &.o_snippet_mobile_invisible, &.o_conditional_hidden {
+                        display: block !important;
+                        &.d-lg-flex, &.d-md-flex, &.o_half_screen_height, &.o_full_screen_height {
+                            // e.g. Useful if "Height" option (50% or 100%) is enabled.
+                            display: flex !important;
+                        }
+                    }
+                }
             }
             &::after {
                 content: "";


### PR DESCRIPTION
When saving a snippet with visibility options (e.g. Hide on desktop), those options were also saved in the snippet template. As a result, the custom snippet preview was not displayed in the "Insert a block" dialog.

This commit fixes the issue by explicitly forcing `display: block` on custom snippets in the dialog, ensuring they remain visible regardless of the saved visibility options.
