### PR TITLE
[FIX] payment_razorpay: fix proxy call in onboarding

### DIFF
--- a/addons/payment_razorpay/controllers/onboarding.py
+++ b/addons/payment_razorpay/controllers/onboarding.py
@@ -54,7 +54,7 @@ class RazorpayController(Controller):
         )
         try:
             response_content = provider_sudo._send_api_request(
-                'POST', '/get_access_token', json=proxy_payload
+                'POST', '/get_access_token', json=proxy_payload, is_proxy_request=True
             )
         except ValidationError as e:
             return request.render(


### PR DESCRIPTION
Fix the lack of 'is_proxy_request' parameter, when the api request to get access token is made. This call should be made to odoo proxy server instad of Mercado Pago, as it is a part of OAuth onboarding process.