### PR TITLE
wip add tests for history undo with same text mutation

### DIFF
--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -85,6 +85,16 @@ describe("undo", () => {
         redo(editor);
         expect(getContent(el)).toBe(`<p>a[]c</p>`);
     });
+
+    test("should undo same-text mutation", async () => {
+        const { el, editor } = await setupEditor(`<p>a</p>`);
+        const p = el.querySelector("p");
+        p.textContent = "b";
+        p.textContent = "b";
+        editor.shared.history.addStep();
+        undo(editor);
+        expect(p).toHaveText("a");
+    });
 });
 
 describe("redo", () => {
@@ -249,6 +259,14 @@ describe("step", () => {
             },
             contentAfter: `<div contenteditable="false"><div contenteditable="true">abc</div></div>`,
         });
+    });
+
+    test("should not add step after same-text mutation", async () => {
+        const { el, editor } = await setupEditor(`<p>a</p>`);
+        const p = el.querySelector("p");
+        p.textContent = "a";
+        editor.shared.history.addStep();
+        expect(editor.shared.history.canUndo()).toBe(false);
     });
 });
 


### PR DESCRIPTION
there is already this todo that seems to be aware of it
> @todo: this removes mutation records that change the node reference.
