### PR TITLE
[FIX] project: close recurrent task in private project

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -98,7 +98,7 @@ class ProjectTaskRecurrence(models.Model):
             fields_to_postpone.pop('id', None)
             create_values = {
                 'priority': '0',
-                'stage_id': task.project_id.type_ids[0].id if task.project_id.type_ids else task.stage_id.id,
+                'stage_id': task.sudo().project_id.type_ids[0].id if task.sudo().project_id.type_ids else task.stage_id.id,
                 'child_ids': [Command.create(vals) for vals in self._create_next_occurrences_values({child: recurrence for child in task.child_ids})]
             }
             create_values.update({


### PR DESCRIPTION
to reproduce:
=============
- create a private project and a recurrent task in it
- assign the task to an employee
- log in as the employee
- mark the task as done
- the task should be closed but it is not and the employee gets an error

Problem:
========
while changing the state of a recurrent task, we need to read the project which is not allowed for this employee since the project is private.

Solution:
========
we need to use sudo() to read the project in this case.

opw-5012231

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
