### PR TITLE
[REM] hr: remove redundant "Tasks" Menu from Employees

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -725,20 +725,6 @@
             <field name="search_view_id" ref="view_employee_filter"/>
         </record>
 
-        <record id="action_hr_employee_my_activities" model="ir.actions.act_window">
-            <field name="name">My activities</field>
-            <field name="path">my_activities</field>
-            <field name="res_model">hr.employee</field>
-            <field name="domain">[
-                ('company_id', 'in', allowed_company_ids),
-                ('activity_user_id', '=', uid),
-            ]</field>
-            <field name="context">{'chat_icon': True, 'searchpanel_default_company_id': allowed_company_ids[0]}</field>
-            <field name="view_mode">list,kanban,form,activity,graph,pivot</field>
-            <field name="view_id" eval="False"/>
-            <field name="search_view_id" ref="view_employee_filter"/>
-        </record>
-
         <record id="action_hr_employee_all_activities" model="ir.actions.act_window">
             <field name="name">All activities</field>
             <field name="path">all_activities</field>

--- a/addons/hr/views/hr_views.xml
+++ b/addons/hr/views/hr_views.xml
@@ -44,29 +44,6 @@
             sequence="4"/>
 
         <menuitem
-            id="hr_menu_hr_task"
-            name="Tasks"
-            parent="menu_hr_root"
-            groups="group_hr_user"
-            sequence="90"/>
-
-            <menuitem
-                id="hr_menu_hr_my_activities"
-                name="My Activities"
-                parent="hr_menu_hr_task"
-                action="action_hr_employee_my_activities"
-                groups="group_hr_user"
-                sequence="91"/>
-
-            <menuitem
-                id="hr_menu_hr_all_activities"
-                name="All Activities"
-                parent="hr_menu_hr_task"
-                action="action_hr_employee_all_activities"
-                groups="group_hr_user"
-                sequence="92"/>
-
-        <menuitem
             id="hr_menu_hr_reports"
             name="Reporting"
             parent="menu_hr_root"


### PR DESCRIPTION
The menu is currently broken since clicking on "New" opens up the employee creation form instead of the creation of a new task. Moreover, the functionality is available through the global Activities page, including a default "My Activities" filter.
Because of redundancy and no functionality, this adds confusion without added value

