### PR TITLE
[FIX] pos_online_payment_self_order: send order to prep display

### DIFF
--- a/addons/pos_online_payment_self_order/controllers/payment_portal.py
+++ b/addons/pos_online_payment_self_order/controllers/payment_portal.py
@@ -33,3 +33,5 @@ class PaymentPortalSelfOrder(PaymentPortal):
                 'pos.payment': pos_order.payment_ids.read(pos_order.payment_ids._load_pos_self_data_fields(pos_order.config_id.id), load=False),
             }
         })
+        if status == 'success':
+            pos_order._send_order()


### PR DESCRIPTION
After this pr: https://github.com/odoo/odoo/pull/213493 the orders were not sent to the preparation display if the order was payed with and online payment method.

This commit add the same logic as the terminal payments to send the order to the preparation display.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
