### PR TITLE
[FIX] web: editable list, listen window clicks in

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -144,7 +144,7 @@ export class ListRenderer extends Component {
         this.keyDebugOpenView = `debug_open_view,${key}`;
         this.cellClassByColumn = {};
         this.groupByButtons = this.props.archInfo.groupBy.buttons;
-        useExternalListener(document, "click", this.onGlobalClick.bind(this));
+        useExternalListener(window, "click", this.onGlobalClick.bind(this), { capture: true });
         this.tableRef = useRef("table");
 
         this.longTouchTimer = null;
@@ -2135,8 +2135,24 @@ export class ListRenderer extends Component {
         if (target.closest(".o_datetime_picker")) {
             return;
         }
-        // Legacy autocomplete
-        if (ev.target.closest(".ui-autocomplete")) {
+        // Save, Discard
+        if (
+            target.closest(".o_list_button_save") ||
+            target.closest(".o_list_button_discard") ||
+            target.closest(".o_form_status_indicator_buttons")
+        ) {
+            return;
+        }
+        // Add row
+        if (target.closest(".o_field_x2many_list_row_add a")) {
+            return;
+        }
+        // Optional columns
+        if (target.closest(".o_optional_columns_dropdown")) {
+            return;
+        }
+        // Overlay
+        if (this.rootRef.el.closest(".o-overlay-item") !== target.closest(".o-overlay-item")) {
             return;
         }
         this.props.list.leaveEditMode();

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -19142,6 +19142,20 @@ test(`multi_edit: edit field with operator with localization`, async () => {
 });
 
 test.tags("desktop");
+test(`list_view: leave edition when click on searchbar dropdown`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list editable="top"><field name="foo"/></list>`,
+    });
+    await contains(".o_data_cell").click();
+    await contains(".o_data_cell input").edit("blabla", { confirm: false });
+    await contains(".o_searchview_dropdown_toggler").click();
+    expect(`.o_data_cell:eq(0)`).toHaveText("blabla");
+    expect(`.o_control_panel_breadcrumbs .o_list_button_add`).toHaveCount(1);
+});
+
+test.tags("desktop");
 test(`basic open record with allowOpenAction`, async () => {
     mockService("action", {
         doActionButton(params) {


### PR DESCRIPTION
In list_renderer.js, we add a click event listener on document to switch the edited row in readonly when we click outside the table. This obviously doesn't work if the user clicks somewhere, and the click event is stopped (stopPropagation).

In particular, 2 issues arose:
1. clicking on the search bar caret to open the search menu doesn't leave edition.
2. clicking on a many2one input doesn't leave edition.

This commit fix these two points.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
