### PR TITLE
[IMP] mail, im_livechat, test_mail: reset bus within assertBus

### DIFF
--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -278,21 +278,29 @@ class TestEventNotifications(CalendarMailCommon):
             'duration': 30,
         })
         now = fields.Datetime.now()
-        self._reset_bus()
+
+        def get_bus_params():
+            return (
+                [(self.env.cr.dbname, "res.partner", self.partner.id)],
+                [
+                    {
+                        "type": "calendar.alarm",
+                        "payload": [
+                            {
+                                "alarm_id": alarm.id,
+                                "event_id": self.event.id,
+                                "title": "Doom's day",
+                                "message": self.event.display_time,
+                                "timer": 20 * 60,
+                                "notify_at": fields.Datetime.to_string(now + relativedelta(minutes=20)),
+                            },
+                        ],
+                    },
+                ],
+            )
+
         with patch.object(fields.Datetime, 'now', lambda: now):
-            with self.assertBus([(self.env.cr.dbname, 'res.partner', self.partner.id)], [
-                {
-                    "type": "calendar.alarm",
-                    "payload": [{
-                        "alarm_id": alarm.id,
-                        "event_id": self.event.id,
-                        "title": "Doom's day",
-                        "message": self.event.display_time,
-                        "timer": 20 * 60,
-                        "notify_at": fields.Datetime.to_string(now + relativedelta(minutes=20)),
-                    }],
-                },
-            ]):
+            with self.assertBus(get_params=get_bus_params):
                 self.event.with_context(no_mail_to_attendees=True).write({
                     'start': now + relativedelta(minutes=50),
                     'stop': now + relativedelta(minutes=55),
@@ -580,21 +588,29 @@ class TestEventNotifications(CalendarMailCommon):
         })
 
         now = fields.Datetime.now()
-        self._reset_bus()
+
+        def get_bus_params():
+            return (
+                [(self.env.cr.dbname, "res.partner", self.partner.id)],
+                [
+                    {
+                        "type": "calendar.alarm",
+                        "payload": [
+                            {
+                                "alarm_id": alarm.id,
+                                "event_id": self.event.id,
+                                "title": "Doom's day",
+                                "message": self.event.display_time,
+                                "timer": 20 * 60,
+                                "notify_at": fields.Datetime.to_string(now + relativedelta(minutes=20)),
+                            },
+                        ],
+                    },
+                ],
+            )
+
         with patch.object(fields.Datetime, 'now', lambda: now):
-            with self.assertBus([(self.env.cr.dbname, 'res.partner', self.partner.id)], [
-                {
-                    "type": "calendar.alarm",
-                    "payload": [{
-                        "alarm_id": alarm.id,
-                        "event_id": self.event.id,
-                        "title": "Doom's day",
-                        "message": self.event.display_time,
-                        "timer": 20 * 60,
-                        "notify_at": fields.Datetime.to_string(now + relativedelta(minutes=20)),
-                    }],
-                },
-            ]):
+            with self.assertBus(get_params=get_bus_params):
                 self.event.with_context(no_mail_to_attendees=True).write({
                     'start': now + relativedelta(minutes=50),
                     'stop': now + relativedelta(minutes=55),

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -375,7 +375,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             )
 
             return (channels, message_items)
-        self._reset_bus()
         with self.assertBus(get_params=get_forward_op_bus_params):
             discuss_channel._forward_human_operator(self.step_forward_operator, users=self.user_employee)
         self.assertEqual(discuss_channel.name, "OdooBot Ernest Employee")

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -338,7 +338,6 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                 ],
             )
 
-        self._reset_bus()
         with self.assertBus(get_params=_get_feedback_bus):
             self.make_jsonrpc_request(
                 "/im_livechat/feedback",

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1360,6 +1360,7 @@ class MailCase(common.TransactionCase, MockEmail):
         def notif_to_string(notif):
             return f"{format_notif(notif)}\n{notif.message}"
 
+        self._reset_bus()
         try:
             with self.mock_bus():
                 yield

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -181,7 +181,6 @@ class TestChannelInternals(MailCommon, HttpCase):
                 ],
             )
 
-        self._reset_bus()
         with self.assertBus(get_params=get_add_member_bus):
             test_group._add_members(partners=self.test_partner)
 
@@ -228,7 +227,6 @@ class TestChannelInternals(MailCommon, HttpCase):
                     },
                 ],
             )
