### PR TITLE
[FIX] mail: avoid access error from "View all activities"

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -584,8 +584,18 @@ class MailActivity(models.Model):
 
     @api.readonly
     def action_open_document(self):
-        """ Opens the related record based on the model and ID """
+        """ Opens the related record based on the model and ID, or activity if user has no
+         access to the related record."""
         self.ensure_one()
+        if not self.env[self.res_model].browse(self.res_id).has_access('read'):
+            return {
+                'res_id': self.id,
+                'res_model': 'mail.activity',
+                'target': 'current',
+                'type': 'ir.actions.act_window',
+                'view_mode': 'form',
+                'views': [(self.env.ref('mail.mail_activity_view_form_without_record_access').id, 'form')],
+            }
         return {
             'res_id': self.res_id,
             'res_model': self.res_model,


### PR DESCRIPTION
**Steps to reproduce**
1. Create an activity on a record and assign it to a user who doesn't have access to this record. (e.g. create an activity on a `hr.employee` record and assign to a user without HR rights).
2. With this user lacking access rights, click on "View all activities" in the systray.
3. Click on the activity: error

**Cause**
The user may not have access rights to the record related to an activity.

**Change**
Open the activity's form view, we use `mail_activity_view_form_without_record_access` to display the "Mark as done" button.

opw-4925744