### PR TITLE
[FIX] html_builder: remove `savePlugin` dependency from `dragAndDrop`

### DIFF
--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -6,7 +6,7 @@ import { uniqueId } from "@web/core/utils/functions";
 
 export class SavePlugin extends Plugin {
     static id = "savePlugin";
-    static shared = ["save", "isAlreadySaved", "saveView", "ignoreDirty"];
+    static shared = ["save", "isAlreadySaved", "saveView"];
     static dependencies = ["history"];
 
     resources = {
@@ -42,6 +42,7 @@ export class SavePlugin extends Plugin {
             // }
         ],
         get_dirty_els: () => this.editable.querySelectorAll(".o_dirty"),
+        on_prepare_drag_handlers: withSequence(1, this.ignoreDirty.bind(this)),
     };
 
     setup() {

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -246,7 +246,6 @@ export class BlockTab extends Component {
                     this.shared.dropzone.removeDropzones();
                     // Undo the changes needed to ease the drag and drop.
                     this.dragState.restoreCallbacks?.forEach((restore) => restore());
-                    this.dragState.restoreDirty();
                     restoreDragSavePoint();
                 };
                 this.hideSnippetToolTip?.();
@@ -257,10 +256,9 @@ export class BlockTab extends Component {
                 this.dragState = {};
                 dropzoneEls = [];
 
-                // Stop marking the elements with mutations as dirty.
-                this.dragState.restoreDirty = this.shared.savePlugin.ignoreDirty();
-
                 // Make some changes on the page to ease the drag and drop.
+                // Notably, this will stop marking the elements with mutations as
+                // dirty.
                 const restoreCallbacks = [];
                 for (const prepareDrag of this.env.editor.getResource("on_prepare_drag_handlers")) {
                     const restore = prepareDrag();
@@ -386,7 +384,6 @@ export class BlockTab extends Component {
                     // Undo the changes needed to ease the drag and drop.
                     this.dragState.restoreCallbacks.forEach((restore) => restore());
                     this.dragState.restoreCallbacks = null;
-                    this.dragState.restoreDirty();
 
                     currentDropzoneEl.after(snippetEl);
                     this.shared.dropzone.removeDropzones();

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -201,7 +201,10 @@ export class HistoryPlugin extends Plugin {
             this.enableObserver();
             this.reset(this.config.content);
         },
-        on_prepare_drag_handlers: this.disableIsCurrentStepModifiedWarning.bind(this),
+        on_prepare_drag_handlers: withSequence(
+            1,
+            this.disableIsCurrentStepModifiedWarning.bind(this)
+        ),
         // Resource definitions:
         normalize_handlers: [
             // (commonRootOfModifiedEl or editableEl) => {


### PR DESCRIPTION
[Commit] introduced a way to prevent mutations from being saved when a change
was caused by a `dragAndDrop` operation. However it did so by adding a
dependency to `savePlugin`, which is not desirable for the upcoming
`mass_mailing` refactoring, which will use the `html_builder` in coordination
with a Form View, which has its independent way of saving user content.

This commit introduces a resource in order to remove that dependency.

[Commit]: https://github.com/odoo/odoo/commit/6fdf188fdf5cfdc11e5e1a8429d0a652054344de

task-4367641