### PR TITLE
[IMP] hr_work_entry: Work Entry UX

### DIFF
--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -2,7 +2,8 @@
 <odoo><data noupdate="1">
     <record id="work_entry_type_attendance" model="hr.work.entry.type">
         <field name="name">Attendance</field>
-        <field name="color">0</field>
+        <field name="color">10</field>
+        <field name="display_code">A</field>
         <field name="code">WORK100</field>
         <field name="is_leave">False</field>
     </record>
@@ -10,59 +11,20 @@
     <record id="work_entry_type_overtime" model="hr.work.entry.type">
         <field name="name">Overtime Hours</field>
         <field name="color">4</field>
+        <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-    </record>
-
-    <record id="work_entry_type_leave" model="hr.work.entry.type">
-        <field name="name">Generic Time Off</field>
-        <field name="code">LEAVE100</field>
-        <field name="color">3</field>
-        <field name="is_leave" eval="True"/>
-    </record>
-
-    <record id="work_entry_type_compensatory" model="hr.work.entry.type">
-        <field name="name">Compensatory Time Off</field>
-        <field name="code">LEAVE105</field>
-        <field name="color">3</field>
-        <field name="is_leave" eval="True"/>
-    </record>
-
-    <record id="work_entry_type_home_working" model="hr.work.entry.type">
-        <field name="name">Remote Work</field>
-        <field name="code">WORK110</field>
-        <field name="color">2</field>
-        <field name="is_leave" eval="True"/>
-    </record>
-
-    <record id="work_entry_type_unpaid_leave" model="hr.work.entry.type">
-        <field name="name">Unpaid</field>
-        <field name="color">5</field>
-        <field name="code">LEAVE90</field>
-        <field name="is_leave" eval="True"/>
-    </record>
-
-    <record id="work_entry_type_sick_leave" model="hr.work.entry.type">
-        <field name="name">Sick Time Off</field>
-        <field name="code">LEAVE110</field>
-        <field name="color">5</field>
-        <field name="is_leave" eval="True"/>
-    </record>
-
-    <record id="work_entry_type_legal_leave" model="hr.work.entry.type">
-        <field name="name">Paid Time Off</field>
-        <field name="code">LEAVE120</field>
-        <field name="color">5</field>
-        <field name="is_leave" eval="True"/>
     </record>
 
     <record id="hr_work_entry_type_out_of_contract" model="hr.work.entry.type">
         <field name="name">Out of Contract</field>
         <field name="color">0</field>
+        <field name="display_code">OoC</field>
         <field name="code">OUT</field>
     </record>
 
      <record id="work_entry_type_leave" model="hr.work.entry.type">
         <field name="name">Generic Time Off</field>
+         <field name="display_code">GTO</field>
         <field name="code">LEAVE100</field>
         <field name="color">3</field>
         <field name="is_leave">True</field>
@@ -70,6 +32,7 @@
 
     <record id="work_entry_type_compensatory" model="hr.work.entry.type">
         <field name="name">Compensatory Time Off</field>
+        <field name="display_code">CTO</field>
         <field name="code">LEAVE105</field>
         <field name="color">3</field>
         <field name="is_leave">True</field>
@@ -77,6 +40,7 @@
 
     <record id="work_entry_type_home_working" model="hr.work.entry.type">
         <field name="name">Home Working</field>
+        <field name="display_code">HW</field>
         <field name="code">WORK110</field>
         <field name="color">2</field>
         <field name="is_leave">True</field>
@@ -85,12 +49,14 @@
     <record id="work_entry_type_unpaid_leave" model="hr.work.entry.type">
         <field name="name">Unpaid</field>
         <field name="color">5</field>
+        <field name="display_code">UN</field>
         <field name="code">LEAVE90</field>
         <field name="is_leave">True</field>
     </record>
 
     <record id="work_entry_type_sick_leave" model="hr.work.entry.type">
         <field name="name">Sick Time Off</field>
+        <field name="display_code">STO</field>
         <field name="code">LEAVE110</field>
         <field name="color">5</field>
         <field name="is_leave">True</field>
@@ -98,6 +64,7 @@
 
      <record id="work_entry_type_legal_leave" model="hr.work.entry.type">
         <field name="name">Paid Time Off</field>
+         <field name="display_code">PTO</field>
         <field name="code">LEAVE120</field>
         <field name="color">5</field>
         <field name="is_leave">True</field>

--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -7,7 +7,7 @@ import pytz
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.fields import Command, Domain
 from odoo.tools import ormcache
@@ -344,7 +344,7 @@ class HrVersion(models.Model):
             tz = pytz.timezone(version_tz) if version_tz else utc
             date_start_tz = tz.localize(date_start).astimezone(utc).replace(tzinfo=None)
             date_stop_tz = tz.localize(date_stop).astimezone(utc).replace(tzinfo=None)
