### PR TITLE
[IMP] dun_and_bradstreet: send `industry_code` instead of `industry_id`

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -44,6 +44,13 @@ class ResPartner(models.Model):
         return iap_data
 
     @api.model
+    def _iap_replace_industry_code(self, iap_data):
+        if industry_code := iap_data.pop('industry_code', False):
+            if industry := self.env.ref(f'base.res_partner_industry_{industry_code}', raise_if_not_found=False):
+                iap_data['industry_id'] = {'id': industry.id, 'display_name': industry.display_name}
+        return iap_data
+
+    @api.model
     def _iap_replace_language_codes(self, iap_data):
         if lang := iap_data.pop('preferred_language', False):
             if installed_lang := (
@@ -57,6 +64,7 @@ class ResPartner(models.Model):
     @api.model
     def _format_data_company(self, iap_data):
         self._iap_replace_location_codes(iap_data)
+        self._iap_replace_industry_code(iap_data)
         self._iap_replace_language_codes(iap_data)
         return iap_data
 

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -66,7 +66,7 @@ export class PartnerAutoCompleteCharField extends CharField {
         }
 
         // Format the many2one fields
-        const many2oneFields = ['country_id', 'state_id'];
+        const many2oneFields = ['country_id', 'state_id', 'industry_id'];
         many2oneFields.forEach((field) => {
             if (data.company[field]) {
                 data.company[field] = [data.company[field].id, data.company[field].display_name];


### PR DESCRIPTION
Ticket #4992568 highlighted a weird way of sending the industry from IAP to the Odoo client. Before this commit, we were sending the IAP psql id of the industry to the client. There, it would be use as is. It works because these industries haven't been changed in years and they're created in the same order.
However the ticket highlighted the fact that a user can edit/delete/create its own industries, therefore some ids that exist on IAP might not exist on the client's Odoo instance. This resulted in a traceback on the client's side.

With this commit, we now send the industry code (the ISIC: International Standard Industrial Classification) instead to the client. There it can correctly be mapped if it exists on the client's DB (e.g. not deleted)

opw-4992568

https://github.com/odoo/iap-apps/pull/1152