### PR TITLE
[IMP] uom, l10n_ro_edi: add RO SAF-T code to UoM for Romanian e-invoice

### DIFF
--- a/addons/l10n_ro/__manifest__.py
+++ b/addons/l10n_ro/__manifest__.py
@@ -23,6 +23,8 @@ Romanian accounting chart and localization.
         'views/res_partner_view.xml',
         'data/account_tax_report_data.xml',
         'data/res.bank.csv',
+        'data/uom_ro_saft_codes.xml',
+        'views/ro_saft_uom_view.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_ro/data/uom_ro_saft_codes.xml
+++ b/addons/l10n_ro/data/uom_ro_saft_codes.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="uom.product_uom_unit" model="uom.uom">
+            <field name="ro_saft_code">H87</field>
+        </record>
+        <record id="uom.product_uom_litre" model="uom.uom">
+            <field name="ro_saft_code">L2</field>
+        </record>
+        <record id="uom.product_uom_kgm" model="uom.uom">
+            <field name="ro_saft_code">KGM</field>
+        </record>
+        <record id="uom.product_uom_cubic_meter" model="uom.uom">
+            <field name="ro_saft_code">MTQ</field>
+        </record>
+        <record id="uom.product_uom_hour" model="uom.uom">
+            <field name="ro_saft_code">HUR</field>
+        </record>
+        <record id="uom.product_uom_km" model="uom.uom">
+            <field name="ro_saft_code">KMT</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_ro/models/__init__.py
+++ b/addons/l10n_ro/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_ro
 from . import res_partner
+from . import uom_uom

--- a/addons/l10n_ro/models/uom_uom.py
+++ b/addons/l10n_ro/models/uom_uom.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class UoM(models.Model):
+    _inherit = "uom.uom"
+
+    ro_saft_code = fields.Char(string="RO SAF-T Code", help="Romanian SAF-T code used for e-Factura.", store=True)

--- a/addons/l10n_ro/views/ro_saft_uom_view.xml
+++ b/addons/l10n_ro/views/ro_saft_uom_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_uom_form_inherit_ro_saft_code" model="ir.ui.view">
+        <field name="name">uom.uom.form.inherit.ro.saft.code</field>
+        <field name="model">uom.uom</field>
+        <field name="inherit_id" ref="uom.product_uom_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='relative_factor']" position="after">
+                <field name="ro_saft_code"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds ro_saft_code field on uom.uom to store Romanian-specific SAF-T unit codes. Also uses this field in the e-invoice XML export for Romania to comply with RO standards. Includes data file to populate standard codes (e.g. H87, L2, KGM).
Allow users to write custom ro_saft_code inside single unit code form.

4976455

