### PR TITLE
[FIX] hr_fleet: auto-assign vehicle driver on assignation log creation

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -400,6 +400,13 @@ class FleetVehicle(models.Model):
         if 'driver_id' in vals and vals['driver_id']:
             driver_id = vals['driver_id']
             for vehicle in self.filtered(lambda v: v.driver_id.id != driver_id):
+                # We need to set an end date for the vehicle assignation log
+                driver_assignation = self.env["fleet.vehicle.assignation.log"].search([
+                    ("vehicle_id", "=", vehicle.id),
+                    ("driver_id", "=", vehicle.driver_id.id),
+                ], order="write_date desc", limit="1")
+                if not driver_assignation.date_end:
+                    driver_assignation.date_end = datetime.today().date()
                 vehicle.create_driver_history(vals)
 
         if 'future_driver_id' in vals and vals['future_driver_id']:
@@ -464,6 +471,8 @@ class FleetVehicle(models.Model):
         }
 
     def create_driver_history(self, vals):
+        if self.env.context.get("skip_driver_history"):
+            return
         for vehicle in self:
             self.env['fleet.vehicle.assignation.log'].create(
                 vehicle._get_driver_history_data(vals),
@@ -477,7 +486,7 @@ class FleetVehicle(models.Model):
             'driver_id': False,
             'plan_to_change_vehicle': False,
         })
-        
+
         for vehicle in self:
             vehicle.plan_to_change_vehicle = False
             vehicle.driver_id = vehicle.future_driver_id

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -576,7 +576,7 @@
             <list default_order="date_start desc, id desc" string="Assignment Logs" editable="bottom">
                 <field name="vehicle_id" />
                 <field name="driver_id" widget="many2one_avatar_user" string="Current Driver" />
-                <field name="date_start"/>
+                <field name="date_start" required="True"/>
                 <field name="date_end"/>
             </list>
         </field>

--- a/addons/hr_fleet/data/hr_fleet_demo.xml
+++ b/addons/hr_fleet/data/hr_fleet_demo.xml
@@ -32,12 +32,6 @@
         <value model="fleet.vehicle.assignation.log" eval="obj().search([('vehicle_id', '=', obj().env.ref('fleet.vehicle_3').id)], limit=1).id"/>
         <value eval="{'date_start': DateTime.today() - relativedelta(days=138)}"/>
     </function>
-    <record id="hr_fleet_vehicle_3_assignation_log_1" model="fleet.vehicle.assignation.log">
-        <field name="vehicle_id" ref="fleet.vehicle_3"/>
-        <field name="driver_id" ref="hr.work_contact_jog"/>
-        <field name="date_start" eval="DateTime.today() - relativedelta(days=481)"/>
-        <field name="date_end" eval="DateTime.today() - relativedelta(days=138)"/>
-    </record>
 
     <record id="fleet.vehicle_4" model="fleet.vehicle">
         <field name="driver_employee_id" ref="hr.employee_jog"/>

--- a/addons/hr_fleet/models/fleet_vehicle.py
+++ b/addons/hr_fleet/models/fleet_vehicle.py
@@ -97,6 +97,16 @@ class FleetVehicle(models.Model):
 
     def write(self, vals):
         self._update_create_write_vals(vals)
+        if 'driver_employee_id' in vals and not vals['driver_employee_id']:
+            today = fields.Date.today()
+            for vehicle in self:
+                if vehicle.driver_employee_id:
+                    current_log = self.env['fleet.vehicle.assignation.log'].search([
+                        ('vehicle_id', '=', vehicle.id),
+                        ('date_end', '=', False)])
+                    if current_log:
+                        current_log.date_end = today
+
         if 'driver_employee_id' in vals:
             for vehicle in self:
                 if vehicle.driver_employee_id and vehicle.driver_employee_id.id != vals['driver_employee_id']:

--- a/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
+++ b/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.fields import Domain
 
 
 class FleetVehicleAssignationLog(models.Model):
@@ -38,3 +40,60 @@ class FleetVehicleAssignationLog(models.Model):
         res['domain'] = [('res_model', '=', 'fleet.vehicle.assignation.log'), ('res_id', 'in', self.ids)]
         res['context'] = {'default_res_model': 'fleet.vehicle.assignation.log', 'default_res_id': self.id}
         return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+
