### PR TITLE
[FIX] account: ignore manual tax amounts on discount lines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -3074,6 +3074,10 @@ class AccountTax(models.Model):
                 computation_key=computation_key,
                 price_unit=base_line['price_unit'] * -percentage,
             )
+
+            if new_base_line['special_type'] == 'global_discount':
+                new_base_line['manual_tax_amounts'] = None
+
             self._add_tax_details_in_base_line(new_base_line, company)
 
             # Propagate custom values.


### PR DESCRIPTION
When creating a global discount more than once, the values on the second time onward would be incorrect due to the manual tax amounts being propogated from the sale order lines. This would cause the discount amount to increase when discounting an already discounted sale order.

This happened because manual tax amounts that were from the lines that the discount lines were created from were being propogated and used to attempt to find the correct tax amounts up to the
target_amount_currency, but this is incorrect.

Removing the manual tax amounts when the special type of the line is global_discount resolves this issue and allows multiple global discounts to be used.

opw-4985380
