### PR TITLE
[FIX] *: fix templates after subsection introduction

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -175,11 +175,7 @@
                                     <t t-set="current_total" t-value="current_total + line.price_total"/>
                                     <t t-set="hide_details" t-value="line.collapse_composition"/>
 
-                                    <tr t-att-class="{
-                                        'fw-bolder': line.display_type == 'line_section',
-                                        'fw-bold': line.display_type == 'line_subsection',
-                                        'fst-italic': line.display_type == 'line_note',
-                                    }" >
+                                    <tr t-att-class="'fw-bolder o_line_section' if line.display_type == 'line_section' else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                                         <t t-if="line.id in treated_lines"/>
                                         <t t-elif="hide_details">
                                             <t t-set="grouped_lines" t-value="line.get_lines_grouped_by_section()"/>

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -255,11 +255,7 @@
                             <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                             <t t-set="current_total" t-value="current_subtotal + line.price_total" t-if="o.tax_calculation_rounding_method == 'round_per_line'"/>
 
-                            <tr t-att-class="{
-                                'fw-bolder': line.display_type == 'line_section',
-                                'fw-bold': line.display_type == 'line_subsection',
-                                'fst-italic': line.display_type == 'line_note',
-                            }" >
+                            <tr t-att-class="'fw-bolder o_line_section' if line.display_type == 'line_section' else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                                 <t t-if="line.display_type not in ('line_section', 'line_subsection', 'line_note')" name="account_invoice_line_accountable">
                                     <td class="text-end o_price_total">
                                         <span class="text-nowrap" t-field="line.price_total"/>

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -69,11 +69,7 @@
                     <t t-foreach="o.order_line.filtered(lambda l: l.display_type or l.product_qty != 0)" t-as="line">
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
 
-                        <tr t-att-class="{
-                            'fw-bolder': line.display_type == 'line_section',
-                            'fw-bold': line.display_type == 'line_subsection',
-                            'fst-italic': line.display_type == 'line_note',
-                        }" >
+                        <tr t-att-class="'fw-bolder o_line_section' if line.display_type == 'line_section' else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                             <t t-if="not line.display_type">
                                 <td id="product" class="text-start">
                                     <span t-field="line.name"/>

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -35,11 +35,7 @@
                 </thead>
                 <tbody>
                     <t t-foreach="o.order_line.filtered(lambda l: l.display_type or l.product_qty != 0)" t-as="order_line">
-                        <tr t-att-class="{
-                            'fw-bolder o_line_section': order_line.display_type == 'line_section',
-                            'fw-bold o_line_subsection': order_line.display_type == 'line_subsection',
-                            'fst-italic o_line_note': order_line.display_type == 'line_note',
-                        }">
+                        <tr t-att-class="'fw-bolder o_line_section' if order_line.display_type == 'line_section' else 'fw-bold o_line_subsection' if order_line.display_type == 'line_subsection' else 'fst-italic o_line_note' if order_line.display_type == 'line_note' else ''">
                             <t t-if="not order_line.display_type">
                                 <td id="product">
                                     <span t-field="order_line.name"/>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -304,11 +304,7 @@
 
                               <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
 
-                            <tr t-att-class="{
-                                'fw-bolder o_line_section': line.display_type == 'line_section',
-                                'fw-bold o_line_subsection': line.display_type == 'line_subsection',
-                                'fst-italic o_line_note': line.display_type == 'line_note',
-                            }">
+                            <tr t-att-class="'fw-bolder o_line_section' if line.display_type == 'line_section' else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection' else 'fst-italic text-break o_line_note' if line.display_type == 'line_note' else ''">
                                 <t t-if="not line.display_type">
                                     <td id="product_name" class="d-flex">
                                         <img t-att-src="image_data_uri(resize_to_48(line.product_id.image_1024))" alt="Product" class="d-none d-lg-inline"/>

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -106,11 +106,13 @@
                         >
                         <tr
                             t-if="not line.collapse_composition"
-                            t-att-class="{
-                                'fw-bolder o_line_section': line.display_type == 'line_section' or line.product_type == 'combo',
-                                'fw-bold o_line_subsection': line.display_type == 'line_subsection',
-                                'fst-italic o_line_note': line.display_type == 'line_note',
-                            }"
+                            t-att-class="'fw-bold o_line_section' if (
+                                line.display_type == 'line_section'
+                                or line.product_type == 'combo'
+                            )
+                            else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection'
+                            else 'fst-italic o_line_note' if line.display_type == 'line_note'
+                            else ''"
                         >
                             <t t-if="not line.display_type and line.product_type != 'combo'">
                                 <td name="td_name"><span t-field="line.name">Bacon Burger</span></td>
@@ -203,7 +205,7 @@
                                     </span>
                                 </td>
                             </tr>
-                            <t t-if="line.display_type == 'line_section'">                                
+                            <t t-if="line.display_type == 'line_section'">
                                 <t t-set="current_section" t-value="line"/>
                                 <t t-set="current_subtotal" t-value="0"/>
                             </t>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -732,11 +732,13 @@
                                 >
                                 <tr
                                     t-if="not line.collapse_composition"
-                                    t-att-class="{
-                                        'fw-bolder o_line_section': line.display_type == 'line_section' or line.product_type == 'combo',
-                                        'fw-bold o_line_subsection': line.display_type == 'line_subsection',
-                                        'fst-italic o_line_note': line.display_type == 'line_note',
-                                    }"
+                                    t-att-class="'fw-bold o_line_section' if (
+                                        line.display_type == 'line_section'
+                                        or line.product_type == 'combo'
+                                    )
+                                    else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection'
+                                    else 'fst-italic o_line_note' if is_note
+                                    else ''"
                                 >
                                     <t
                                         name="product_line_row"


### PR DESCRIPTION
\* account,l10n_gcc_invoice,purchase,sale

This commit fixes templates broken after the introduction of subsection in the section and note field ([1]). We wrote owl like "t-att-class" in python templates.

task-5005432

[1]: https://github.com/odoo/odoo/pull/221229