-            new_work_entries += versions.with_company(company).sudo()._generate_work_entries(
+            new_work_entries += versions.with_user(SUPERUSER_ID).with_company(company)._generate_work_entries(
                 date_start_tz, date_stop_tz, force=force)
         return new_work_entries
 

--- a/addons/hr_work_entry/models/hr_work_entry_type.py
+++ b/addons/hr_work_entry/models/hr_work_entry_type.py
@@ -9,6 +9,7 @@ class HrWorkEntryType(models.Model):
     _description = 'HR Work Entry Type'
 
     name = fields.Char(required=True, translate=True)
+    display_code = fields.Char(string="Display Code", size=3, translate=True, help="This code can be changed, it is only for a display purpose (3 letters max)")
     code = fields.Char(string="Payroll Code", required=True, help="Careful, the Code is used in many references, changing it could lead to unwanted changes.")
     external_code = fields.Char(help="Use this code to export your data to a third party")
     color = fields.Integer(default=0)

--- a/addons/hr_work_entry/static/src/components/class_many2many_avatar_employee_field/many2many_avatar_employee_error_field.js
+++ b/addons/hr_work_entry/static/src/components/class_many2many_avatar_employee_field/many2many_avatar_employee_error_field.js
@@ -1,0 +1,46 @@
+import { registry } from "@web/core/registry";
+import {
+    Many2ManyTagsAvatarEmployeeField,
+    many2ManyTagsAvatarEmployeeField,
+} from "@hr/views/fields/many2many_avatar_employee_field/many2many_avatar_employee_field";
+import { Many2ManyAvatarUserTagsList } from "@mail/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field";
+
+export class Many2ManyAvatarUserTagsListError extends Many2ManyAvatarUserTagsList {
+    static template = "hr_work_entry.Many2ManyAvatarUserTagsListError";
+}
+
+export class Many2ManyTagsAvatarEmployeeErrorField extends Many2ManyTagsAvatarEmployeeField {
+    static props = {
+        ...Many2ManyTagsAvatarEmployeeField.props,
+        inErrorField: { type: String, optional: true },
+    };
+    static components = {
+        ...Many2ManyTagsAvatarEmployeeField.components,
+        TagsList: Many2ManyAvatarUserTagsListError,
+    };
+
+    /**
+     * @override
+     */
+    getTagProps(record) {
+        return {
+            ...super.getTagProps(record),
+            inError: this.props.record.data[this.props.inErrorField].currentIds.includes(
+                record.resId
+            ),
+        };
+    }
+}
+
+export const many2ManyTagsAvatarEmployeeErrorField = {
+    ...many2ManyTagsAvatarEmployeeField,
+    component: Many2ManyTagsAvatarEmployeeErrorField,
+    extractProps: (fieldInfo, dynamicInfo) => ({
+        ...many2ManyTagsAvatarEmployeeField.extractProps(fieldInfo, dynamicInfo),
+        inErrorField: fieldInfo.attrs.in_error,
+    }),
+};
+
+registry
+    .category("fields")
+    .add("many2many_avatar_employee_class", many2ManyTagsAvatarEmployeeErrorField);

--- a/addons/hr_work_entry/static/src/components/class_many2many_avatar_employee_field/many2many_avatar_employee_error_field.xml
+++ b/addons/hr_work_entry/static/src/components/class_many2many_avatar_employee_field/many2many_avatar_employee_error_field.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<template>
+    <t t-name="hr_work_entry.Many2ManyAvatarUserTagsListError" t-inherit="mail.Many2ManyAvatarUserTagsList" t-inherit-mode="primary">
+        <xpath expr="//span[hasclass('o_tag')]" position="attributes">
+            <attribute name="t-attf-class" separator=" " add="#{tag.inError ? 'text-danger' : ''}"/>
+        </xpath>
+        <div t-if="props.displayText" position="after">
+            <i t-if="tag.inError" class="ms-1 fa fa-lock z-1"/>
+        </div>
+    </t>
+</template>

--- a/addons/hr_work_entry/static/src/components/work_entry_type_field/work_entry_type_field.js
+++ b/addons/hr_work_entry/static/src/components/work_entry_type_field/work_entry_type_field.js
@@ -1,0 +1,86 @@
+import { registry } from "@web/core/registry";
+import { buildM2OFieldDescription, Many2OneField } from "@web/views/fields/many2one/many2one_field";
+import { Component, onWillRender, onWillUpdateProps, useState } from "@odoo/owl";
+import { Many2One } from "@web/views/fields/many2one/many2one";
+
+export class WorkEntryType extends Component {
+    static template = "hr_work_entry.WorkEntryType";
+    static props = {
+        data: Object,
+        className: { type: String, optional: true },
+    };
+
+    setup() {
+        this.state = useState({ data: this.props.data });
+        onWillUpdateProps((nextProps) => {
+            this.state.data = nextProps.data;
+        });
+    }
+}
+
+function extractData(record) {
+    let name;
+    if ("display_name" in record) {
+        name = record.display_name;
+    } else if ("name" in record) {
+        name = record.name.id ? record.name.display_name : record.name;
+    }
+    return {
+        id: record.id,
+        display_name: name,
+        display_code: record.display_code,
+        color: record.color,
+    };
+}
+
+export class WorkEntryTypeMany2One extends Many2One {
+    get many2XAutocompleteProps() {
+        const props = super.many2XAutocompleteProps;
+        return {
+            ...props,
+            update: (records) => {
+                const idNamePair = records && extractData(records[0]) ? records[0] : false;
+                this.update(idNamePair);
+            },
+        };
+    }
+}
+
+export class Many2OneWorkEntryTypeField extends Many2OneField {
+    static template = "hr_work_entry.Many2OneWorkEntryTypeField";
+    static components = {
+        ...Many2OneField.components,
+        Many2One: WorkEntryTypeMany2One,
+        WorkEntryType,
+    };
+
+    setup() {
+        super.setup();
+        this.state = useState({ data: this.props.record.data });
+        onWillRender(() => {
+            if (this.props.record.data?.work_entry_type_id.color) {
+                this.state.data = this.props.record.data.work_entry_type_id;
+            } else {
+                this.state.data = this.props.record.data;
+            }
+        });
+    }
+
+    get m2oProps() {
+        const props = super.m2oProps;
+        return {
+            ...props,
+            specification: { display_code: 1, color: 1 },
+        };
+    }
+}
+
+export const many2OneWorkEntryTypeField = {
+    ...buildM2OFieldDescription(Many2OneWorkEntryTypeField),
+    fieldDependencies: [
+        { name: "display_code", type: "char" },
+        { name: "color", type: "char" },
+    ],
+};
+
+registry.category("fields").add("many2one_work_entry_type", many2OneWorkEntryTypeField);

--- a/addons/hr_work_entry/static/src/components/work_entry_type_field/work_entry_type_field.xml
+++ b/addons/hr_work_entry/static/src/components/work_entry_type_field/work_entry_type_field.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="hr_work_entry.Many2OneWorkEntryTypeField">
+        <div class="d-flex align-items-center gap-1">
+            <t t-if="value !== false">
+                <WorkEntryType data="state.data"/>
+            </t>
+            <Many2One t-props="m2oProps" cssClass="'w-100'">
+                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                    <div class="o_avatar_many2x_autocomplete d-flex align-items-center">
+                        <WorkEntryType data="autoCompleteItemScope.record" className="'me-1'"/>
+                        <t t-out="autoCompleteItemScope.label"/>
+                    </div>
+                </t>
+            </Many2One>
+        </div>
+    </t>
+
+    <t t-name="hr_work_entry.WorkEntryType">
+        <div class="o_calendar_renderer o_radio_item position-relative cursor-pointer d-flex gap-1 align-items-center"
+             t-att-class="props.className"
+             style="background-color: inherit;">
+            <span class="small rounded-3 d-flex justify-content-center" t-esc="state.data?.display_code || ' '"
+                  t-attf-class="o_calendar_color_#{state.data?.color || 0}"
+                  style="background-color: rgb(var(--o-event-bg--subtle-rgb)); width: 5ch; height:23px; padding: 2px;"/>
+        </div>
+    </t>
+</templates>

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_popover.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_popover.js
@@ -1,0 +1,53 @@
+import { CalendarCommonPopover } from "@web/views/calendar/calendar_common/calendar_common_popover";
+
+export class WorkEntryCalendarCommonPopover extends CalendarCommonPopover {
+    static subTemplates = {
+        ...CalendarCommonPopover.subTemplates,
+        footer: "hr_work_entry.WorkEntryCalendarCommonPopover.footer",
+    };
+    static props = {
+        ...CalendarCommonPopover.props,
+        splitRecord: Function,
+    };
+
+    get isWorkEntryValidated() {
+        return this.props.record.rawRecord.state === "validated";
+    }
+
+    get isSplittable() {
+        return this.props.record.rawRecord.duration >= 1;
+    }
+
+    /**
+     * @override
+     */
+    get isEventEditable() {
+        return !this.isWorkEntryValidated && super.isEventEditable;
+    }
+
+    /**
+     * @override
+     */
+    get isEventDeletable() {
+        return !this.isWorkEntryValidated && super.isEventDeletable;
+    }
+
+    /**
+     * @override
+     */
+    get isEventViewable() {
+        return !this.isWorkEntryValidated && super.isEventViewable;
+    }
+
+    /**
+     * @override
+     */
+    get hasFooter() {
+        return this.isWorkEntryValidated || super.hasFooter;
+    }
+
+    onSplitEvent() {
+        this.props.splitRecord(this.props.record);
+        this.props.close();
+    }
+}

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_popover.xml
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_popover.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<template>
+    <t t-name="hr_work_entry.WorkEntryCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary">
+        <xpath expr="." position="inside">
+            <span t-if="isWorkEntryValidated"><i class="fa fa-lock me-1"/> You cannot edit a validated work entry</span>
+        </xpath>
+        <a t-on-click="onEditEvent" position="after">
+            <a href="#" class="btn btn-secondary" t-if="isSplittable" t-on-click="onSplitEvent">
+                Split
+            </a>
+        </a>
+        <a t-on-click="onDeleteEvent" position="attributes">
+            <attribute name="class" add="ms-auto btn-danger" remove="btn-secondary" separator=" "/>
+        </a>
+    </t>
+</template>

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_renderer.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_renderer.js
@@ -1,0 +1,34 @@
+import { convertRecordToEvent } from "@web/views/calendar/utils";
+import { CalendarCommonRenderer } from "@web/views/calendar/calendar_common/calendar_common_renderer";
+import { WorkEntryCalendarCommonPopover } from "@hr_work_entry/views/work_entry_calendar/calendar_common/work_entry_calendar_common_popover";
+
+export class WorkEntryCalendarCommonRenderer extends CalendarCommonRenderer {
+    static eventTemplate = "hr_work_entry.WorkEntryCalendarCommonRenderer.event";
+    static components = {
+        ...CalendarCommonRenderer,
+        Popover: WorkEntryCalendarCommonPopover,
+    };
+    static props = {
+        ...CalendarCommonRenderer.props,
+        splitRecord: Function,
+    };
+
+    /**
+     * @override
+     */
+    convertRecordToEvent(record) {
+        const event = convertRecordToEvent(record);
+        const editable = record.rawRecord.state !== "validated" && (event.editable ?? null);
+        return {
+            ...event,
+            ...(editable ? { editable: editable } : {}),
+        };
+    }
+
+    getPopoverProps(record) {
+        return {
+            ...super.getPopoverProps(record),
+            splitRecord: this.props.splitRecord,
+        };
+    }
+}

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_renderer.xml
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_renderer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<templates>
+    <t t-name="hr_work_entry.WorkEntryCalendarCommonRenderer.event" t-inherit="web.CalendarCommonRenderer.event" t-inherit-mode="primary">
+        <div t-out="title" position="after">
+            <i t-if="rawRecord.state === 'validated'" class="fa fa-lock position-absolute top-0 end-0" style="font-size: x-small"/>
+        </div>
+    </t>
+</templates>

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar.scss
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar.scss
@@ -1,0 +1,19 @@
+.o_calendar_header {
+	@for $index from 1 through length($o-colors-complete) {
+		$color: nth($o-colors-complete, $index);
+		$color-subtle: mix($o-white, $color, 55%);
+		$color-hover: mix($o-white, $color, 45%);
+
+		.o_gantt_color_#{$index - 1} {
+			color: color-contrast($color-subtle);
+			background-color: $color-subtle;
+			border-color: $color-subtle;
+		}
+
+		.btn.o_gantt_color_#{$index - 1}:hover {
+			color: color-contrast($color-hover);
+			background-color: $color-hover;
+			border-color: $color-hover;
+		}
+	}
+}

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar.xml
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar.xml
@@ -3,11 +3,9 @@
 <templates>
     <t t-name="hr_work_entry.calendar.controlButtons" t-inherit="web.CalendarController.controlButtons" t-inherit-mode="primary">
         <xpath expr="." position="inside">
