### PR TITLE
[FIX] web: display start typing if no create edit

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -421,6 +421,12 @@ export class Many2XAutocomplete extends Component {
                     classList: "o_m2o_no_result",
                     unselectable: true,
                 });
+            } else if (!request.length && !this.activeActions.createEdit) {
+                options.push({
+                    label: _t("Start typing..."),
+                    classList: "o_m2o_start_typing",
+                    unselectable: true,
+                });
             }
         }
 

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -995,6 +995,35 @@ test("empty many2one field with no result", async () => {
     expect(".dropdown-menu li.o_m2o_no_result").toHaveCount(0);
 });
 
+test("empty many2one field with no result and no create & edit", async () => {
+    class M2O extends models.Model {
+        m2o = fields.Many2one({ relation: "m2o" });
+    }
+    defineModels([M2O]);
+    await mountView({
+        type: "form",
+        resModel: "m2o",
+        arch: `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="m2o" options="{'no_create_edit': 1}"/>
+                    </group>
+                </sheet>
+            </form>`,
+    });
+
+    await contains(".o_field_many2one input").click();
+    expect(".dropdown-menu li").toHaveCount(1);
+    expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(1);
+
+    await contains(".o_field_many2one input").edit("a", { confirm: false });
+    await runAllTimers();
+
+    expect(".dropdown-menu li").toHaveCount(1);
+    expect(".dropdown-menu li.o_m2o_dropdown_option_create").toHaveCount(1);
+});
+
 test("empty many2one field with node options", async () => {
     expect.assertions(2);
 


### PR DESCRIPTION
Before this commit, the m2x dropdown flickered when the option "create and edit" was disabled and there was no data. Now, we display at least the "start typing" message.

task-4920761