### PR TITLE
[FIX] html_editor: add .o_editable_media to not contenteditable elements

### DIFF
--- a/addons/html_editor/static/src/core/content_editable_plugin.js
+++ b/addons/html_editor/static/src/core/content_editable_plugin.js
@@ -16,7 +16,6 @@ export class ContentEditablePlugin extends Plugin {
     resources = {
         normalize_handlers: withSequence(5, this.normalize.bind(this)),
         clean_for_save_handlers: withSequence(Infinity, this.cleanForSave.bind(this)),
-        filter_contenteditable_handlers: this.filterContentEditable.bind(this),
         system_classes: ["o_editable_media"],
     };
 
@@ -26,7 +25,6 @@ export class ContentEditablePlugin extends Plugin {
         for (const toDisable of toDisableEls) {
             toDisable.setAttribute("contenteditable", "false");
         }
-
         const toEnableSelector = this.getResource("force_editable_selector").join(",");
         let filteredContentEditableEls = toEnableSelector
             ? [...selectElements(root, toEnableSelector)]
@@ -50,7 +48,9 @@ export class ContentEditablePlugin extends Plugin {
                     contentEditableEl.classList.add("o_editable_media");
                     continue;
                 }
-                contentEditableEl.setAttribute("contenteditable", true);
+                if (!contentEditableEl.matches(toDisableSelector)) {
+                    contentEditableEl.setAttribute("contenteditable", true);
+                }
             }
         }
     }
@@ -63,10 +63,5 @@ export class ContentEditablePlugin extends Plugin {
         for (const contenteditableEl of contenteditableEls) {
             contenteditableEl.removeAttribute("contenteditable");
         }
-    }
-
-    filterContentEditable(contentEditableEls) {
-        const toDisableSelector = this.getResource("force_not_editable_selector").join(",");
-        return contentEditableEls.filter((el) => !el.matches(toDisableSelector));
     }
 }

--- a/addons/html_editor/static/tests/content_editable.test.js
+++ b/addons/html_editor/static/tests/content_editable.test.js
@@ -1,0 +1,24 @@
+import { expect, test } from "@odoo/hoot";
+import { setupEditor } from "./_helpers/editor";
+import { Plugin } from "@html_editor/plugin";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+
+test("set o_editable_media class on contenteditable false media elements", async () => {
+    class TestPlugin extends Plugin {
+        static id = "test";
+        resources = {
+            force_not_editable_selector: "i",
+            force_editable_selector: "i",
+        };
+    }
+    const Plugins = [...MAIN_PLUGINS, TestPlugin];
+    await setupEditor(
+        `
+        <div class="wrapper"><i class="fa fa-shopping-cart fa-stack"></i></div>`,
+        {
+            config: { Plugins },
+        }
+    );
+    expect(".wrapper > i").toHaveClass("o_editable_media");
+    expect(".wrapper > i").toHaveAttribute("contenteditable", "false");
+});


### PR DESCRIPTION
Following this [commit], in some cases we need to have .o_editable_media
class while the element is not editable itself. In order to do this, we
shouldn't filter out elements again based on
`force_not_editable_selector`s, but rather just not set element's
contenteditable to true, when the element matches those selectors, then
the .o_editable_media will be added successfully.
To see the issue:
- open website and start editing
- inspect the cart icon in the header

=> It's missing the .o_editable_media class.

Related to task-4367641

[commit]: https://github.com/odoo/odoo/commit/b455ea85853df