### PR TITLE
[FIX] html_editor: prevent traceback when fetch request fails

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -482,7 +482,12 @@ export class LinkPopover extends Component {
             // Set state based on cached link meta data
             // for record missing errors, we push a warning that the url is likely invalid
             // for other errors, we log them to not block the ui
-            const internalMetadata = await this.props.getInternalMetaData(url.href);
+            const internalMetadata = await this.props
+                .getInternalMetaData(url.href)
+                .catch((error) => {
+                    console.warn(`Error fetching internal metadata for ${url.href}:`, error);
+                    return {};
+                });
             if (internalMetadata.favicon) {
                 this.state.previewIcon = {
                     type: "imgSrc",

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -248,6 +248,24 @@ describe("popover should edit,copy,remove the link", () => {
             '<p>this is a <a href="/contactus">li[]nk</a></p>'
         );
     });
+    test("Should properly show the preview if fetching metadata fails", async () => {
+        const id = Math.random().toString();
+        onRpc("/html_editor/link_preview_internal", () =>
+            Promise.reject(new Error(`No data ${id}`))
+        );
+        onRpc("/contactus", () => ({}));
+        const originalConsoleWarn = console.warn.bind(console);
+        patchWithCleanup(console, {
+            warn: (msg, error, ...args) => {
+                if (!error?.message?.includes?.(id)) {
+                    originalConsoleWarn(msg, error, ...args);
+                }
+            },
+        });
+        const { el } = await setupEditor('<p><a href="/contactus">a[]b</a></p>');
+        await waitFor(".o-we-linkpopover");
+        expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="/contactus">a[]b</a></p>');
+    });
     test("after clicking on copy button, the url should be copied to clipboard", async () => {
         await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");


### PR DESCRIPTION
Problem:
When a fetch request fails (e.g., due to CORS restrictions), a
traceback occurs in the editor.

Solution:
Catch errors on `await this.props.getInternalMetaData`.

Steps to reproduce:
- Go to Website
- Change the footer to "Links"
- Click on a social media link to preview
> A traceback occurs

opw-4979674

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
