### PR TITLE
[FIX] website: await the navigation to complete on editing

### DIFF
--- a/addons/website/static/tests/tours/navigation.js
+++ b/addons/website/static/tests/tours/navigation.js
@@ -1,0 +1,39 @@
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "website_editing_awaits_navigation",
+    {
+        url: "/",
+    },
+    () => [
+        {
+            content: "Navigate to the 'Contact Us' page",
+            trigger: ":iframe .top_menu a[href='/contactus']:not(:visible)",
+            run: "click",
+        },
+        {
+            content: "Click on Edit right after that",
+            trigger: ".o_menu_systray_item.o_edit_website_container > button",
+            run: "click",
+        },
+        stepUtils.waitIframeIsReady(),
+        {
+            content: "Contact us page appears first before the builder sidebar",
+            trigger: ":iframe section h1:contains('Contact Us'), :not(.o-website-builder_sidebar)",
+        },
+        {
+            content: "Can insert a snippet",
+            trigger: ".o-website-builder_sidebar",
+        },
+        ...insertSnippet({
+            id: "s_banner",
+            name: "Banner",
+            groupName: "Intro",
+        }),
+        {
+            content: "",
+            trigger: ":iframe section.s_banner",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -724,3 +724,6 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_systray_items_disappear(self):
         self.start_tour("/", "website_systray_items_disappear", login="admin")
+
+    def test_editing_awaits_navigation(self):
+        self.start_tour("/", "website_editing_awaits_navigation", login="admin")


### PR DESCRIPTION
Following the [html_builder refactoring], we could start editing right after we clicked to navigate to another page, and the editor wouldn't wait for the new iframe, which isn't the expected behavior. Steps to reproduce the issue:
- Open website
- Click on any nav link, e.g. contact us and click edit right away

=> Sidebar opens before the contact us page is opened. This is not an expected behavior and also if we try to drop a snippet - the editor breaks.
This commit follows the [html_builder refactoring]. Related to task-4367641

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb
