### PR TITLE
[IMP] web: improve breadcrumb restoration

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -167,7 +167,11 @@ export function makeActionManager(env, router = _router) {
      * @returns {Promise<object[]>} an array of virtual controllers
      */
     async function _controllersFromState() {
-        const state = router.current;
+        const currentState = JSON.parse(browser.sessionStorage.getItem("current_state") || "{}");
+        let state = router.current;
+        if (router.stateToUrl(currentState) === browser.location.pathname) {
+            state = currentState;
+        }
         if (!state?.actionStack?.length) {
             return [];
         }
@@ -805,11 +809,14 @@ export function makeActionManager(env, router = _router) {
 
         // Store current action of the current window
         const currentAction = browser.sessionStorage.getItem("current_action");
+        const currentState = browser.sessionStorage.getItem("current_state");
         // Store on the session the action for the new window
         browser.sessionStorage.setItem("current_action", action._originalAction || "{}");
+        browser.sessionStorage.setItem("current_state", JSON.stringify(state));
         _openURL(stateToUrl(state));
         // restore the current action from the current window
         browser.sessionStorage.setItem("current_action", currentAction);
+        browser.sessionStorage.setItem("current_state", currentState);
     }
 
     /**
@@ -1775,6 +1782,7 @@ export function makeActionManager(env, router = _router) {
         }
 
         const newState = makeState(cStack);
+        browser.sessionStorage.setItem("current_state", JSON.stringify(newState));
 
         cStack.at(-1).state = newState;
         router.pushState(newState, { replace: true });

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -7637,7 +7637,9 @@ test("rendering date and datetime (value)", async () => {
     });
 
     expect(getKanbanRecord({ index: 0 }).querySelector(".date")).toHaveText("Jan 25, 2017");
-    expect(getKanbanRecord({ index: 1 }).querySelector(".datetime")).toHaveText("Dec 12, 2016, 11:55 AM");
+    expect(getKanbanRecord({ index: 1 }).querySelector(".datetime")).toHaveText(
+        "Dec 12, 2016, 11:55 AM"
+    );
 });
 
 test("rendering date and datetime (raw value)", async () => {
@@ -13434,12 +13436,17 @@ test("kanban records are middle clickable by default", async () => {
 
     await contains(".o_kanban_record").click({ ctrlKey: true });
     expect.verifySteps([
+        "get current_state-null",
         "get current_action-null",
+        'set current_state-{"actionStack":[{"displayName":"","action":1,"view_type":"kanban"}],"action":1}',
         'set current_action-{"id":1,"res_model":"partner","type":"ir.actions.act_window","views":[[false,"kanban"],[false,"form"]]}',
         'get current_action-{"id":1,"res_model":"partner","type":"ir.actions.act_window","views":[[false,"kanban"],[false,"form"]]}',
+        'get current_state-{"actionStack":[{"displayName":"","action":1,"view_type":"kanban"}],"action":1}',
         'set current_action-{"id":1,"res_model":"partner","type":"ir.actions.act_window","views":[[false,"kanban"],[false,"form"]]}',
+        'set current_state-{"actionStack":[{"displayName":"","action":1,"view_type":"kanban"},{"displayName":"","action":1,"view_type":"form","resId":1}],"resId":1,"action":1}',
         "opened in new window: /odoo/action-1/1",
         'set current_action-{"id":1,"res_model":"partner","type":"ir.actions.act_window","views":[[false,"kanban"],[false,"form"]]}',
+        'set current_state-{"actionStack":[{"displayName":"","action":1,"view_type":"kanban"}],"action":1}',
     ]);
 });
 

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -1874,8 +1874,10 @@ test.tags("desktop");
 test("current act_window action is stored in session_storage if possible", async () => {
     let expectedAction;
     patchWithCleanup(browser.sessionStorage, {
-        setItem(k, value) {
-            expect(JSON.parse(value)).toEqual(expectedAction);
+        setItem(key, value) {
+            if (key === "current_action") {
+                expect(JSON.parse(value)).toEqual(expectedAction);
+            }
         },
     });
     await mountWithCleanup(WebClient);

--- a/addons/web_hierarchy/static/tests/hierarchy_view.test.js
+++ b/addons/web_hierarchy/static/tests/hierarchy_view.test.js
@@ -1557,12 +1557,17 @@ test("Open record on new window", async () => {
     expect(".o_hierarchy_view").toHaveCount(1);
     expect(".o_form_view").toHaveCount(0);
     expect.verifySteps([
+        "get current_state-null",
         "get current_action-null",
+        'set current_state-{"actionStack":[{"displayName":"","model":"hr.employee","view_type":"hierarchy"}],"model":"hr.employee"}',
         'set current_action-{"res_model":"hr.employee","type":"ir.actions.act_window","views":[[false,"hierarchy"],[false,"form"]]}',
         'get current_action-{"res_model":"hr.employee","type":"ir.actions.act_window","views":[[false,"hierarchy"],[false,"form"]]}',
+        'get current_state-{"actionStack":[{"displayName":"","model":"hr.employee","view_type":"hierarchy"}],"model":"hr.employee"}',
         'set current_action-{"res_model":"hr.employee","type":"ir.actions.act_window","views":[[false,"hierarchy"],[false,"form"]]}',
+        'set current_state-{"actionStack":[{"displayName":"","model":"hr.employee","view_type":"hierarchy"},{"displayName":"","model":"hr.employee","view_type":"form","resId":2}],"resId":2,"model":"hr.employee"}',
         "opened in new window: /odoo/hr.employee/hr.employee/2",
         'set current_action-{"res_model":"hr.employee","type":"ir.actions.act_window","views":[[false,"hierarchy"],[false,"form"]]}',
+        'set current_state-{"actionStack":[{"displayName":"","model":"hr.employee","view_type":"hierarchy"}],"model":"hr.employee"}',
     ]);
 });
 


### PR DESCRIPTION
Since [1] when reloading the browser the breadcrumb is restored based on the URL.

This was implemented in a very naive way. For each action found in the URL, a multiview was added to the breadcrumb. Similarly, for each pain action/ID found in the URL, a form view was added to the breadcrumb. Note that the active_id (found before the action in the URL), is taken into account in the context of the action.

For example, if the URL is : `/odoo/project/5/tasks`:
 - for the `project` action, the list of projects will be added to the breadcrumb;
 - for the `project/5` action/ID pair, the form view of the project 5 will be added;
- for the `5/tasks` action (with active_id 5), the list of tasks for the project 5 will be added.

However, this naive implementation does not consider that the user can navigate directly from the list of projects to the list of tasks for a project without passing through the project form view.

This commit saves the current state in the session storage, to be used to restore the breadcrumb when the page is reloaded.

Note that similar behaviour was implemented to improve action restoration [2].

[1] https://github.com/odoo/odoo/commit/c63d14a0485a553b74a8457aee158384e9ae6d3f
[2] https://github.com/odoo/odoo/commit/e8afebdcbf5d725091983fbe3b425fec4aa3a071

task-id 5011505
