### PR TITLE
[FIX] account: filter NULL values in duplicate bank partner query

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -72,7 +72,7 @@ class ResPartnerBank(models.Model):
                 SELECT this.id,
                        ARRAY_AGG(other.partner_id)
                   FROM res_partner_bank this
-             LEFT JOIN res_partner_bank other ON this.acc_number = other.acc_number
+                  JOIN res_partner_bank other ON this.acc_number = other.acc_number
                                              AND this.id != other.id
                  WHERE this.id = ANY(%(ids)s)
                    AND (

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -2036,3 +2036,15 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
         self.env.company.parent_ids.invalidate_recordset()
         payment = wizard._create_payments()
         self.assertTrue(payment)
+
+    def test_duplicate_bank_partner(self):
+        """Test that duplicate_bank_partner_ids doesn't return res.partner(None,)"""
+        partner1 = self.env['res.partner'].create({'name': 'Partner 1'})
+
+        # Bank with no duplicates
+        bank_unique = self.env['res.partner.bank'].create({
+            'acc_number': 'UNIQUE123',
+            'partner_id': partner1.id,
+        })
+
+        self.assertFalse(bank_unique.duplicate_bank_partner_ids)


### PR DESCRIPTION
To reproduce:
=============
- go to the contact form of any company contact
- add a new bank account "e.g. with account number 'DE'" (there should now only be one account)
- save the contact form
- remove the bank account via bin icon

Problem:
=========
ARRAY_AGG returns [NULL] when no duplicates found in query: 
https://github.com/odoo/odoo/blob/d7577430f229ed1770bbe2ccfa0d45eabbb394c7/addons/account/models/res_partner_bank.py#L73

This causes browse([None]) to create res_partner(None,) recordset: https://github.com/odoo/odoo/blob/d7577430f229ed1770bbe2ccfa0d45eabbb394c7/addons/account/models/res_partner_bank.py#L88

Which fails when accessing id_ field which will be None: https://github.com/odoo/odoo/blob/d7577430f229ed1770bbe2ccfa0d45eabbb394c7/addons/web/models/models.py#L1173

Solution:
=========
Add FILTER clause to ARRAY_AGG to exclude NULL partner_id values, preventing creation of null records in duplicate_bank_partner_ids.

opw-4988134
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
