### PR TITLE
[IMP] l10n_ubl_pint: new PINT rules; improve existing contraints

### DIFF
--- a/addons/l10n_anz_ubl_pint/models/account_edi_xml_pint_anz.py
+++ b/addons/l10n_anz_ubl_pint/models/account_edi_xml_pint_anz.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, _
+from odoo.tools import float_is_zero
 
 ANZ_TAX_CATEGORIES = {'S', 'E', 'Z', 'G', 'O'}
 
@@ -81,6 +82,18 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
                 vals['company_id_attrs'] = {'schemeID': partner.peppol_eas}
         return vals_list
 
+    def _get_invoice_line_item_vals(self, line, taxes_vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        line_item_vals = super()._get_invoice_line_item_vals(line, taxes_vals)
+
+        for val in line_item_vals['classified_tax_category_vals']:
+            # As of PINT A-NZ v1.1.0: [aligned-ibrp-o-05-aunz] tax categories of type "Not Subject to tax" (i.e. tax_category_code == 'O') must NOT have
+            # tax rate ('cbc:Percent').
+            if val.get('id') == 'O' and float_is_zero(val.get('percent'), precision_digits=2):
+                del val['percent']
+
+        return line_item_vals
+
     def _export_invoice_vals(self, invoice):
         # EXTENDS account_edi_ubl_cii
         vals = super()._export_invoice_vals(invoice)
@@ -105,6 +118,39 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
             for tax_subtotal_val in tax_total_val.get('tax_subtotal_vals', ()):
                 if tax_subtotal_val['tax_category_vals']['tax_category_code'] not in ANZ_TAX_CATEGORIES:
                     constraints['sg_vat_category_required'] = _("You must set a tax category on each taxes of the invoice.\nValid categories are: S, E, Z, G, O")
+
+        # Tax category of type "Not subject to tax" must have tax amount 0
+        count_outside_of_scope_breakdown = 0
+        for tax_category, tax_category_vals in vals['taxes_vals']['tax_details'].items():
+            if tax_category['tax_category_id'] != 'O':
+                continue
+            count_outside_of_scope_breakdown += 1
+
+            if float_is_zero(tax_category_vals['tax_amount'], precision_digits=2):
+                continue
+
+            if vals['supplier'].vat:
+                constraints['anz_tax_breakdown_amount'] = \
+                    self.env._("A tax category of type 'Not subject to tax' must have tax"
+                               " amount set to 0")
+            else:
+                # If a company is not GST registered, this module remaps all tax categories
+                # to 'O' (Other/Out of Scope). This causes an issue when a line contained a
+                # non-zero tax, as it would create a tax subtotal with (Code: 'O', Amount:
+                # non-zero), which violates PINT rules.
+                # Since the code silently remaps tax classification code, the original error
+                # message might be misleading for users. This constraint contains better
+                # explaination of error and intructions on how to prevent it.
+                constraints['anz_non_gst_supplier_tax_scope'] = \
+                    self.env._("Suppliers not registered for GST cannot use taxes that are"
+                               " not zero-rated. Please ensure the tax category is set to"
+                               " 'O' (Services outside scope of tax) with a tax amount of 0.")
+
+        # There should be at most one tax breakdown of type "Not subject to tax".
+        if count_outside_of_scope_breakdown > 1 and vals['supplier'].vat:
+            constraints['anz_duplicate_tax_breakdown'] = \
+                self.env._("A tax breakdown of type 'Not subject to tax' should appear at most"
+                           " once in the tax breakdown")
 
         # ALIGNED-IBR-001-AUNZ and ALIGNED-IBR-002-AUNZ
         for partner_type in ('supplier', 'customer'):

--- a/addons/l10n_my_ubl_pint/models/account_edi_xml_pint_my.py
+++ b/addons/l10n_my_ubl_pint/models/account_edi_xml_pint_my.py
@@ -53,7 +53,7 @@ class AccountEdiXmlUBLPINTMY(models.AbstractModel):
             # TIN
             gst_tax_scheme = tax_scheme_vals_list[0].copy()
             gst_tax_scheme.update({
-                'company_id': partner.vat,
+                'company_id': partner.vat or 'NA',
                 'tax_scheme_vals': {'id': 'GST'},
             })
             tax_scheme_vals_list.append(gst_tax_scheme)

--- a/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
+++ b/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
@@ -3,7 +3,8 @@
 from odoo import models, _
 
 
-SG_TAX_CATEGORIES = {'SR', 'SRCA-S', 'SRCA-C', 'SROVR-RS', 'SROVR-LVG', 'SRLVG', 'ZR', 'ES33', 'ESN33', 'DS', 'OS', 'NG', 'NA'}
+SG_TAX_CATEGORIES = {'SR', 'SRCA-S', 'SRCA-C', 'SROVR-RS', 'SRRC', 'SROVR-LVG', 'SRLVG', 'ZR', 'ES33', 'ESN33', 'DS', 'OS', 'NG', 'NA'}
+SG_GST_CODES_REQUIRING_ADDRESS = {'SR', 'SRCA-S', 'SRCA-C', 'ZR', 'SRRC', 'SROVR-RS', 'SROVR-LVG', 'SRLVG', 'NA'}
 
 
 class AccountEdiXmlUBLPINTSG(models.AbstractModel):
@@ -98,5 +99,12 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
             for tax_subtotal_val in tax_total_val.get('tax_subtotal_vals', ()):
                 if tax_subtotal_val['tax_category_vals']['tax_category_code'] not in SG_TAX_CATEGORIES:
                     constraints['sg_vat_category_required'] = _("You must set a Singaporean tax category on each taxes of the invoice.")
+
+        # Invoice with GST category code of value 'SR', 'SRCA-S', 'SRCA-C', 'ZR', 'SRRC', 'SROVR-RS', 'SROVR-LVG', 'SRLVG', 'NA' should contain
+        # seller address line and seller post code
+        for tax_category in vals['taxes_vals']['tax_details']:
+            if tax_category['tax_category_id'] in SG_GST_CODES_REQUIRING_ADDRESS:
+                constraints['sg_seller_street_addr_required'] = self._check_required_fields(vals['supplier'], 'street')
+                constraints['sg_seller_post_code_required'] = self._check_required_fields(vals['supplier'], 'zip')
 
         return constraints

--- a/addons/l10n_sg_ubl_pint/models/account_tax.py
+++ b/addons/l10n_sg_ubl_pint/models/account_tax.py
@@ -14,6 +14,7 @@ class AccountTax(models.Model):
             ('SRCA-C', "SG - Customer accounting supply made by the customer on supplier’s behalf"),
             ('SROVR-RS', "SG - Supply of remote services accountable by the electronic marketplace under the Overseas Vendor Registration Regime"),
             ('SROVR-LVG', "SG - Supply of low-value goods accountable by the redeliverer or electronic marketplace on behalf of third-party suppliers"),
+            ('SRRC', "SG - Reverse charge regime for Business-to-Business (“B2B”) supplies of imported services"),
             ('SRLVG', "SG - Own supply of low-value goods"),
             ('ZR', "SG - Supplies involving goods for export/ provision of international services"),
             ('ES33', "SG - Specific categories of exempt supplies listed under regulation 33 of the GST (General) Regulations"),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- AU&NZ: Current behavior is that when VAT is not set on the partner, the tax category code defaults to zero. This becomes problematic with certain rules (e.g. the tax totals of tax category code 'O' should have amount of zero, but current code can set this value to something other than zero). The change focuses on edge cases when VAT of partner is not set. Changes are not related to the Q2 2025 release changes.
- MY: Added fallback for <cac:PartyTaxScheme> to always have <cbc:CompanyID>. Currently breaks if the partner does not have VAT set. Changes are not related to the Q2 2025 release changes.
- JP: No changes are made.
- SG: Invoice with taxes of certain tax category codes must have seller and buyer street address and post code. Added constraint to make sure they are set. New PINT SG rule adds one more tax category code (Standard Rate, SRRC). New code is added to `ubl_cii_tax_category_code`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
