### PR TITLE
[FIX] orm: Avoid overflow error for date.min used in domain

### DIFF
--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1518,7 +1518,7 @@ def _value_to_datetime(value, env, iso_only=False):
         return _value_to_datetime(value, env)
     if isinstance(value, date):
         tz = env.context.get('tz') or env.user.tz or None
-        if value.year == 9999:
+        if value.year in (1, 9999):
             # avoid overflow errors, treat as UTC timezone
             tz = None
         elif tz:


### PR DESCRIPTION
To avoid overflow error when date.min is used, it should be treated as UTC timezone.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
