### PR TITLE
[FIX] website: use name as value for radio options

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -599,13 +599,13 @@ export class FormOptionPlugin extends Plugin {
                     );
                     for (const record of records) {
                         conditionValueList.push({
-                            value: String(record[idField]),
+                            value: String(record[displayNameField]),
                             textContent: record[displayNameField],
                         });
                     }
                     if (!inputContainerEl.dataset.visibilityCondition) {
                         inputContainerEl.dataset.visibilityCondition = String(
-                            records[0]?.[idField]
+                            records[0]?.[displayNameField]
                         );
                     }
                 } else {


### PR DESCRIPTION
Radio options and checkboxes for the website form were changed such that the values that were linked to their html elements were set as their ID's instead of their display names. This caused issues with sending an email from the form as these ID's are nonsensical to the end user.

This change reverts the functionality to instead set the value to the display name in order to give meaningful values back on the email.

issue introduced in: https://github.com/odoo/odoo/commit/f4230d74c2209d7902df60d9fed91d8000aa267b
value was set to the record idField instead of the record displayNameField causing this issue

related change: https://github.com/odoo/odoo/pull/214182

opw-4994387
