### PR TITLE
[FIX] web: Prevent openAction for select_create_dialog

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -60,6 +60,7 @@ export class ListController extends Component {
         editable: { type: Boolean, optional: true },
         onSelectionChanged: { type: Function, optional: true },
         showButtons: { type: Boolean, optional: true },
+        allowOpenAction: { type: Boolean, optional: true },
         Model: Function,
         Renderer: Function,
         buttonTemplate: String,
@@ -71,6 +72,7 @@ export class ListController extends Component {
         editable: true,
         selectRecord: () => {},
         showButtons: true,
+        allowOpenAction: true,
     };
 
     setup() {
@@ -288,7 +290,7 @@ export class ListController extends Component {
         if (dirty) {
             await record.save();
         }
-        if (this.archInfo.openAction) {
+        if (this.props.allowOpenAction && this.archInfo.openAction) {
             this.actionService.doActionButton({
                 name: this.archInfo.openAction.action,
                 type: this.archInfo.openAction.type,

--- a/addons/web/static/src/views/view_dialogs/select_create_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/select_create_dialog.js
@@ -75,6 +75,7 @@ export class SelectCreateDialog extends Component {
         };
         if (type === "list") {
             props.allowSelectors = this.props.multiSelect;
+            props.allowOpenAction = false;
         } else if (type === "kanban") {
             props.forceGlobalClick = true;
         }

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -16686,3 +16686,20 @@ test(`hide pager in the list view with sample data`, async () => {
     expect(".o_content").toHaveClass("o_view_sample_data");
     expect(".o_cp_pager").not.toHaveCount();
 });
+
+test(`basic open record with allowOpenAction`, async () => {
+    mockService("action", {
+        doActionButton(params) {
+            const { name } = params;
+            expect.step(`execute_action: ${name}`, params);
+        },
+    });
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list action="test_action" type="object"><field name="foo"/></list>`,
+        allowOpenAction: false,
+    });
+    await contains(".o_field_cell").click();
+    expect.verifySteps([]);
+});

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -15,6 +15,7 @@ import {
     fields,
     getService,
     models,
+    mockService,
     mountView,
     mountWithCleanup,
     onRpc,
@@ -496,4 +497,42 @@ test("SelectCreateDialog empty list, noContentHelp props", async () => {
     expect(queryOne(".o_dialog .o_list_view .o_view_nocontent")).toHaveInnerHTML(
         `<div class="o_nocontent_help"><p class="custom_classname">Hello</p><p>I'm an helper</p></div>`
     );
+});
+
+test("SelectCreateDialog with open action", async () => {
+    Instrument._records = [];
+    for (let i = 0; i < 25; i++) {
+        Instrument._records.push({
+            id: i + 1,
+            name: "Instrument " + i,
+        });
+    }
+    mockService("action", {
+        doActionButton(params) {
+            const { name } = params;
+            expect.step(`execute_action: ${name}`, params);
+        },
+    });
+    Instrument._views["list"] = /* xml */ `
+        <list action="test_action" type="object">
+            <field name="name"/>
+        </list>
+    `;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <field name="instrument"/>
+            </form>
+        `,
+    });
+    await contains(`.o_field_widget[name="instrument"] .dropdown input`).click();
+    await contains(`.o_field_widget[name="instrument"] .o_m2o_dropdown_option_search_more`).click();
+    await contains(
+        `.o_list_renderer .o_data_row .o_field_cell.o_list_char[data-tooltip="Instrument 10"]`
+    ).click();
+    expect("input").toHaveValue("Instrument 10");
+    expect.verifySteps([]);
 });


### PR DESCRIPTION
Example of steps:
- install web, purchase and studio
- add a many2one with studio anywhere and choose purchase.order.line
- close studio
- try to use this new field, select "Search more"
- select a random record
- It opens the form view record instead of select It

This is because purchase order line has an openAction that forces the opening of a form view.
However, for a select_create_dialog, we must bypass this action to allow nothing except selection.
To do this, a new prop has been added, “allowOpenAction,” in the list_controller, which will be true by default, but will be false for select_create_dialog.

opw-4958121