### PR TITLE
[FIX] mail: minor discuss style adjustments

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -9,7 +9,7 @@
         outline-color: rgba($o-action, var(--mail-NotificationItem-activeOutlineOpacity, 0.5));
     }
     &:hover, &.o-active {
-        filter: contrast(.9);
+        backdrop-filter: contrast(.9);
     }
 }
 

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -1,6 +1,7 @@
 .o-mail-NotificationItem {
     outline: 1px solid transparent;
     outline-offset: -1px;
+    background-color: inherit !important;
 
     &:not(.o-interest) {
         --border-opacity: .35;

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -53,10 +53,10 @@
                         <ImStatus persona="installationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
                     <t t-set-slot="sideContent">
-                        <div class="d-flex align-items-center justify-content-center o-gap-1_5" t-att-class="{ 'pe-1': !ui.isSmall }">
+                        <div class="d-flex align-items-center justify-content-center o-gap-1_5" t-att-class="{ 'o-pe-0_5': !ui.isSmall }">
                             <a t-if="ui.isSmall" class="btn fa fa-cloud-download px-0"/>
                             <t t-else="">
-                                <a class="btn btn-primary px-2 py-1 smaller">Install</a>
+                                <a class="btn btn-primary px-1 py-0 smaller">Install</a>
                                 <span t-if="!hasTouch()" t-on-click.stop="() => this.pwa.decline()" class="text-dark bg-transparent oi oi-close opacity-50 opacity-100-hover" title="Dismiss"></span>
                             </t>
                         </div>
@@ -77,7 +77,7 @@
                         <ImStatus persona="notificationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
                     <t t-set-slot="sideContent">
-                        <div class="d-flex align-items-center justify-content-center o-gap-1_5" t-att-class="{ 'pe-1': !ui.isSmall }">
+                        <div class="d-flex align-items-center justify-content-center o-gap-1_5" t-att-class="{ 'o-pe-0_5': !ui.isSmall }">
                             <a t-if="ui.isSmall" class="btn fa fa-bell px-0"/>
                             <t t-else="">
                                 <a class="btn btn-primary btn-sm px-1 py-0">Enable</a>


### PR DESCRIPTION

Before / After
<img width="480" height="634" alt="Screenshot 2025-08-12 at 14 47 20" src="https://github.com/user-attachments/assets/cefad725-1de2-4126-9c89-92633a1ca472" /> <img width="481" height="638" alt="Screenshot 2025-08-12 at 14 46 54" src="https://github.com/user-attachments/assets/16f8af98-b980-45d5-bb21-578e8764bfe5" />

See:
- 1st notification item title has reduced spacing thanks to smaller "Enable" button footprint
- 1st notification right part items have better alignment
- heart and whatsapp IM status icon show proper `.bg-inherit` mask