### PR TITLE
[FIX] web: Fix company switcher navigation and select all visible

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -129,6 +129,7 @@ export class Dropdown extends Component {
         this.group = useDropdownGroup();
 
         this.navigation = useNavigation(this.menuRef, {
+            shouldRegisterHotkeys: false,
             isNavigationAvailable: () => this.state.isOpen,
             getItems: () => {
                 if (this.state.isOpen && this.menuRef.el) {
@@ -350,6 +351,7 @@ export class Dropdown extends Component {
     onOpened() {
         this._focusedElBeforeOpen = document.activeElement;
         this.activeEl = this.uiService.activeElement;
+        this.navigation.registerHotkeys();
         this.navigation.update();
         this.props.onOpened?.();
         this.props.onStateChanged?.(true);
@@ -367,6 +369,7 @@ export class Dropdown extends Component {
     }
 
     onClosed() {
+        this.navigation.unregisterHotkeys();
         this.navigation.update();
         this.props.onStateChanged?.(false);
         delete this.activeEl;

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -30,10 +30,10 @@
     <div class="d-flex flex-row pe-2 mb-2" t-att-class="{ 'visually-hidden': !state.showFilter }">
         <div
             role="menuitemcheckbox"
-            t-att-aria-checked="companySelector.selectedCompaniesIds.length > 0 ? 'true' : 'false'"
-            t-att-aria-label="companySelector.selectedCompaniesIds.length > 0 ? 'Deselect all' : 'Select all'"
-            t-att-title="companySelector.selectedCompaniesIds.length > 0 ? 'Deselect all' : 'Select all'"
-            t-on-click="() => companySelector.selectAll()"
+            t-att-aria-checked="hasSelectedCompanies ? 'true' : 'false'"
+            t-att-aria-label="hasSelectedCompanies ? 'Deselect all' : 'Select all'"
+            t-att-title="hasSelectedCompanies ? 'Deselect all' : 'Select all'"
+            t-on-click="() => this.selectAll()"
         >
             <span class="btn border-0 pt-2 px-2" t-att-class="selectAllClass">
                 <i class="fa fa-fw" t-att-class="selectAllIcon"/>
@@ -59,7 +59,7 @@
     </div>
 
     <div class="o_switch_company_menu_items">
-        <t t-foreach="companiesEntries" t-as="entry" t-key="entry.company.id">
+        <t t-foreach="visibleCompanies" t-as="entry" t-key="entry.company.id">
             <SwitchCompanyItem company="entry.company" level="entry.level"/>
         </t>
     </div>

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -1488,8 +1488,7 @@ test("multi-level dropdown: unsubscribe all keynav when root destroyed", async (
 
     await mountWithCleanup(Parent);
     expect(DROPDOWN_MENU).toHaveCount(0);
-    expect(registeredHotkeys.size).toBe(10);
-    checkKeys(registeredHotkeys);
+    expect(registeredHotkeys.size).toBe(0);
 
     // Open dropdowns one by one
     await click(".first");
@@ -1510,7 +1509,7 @@ test("multi-level dropdown: unsubscribe all keynav when root destroyed", async (
     await press("escape");
     await animationFrame();
     expect(DROPDOWN_MENU).toHaveCount(2);
-    expect(removedHotkeys.size).toBe(0);
+    checkKeys(removedHotkeys);
 
     // Reset hover
     await hover(getFixture());
@@ -1519,7 +1518,7 @@ test("multi-level dropdown: unsubscribe all keynav when root destroyed", async (
     await hover(".third");
     await animationFrame();
     expect(DROPDOWN_MENU).toHaveCount(3);
-    expect(registeredHotkeys.size).toBe(0);
+    checkKeys(registeredHotkeys);
 
     // Close third, second and first
     await press("escape");

--- a/addons/web/static/tests/webclient/switch_company_menu.test.js
+++ b/addons/web/static/tests/webclient/switch_company_menu.test.js
@@ -607,3 +607,40 @@ test("select and de-select all", async () => {
     expect("[role=menuitemcheckbox][title='Select all'] i").toHaveClass("fa-square-o");
     expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])").toHaveCount(0);
 });
+
+test("de-select only changes visible companies", async () => {
+    await createSwitchCompanyMenu();
+    await openCompanyMenu();
+
+    // Show search
+    await edit(" ");
+    await toggleCompany(4);
+    expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])").toHaveCount(2);
+
+    // Show search
+    await contains("input").edit("m");
+    await animationFrame();
+
+    // One company is selected, unselect all
+    await contains("[role=menuitemcheckbox][title='Deselect all']").click();
+    expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])").toHaveCount(0);
+
+    // Hidden company is still selected
+    await contains("input").clear();
+    await animationFrame();
+    expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])").toHaveCount(1);
+
+    // Filter and select all visible companies
+    await contains("input").edit("m");
+    await animationFrame();
+    await contains("[role=menuitemcheckbox][title='Select all']").click();
+    expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])").toHaveCount(3);
+
+    // Hidden company is unchanged
+    await contains("input").clear();
+    await animationFrame();
+    expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])").toHaveCount(4);
+    expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=false])").toHaveCount(
+        1
+    );
+});


### PR DESCRIPTION
The navigation hook registers hotkeys when created but it can sometimes cause issues if other hotkeys are registered afterwards which caused the priority to be on the new hotkeys, even if the company switcher is opened after. We now add the hotkeys only when it opens.

Also, the select and deselect all feature now only affects visible companies when searching.

Task: 4976664

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
