### PR TITLE
[FIX] {,website_}sale: get correct pricelist discount for combo items

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -754,6 +754,10 @@ class SaleOrderLine(models.Model):
             if not (line.order_id.pricelist_id and discount_enabled):
                 continue
 
+            if line.combo_item_id:
+                line.discount = line._get_linked_line().discount
+                continue
+
             line.discount = 0.0
 
             if not line.pricelist_item_id._show_discount():

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -42,9 +42,14 @@ class SaleOrderLine(models.Model):
     def _get_displayed_unit_price(self):
         show_tax = self.order_id.website_id.show_line_subtotals_tax_selection
         tax_display = 'total_excluded' if show_tax == 'tax_excluded' else 'total_included'
+        is_combo = self.product_type == 'combo'
 
         return self.tax_id.compute_all(
-            self.price_unit, self.currency_id, 1, self.product_id, self.order_partner_id,
+            price_unit=self._get_display_price_ignore_combo() if is_combo else self.price_unit,
+            currency=self.currency_id,
+            quantity=1.0,
+            product=self.product_id,
+            partner=self.order_partner_id,
         )[tax_display]
 
     def _get_displayed_quantity(self):


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a combo product;
2. create a pricelist that gives a 10% discount on the product;
3. go to product's website page;
4. observe the displayed discount;
5. add product to cart;
6. go to checkout.

Issue
-----
The discount has disappeared, instead it displays the original price next to a stricken-through "$ 0.00"

Cause
-----
The `_compute_discount` method does not get the correct `pricelist_item_id` for the combo items.

Additionally, on checkout, it shows the `price_unit` of the combo line in the strike-through, which is always 0.

Solution
--------
When computing the discount of a combo item, retrieve the discount of its linked line, which has the correct value.

Additionally, when displaying a combo product in eCommerce, use `_get_display_price_ignore_combo` instead of the `price_unit`.

opw-4968848