### PR TITLE
[IMP] website_sale: consistent padding-bottom for chips product design

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -532,8 +532,9 @@
 }
 
 .o_wsale_products_opt_design_cards {
+    --_padding-base: #{map-get($spacers, 2)};
     --o-wsale-card-border-width: 1px;
-    --o-wsale-card-info-padding: #{map-get($spacers, 2)} #{map-get($spacers, 2)} #{map-get($spacers, 3)};
+    --o-wsale-card-info-padding: #{map-get($spacers, 2)} var(--_padding-base) var(--_padding-base);
     --o-wsale-card-info-grow: 1;
     --o-wsale-card-border-radius: var(--o-wsale-opt-border-radius, 0px);
     --o-wsale-card-pseudobg-y: 0;
@@ -543,6 +544,20 @@
 
     $-br-top: MAX(0px, calc(var(--o-wsale-card-border-radius) - 1px));
     --o-wsale-card-thumb-border-radius: #{$-br-top} #{$-br-top} 0 0;
+
+    &:where(.o_wsale_products_opt_rounded_5) {
+        --_padding-base: min(#{map-get($spacers, 3)}, max(calc(var(--o-wsale-opt-border-radius) - var(--btn-border-radius)), #{map-get($spacers, 2)}));
+        &.o_wsale_products_opt_actions_onhover {
+            --o-wsale-card-info-padding: #{map-get($spacers, 2)} var(--_padding-base);
+        }
+    }
+
+    &.o_wsale_products_opt_actions_inline {
+        &:where(:not(.o_wsale_products_opt_rounded_0)) {
+            --o-wsale-card-info-padding: #{map-get($spacers, 2)} max(var(--_padding-base), calc(var(--o-wsale-opt-border-radius) - max(var(--btn-border-radius), var(--_padding-base)))) var(--_padding-base);
+        }
+    }
+
 
     &.o_wsale_products_opt_layout_list {
         $-br-top: MAX(0px, calc(var(--o-wsale-opt-border-radius, 0px) - 1px));
@@ -589,6 +604,7 @@
 
     --o-wsale-card-border-width: #{$border-width};
     --o-wsale-card-border-radius: var(--o-wsale-opt-border-radius, 0px);
+    --o-wsale-card-info-padding: #{map-get($spacers, 2)} 0 0 0;
     --o-wsale-card-padding: var(--_padding-base);
     --o-wsale-card-btns-margin-bottom: 0;
     --o-wsale-card-pseudobg-y: 0;
@@ -603,6 +619,9 @@
     }
 
     &:where(:not(.o_wsale_products_opt_rounded_0)) {
+        &.o_wsale_products_opt_actions_inline {
+            --o-wsale-card-info-padding: #{map-get($spacers, 2)} 0 min(#{map-get($spacers, 2)}, calc(var(--o-wsale-opt-border-radius) - calc(var(--_padding-base) + var(--btn-border-radius)))) 0;
+        }
         --o-wsale-card-thumb-border-radius: max(var(--border-radius-sm), calc(var(--o-wsale-opt-border-radius) - var(--_padding-base)));
 
         --_offset-top: calc(var(--o-wsale-card-thumb-border-radius) * 0.1);


### PR DESCRIPTION
This PR changes the behavior of the padding of the chips and thumbnails product design.

The "Chips" design has now its bottom padding that changes based on the roundness of the inner buttons, in addition to being equal to the horizontal padding by default.

| Before | After |
|--------|--------|
| <img width="356" height="435" alt="image" src="https://github.com/user-attachments/assets/0c421986-4119-4bbd-aebf-65062222ee1b" /> | <img width="356" height="428" alt="image" src="https://github.com/user-attachments/assets/d56a79f2-7421-45b0-8239-097b8b2846ea" /> |

The "Cards" design works in the same way, but its horizontal padding changes instead of the bottom one.

| Before | After |
|--------|--------|
| <img width="268" height="356" alt="image" src="https://github.com/user-attachments/assets/b4fd146f-a750-45c7-b549-179f700cbd06" /> | <img width="268" height="361" alt="image" src="https://github.com/user-attachments/assets/1988e418-2e7e-4697-b52f-1f964be56fe9" /> |

task-5003290




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
