### PR TITLE
[FIX] sale: ensure correct `active_model` in context for invoice QR

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1414,6 +1414,7 @@ class SaleOrder(models.Model):
         }
         if len(self) == 1:
             context.update({
+                'active_model': 'account.move',
                 'default_partner_id': self.partner_id.id,
                 'default_partner_shipping_id': self.partner_shipping_id.id,
                 'default_invoice_payment_term_id': self.payment_term_id.id or self.partner_id.property_payment_term_id.id or self.env['account.move'].default_get(['invoice_payment_term_id']).get('invoice_payment_term_id'),


### PR DESCRIPTION
### Issue

When "Add QR-code link on PDF" is enabled, printing an invoice in a regular Sales → Accounting flow raises an error.

The report printing process internally calls
`_generate_portal_payment_qr`, which creates a `payment.link.wizard` record. This model overrides `default_get` and reads `self.env.context.get('active_model')`.

At that moment, the context still contains `'sale.advance.payment.inv'`, a model that does not implement `_get_default_payment_link_values`. This causes:

AttributeError: 'sale.advance.payment.inv' object has no attribute '_get_default_payment_link_values'

#### Affected versions
- saas-18.3 and later

### Steps to reproduce
1. Install `account_accountant`, `sale_management`
2. Go to Settings
3. Enable "Invoice Online Payment" and "Add QR-code link on PDF"
4. Go to Sales → Quotations
5. Create any quotation
6. Confirm quotation
7. Create invoice (full)
8. Confirm invoice
9. Click "Print"

#### Current behavior
- Error is raised

#### Expected behavior
- Invoice prints with QR code without error

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