-            <span class="btn-regenerate-work-entries">
-                <button class="btn btn-secondary ms-3" t-on-click="onRegenerateWorkEntries">
-                    Regenerate Work Entries
-                </button>
-            </span>
+            <button class="btn btn-secondary" t-on-click="onRegenerateWorkEntries">
+                Reset
+            </button>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_controller.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_controller.js
@@ -1,30 +1,173 @@
-import { registry } from "@web/core/registry";
-import { CalendarController } from '@web/views/calendar/calendar_controller';
-import { WorkEntryCalendarModel } from "@hr_work_entry/views/work_entry_calendar/work_entry_calendar_model";
-import { calendarView } from "@web/views/calendar/calendar_view";
+import { CalendarController } from "@web/views/calendar/calendar_controller";
+import { useMultiSelectionButtons } from "@web/views/view_components/multi_selection_buttons";
+import { CallbackRecorder } from "@web/search/action_hook";
+import { useBus } from "@web/core/utils/hooks";
+import { WorkEntryCalendarMultiSelectionButtons } from "@hr_work_entry/views/work_entry_calendar/work_entry_multi_selection_buttons";
+import { onWillRender } from "@odoo/owl";
+import { user } from "@web/core/user";
 import { useWorkEntry } from "@hr_work_entry/views/work_entry_hook";
