### PR TITLE
[FIX] l10n_tr_nilvera_edispatch: translation issue

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_edispatch/i18n/tr.po
@@ -498,10 +498,5 @@ msgstr "Teslimat Adresi belirtilmediği için e-İrsaliye oluşturulmayacaktır.
 
 #. module: l10n_tr_nilvera_edispatch
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format
-msgid "false"
-msgstr "yanlış"
-
-#. module: l10n_tr_nilvera_edispatch
-#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format
 msgid "Şoför"
 msgstr "Şoför"

--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
@@ -231,6 +231,7 @@ class StockPicking(models.Model):
             'drivers': drivers,
             'default_tckn': '22222222222',
             'dispatch_scenario': 'TEMELIRSALIYE',
+            'copy_indicator': 'false',
         }
         xml_content = self.env['ir.qweb']._render(
             'l10n_tr_nilvera_edispatch.l10n_tr_edispatch_format',

--- a/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
+++ b/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
@@ -94,7 +94,7 @@
             <cbc:CustomizationID t-out="customization_id"/>
             <cbc:ProfileID t-out="dispatch_scenario"/>
             <cbc:ID t-out="picking.picking_type_id.sequence_code"/>
-            <cbc:CopyIndicator>false</cbc:CopyIndicator>
+            <cbc:CopyIndicator t-out="copy_indicator"/>
             <cbc:UUID t-out="uuid"/>
             <cbc:IssueDate t-out="issue_date"/>
             <cbc:IssueTime t-out="issue_time"/>


### PR DESCRIPTION
Before this commit, since we hardcoded the value, the value was present in the pot and po file. Except that nilvera want a precise value which is 'false' or 'true' and not something translated.

task-5009049




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