-        self._reset_bus()
         with self.assertBus(get_params=get_add_member_again_bus):
             test_group._add_members(partners=self.test_partner)
         self.assertEqual(test_group.message_partner_ids, self.env["res.partner"])
@@ -403,7 +401,6 @@ class TestChannelInternals(MailCommon, HttpCase):
         chat = self.env['discuss.channel'].with_user(self.user_admin)._get_or_create_chat((self.partner_employee | self.user_admin.partner_id).ids)
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
         member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
-        self._reset_bus()
         with self.assertBus(
             [
                 (self.env.cr.dbname, "discuss.channel", chat.id),
@@ -458,7 +455,6 @@ class TestChannelInternals(MailCommon, HttpCase):
             member._mark_as_read(msg_1.id)
         # There should be no channel member to be set as seen in the second time
         # So no notification should be sent
-        self._reset_bus()
         with self.assertBus([], []):
             member._mark_as_read(msg_1.id)
 
@@ -608,7 +604,6 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     def test_channel_write_should_send_notification(self):
         channel = self.env['discuss.channel'].create({"name": "test", "description": "test"})
-        self._reset_bus()
         with self.assertBus(
             [(self.cr.dbname, "discuss.channel", channel.id)],
             [
@@ -626,7 +621,6 @@ class TestChannelInternals(MailCommon, HttpCase):
         channel.image_128 = base64.b64encode(("<svg/>").encode())
         avatar_cache_key = channel.avatar_cache_key
         channel.image_128 = False
-        self._reset_bus()
         with self.assertBus(
             [(self.cr.dbname, "discuss.channel", channel.id)],
             [
@@ -820,7 +814,6 @@ class TestChannelInternals(MailCommon, HttpCase):
         """Ensures the command '/help' works in a channel"""
         channel = self.env["discuss.channel"].browse(self.test_channel.ids)
         channel.name = "<strong>R&D</strong>"
-        self._reset_bus()
         with self.assertBus(
             [(self.env.cr.dbname, "res.partner", self.env.user.partner_id.id)],
             [
@@ -857,7 +850,6 @@ class TestChannelInternals(MailCommon, HttpCase):
             'channel_partner_ids': [(6, 0, test_user.partner_id.id)]
         })
         test_group._add_members(users=self.user_employee_nomail)
-        self._reset_bus()
         with self.assertBus(
             [(self.env.cr.dbname, "res.partner", self.env.user.partner_id.id)],
             [

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -23,7 +23,6 @@ class TestChannelRTC(MailCommon):
         channel = self.env['discuss.channel']._create_channel(name='Test Channel', group_id=self.env.ref('base.group_user').id)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
-        self._reset_bus()
         with self.assertBus(
             [
                 # delete of old sessions
@@ -173,7 +172,6 @@ class TestChannelRTC(MailCommon):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         channel_member._rtc_leave_call()
 
-        self._reset_bus()
         with self.assertBus(
             [
                 # update new session
@@ -284,7 +282,6 @@ class TestChannelRTC(MailCommon):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         channel_member._rtc_leave_call()
 
-        self._reset_bus()
         with self.assertBus(
             [
                 # update new session
@@ -458,7 +455,6 @@ class TestChannelRTC(MailCommon):
         channel_member._rtc_join_call()
 
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
-        self._reset_bus()
         with self.assertBus(
             [
                 # update invitation
@@ -559,7 +555,6 @@ class TestChannelRTC(MailCommon):
             channel_member_test_user._rtc_join_call()
 
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
-        self._reset_bus()
         with self.assertBus(
             [
                 # update invitation
@@ -672,7 +667,6 @@ class TestChannelRTC(MailCommon):
         channel_member._rtc_join_call()
 
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
-        self._reset_bus()
         with self.assertBus(
             [
                 # update invitation
@@ -732,7 +726,6 @@ class TestChannelRTC(MailCommon):
             channel_member_test_user._rtc_leave_call()
 
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
-        self._reset_bus()
         with self.assertBus(
             [
                 # update invitation
@@ -803,7 +796,6 @@ class TestChannelRTC(MailCommon):
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
         channel_member._rtc_join_call()
 
-        self._reset_bus()
         with self.assertBus(
             [
                 # update invitation
@@ -1129,7 +1121,6 @@ class TestChannelRTC(MailCommon):
         channel = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
-        self._reset_bus()
         with self.assertBus(
             [
                 # update list of sessions
@@ -1170,7 +1161,6 @@ class TestChannelRTC(MailCommon):
         channel_member._rtc_join_call()
         channel_member.rtc_session_ids.flush_model()
         channel_member.rtc_session_ids._write({'write_date': fields.Datetime.now() - relativedelta(days=2)})
-        self._reset_bus()
         with self.assertBus(
             [
                 # update list of sessions
@@ -1207,7 +1197,6 @@ class TestChannelRTC(MailCommon):
         channel = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
-        self._reset_bus()
         with self.assertBus(
             [
                 # update list of sessions
@@ -1255,7 +1244,6 @@ class TestChannelRTC(MailCommon):
         test_session.flush_model()
         test_session._write({'write_date': fields.Datetime.now() - relativedelta(days=2)})
         unused_ids = [9998, 9999]
-        self._reset_bus()
         with self.assertBus(
             [
                 # update list of sessions

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -141,7 +141,6 @@ class TestLinkPreview(MailCommon):
             message = self.test_partner.message_post(
                 body=Markup(f'<a href={self.source_url}>Nothing link</a>'),
             )
-            self._reset_bus()
 
             def get_bus_params():
                 return (

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -15,7 +15,6 @@ class TestMailMessage(common.MailCommon):
         self.assertEqual(message.notification_ids.failure_type, "mail_email_invalid")
         self.assertEqual(message.notification_ids.res_partner_id, recipient.partner_id)
         self.assertEqual(message.notification_ids.author_id, self.env.user.partner_id)
-        self._reset_bus()
         with self.assertBus(
             [
                 (self.cr.dbname, "res.partner", recipient.partner_id.id),

--- a/addons/mail/tests/test_res_users.py
+++ b/addons/mail/tests/test_res_users.py
@@ -212,7 +212,6 @@ class TestUserSettings(MailCommon):
         settings.is_discuss_sidebar_category_chat_open = False
         settings.is_discuss_sidebar_category_channel_open = False
 
-        self._reset_bus()
         with self.assertBus(
                 [(self.cr.dbname, 'res.partner', self.partner_employee.id)],
                 [{

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -474,10 +474,8 @@ class TestActivitySystrayBusNotify(TestActivityCommon):
             (expected_unlink_notif_channels, expected_unlink_notif_message_items),
         ) in zip(users, expected_create_notifs, expected_unlink_notifs):
             user_activity_vals = [vals | {'user_id': user.id} for vals in self.activity_vals]
-            self._reset_bus()
             with self.assertBus(expected_create_notif_channels, expected_create_notif_message_items):
                 activities = self.env['mail.activity'].create(user_activity_vals)
-            self._reset_bus()
             with self.assertBus(expected_unlink_notif_channels, expected_unlink_notif_message_items):
                 activities.unlink()
 

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -257,7 +257,6 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
     def test_recipients_multi_company(self):
         """Test mentioning a partner with no common company."""
         test_records_mc_c2 = self.test_records_mc[1]
-        self._reset_bus()
         with self.assertBus([(self.cr.dbname, "res.partner", self.user_employee_c3.partner_id.id)]):
             test_records_mc_c2.with_user(self.user_employee_c2).with_context(
                 allowed_company_ids=self.company_2.ids

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1158,7 +1158,6 @@ class TestDiscuss(MailCommon, TestRecipients):
 
             # mark all as read clear needactions
             msg1 = self.test_record.message_post(body='Test', message_type='comment', subtype_xmlid='mail.mt_comment', partner_ids=[employee_partner.id])
-            self._reset_bus()
             with self.assertBus(
                     [(self.cr.dbname, 'res.partner', employee_partner.id)],
                     message_items=[{
@@ -1185,7 +1184,6 @@ class TestDiscuss(MailCommon, TestRecipients):
             na_count = employee_partner._get_needaction_count()
             self.assertEqual(na_count, 1, "message not accessible is currently still counted")
 
-            self._reset_bus()
             with self.assertBus(
                     [(self.cr.dbname, 'res.partner', employee_partner.id)],
                     message_items=[{

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1715,7 +1715,6 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                 ],
             )
 
-        self._reset_bus()
         self.env.invalidate_all()
         with self.assertBus(get_params=get_bus_params):
             with self.assertQueryCount(17):


### PR DESCRIPTION
With this change, the `assertBus` context manager is now responsible for resetting the bus state before executing its code block. Previously, `_reset_bus ()` had to be called manually before assertBus in order to explicitly check the bus notification for the targeted test process. This was repetitive and error prone, as forgetting to reset could cause notifications from previous actions to leak into the current assertion, leading to confusing test failures.

[Enterprise PR](https://github.com/odoo/enterprise/pull/92270)
