### PR TITLE
[FIX] hr_version: set _rec_name to 'name' instead of 'employee_id' to fix quick-create

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -27,7 +27,7 @@ class HrVersion(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']  # TODO: remove later ? (see if still needed because contract template)
     _mail_post_access = 'read'
     _order = 'date_version'
-    _rec_name = 'employee_id'
+    _rec_name = 'name'
 
     def _get_default_address_id(self):
         address = self.env.user.company_id.partner_id.address_get(['default'])


### PR DESCRIPTION
Previously, _rec_name was set to 'employee_id', causing quick-create on the Many2one to fail with a type error when typing a new contract template name.
Changing _rec_name to 'name' ensures that the typed string is correctly used to create a new hr.version record, fixing the invalid input syntax error during creation.
Related task: 5005987.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