+const { DateTime } = luxon;
 
 export class WorkEntryCalendarController extends CalendarController {
+    static components = {
+        ...CalendarController.components,
+        MultiSelectionButtons: WorkEntryCalendarMultiSelectionButtons,
+    };
+
     setup() {
         super.setup(...arguments);
         const { onRegenerateWorkEntries } = useWorkEntry({
             getEmployeeIds: this.getEmployeeIds.bind(this),
             getRange: this.model.computeRange.bind(this.model),
-            onClose: this.model.load.bind(this.model)
+            onClose: this.model.load.bind(this.model),
         });
         this.onRegenerateWorkEntries = onRegenerateWorkEntries;
+
+        onWillRender(async () => {
+            const userFavoritesWorkEntriesIds = await this.orm.formattedReadGroup(
+                "hr.work.entry",
+                [
+                    ["create_uid", "=", user.userId],
+                    ["create_date", ">", DateTime.local().minus({ months: 3 }).toISODate()],
+                ],
+                ["work_entry_type_id", "create_date:day"],
+                [],
+                {
+                    order: "create_date:day desc",
+                    limit: 6,
+                }
+            );
+            this.userFavoritesWorkEntries = await this.orm.read(
+                "hr.work.entry.type",
+                userFavoritesWorkEntriesIds.map((r) => r.work_entry_type_id[0]),
+                ["display_name", "display_code", "color"]
+            );
+            this.userFavoritesWorkEntries = this.userFavoritesWorkEntries.sort((a, b) =>
+                a.display_code
+                    ? a.display_code.localeCompare(b.display_code)
+                    : a.display_name.localeCompare(b.display_name)
+            );
+        });
+    }
+
+    async splitRecord(record) {
+        const split_work_entry_id = await this.orm.call("hr.work.entry", "action_split", [
+            record.id,
+        ]);
+        if (split_work_entry_id) {
+            await this.editRecord({ ...record, id: split_work_entry_id });
+        }
+    }
+
+    /**
+     * @override
+     */
+    get rendererProps() {
+        return {
+            ...super.rendererProps,
+            splitRecord: this.splitRecord.bind(this),
+        };
     }
 
     getEmployeeIds() {
-        return [...new Set(Object.values(this.model.records).map(rec => rec.rawRecord.employee_id.id))];
+        return [
+            ...new Set(
+                Object.values(this.model.records).map((rec) => rec.rawRecord.employee_id[0])
+            ),
+        ];
+    }
+
+    getSelectedRecords(selectedCells) {
+        const ids = this.getSelectedRecordIds(selectedCells);
+        return Object.values(this.model.records)
+            .filter((r) => ids.includes(r.id))
+            .map((r) => r.rawRecord);
+    }
+
+    /**
+     * @override
+     */
+    prepareSelectionFeature() {
+        this.selectedCells = null;
+        this.multiSelectionButtonsReactive = useMultiSelectionButtons({
+            onCancel: this.cleanSquareSelection.bind(this),
+            onAdd: (multiCreateData) => {
+                this.onMultiCreate(multiCreateData, this.selectedCells);
+                this.cleanSquareSelection();
+            },
+            onDelete: () => {
+                this.onMultiDelete(this.selectedCells);
+                this.cleanSquareSelection();
+            },
+            nbSelected: 0,
+            multiCreateView: this.model.meta.multiCreateView,
+            resModel: this.model.meta.resModel,
+            multiCreateValues: this.props.state?.multiCreateValues,
+            showMultiCreateTimeRange: this.model.showMultiCreateTimeRange,
+            context: this.props.context,
+        });
+
+        this.callbackRecorder = new CallbackRecorder();
+        this._baseRendererProps.callbackRecorder = this.callbackRecorder;
+        this._baseRendererProps.onSquareSelection = (selectedCells) =>
+            this.updateMultiSelection(selectedCells);
+        this._baseRendererProps.cleanSquareSelection = this.cleanSquareSelection.bind(this);
+
+        useBus(this.model.bus, "update", this.cleanSquareSelection.bind(this));
+    }
+
+    updateMultiSelection(selectedCells) {
+        this.selectedCells = selectedCells;
+        this.multiSelectionButtonsReactive.visible = true;
+        this.multiSelectionButtonsReactive.userFavoritesWorkEntries = this.userFavoritesWorkEntries;
+        this.multiSelectionButtonsReactive.nbSelected = this.getSelectedRecordIds(
+            this.selectedCells
+        ).length;
+        this.multiSelectionButtonsReactive.selection = this.getSelectedRecords(this.selectedCells);
+        this.multiSelectionButtonsReactive.onQuickReplace = (multiCreateData) => {
+            this.onMultiReplace(multiCreateData, this.selectedCells);
+        };
+        this.multiSelectionButtonsReactive.onQuickReset = () => {
+            this.onResetWorkEntries(this.selectedCells);
+        };
+    }
+
+    getDatesWithoutValidatedWorkEntry(selectedCells, records) {
+        return this.getDates(selectedCells).filter(
+            (d) =>
+                !records
+                    .filter((r) => r.state === "validated")
+                    .map((r) => r.date)
+                    .includes(d.toISODate())
+        );
+    }
+
+    /**
+     * @override
+     */
+    onMultiDelete(selectedCells) {
+        const records = this.getSelectedRecords(selectedCells);
+        return this.model.unlinkRecords(
+            records.filter((r) => r.state !== "validated").map((r) => r.id)
+        );
+    }
+
+    onMultiReplace(multiCreateData, selectedCells) {
+        const records = this.getSelectedRecords(selectedCells);
+        const dates = this.getDatesWithoutValidatedWorkEntry(selectedCells, records);
+        return this.model.multiReplaceRecords(
+            multiCreateData,
+            dates,
+            records.filter((r) => r.state !== "validated").map((r) => r.id)
+        );
+    }
+
+    onResetWorkEntries(selectedCells) {
+        const records = this.getSelectedRecords(selectedCells);
+        const dates = this.getDatesWithoutValidatedWorkEntry(selectedCells, records);
+        this.model.resetWorkEntries(
+            dates,
+            records.filter((r) => r.state !== "validated").map((r) => r.id)
+        );
     }
 }
-
-export const WorkEntryCalendarView = {
-    ...calendarView,
-    Controller: WorkEntryCalendarController,
-    Model: WorkEntryCalendarModel,
-    buttonTemplate: "hr_work_entry.calendar.controlButtons",
-}
-
-registry.category("views").add("work_entries_calendar", WorkEntryCalendarView);

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
@@ -1,21 +1,59 @@
 import { CalendarModel } from "@web/views/calendar/calendar_model";
