### PR TITLE
[FIX] base_import: TypeError when looking up image mimetype

### DIFF
--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -201,6 +201,8 @@ if magic:
         _guesser = ms.buffer
 
     def guess_mimetype(bin_data, default=None):
+        if isinstance(bin_data, bytearray):
+            bin_data = bytes(bin_data[:1024])
         mimetype = _guesser(bin_data[:1024])
         # upgrade incorrect mimetype to official one, fixed upstream
         # https://github.com/file/file/commit/1a08bb5c235700ba623ffa6f3c95938fe295b262


### PR DESCRIPTION
Currently on SaaS it is not possible to import field image_1920 from file as the operation fails

Steps to reproduce:
- Have python-magic library installed
- Products > Import records
- Upload a file containing an URL as image_1920
- Test upload

Upload fill fail with error
`Could not retrieve URL: <img-url> [image_1920: L1]: argument 2: TypeError: wrong type`

Investigation:
It occurs because the python-magic library does not work with bytearray

opw-5004768