+        if not self.env.context.get("skip_driver_history"):
+            records._update_vehicle_driver()
+
+        return records
+
+    def _update_vehicle_driver(self):
+        today = fields.Date.today()
+        for rec in self:
+            vehicle = rec.vehicle_id
+            if (
+                not vehicle
+                or vehicle.driver_id
+                or (rec.date_start and rec.date_start > today)
+                or (rec.date_end and rec.date_end < today)
+            ):
+                continue
+            vehicle.with_context(skip_driver_history=True).write({
+                "driver_id": rec.driver_id.id,
+                "plan_to_change_vehicle": False,
+            })
+
+    @api.constrains('vehicle_id', 'date_start', 'date_end')
+    def _check_date_overlap(self):
+        for rec in self:
+            base_domain = [('vehicle_id', '=', rec.vehicle_id.id), ('id', '!=', rec.id)]
+            if rec.date_end:
+                overlap_domain = Domain.OR([
+                    Domain.AND([
+                        Domain('date_start', '<', rec.date_end),
+                        Domain.OR([
+                            Domain('date_end', '>', rec.date_start),
+                            Domain('date_end', '=', False),
+                        ]),
+                    ]),
+                ])
+            else:
+                overlap_domain = Domain.OR([
+                    Domain('date_end', '=', False),
+                    Domain('date_end', '>', rec.date_start),
+                ])
+            domain = Domain.AND([base_domain, overlap_domain])
+
+            overlapping = self.search(domain, limit=1)
+            if overlapping:
+                raise ValidationError(
+                    self.env._(
+                        "This assignment overlaps with an existing assignment for %(vehicle)s "
+                        "(Driver: %(driver)s, Period: %(start)s to %(end)s)",
+                        vehicle=rec.vehicle_id.name,
+                        driver=overlapping.driver_id.name,
+                        start=overlapping.date_start,
+                        end=overlapping.date_end or self.env._('Ongoing')))

--- a/addons/hr_fleet/models/hr_employee.py
+++ b/addons/hr_fleet/models/hr_employee.py
@@ -23,9 +23,19 @@ class HrEmployee(models.Model):
         return {
             "type": "ir.actions.act_window",
             "res_model": "fleet.vehicle.assignation.log",
-            "views": [[self.env.ref("hr_fleet.fleet_vehicle_assignation_log_employee_view_list").id, "list"], [False, "form"]],
+            "views": [
+                [self.env.ref("hr_fleet.fleet_vehicle_assignation_log_employee_view_list").id, "list"],
+                [False, "form"],
+            ],
             "domain": [("driver_employee_id", "in", self.ids), ("driver_id", "in", self.work_contact_id.ids)],
-            "context": dict(self.env.context, default_driver_id=self.user_id.partner_id.id, default_driver_employee_id=self.id),
+            "context": dict(
+                self.env.context,
+                default_driver_id=self.work_contact_id.id,
+                default_driver_employee_id=self.id,
+                create=False,
+                edit=False,
+                delete=False,
+            ),
             "name": self.env._("Cars History"),
         }
 

--- a/addons/hr_fleet/tests/test_hr_fleet_driver.py
+++ b/addons/hr_fleet/tests/test_hr_fleet_driver.py
@@ -1,5 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import timedelta
+from odoo import fields
+from odoo.exceptions import ValidationError
 from odoo.tests import tagged, common
 
 
@@ -85,3 +88,120 @@ class TestHrFleetDriver(common.TransactionCase):
         ])
         self.assertEqual(len(assignation_log), 1)
         self.assertEqual(assignation_log.driver_employee_id, test_employee2)
