### PR TITLE
[FIX] hr: make sure calendar is synced between employee and resource

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -545,7 +545,7 @@ class HrVersion(models.Model):
         for employee, versions in self.grouped('employee_id').items():
             current_version = employee.current_version_id
             for version in versions:
-                if version == current_version:
+                if version == current_version and employee.resource_id.calendar_id != version.resource_calendar_id:
                     employee.resource_id.calendar_id = version.resource_calendar_id
 
     def _get_salary_costs_factor(self):

--- a/addons/hr/models/resource.py
+++ b/addons/hr/models/resource.py
@@ -22,6 +22,7 @@ class ResourceResource(models.Model):
     work_phone = fields.Char(related='employee_id.work_phone')
     show_hr_icon_display = fields.Boolean(related='employee_id.show_hr_icon_display')
     hr_icon_display = fields.Selection(related='employee_id.hr_icon_display')
+    calendar_id = fields.Many2one(inverse='_inverse_calendar_id')
 
     @api.depends('employee_id')
     def _compute_job_title(self):
@@ -51,6 +52,11 @@ class ResourceResource(models.Model):
                 resource.avatar_128 = employee[0].avatar_128
             else:
                 resource.avatar_128 = avatar_per_employee_id[employee[0].id]
+
+    def _inverse_calendar_id(self):
+        for resource in self:
+            if resource.calendar_id != resource.employee_id.resource_calendar_id:
+                resource.employee_id.resource_calendar_id = resource.calendar_id
 
     def _get_calendars_validity_within_period(self, start, end, default_company=None):
         assert start.tzinfo and end.tzinfo

--- a/addons/hr/tests/test_resource.py
+++ b/addons/hr/tests/test_resource.py
@@ -206,3 +206,10 @@ class TestResource(TestHrCommon):
         attendances = self.employee._get_calendar_attendances(date_from, date_to)
         self.assertEqual(21 * 7 + 21 * 8, attendances['hours'],
             "Attendances should add up multiple contracts with varying work weeks.")
+
+    def test_alter_resource_calendar_of_resouce(self):
+        self.assertEqual(self.employee.resource_calendar_id, self.employee.resource_id.calendar_id)
+        self.assertEqual(self.employee.version_id.resource_calendar_id, self.employee.resource_id.calendar_id)
+        self.employee.resource_id.write({'calendar_id': self.calendar_40h})
+        self.assertEqual(self.employee.resource_calendar_id, self.employee.resource_id.calendar_id)
+        self.assertEqual(self.employee.version_id.resource_calendar_id, self.employee.resource_id.calendar_id)


### PR DESCRIPTION
Before this commit, when the user updates the working schedule of a human resource, the resource calendar of the employee linked to that resource is not altered as well.

This commit makes sure the working schedule between employee and resource is synchronised.

task-4916569