-import { useWorkEntry } from "@hr_work_entry/views/work_entry_hook";
-
-const { DateTime } = luxon;
+import { useService } from "@web/core/utils/hooks";
+import { serializeDate } from "@web/core/l10n/dates";
 
 export class WorkEntryCalendarModel extends CalendarModel {
     setup() {
         super.setup(...arguments);
-        const { generateWorkEntries } = useWorkEntry({ getRange: this.computeRange.bind(this) });
-        this.generateWorkEntries = generateWorkEntries;
+        this.orm = useService("orm");
     }
 
+    /**
+     * @override
+     */
     async updateData(data) {
-        const { start } = this.computeRange();
-        const shouldGenerateWorkEntries = start <= DateTime.now();
-        if (shouldGenerateWorkEntries) {
-            await this.generateWorkEntries();
+        const { start, end } = this.computeRange();
+        await this.orm.call("hr.employee", "generate_work_entries", [
+            [this.meta.context.active_id],
+            serializeDate(start),
+            serializeDate(end),
+        ]);
+        await super.updateData(...arguments);
+    }
+
+    async multiReplaceRecords(multiCreateData, dates, records) {
+        if (!dates.length) {
+            return;
         }
-        await super.updateData(data);
+        const new_records = [];
+        const values = await multiCreateData.record.getChanges();
+
+        for (const date of dates) {
+            const rawRecord = this.buildRawRecord({ start: date });
+            new_records.push({
+                ...rawRecord,
+                ...values,
+            });
+        }
+        const created = await this.orm.create(this.meta.resModel, new_records, {
+            context: this.meta.context,
+        });
+        if (records.length && created) {
+            await this.orm.unlink(this.meta.resModel, records);
+        }
+        return this.load();
+    }
+
+    async resetWorkEntries(dates, recordIds) {
+        const cellsFormattedData = dates.map((date) => ({
+            date,
+            employee_id: this.meta.context.active_id,
+        }));
+        await this.orm.call("hr.work.entry.regeneration.wizard", "regenerate_work_entries", [
+            [],
+            [...cellsFormattedData],
+            recordIds,
+        ]);
+        return this.load();
     }
 }

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_renderer.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_renderer.js
@@ -1,0 +1,13 @@
+import { CalendarRenderer } from "@web/views/calendar/calendar_renderer";
+import { WorkEntryCalendarCommonRenderer } from "@hr_work_entry/views/work_entry_calendar/calendar_common/work_entry_calendar_common_renderer";
+
+export class WorkEntryCalendarRenderer extends CalendarRenderer {
+    static components = {
+        ...CalendarRenderer.components,
+        month: WorkEntryCalendarCommonRenderer,
+    };
+    static props = {
+        ...CalendarRenderer.props,
+        splitRecord: Function,
+    };
+}

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_view.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_view.js
@@ -1,0 +1,15 @@
+import { calendarView } from "@web/views/calendar/calendar_view";
+import { WorkEntryCalendarRenderer } from "@hr_work_entry/views/work_entry_calendar/work_entry_calendar_renderer";
+import { WorkEntryCalendarModel } from "@hr_work_entry/views/work_entry_calendar/work_entry_calendar_model";
+import { registry } from "@web/core/registry";
+import { WorkEntryCalendarController } from "@hr_work_entry/views/work_entry_calendar/work_entry_calendar_controller";
+
+export const WorkEntryCalendarView = {
+    ...calendarView,
+    Controller: WorkEntryCalendarController,
+    Renderer: WorkEntryCalendarRenderer,
+    Model: WorkEntryCalendarModel,
+    buttonTemplate: "hr_work_entry.calendar.controlButtons",
+};
+
+registry.category("views").add("work_entries_calendar", WorkEntryCalendarView);

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_create_popover.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_create_popover.js
@@ -1,0 +1,14 @@
+import { MultiCreatePopover } from "@web/views/view_components/multi_create_popover";
+
+export class WorkEntryMultiCreatePopover extends MultiCreatePopover {
+    static template = "hr_work_entry.WorkEntryMultiCreatePopover";
+    static props = {
+        ...MultiCreatePopover.props,
+        onReplace: Function,
+    };
+
+    async onReplace() {
+        this.props.onReplace(this.multiCreateData);
+        this.props.close();
+    }
+}

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_create_popover.xml
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_create_popover.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="hr_work_entry.WorkEntryMultiCreatePopover" t-inherit="web.MultiCreatePopover" t-inherit-mode="primary">
+        <button t-on-click="() => this.onAdd()" position="after">
+            <button class="btn btn-sm btn-secondary" t-on-click="() => this.onReplace()">Replace</button>
+        </button>
+    </t>
+</templates>

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.js
@@ -1,0 +1,77 @@
+import { MultiSelectionButtons } from "@web/views/view_components/multi_selection_buttons";
+import { useService } from "@web/core/utils/hooks";
+import { useState } from "@odoo/owl";
+import { WorkEntryMultiCreatePopover } from "@hr_work_entry/views/work_entry_calendar/work_entry_multi_create_popover";
+import { addFieldDependencies } from "@web/model/relational_model/utils";
+
+export class WorkEntryCalendarMultiSelectionButtons extends MultiSelectionButtons {
+    static template = "hr_work_entry.WorkEntryCalendarMultiSelectionButtons";
+    static components = {
+        ...MultiSelectionButtons.components,
+        Popover: WorkEntryMultiCreatePopover,
+    };
+
+    setup() {
+        super.setup(...arguments);
+        this.orm = useService("orm");
+        this.actionService = useService("action");
+        this.state = useState({ favoritesWorkEntries: null });
+    }
+
+    /**
+     * @override
+     */
+    getMultiCreatePopoverProps() {
+        return {
+            ...super.getMultiCreatePopoverProps(),
+            onReplace: (multiCreateData) => {
+                this.props.reactive.onQuickReplace(multiCreateData);
+            },
+        };
+    }
+
+    /**
+     * @override
+     */
+    async loadMultiCreateView() {
+        await super.loadMultiCreateView();
+        addFieldDependencies(
+            this.multiCreateRecordProps.activeFields,
+            this.multiCreateRecordProps.fields,
+            [
+                { name: "display_code", type: "char" },
+                { name: "color", type: "integer" },
+                { name: "employee_id", type: "many2one" },
+            ]
+        );
+    }
+
+    get favoritesWorkEntries() {
+        return this.props.reactive.userFavoritesWorkEntries;
+    }
+
+    createFakeMultiCreateData(workEntryType) {
+        const multiCreateData = {
+            timeRange: this.props.timeRange && { ...this.props.timeRange },
+            record: {
+                data: {
+                    employee_id: this.actionService.currentController.currentState.active_id,
+                    duration: 8,
+                    work_entry_type_id: workEntryType.id,
+                },
+                fields: {
+                    employee_id: { type: "many2one" },
+                    duration: { type: "float" },
+                    work_entry_type_id: { type: "many2one" },
+                },
+            },
+        };
+        multiCreateData.record.getChanges = () => multiCreateData.record.data;
+        return multiCreateData;
+    }
+
+    async onQuickReplace(workEntryType) {
+        const multiCreateData = this.createFakeMultiCreateData(workEntryType);
+        this.props.reactive.onQuickReplace(multiCreateData);
+    }
+}

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.xml
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="hr_work_entry.WorkEntryCalendarMultiSelectionButtons" t-inherit="web.MultiSelectionButtons" t-inherit-mode="primary">
+        <button data-tooltip="Delete" position="replace">
+            <button class="btn btn-secondary" data-tooltip="Reset Selected Work Entries" t-on-click="() => this.props.reactive.onQuickReset()">
+                <i class="fa fa-undo"/>
+            </button>
+        </button>
+        <button t-ref="addButton" position="after">
+            <t t-foreach="favoritesWorkEntries" t-as="workEntry" t-key="workEntry.id">
+                <button class="small btn btn-secondary rounded-1"
+                        t-attf-class="o_gantt_color_#{workEntry.color}"
+                        t-attf-data-tooltip="Replace by #{workEntry.display_name}"
+                        t-on-click="() => this.onQuickReplace(workEntry)">
+                    <t t-if="workEntry.display_code" t-out="workEntry.display_code"/>
+                    <t t-else="" t-out="workEntry.display_name"/>
+                </button>
+            </t>
+        </button>
+    </t>
+</templates>

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -7,14 +7,14 @@
         <field name="name">Work Entry</field>
         <field name="res_model">hr.work.entry</field>
         <field name="context">{'search_default_work_entries_error': 1}</field>
-        <field name="view_mode">list,calendar,form,pivot</field>
+        <field name="view_mode">list,form,pivot</field>
     </record>
 
     <record id="hr_work_entry_action" model="ir.actions.act_window">
         <field name="name">Work Entry</field>
         <field name="res_model">hr.work.entry</field>
         <field name="path">work-entries</field>
-        <field name="view_mode">calendar,list,form,pivot</field>
+        <field name="view_mode">list,form,pivot</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No data to display
@@ -33,13 +33,16 @@
         <field name="arch" type="xml">
             <form>
                 <group>
-                    <field name="work_entry_type_id"/>
                     <field name="duration" widget="float_time"/>
+                    <field name="work_entry_type_id" widget="many2one_work_entry_type"/>
+                    <field name="name" string="Description" placeholder="Additional Description..."/>
                 </group>
+                <field name="employee_id" invisible="1"/>
+                <field name="color" invisible="1"/>
+                <field name="display_code" invisible="1"/>
             </form>
         </field>
     </record>
-
 
     <record id="hr_work_entry_view_calendar" model="ir.ui.view">
         <field name="name">hr.work.entry.calendar</field>
@@ -49,15 +52,21 @@
                 date_start="date"
                 date_stop="date"
                 mode="month"
+                scales="month"
+                show_unusual_days="True"
                 month_overflow="0"
                 quick_create="0"
                 color="color"
-                event_limit="5"
+                event_limit="9"
+                show_date_picker="0"
                 multi_create_view="hr_work_entry.hr_work_entry_view_calendar_multi_create_form"
                 js_class="work_entries_calendar">
-                <!-- Sidebar favorites filters -->
-                <field name="employee_id" write_model="hr.user.work.entry.employee" write_field="employee_id" filter_field="is_checked" avatar_field="avatar_128" widget="many2one_avatar_employee"/>
                 <field name="state"/>
+                <field name="name" string="Description" invisible="not name"/>
+                <field name="duration" invisible="1"/>
+                <field name="display_code" invisible="1"/>
+                <field name="employee_id" invisible="1"/>
+                <field name="work_entry_type_id" invisible="1"/>
             </calendar>
         </field>
     </record>
@@ -68,7 +77,8 @@
         <field name="arch" type="xml">
             <form string="Work Entry" >
                 <header>
-                    <field name="state" widget="statusbar" readonly="1" statusbar_visible="draft,validated,conflict"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,validated" invisible="state == 'conflict'"/>
+                    <field name="state" widget="statusbar" readonly="1" statusbar_visible="draft,validated,conflict" invisible="state != 'conflict'"/>
                 </header>
                 <div class="alert alert-warning text-center" role="alert" invisible="state != 'validated'">
                     Note: Validated work entries cannot be modified.
@@ -81,9 +91,9 @@
                 <sheet>
                     <group>
                         <group>
-                            <field name="name" string="Description" placeholder="Work Entry Name" readonly="state == 'validated'"/>
+                            <field name="name" string="Description" placeholder="Additional Description..." readonly="state == 'validated'"/>
+                            <field name="work_entry_type_id" readonly="state == 'validated'" options="{'no_create': True, 'no_open': True}" widget="many2one_work_entry_type"/>
                             <field name="employee_id" readonly="state != 'draft'" widget="many2one_avatar_employee"/>
-                            <field name="work_entry_type_id" readonly="state == 'validated'" options="{'no_create': True, 'no_open': True}"/>
                         </group>
                         <group>
                             <field name="date" readonly="state != 'draft'"/>
@@ -109,13 +119,18 @@
         <field name="model">hr.work.entry</field>
         <field name="arch" type="xml">
             <list multi_edit="1" sample="1">
-                <field name="name"/>
-                <field name="work_entry_type_id" options="{'no_create': True, 'no_open': True}"/>
+                <field name="date"/>
+                <field name="employee_id" widget="many2one_avatar_employee"/>
+                <field name="work_entry_type_id" options="{'no_create': True, 'no_open': True}" widget="many2one_work_entry_type"/>
+                <field name="duration" widget="float_time"/>
+                <field name="state" optional="show" widget="badge"
+                       decoration-info="state == 'draft'"
+                       decoration-success="state == 'validated'"
+                       decoration-warning="state == 'conflict'"
+                />
+                <field name="name" optional="hide"/>
                 <field name="code" optional="hidden"/>
                 <field name="external_code" optional="hidden"/>
-                <field name="duration" widget="float_time"/>
-                <field name="state"/>
-                <field name="date"/>
             </list>
         </field>
     </record>
@@ -139,7 +154,7 @@
             <search string="Search Work Entry">
                 <field name="employee_id"/>
                 <field name="department_id"/>
-                <field name="work_entry_type_id"/>
+                <field name="work_entry_type_id" widget="many2one_work_entry_type"/>
                 <field name="name"/>
                 <filter name="work_entries_draft" string="Draft" domain="[('state', '=', 'draft')]"/>
                 <filter name="work_entries_validated" string="Validated" domain="[('state', '=', 'validated')]"/>
@@ -192,6 +207,7 @@
         <field name="arch" type="xml">
             <list>
                 <field name="name"/>
+                <field name="display_code"/>
                 <field name="code"/>
                 <field name="color" widget="color_picker"/>
                 <field name="country_id" optional="hide"/>
@@ -215,6 +231,7 @@
                         <group name="identification" class="o_form_fw_labels">
                             <field name="active" invisible="1"/>
                             <field name="code"/>
+                            <field name="display_code"/>
                             <field name="external_code"/>
                             <field name="sequence" groups="base.group_no_one"/>
                             <field name="color" widget="color_picker"/>
@@ -247,7 +264,12 @@
                     </t>
                     <t t-name="card" t-attf-class="#{!selection_mode ? record.color.raw_value : ''}">
                         <field class="fw-bold fs-5" name="name"/>
-                        <field class="text-muted" name="code"/>
+                        <span class="text-muted">
+                            <field name="code"/>
+                            <t t-if="record.display_code.raw_value" class="text-muted">
+                                (<field name="display_code"/>)
+                            </t>
+                        </span>
                     </t>
                 </templates>
             </kanban>

--- a/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
+++ b/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+from collections import defaultdict
+from itertools import groupby
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-
+from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 
 
@@ -19,8 +20,8 @@ class HrWorkEntryRegenerationWizard(models.TransientModel):
             readonly=False, default=lambda self: self.env.context.get('date_end'))
     employee_ids = fields.Many2many('hr.employee', string='Employees',
                                     domain=lambda self: [('company_id', 'in', self.env.companies.ids)], required=True)
