### PR TITLE
[REF] web,project,mail: refactor embedded actions settings logic and add tests

### DIFF
--- a/addons/mail/static/tests/mock_server/mock_models/res_users_settings.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users_settings.js
@@ -1,103 +1,15 @@
-import { fields, getKwArgs, models } from "@web/../tests/web_test_helpers";
+import { fields, getKwArgs, webModels } from "@web/../tests/web_test_helpers";
 import { ensureArray } from "@web/core/utils/arrays";
+import { patch } from "@web/core/utils/patch";
 
 /**
  * @template T
  * @typedef {import("@web/../tests/web_test_helpers").KwArgs<T>} KwArgs
  */
 
-const ORM_AUTOMATIC_FIELDS = new Set([
-    "create_date",
-    "create_uid",
-    "display_name",
-    "name",
-    "write_date",
-    "write_uid",
-]);
-
-export class ResUsersSettings extends models.ServerModel {
-    _name = "res.users.settings";
-
+export class ResUsersSettings extends webModels.ResUsersSettings {
     is_discuss_sidebar_category_channel_open = fields.Generic({ default: true });
     is_discuss_sidebar_category_chat_open = fields.Generic({ default: true });
-
-    /** @param {number|number[]} userIdOrIds */
-    _find_or_create_for_user(userIdOrIds) {
-        const [userId] = ensureArray(userIdOrIds);
-        const settings = this._filter([["user_id", "=", userId]])[0];
-        if (settings) {
-            return settings;
-        }
-        const settingsId = this.create({ user_id: userId });
-        return this.browse(settingsId)[0];
-    }
-
-    /**
-     * @param {number} id
-     * @param {string[]} [fields_to_format]
-     */
-    res_users_settings_format(id, fields_to_format) {
-        const kwargs = getKwArgs(arguments, "id", "fields_to_format");
-        id = kwargs.id;
-        delete kwargs.id;
-        fields_to_format = kwargs.fields_to_format;
-
-        /** @type {import("mock_models").ResUsersSettingsVolumes} */
-        const ResUsersSettingsVolumes = this.env["res.users.settings.volumes"];
-
-        const [settings] = this.browse(id);
-        const filterPredicate = fields_to_format
-            ? ([fieldName]) => fields_to_format.includes(fieldName)
-            : ([fieldName]) => !ORM_AUTOMATIC_FIELDS.has(fieldName);
-        const res = Object.fromEntries(Object.entries(settings).filter(filterPredicate));
-        if (Reflect.ownKeys(res).includes("user_id")) {
-            res.user_id = { id: settings.user_id };
-        }
-        if (Reflect.ownKeys(res).includes("volume_settings_ids")) {
-            const volumeSettings = ResUsersSettingsVolumes.discuss_users_settings_volume_format(
-                settings.volume_settings_ids
-            );
-            res.volumes = [["ADD", volumeSettings]];
-        }
-        return res;
-    }
-
-    /**
-     * @param {number | Iterable<number>} idOrIds
-     * @param {Object} newSettings
-     * @param {KwArgs<{ new_settings }>} [kwargs]
-     */
-    set_res_users_settings(idOrIds, new_settings) {
-        const kwargs = getKwArgs(arguments, "idOrIds", "new_settings");
-        idOrIds = kwargs.idOrIds;
-        delete kwargs.idOrIds;
-        new_settings = kwargs.new_settings || {};
-
-        /** @type {import("mock_models").BusBus} */
-        const BusBus = this.env["bus.bus"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
-        /** @type {import("mock_models").ResUsers} */
-        const ResUsers = this.env["res.users"];
-
-        const [id] = ensureArray(idOrIds);
-        const [oldSettings] = this.browse(id);
-        const changedSettings = {};
-        for (const setting in new_settings) {
-            if (setting in oldSettings && new_settings[setting] !== oldSettings[setting]) {
-                changedSettings[setting] = new_settings[setting];
-            }
-        }
-        this.write(id, changedSettings);
-        const [relatedUser] = ResUsers.search_read([["id", "=", oldSettings.user_id]]);
-        const [relatedPartner] = ResPartner.search_read([["id", "=", relatedUser.partner_id[0]]]);
-        BusBus._sendone(relatedPartner, "res.users.settings", {
-            ...changedSettings,
-            id,
-        });
-
-        return changedSettings;
-    }
 
     /**
      * @param {number} guest_id
@@ -147,3 +59,49 @@ export class ResUsersSettings extends models.ServerModel {
         this.set_res_users_settings(ids, { channel_notifications: custom_notifications });
     }
 }
+
+patch(webModels.ResUsersSettings.prototype, {
+    res_users_settings_format(id, fields_to_format) {
+        const kwargs = getKwArgs(arguments, "id", "fields_to_format");
+        id = kwargs.id;
+        delete kwargs.id;
+        fields_to_format = kwargs.fields_to_format;
+        const res = super.res_users_settings_format(id, fields_to_format);
+
+        /** @type {import("mock_models").ResUsersSettingsVolumes} */
+        const ResUsersSettingsVolumes = this.env["res.users.settings.volumes"];
+
+        const [settings] = this.browse(id);
+        if (Reflect.ownKeys(res).includes("volume_settings_ids")) {
+            const volumeSettings = ResUsersSettingsVolumes.discuss_users_settings_volume_format(
+                settings.volume_settings_ids
+            );
+            res.volumes = [["ADD", volumeSettings]];
+        }
+        return res;
+    },
+    set_res_users_settings(idOrIds, new_settings) {
+        const kwargs = getKwArgs(arguments, "idOrIds", "new_settings");
+        idOrIds = kwargs.idOrIds;
+        delete kwargs.idOrIds;
+        new_settings = kwargs.new_settings || {};
+        const changedSettings = super.set_res_users_settings(idOrIds, new_settings);
+
+        /** @type {import("mock_models").BusBus} */
+        const BusBus = this.env["bus.bus"];
+        /** @type {import("mock_models").ResPartner} */
+        const ResPartner = this.env["res.partner"];
+        /** @type {import("mock_models").ResUsers} */
+        const ResUsers = this.env["res.users"];
+
+        const [id] = ensureArray(idOrIds);
+        const [oldSettings] = this.browse(id);
+        const [relatedUser] = ResUsers.search_read([["id", "=", oldSettings.user_id]]);
+        const [relatedPartner] = ResPartner.search_read([["id", "=", relatedUser.partner_id[0]]]);
+        BusBus._sendone(relatedPartner, "res.users.settings", {
+            ...changedSettings,
+            id,
+        });
+        return changedSettings;
+    },
+});

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_access_rights
 from . import test_burndown_chart
 from . import test_project_base
 from . import test_project_config
