### PR TITLE
[FIX] website: fix traceback when editing 'Contact Us' page website

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -5,7 +5,7 @@
     <BuilderRow t-if="!modelCantChange and this.state.models"
             label.translate="Action" preview="false">
         <BuilderSelect>
-            <t t-foreach="this.state.models" t-as="model" t-key="model.name">
+            <t t-foreach="this.state.models" t-as="model" t-key="model.id">
                 <BuilderSelectItem t-out="model.website_form_label" action="'selectAction'" actionValue="model.id.toString()"/>
             </t>
         </BuilderSelect>


### PR DESCRIPTION
**Steps to reproduce:**

-Install the Website module.
-Change the language to Italian.
-Enable debug mode.
-Go to the website.
-Navigate to Website → Contact Us  page
-Click  to Edit
-Try to edit the Question block.

**Issue:**
A traceback occurs with the error:
Uncaught Promise > Got duplicate key in t-foreach: Contatto

**Cause:**
https://github.com/odoo/odoo/blob/d69402a13914428fe6e05cc772157f0eec2c5627/addons/website/static/src/builder/plugins/form/form_option.xml#L7-L11
The t-foreach loop was using model.name as the key, which can result in duplicates (e.g., multiple records with the name 'Contatto'), causing the editor to fail.

**Solution:**
Use model.id as the t-foreach key instead, ensuring uniqueness for all records.

**opw**- 4972693
