### PR TITLE
[REF] account: extract total_per_tax rounding into separate method

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1503,6 +1503,15 @@ class AccountTax(models.Model):
             amounts_to_distribute[i] += amount_to_distribute
         return amounts_to_distribute
 
+    def _round_total_per_tax(self, total_per_tax, company):
+        for (_tax, currency, _is_refund, _is_reverse_charge), tax_amounts in total_per_tax.items():
+            tax_amounts['raw_tax_amount_currency'] = currency.round(tax_amounts['raw_tax_amount_currency'])
+            tax_amounts['raw_tax_amount'] = company.currency_id.round(tax_amounts['raw_tax_amount'])
+            tax_amounts['raw_base_amount_currency'] = currency.round(tax_amounts['raw_base_amount_currency'])
+            tax_amounts['raw_base_amount'] = company.currency_id.round(tax_amounts['raw_base_amount'])
+            tax_amounts['raw_total_amount_currency'] = currency.round(tax_amounts['raw_total_amount_currency'])
+            tax_amounts['raw_total_amount'] = company.currency_id.round(tax_amounts['raw_total_amount'])
+
     @api.model
     def _round_base_lines_tax_details(self, base_lines, company, tax_lines=None):
         """ Round the 'tax_details' added to base_lines with the '_add_accounting_data_to_base_line_tax_details'.
@@ -1664,13 +1673,7 @@ class AccountTax(models.Model):
                     base_amounts['base_lines'].append(base_line)
 
         # Round 'total_per_tax'.
-        for (_tax, currency, _is_refund, _is_reverse_charge), tax_amounts in total_per_tax.items():
-            tax_amounts['raw_tax_amount_currency'] = currency.round(tax_amounts['raw_tax_amount_currency'])
-            tax_amounts['raw_tax_amount'] = company.currency_id.round(tax_amounts['raw_tax_amount'])
-            tax_amounts['raw_base_amount_currency'] = currency.round(tax_amounts['raw_base_amount_currency'])
-            tax_amounts['raw_base_amount'] = company.currency_id.round(tax_amounts['raw_base_amount'])
-            tax_amounts['raw_total_amount_currency'] = currency.round(tax_amounts['raw_total_amount_currency'])
-            tax_amounts['raw_total_amount'] = company.currency_id.round(tax_amounts['raw_total_amount'])
+        self._round_total_per_tax(total_per_tax, company)
 
         # Round 'total_per_base'.
         for (currency, _is_refund), base_amounts in total_per_base.items():


### PR DESCRIPTION
Move the code block responsible for rounding `total_per_tax` aggregates inside `_round_base_lines_tax_details` into a dedicated helper method `_round_total_per_tax`.

This refactor allows custom modules to override only the rounding logic without reimplementing the entire `_round_base_lines_tax_details` method, improving maintainability.

Related: https://github.com/OCA/l10n-japan/pull/70

@qrtl QT5088



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
