### PR TITLE
[FIX] payment_razorpay_oauth: add missing constraint check on credentials

### DIFF
--- a/addons/payment_razorpay_oauth/models/payment_provider.py
+++ b/addons/payment_razorpay_oauth/models/payment_provider.py
@@ -140,11 +140,12 @@ class PaymentProvider(models.Model):
         :raise ValidationError: If the Razorpay credentials are not valid.
         """
         for provider in self.filtered(lambda p: p.code == 'razorpay' and p.state != 'disabled'):
-            if not provider.razorpay_key_id or not provider.razorpay_key_secret:
-                raise ValidationError(_(
-                    "Razorpay credentials are missing. Click the \"Connect\" button to set up your"
-                    " account"
-                ))
+            if not provider.razorpay_account_id:
+                if not provider.razorpay_key_id or not provider.razorpay_key_secret:
+                    raise ValidationError(_(
+                        "Razorpay credentials are missing. Click the \"Connect\" button to set up"
+                        " your account"
+                    ))
 
     # === BUSINESS METHODS - OAUTH === #
 


### PR DESCRIPTION
## Version
17.0

## Issue
An error is raised when trying to connect Razorpay.

## Steps to reproduce
Ensure debug mode is enabled.
- Go to `Payment Providers` and open `Razorpay`;
- Empty all fields if needed;
- Click "Connect" button and follow the process;
- A validation error is raised when coming back to Odoo.

## Cause
Commit 9eee91ec76740480f6630598b64f8da917efe45a adds constraints by only looking at Odoo's Razorpay form data: https://github.com/odoo/odoo/blob/f6edaaef6cbc86b74511a29b4f02986f6230f5ce/addons/payment_razorpay_oauth/models/payment_provider.py#L143 These data aren't filled with OAuth flow which returns an `account_id` but no `key_id` or `key_secret`

opw-4922315