### PR TITLE
[FIX] base: disable strict mode when merging pdfs using pypdf2

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -668,7 +668,7 @@ class IrActionsReport(models.Model):
         writer = PdfFileWriter()
         for stream in streams:
             try:
-                reader = PdfFileReader(stream)
+                reader = PdfFileReader(stream, strict=False)
                 writer.appendPagesFromReader(reader)
             except (PdfReadError, TypeError, NotImplementedError, ValueError):
                 # TODO : make custom_error_handler a parameter in master


### PR DESCRIPTION
**Issue description:**
The `pypdf2` library uses `strict=True` by default.
In this mode, if the library fails to parse any part of the PDF, it will stop with an error. This was often triggered by PDFs containing special characters (e.g., ü) or non-standard font definitions, causing errors in the `pypdf2` library.

**Steps to reproduce:**
- Have multiple PDF invoices with some special characters like "ü".
- Import two or more of those PDFs as vendor bills and confirm them.
- From the vendor bills list, select two or more, then download - "original bill".
- The merge operation fails with a `pypdf2` parsing error. 
(Note: Downloading a single bill works as the `_merge_pdfs` method is not called.)

**Solution:**
The `PdfReader` object within the `_merge_pdfs` method is now initialized with `strict=False`.
This solution is already used in other modules using `pypdf2`.
This change makes the parser more lenient, allowing it to bypass errors in non-standard PDFs and complete the merge operation. While this prevents the process from crashing,
some malformed parts of a PDF might not be rendered perfectly.

opw-4991601

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
