### PR TITLE
[FIX][17.0] mail: Error allowing selection when data has not been loaded yet

### DIFF
--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -73,6 +73,9 @@ export class NavigableList extends Component {
 
     selectOption(ev, index, params = {}) {
         const option = this.props.options[index];
+        if (!option) {
+            return;
+        }
         if (option.unselectable) {
             this.close();
             return;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

---

**Reason for PR**
When a user searches for a chat group, if the network is slow and the search results have not yet been loaded, pressing **Enter** will cause the system to attempt to access the `unselectable` property of an `option` variable that is not yet initialized.
This leads to the following error:

```
Uncaught Javascript Error: undefined is not an object (evaluating 'option.unselectable')
```

This PR adds handling to prevent the error when data has not been fully loaded.

---


Current behavior before PR:




https://github.com/user-attachments/assets/de3964c7-ff83-4f94-bc1a-cb8e09bfb62f









---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
