### PR TITLE
[FIX] sale_stock: show lots on inter-company invoices

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -61,7 +61,7 @@ class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
     def _should_show_lot_in_invoice(self):
-        return 'customer' in {self.location_id.usage, self.location_dest_id.usage}
+        return 'customer' in {self.location_id.usage, self.location_dest_id.usage} or self.env.ref('stock.stock_location_inter_company') in (self.location_id, self.location_dest_id)
 
 
 class ProcurementGroup(models.Model):


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable: "show serial numbers/lot on invoice"
- Create a product tracked by SN and put SN001 in stock
- With company 1, create and confirm an SO for company 2 (`partner_id`)
- Validate the delivery (using SN001)
- Create and confirm the invoice associated to the SO.
- Print the delivery
#### > The lots and serial numbers are not displayed but they would be for any other customer type.

### Cause of the issue:

Since 17.2 (commit 08536d687880ca6d9ad5c37b639c0ad4c2599d74), the `location_dest_id` of a delivery for a inter-company partner is set to the `Inter-company transit` location:
https://github.com/odoo/odoo/blob/23e63f4394c72939286e00d54ffd5da98d034d24/addons/stock/data/stock_data.xml#L54-L60 However, the lots are only displayed on the invoice if the usage of either the location or destination of the move line is `customer`: https://github.com/odoo/odoo/blob/23e63f4394c72939286e00d54ffd5da98d034d24/addons/sale_stock/models/stock.py#L60-L64 which fails for the `Inter-company transit` which is a transit location.

opw-4962700
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
