### PR TITLE
[IMP] website: improve search on published models

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1914,7 +1914,9 @@ class Website(models.Model):
                 and not self.env.user.has_group('base.group_user')
             )
             if filter_is_published:
-                where_clause = sql.SQL("WHERE is_published")
+                where_clause = sql.SQL("WHERE {table}.is_published").format(
+                    table=sql.Identifier(model._table),
+                )
 
             from_clause = sql.SQL("FROM {table}").format(table=sql.Identifier(model._table))
             # Specific handling for fields being actually part of another model


### PR DESCRIPTION
**Only for 17.0**

**Description of the issue/feature this PR addresses:**
If a customization makes two models published on the website, one model inheriting from the other, the where clause defined on the `website` model in the `_trigram_enumerate_words` method can cause a SQL error ("column reference 'is_published' is ambiguous").

**Current behavior before PR:**
Server error on website, if a customization defines two published models, one inheriting from the other.

**Desired behavior after PR is merged:**
No error



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
