### PR TITLE
[FIX] account: don't remove readonly for every field

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -48,6 +48,10 @@ export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRend
     }
 
     isCellReadonly(column, record) {
+        if (!["name", "product_id"].includes(column.name)) {
+            return super.isCellReadonly(column, record);
+        }
+
         // The isCellReadonly method from the ListRenderer is used to determine the classes to apply to the cell.
         // We need this override to make sure some readonly classes are not applied to the cell if it is still editable.
         let isReadonly = super.isCellReadonly(column, record);


### PR DESCRIPTION
Steps to reproduce
==================

- Go to invoices
- Open studio
- Click on the invoice lines
- Edit the list view
- Add a new field of type checkbox
- Mark that field as readonly
- Exit studio
- Open an invoice
- Click on the checkbox

=> The form is marked as dirty and the checkbox is toggled

Cause of the issue
==================

https://github.com/odoo/odoo/commit/291518a7e7708690d183b9d1ca53c84d0c56ad90

If the state is not in ["cancel", "done", "posted"], the fields are never in readonly

Solution
========

Only do this for the "name" and "product_id" fields

opw-4917471