### PR TITLE
[FIX] account_payment: ensure correct context for invoice QR

### DIFF
--- a/addons/account_payment/models/account_move.py
+++ b/addons/account_payment/models/account_move.py
@@ -175,7 +175,9 @@ class AccountMove(models.Model):
 
     def _get_portal_payment_link(self):
         self.ensure_one()
-        payment_link_wizard = self.env['payment.link.wizard'].create({
+        payment_link_wizard = self.env['payment.link.wizard'].with_context(
+            active_id=self.id, active_model=self._name
+        ).create({
             'amount': self.amount_residual,
             'res_model': self._name,
             'res_id': self.id,


### PR DESCRIPTION
### Issue

When "Add QR-code link on PDF" is enabled, printing an invoice in a regular Sales → Accounting flow raises an error.

The report printing process internally calls
`_generate_portal_payment_qr`, which creates a `payment.link.wizard` record. This model overrides `default_get` and reads `self.env.context.get('active_model')`.

At that moment, the context still contains `'sale.advance.payment.inv'`, a model that does not implement `_get_default_payment_link_values`. This causes:

AttributeError: 'sale.advance.payment.inv' object has no attribute '_get_default_payment_link_values'

#### Affected versions
- saas-18.3 and later

### Steps to reproduce
1. Install `account_accountant`, `sale_management`
2. Go to Settings
3. Enable "Invoice Online Payment" and "Add QR-code link on PDF"
4. Go to Sales → Quotations
5. Create any quotation
6. Confirm quotation
7. Create invoice (full)
8. Confirm invoice
9. Click "Print"

#### Current behavior
- Error is raised

#### Expected behavior
- Invoice prints with QR code without error

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
