### PR TITLE
[FIX] hr: explicitly define view_mode for department and employee actions

### DIFF
--- a/addons/hr/views/hr_department_views.xml
+++ b/addons/hr/views/hr_department_views.xml
@@ -139,6 +139,7 @@
         <record id="hr_department_tree_action" model="ir.actions.act_window">
             <field name="name">Departments</field>
             <field name="res_model">hr.department</field>
+            <field name="view_mode">list,form,kanban</field>
             <field name="search_view_id" ref="view_department_filter"/>
             <field name="domain">[("has_read_access", "=", True)]</field>
             <field name="help" type="html">
@@ -172,6 +173,7 @@
         <record id="hr_department_kanban_action" model="ir.actions.act_window">
             <field name="name">Departments</field>
             <field name="res_model">hr.department</field>
+            <field name="view_mode">kanban,list,form</field>
             <field name="path">departments</field>
             <field name="domain">[("has_read_access", "=", True)]</field>
             <field name="search_view_id" ref="view_department_filter"/>

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -167,6 +167,7 @@
         <record id="hr_employee_public_action" model="ir.actions.act_window">
             <field name="name">Employees</field>
             <field name="res_model">hr.employee.public</field>
+            <field name="view_mode">kanban,list,form</field>
             <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
             <field name="context">{'chat_icon': True}</field>
             <field name="view_id" eval="False"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -388,6 +388,7 @@
             <field name="name">Employees</field>
             <field name="path">employees</field>
             <field name="res_model">hr.employee</field>
+            <field name="view_mode">kanban,list,form,activity,graph,pivot</field>
             <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
             <field name="context">{'chat_icon': True}</field>
             <field name="view_id" eval="False"/>


### PR DESCRIPTION
**Steps to reproduce:**
- Install `hr` and `web_studio`.
- Go to Employees → click Studio icon.
- Views → activate Calendar view.

**Observation:**
- Existing views (activity, kanban, pivot, etc.) disappear from the view types.

**Issue:**
- After commit https://github.com/odoo/odoo/pull/160280/commits/e67ed24320c555c0cc63d59aa4921267e10a472d, view_mode in actions was removed, so only default (list, form) and Studio-added views remain.

**Solution:**
- Add view_mode to the action to preserve standard views after customisation.

opw-4967654


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
