### PR TITLE
[FIX] html_editor: fix non-deterministic test failure

### DIFF
--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -339,6 +339,7 @@ test("should focus the editable area after selecting a font size item", async ()
     const iframeEl = queryOne(".o-we-toolbar [name='font-size'] iframe");
     const inputEl = iframeEl.contentWindow.document?.querySelector("input");
     await click(inputEl);
+    await expectElementCount(".o_font_size_selector_menu .dropdown-item:contains('34')", 1);
     await contains(".o_font_size_selector_menu .dropdown-item:contains('34')").click();
     expect(getActiveElement()).toBe(editor.editable);
     expect(getActiveElement()).not.toBe(inputEl);


### PR DESCRIPTION
The input dropdown is a popover and is therefore affected by [1]. Because of that, we cannot simply use `contains` without awaiting properly as it can easily break non-deterministically on the runbot.

[1]: https://github.com/odoo/odoo/pull/211426/commits/54da715df84789f9a1acc0cfc91be41dcdbab140