### PR TITLE
[FIX] account: show product and description pdf

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -42,6 +42,16 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
         return record.data.display_type === "line_note";
     }
 
+    updateLabel(value) {
+        this.props.record.update({
+            name: String(
+                (this.productName && value && this.productName.concat("\n", value))
+                || (this.productName && !value && this.productName)
+                || (value || '')
+            ),
+        });
+    }
+
     shouldShowWarning() {
         return (
             !this.productName &&


### PR DESCRIPTION
When printing an invoice for a product that has a description, only the description appears on the PDF. Commit https://github.com/odoo/odoo/commit/7e553d25890d1e236123f0fa7e11ce86f59448ab removed the concatenation of the product name and description in updateLabel (in product_name_and_description in product module).

This commit reintroduce the concatenation of the product name and the product description for invoices by overriding updateLabel in product_label_section_and_note_field in account.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4988340)
opw-4988340