### PR TITLE
[FIX] sale_pdf_quote_builder: show zero values in quotation docs

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -142,7 +142,7 @@ class IrActionsReport(models.Model):
                     formatted_value_ = format_amount(
                         self.env, value_, currency_id_ or order.currency_id
                     )
-                elif not value_:
+                elif not value_ and field_type_ not in {'integer', 'float'}:
                     formatted_value_ = ''
                 elif field_type_ == 'date':
                     formatted_value_ = format_date(self.env, value_)

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -116,6 +116,7 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
         self.sale_order.commitment_date = '2121-12-21 12:21:12'
         sol_1, sol_2 = self.sale_order.order_line
         sol_1.update({
+            'sequence': 0,
             'discount': 4.99,
             'tax_id': [
                 Command.create({'name': "test tax1"}),
@@ -143,7 +144,7 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
             'date_test': "11/04/2020",
             'datetime_test': "12/21/2121 13:21:12",
             'float_test': "4.99",
-            'integer_test': "10",
+            'integer_test': "0",
             'selection_test': "Quotation",
             'monetary_test': self.sale_order.currency_id.format(720.01),
 


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Using Studio, add an integer or float field to the sale order form;
2. upload a PDF using forms as a quotation header[^1];
3. add a mapping of the form field to the studio field;
4. create a quoation using the header;
5. have the studio field be 0;
6. print quotation.

[^1]: e.g. `tests/files/test_forms.pdf`

Issue
-----
The form field where the zero should be displayed is empty.

Cause
-----
When formatting values, it returns an empty string for any falsy value whose field isn't of type boolean or monetary.

Solution
--------
If the value is falsy, only return the empty string if the field type is not integer or float, this way, the zero value will get formatted in the final `else` as a string value (same as non-zero numeric values).

opw-4937052