### PR TITLE
[FIX] website_sale: fix access for website set ribbons

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1041,7 +1041,7 @@ class ProductTemplate(models.Model):
         :rtype: `product.ribbon` recordset
         """
         variant = variant or self.product_variant_id
-        ribbon = variant.variant_ribbon_id or self.website_ribbon_id
+        ribbon = variant.variant_ribbon_id or self.sudo().website_ribbon_id
         if not ribbon:
             # The None check ensures that we do not recompute the ribbons when no ribbons were
             # previously found.


### PR DESCRIPTION
commit 63bb4926868678342c23adc1542229ed8e086dd5 introduced a way to set ribbons dynamically but a sudo was needed to access manually set ones using the website editor




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
