### PR TITLE
[FIX] website_sale: fix error when accessing the shop page

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -291,7 +291,9 @@ class ProductTemplate(models.Model):
             )
             if available_attribute_lines:
                 previewed_ptal = available_attribute_lines[0]
-                previewed_ptavs = previewed_ptal.product_template_value_ids._only_active()
+                previewed_ptavs = previewed_ptal.product_template_value_ids.filtered(
+                    lambda ptav: ptav.ptav_active and ptav.ptav_product_variant_ids
+                )
                 if len(previewed_ptavs) > 1:
                     previewed_ptavs_data = []
                     for ptav in previewed_ptavs[:show_count]:

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -157,3 +157,21 @@ class TestWebsiteSaleProductAttributeValueConfig(AccountTestInvoicingCommon, Tes
             combination_info = product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
         self.assertEqual(round(combination_info['list_price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
+
+    def test_hide_attribute_value_without_matching_product_variant(self):
+        """Ensure attribute values are hidden if they don't have a matching product variant"""
+        self.ssd_attribute.preview_variants = 'visible'
+
+        product_template = self.env['product.template'].create({
+            'name': 'Test Product Template',
+        })
+
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.ssd_attribute.id,
+            'value_ids': [Command.set((self.ssd_256.id, self.ssd_512.id))],
+        })
+
+        product_template.product_variant_ids.unlink()
+        previewed_attribute_values = product_template._get_previewed_attribute_values()
+        self.assertFalse(previewed_attribute_values)


### PR DESCRIPTION
When a product template's variants are deleted, accessing the shop page raises an traceback.

Steps to reproduce the error:
- Install ``website_sale`` module
- Enable Product Variants From Settings
- Go to Website > eCommerce > Attributes > Open Color > On Product Cards: Visible > Add 2 Attribute values
- Create a new Product Template > Attributes & Variants > Add Color attribute with 2 values
- Delete the variants of this Product Template
- Go to Website > Shop

Traceback:
``IndexError: tuple index out of range``

https://github.com/odoo/odoo/blob/c7bedc25c9702956aab73cb6a0c0c544c062a3dd/addons/website_sale/models/product_template.py#L298
When a product template's variants are deleted,
``ptav.ptav_product_variant_ids`` becomes empty.
The code tries to access the first element by index, causing the traceback.

sentry-6801851377

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
