### PR TITLE
[FIX] html_builder: reset history on save

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -212,7 +212,7 @@ export class Builder extends Component {
     }
 
     discard() {
-        if (this.state.canUndo) {
+        if (this.editor.shared.history.canUndo()) {
             this.dialog.add(ConfirmationDialog, {
                 body: _t(
                     "If you discard the current edits, all unsaved changes will be lost. You can cancel to return to edit mode."
@@ -288,14 +288,14 @@ export class Builder extends Component {
     }
 
     onBeforeUnload(event) {
-        if (!this.isSaving && this.state.canUndo) {
+        if (!this.isSaving && this.editor.shared.history.canUndo()) {
             event.preventDefault();
             event.returnValue = "Unsaved changes";
         }
     }
 
     async onBeforeLeave() {
-        if (this.state.canUndo && !this.editor.shared.savePlugin.isAlreadySaved()) {
+        if (this.editor.shared.history.canUndo()) {
             let continueProcess = true;
             await new Promise((resolve) => {
                 this.dialog.add(ConfirmationDialog, {

--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -6,7 +6,7 @@ import { uniqueId } from "@web/core/utils/functions";
 
 export class SavePlugin extends Plugin {
     static id = "savePlugin";
-    static shared = ["save", "isAlreadySaved", "saveView", "ignoreDirty"];
+    static shared = ["save", "saveView", "ignoreDirty"];
     static dependencies = ["history"];
 
     resources = {
@@ -102,18 +102,11 @@ export class SavePlugin extends Plugin {
         // used to track dirty out of the editable scope, like header, footer or wrapwrap
         const willSaves = this.getResource("save_handlers").map((c) => c());
         await Promise.all(saveProms.concat(willSaves));
-        this.lastSavedStep = this.dependencies.history.getHistorySteps().at(-1);
+        this.dependencies.history.reset();
     }
 
     groupElementHandler(model, field) {
         return model === "ir.ui.view" && field === "arch" ? uniqueId("view-part-to-save-") : "";
-    }
-
-    isAlreadySaved() {
-        return (
-            !this.dependencies.history.getHistorySteps().length ||
-            this.lastSavedStep === this.dependencies.history.getHistorySteps().at(-1)
-        );
     }
 
     /**

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -2,7 +2,7 @@ import { setSelection } from "@html_editor/../tests/_helpers/selection";
 import { insertText } from "@html_editor/../tests/_helpers/user_actions";
 import { expect, test } from "@odoo/hoot";
 import { animationFrame, click, Deferred, queryOne } from "@odoo/hoot-dom";
-import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { contains, defineActions, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { WebsiteBuilderClientAction } from "@website/client_actions/website_preview/website_builder_action";
 import {
     addActionOption,
@@ -14,9 +14,10 @@ import {
     setupWebsiteBuilder,
     wrapExample,
 } from "./website_helpers";
-import { xml } from "@odoo/owl";
+import { Component, xml } from "@odoo/owl";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
 
 defineWebsiteModels();
 
@@ -262,3 +263,30 @@ function setupSaveAndReloadIframe() {
     });
     return resultSave;
 }
+
+test("'Switch Theme' after a mutation should only ask one confirmation", async () => {
+    class MockSwitchThemeAction extends Component {
+        static props = ["*"];
+        static template = xml`<div class="mock-switch-theme"></div>`;
+    }
+    defineActions([
+        {
+            tag: "__test__switch_theme__action__",
+            xml_id: "website.theme_install_kanban_action",
+            type: "ir.actions.client",
+        },
+    ]);
+    registry.category("actions").add("__test__switch_theme__action__", MockSwitchThemeAction);
+
+    setupSaveAndReloadIframe();
+    const { getEditor, getEditableContent } = await setupWebsiteBuilder(exampleWebsiteContent);
+    await modifyText(getEditor(), getEditableContent());
+    await contains(`.o-snippets-tabs button[data-name="theme"]`).click();
+    await contains(`.o_theme_tab button[data-action-id="switchTheme"]`).click();
+    expect(".modal main").toHaveText(/Changing theme/);
+    await contains(`.modal button:contains(Ok)`).click();
+    expect(".modal").toHaveCount(0, {
+        message: "There should not be the modal telling changes will be lost",
+    });
+    expect(".mock-switch-theme").toHaveCount(1);
+});


### PR DESCRIPTION
Some actions (like "Switch Theme" or "Add Language") perform a save during their `apply` followed by a change of page. The change of page is blocked by a dialog (with a warning about lost changes) because there is a step added after the end of the call to their `apply`.

The commit 30bbe413f1122bf243eb6e073be6fa19dddf984a already fixed similar issues, but did not handled that case (`save` that adds mutations and is called inside `apply`).

By resetting the history at the end of a save, the extra step is not added (unless something actually made more changes after the save).

Steps to reproduce:
- Open website builder
- Drop a snippet (or do an other change)
- In the "Theme" tab, click "Switch Theme"
- A "Confirmation" dialog appears, telling it will save the changes
- Click "Ok"
- Bug: There is a dialog that appears, telling the changes will be lost (The changes won't be lost)

task-4367641