+
+    def test_assignation_log_create_sets_vehicle_driver(self):
+        """
+        Creating a fleet.vehicle.assignation.log should assign vehicle.driver_id
+        only if vehicle has no driver and today is within assignation period.
+        """
+
+        today = fields.Date.today()
+        yesterday = today - timedelta(days=1)
+        tomorrow = today + timedelta(days=1)
+
+        # vehicle with no driver yet
+        vehicle = self.car2
+        vehicle.write({"plan_to_change_vehicle": True})
+        self.assertFalse(vehicle.driver_id, "Precondition: vehicle2 has no driver")
+
+        # Create assignation log with valid today-included date range
+        self.env["fleet.vehicle.assignation.log"].create({
+            "vehicle_id": vehicle.id,
+            "driver_id": self.test_employee.work_contact_id.id,
+            "date_start": yesterday,
+            "date_end": tomorrow,
+        })
+        self.assertEqual(
+            vehicle.driver_id,
+            self.test_employee.work_contact_id,
+            "Vehicle driver should be set when date includes today and no driver assigned",
+        )
+        self.assertFalse(vehicle.plan_to_change_vehicle, "Plan to change car should be set to False")
+        # Create another assignation for same vehicle, driver should NOT be changed because vehicle has driver
+        self.env["fleet.vehicle.assignation.log"].create({
+            "vehicle_id": vehicle.id,
+            "driver_id": self.test_user.partner_id.id,
+            "date_start": tomorrow + timedelta(days=1),
+            "date_end": tomorrow + timedelta(days=3),
+        })
+        # driver stays unchanged
+        self.assertEqual(
+            vehicle.driver_id,
+            self.test_employee.work_contact_id,
+            "Vehicle driver should not change if already assigned",
+        )
+
+        # Create assignation where date range excludes today, driver should NOT be assigned
+        vehicle3 = self.car
+        vehicle3.driver_id = False  # reset driver for test
+        self.env["fleet.vehicle.assignation.log"].create({
+            "vehicle_id": vehicle3.id,
+            "driver_id": self.test_user.partner_id.id,
+            "date_start": today + timedelta(days=2),
+            "date_end": today + timedelta(days=3),
+        })
+        self.assertFalse(vehicle3.driver_id, "Vehicle driver should not be set if today not in assignation period")
+
+    def test_assignation_overlap_validation(self):
+        """Overlapping assignation logs for the same vehicle should raise a ValidationError."""
+
+        today = fields.Date.today()
+        vehicle = self.car
+
+        # Base assignation: yesterday → tomorrow
+        self.env['fleet.vehicle.assignation.log'].create({
+            'vehicle_id': vehicle.id,
+            'driver_id': self.test_employee.work_contact_id.id,
+            'date_start': today - timedelta(days=1),
+            'date_end': today + timedelta(days=1),
+        })
+
+        # No overlap (ends before the first starts)
+        self.env['fleet.vehicle.assignation.log'].create({
+            'vehicle_id': vehicle.id,
+            'driver_id': self.test_user.partner_id.id,
+            'date_start': today - timedelta(days=5),
+            'date_end': today - timedelta(days=3),
+        })
+
+        # Overlaps at the start
+        with self.assertRaises(ValidationError, msg="Overlap at the start should raise ValidationError"):
+            self.env['fleet.vehicle.assignation.log'].create({
+                'vehicle_id': vehicle.id,
+                'driver_id': self.test_user.partner_id.id,
+                'date_start': today - timedelta(days=2),
+                'date_end': today,
+            })
+
+        # Overlaps at the end
+        with self.assertRaises(ValidationError, msg="Overlap at the end should raise ValidationError"):
+            self.env['fleet.vehicle.assignation.log'].create({
+                'vehicle_id': vehicle.id,
+                'driver_id': self.test_user.partner_id.id,
+                'date_start': today,
+                'date_end': today + timedelta(days=2),
+            })
+
+        # Fully enclosed inside first assignation
+        with self.assertRaises(ValidationError, msg="Enclosed overlap should raise ValidationError"):
+            self.env['fleet.vehicle.assignation.log'].create({
+                'vehicle_id': vehicle.id,
+                'driver_id': self.test_user.partner_id.id,
+                'date_start': today,
+                'date_end': today,
+            })
+
+        # Overlaps open-ended assignation (no date_end)
+        self.env['fleet.vehicle.assignation.log'].create({
+            'vehicle_id': vehicle.id,
+            'driver_id': self.test_employee.work_contact_id.id,
+            'date_start': today + timedelta(days=5),
+            'date_end': False,
+        })
+        with self.assertRaises(ValidationError, msg="Open-ended overlap should raise ValidationError"):
+            self.env['fleet.vehicle.assignation.log'].create({
+                'vehicle_id': vehicle.id,
+                'driver_id': self.test_user.partner_id.id,
+                'date_start': today + timedelta(days=6),
+                'date_end': today + timedelta(days=10),
+            })

--- a/addons/hr_fleet/views/fleet_vehicle_views.xml
+++ b/addons/hr_fleet/views/fleet_vehicle_views.xml
@@ -22,7 +22,7 @@
                 <attribute name="optional">hide</attribute>
             </field>
             <field name="driver_id" position="after">
-                <field name="driver_employee_id" widget="many2one_avatar_user"/>
+                <field name="driver_employee_id" widget="many2one_avatar_user" optional="hide"/>
             </field>
             <field name="date_end" position="after">
                 <field name="attachment_number" optional="show" />

--- a/addons/hr_fleet/views/hr_employee_views.xml
+++ b/addons/hr_fleet/views/hr_employee_views.xml
@@ -9,8 +9,7 @@
         <field name="arch" type="xml">
             <button name="action_open_versions" position="before">
                 <button name="action_open_employee_cars" type="object"
-                        class="oe_stat_button" icon="fa-car" groups="fleet.fleet_group_user"
-                        invisible="employee_cars_count == 0">
+                        class="oe_stat_button" icon="fa-car" groups="fleet.fleet_group_user" invisible="not employee_cars_count">
                     <field name="employee_cars_count" widget="statinfo" string="Cars History" />
                 </button>
             </button>
@@ -37,7 +36,7 @@
             <div name="button_box" position="inside">
                 <button name="action_open_employee_cars" type="object"
                         class="oe_stat_button" icon="fa-car" groups="fleet.fleet_group_user"
-                        invisible="employee_cars_count == 0">
+                        invisible="not employee_cars_count">
                     <field name="employee_cars_count" widget="statinfo" string="Cars History" />
                 </button>
             </div>


### PR DESCRIPTION
In this PR, we improve the vehicle assignation log so that when a new assignation is created, the vehicle’s driver is automatically set if the vehicle doesn’t already have one and the assignation includes today..

Related task: 5008856.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