-    validated_work_entry_ids = fields.Many2many('hr.work.entry', string='Work Entries Within Interval',
-                                   compute='_compute_validated_work_entry_ids')
+    validated_work_entry_employee_ids = fields.Many2many('hr.employee', export_string_translation=False,
+                                   compute='_compute_validated_work_entry_employee_ids')
     search_criteria_completed = fields.Boolean(compute='_compute_search_criteria_completed')
     valid = fields.Boolean(compute='_compute_valid')
 
@@ -42,21 +43,24 @@ class HrWorkEntryRegenerationWizard(models.TransientModel):
             wizard.latest_available_date = max(dates) if dates else None
 
     @api.depends('date_from', 'date_to', 'employee_ids')
-    def _compute_validated_work_entry_ids(self):
+    def _compute_validated_work_entry_employee_ids(self):
         for wizard in self:
-            validated_work_entry_ids = self.env['hr.work.entry']
+            employee_ids = self.env['hr.employee']
             if wizard.search_criteria_completed:
-                search_domain = [('employee_id', 'in', wizard.employee_ids.ids),
-                                 ('date', '>=', wizard.date_from),
-                                 ('date', '<=', wizard.date_to),
-                                 ('state', '=', 'validated')]
-                validated_work_entry_ids = self.env['hr.work.entry'].search(search_domain, order="date")
-            wizard.validated_work_entry_ids = validated_work_entry_ids
+                validated_work_entry_by_employee = self.env['hr.work.entry']._read_group([
+                    ('employee_id', 'in', wizard.employee_ids.ids),
+                    ('date', '>=', wizard.date_from),
+                    ('date', '<=', wizard.date_to),
+                    ('state', '=', 'validated')
+                ], ['employee_id'])
+                for per_employee in validated_work_entry_by_employee:
+                    employee_ids |= per_employee[0]
+            wizard.validated_work_entry_employee_ids = employee_ids
 
