### PR TITLE
[FIX] pos_loyalty: prevent hiding a reward product

### DIFF
--- a/addons/pos_loyalty/models/product_template.py
+++ b/addons/pos_loyalty/models/product_template.py
@@ -19,6 +19,9 @@ class ProductTemplate(models.Model):
 
         missing_product_templates = self.env['product.template'].browse(missing_product_tmpl_ids).read(fields=fields, load=False)
         product_ids_to_hide = reward_products.product_tmpl_id - self.env['product.template'].browse(already_loaded_product_tmpl_ids)
+        if self.env.context.get('pos_limited_loading', True):
+            # Filter out products that can be loaded in the PoS but are not loaded yet
+            product_ids_to_hide = product_ids_to_hide - product_ids_to_hide.filtered_domain(self._load_pos_data_domain(data))
         data['pos.session'][0]['_pos_special_products_ids'] += product_ids_to_hide.product_variant_id.ids
         res.extend(missing_product_templates)
 

--- a/addons/pos_loyalty/tests/__init__.py
+++ b/addons/pos_loyalty/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_frontend
 from . import test_loyalty_history
 from . import test_unlink_reward
+from . import test_product_loading

--- a/addons/pos_loyalty/tests/test_product_loading.py
+++ b/addons/pos_loyalty/tests/test_product_loading.py
@@ -1,0 +1,75 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details
+
+from odoo.tests import tagged
+
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+@tagged('post_install', '-at_install')
+class TestPOSLoyaltyProductLoading(TestPointOfSaleHttpCommon):
+    def test_loyalty_product_loading(self):
+        """ Test that loyalty products are loaded correctly in the PoS session. """
+        new_product = self.env['product.product'].create({
+            'name': 'New Product',
+            'is_storable': True,
+            'list_price': 1,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+
+        program = self.env['loyalty.program'].create({
+            'name': 'Program',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'reward_ids': [(0, 0, {
+                'reward_type': 'product',
+                'reward_product_id': new_product.id,
+                'reward_product_qty': 1,
+                'required_points': 2,
+            })],
+        })
+        self.env['loyalty.program'].search([]).write({
+            'active': False,
+        })
+
+        self.env['ir.config_parameter'].sudo().set_param('point_of_sale.limited_product_count', 1)
+
+        self.main_pos_config.open_ui()
+        current_session = self.main_pos_config.current_session_id
+
+        data = current_session.with_context(
+            pos_limited_loading=True,
+        ).load_data(['pos.config', 'product.template'])
+
+        self.assertNotIn(new_product.product_tmpl_id.id, [product['id'] for product in data['product.template']],
+                        "Loyalty product should not be loaded in the PoS session when limited loading is enabled and program is inactive.")
+
+        self.assertNotIn(new_product.id, data['pos.session'][0]['_pos_special_products_ids'],
+                        "Loyalty product should not be in _pos_special_products_ids when program is inactive.")
+
+        # Activate the program to ensure the product is loaded
+        program.write({'active': True})
+
+        data = current_session.with_context(
+            pos_limited_loading=True,
+        ).load_data(['pos.config', 'product.template'])
+
+        self.assertIn(new_product.product_tmpl_id.id, [product['id'] for product in data['product.template']],
+                        "Loyalty product should be loaded in the PoS session when program is active.")
+
+        self.assertNotIn(new_product.id, data['pos.session'][0]['_pos_special_products_ids'],
+                        "Loyalty product should not be in _pos_special_products_ids since it is loaded.")
+
+        # Make the product not available in the PoS
+        new_product.write({'available_in_pos': False})
+
+        data = current_session.with_context(
+            pos_limited_loading=True,
+        ).load_data(['pos.config', 'product.template'])
+
+        self.assertIn(new_product.product_tmpl_id.id, [product['id'] for product in data['product.template']],
+                        "Loyalty product should be loaded in the PoS session when it is used in a program, even if not available in the PoS.")
+
+        self.assertIn(new_product.id, data['pos.session'][0]['_pos_special_products_ids'],
+                        "Loyalty product should be in _pos_special_products_ids since it is loaded but not available in the PoS.")


### PR DESCRIPTION
Before this commit, a product used as a loyalty reward could be hidden in the PoS.

opw-5005934

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
