### PR TITLE
[FIX] account: fix payment wizard round issue

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -1748,3 +1748,44 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         ctx = {'active_model': 'account.move', 'active_ids': self.out_invoice_1.ids}
         wizard = self.env['account.payment.register'].with_context(**ctx).create({})
         self.assertEqual(wizard.communication, "test")
+
+    def test_payment_register_wizard_convert_rounding(self):
+        """
+        Test that the payment register wizard convert the amount the same way as the account move when conversion are involved
+        """
+        eur_curr = self.env.ref('base.EUR')
+        eur_curr.active = True
+
+        self.env['res.currency.rate'].create({
+            'currency_id': eur_curr.id,
+            'name': '2025-10-03',
+            'company_rate': 0.051908143350,
+            'inverse_company_rate': 19.264800000000,
+        })
+
+        tax_16 = self.env['account.tax'].create({
+            'name': 'tax 16%',
+            'amount_type': 'percent',
+            'amount': 16.0,
+        })
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'currency_id': eur_curr.id,
+            'date': '2025-10-03',
+            'line_ids': [Command.create({
+                'name': 'line',
+                'quantity': 2.0,
+                'price_unit': 432.0,
+                'tax_ids': [tax_16.id],
+            })]
+        })
+        invoice.action_post()
+
+        ctx = {'active_model': 'account.move', 'active_ids': invoice.ids}
+        wizard = self.env['account.payment.register'].with_context(**ctx).create({
+            'currency_id': self.env.company.currency_id.id,
+        })
+
+        self.assertEqual(wizard.amount, invoice.line_ids[2].balance)


### PR DESCRIPTION
With a company where the main currency is, for instance, MXN (easier to reproduce with l10n_mx):

- Create a currency exchange rate for USD: 0.051908143350 unit per MXN and 19.264800000000 MXN per unit.
- Create an invoice in USD with a product priced at 432, quantity of 2, and 16% taxes.

In the journal items of the invoice, the balance is 19307.96 MXN.
However, in the payment wizard, the amount shown when switching to MXN currency is 19307.95.

In _get_total_amount_in_wizard_currency_to_full_reconcile, we convert the source amount currency (which includes line + tax not yet converted), then perform the conversion.
Whereas in the invoice, we first convert the product line and tax line separately and then sum them up.

enterprise: https://github.com/odoo/enterprise/pull/92522

opw-4846090



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
