### PR TITLE
[FIX] project_timesheet_holidays: Get tz for fully flexible employees

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -83,7 +83,7 @@ class Holidays(models.Model):
                 continue
 
             calendar = leave.employee_id.resource_calendar_id
-            calendar_timezone = pytz.timezone(calendar.tz)
+            calendar_timezone = pytz.timezone((calendar or leave.employee_id).tz)
 
             if calendar.flexible_hours and (leave.request_unit_hours or leave.request_unit_half or leave.date_from.date() == leave.date_to.date()):
                 leave_date = leave.date_from.astimezone(calendar_timezone).date()

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -330,3 +330,17 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         self.assertEqual(len(timesheet), 1, "One timesheet should be created")
         self.assertEqual(sum(timesheet.mapped('unit_amount')), 10, "The duration of the timesheet for flexible employee leave "
                                                         "should be 10 hours")
+
+    def test_timeoff_validation_fully_flexible_employee(self):
+        self.empl_employee.resource_calendar_id = False
+
+        time_off = self.Requests.with_user(self.user_employee).create({
+            'name': 'Test Fully Flexible Employee Validation',
+            'employee_id': self.empl_employee.id,
+            'holiday_status_id': self.hr_leave_type_with_ts.id,
+            'request_date_from': datetime(2025, 8, 12),
+            'request_date_to': datetime(2025, 8, 12)
+        })
+        time_off.with_user(SUPERUSER_ID).action_validate()
+
+        self.assertEqual(time_off.state, 'validate', "The time off for a fully flexible employee should be validated")


### PR DESCRIPTION
Currently, if we try to validate a leave for a fully flexible employee (employee without a working schedule), we get a traceback when fetching the timezone from the working schedule.

To rectify this issue, we default to the timezone of the resource.

opw-4979974