-    @api.depends('validated_work_entry_ids')
+    @api.depends('validated_work_entry_employee_ids', 'employee_ids')
     def _compute_valid(self):
         for wizard in self:
-            wizard.valid = wizard.search_criteria_completed and len(wizard.validated_work_entry_ids) == 0
+            wizard.valid = wizard.search_criteria_completed and len(wizard.employee_ids - wizard.validated_work_entry_employee_ids) > 0
 
     @api.depends('date_from', 'date_to', 'employee_ids')
     def _compute_search_criteria_completed(self):
@@ -90,23 +94,43 @@ class HrWorkEntryRegenerationWizard(models.TransientModel):
     def _work_entry_fields_to_nullify(self):
         return ['active']
 
-    def regenerate_work_entries(self):
-        self.ensure_one()
-        if not self.env.context.get('work_entry_skip_validation'):
-            if not self.valid:
-                raise ValidationError(_("In order to regenerate the work entries, you need to provide the wizard with an employee_id, a date_from and a date_to. In addition to that, the time interval defined by date_from and date_to must not contain any validated work entries."))
-
-            if self.date_from < self.earliest_available_date or self.date_to > self.latest_available_date:
-                raise ValidationError(_("The from date must be >= '%(earliest_available_date)s' and the to date must be <= '%(latest_available_date)s', which correspond to the generated work entries time interval.", earliest_available_date=self._date_to_string(self.earliest_available_date), latest_available_date=self._date_to_string(self.latest_available_date)))
-
-        date_from = max(self.date_from, self.earliest_available_date) if self.earliest_available_date else self.date_from
-        date_to = min(self.date_to, self.latest_available_date) if self.latest_available_date else self.date_to
-        work_entries = self.env['hr.work.entry'].search([
-            ('employee_id', 'in', self.employee_ids.ids),
-            ('date', '>=', date_from),
-            ('date', '<=', date_to),
-            ('state', '!=', 'validated')])
-
+    def regenerate_work_entries(self, slots=None, record_ids=None):
         write_vals = {field: False for field in self._work_entry_fields_to_nullify()}
-        work_entries.write(write_vals)
-        self.employee_ids.generate_work_entries(date_from, date_to, True)
+        if not slots:
+            if not self.env.context.get('work_entry_skip_validation'):
+                if not self.search_criteria_completed:
+                    raise ValidationError(_("In order to regenerate the work entries, you need to provide the wizard with an employee_id, a date_from and a date_to."))
+
+                if self.date_from < self.earliest_available_date or self.date_to > self.latest_available_date:
+                    raise ValidationError(_("The from date must be >= '%(earliest_available_date)s' and the to date must be <= '%(latest_available_date)s', which correspond to the generated work entries time interval.", earliest_available_date=self._date_to_string(self.earliest_available_date), latest_available_date=self._date_to_string(self.latest_available_date)))
+
+                if not self.valid:
+                    raise ValidationError(self.env._("No work entry can be regenerated in this range of dates and these employees."))
+
+            valid_employees = self.employee_ids - self.validated_work_entry_employee_ids
+            date_from = max(self.date_from, self.earliest_available_date) if self.earliest_available_date else self.date_from
+            date_to = min(self.date_to, self.latest_available_date) if self.latest_available_date else self.date_to
+            work_entries = self.env['hr.work.entry'].search([
+                ('employee_id', 'in', valid_employees.ids),
+                ('date', '>=', date_from),
+                ('date', '<=', date_to),
+                ('state', '!=', 'validated')])
+            work_entries.write(write_vals)
+            valid_employees.generate_work_entries(date_from, date_to, True)
+        else:
+            range_by_employee = defaultdict(list)
+            slots.sort(key=lambda d: (d['employee_id'], d['date']))
+            for employee_id, records in groupby(slots, lambda d: d['employee_id']):
+                dates = [fields.Date.from_string(r['date']) for r in records]
+                start = end = dates[0]
+                for current in dates[1:]:
+                    if current - end != timedelta(days=1):
+                        range_by_employee[start, end].append(employee_id)
+                        start = current
+                    end = current
+                range_by_employee[start, end].append(employee_id)
+            work_entries = self.env['hr.work.entry'].browse(record_ids)
+            work_entries.write(write_vals)
+            for (date_from, date_to), employee_ids in range_by_employee.items():
+                valid_employees = self.env["hr.employee"].browse(employee_ids)
+                valid_employees.generate_work_entries(date_from, date_to, True)

