### PR TITLE
[FIX] {,website_}sale_loyalty: enforce consistent loyalty expiration

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -2,8 +2,9 @@
 
 import itertools
 import random
-
 from collections import defaultdict
+
+from pytz import timezone
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
@@ -457,7 +458,7 @@ class SaleOrder(models.Model):
         Returns the base domain that all programs have to comply to.
         """
         self.ensure_one()
-        today = fields.Date.context_today(self)
+        today = self._get_confirmed_tx_create_date()
         return [('active', '=', True), ('sale_ok', '=', True),
                 *self.env['loyalty.program']._check_company_domain([self.company_id.id, self.company_id.parent_id.id]),
                 '|', ('pricelist_ids', '=', False), ('pricelist_ids', 'in', [self.pricelist_id.id]),
@@ -469,13 +470,35 @@ class SaleOrder(models.Model):
         Returns the base domain that all triggers have to comply to.
         """
         self.ensure_one()
-        today = fields.Date.context_today(self)
+        today = self._get_confirmed_tx_create_date()
         return [('active', '=', True), ('program_id.sale_ok', '=', True),
                 *self.env['loyalty.program']._check_company_domain([self.company_id.id, self.company_id.parent_id.id]),
                 '|', ('program_id.pricelist_ids', '=', False),
                      ('program_id.pricelist_ids', 'in', [self.pricelist_id.id]),
                 '|', ('program_id.date_from', '=', False), ('program_id.date_from', '<=', today),
                 '|', ('program_id.date_to', '=', False), ('program_id.date_to', '>=', today)]
+
+    def _get_program_timezone(self):
+        """Get the timezone to be used for loyalty date checking on the current order."""
+        self.ensure_one()
+        return (
+            self.company_id.partner_id.tz
+            or self.env['ir.config_parameter'].sudo().get_param('loyalty.timezone', 'UTC')
+        )
+
+    def _get_confirmed_tx_create_date(self):
+        """Return the creation date of the earliest confirmed transaction to check which loyalty
+        programs are applicable. If no transactions are confirmed, return the current day, using
+        the company's time zone.
+        """
+        self.ensure_one()
+        order_tz = self._get_program_timezone()
+        confirmed_txs = self.transaction_ids.filtered(lambda tx: tx.state in ('done', 'authorized'))
+        if confirmed_txs:
+            # If order is getting confirmed, use the earliest finalized transaction's create date
+            tx_date = min(confirmed_txs.mapped('create_date'))
+            return tx_date.astimezone(timezone(order_tz)).date()
+        return fields.Date.context_today(self.with_context(tz=order_tz))
 
     def _get_applicable_program_points(self, domain=None):
         """
@@ -1071,6 +1094,7 @@ class SaleOrder(models.Model):
         rule = self.env['loyalty.rule'].search(domain)
         program = rule.program_id
         coupon = False
+        check_date = self._get_confirmed_tx_create_date()
 
         if rule in self.code_enabled_rule_ids:
             return {'error': _('This promo code is already applied.')}
@@ -1083,7 +1107,7 @@ class SaleOrder(models.Model):
                 not coupon.program_id.reward_ids or\
                 not coupon.program_id.filtered_domain(self._get_program_domain()):
                 return {'error': _('This code is invalid (%s).', code), 'not_found': True}
-            elif coupon.expiration_date and coupon.expiration_date < fields.Date.today():
+            if coupon.expiration_date and coupon.expiration_date < check_date:
                 return {'error': _('This coupon is expired.')}
             elif coupon.points < min(coupon.program_id.reward_ids.mapped('required_points')):
                 return {'error': _('This coupon has already been used.')}

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -761,9 +761,13 @@ class SaleOrder(models.Model):
         coupons_to_unlink = self.env['loyalty.card']
         point_entries_to_unlink = self.env['sale.order.coupon.points']
         # Remove any coupons that are expired
-        self.applied_coupon_ids = self.applied_coupon_ids.filtered(lambda c:
-            (not c.expiration_date or c.expiration_date >= fields.Date.today())
+        initial_coupons = self.applied_coupon_ids
+        check_date = self._get_confirmed_tx_create_date()
+        self.applied_coupon_ids = initial_coupons.filtered(
+            lambda c: not c.expiration_date or c.expiration_date >= check_date,
         )
+        removed_coupons = initial_coupons - self.applied_coupon_ids
+        lines_to_unlink |= self.order_line.filtered(lambda sol: sol.coupon_id in removed_coupons)
         point_ids_per_program = defaultdict(lambda: self.env['sale.order.coupon.points'])
         for pe in self.coupon_point_ids:
             # Remove any point entry for a coupon that does not belong to the customer

--- a/addons/sale_loyalty/tests/test_program_rules.py
+++ b/addons/sale_loyalty/tests/test_program_rules.py
@@ -1,15 +1,18 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date, timedelta
+
 from freezegun import freeze_time
+from pytz import timezone
 
-from odoo import Command
 from odoo.exceptions import ValidationError
+from odoo.fields import Command, Datetime
 
+from odoo.addons.payment.tests.common import PaymentCommon
 from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
 
 
-class TestProgramRules(TestSaleCouponCommon):
+class TestProgramRules(TestSaleCouponCommon, PaymentCommon):
     # Test all the validity rules to allow a customer to have a reward.
     # The check based on the products is already done in the basic operations test
 
@@ -401,3 +404,81 @@ class TestProgramRules(TestSaleCouponCommon):
         self._auto_rewards(order, self.immediate_promotion_program)
         msg = "The promo offer shouldn't have been applied as the number of uses is exceeded"
         self.assertEqual(len(order.order_line.ids), 1, msg)
+
+    def test_program_rules_validity_date_timezones(self):
+        """Test that the validity dates are checked according to the company's time zone"""
+        self.env.company.partner_id.tz = 'Europe/London'
+        self.steve.tz = 'America/Los_Angeles'
+        midnight = Datetime.today()
+        yesterday = (midnight - timedelta(days=1)).date()
+        self.immediate_promotion_program.update({
+            'date_to': yesterday,
+            'limit_usage': True,
+            'max_usage': 1,
+        })
+        order = self.empty_order.with_context(tz=self.steve.tz)
+        order.order_line = [
+            Command.create({'product_id': self.product_A.id}),
+            Command.create({'product_id': self.product_B.id}),
+        ]
+
+        with freeze_time(midnight):
+            # Try apply reward at UTC midnight with LA time zone in context (expired)
+            self._auto_rewards(order, self.immediate_promotion_program)
+            self.assertFalse(
+                order.order_line.filtered('is_reward_line'),
+                "Promo should not be applied if only valid in the customer's time zone",
+            )
+
+        with freeze_time(timezone(self.env.company.partner_id.tz).localize(midnight)):
+            # Try apply reward at London midnight (expired)
+            self._auto_rewards(order, self.immediate_promotion_program)
+            self.assertFalse(
+                order.order_line.filtered('is_reward_line'),
+                "Promo should not be applied if only valid in the customer's time zone",
+            )
+
+        self.steve.tz = 'Europe/Brussels'
+        with freeze_time(timezone(self.steve.tz).localize(midnight)):
+            # Apply reward at Brussels midnight (still valid in company's time zone)
+            self._auto_rewards(order, self.immediate_promotion_program)
+            self.assertTrue(
+                order.order_line.filtered('is_reward_line'),
+                "Promo should be applied if valid in the company's time zone",
+            )
+
+    def test_program_rules_validity_date_transactions(self):
+        """Test that the validity dates are checked according to the time of transaction."""
+        today = Datetime.today()
+        tomorrow = today + timedelta(days=1)
+        self.immediate_promotion_program.update({
+            'date_to': today,
+            'limit_usage': True,
+            'max_usage': 1,
+            'reward_ids': [Command.set(self.program_gift_card.reward_ids.ids)],
+        })
+        order = self.empty_order
+        order.order_line = [
+            Command.create({'product_id': self.product_A.id}),
+            Command.create({'product_id': self.product_B.id}),
+        ]
+
+        intial_amount = order.amount_total
+        self._auto_rewards(order, self.immediate_promotion_program)
+        self.assertLess(order.amount_total, intial_amount, "A discount should be applied")
+
+        tx = order.transaction_ids = self._create_transaction(
+            flow='redirect',
+            sale_order_ids=[order.id],
+            state='pending',
+            reference=order.name,
+            amount=order.amount_total,
+        )
+        # Our slow provider only gets around to confirming the transaction the next day
+        with freeze_time(tomorrow):
+            tx._set_done()
+            tx._reconcile_after_done()
+            self.assertAlmostEqual(
+                order.amount_total, tx.amount,
+                msg="Discount should still apply if transaction gets confirmed post-expiration",
+            )

