### PR TITLE
[FIX] mail: fix error when editing guest name linked to multiple channels

### DIFF
--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -78,7 +78,8 @@ class MailGuest(models.Model):
         if len(name) > 512:
             raise UserError(_("Guest's name is too long."))
         self.name = name
-        Store(self, ["avatar_128", "name"], bus_channel=self.channel_ids).bus_send()
+        for channel in self.channel_ids:
+            Store(self, ["avatar_128", "name"], bus_channel=channel).bus_send()
         Store(self, ["avatar_128", "name"], bus_channel=self).bus_send()
 
     def _update_timezone(self, timezone):

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -14,6 +14,7 @@ from . import test_discuss_reaction_controller
 from . import test_discuss_res_role
 from . import test_discuss_sub_channels
 from . import test_discuss_thread_controller
+from . import test_guest
 from . import test_message_controller
 from . import test_guest_feature
 from . import test_toggle_upload

--- a/addons/mail/tests/discuss/test_guest.py
+++ b/addons/mail/tests/discuss/test_guest.py
@@ -1,0 +1,47 @@
+from odoo import fields
+from odoo.addons.mail.tests.common import MailCase
+from odoo.tests.common import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestGuest(MailCase):
+
+    def test_updating_guest_name_linked_to_multiple_channels(self):
+        """This test ensures that when a guest is linked to multiple channels,
+        the guest's name is updated correctly and the appropriate bus notifications are sent.
+        """
+        guest = self.env['mail.guest'].create({'name': 'Guest'})
+        channel_1 = self.env["discuss.channel"]._create_channel(name="Channel 1", group_id=None)
+        channel_2 = self.env["discuss.channel"]._create_channel(name="Channel 2", group_id=None)
+        channel_1._add_members(guests=guest)
+        channel_2._add_members(guests=guest)
+
+        def get_guest_bus_params():
+            guest_write_date = fields.Datetime.to_string(guest.write_date)
+            message = {
+                "type": "mail.record/insert",
+                "payload": {
+                    "mail.guest": [
+                        {
+                            "avatar_128_access_token": guest._get_avatar_128_access_token(),
+                            "id": guest.id,
+                            "name": "Guest Name Updated",
+                            "write_date": guest_write_date,
+                        },
+                    ],
+                },
+            }
+
+            return (
+                [
+                    (self.cr.dbname, "discuss.channel", channel_1.id),
+                    (self.cr.dbname, "discuss.channel", channel_2.id),
+                    (self.cr.dbname, "mail.guest", guest.id),
+                ],
+                [message, message, message],
+            )
+
+        self._reset_bus()
+        with self.assertBus(get_params=get_guest_bus_params):
+            guest._update_name("Guest Name Updated")
+        self.assertEqual(guest.name, "Guest Name Updated")


### PR DESCRIPTION
Guests linked to more than one discuss channel cause a traceback when
their name is updated.

Steps to reproduce the error:
- Install ``website_livechat`` module with demo data
- Login in as ``Mitchell Admin`` in one tab
- Open Incognito Tab, start a conversation via the ``livechat`` button twice.
- Switch back to Mitchell Admin Tab > Open that latest discuss channel >
  Invite People > Copy Link > paste the link into the same incognito tab
- Edit the guest name (top-right corner)

Traceback:
``AssertionError: channel should be empty or should be a single record: discuss.channel(5, 7)``

When the guest starts two separate conversations,
two discuss.channel records are created.

https://github.com/odoo/odoo/blob/f4bd509a8c828596db5aacd42099224ad9f54007/addons/mail/models/discuss/mail_guest.py#L81
During the guest name update, ``self.channel_ids`` contains multiple channels.

This triggers an error from the below line.
https://github.com/odoo/odoo/blob/f4bd509a8c828596db5aacd42099224ad9f54007/addons/mail/tools/discuss.py#L298-L300

sentry-6803396766

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
