### PR TITLE
[FIX] website_sale: fix category issue related to category list snippet

### DIFF
--- a/addons/website_sale/tests/test_dynamic_snippet_category.py
+++ b/addons/website_sale/tests/test_dynamic_snippet_category.py
@@ -1,10 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
+from odoo.tests import tagged
+
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
+@tagged('post_install', '-at_install')
 class TestDynamicSnippetCategory(WebsiteSaleCommon):
     def setUp(self):
         super().setUp()
@@ -33,9 +36,10 @@ class TestDynamicSnippetCategory(WebsiteSaleCommon):
 
     def test_snippet_categories_returns_only_published_and_with_children(self):
         categories = self.env['product.public.category'].get_available_snippet_categories(
-            self.website.id
+            self.website.id,
         )
-        self.assertEqual(self.category1.id, categories[0]['id'])
+        category_ids = [c['id'] for c in categories]
+        self.assertIn(self.category1.id, category_ids)
 
     def test_set_category_image(self):
         """Test setting a cover image via JSON-RPC route"""


### PR DESCRIPTION
Follow up of PR https://github.com/odoo/odoo/pull/208574 that introduced category list snippet and its related category related issue.

For Error https://runbot.odoo.com/odoo/runbot.build.error/230548 :

Issue:
- Demo data loads more categories than expected in categories, resulting
  in additional published categories.
- The test assumed the first element would always be the expected one,
  which failed when extra categories were present.
- Test execution also failed in some environments due to dependency and
  module load timing issues (e.g., delivery), requiring test tagging- Errors

Fix:
- Adapted the test to check that the expected category is included in
  the results instead of relying on its position.
- Added `post_install` to the test class to ensure
  it runs at the correct stage and avoids dependency/module load errors.