### PR TITLE
[FIX] html_builder: remove `savePlugin` dependency from drag and drop

### DIFF
--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -42,6 +42,9 @@ export class SavePlugin extends Plugin {
             // }
         ],
         get_dirty_els: () => this.editable.querySelectorAll(".o_dirty"),
+        // Do not change the sequence of this resource, it must stay the first
+        // one to avoid marking dirty when not needed during the drag and drop.
+        on_prepare_drag_handlers: withSequence(0, this.ignoreDirty.bind(this)),
     };
 
     setup() {

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -246,7 +246,6 @@ export class BlockTab extends Component {
                     this.shared.dropzone.removeDropzones();
                     // Undo the changes needed to ease the drag and drop.
                     this.dragState.restoreCallbacks?.forEach((restore) => restore());
-                    this.dragState.restoreDirty();
                     restoreDragSavePoint();
                 };
                 this.hideSnippetToolTip?.();
@@ -257,10 +256,8 @@ export class BlockTab extends Component {
                 this.dragState = {};
                 dropzoneEls = [];
 
-                // Stop marking the elements with mutations as dirty.
-                this.dragState.restoreDirty = this.shared.savePlugin.ignoreDirty();
-
-                // Make some changes on the page to ease the drag and drop.
+                // Stop marking the elements with mutations as dirty and make
+                // some changes on the page to ease the drag and drop.
                 const restoreCallbacks = [];
                 for (const prepareDrag of this.env.editor.getResource("on_prepare_drag_handlers")) {
                     const restore = prepareDrag();
@@ -383,10 +380,10 @@ export class BlockTab extends Component {
                 }
 
                 if (currentDropzoneEl) {
-                    // Undo the changes needed to ease the drag and drop.
+                    // Undo the changes needed to ease the drag and drop and
+                    // re-allow to mark dirty.
                     this.dragState.restoreCallbacks.forEach((restore) => restore());
                     this.dragState.restoreCallbacks = null;
-                    this.dragState.restoreDirty();
 
                     currentDropzoneEl.after(snippetEl);
                     this.shared.dropzone.removeDropzones();


### PR DESCRIPTION
In commit [1], in order to prevent the drag and drop from marking unwanted elements as dirty, a dependency to the `savePlugin` was added to use its `ignoreDirty` shared function. However, this dependency is problematic for the upcoming `mass_mailing` refactoring, as it will not use this plugin.

This commit uses the `on_prepare_drag_handlers` resource instead, to remove that dependency.

[1]: 6fdf188fdf5cfdc11e5e1a8429d0a652054344de

task-4367641

Co-authored-by: Damien Abeloos <abd@odoo.com>