### PR TITLE
[FIX] core: preserve translated values in cache

### DIFF
--- a/odoo/addons/test_new_api/tests/test_related_translation.py
+++ b/odoo/addons/test_new_api/tests/test_related_translation.py
@@ -192,6 +192,18 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
         self.assertEqual(self.test3.with_context(lang='en_US').html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
         self.assertEqual(self.test3.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
 
+    def test_write_from_related_term_more(self):
+        # same as above, but making sure that the related field's cache is invalidated
+        self.assertEqual(self.test1.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test1.with_context(lang='fr_FR').html, '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test2.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test2.with_context(lang='fr_FR').html, '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.test2.with_context(lang='fr_FR').html = '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>'
+        self.assertEqual(self.test1.with_context(lang='en_US').html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test1.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test2.with_context(lang='en_US').html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test2.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
     def test_delay_write_from_related_term(self):
         self.test3.with_context(lang='fr_FR', delay_translations=True).html = '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>'
         self.assertEqual(self.test1.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
@@ -265,3 +277,74 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
         self.assertEqual(self.test3.with_context(lang='en_US').mapped('related_id.name'), ['New knife'])
         self.assertEqual(self.test3.with_context(lang='fr_FR').mapped('name'), ['Nouveau couteau'])
         self.assertEqual(self.test3.with_context(lang='fr_FR').mapped('related_id.name'), ['Nouveau couteau'])
+
+    def test_new_records(self):
+        self.env['res.lang']._activate_lang('nl_NL')
+        model = self.env['test_new_api.related_translation_1']
+
+        # The value in env lang should persist after reading the second lang value
+        record_en = model.new({'name': 'en'})
+        record_fr = record_en.with_context(lang='fr_FR')
+        record_nl = record_fr.with_context(lang='nl_NL')
+        self.assertEqual(record_fr.name, 'en')
+        self.assertEqual(record_en.name, 'en')
+
+        record_fr.name = 'fr'
+        self.assertEqual(record_en.name, 'en')
+        self.assertEqual(record_fr.name, 'fr')
+        self.assertEqual(record_nl.name, 'en')
+
+        # The value in second lang should persist after reading the env lang value
+        record_fr = model.with_context(lang='fr_FR').new({'name': 'fr'})
+        record_en = record_fr.with_context(lang=None)
+        record_nl = record_fr.with_context(lang='nl_NL')
+        self.assertEqual(record_en.name, 'fr')
+        self.assertEqual(record_nl.name, 'fr')
+        self.assertEqual(record_fr.name, 'fr')
+
+        # get() on a third language should fallback to the value in en_US that was set by default
+        record_fr = model.with_context(lang='fr_FR').new({'name': 'fr'})
+        record_en = record_fr.with_context(lang=None)
+        record_nl = record_fr.with_context(lang='nl_NL')
+        self.assertEqual(record_nl.name, 'fr')
+        self.assertEqual(record_fr.name, 'fr')
+        self.assertEqual(record_en.name, 'fr')
+
+        # _update_cache should not nullify the values in other langs
+        record_en = model.new({'name': 'en'})
+        record_fr = record_en.with_context(lang='fr_FR')
+        record_fr._update_cache({'name': 'fr'}, validate=False)
+        self.assertEqual(record_en.name, 'en')
+        self.assertEqual(record_fr.name, 'fr')
+
+        # update should not nullify the values in other langs
+        record_en = model.new({'name': 'en'})
+        record_fr = record_en.with_context(lang='fr_FR')
+        record_fr.name = 'fr'
+        self.assertEqual(record_en.name, 'en')
+        self.assertEqual(record_fr.name, 'fr')
+
+        # check with computed field
+        child_en = self.env['test_new_api.related_translation_2'].new({'related_id': record_en.id})
+        child_fr = child_en.with_context(lang='fr_FR')
+        self.assertEqual(child_fr.name, 'fr')
+        self.assertEqual(child_en.name, 'en')
+        self.assertEqual(child_fr.computed_name, 'fr')
+        self.assertEqual(child_en.computed_name, 'en')
+
+    def test_new_records_html(self):
+        model = self.env['test_new_api.related_translation_1']
+
+        record_en = model.create({'html': '<p>Knife</p><p>Fork</p><p>Spoon</p>'})
+        record_fr = record_en.with_context(lang='fr_FR')
+        record_fr.html = '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>'
+        # expected behavior since the user `write` instead of `update_field_translations`
+        self.assertEqual(record_en.html, '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(record_fr.html, '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
+        record_en = model.new({'html': '<p>Knife</p><p>Fork</p><p>Spoon</p>'})
+        record_fr = record_en.with_context(lang='fr_FR')
+        record_fr.html = '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>'
+        # inconsistent behavior but usually users don't care or may even be happy about it
+        self.assertEqual(record_en.html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(record_fr.html, '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>')

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -998,6 +998,8 @@ class Cache(object):
             cache_value = field_cache[record._ids[0]]
             if field.translate and cache_value is not None:
                 lang = field._lang(record.env)
+                if not (field.compute or field.store and record._origin):
+                    return cache_value.get(lang, cache_value.get('en_US'))
                 return cache_value[lang]
             return cache_value
         except KeyError:
@@ -1024,6 +1026,8 @@ class Cache(object):
             lang = record.env.lang or 'en_US'
             cache_value = field_cache.get(record_id) or {}
             cache_value[lang] = value
+            if not (field.compute or field.store and record._origin):
+                cache_value.setdefault('en_US', value)
             value = cache_value
 
         field_cache[record_id] = value
@@ -1057,15 +1061,17 @@ class Cache(object):
         """
         if field.translate:
             # only for model translated fields
-            lang = records.env.lang or 'en_US'
+            lang = (records.env.lang or 'en_US') if dirty else field._lang(records.env)
             field_cache = self._get_field_cache(records, field)
             cache_values = []
-            for id_, value in zip(records._ids, values):
+            for record, value in zip(records, values):
                 if value is None:
                     cache_values.append(None)
                 else:
-                    cache_value = field_cache.get(id_) or {}
+                    cache_value = field_cache.get(record.id) or {}
                     cache_value[lang] = value
+                    if not (field.compute or field.store and record._origin):
+                        cache_value.setdefault('en_US', value)
                     cache_values.append(cache_value)
             values = cache_values
 
@@ -1198,7 +1204,7 @@ class Cache(object):
         """ Return the subset of ``records`` that has not ``value`` for ``field``. """
         field_cache = self._get_field_cache(records, field)
         if field.translate:
-            lang = records.env.lang or 'en_US'
+            lang = field._lang(records.env)
 
             def get_value(id_):
                 cache_value = field_cache[id_]

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1822,8 +1822,13 @@ class _String(Field):
 
         # not dirty fields
         if not dirty:
-            lang = self._lang(records.env)
-            cache.update_raw(records, self, [{lang: cache_value} for _id in records._ids], dirty=False)
+            if self.compute and self.inverse:
+                # invalidate the values in other languages to force their recomputation
+                lang = self._lang(records.env)
+                values = [{lang: cache_value} for _id in records._ids]
+                cache.update_raw(records, self, values, dirty=False)
+            else:
+                cache.update(records, self, itertools.repeat(cache_value), dirty=False)
             return
 
         # model translation


### PR DESCRIPTION
Steps to reproduce the issue:
1. Install a second language (eg, ar_001) and `product`
2. Start odoo shell
3. Run the following:

`(env := env(context=dict(env.context,lang='ar_001')))['product.template'].new({'name':'test'}).with_context(lang='en_US').name`

Current behavior before PR:
The `get` method of the cache will not find a value for the `en_US` language and set the value stored in the env language to a default (`None` in this case) after raising `CacheMiss`

Desired behavior after PR is merged:
We can read and write translatable fields in different languages on transient records without data loss.

opw-4943458
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
