### PR TITLE
[FIX] survey: randomize question order in section

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -380,7 +380,7 @@ class Survey(http.Controller):
                 })
             elif survey_sudo.questions_layout == 'page_per_question':
                 page_ids = (answer_sudo.predefined_question_ids.ids
-                            if not answer_sudo.is_session_answer and survey_sudo.questions_selection == 'random'
+                            if not answer_sudo.is_session_answer and survey_sudo.questions_selection != 'all'
                             else survey_sudo.question_ids.ids)
                 survey_progress = IrQweb._render('survey.survey_progression', {
                     'survey': survey_sudo,

--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -559,7 +559,7 @@ class SurveyUser_Input(models.Model):
         triggering_answers_by_question = {}
         triggered_questions_by_answer = {}
         # Ignore conditional configuration if randomised questions selection
-        if self.survey_id.questions_selection != 'random':
+        if self.survey_id.questions_selection == 'all':
             triggering_answers_by_question, triggered_questions_by_answer = self.survey_id._get_conditional_maps()
         selected_answers = self._get_selected_suggested_answers()
 

--- a/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.js
+++ b/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.js
@@ -30,7 +30,7 @@ export class SurveyQuestionTriggerWidget extends Component {
                 } else if (triggerError === "WRONG_QUESTIONS_SELECTION_WARNING") {
                     this.state.surveyIconWarning = true;
                     this.state.triggerTooltip = '⚠ ' + _t(
-                        "Conditional display is not available when questions are randomly picked."
+                        "Conditional display is not available when questions or sections are randomly picked."
                     );
                 } else if (triggerError === "MISSING_TRIGGER_ERROR") {
                     // This case must be handled to not temporarily render the "normal" icon if previously
@@ -78,7 +78,7 @@ export class SurveyQuestionTriggerWidget extends Component {
         if (!record.data.triggering_question_ids.records.length) {
             return { triggerError: "", misplacedTriggerQuestionRecords: [] };
         }
-        if (this.props.record.data.questions_selection === 'random') {
+        if (['random', 'random_sections_order'].includes(this.props.record.data.questions_selection)) {
             return { triggerError: 'WRONG_QUESTIONS_SELECTION_WARNING', misplacedTriggerQuestionRecords: [] };
         }
 

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -44,7 +44,7 @@
                             <t t-set="page_number" t-value="page_ids.index(page.id) + (1 if survey.progression_mode == 'number' else 0)"/>
                         </t>
                         <t t-else="">
-                            <t t-if="not answer.is_session_answer and survey.questions_selection == 'random'">
+                            <t t-if="not answer.is_session_answer and survey.questions_selection != 'all'">
                                 <t t-set="page_ids" t-value="answer.predefined_question_ids.ids"/>
                             </t>
                             <t t-else="">
@@ -207,7 +207,7 @@
             <!-- Questions with section -->
             <t t-foreach="survey.page_ids" t-as="page">
                 <t t-set="display_section" t-value="page.description or any(not q.triggering_answer_ids for q in page.question_ids)
-                    or (survey.questions_selection == 'random' and page.question_ids and page.random_questions_count > 0)"/>
+                    or (survey.questions_selection != 'all' and page.question_ids and page.random_questions_count > 0)"/>
                 <div t-attf-class="js_section_wrapper #{'d-none' if not display_section else ''}">
                     <h2 t-field="page.title" class="o_survey_title pb16 text-break"/>
                     <div t-field="page.description" class="o_survey_description text-break"/>
@@ -347,7 +347,7 @@
     <template id="question_container" name="Survey: question container">
         <t t-set="display_question"
            t-value="survey.questions_layout == 'page_per_question'
-                    or survey.questions_selection == 'random'
+                    or survey.questions_selection != 'all'
                     or (survey.questions_layout == 'one_page' and not question.triggering_answer_ids)
                     or (survey.questions_layout == 'page_per_section' and (not question.triggering_answer_ids
                         or any(triggering_answer in selected_answers for triggering_answer in triggering_answers_by_question[question.id])))"/>


### PR DESCRIPTION
1/ When using Question Selection "Randomize per section", and a small number of questions is chosen, the order in which questions are shown is random. If, however, we choose to show all questions of the section (choose N of N), the order is not random, which is inconsistent, especially as setting `random_questions_count=0` can already be used to show them all in order.

2/ It was possible to randomize questions order per section but not sections order. It doesn't cost much and it's useful from saas-18.3.

Task-4962940

