### PR TITLE
[FIX] base, test_orm: avoid non-stored fields in default Calendar view

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2791,7 +2791,7 @@ class Base(models.AbstractModel):
             the attribute) or not
             """
             for item in seq:
-                if item in in_:
+                if item in in_ and in_[item]._description_searchable:
                     view.set(to, item)
                     return True
             return False

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -2442,3 +2442,15 @@ class BinaryTest(models.Model):
 
     def _compute_bin2(self):
         self.bin2 = {}
+
+
+class CalendarTest(models.Model):
+    _name = _description = "calendar.test"
+
+    date_start = fields.Date(compute="_compute_date")
+    date_end = fields.Date(compute="_compute_date")
+    x_date_start = fields.Date()
+    x_date_end = fields.Date()
+
+    def _compute_date(self):
+        self.date_start = self.date_end = fields.Date.today()

--- a/odoo/addons/test_orm/security/ir.model.access.csv
+++ b/odoo/addons/test_orm/security/ir.model.access.csv
@@ -157,3 +157,4 @@ access_test_performance_eggs,access_test_performance_eggs,model_test_performance
 access_test_performance_mozzarella,access_test_performance_mozzarella,model_test_performance_mozzarella,base.group_system,1,1,1,1
 access_test_performance_simple_minded,access_test_performance_simple_minded,model_test_performance_simple_minded,base.group_system,1,1,1,1
 access_binary_test,access_binary_test,model_binary_test,base.group_user,1,0,0,0
+access_calendar_test,access_calendar_test,model_calendar_test,base.group_user,1,0,0,0

--- a/odoo/addons/test_orm/tests/test_views.py
+++ b/odoo/addons/test_orm/tests/test_views.py
@@ -28,6 +28,12 @@ class TestDefaultView(common.TransactionCase):
             b'<form><sheet string="binary.test"><group><group><field name="img"/></group><group><field name="bin1"/></group></group><group><separator/></group></sheet></form>'
         )
 
+    def test_default_calender_view(self):
+        self.assertEqual(
+            etree.tostring(self.env['calendar.test']._get_default_calendar_view()),
+            b'<calendar string="calendar.test" date_start="x_date_start" date_stop="x_date_end"><field name="id"/></calendar>'
+        )
+
 
 @common.tagged('at_install', 'groups')
 class TestViewGroups(ViewCase):


### PR DESCRIPTION
**Steps to reproduce:**
- Install `hr` and `web_studio`
- Go to Employees → click Studio icon.
- Click on Views → try to activate Calendar view.

**Observation:**
- You will get a traceback 
`ValueError: Cannot convert hr.version.date_end to SQL because it is not stored
`
**Issue:**
- Since saas-18.4, the `hr_version` model introduced `date_start` and `date_end` fields, which are non-stored computed fields.
https://github.com/odoo/odoo/blob/21f18b1a6fdbf1a01c3dda83acfa66addd01a759/addons/hr/models/hr_version.py#L139-L140
- These field names overlap with the default date field names (`date_start` and `date_end`) used when generating Calendar views. So, the Calendar view tried to use a non-stored field, and it caused the error.
https://github.com/odoo/odoo/blob/21f18b1a6fdbf1a01c3dda83acfa66addd01a759/odoo/addons/base/models/ir_ui_view.py#L2591-L2630

**Solution:**
- Add an extra check in `set_first_of` to ensure that only stored fields are considered when selecting the default date field for Calendar views.

opw-4967654


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
