### PR TITLE
[IMP] l10n_ar: Add support for VAT zero base amount.

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -303,6 +303,7 @@ class AccountMove(models.Model):
                 # For invoices of letter C should not pass VAT
                 'vat_taxable_amount': sign * sum(vat_taxable.mapped(amount_field)) if self.l10n_latam_document_type_id.l10n_ar_letter != 'C' else self.amount_untaxed,
                 'vat_exempt_base_amount': sign * sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '2')).mapped(amount_field)),
+                'vat_zero_base_amount': sign * sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '3')).mapped(amount_field)),
                 'vat_untaxed_base_amount': sign * sum(self.invoice_line_ids.filtered(lambda x: x.tax_ids.filtered(lambda y: y.tax_group_id.l10n_ar_vat_afip_code == '1')).mapped(amount_field)),
                 # used on FE
                 'not_vat_taxes_amount': sign * sum((tax_lines - vat_taxes).mapped(amount_field)),


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**: 
When uploading the digital VAT book txt file to ARCA, the operation code must be reported when the VAT rate is zero. Validation file: https://www.arca.gob.ar/iva/documentos/Libro-IVA-Digital-Especificaciones.pdf page 10, "Campo 20: Código de operación." Specification: https://www.arca.gob.ar/iva/documentos/libro-iva-digital-diseno-registros.pdf (page 4 "Diseño de Registro Compras e Importación de Bienes- Cabecera").

**Current behavior before PR**:
The operation code is not being reported in the digital VAT book txt file when the VAT rate is zero.

**Desired behavior after PR is merged**:
The operation code is being reported in the digital VAT book txt file when the VAT rate is zero.

_Task Adhoc side_: 55146
_Task latam side_: 1357


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