--- a/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard_views.xml
+++ b/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard_views.xml
@@ -6,56 +6,38 @@
         <field name="arch" type="xml">
             <form string="Regenerate Employee Work Entries">
                 <group>
-                    <group>
-                        <field name="employee_ids" widget="many2many_avatar_employee"
-                            domain="[('company_id', 'in', allowed_company_ids), ('version_ids.id','!=', False)]"/>
-                        <label for="date_from"></label>
-                        <div name="date_from">
-                            <div class="text-info" invisible="earliest_available_date_message == ''">
-                                <i class="fa fa-info-circle me-1" title="Hint"/>
-                                <field name="earliest_available_date_message" nolabel="1"/>
-                            </div >
-                            <field name="date_from"/>
-                        </div>
-                        <label for="date_to"></label>
-                        <div name="date_to">
-                            <div class="text-info" invisible="latest_available_date_message == ''">
-                                <i class="fa fa-info-circle me-1" title="Hint"/>
-                                <field name="latest_available_date_message" nolabel="1"/>
-                            </div>
-                            <field name="date_to"/>
-                        </div>
-                    </group>
+                    <field name="employee_ids" widget="many2many_avatar_employee_class"
+                           in_error="validated_work_entry_employee_ids"
+                           domain="[('company_id', 'in', allowed_company_ids), ('version_ids.id','!=', False)]"/>
+                    <field name="date_to" invisible="1"/>
+                    <label for="date_from" string="Period"/>
+                    <field name="date_from" style="width: 200px;" nolabel="1" widget="daterange" options="{'end_date_field': 'date_to'}"/>
+                    <div colspan="2" class="text-info" invisible="earliest_available_date_message == ''">
+                        <i class="fa fa-info-circle me-1" title="Hint"/>
+                        <field name="earliest_available_date_message" class="oe_inline" nolabel="1"/>
+                    </div>
+                    <div colspan="2" class="text-info" invisible="latest_available_date_message == ''">
+                        <i class="fa fa-info-circle me-1" title="Hint"/>
+                        <field name="latest_available_date_message" class="oe_inline" nolabel="1"/>
+                    </div>
                 </group>
                 <div>
                     <span class="text-muted">Warning: The work entry regeneration will delete all manual changes on the selected period.</span>
                 </div>
                 <field name="search_criteria_completed" invisible="1"/>
-                <field name="valid" invisible="1"/>
-                <div invisible="not search_criteria_completed or valid">
-                    <div class="text-danger"><i class="fa fa-exclamation-triangle me-1" title="Warning"/>You are not allowed to regenerate validated work entries</div>
-                    <field name="validated_work_entry_ids" widget="many2many" nolabel="1">
-                        <list string="Work Entries"
-                              default_order = "date"
-                              editable="bottom"
-                              no_open="1" decoration-danger="state == 'validated'">
-                            <field name="state" column_invisible="True"/>
-                            <field name="date"/>
-                            <field name="work_entry_type_id"/>
-                            <field name="state"/>
-                        </list>
-                    </field>
+                <div invisible="not search_criteria_completed or not validated_work_entry_employee_ids">
+                    <div class="text-danger"><i class="fa fa-exclamation-triangle me-1" title="Warning"/>Employees in red will be skipped because they have at least one validated work entry.</div>
                 </div>
                 <footer>
                     <button name="regenerate_work_entries"
                             string="Regenerate Work Entries" data-hotkey="q"
                             class="btn btn-primary oe_highlight"
                             type="object"
-                            invisible="not search_criteria_completed or not valid"/>
+                            invisible="not valid"/>
                     <button name="regenerate_work_entries_disabled"
                             string="Regenerate Work Entries"
                             class="btn btn-primary disabled"
-                            invisible="search_criteria_completed and valid"/>
+                            invisible="valid"/>
                     <button name="cancel_button" string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>

--- a/addons/web/static/src/views/view_components/multi_selection_buttons.js
+++ b/addons/web/static/src/views/view_components/multi_selection_buttons.js
@@ -13,6 +13,9 @@ import { MultiCreatePopover } from "./multi_create_popover";
 export class MultiSelectionButtons extends Component {
     static template = "web.MultiSelectionButtons";
     static props = { reactive: Object };
+    static components = {
+        Popover: MultiCreatePopover,
+    };
 
     setup() {
         this.viewService = useService("view");
@@ -37,7 +40,7 @@ export class MultiSelectionButtons extends Component {
             },
         });
 
-        this.multiCreatePopover = usePopover(MultiCreatePopover, {
+        this.multiCreatePopover = usePopover(this.constructor.components.Popover, {
             onClose: () => {
                 const multiCreateData = this.getMultiCreateDataFromPopover();
                 if (multiCreateData) {


### PR DESCRIPTION
Problem
----------
With the new system of date + duration, and the multi_select in the Gantt and the Calendar views, new UX is needed

Solution
----------
Work Entry Types:
- new `display_code`, a char with a max length of 3.
- new widget `many2one_work_entry_type` to display the code and the color of the work entry type

Calendar:
- `get_unusual_days` for the calendar grey days
- limit the scales: month only
- only for one employee via the smart button on employee form
- custom popover to add/split/delete work entries
- lock system on validated work entries (undraggable,...)
- custom multi_select:
        - quickReplace buttons 6max (depending on the last work entry type created for the user)
        - eraser instead of trash to reset selected cells (regenerate work entries)
        - custom add popover to Add and Replace
        - Add is available everywhere in contract range
        - Replace will delete all records in a cell and add a new one (cells with validated work entries are skipped)

Regeneration Wizard:
- Reset will show a red lock next to employees with validated work entries in the range (they will be skipped)
- Resetting by using the multiselect eraser will cut ranges to avoid forced generation for validated work entries records

task-4892209