### PR TITLE
[FIX] mail: re-enable call infinite mirror warning

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -32,7 +32,7 @@ export class Call extends Component {
         CallParticipantCard,
         PttAdBanner,
     };
-    static props = ["thread", "compact?", "isPip?"];
+    static props = ["thread?", "compact?", "isPip?"];
     static template = "discuss.Call";
 
     overlayTimeout;

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -2230,7 +2230,20 @@ export const rtcService = {
         });
         rtc.fullscreen = services["mail.fullscreen"];
         onChange(rtc.fullscreen, "id", () => {
+            const wasFullscreen = rtc.state.isFullscreen;
             rtc.state.isFullscreen = rtc.fullscreen.id === CALL_FULLSCREEN_ID;
+            if (
+                rtc.state.screenTrack &&
+                rtc.displaySurface !== "browser" &&
+                rtc.fullscreen.id === CALL_FULLSCREEN_ID
+            ) {
+                rtc.showMirroringWarning();
+            } else if (!rtc.state.isFullscreen) {
+                rtc.removeMirroringWarning?.();
+                if (wasFullscreen && rtc.state.screenTrack) {
+                    rtc.state.screenTrack.enabled = true;
+                }
+            }
         });
         rtc.p2pService = services["discuss.p2p"];
         rtc.p2pService.acceptOffer = async (id, sequence) => {

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -653,3 +653,24 @@ test("can join / leave call from discuss sidebar actions", async () => {
     await click(".o-dropdown-item:contains('Disconnect')");
     await contains(".o-discuss-Call", { count: 0 });
 });
+
+test("shows warning on infinite mirror effect (screen-sharing then fullscreen)", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await click("[title='More']");
+    await click("[title='Share Screen']");
+    await contains("video");
+    await triggerEvents(".o-discuss-Call-mainCards", ["mousemove"]); // show overlay
+    await click("[title='More']");
+    await click("[title='Fullscreen']");
+    await contains(".o-discuss-CallInfiniteMirroringWarning");
+    await contains(
+        ".o-discuss-CallInfiniteMirroringWarning:contains('To avoid the infinite mirror effect, please share a specific window or tab or another monitor.')"
+    );
+    await contains("button:contains('Stream paused') i.fa-pause-circle-o");
+    await hover(queryFirst("button:contains('Stream paused')"));
+    await contains("button:contains('Resume stream') i.fa-play-circle-o");
+});


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/194974 adds a new feature to warn user for risk of infinite mirror effect in call while screen-sharing and opening call in full-screen.

https://github.com/odoo/odoo/pull/218119 made changes to fullscreen and mistakenly broke the warning code, thus there was not warning for infinite mirror.

This commit fixes it and brings back the feature.