### PR TITLE
[FIX] stock: fix forecast widget

### DIFF
--- a/addons/stock/static/src/widgets/forecast_widget.js
+++ b/addons/stock/static/src/widgets/forecast_widget.js
@@ -28,7 +28,11 @@ export class ForecastWidgetField extends FloatField {
         const options = { digits, thousandsSep: "", decimalPoint: "." };
         const forecast_availability = parseFloat(formatFloat(data.forecast_availability, options));
         const product_qty = parseFloat(formatFloat(data.product_qty, options));
-        this.willBeFulfilled = forecast_availability >= product_qty;
+        if (data.state === 'draft'  ) {
+            this.willBeFulfilled = forecast_availability >= 0;
+        } else {
+            this.willBeFulfilled = forecast_availability >= product_qty;
+        }
         this.state = data.state;
     }
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The forecast widget was incorrectly showing "Not available" on some consuming draft stock moves

In consuming draft stock moves, the forecast_availability field is computed by subtracting the quantity of the current move [1]. However in the forecast widget, the forecast is being compared against the current move's quantity, as if it hadn't already been taken into account [2].

Current behavior before PR:
If a consuming draft stock move is created (such as the ones created inside manufacturing orders) with a quantity that is smaller than the stock but bigger than half of the stock, the forecast widget will incorrectly show "Not Available"

Desired behavior after PR is merged:
In those cases it should show "Available", since there is indeed enough stock


[1] https://github.com/odoo/odoo/blob/d6175d0552c18006913e969eac7006666164609c/addons/stock/models/stock_move.py#L466
[2] https://github.com/odoo/odoo/blob/d6175d0552c18006913e969eac7006666164609c/addons/stock/static/src/widgets/forecast_widget.js#L31
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
