### PR TITLE
[FIX] website_sale: hide product size option

### DIFF
--- a/addons/website_sale/static/src/website_builder/products_item_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_item_option.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="website_sale.ProductsItemOptionPlugin">
-        <div t-if="this.displaySizeOption" class="o_wsale_soptions_menu_sizes">
+        <div t-attf-class="o_wsale_soptions_menu_sizes {{domState.displaySizeOption ? '' : 'd-none'}}">
             <BuilderRow label.translate="Size">
                 <BuilderButtonGroup action="'setItemSize'">
                     <table t-ref="table" t-on-mouseenter="_onTableMouseEnter" t-on-mouseleave="_onTableMouseLeave">


### PR DESCRIPTION
This PR hides the product size option when the layout is set to list mode, as it is not considered in this context.

task-5003377

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
