### PR TITLE
[IMP] website_sale: snippet arrows alignment

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -1,4 +1,43 @@
 .s_dynamic_snippet_products {
+    // Adjusts carousel arrows' aligments
+    @mixin o-aligns-controlers {
+
+        .carousel-control-next,
+        .carousel-control-prev {
+            aspect-ratio: var(--o-wsale-card-thumb-aspect-ratio, 1/1);
+            width: var(--o-wsale-dynamic-snippet-col-size) !important;
+            transform: scaleX(.2);
+            bottom: auto;
+            isolation: isolate;
+            padding-top: 1rem;
+
+            .oi {
+                transform: scaleX(5);
+            }
+        }
+
+        .carousel-control-next {
+            transform-origin: center right;
+        }
+
+        .carousel-control-prev {
+            transform-origin: center left;
+        }
+    }
+
+    // Adapts arrow container width
+    @mixin o-adapts-col-size {
+
+        // For mobile
+        .carousel:has(:where(.s_dynamic_snippet_row > div:nth-child(2))) {
+            --o-wsale-dynamic-snippet-col-size: 50%;
+        }
+
+        // For desktop
+        .carousel:has(:where(.s_dynamic_snippet_row > div:nth-child(4))) {
+            --o-wsale-dynamic-snippet-col-size: 25%;
+        }
+    }
     .s_dynamic_snippet_row.row {
         --gutter-x: var(--o-wsale-products-grid-gap, 16px);
     }
@@ -14,6 +53,21 @@
 
         > div:first-of-type {
             --o-wsale-card-border-width: 1px;
+        }
+    }
+
+    // Applies arrows' alignment except when title is on the left + desktop
+    &:where(.o_wsale_products_opt_design_thumbs) {
+        &:not(:has(.s_dynamic_snippet_title_aside)) {
+            @include o-aligns-controlers;
+            @include o-adapts-col-size;
+        }
+
+        @include media-breakpoint-down(lg) {
+            &:has(.s_dynamic_snippet_title_aside) {
+                @include o-aligns-controlers;
+                @include o-adapts-col-size;
+            }
         }
     }
 }


### PR DESCRIPTION
Before this PR, the snippet's arrows were aligned to the container which would make it look unaligned when a card is bigger. The arrows are now aligned to the cards' image.

task-4997544

| Before | After |
|--------|--------|
| <img width="1414" height="664" alt="Screenshot 2025-08-12 at 17 12 15" src="https://github.com/user-attachments/assets/6fd9f200-4505-4a25-9019-a92d9fa50450" /> | <img width="1414" height="664" alt="Screenshot 2025-08-12 at 17 12 26" src="https://github.com/user-attachments/assets/ea949fc7-55cc-446c-a23d-6f7fb2381695" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
