### PR TITLE
[FIX] point_of_sale: prevent single attribute display

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -1,5 +1,9 @@
 import { registry } from "@web/core/registry";
-import { constructFullProductName, uuidv4 } from "@point_of_sale/utils";
+import {
+    constructFullProductName,
+    uuidv4,
+    constructFullProductNameWithProduct,
+} from "@point_of_sale/utils";
 import { Base } from "./related_models";
 import { parseFloat } from "@web/views/fields/parsers";
 import { formatFloat, roundDecimals, roundPrecision, floatIsZero } from "@web/core/utils/numbers";
@@ -29,7 +33,11 @@ export class PosOrderline extends Base {
     }
 
     set_full_product_name() {
-        this.full_product_name = constructFullProductName(this);
+        if (this.attribute_value_ids?.length) {
+            this.full_product_name = constructFullProductName(this);
+        } else if (this.product_id.attribute_line_ids?.length) {
+            this.full_product_name = constructFullProductNameWithProduct(this.product_id);
+        }
     }
 
     setOptions(options) {

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -33,27 +33,44 @@ export function deduceUrl(url) {
 
 export function constructFullProductName(line) {
     let attributeString = "";
-
-    if (line.attribute_value_ids && line.attribute_value_ids.length > 0) {
-        for (const value of line.attribute_value_ids) {
-            if (value.is_custom) {
-                const customValue = line.custom_attribute_value_ids.find(
-                    (cus) =>
-                        cus.custom_product_template_attribute_value_id?.id == parseInt(value.id)
-                );
-                if (customValue) {
-                    attributeString += `${value.attribute_id.name}: ${value.name}: ${customValue.custom_value}, `;
-                }
-            } else {
-                attributeString += `${value.name}, `;
+    for (const value of line.attribute_value_ids) {
+        if (value.is_custom) {
+            const customValue = line.custom_attribute_value_ids.find(
+                (cus) => cus.custom_product_template_attribute_value_id?.id == parseInt(value.id)
+            );
+            if (customValue) {
+                attributeString += `${value.attribute_id.name}: ${value.name}: ${customValue.custom_value}, `;
             }
+        } else {
+            attributeString += `${value.name}, `;
         }
+    }
 
+    attributeString = attributeString.slice(0, -2);
+    attributeString = ` (${attributeString})`;
+
+    return `${line?.product_id?.display_name}${attributeString}`;
+}
+
+export function constructFullProductNameWithProduct(product) {
+    let attributeString = "";
+    let hasMultipleValues = false;
+    for (const value of product.attribute_line_ids) {
+        if (value.product_template_value_ids.length === 1) {
+            attributeString += `${value.product_template_value_ids[0].name}, `;
+        } else if (product.attribute_line_ids.length > 1) {
+            hasMultipleValues = true;
+        }
+    }
+    if (hasMultipleValues && attributeString !== "") {
+        product.display_name = product.display_name.slice(0, -1);
+        attributeString = attributeString.slice(0, -2);
+        attributeString = `, ${attributeString})`;
+    } else if (attributeString !== "") {
         attributeString = attributeString.slice(0, -2);
         attributeString = ` (${attributeString})`;
     }
-
-    return `${line?.product_id?.display_name}${attributeString}`;
+    return `${product.display_name}${attributeString}`;
 }
 /**
  * Returns a random 5 digits alphanumeric code

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -751,3 +751,21 @@ registry.category("web_tour.tours").add("test_pos_ui_round_globally", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_single_attributes_dont_show_in_name", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Product with Attributes"),
+            {
+                content: "Check that the product configurator is opened",
+                trigger: ".section-product-info-title:contains('Product with Attributes')",
+            },
+            Dialog.confirm("Add"),
+            ProductScreen.selectedOrderlineHas("Product with Attributes (red, big, heavy)", "1.0"),
+            ProductScreen.clickDisplayedProduct("Product without Attributes"),
+            scan_barcode("0100201"),
+            ProductScreen.selectedOrderlineHas("Product without Attributes (big, heavy)", "2.0"),
+        ].flat(),
+});


### PR DESCRIPTION
**Steps to reproduce:**
- Make a product with 2 attributes, like color and shape
- Enter a single value for each of them
- Enter a Barcode on it
- Go to PoS, click on it, the variants will be shown in it's name
- Order it using the Barcode you defined
- The product will not display the variants

**Problem:**
When ordering a product that has multiple attributes with a single value, the "selected" variants will be shown, even though it is always the same. When
ordering it through the Barcode, the variants will not be shown.

**Why the fix:**
The variants are now not shown if all attributes only have one value, like it is done with the Barcode. If there are some attributes that have multiple values, it will be displayed when clicking on it. It is not possible to order them through Barcode as it does not support the value selection in 18.0.

Only showing the variants if there are some choices to be made is how it is done from 18.2 onwards.

opw-4946547