### PR TITLE
[IMP] calendar: redesign calendar event quick create

### DIFF
--- a/addons/calendar/static/src/scss/calendar_event_views.scss
+++ b/addons/calendar/static/src/scss/calendar_event_views.scss
@@ -10,3 +10,25 @@
         }
     }
 }
+
+/*                 Quick-Edit Form View
+ **********************************************************/
+
+.modal-dialog:has(.o_calendar_event_form_quick_create) {
+    --modal-width: 450px;
+}
+
+.o_calendar_event_form_quick_create {
+    .o_form_nosheet {
+        padding: 0;
+        > div {
+            margin-top: 0.5rem;
+            margin-left: 5px;
+            margin-right: 5px;
+        }
+    }
+    i.fa {
+        text-align: center;
+        min-width: 2rem;
+    }
+}

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
@@ -58,13 +58,7 @@ export class AttendeeCalendarController extends CalendarController {
         return {
             ...props,
             size: "md",
-            goToFullEvent: (contextData) => {
-                const fullContext = {
-                    ...props.context,
-                    ...contextData,
-                };
-                this.goToFullEvent(false, fullContext);
-            },
+            context: { ...props.context, ...this.props.context },
             onRecordSaved: () => onDialogClosed(),
         };
     }

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -212,4 +212,12 @@ export class AttendeeCalendarModel extends CalendarModel {
         }
         await this.load();
     }
+
+    normalizeRecord(rawRecord) {
+        const normalizedRecord = super.normalizeRecord(rawRecord);
+        if (rawRecord.effective_privacy === "private") {
+            normalizedRecord.titleIcon = "fa fa-lock";
+        }
+        return normalizedRecord;
+    }
 }

--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
@@ -18,7 +18,11 @@
 
     <t t-name="calendar.AttendeeCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='isEventDeletable']" position="after">
-            <a t-if="isEventArchivable and isEventDetailsVisible" href="#" class="btn btn-secondary o_cw_popover_archive_g" t-on-click="onClickArchive">Delete</a>
+            <a t-if="isEventArchivable and isEventDetailsVisible" href="#" class="btn btn-secondary" t-on-click="onClickArchive">
+                <i class="fa fa-trash"/>
+            </a>
+        </xpath>
+        <xpath expr="//t[@t-if='isEventDeletable']" position="before">
             <t t-if="displayAttendeeAnswerChoice">
                 <div class="btn-group w-100 w-lg-auto ms-lg-auto order-first order-lg-0 px-2 px-lg-0">
                     <button class="btn"

--- a/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
@@ -1,21 +1,12 @@
 import { FormController } from "@web/views/form/form_controller";
 import { useAskRecurrenceUpdatePolicy } from "@calendar/views/ask_recurrence_update_policy_hook";
 import { useService } from "@web/core/utils/hooks";