--- a/addons/sale_loyalty/tests/test_unlink_reward.py
+++ b/addons/sale_loyalty/tests/test_unlink_reward.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import date, timedelta
+
 from odoo import Command
 
 from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
@@ -53,3 +55,19 @@ class TestUnlinkReward(TestSaleCouponCommon):
         # Check that the reward is archived and not deleted
         self.assertTrue(self.reward.exists())
         self.assertFalse(self.reward.active)
+
+    def test_unlink_expired_coupon_line(self):
+        """Ensure that lines linked to expired coupons get unlinked from the order."""
+        order = self.empty_order
+        order.order_line = [Command.create({'product_id': self.product_A.id})]
+        coupon_program = self.code_promotion_program
+        self.env['loyalty.generate.wizard'].with_context(active_id=coupon_program.id).create({
+            'coupon_qty': 1,
+            'points_granted': 1,
+        }).generate_coupons()
+        coupon = coupon_program.coupon_ids
+        self._apply_promo_code(order, coupon.code)
+        self.assertTrue(order.order_line.coupon_id)
+        coupon.expiration_date = date.today() - timedelta(days=1)
+        order._update_programs_and_rewards()
+        self.assertFalse(order.order_line.coupon_id)

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -38,6 +38,9 @@ class SaleOrder(models.Model):
                 return expression.AND([res, [('program_id.website_id', 'in', (self.website_id.id, False))]])
         return res
 
+    def _get_program_timezone(self):
+        return self.website_id.salesperson_id.tz or super()._get_program_timezone()
+
     def _try_pending_coupon(self):
         if not request:
             return False


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have a database with GeoIP enabled;
2. have a promotion program that gives a discount on a specific product;
3. use a VPN to browse /shop from California before 7:00 UTC;
4. add the product to your cart;
5. go to checkout;
6. pay for the order.

Issue
-----
Order cannot be confirmed due to incomplete payment.

Cause
-----
The `_frontend_pre_dispatch` method of `website` adds a timezone value to the context based on the request's `geoip`. This context value then gets used to find applicable loyalty programs via `Date.context_today`, and applies them to the order.

Then after payment was initiated, the order gets validated again using server time (UTC), which now considers the applied program expired, and removes the reward before confirming the order.

Consequently, with the discount removed, the paid amount no longer matches the order total, thus the order remains unconfirmed.

Solution
--------
If the order has a confirmed transaction, use its `create_date` to verify loyalty expiration dates.

For time zone, instead of `Date.context_today`, using whatever `tz` value is in the context, use a helper function which retrieves the current day in the company's timezone.

For website orders, if defined, use the eCommerce salesperson's time zone instead.

Also fix an issue where expired coupon lines weren't getting removed from the order.

opw-4765873
opw-4781346
opw-4939268