### PR TITLE
[FIX] pos_restaurant: added steps to wait for order sync

### DIFF
--- a/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/chrome_util.js
@@ -45,11 +45,14 @@ export function isSyncStatusConnected() {
     };
 }
 export function clickPlanButton() {
-    return {
-        content: "go back to the floor screen",
-        trigger: ".pos-leftheader .back-button:not(.btn-primary)",
-        run: "click",
-    };
+    return [
+        {
+            content: "go back to the floor screen",
+            trigger: ".pos-leftheader .back-button:not(.btn-primary)",
+            run: "click",
+        },
+        ...waitRequest(),
+    ];
 }
 export function startPoS() {
     return [


### PR DESCRIPTION
### Issue:
- In `test_14_pos_payment_sync`, the tour could end before the order was synced to the server, causing errors in later steps.

### Fix:
- Added steps to wait until the sync is done before finishing the tour.

Runbot Error: 113594, 181563
Task: 4974068