### PR TITLE
[FIX] website_sale: Hide Buy Now button when zero-priced products

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2501,7 +2501,7 @@
         active="False"
         name="Buy Now Button"
     >
-        <xpath expr="//div[@id='product_option_block']" position="before">
+        <xpath expr="//div[@id='add_to_cart_wrap']" position="inside">
             <a
                 role="button"
                 t-attf-class="btn btn-outline-primary o_we_buy_now {{'w-100' if is_view_active('website_sale.cta_wrapper_boxed') or is_view_active('website_sale.cta_wrapper_large') else ''}} {{'flex-grow-1' if not is_50_pc else ''}}"


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the `Ecommerce` module.
2. Enable the following settings:
   * `Settings → Website → Shop - Checkout Process → Buy Now`
   * `Settings → Website → Shop - Products → Prevent Sale of Zero-Priced Product`
3. Create a product with a selling price of `0`.
4. Open the product page on the website.

**Observed behavior:**
- Even with `Prevent Sale of Zero-Priced Product` enabled, the `Buy Now` button remains visible on the product page, but clicking it does nothing.

**Root cause:**
- In `saas-18.4`, there was no condition controlling the visibility of the `Buy Now` button based on the `Prevent Sale of Zero-Priced Product` setting.

**Solution:**
- Added the `Buy Now` button inside `add_to_cart_wrap` so that it behaves consistently with the `Add to Cart` button which is hidden when the `Prevent Sale of Zero-Priced Products` setting is enabled.


opw-4984680