### PR TITLE
[FIX] point_of_sale: give context on product reload

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -357,15 +357,31 @@ export class PosData extends Reactive {
                     break;
                 case "read":
                     queue = false;
+                    if (!options) {
+                        options = { context: {} };
+                    }
+                    if (!options.context) {
+                        options.context = {};
+                    }
+                    options.context.display_default_code ??= false;
                     result = await this.orm.read(model, ids, fields, {
                         ...options,
+                        context: { ...options.context },
                         load: false,
                     });
                     break;
                 case "search_read":
                     queue = false;
+                    if (!options) {
+                        options = { context: {} };
+                    }
+                    if (!options.context) {
+                        options.context = {};
+                    }
+                    options.context.display_default_code ??= false;
                     result = await this.orm.searchRead(model, args, fields, {
                         ...options,
+                        context: { ...options.context },
                         load: false,
                     });
             }
@@ -533,6 +549,7 @@ export class PosData extends Reactive {
 
             const data = await this.orm.read(model, Array.from(ids), this.fields[model], {
                 load: false,
+                context: { display_default_code: false },
             });
             newRecordMap[model] = data;
         }

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -751,3 +751,25 @@ registry.category("web_tour.tours").add("test_pos_ui_round_globally", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_product_ref_displayed", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Test name"),
+            ProductScreen.clickInfoProduct("Test name"),
+            {
+                trigger: ".modal .btn-secondary:contains(Edit)",
+                run: "click",
+            },
+            {
+                trigger: ".modal .btn-primary:contains(Save)",
+                run: "click",
+            },
+            ProductScreen.clickDisplayedProduct("Test name"),
+            ProductScreen.selectedOrderlineHas("Test name", "2.0"),
+
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2172,6 +2172,16 @@ class TestUi(TestPointOfSaleHttpCommon):
             self.start_pos_tour("test_sync_from_ui_one_by_one", login="pos_user")
             self.assertEqual(sync_counter['count'], 6)
 
+    def test_product_ref_displayed(self):
+        self.env['product.product'].create({
+            'name': 'Test name',
+            'available_in_pos': True,
+            'default_code': 'Test ref',
+            'list_price': 10,
+        })
+        # Need to log as admin to be able to edit the product info
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_product_ref_displayed', login="pos_admin")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
In PoS, when editing and saving a product’s information, there was a bug where the product reference was shown before its name.

Steps to reproduce:
-------------------
* Add a reference to a product available in PoS
* Open PoS
* Click on the 'i' on the top right of that product
* Click on Edit
* Click on Save (no need to do any modification)

> Observation:
The reference appears before the name.
Refreshing the page removes, as it triggers a new read.

Why the fix:
------------
Reference are never shown in pos thank to this context key `display_default_code: false`

opw-5001355

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
