### PR TITLE
[FIX] web: prevent SelectMenu popover overflow

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.scss
+++ b/addons/web/static/src/core/select_menu/select_menu.scss
@@ -66,8 +66,12 @@
         }
     }
 
-    &:not(.o_bottom_sheet) .o-dropdown-item:before {
-        display: none;
+    &:not(.o_bottom_sheet) {
+        max-height: 300px;
+
+        .o-dropdown-item:before {
+            display: none;
+        }
     }
 }
 


### PR DESCRIPTION
This commit reworks the maxHeight calculation when positioning a popover. Previously, the 'fit' variant was not supported, which made SelectMenu's get out of the window when the list is too long.

Also, the commit respects the max-height that might have been given for dropdowns. 70vh is set by default, but it is possible to have a custom max-height for a menu, while the computation of the hook would override this height by setting the attribute on the element.

It all comes from a feedback when using a selection field in a form view with many available options and items getting out of the window. We may also prefer to have less visible elements on the list in that case, and use a scrolling area similar to the many2one height, instead of having to move the pointer to more than ~8 choices.

Changes have also been made in the position_hook, because the issue would still be present with a smaller window height: for example if the SelectMenu is opened at half of the screen, with a 400px window height. The menu would not have been resized, and some items would be unreachable.

Two tests now cover the case when a max-height has been set on a popper element, while its value is lower than the actual container, but also when the value is greater than the container. In the first case, the given max-height must be respected, in the other case, the calculated max-height must be used.

task-4996554