### PR TITLE
[FIX] html_editor: url preview no access

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -604,9 +604,9 @@ class HTML_Editor(http.Controller):
                 action_type = action.type
                 if action_type != 'ir.actions.act_window':
                     return {'other_error_msg': _("Action %s is not a window action, link preview is not available", action_name)}
-                action = request.env[action_type].browse(action.id)
+                action_sudo = request.env[action_type].sudo().browse(action.id)
 
-                model = request.env[action.res_model].with_context(context)
+                model = request.env[action_sudo.res_model].with_context(context)
 
             record = model.browse(record_id)
 


### PR DESCRIPTION
Users without access for specific actions cannot see the right preview information, using sudo like the search for generic action but on specific model solve the issue.

Steps:
- Login with a user without window actions access
- Copy a link somewhere to have preview dialog

Actual result:
- Preview title is Odoo due to access error

Expected result:
- Preview title is the one of the page

opw-4933194