### PR TITLE
[FIX] website_sale: fix category list snippet name, selector issues

### DIFF
--- a/addons/website_sale/views/snippets/s_dynamic_snippet_categories.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_categories.xml
@@ -15,10 +15,11 @@
 
     <template id="s_dynamic_snippet_category_list" name="Category List">
         <t t-call="website_sale.s_dynamic_snippet_category_template">
-            <t t-set="snippet_name" t-value="'s_dynamic_snippet_category'"/>
+            <t t-set="snippet_name" t-value="'s_dynamic_snippet_category_list'"/>
             <t
                 t-set="snippet_classes"
-                t-value="'oe_website_sale s_dynamic_category_clickable_items'"
+                t-value="'oe_website_sale s_dynamic_category_clickable_items
+                          s_dynamic_snippet_category'"
             />
             <t t-set="main_page_url" t-value="'/shop'"/>
             <t t-call="website_sale.s_dynamic_snippet_category_preview_data"/>


### PR DESCRIPTION
Follow up of PR https://github.com/odoo/odoo/pull/208574 that introduced category list snippet and its name, selector related issue.

For Error https://runbot.odoo.com/odoo/runbot.build.error/230544 :

Steps:
- Open website app and select Edit
- Drop category list snippet on the page.
- It has data-snippet as 's_dynamic_snippet_category'

Issue:
- Test 'test_03_snippets_all_drag_and_drop' throw error as it will not find
  snippet with such name.

Cause:
- snippet name is assigned wrong snippet name that is
  (s_dynamic_snippet_category)

Fix:
- 's_dynamic_snippet_category_list' is the correct snippet name to be
  replaced with.