-import { onWillStart } from "@odoo/owl";
 
 export class CalendarFormController extends FormController {
     setup() {
         super.setup();
-        const ormService = useService("orm");
         this.actionService = useService("action");
         this.askRecurrenceUpdatePolicy = useAskRecurrenceUpdatePolicy();
-
-        onWillStart(async () => {
-            this.discussVideocallLocation = await ormService.call(
-                "calendar.event",
-                "get_discuss_videocall_location"
-            );
-        });
     }
 
     /**
@@ -23,21 +14,12 @@ export class CalendarFormController extends FormController {
      */
     async beforeExecuteActionButton(clickParams) {
         const action = clickParams.name;
-        if (action === "clear_videocall_location" || action === "set_discuss_videocall_location") {
-            let newVal = "";
-            let videoCallSource = "custom";
-            let changes = {};
-            if (action === "set_discuss_videocall_location") {
-                newVal = this.discussVideocallLocation;
-                videoCallSource = "discuss";
-                changes.access_token = this.discussVideocallLocation.split("/").pop();
-            }
-            changes = Object.assign(changes, {
-                videocall_location: newVal,
-                videocall_source: videoCallSource,
-            });
-            this.model.root.update(changes);
-            return false; // no continue
+        if (action === "clear_videocall_location") {
+            this.model.root.clearLocation();
+            return false;
+        } else if (action === "set_discuss_videocall_location") {
+            this.model.root.setLocation();
+            return false;
         }
         return super.beforeExecuteActionButton(...arguments);
     }

--- a/addons/calendar/static/src/views/calendar_form/calendar_form_model.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_form_model.js
@@ -1,0 +1,37 @@
+import { onWillStart } from "@odoo/owl";
+
+import { RelationalModel } from "@web/model/relational_model/relational_model";
+import { Record } from "@web/model/relational_model/record";
+
+class CalendarFormRecord extends Record {
+
+    async setLocation() {
+        const videoLocation = await this.model.discussVideocallLocation;
+        this.update({
+            access_token: videoLocation.split("/").pop(),
+            videocall_location: videoLocation,
+            videocall_source: "discuss",
+        });
+    }
+
+    async clearLocation() {
+        this.update({
+            videocall_location: false,
+            videocall_source: "custom",
+        });
+    }
+}
+
+export class CalendarFormModel extends RelationalModel {
+    static Record = CalendarFormRecord;
+
+    setup() {
+        super.setup(...arguments);
+        onWillStart(async () => {
+            this.discussVideocallLocation = this.orm.call(
+                "calendar.event",
+                "get_discuss_videocall_location"
+            );
+        });
+    }
+}

--- a/addons/calendar/static/src/views/calendar_form/calendar_form_view.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_form_view.js
@@ -1,10 +1,12 @@
 import { registry } from "@web/core/registry";
 import { formView } from "@web/views/form/form_view";
 import { CalendarFormController } from "@calendar/views/calendar_form/calendar_form_controller";
+import { CalendarFormModel } from "@calendar/views/calendar_form/calendar_form_model";
 
 export const CalendarFormView = {
     ...formView,
     Controller: CalendarFormController,
+    Model: CalendarFormModel,
 };
 
 registry.category("views").add("calendar_form", CalendarFormView);

--- a/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
@@ -4,7 +4,7 @@ import { CalendarFormView } from "./calendar_form_view";
 import { CalendarFormController } from "./calendar_form_controller";
 import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 
-const QUICK_CREATE_CALENDAR_EVENT_FIELDS = {
+export const QUICK_CREATE_CALENDAR_EVENT_FIELDS = {
     name: { type: "string" },
     start: { type: "datetime" },
     start_date: { type: "date" },
@@ -36,14 +36,23 @@ function getDefaultValuesFromRecord(data) {
 }
 
 export class CalendarQuickCreateFormController extends CalendarFormController {
-    static props = {
-        ...CalendarFormController.props,
-        goToFullEvent: Function,
-    };
 
     goToFullEvent() {
-        const context = getDefaultValuesFromRecord(this.model.root.data)
-        this.props.goToFullEvent(context);
+        const context = getDefaultValuesFromRecord(this.model.root.data);
+        return this.actionService.doAction(
+            {
+                type: "ir.actions.act_window",
+                res_model: "calendar.event",
+                views: [[false, "form"]],
+                res_id: this.model.root.resId || false,
+            },
+            {
+                additionalContext: {
+                    ...this.props.context,
+                    ...context,
+                },
+            }
+        );
     }
 
     /**
@@ -68,19 +77,12 @@ registry.category("views").add("calendar_quick_create_form_view", {
 });
 
 export class CalendarQuickCreate extends FormViewDialog {
-    static props = {
-        ...FormViewDialog.props,
-        goToFullEvent: Function,
-    };
 
     setup() {
         super.setup();
         Object.assign(this.viewProps, {
             ...this.viewProps,
             buttonTemplate: "calendar.CalendarQuickCreateButtons",
-            goToFullEvent: (contextData) => {
-                this.props.goToFullEvent(contextData);
-            }
         });
     }
 }

--- a/addons/calendar/static/src/views/calendar_form/calendar_quick_create.xml
+++ b/addons/calendar/static/src/views/calendar_form/calendar_quick_create.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="calendar.CalendarQuickCreateButtons" t-inherit="web.FormViewDialog.ToOne.buttons">
-        <xpath expr="//button[hasclass('o_form_button_cancel')]" position="after">
-            <button class="btn btn-link ms-auto" t-on-click="goToFullEvent">More Options</button>
+        <xpath expr="//button[hasclass('o_form_button_save')]" position="after">
+            <button t-if="!props.resId" class="btn btn-secondary" t-on-click="goToFullEvent">More Options</button>
+        </xpath>
+        <xpath expr="//button[hasclass('o_form_button_cancel')]" position="attributes">
+            <attribute name="class" add="ms-auto" separator=" "/>
         </xpath>
     </t>
 </templates>

--- a/addons/calendar/static/src/views/fields/calendar_notes_html_field.js
+++ b/addons/calendar/static/src/views/fields/calendar_notes_html_field.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+import { htmlField, HtmlField } from "@html_editor/fields/html_field";
+import { MoveNodePlugin } from "@html_editor/main/movenode_plugin";
+
+class CalendarEventNotesHtmlField extends HtmlField {
+    getConfig() {
+        const config = super.getConfig();
+        config.Plugins = config.Plugins.filter((plugin) => plugin !== MoveNodePlugin);
+        return config;
+    }
+}
+
+export const calendarEventNotesHtmlField = { ...htmlField, component: CalendarEventNotesHtmlField };
+registry.category("fields").add("calendar_event_notes_html", calendarEventNotesHtmlField);

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -332,48 +332,73 @@
         <field name="model">calendar.event</field>
         <field name="priority" eval="2"/>
         <field name="arch" type="xml">
-            <form string="Meetings" js_class="calendar_quick_create_form_view">
-                <sheet>
+            <form string="Meetings" class="o_calendar_event_form_quick_create" js_class="calendar_quick_create_form_view">
+                <field name="invalid_email_partner_ids" invisible="1"/> <!--used in many2many_attendees widget-->
+                <div class="d-flex align-items-center" colspan="2">
+                    <i class="fa fa-tag text-600" title="Booking Name"/>
+                    <field name="name" nolabel="1"
+                        placeholder="Add Title"
+                        class="w-100 mb-0"
+                    />
+                </div>
+                <div class="d-flex align-items-center" colspan="2">
+                    <i class="fa fa-clock-o text-600" title="Dates"/>
+                    <field name="start" nolabel="1"
+                        widget="daterange" options="{'end_date_field': 'stop'}"
+                        placeholder="Dates" class="w-100 mb-0"
+                        invisible="allday"
+                    />
+                    <field name="start_date" nolabel="1"
+                        widget="daterange" options="{'end_date_field': 'stop_date'}"
+                        placeholder="Dates" class="w-100 mb-0"
+                        invisible="not allday"
+                    />
+                    <span class="ms-1 w-25">
+                        <field name="allday" class="mb-0" title="All Day" nolabel="1"/>
+                        <span>All day</span>
+                    </span>
+                    <field name="stop" invisible="1"/>
+                </div>
+                <div class="d-flex" colspan="2">
+                    <i class="fa fa-user mt-1 text-600" title="Participants"/>
+                    <field name="partner_ids" nolabel="1"
+                        widget="many2many_tags"
+                        placeholder="Participants"
+                        class="w-75 mb-0"
+                    />
+                </div>
+                <div class="d-flex align-items-center" colspan="2">
+                    <i class="fa fa-map text-600" title="Location"/>
+                    <field name="location" nolabel="1"
+                        placeholder="Location"
+                        class="w-100 mb-0"
+                    />
+                    <!--fields set via the fake front-end only actions must be force saved (see calendar_form)-->
                     <field name="recurrence_update" invisible="1"/>
-                    <field name="videocall_source" invisible="1"/>
-                    <field name="access_token" invisible="1" force_save="1"/>
-                    <field name="access_token" invisible="1"/>
-                    <field name="invalid_email_partner_ids" invisible="1"/> <!-- this field will be used in
-                        many2many_attendees widget -->
-                    <div class="o_row">
-                        <h1 class="w-100"><field name="name" nolabel="1" placeholder="Add title" colspan="2"/></h1>
-                    </div>
-                    <group>
-                        <field name="start_date" widget="daterange" options="{'end_date_field': 'stop_date'}" invisible="not allday" required="allday"/>
-                        <field name="start" widget="daterange" options="{'end_date_field': 'stop'}" invisible="allday" required="not allday"/>
-                        <field name="stop_date" invisible="1" />
-                        <field name="stop" invisible="1" />
-                        <field name="unavailable_partner_ids" invisible="1" /> <!-- this field will be used in many2many_attendees widget -->
-                        <field name="allday"/>
-                        <field name="partner_ids" widget="many2manyattendee"
-                            placeholder="Add attendees..."
-                            options="{'no_quick_create': True}"
-                            context="{'form_view_ref': 'base.view_partner_simple_form'}"
-                        />
-                        <field name="location"/>
-                        <label for="videocall_location" class="opacity-100"/>
-                        <div col="2">
-                            <field name="videocall_location" string="Meeting Link" widget="CopyClipboardChar" force_save="1" readonly="videocall_source == 'discuss'"/>
-                            <button name="clear_videocall_location" type="object" class="btn btn-link p-0"
-                                invisible="not videocall_location" context="{'recurrence_update': recurrence_update}">
-                                <span class="fa fa-times"></span><span> Clear meeting</span>
-                            </button>
-                            <button name="set_discuss_videocall_location" type="object" class="btn btn-link p-0"
-                                invisible="videocall_location" context="{'recurrence_update': recurrence_update}">
-                                <span class="fa fa-plus"></span> <span>Odoo meeting</span>
-                            </button>
-                            <button name="action_join_video_call" class="btn btn-link" help="Join Video Call" type="object" invisible="not videocall_location">
-                                <span class="oi oi-arrow-right"></span><span> Join video call</span>
-                            </button>
-                        </div>
-                        <field name="description" placeholder="Describe your meeting"/>
-                    </group>
-                </sheet>
+                    <field name="access_token" force_save="1" invisible="1"/>
+                    <field name="videocall_location" force_save="1" invisible="1"/>
+                    <field name="videocall_source" force_save="1" invisible="1"/>
+                    <button name="set_discuss_videocall_location" type="object" class="mx-1 btn-link text-nowrap"
+                        invisible="videocall_location" context="{'recurrence_update': recurrence_update}">
+                        <span class="fa fa-plus me-1"/>Video
+                    </button>
+                </div>
+                <div class="d-flex align-items-center" colspan="2" invisible="not videocall_location">
+                    <i class="fa fa-video-camera text-600" title="Videocall URL"/>
+                    <field name="videocall_location" nolabel="1"
+                        widget="CopyClipboardChar"
+                        class="w-100 mb-0 o_field_CopyClipboardChar" 
+                    />
+                    <button name="clear_videocall_location" class="btn btn-sm px-0"><i class="fa fa-remove" title="Remove"/></button>
+                </div>
+                <div class="d-flex align-items-center" colspan="2">
+                    <i class="fa fa-lock text-600" title="Visibility"/>
+                    <field name="privacy" nolabel="1" class="w-100 mb-0" placeholder="Visibility"/>
+                </div>
+                <div class="d-flex" colspan="2">
+                    <i class="fa fa-sticky-note mt-2 text-600" title="Notes"/> 
+                    <field name="notes" nolabel="1" class="w-100" placeholder="Notes" widget="calendar_event_notes_html"/>
+                </div>
             </form>
         </field>
     </record>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -414,30 +414,30 @@
                 quick_create="true"
                 quick_create_view_id="%(calendar.view_calendar_event_form_quick_create)d"
                 color="partner_ids">
-                <field name="location" invisible="not location" options="{'icon': 'fa fa-map-marker'}"/>
                 <field name="attendees_count" invisible="1"/>
                 <field name="accepted_count" invisible="1"/>
                 <field name="declined_count" invisible="1"/>
                 <field name="user_can_edit" invisible="1"/>
+                <field name="is_highlighted" invisible="1"/>
+                <field name="privacy" invisible="1"/>
+                <field name="effective_privacy" invisible="1"/>
+                <!-- For recurrence update Dialog -->
+                <field name="recurrency" invisible="1"/>
+                <field name="recurrence_update" invisible="1"/>
+
+                <field name="location" invisible="not location" options="{'icon': 'fa fa-map-marker'}"/>
                 <field name="partner_ids" options="{'block': True, 'icon': 'fa fa-users'}"
                        filters="1" widget="many2manyattendeeexpandable" write_model="calendar.filters"
                        write_field="partner_id" filter_field="partner_checked" avatar_field="avatar_128"
                 />
-                <field name="videocall_location" widget="url" text="Join Video Call" options="{'icon': 'fa fa-lg fa-video-camera'}" invisible="not videocall_location"/>
-                <field name="is_highlighted" invisible="1"/>
-                <field name="is_organizer_alone" invisible="1"/>
-                <field name="display_description" invisible="1"/>
-                <field name="description" invisible="not display_description" options="{'icon': 'fa fa-bars'}"/>
-                <field name="privacy" invisible="1"/>
-                <field name="effective_privacy" invisible="1"/>
+                <field name="videocall_location" widget="CopyClipboardURL" text="Join Video Call"
+                       options="{'icon': 'fa fa-lg fa-video-camera'}" invisible="not videocall_location"/>
                 <field name="res_model_name" invisible="not res_model_name"
                        options="{'icon': 'fa fa-link', 'shouldOpenRecord': true}"/>
                 <field name="alarm_ids" invisible="not alarm_ids" options="{'icon': 'fa fa-bell-o'}"/>
                 <field name="categ_ids" invisible="not categ_ids" options="{'icon': 'fa fa-tag', 'color_field': 'color'}"/>
-                <!-- For recurrence update Dialog -->
-                <field name="recurrency" invisible="1"/>
-                <field name="recurrence_update" invisible="1"/>
                 <field name="partner_id" string="Organizer" options="{'icon': 'fa fa-user-o'}"/>
+                <field name="description" invisible="not display_description" options="{'icon': 'fa fa-sticky-note'}"/>
             </calendar>
         </field>
     </record>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -404,6 +404,7 @@
                 <field name="display_description" invisible="1"/>
                 <field name="description" invisible="not display_description" options="{'icon': 'fa fa-bars'}"/>
                 <field name="privacy" invisible="1"/>
+                <field name="effective_privacy" invisible="1"/>
                 <field name="res_model_name" invisible="not res_model_name"
                        options="{'icon': 'fa fa-link', 'shouldOpenRecord': true}"/>
                 <field name="alarm_ids" invisible="not alarm_ids" options="{'icon': 'fa fa-bell-o'}"/>

--- a/addons/project/static/tests/project_project_calendar.test.js
+++ b/addons/project/static/tests/project_project_calendar.test.js
@@ -35,7 +35,8 @@ test("check 'Edit' and 'View Tasks' buttons are in Project Calendar Popover", as
     await runAllTimers();
     expect(".o_popover").toHaveCount(1);
     expect(".o_popover .card-footer .btn").toHaveCount(3);
-    expect(queryAllTexts(".o_popover .card-footer .btn")).toEqual(["Edit", "View Tasks", "Delete"]);
+    expect(queryAllTexts(".o_popover .card-footer .btn")).toEqual(["Edit", "View Tasks", ""]);
+    expect(".o_popover .card-footer .btn i.fa-trash").toHaveCount(1);
 
     await click(".o_popover .card-footer a:contains(View Tasks)");
     await click(".o_popover .card-footer a:contains(Edit)");

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
@@ -75,13 +75,29 @@ $o-cw-popup-avatar-size: 16px;
     }
 }
 
-@for $i from 1 through length($o-colors-complete) {
-    $color: nth($o-colors-complete, $i);
-    $color-subtle: mix($o-white, $color, 55%);
+// Put logic in a function so that temporary variable like $-color
+// are not assigned to the global scope and potentially mess with
+// other global variables
+@function o-build-web-calendar-colors() {
+    $-calendar-colors: ();
+    @for $i from 1 through length($o-colors-complete) {
+        $-color: nth($o-colors-complete, $i);
+        $-color-subtle: mix($o-white, $-color, 55%);
+        $-calendar-colors: append($-calendar-colors, (
+            color-subtle: $-color-subtle,
+            popover-background-color: lighten($-color-subtle, 10%),
+            popover-color:  color-contrast($-color-subtle),
+        ));
+    }
+    @return $-calendar-colors;
+}
+$o-web-calendar-colors: o-build-web-calendar-colors();
 
+
+@for $i from 1 through length($o-web-calendar-colors) {
     .modal.o_technical_modal.o_modal_full .modal-dialog .modal-content.o_calendar_color_#{$i - 1} {
         .modal-header {
-            background-color: $color-subtle;
+            background-color: map-get(nth($o-web-calendar-colors, $i), "color-subtle");
 
             .btn {
                 color: $body-color;
@@ -90,14 +106,15 @@ $o-cw-popup-avatar-size: 16px;
     }
 
     .o_cw_popover.o_calendar_color_#{$i - 1} {
+        $-calendar-colors-map: nth($o-web-calendar-colors, $i);
         .card-header,
         .card-header .popover-header {
-            background-color: lighten($color-subtle, 10%);
-            color: color-contrast($color-subtle);
+            background-color: map-get($-calendar-colors-map, "popover-background-color");
+            color: map-get($-calendar-colors-map, "popover-color");
         }
 
         .card-header {
-            --#{$variable-prefix}card-border-color: #{$color-subtle};
+            --#{$variable-prefix}card-border-color: #{map-get($-calendar-colors-map, "color-subtle")};
         }
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -50,7 +50,7 @@
                     <t t-set="fieldInfo" t-value="props.model.popoverFieldNodes[fieldId]"/>
                     <t t-set="fieldType" t-value="props.model.fields[fieldId].type"/>
                     <t t-if="!isInvisible(fieldInfo, slot.record)">
-                        <li class="list-group-item d-flex text-nowrap align-items-center" t-att-class="fieldInfo.attrs.class"  t-att-data-tooltip="fieldType === 'html' ? '' : getFormattedValue(fieldId, slot.record)">
+                        <li class="list-group-item d-flex text-nowrap" t-att-class="fieldInfo.attrs.class"  t-att-data-tooltip="fieldType === 'html' ? '' : getFormattedValue(fieldId, slot.record)">
                             <span class="fw-bold me-2" t-if="!fieldInfo.options.noLabel and fieldInfo.type !== 'properties'">
                                 <t t-if="fieldInfo.options.icon">
                                     <i t-attf-class="fa-fw {{fieldInfo.options.icon}} text-400" />
@@ -77,7 +77,7 @@
             </a>
         </t>
         <t t-if="isEventDeletable">
-            <a href="#" class="btn btn-secondary o_cw_popover_delete" t-on-click="onDeleteEvent">Delete</a>
+            <a href="#" class="btn btn-secondary o_cw_popover_delete" t-on-click="onDeleteEvent"><i class="fa fa-trash"/></a>
         </t>
     </t>
 

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -17,7 +17,10 @@
 
     <t t-name="web.CalendarCommonPopover.popover">
         <div class="card-header d-flex justify-content-between py-2 pe-2">
-            <span class="popover-header border-0 text-truncate" t-esc="props.record.title" t-att-data-tooltip="props.record.title"/>
+            <span class="popover-header border-0 text-truncate">
+                <i t-if="props.record.titleIcon" t-attf-class="me-2 {{props.record.titleIcon}}"/>
+                <span t-esc="props.record.title" t-att-data-tooltip="props.record.title"/>
+            </span>
             <span class="o_cw_popover_close ms-4 mt-2 me-2" t-on-click.stop="() => props.close()">
                 <i class="fc-close fc-icon fc-icon-x" />
             </span>

--- a/addons/web/static/src/views/fields/integer/integer_field.js
+++ b/addons/web/static/src/views/fields/integer/integer_field.js
@@ -16,6 +16,8 @@ export class IntegerField extends Component {
         humanReadable: { type: Boolean, optional: true },
         decimals: { type: Number, optional: true },
         inputType: { type: String, optional: true },
+        min: { type: Number, optional: true },
+        max: { type: Number, optional: true },
         step: { type: Number, optional: true },
     };
     static defaultProps = {
@@ -114,6 +116,8 @@ export const integerField = {
             options?.enable_formatting !== undefined ? Boolean(options.enable_formatting) : true,
         humanReadable: !!options.human_readable,
         inputType: options.type,
+        min: options.min,
+        max: options.max,
         step: options.step,
         decimals: options.decimals || 0,
     }),

--- a/addons/web/static/src/views/fields/integer/integer_field.xml
+++ b/addons/web/static/src/views/fields/integer/integer_field.xml
@@ -9,6 +9,8 @@
             t-on-focusin="onFocusIn" 
             t-on-focusout="onFocusOut" 
             t-att-id="props.id" 
+            t-att-min="props.min"
+            t-att-max="props.max"
             t-att-type="props.inputType" 
             inputmode="numeric" 
             class="o_input" 

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -67,7 +67,7 @@ export class FormViewDialog extends Component {
             preventCreate: this.props.preventCreate,
             preventEdit: this.props.preventEdit,
             discardRecord: this.discardRecord.bind(this),
-            saveRecord: async (record, { saveAndNew }) => {
+            saveRecord: async (record, params) => {
                 let saved;
                 if (this.props.onRecordSave) {
                     saved = await this.props.onRecordSave(record);
@@ -79,13 +79,7 @@ export class FormViewDialog extends Component {
                     }
                 }
                 if (saved) {
-                    if (saveAndNew) {
-                        this.currentResId = false;
-                        const context = this.props.nextRecordsContext || this.props.context || {};
-                        await record.model.load({ resId: false, context });
-                    } else {
-                        this.props.close();
-                    }
+                    await this.onRecordSaved(record, params);
                 }
                 return saved;
             },
@@ -97,6 +91,21 @@ export class FormViewDialog extends Component {
                 await this.props.removeRecord();
                 this.props.close();
             };
+        }
+    }
+
+    /**
+     * overridable method defining what to do on save
+     * @param {*} record, record that was saved
+     * @param {*} params, additional parameters passed to "save"
+     */
+    async onRecordSaved(record, params) {
+        if (params?.saveAndNew) {
+            this.currentResId = false;
+            const context = this.props.nextRecordsContext || this.props.context || {};
+            await record.model.load({ resId: false, context });
+        } else {
+            this.props.close();
         }
     }
 

--- a/addons/web/static/tests/views/fields/integer_field.test.js
+++ b/addons/web/static/tests/views/fields/integer_field.test.js
@@ -155,6 +155,18 @@ test("with 'step' option", async () => {
     expect(".o_field_widget input").toHaveAttribute("step", "3");
 });
 
+test("with 'min'/'max' option", async () => {
+    Product._records = [{ id: 1, price: 10 }];
+    await mountView({
+        type: "form",
+        resModel: "product",
+        resId: 1,
+        arch: `<form><field name="price" options="{'type': 'number', 'min': 3, 'max': 10}"/></form>`,
+    });
+    expect(".o_field_widget input").toHaveAttribute("min", "3");
+    expect(".o_field_widget input").toHaveAttribute("max", "10");
+});
+
 test("without input type option", async () => {
     // `localization > grouping` required for this test is [3, 0], which is the default in mock server
     Product._records = [{ id: 1, price: 10 }];


### PR DESCRIPTION
The calendar quick create and pop-up windows now uses icons instead of field labels.
Additionally it's made possible to use that (custom) form view from other views. Such as
to be used for the quick-create in appointment gantt. Enabling notably the "more options"
feature when creating an appointment.

A new widget is added to allow removing the videocall url without the need for an additional button.

Some fields and buttons are moved around.

task-4909129