### PR TITLE
[IMP] hr_attendance: add read-only mode for attendance approver

### DIFF
--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -95,7 +95,7 @@
                 </button>
             </xpath>
             <xpath expr="//group[@name='managers']" position="inside">
-                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user"/>
+                <field name="attendance_manager_id" readonly="not can_edit" string="Attendance" widget="many2one_avatar_user"/>
             </xpath>
             <xpath expr="//group[@name='managers']" position="attributes">
                 <attribute name="invisible">0</attribute>


### PR DESCRIPTION
Add read-only mode for the attendance approver in the My Profile Work Information tab when `allow employee to edit own data` is disabled.

task-5008352

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
