### PR TITLE
[FIX] payment{,_stripe}: avoid traceback on comparing validation data

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -710,6 +710,9 @@ class PaymentTransaction(models.Model):
         """
         self.ensure_one()
 
+        if self.operation == 'validation':
+            return  # no need to validate validations
+
         if not amount or not currency_code:
             raise ValidationError(_("The amount or currency is missing from the payment data."))
 

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -372,18 +372,20 @@ class PaymentTransaction(models.Model):
             notification data.
         """
         if self.provider_code != 'stripe':
-            return super()._compare_notification_data(notification_data)
+            super()._compare_notification_data(notification_data)
+            return
 
         if self.operation == 'validation':
-            payment_data = notification_data['setup_intent']
-        elif self.operation == 'refund':
+            return  # no need to validate validations
+
+        if self.operation == 'refund':
             payment_data = notification_data['refund']
         else:  # 'online_direct', 'online_token', 'offline'
             payment_data = notification_data['payment_intent']
         amount = payment_utils.to_major_currency_units(
             payment_data.get('amount', 0), self.currency_id
         )
-        currency_code = payment_data.get('currency').upper()
+        currency_code = payment_data.get('currency', '').upper()
         self._validate_amount_and_currency(amount, currency_code)
 
     def _process_notification_data(self, notification_data):

--- a/addons/payment_stripe/tests/common.py
+++ b/addons/payment_stripe/tests/common.py
@@ -2,6 +2,7 @@
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.tests.common import PaymentCommon
+from odoo.addons.payment_stripe import const
 
 
 class StripeCommon(PaymentCommon):
@@ -68,4 +69,27 @@ class StripeCommon(PaymentCommon):
                 'object': dict(cls.refund_object, status='failed'),
             },
             'type': 'charge.refund.updated',
+        }
+
+    def _mock_setup_intent_request(self, *args, **kwargs):
+        # See: https://docs.stripe.com/api/setup_intents/confirm
+        mandate_options = {
+            'amount': 1500000,
+            'amount_type': 'maximum',
+            'currency': self.currency.name.lower(),
+        } if self.currency.name in const.INDIAN_MANDATES_SUPPORTED_CURRENCIES else None
+        return {
+            'object': 'setup_intent',
+            'id': 'seti_XXXX',
+            'customer': 'cus_XXXX',
+            'description': self.reference,
+            'payment_method': {
+                'id': 'pm_XXXX',
+                'type': 'card',
+                'card': {'brand': 'dummy'},
+            },
+            'payment_method_options': {'card': {
+                'mandate_options': mandate_options,
+            }},
+            'status': 'succeeded',
         }


### PR DESCRIPTION
Versions
--------
- saas-18.4+

Steps
-----
1. Configure Stripe;
2. go to `/my/payment_method`;
3. create a payment token.

Issue
-----
> Internal Server Error

Cause
-----
Commit 5db75d32d718a added a method that compares notification data values to the transaction values. For most operations, the structure of Stripe notification data is similar, but for `SetupIntent` responses, these don't include an amount or currency value (unless the currency is supported by Indian eMandates, in which case it's part of a `mandate_options` dict)[^1].

The error is the result of `payment_data.get('currency').upper()`. Because there is no currency value, `upper` gets called on `None`.

Additionally, when the transaction amount is zero (as is expected for validation operations), the base `_compare_notification_data` method assumes the amount is missing, throwing a validation error.

[^1]: https://docs.stripe.com/api/setup_intents/confirm

Solution
--------
- Skip comparing notification data for validation transactions.
- If the `currency` value is in fact missing unexpectedly, fall back on the empty string, so that we get to the intended validation error.

opw-5008858