### PR TITLE
[IMP] website: adapt tours

### DIFF
--- a/addons/website/static/tests/tours/translate_text_options.js
+++ b/addons/website/static/tests/tours/translate_text_options.js
@@ -2,7 +2,6 @@ import {
     clickOnSave,
     insertSnippet,
     registerWebsitePreviewTour,
-    selectElementInWeSelectWidget,
     selectFullText,
     clickToolbarButton,
 } from "@website/js/tours/tour_utils";
@@ -31,6 +30,11 @@ registerWebsitePreviewTour(
             "Apply highlight",
             true
         ),
+        {
+            content: "Apply underline highlight option from highlight options",
+            trigger: ".o_popover .o_text_highlight_underline",
+            run: "click",
+        },
         ...clickOnSave(),
         {
             content: "Change the language to French",
@@ -39,12 +43,12 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click edit button",
-            trigger: ".o_menu_systray .o_edit_website_container button",
+            trigger: ".o_menu_systray button:contains('Edit').dropdown-toggle",
             run: "click",
         },
         {
             content: "Enable translation",
-            trigger: ".o_popover .o_translate_website_dropdown_item",
+            trigger: ".o_translate_website_dropdown_item",
             run: "click",
         },
         {
@@ -52,40 +56,67 @@ registerWebsitePreviewTour(
             trigger: ".modal-footer .btn-secondary",
             run: "click",
         },
-        // Select the highlighted text content.
+        // Select the highlighted text content and check highlight options were displayed.
         selectFullText("snippet highlighted text content", "#wrap .s_text_block p:last .o_text_highlight"),
         {
-            content: "Check that the highlight options were displayed",
-            trigger: "#toolbar we-select[data-name=text_highlight_opt]",
+            content: "Expand the toolbar for more buttons",
+            trigger: ".o-we-toolbar button[name='expand_toolbar']",
+            run: "click",
         },
-        ...selectElementInWeSelectWidget("text_highlight_opt", "Jagged"),
-        // Select the animated text content.
-        selectFullText("animated text content", "#wrap .s_text_block p:first .o_animated_text"),
         {
-            content:
-                "Check that the animation options are displayed and highlight options are no longer visible",
-            trigger:
-                "#toolbar:not(:has(.snippet-option-TextHighlight)) .snippet-option-WebsiteAnimate",
+            content: "Check that the highlight options were displayed and open highlight options",
+            trigger: ".o-we-toolbar button[title='Apply highlight'].active",
+            run: "click",
+        },
+        {
+            content: "Open highlight options picker",
+            trigger: ".o_popover button#highlightPicker",
+            run: "click",
+        },
+        {
+            content: "Change highlight to jagged",
+            trigger: ".o_popover .o_text_highlight_jagged",
+            run: "click",
+        },
+        // Select the animated text content and check animate options were displayed.
+        selectFullText("animated text content", "#wrap .s_text_block p:first span"),
+        {
+            content: "Expand the toolbar for more buttons",
+            trigger: ".o-we-toolbar button[name='expand_toolbar']",
+            run: "click",
+        },
+        {
+            content: "Check that the animate options were displayed",
+            trigger: ".o-we-toolbar button[title='Animate Text'].active",
         },
         // Select a text content without any option.
         selectFullText("text content without any option", "footer .s_text_block p:first span"),
         {
-            content: "Check that all text options are removed",
-            trigger:
-                "#toolbar:not(:has(.snippet-option-TextHighlight, .snippet-option-WebsiteAnimate))",
+            content: "Expand the toolbar for more buttons",
+            trigger: ".o-we-toolbar button[name='expand_toolbar']",
+            run: "click",
         },
-        // Select the highlighted text content again.
-        selectFullText("highlighted text content again", "#wrap .s_text_block p:last .o_text_highlight"),
+        {
+            content: "Check that all text options are removed",
+            trigger: ".o-we-toolbar button[title='Apply highlight']:not(:has(.active)), .o-we-toolbar button[title='Animate Text']:not(:has(.active))",
+        },
+        selectFullText(
+            "highlighted text content again",
+            "#wrap .s_text_block p:last .o_text_highlight"
+        ),
+        {
+            content: "Expand the toolbar for more buttons",
+            trigger: ".o-we-toolbar button[name='expand_toolbar']",
+            run: "click",
+        },
         {
             content: "Check that only the highlight options are displayed",
-            trigger:
-                "#toolbar:not(:has(.snippet-option-WebsiteAnimate)) .snippet-option-TextHighlight",
+            trigger: ".o-we-toolbar button[title='Apply highlight'].active, .o-we-toolbar button[title='Animate Text']:not(.active)",
         },
         ...clickOnSave(),
         {
             content: "Check that the highlight effect was correctly translated",
-            trigger:
-                ":iframe .s_text_block .o_text_highlight:has(.o_text_highlight_item:has(.o_text_highlight_path_jagged))",
+            trigger: ":iframe .s_text_block:has(.o_text_highlight_jagged)",
         },
     ]
 );

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -2,7 +2,6 @@
 
 import base64
 import json
-import unittest
 
 from werkzeug.urls import url_encode
 
@@ -236,8 +235,6 @@ class TestUiTranslate(odoo.tests.HttpCase):
         self.assertNotEqual(new_menu.name, 'value pa-GB', msg="The new menu should not have its value edited, only its translation")
         self.assertEqual(new_menu.with_context(lang=parseltongue.code).name, 'value pa-GB', msg="The new translation should be set")
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_translate_text_options(self):
         lang_en = self.env.ref('base.lang_en')
         lang_fr = self.env.ref('base.lang_fr')


### PR DESCRIPTION
The `translate_text_options` tour was previously broken due to DOM structure changes
introduced by the new website builder and was consequently disabled.

This commit updates the tour steps to align with the new DOM and
re-enables the associated test.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
