### PR TITLE
[FIX] website_sale: align showcase and chips products attributes

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -587,6 +587,7 @@
 .o_wsale_products_opt_design_chips {
     --_padding-base: calc(#{map-get($spacers, 2)} + calc(var(--o-wsale-products-grid-gap) * 0.25));
 
+    --o-wsale-card-info-position: none;
     --o-wsale-card-border-width: #{$border-width};
     --o-wsale-card-border-radius: var(--o-wsale-opt-border-radius, 0px);
     --o-wsale-card-padding: var(--_padding-base);
@@ -595,8 +596,8 @@
     --o-wsale-card-pseudobg-x: 0;
     --o-wsale-card-btns-inset: var(--_padding-base) var(--_padding-base) auto var(--_padding-base);
 
-    --o-wsale-card-offset-top: calc(var(--_padding-base));
-    --o-wsale-card-offset-x: calc(var(--_padding-base));
+    --o-wsale-card-offset-top: var(--_padding-base);
+    --o-wsale-card-offset-x: var(--_padding-base);
 
     &.o_wsale_products_opt_actions_onhover {
         --o-wsale-card-btns-inset: var(--o-wsale-card-offset-top) var(--o-wsale-card-offset-x) auto var(--o-wsale-card-offset-x);
@@ -610,6 +611,18 @@
 
         --o-wsale-card-offset-top: calc(var(--_padding-base) + var(--_offset-top));
         --o-wsale-card-offset-x: calc(var(--_padding-base) + var(--_offset-h));
+        --o-wsale-ribbon-badge-offset-x: calc(#{map-get($spacers, 2)} + var(--_offset-h));
+    }
+
+    .o_wsale_product_action_row {
+        --o-wsale-card-offset-top: 0px;
+        --o-wsale-card-offset-x: 0px;
+    }
+
+    @include media-breakpoint-up(lg) {
+        .o_wsale_attribute_previewer {
+            width: calc(100% - (var(--o-wsale-card-offset-x) + #{map-get($spacers, 2)}) * 2);
+        }
     }
 }
 .o_wsale_products_opt_design_grid {

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -304,7 +304,7 @@
             --btn-padding-x: var(--o-wsale-card-btns-btn-padding-x, 0.8em);
 
             flex-grow: var(--o-wsale-card-btns-btn-flex-grow);
-            font-size: var(--o-wsale-card-btns-btn-font-size);
+            font-size: var(--o-wsale-card-btns-btn-font-size, var(--btn-font-size));
             min-height: var(--o-wsale-card-btns-btn-min-height);
             align-items: center;
             justify-content: center;
@@ -325,7 +325,7 @@
 
                 .o_label {
                     display: var(--o-wsale-card-btn-submit-label-display,  var(--o-wsale-card-btn-label-display));
-                    font-size: .8em;
+                    font-size: var(--o-wsale-card-btn-submit-label-font-size, .8em);
                     line-height: 1;
                 }
             }
@@ -614,11 +614,6 @@
         --o-wsale-ribbon-badge-offset-x: calc(#{map-get($spacers, 2)} + var(--_offset-h));
     }
 
-    .o_wsale_product_action_row {
-        --o-wsale-card-offset-top: 0px;
-        --o-wsale-card-offset-x: 0px;
-    }
-
     @include media-breakpoint-up(lg) {
         .o_wsale_attribute_previewer {
             width: calc(100% - (var(--o-wsale-card-offset-x) + #{map-get($spacers, 2)}) * 2);
@@ -694,7 +689,7 @@
     --o-wsale-card-info-position: absolute;
     --o-wsale-card-info-muted: var(--o-wsale-card-cc-text, inherit);
     --o-wsale-card-info-inset: 0;
-    --o-wsale-card-info-padding: 3% 2.5%;
+    --o-wsale-card-info-padding: clamp(4%, calc((var(--o-wsale-card-border-radius) * .7)), 6rem) clamp(3.2%, calc((var(--o-wsale-card-border-radius) * .56)), 4.8rem);
     --o-wsale-card-info-description-font-size: MAX(0.86em, 1rem);
     --o-wsale-card-sub-display: contents;
     --o-wsale-card-thumb-min-height: 50vh;
@@ -709,6 +704,9 @@
         rgba(var(--o-wsale-card-cc-bg-rgb), .35),
         rgba(var(--o-wsale-card-cc-bg-rgb), .46)
     );
+
+    // o_label equivalent
+    --o-wsale-card-btn-submit-label-font-size: .8em;
 
     .oe_product {
         &:has(.o_wsale_products_item_title a:hover), &:has(.o_wsale_products_item_title a:focus-visible) {
@@ -759,27 +757,75 @@
         justify-self: end;
         width: 100%;
         justify-content: end;
+
+        .o_product_variant_preview {
+            display: flex;
+            height: 100%;
+
+            .o_wsale_product_ptav_pill {
+                display: flex;
+                align-items: center;
+
+                .o_wsale_product_ptav_pill_label {
+                    font-size: var(--o-wsale-card-btn-submit-label-font-size);
+                }
+            }
+        }
+
+        .css_attribute_color {
+            --o-wsale-css-attribute-color__height: calc(var(--o-wsale-product-variant-preview-height) - var(--o-wsale-css-attribute-color__border-width));
+        }
+
+        span[name="hidden_ptavs_count"] {
+            --link-color-rgb: var(--o-wsale-card-cc-text-rgb);
+            --link-hover-color-rgb: var(--o-wsale-card-cc-text-rgb);
+        }
     }
     @include media-breakpoint-down(sm) {
         --o-wsale-card-btn-label-display: none;
         --o-wsale-card-btn-submit-label-display: none;
     }
+    @include media-breakpoint-down(md) {
+        --o-wsale-card-attribute-previewer-padding: 0;
+    }
     @include media-breakpoint-down(lg) {
         --o-wsale-card-info-title-font-size: calc(#{$h5-font-size} + 1.5vw);
         --o-wsale-card-btn-submit-label-display: inline;
+
+        .o_wsale_attribute_previewer {
+            // Needed else --btn-font-size is 1.5rem outside of .btn class
+            @include rfs($btn-font-size, --btn-font-size-rfs);
+
+            --o-wsale-product-variant-preview-height: MAX(var(--o-wsale-card-btns-btn-min-height), calc(var(--btn-font-size-rfs) + #{$btn-padding-y * 2} + #{$btn-border-width} * 2));
+
+            height: var(--o-wsale-product-variant-preview-height);
+
+            // --o-wsale-card-btns-btn-min-height is em, so the font-size needs to be set.
+            font-size: var(--btn-font-size-rfs);
+
+
+            .o_product_variant_preview .btn {
+                @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $border-radius);
+                --btn-padding-x: var(--o-wsale-card-btns-btn-padding-x, 0.8em);
+
+                font-size: var(--btn-font-size);
+            }
+        }
     }
     @include media-breakpoint-up(lg) {
         --o-wsale-card-info-title-font-size: calc(#{$h4-font-size} + 1.5vw);
-        --o-wsale-card-info-padding: 7% 5%;
+        --o-wsale-card-info-padding: clamp(7%, calc((var(--o-wsale-card-border-radius) * .6)), 8rem) clamp(5.6%, calc((var(--o-wsale-card-border-radius) * .48)), 6.4rem);
         --o-wsale-card-thumb-aspect-ratio: 16/9 !important;
         --o-wsale-card-btns-gap: #{map-get($spacers, 3)};
 
         .o_wsale_attribute_previewer {
-            // TODO:Align attributes and buttons doesn't always work, to improve
-            // margin-bottom: var(--btn-padding-y-lg);
+            --o-wsale-product-variant-preview-height: MAX(var(--o-wsale-card-btns-btn-min-height), calc(#{$btn-padding-y-lg * 2} + #{$btn-font-size-lg} + #{$btn-border-width} * 2));
+
+            height: var(--o-wsale-product-variant-preview-height);
+            font-size: $btn-font-size-lg;
         }
 
-        .o_wsale_product_btn .btn {
+        .btn {
             @include o-wsale-card-btn-lg();
             --btn-padding-x: var(--btn-padding-y);
         }
@@ -1162,6 +1208,7 @@ $_wsale_products_roundness_map: (
         --o-wsale-card-cc-bg: #{$-bg-color};
         --o-wsale-card-cc-bg-rgb: #{to-rgb($-bg-color)};
         --o-wsale-card-cc-text: #{$-text};
+        --o-wsale-card-cc-text-rgb: #{to-rgb($-text)};
         --o-wsale-card-cc-muted: #{$-muted};
         --o-wsale-card-cc-headings: #{$-headings};
         --o-wsale-card-cc-link: #{$-link-color};

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1499,11 +1499,11 @@ body.modal-open:has(.js_sale.o_wsale_product_page) {
     }
 
     .o_wsale_badge.o_left {
-        @include o-position-absolute($top: map-get($spacers, 2), $left: map-get($spacers, 2));
+        @include o-position-absolute($top: map-get($spacers, 2), $left: var(--o-wsale-ribbon-badge-offset-x, map-get($spacers, 2)));
     }
 
     .o_wsale_badge.o_right {
-        @include o-position-absolute($top: map-get($spacers, 2), $right: map-get($spacers, 2));
+        @include o-position-absolute($top: map-get($spacers, 2), $right: var(--o-wsale-ribbon-badge-offset-x, map-get($spacers, 2)));
     }
 
 }

--- a/addons/website_sale/static/src/website_builder/products_design_panel.xml
+++ b/addons/website_sale/static/src/website_builder/products_design_panel.xml
@@ -101,7 +101,7 @@
                 id: 'wsale_design_showcase_list',
                 label: showcaseLabel,
                 type: 'list',
-                className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_showcase',
+                className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_showcase o_wsale_products_opt_rounded_0',
                 img: '/website_sale/static/src/img/products_entries_design/style_list_showcase.svg',
                 suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_thumb_6_5 o_wsale_products_opt_cc o_wsale_products_opt_cc5 o_wsale_products_opt_name_color_regular o_wsale_products_opt_actions_theme',
                 gap: 0,

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -361,7 +361,7 @@
 
     <template id="product_variant_preview">
         <div
-            t-attf-class="o_wsale_attribute_previewer d-flex align-items-center gap-1 flex-nowrap z-1 overflow-hidden {{
+            t-attf-class="o_wsale_attribute_previewer d-flex align-items-center gap-1 flex-nowrap overflow-hidden {{
                 'show_on_hover' if product_ptavs[0]['ptav'].attribute_id.preview_variants == 'hover' and layout_mode != 'list' else ''
             }}"
             t-att-data-hidden-ptav-count="product_ptavs_data.get('hidden_ptavs_count')"
@@ -375,7 +375,7 @@
                     t-value="product_href.split('#')[0] + '#attribute_values=%s' % (selected_attribute_value)"
                 />
                 <a
-                    class="o_product_variant_preview d-none"
+                    class="o_product_variant_preview d-none z-2"
                     t-att-data-variant-image="previewed_ptav['variant_image_url']"
                     t-att-href="variant_href"
                 >
@@ -411,12 +411,13 @@
                     </div>
                     <span
                         t-else=""
-                        t-attf-class="{{'' if ppr == 2 and layout_mode != 'list' else 'btn-sm'}} btn bg-body w-100 text-body text-truncate"
-                        t-out="ptav.name"
-                    />
+                        t-attf-class="{{'' if ppr == 2 and layout_mode != 'list' else 'btn-sm'}} o_wsale_product_ptav_pill btn w-100 bg-body text-body"
+                    >
+                        <span class="o_wsale_product_ptav_pill_label d-block text-truncate" t-out="ptav.name"/>
+                    </span>
                 </a>
             </t>
-            <span name="hidden_ptavs_count" class="d-none ms-1 small">
+            <span name="hidden_ptavs_count" class="d-none ms-1 small z-2">
                 <a t-att-href="product_href"/>
             </span>
         </div>


### PR DESCRIPTION
### Global
- Fixed a bug where the btn-font-size was unset, not taking in account the website theme values.

### Chips
- Set `o_wsale_product_information` to position: none;
- Added width computation on attributes to avoid the `+x` overflowing when there are multiple attributes.
- Review the badge gap with a custom property to follow the attribute alignment when a roundness is applied.
- Review the position of the `o_wsale_product_action_row` (CTA when set on hover)

### Showcase
- Added `o_wsale_products_opt_rounded_0` class by default with the layout to avoid a value of `0` without units (breaking calc())
- Moved `z-2` to the `o_product_variant_preview` to not have the flex-gap interfer with our interaction areas. (+1 z-index to solve issue)
- Align buttons height of the attributes with the `o_wsale_product_btn` accross all viewports.
- Fix misaligment due to the list padding bottom applied on `.o_wsale_attribute_previewer` < md viewports
- Fix wrong text-color on the name="hidden_ptavs_count" (unshown attribute count)
- Improve padding on big border-radius

Note: this PR shares the same commit with https://github.com/odoo/odoo/pull/222863 to avoid conflict if one is merged before the other

task-4997562

| Chips Before | Chips After |
|--------|--------|
| <img width="365" height="445" alt="SCR-20250811-osyh" src="https://github.com/user-attachments/assets/c08e0490-db0d-4e25-a043-dc608fd17a47" /> | <img width="357" height="450" alt="SCR-20250811-osgv" src="https://github.com/user-attachments/assets/940bf41e-4427-422a-8674-dc9732b93358" /> l

| Showcase Before | Showcase After |
| ---- | ---- |
| <img width="1060" height="601" alt="image" src="https://github.com/user-attachments/assets/a44640ad-b4f9-4b47-9069-0f5d7b68654e" /> | <img width="1060" height="596" alt="image" src="https://github.com/user-attachments/assets/180d4697-9153-4213-a7e9-7e995d6b8742" /> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
