### PR TITLE
[FIX] point_of_sale: duplicate warehouse with Pos Operation Type

### DIFF
--- a/addons/point_of_sale/models/stock_warehouse.py
+++ b/addons/point_of_sale/models/stock_warehouse.py
@@ -6,7 +6,7 @@ from odoo import models, fields, api, _
 class Warehouse(models.Model):
     _inherit = "stock.warehouse"
 
-    pos_type_id = fields.Many2one('stock.picking.type', string="Point of Sale Operation Type")
+    pos_type_id = fields.Many2one('stock.picking.type', string="Point of Sale Operation Type", copy=False)
 
     def _get_sequence_values(self, name=False, code=False):
         sequence_values = super(Warehouse, self)._get_sequence_values(name=name, code=code)

--- a/addons/point_of_sale/tests/test_stock_product_updates.py
+++ b/addons/point_of_sale/tests/test_stock_product_updates.py
@@ -95,4 +95,13 @@ class TestStockProductUpdates(TestPoSCommon, TestProductCommon):
         self.product_template.attribute_line_ids[0].with_user(self.inventory_admin_without_pos).value_ids = [
             Command.unlink(attr_value_lg.id),
         ]
-        
+
+    def test_stock_duplicate_warehouse_with_PoS_operation_type(self):
+        wh = self.env['stock.warehouse'].create({
+            'name': 'WH1',
+            'code': 'WH1',
+            'company_id': self.env.company.id,
+        })
+        wh_copy = wh.copy()
+        self.assertTrue(wh_copy.pos_type_id)
+        self.assertNotEqual(wh.pos_type_id, wh_copy.pos_type_id)


### PR DESCRIPTION
## Short functional explanation of the error
When duplicating a warehouse, if it has an PoS operation type,
this operation type will not be duplicated. On the other hand,
all other operation types will be duplicated. 

## Reproduction Steps
1. Make sure PoS and inventory are well installed.
2. Go to inventory. 
3. Click on configuration, then warehouse.
4. Select a warehouse, click on action, then duplicate.
5. Click on configuration, then on Operation Types.

### Expected behavior
We should be able to see 2 instances of PoS operation type:
one for the original company, and one for the copy.

### Unexpected behavior
There's only one instance of PoS operation type, which is
related to the original company.


## Origin of the issue
PoS operation type is a model inherited from stock.warehouse,
and no copy method was defined. Therefore, upon duplication,
the copy method of the original stock.warehouse was called,
leading to issues with the field created in the inherited
version.

__
opw-4991271