### PR TITLE
[FIX] stock_account: rounding error on revaluation

### DIFF
--- a/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
@@ -239,6 +239,28 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
         credit_lines = [l for l in new_layer.account_move_id.line_ids if l.credit > 0]
         self.assertEqual(len(credit_lines), 1)
 
+    def test_stock_valuation_layer_revaluation_fifo_rounding_2_digits(self):
+        """ make sure that the rounding in the wizard does not incur a negative remaining value
+        """
+
+        self.product1.categ_id.property_cost_method = 'fifo'
+        context = {
+            'default_product_id': self.product1.id,
+            'default_company_id': self.env.company.id,
+            'default_added_value': 0.0
+        }
+
+        self._make_in_move(self.product1, 67104, unit_cost=0.00952)
+        self._make_in_move(self.product1, 898, unit_cost=0.00952)
+
+        self.assertEqual(self.product1.standard_price, 0.01)
+        revaluation_wizard = Form(self.env['stock.valuation.layer.revaluation'].with_context(context))
+        revaluation_wizard.added_value = 636  # triggers the rounding problem
+        revaluation_wizard.account_id = self.stock_valuation_account
+        revaluation_wizard.save().action_validate_revaluation()
+
+        self.assertEqual(self.product1.standard_price, 0.02)
+
     def test_multi_company_fifo_svl_negative_revaluation(self):
         """
         Check that the journal entries and stock valuation layers are created for the company related

--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
@@ -94,12 +94,13 @@ class StockValuationLayerRevaluation(models.TransientModel):
 
         remaining_qty = sum(remaining_svls.mapped('remaining_qty'))
         remaining_value = self.added_value
-        remaining_value_unit_cost = self.currency_id.round(remaining_value / remaining_qty)
+        remaining_value_unit_cost = remaining_value / remaining_qty
         for svl in remaining_svls:
             if float_is_zero(svl.remaining_qty - remaining_qty, precision_rounding=self.product_id.uom_id.rounding):
                 taken_remaining_value = remaining_value
             else:
                 taken_remaining_value = remaining_value_unit_cost * svl.remaining_qty
+            taken_remaining_value = self.currency_id.round(taken_remaining_value)
             if float_compare(svl.remaining_value + taken_remaining_value, 0, precision_rounding=self.product_id.uom_id.rounding) < 0:
                 raise UserError(_('The value of a stock valuation layer cannot be negative. Landed cost could be use to correct a specific transfer.'))
 


### PR DESCRIPTION
Before this commit, the remaining_value_unit_cost was rounded before any computation.
In the case where the numer of layers with remaining value and remaining quantity increase, the rounding error introduced by that rounding quickly explodes, leading to a
negative remaining_value during revaluation computation.

After this commit, the remaining value is rounded at the end, after the computations and the checks.
This ensures that the rounding error remains constant and does not accumulate over the execution of the method.

opw-4901966