### PR TITLE
[FIX] hr_work_entry_contract: skip check leave outside schedule for fully flexible employee

### DIFF
--- a/addons/hr_work_entry_contract/models/hr_work_entry.py
+++ b/addons/hr_work_entry_contract/models/hr_work_entry.py
@@ -167,7 +167,7 @@ class HrWorkEntry(models.Model):
 
         outside_entries = self.env['hr.work.entry']
         for calendar, entries in entries_by_calendar.items():
-            if calendar.flexible_hours:
+            if not calendar or calendar.flexible_hours:
                 continue
             datetime_start = min(entries.mapped('date_start'))
             datetime_stop = max(entries.mapped('date_stop'))


### PR DESCRIPTION
When we validate/write/create a work entry for an employee with a fully flexible working schedule, we can encounter a traceback when trying to call `_attendance_intervals_batch` on a non-existing calendar.

To rectify this issue, we continue in the loop when no calendar is set.

opw-4979974
opw-4968312