### PR TITLE
[FIX] l10n_es_edi_verifactu_pos: no cancel; sending vs states

### DIFF
--- a/addons/l10n_es_edi_verifactu_pos/i18n/es.po
+++ b/addons/l10n_es_edi_verifactu_pos/i18n/es.po
@@ -225,6 +225,14 @@ msgstr ""
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
+#, python-format
+msgid ""
+"Veri*Factu documents can only be generated for paid or posted Point of Sale Orders."
+msgstr ""
+
+#. module: l10n_es_edi_verifactu_pos
+#. odoo-python
+#: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
 #: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
 #, python-format
 msgid "You can only refund products from the same order."

--- a/addons/l10n_es_edi_verifactu_pos/i18n/l10n_es_edi_verifactu_pos.pot
+++ b/addons/l10n_es_edi_verifactu_pos/i18n/l10n_es_edi_verifactu_pos.pot
@@ -225,6 +225,14 @@ msgstr ""
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
+#, python-format
+msgid ""
+"Veri*Factu documents can only be generated for paid or posted Point of Sale Orders."
+msgstr ""
+
+#. module: l10n_es_edi_verifactu_pos
+#. odoo-python
+#: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
 #: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
 #, python-format
 msgid "You can only refund products from the same order."

--- a/addons/l10n_es_edi_verifactu_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/pos_order.py
@@ -135,8 +135,11 @@ class PosOrder(models.Model):
     def l10n_es_edi_verifactu_get_refund_reason_selection(self):
         return self._fields['l10n_es_edi_verifactu_refund_reason']._description_selection(self.env)
 
+    # TODO: remove in master (19.0)
     def l10n_es_edi_verifactu_button_cancel(self):
-        self._l10n_es_edi_verifactu_mark_for_next_batch(cancellation=True)
+        # We should not Veri*Factu cancel orders. There is no clean way to cancel PoS orders.
+        # So they would still be reflected in the accounting.
+        pass
 
     def l10n_es_edi_verifactu_button_send(self):
         self._l10n_es_edi_verifactu_mark_for_next_batch()
@@ -145,8 +148,8 @@ class PosOrder(models.Model):
         self.ensure_one()
         errors = []
 
-        if self.state != 'paid':
-            errors.append(_("Veri*Factu documents can only be generated for paid Point of Sale Orders."))
+        if self.state not in ('paid', 'done'):
+            errors.append(_("Veri*Factu documents can only be generated for paid or posted Point of Sale Orders."))
 
         return errors
 

--- a/addons/l10n_es_edi_verifactu_pos/models/verifactu_document.py
+++ b/addons/l10n_es_edi_verifactu_pos/models/verifactu_document.py
@@ -1,9 +1,4 @@
-import logging
-
 from odoo import fields, models
-from odoo.exceptions import UserError
-
-_logger = logging.getLogger(__name__)
 
 
 class L10nEsEdiVerifactuDocument(models.Model):
@@ -14,14 +9,3 @@ class L10nEsEdiVerifactuDocument(models.Model):
         comodel_name='pos.order',
         readonly=True,
     )
-
-    def _cancel_after_sending(self, info):
-        super()._cancel_after_sending(info)
-        for document in self:
-            order = document.pos_order_id
-            if order.l10n_es_edi_verifactu_state == 'cancelled' and order.state != 'cancel':
-                try:
-                    order.action_pos_order_cancel()
-                except UserError as error:
-                    _logger.error("Error while canceling order %(name)s (id %(record_id)s) after Veri*Factu cancellation:\n%(error)s",
-                                  record_id=order.id, name=order.name, error=error)

--- a/addons/l10n_es_edi_verifactu_pos/views/pos_order_views.xml
+++ b/addons/l10n_es_edi_verifactu_pos/views/pos_order_views.xml
@@ -39,13 +39,8 @@
                 <xpath expr="//header" position="inside">
                     <button name="l10n_es_edi_verifactu_button_send" type="object"
                             string="Send Veri*Factu"
-                            invisible="account_move or not l10n_es_edi_verifactu_required"/>
+                            invisible="account_move or not l10n_es_edi_verifactu_required or l10n_es_edi_verifactu_state in ('registered_with_errors', 'accepted')"/>
                     <field name="l10n_es_edi_verifactu_show_cancel_button" invisible="1"/>
-                    <button name="l10n_es_edi_verifactu_button_cancel"
-                            string="Request Veri*Factu Cancellation"
-                            type="object"
-                            groups="account.group_account_invoice"
-                            invisible="not l10n_es_edi_verifactu_show_cancel_button"/>
                 </xpath>
                 <xpath expr="//header" position="after">
                     <field name="l10n_es_edi_verifactu_warning_level" invisible="1"/>


### PR DESCRIPTION
- The "Send Veri*Factu" button is currently also visible for registered orders (but we can not send documents for such orders anyway; we do not support subsanacion)
- We do not allow generating Veri\*Factu documents for posted orders. That makes it impossible to (Veri\*Factu) send orders after the session is closed.
- We should not allow to Veri*Factu cancel orders. They would still be included in the closing move. The user should create refund instead.

task-None