+from . import test_project_embedded_action_settings
 from . import test_project_flow
 from . import test_project_mail_features
 from . import test_project_milestone

--- a/addons/project/tests/test_project_embedded_action_settings.py
+++ b/addons/project/tests/test_project_embedded_action_settings.py
@@ -1,0 +1,131 @@
+from odoo.addons.project.tests.test_project_base import TestProjectCommon
+
+
+class TestProjectEmbeddedActionSettings(TestProjectCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = cls.env['res.users'].create({
+            'name': 'Test User',
+            'login': 'test_user',
+            'password': 'test_password',
+        })
+        cls.user_settings = cls.env['res.users.settings']._find_or_create_for_user(cls.user)
+        cls.window_action = cls.env['ir.actions.act_window'].create({
+            'name': 'Test Action',
+            'res_model': 'project.project',
+        })
+        cls.embedded_action_1, cls.embedded_action_2 = cls.env['ir.embedded.actions'].create([
+            {
+                'name': 'Embedded Action 1',
+                'parent_res_model': 'project.project',
+                'parent_action_id': cls.window_action.id,
+                'action_id': cls.window_action.id,
+            },
+            {
+                'name': 'Embedded Action 2',
+                'parent_res_model': 'project.project',
+                'parent_action_id': cls.window_action.id,
+                'action_id': cls.window_action.id,
+            },
+        ])
+        cls.embedded_action_settings = cls.env['res.users.settings.embedded.action'].create({
+            'user_setting_id': cls.user_settings.id,
+            'action_id': cls.window_action.id,
+            'res_model': 'project.project',
+            'res_id': cls.project_goats.id,
+            'embedded_actions_order': f'{cls.embedded_action_2.id},false,{cls.embedded_action_1.id}',
+            'embedded_actions_visibility': f'{cls.embedded_action_1.id},{cls.embedded_action_2.id}',
+            'embedded_visibility': True,
+        })
+
+    def test_copy_embedded_action_settings(self):
+        '''
+        Test that embedded action settings are copied correctly when a project is copied.
+        '''
+        copied_project = self.project_goats.copy()
+        # Check if the embedded action settings are copied
+        copied_settings = self.env['res.users.settings.embedded.action'].search([
+            ('user_setting_id', '=', self.user_settings.id),
+            ('action_id', '=', self.window_action.id),
+            ('res_id', '=', copied_project.id),
+        ])
+        self.assertEqual(len(copied_settings), 1, 'There should be one embedded action setting for the copied project.')
+        self.assertEqual(len(self.user_settings.embedded_actions_config_ids), 2, 'There should be two embedded action settings after copying the project.')
+        self.assertEqual(copied_settings.action_id, self.embedded_action_settings.action_id, 'The action_id should match the original.')
+        self.assertEqual(copied_settings.res_id, copied_project.id, 'The res_id should match the copied project id.')
+        self.assertEqual(copied_settings.res_model, self.embedded_action_settings.res_model, 'The res_model should match the original.')
+        self.assertEqual(copied_settings.embedded_actions_order, self.embedded_action_settings.embedded_actions_order, 'The embedded actions order should match the original.')
+        self.assertEqual(copied_settings.embedded_actions_visibility, self.embedded_action_settings.embedded_actions_visibility, 'The embedded actions visibility should match the original.')
+        self.assertEqual(copied_settings.embedded_visibility, self.embedded_action_settings.embedded_visibility, 'The embedded visibility should match the original.')
+
+    def test_copy_custom_embedded_action_settings(self):
+        '''
+        Test that the user-specific actions are not copied in the settings when a project is copied.
+        '''
+        # Create user-specific and shared embedded actions
+        user_specific_embedded_action, shared_embedded_action = self.env['ir.embedded.actions'].create([
+            {
+                'name': 'Custom User-Specific Action',
+                'parent_res_model': 'project.project',
+                'parent_action_id': self.window_action.id,
+                'action_id': self.window_action.id,
+                'parent_res_id': self.project_pigs.id,
+                'user_id': self.user.id,  # User-specific action
+            },
+            {
+                'name': 'Custom Shared Action',
+                'parent_res_model': 'project.project',
+                'parent_action_id': self.window_action.id,
+                'action_id': self.window_action.id,
+                'parent_res_id': self.project_pigs.id,
+                'user_id': False,  # Shared action
+            },
+        ])
+        # Create settings containing those embedded actions
+        self.env['res.users.settings.embedded.action'].create({
+            'user_setting_id': self.user_settings.id,
+            'action_id': self.window_action.id,
+            'res_model': 'project.project',
+            'res_id': self.project_pigs.id,
+            'embedded_actions_order': f'{shared_embedded_action.id},{user_specific_embedded_action.id}',
+            'embedded_actions_visibility': f'{user_specific_embedded_action.id},{shared_embedded_action.id}',
+            'embedded_visibility': True,
+        })
+        # Copy the project
+        copied_project = self.project_pigs.copy()
+        # Get the copied shared embedded action
+        copied_shared_embedded_action = self.env['ir.embedded.actions'].search([
+            ('parent_res_model', '=', 'project.project'),
+            ('parent_res_id', '=', copied_project.id),
+            ('user_id', '=', False)  # Ensure it's a shared action
+        ], limit=1)
+        # Check if the shared embedded action settings are correctly copied
+        copied_settings = self.env['res.users.settings.embedded.action'].search([
+            ('user_setting_id', '=', self.user_settings.id),
+            ('action_id', '=', self.window_action.id),
+            ('res_id', '=', copied_project.id),
+        ])
+        self.assertEqual(len(copied_settings), 1, 'There should be one embedded action setting for the copied project.')
+        self.assertEqual(len(self.user_settings.embedded_actions_config_ids), 3, 'There should be three embedded action settings after copying the project.')
+        self.assertEqual(copied_settings.action_id, self.embedded_action_settings.action_id, 'The action_id should match the original.')
+        self.assertEqual(copied_settings.res_id, copied_project.id, 'The res_id should match the copied project id.')
+        self.assertEqual(copied_settings.res_model, self.embedded_action_settings.res_model, 'The res_model should match the original.')
+        self.assertEqual(copied_settings.embedded_actions_order, str(copied_shared_embedded_action.id), 'Only the shared embedded action should be copied in the actions order.')
+        self.assertEqual(copied_settings.embedded_actions_visibility, str(copied_shared_embedded_action.id), 'Only the shared embedded action should be copied in the visible actions.')
+        self.assertEqual(copied_settings.embedded_visibility, self.embedded_action_settings.embedded_visibility, 'The embedded visibility should match the original.')
+
+    def test_unlink_project_removes_embedded_action_settings(self):
+        '''
+        Test that unlinking a project removes the embedded action settings associated with it.
+        '''
+        self.assertTrue(self.embedded_action_settings.exists(), 'The embedded action settings should exist before unlinking the project.')
+        self.project_goats.unlink()
+        # Check if the embedded action settings are removed
+        self.assertFalse(self.embedded_action_settings.exists(), 'The embedded action settings should be removed when the project is unlinked.')
+        remaining_settings = self.env['res.users.settings.embedded.action'].search([
+            ('user_setting_id', '=', self.user_settings.id),
+            ('action_id', '=', self.window_action.id),
+            ('res_id', '=', self.project_goats.id),
+        ])
+        self.assertEqual(len(remaining_settings), 0, 'There should be no more embedded action settings for the unlinked project.')

--- a/addons/web/models/res_users_settings.py
+++ b/addons/web/models/res_users_settings.py
@@ -22,14 +22,17 @@ class ResUsersSettings(models.Model):
         embedded_actions_config = self.env['res.users.settings.embedded.action'].search([
             ('user_setting_id', '=', self.id), ('action_id', '=', action_id), ('res_id', '=', res_id)
         ], limit=1)
+        new_vals = {}
         for field, value in vals.items():
             if field in ('embedded_actions_order', 'embedded_actions_visibility'):
-                vals[field] = ','.join('false' if action_id is False else str(action_id) for action_id in value)
+                new_vals[field] = ','.join('false' if action_id is False else str(action_id) for action_id in value)
+            else:
+                new_vals[field] = value
         if embedded_actions_config:
-            embedded_actions_config.write(vals)
+            embedded_actions_config.write(new_vals)
         else:
             self.env['res.users.settings.embedded.action'].create({
-                **vals,
+                **new_vals,
                 'user_setting_id': self.id,
                 'action_id': action_id,
                 'res_id': res_id,

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -6,7 +6,7 @@
             <Transition t-if="!env.isSmall" visible="state.embeddedInfos.showEmbedded" name="'o-fade'" t-slot-scope="transition" leaveDuration="500">
                 <div class="o_embedded_actions overflow-hidden d-flex flex-wrap w-100 align-items-center justify-content-center gap-2" t-att-class="transition.className">
                     <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
-                        <t t-if="_checkValueLocalStorage(action)">
+                        <t t-if="_isEmbeddedActionVisible(action)">
                             <button class="btn btn-secondary o_draggable"
                                     t-att-class="{ 'active': state.embeddedInfos.currentEmbeddedAction?.id === action.id}"
                                     t-on-click="() => this.onEmbeddedActionClick(action)"

--- a/addons/web/static/tests/_framework/mock_server/mock_models/res_users_settings.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_models/res_users_settings.js
@@ -1,11 +1,5 @@
 import { ServerModel } from "../mock_model";
-import { getKwArgs } from "../mock_server_utils";
 import { ensureArray } from "@web/core/utils/arrays";
-
-/**
- * @template T
- * @typedef {import("@web/../tests/web_test_helpers").KwArgs<T>} KwArgs
- */
 
 const ORM_AUTOMATIC_FIELDS = new Set([
     "create_date",
@@ -17,7 +11,6 @@ const ORM_AUTOMATIC_FIELDS = new Set([
 ]);
 
 export class ResUsersSettings extends ServerModel {
-    // TODO: merge this class with mail models
     _name = "res.users.settings";
 
     /** @param {number|number[]} userIdOrIds */
@@ -36,11 +29,6 @@ export class ResUsersSettings extends ServerModel {
      * @param {string[]} [fields_to_format]
      */
     res_users_settings_format(id, fields_to_format) {
-        const kwargs = getKwArgs(arguments, "id", "fields_to_format");
-        id = kwargs.id;
-        delete kwargs.id;
-        fields_to_format = kwargs.fields_to_format;
-
         const [settings] = this.browse(id);
         const filterPredicate = fields_to_format
             ? ([fieldName]) => fields_to_format.includes(fieldName)
@@ -55,14 +43,8 @@ export class ResUsersSettings extends ServerModel {
     /**
      * @param {number | Iterable<number>} idOrIds
      * @param {Object} newSettings
-     * @param {KwArgs<{ new_settings }>} [kwargs]
      */
     set_res_users_settings(idOrIds, new_settings) {
-        const kwargs = getKwArgs(arguments, "idOrIds", "new_settings");
-        idOrIds = kwargs.idOrIds;
-        delete kwargs.idOrIds;
-        new_settings = kwargs.new_settings || {};
-
         const [id] = ensureArray(idOrIds);
         const [oldSettings] = this.browse(id);
         const changedSettings = {};

--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -147,7 +147,6 @@ class ResUsersSettings extends WebResUsersSettings {
         } else {
             ResUsersSettingsEmbeddedAction.write(embeddedSettings.id, vals);
         }
-        return embeddedSettings;
     }
 }
 
@@ -268,6 +267,7 @@ defineActions([
 
 beforeEach(() => {
     user.updateUserSettings("id", 1); // workaround to populate the user settings
+    user.updateUserSettings("embedded_actions_config_ids", {}); // workaround to populate the embedded user settings
 });
 
 test("can display embedded actions linked to the current action", async () => {
@@ -310,6 +310,14 @@ test("can toggle visibility of embedded actions", async () => {
     ).click();
     expect(".o_embedded_actions > button").toHaveCount(3, {
         message: "Should have 2 embedded actions in the embedded + the dropdown button",
+    });
+    expect(user.settings.embedded_actions_config_ids).toEqual({
+        "1+": {
+            embedded_actions_order: [],
+            embedded_actions_visibility: [false, 102],
+            embedded_visibility: true,
+            res_model: "partner",
+        },
     });
 });
 
@@ -441,6 +449,14 @@ test("a view coming from a embedded can be saved in the embedded actions", async
     expect(".o_embedded_actions > button").toHaveCount(4, {
         message: "Should have 2 embedded actions in the embedded + the dropdown button",
     });
+    expect(user.settings.embedded_actions_config_ids).toEqual({
+        "1+": {
+            embedded_actions_order: [false, 102, 103, 4],
+            embedded_actions_visibility: [false, 102, 4],
+            embedded_visibility: true,
+            res_model: "partner",
+        },
+    });
 });
 
 test("a view coming from a embedded with python_method can be saved in the embedded actions", async () => {
@@ -499,6 +515,14 @@ test("a view coming from a embedded with python_method can be saved in the embed
     expect(".o_embedded_actions > button").toHaveCount(4, {
         message: "Should have 2 embedded actions in the embedded + the dropdown button",
     });
+    expect(user.settings.embedded_actions_config_ids).toEqual({
+        "1+": {
+            embedded_actions_order: [false, 102, 103, 4],
+            embedded_actions_visibility: [false, 103, 4],
+            embedded_visibility: true,
+            res_model: "partner",
+        },
+    });
 });
 
 test("the embedded actions should not be displayed when switching view", async () => {
@@ -532,6 +556,14 @@ test("User can move the main (first) embedded action", async () => {
     expect(".o_embedded_actions > button:nth-child(2) > span").toHaveText("Partners Action 1", {
         message: "Main embedded action should've been moved to 2nd position",
     });
+    expect(user.settings.embedded_actions_config_ids).toEqual({
+        "1+": {
+            embedded_actions_order: [102, false, 103],
+            embedded_actions_visibility: [false, 102],
+            embedded_visibility: true,
+            res_model: "partner",
+        },
+    });
 });
 
 test("User can unselect the main (first) embedded action", async () => {
@@ -547,6 +579,14 @@ test("User can unselect the main (first) embedded action", async () => {
     await contains(dropdownItem).click();
     expect(dropdownItem).not.toHaveClass("selected", {
         message: "Main embedded action should be unselected",
+    });
+    expect(user.settings.embedded_actions_config_ids).toEqual({
+        "1+": {
+            embedded_actions_order: [],
+            embedded_actions_visibility: [],
+            embedded_visibility: true,
+            res_model: "partner",
+        },
     });
 });
 

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -19,6 +19,7 @@ from . import test_web_search_read
 from . import test_domain
 from . import test_translate
 from . import test_web_redirect
+from . import test_res_users_settings
 from . import test_res_users
 from . import test_webmanifest
 from . import test_ir_qweb

--- a/addons/web/tests/test_res_users_settings.py
+++ b/addons/web/tests/test_res_users_settings.py
@@ -1,0 +1,107 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+
+
+class TestResUsersSettings(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = cls.env['res.users'].create({
+            'name': 'Jean',
+            'login': 'jean@mail.com',
+            'password': 'jean@mail.com',
+        })
+        cls.user_settings = cls.env['res.users.settings']._find_or_create_for_user(cls.user)
+        cls.window_action = cls.env['ir.actions.act_window'].create({
+            'name': 'Test Action',
+            'res_model': 'res.users',
+        })
+
+    def test_fields_validity_embedded_action_settings(self):
+        '''
+        Test that the embedded actions fields 'embedded_actions_order' and 'embedded_actions_visibility' are valid
+        and raise ValidationError when necessary.
+        '''
+        embedded_action_settings_data = {
+            'user_setting_id': self.user_settings.id,
+            'action_id': self.window_action.id,
+            'res_model': 'res.users',
+            'res_id': self.user.id,
+            'embedded_visibility': True,
+        }
+
+        # Invalid case: duplicated ids
+        embedded_action_settings_data.update({
+            'embedded_actions_order': '1,2,1',
+            'embedded_actions_visibility': '3,3,4',
+        })
+        with self.assertRaises(ValidationError, msg='The ids in embedded_actions_order must not be duplicated'):
+            self.env['res.users.settings.embedded.action'].create(embedded_action_settings_data)
+
+        # Invalid case: non-integer ids or non-false values
+        embedded_action_settings_data.update({
+            'embedded_actions_order': '1,2,true',
+            'embedded_actions_visibility': '3,4,false,abc',
+        })
+        with self.assertRaises(ValidationError, msg='The ids in embedded_actions_order must only be integers or "false"'):
+            self.env['res.users.settings.embedded.action'].create(embedded_action_settings_data)
+
+    def test_set_and_get_embedded_action_settings(self):
+        '''
+        Test setting and getting embedded action settings.
+        '''
+        settings_vals = {
+            'embedded_actions_order': [False, 1, 2, 3],
+            'embedded_actions_visibility': [2, False, 3],
+            'embedded_visibility': True,
+        }
+        self.user_settings.set_embedded_actions_setting(
+            action_id=self.window_action.id,
+            res_id=self.user.id,
+            vals={
+                **settings_vals,
+                'res_model': 'res.users',
+            },
+        )
+        # Check if the setting is correctly created
+        embedded_actions_config = self.user_settings.embedded_actions_config_ids
+        self.assertEqual(len(embedded_actions_config), 1, 'There should be one embedded action setting created.')
+        self.assertEqual(embedded_actions_config.action_id, self.window_action, 'The action should match the one set.')
+        self.assertEqual(embedded_actions_config.res_id, self.user.id, 'The res_id should match the one set.')
+        self.assertEqual(embedded_actions_config.res_model, 'res.users', 'The res_model should match the one set.')
+        self.assertEqual(embedded_actions_config.embedded_actions_order, 'false,1,2,3', 'The embedded actions order should match the one set.')
+        self.assertEqual(embedded_actions_config.embedded_actions_visibility, '2,false,3', 'The embedded actions visibility should match the one set.')
+        self.assertEqual(embedded_actions_config.embedded_visibility, True, 'The embedded visibility should be True.')
+        # Check if the settings are correctly formatted from the getter
+        embedded_settings = self.user_settings.get_embedded_actions_settings()
+        expected_settings = {
+            f'{self.window_action.id}+{self.user.id}': settings_vals,
+        }
+        self.assertEqual(embedded_settings, expected_settings, 'The settings should be correctly formatted with the given values.')
+
+        # Edit the settings
+        new_settings_vals = {
+            'embedded_actions_order': [3, 1, False, 2],
+            'embedded_actions_visibility': [1, 3],
+            'embedded_visibility': False,
+        }
+        self.user_settings.set_embedded_actions_setting(
+            action_id=self.window_action.id,
+            res_id=self.user.id,
+            vals=new_settings_vals,
+        )
+        # Check if the setting is correctly updated
+        embedded_actions_config = self.user_settings.embedded_actions_config_ids
+        self.assertEqual(len(embedded_actions_config), 1, 'There should still be one embedded action setting after update.')
+        self.assertEqual(embedded_actions_config.action_id, self.window_action, 'The action should remain the same after update.')
+        self.assertEqual(embedded_actions_config.res_id, self.user.id, 'The res_id should remain the same after update.')
+        self.assertEqual(embedded_actions_config.res_model, 'res.users', 'The res_model should remain the same after update.')
+        self.assertEqual(embedded_actions_config.embedded_actions_order, '3,1,false,2', 'The embedded actions order should be updated.')
+        self.assertEqual(embedded_actions_config.embedded_actions_visibility, '1,3', 'The embedded actions visibility should be updated.')
+        self.assertEqual(embedded_actions_config.embedded_visibility, False, 'The embedded visibility should be updated to False.')
+        # Check if the settings are correctly formatted after the update
+        embedded_settings = self.user_settings.get_embedded_actions_settings()
+        expected_settings = {
+            f'{self.window_action.id}+{self.user.id}': new_settings_vals,
+        }
+        self.assertEqual(embedded_settings, expected_settings, 'The settings should be correctly formatted after the update with the new values.')


### PR DESCRIPTION
In this PR, we rework the embedded actions settings logic in the control panel, to use a "pure" class that contains all the state and logic related to these settings.

We also rework the `ResUserSettings` mock model in `web` to make it generic and use it in other modules, like in `mail`.

Finally, we add Python tests to ensure the correct behavior of the embedded actions settings when copying/removing projects
and when setting/getting those settings from the DB (check validity of fields and correctness).
We also add some checks in the JS tests to ensure that the embedded actions settings are correctly set.

task-5003800

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
