### PR TITLE
[IMP] mail: remove dead code

### DIFF
--- a/addons/mail/static/src/core/common/mail_guest_model.js
+++ b/addons/mail/static/src/core/common/mail_guest_model.js
@@ -14,7 +14,6 @@ const { DateTime } = luxon;
  * @property {number} id
  * @property {string} name
  * @property {string} email
- * @property {'partner'|'guest'} type
  * @property {ImStatus} im_status
  */
 

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -30,8 +30,6 @@ export const pyToJsModels = {
 
 export const addFieldsByPyModel = {
     "discuss.channel": { model: "discuss.channel" },
-    "mail.guest": { type: "guest" },
-    "res.partner": { type: "partner" },
 };
 
 patch(storeInsertFns, {

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -28,7 +28,7 @@
                 <audio autoplay="" t-ref="audio"/>
             </div>
             <div class="d-flex flex-column justify-content-center">
-                <t t-if="store.self.type === 'guest'">
+                <t t-if="store.self_guest">
                     <label class="text-center fs-4" >What's your name?</label>
                     <input class="form-control mb-3 bg-white rounded" type="text" placeholder="Your name" t-model="state.userName" t-on-keydown="onKeydownInput"/>
                 </t>

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -88,7 +88,7 @@
     <t t-name="discuss.GifPicker.gif">
         <div class="o-discuss-Gif position-relative mt-1 fs-5 cursor-pointer rounded overflow-hidden">
             <i
-                t-if="store.self.type === 'partner'"
+                t-if="store.self_partner"
                 class="position-absolute top-0 end-0 me-3 mt-3 p-2 o-bg-black bg-opacity-75 fa cursor-pointer opacity-0"
                 t-att-class="{ 'o-text-white fa-star-o': !isFavorite(gif_value), 'fa-star o-starred': isFavorite(gif_value) }"
                 t-on-click="() => this.onClickFavorite(gif_value)"

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1229,12 +1229,6 @@ export class StoreOne extends StoreRelation {
         if (this.records._name === "discuss.channel") {
             return { id, model: "discuss.channel" };
         }
-        if (this.records._name === "mail.guest") {
-            return { id, type: "guest" };
-        }
-        if (this.records._name === "res.partner") {
-            return { id, type: "partner" };
-        }
         return id;
     }
 }


### PR DESCRIPTION
Since the removal of persona_model, automatically adding type on mail.guest and res.partner is not used anymore.
