### PR TITLE
[FIX] web: Fix invisible icons in dropdown items

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.scss
+++ b/addons/web/static/src/core/select_menu/select_menu.scss
@@ -65,10 +65,10 @@
             top: $dropdown-padding-y * -1;
         }
     }
-}
 
-.dropdown-menu:not(.o_bottom_sheet) .o-dropdown-item:before {
-    display: none;
+    &:not(.o_bottom_sheet) .o-dropdown-item:before {
+        display: none;
+    }
 }
 
 .o_bottom_sheet .o_select_menu_menu {

--- a/addons/web/static/tests/core/dropdown/dropdown_item.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown_item.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click } from "@odoo/hoot-dom";
+import { click, queryOne } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { Component, xml } from "@odoo/owl";
 
@@ -10,6 +10,15 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 const DROPDOWN_TOGGLE = ".o-dropdown.dropdown-toggle";
 const DROPDOWN_MENU = ".o-dropdown--menu.dropdown-menu";
 const DROPDOWN_ITEM = ".o-dropdown-item.dropdown-item:not(.o-dropdown)";
+
+function getHexcode(selector, pseudoSelector) {
+    const content = getComputedStyle(queryOne(selector), pseudoSelector).content;
+    if (content !== "none") {
+        return "\\" + content.replace(/['"]/g, "").charCodeAt(0).toString(16);
+    } else {
+        return content;
+    }
+}
 
 test("can be rendered as <span/>", async () => {
     class Parent extends Component {
@@ -102,4 +111,56 @@ test("can be styled", async () => {
     await animationFrame();
     expect(DROPDOWN_MENU).toHaveClass("test-menu");
     expect(DROPDOWN_ITEM).toHaveClass("test-dropdown-item");
+});
+
+test.tags("desktop");
+test("'active' and 'selected' classes shows a checked icon", async () => {
+    class Parent extends Component {
+        static components = { Dropdown, DropdownItem };
+        static props = [];
+        static template = xml`
+                <Dropdown menuClass="'test-menu'">
+                    <button class="test-toggler">Coucou</button>
+                    <t t-set-slot="content">
+                        <DropdownItem class="'no-check'">Item</DropdownItem>
+                        <DropdownItem class="'selected'">Item</DropdownItem>
+                        <DropdownItem class="'active'">Item</DropdownItem>
+                    </t>
+                </Dropdown>
+            `;
+    }
+
+    await mountWithCleanup(Parent);
+    await click(DROPDOWN_TOGGLE);
+    await animationFrame();
+
+    expect(getHexcode(".o-dropdown-item.no-check", ":before")).toEqual("none");
+    expect(getHexcode(".o-dropdown-item.selected", ":before")).toEqual("\\f00c");
+    expect(getHexcode(".o-dropdown-item.active", ":before")).toEqual("\\f00c");
+});
+
+test.tags("mobile");
+test("'active' and 'selected' classes shows a checked icon (mobile)", async () => {
+    class Parent extends Component {
+        static components = { Dropdown, DropdownItem };
+        static props = [];
+        static template = xml`
+                <Dropdown menuClass="'test-menu'">
+                    <button class="test-toggler">Coucou</button>
+                    <t t-set-slot="content">
+                        <DropdownItem class="'no-check'">Item</DropdownItem>
+                        <DropdownItem class="'selected'">Item</DropdownItem>
+                        <DropdownItem class="'active'">Item</DropdownItem>
+                    </t>
+                </Dropdown>
+            `;
+    }
+
+    await mountWithCleanup(Parent);
+    await click(DROPDOWN_TOGGLE);
+    await animationFrame();
+
+    expect(getHexcode(".o-dropdown-item.no-check", "::after")).toEqual("none");
+    expect(getHexcode(".o-dropdown-item.selected", "::after")).toEqual("\\f00c");
+    expect(getHexcode(".o-dropdown-item.active", "::after")).toEqual("\\f00c");
 });


### PR DESCRIPTION
Some icons such as smalls "v" for selected dropdown items where not displayed do to a too permissive css selector. This commit fixes that by making the selector only affect SelectMenu components.

Task: [5003179](https://www.odoo.com/odoo/project/133/tasks/5003179)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
