### PR TITLE
[IMP] base: forward res.users.settings help to res.users fields

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1311,6 +1311,17 @@ class ResUsers(models.Model):
     def fields_get(self, allfields=None, attributes=None):
         res = super().fields_get(allfields, attributes=attributes)
 
+        # Try to find the missing field metadata in the corresponding
+        # res.users.settings field. This is usually handled automatically
+        # by related fields, but settings fields are implemented with a compute
+        # + inverse instead of a related.
+        settings_fields = self.env["res.users.settings"]._fields
+        for fname, attributes in res.items():
+            if fname not in settings_fields:
+                continue
+            if "help" not in attributes and settings_fields[fname].help:
+                attributes["help"] = settings_fields[fname].help
+
         # add self readable/writable fields
         readable_fields, writeable_fields = self._self_accessible_fields()
         missing = (writeable_fields | readable_fields).difference(res.keys())


### PR DESCRIPTION
Since we want to embed them in user preferences, the res.users.settings fields are redefined on res.users. Rather than using related fields, the "related" behavior is reimplemented using an inverse and a compute. This is because an inverse is necessary to call `_find_or_create_for_user`, and relateds can't be defined alongside inverses.

As a result, the help attributes of res.users.settings fields embedded in res.users aren't properly forwarded to res.users, as it would be with a true related field. This commit overrides fields_get to reimplement this part of the related logic.

Task-4997530