### PR TITLE
[FIX] website_sale: use sudo to retrieve company currency

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -131,7 +131,7 @@ class Website(models.Model):
     @api.depends('all_pricelist_ids', 'pricelist_id', 'company_id')
     def _compute_currency_id(self):
         for website in self:
-            website.currency_id = website.pricelist_id.currency_id or website.company_id.currency_id
+            website.currency_id = website.pricelist_id.currency_id or website.company_id.sudo().currency_id
 
     def _compute_enabled_delivery(self):
         for website in self:


### PR DESCRIPTION
A multi-company issue can occur when a user from another company tries to access products belonging to a different company.

Steps to reproduce:
1. Create a e-commerce website without a pricelist on company A
2. Create a user assigned with only access to company B
3. Connect with this user and try to access the products on the website of company A

An error will be raised because the user does not have access to company A.

opw-4983506