### PR TITLE
[FIX] html_builder: handle null ids in ORM read operation

### DIFF
--- a/addons/html_builder/static/src/core/cached_model_plugin.js
+++ b/addons/html_builder/static/src/core/cached_model_plugin.js
@@ -29,7 +29,9 @@ export class CachedModelPlugin extends Plugin {
         this.modelEditCache.invalidate();
     }
     ormRead(model, ids, fields) {
-        return this.ormReadCache.read({ model, ids, fields });
+        const SAFE_NULL = -1;
+        const newIds = ids.map((id) => (id === null ? SAFE_NULL : id));
+        return this.ormReadCache.read({ model, ids: newIds, fields });
     }
     ormSearchRead(model, domain, fields) {
         return this.ormSearchReadCache.read({ model, domain, fields });


### PR DESCRIPTION
Previously, ORM read would receive `NaN` when there was no specific id. Since website refactoring [1], it was receiving `null` which would cause an error.

Steps to reproduce:
- Install website_hr_recruitment
- Go on /jobs page
- Go on a job offer
- Enter editing mode
- Click on location below the job title
- Traceback occurs

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-5003375