### PR TITLE
[FIX] html_builder, *: save attachment with correct resource info

### DIFF
--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -1,4 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
+import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
 
 export class SetupEditorPlugin extends Plugin {
@@ -6,6 +7,7 @@ export class SetupEditorPlugin extends Plugin {
     static shared = ["getEditableAreas"];
     resources = {
         clean_for_save_handlers: this.cleanForSave.bind(this),
+        closest_savable_providers: withSequence(10, (el) => el.closest(".o_editable")),
     };
 
     setup() {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -67,6 +67,7 @@ export class MediaPlugin extends Plugin {
             ...(this.config.allowImage ? [{ categoryId: "media", commandId: "insertMedia" }] : []),
         ],
         power_buttons: withSequence(1, { commandId: "insertMedia" }),
+        closest_savable_providers: withSequence(20, (el) => this.editable),
 
         /** Handlers */
         clean_for_save_handlers: ({ root }) => this.cleanForSave(root),
@@ -209,17 +210,26 @@ export class MediaPlugin extends Plugin {
     }
 
     async savePendingImages(editableEl = this.editable) {
-        const { resModel, resId } = this.getRecordInfo(editableEl);
         // When saving a webp, o_b64_image_to_save is turned into
         // o_modified_image_to_save by saveB64Image to request the saving
         // of the pre-converted webp resizes and all the equivalent jpgs.
+        const getClosestSavable = (el) => {
+            for (const provider of this.getResource("closest_savable_providers")) {
+                const value = provider(el);
+                if (value) {
+                    return value;
+                }
+            }
+        };
         const b64Proms = [...editableEl.querySelectorAll(".o_b64_image_to_save")].map(
             async (el) => {
+                const { resModel, resId } = this.getRecordInfo(getClosestSavable(el));
                 await this.saveB64Image(el, resModel, resId);
             }
         );
         const modifiedProms = [...editableEl.querySelectorAll(".o_modified_image_to_save")].map(
             async (el) => {
+                const { resModel, resId } = this.getRecordInfo(getClosestSavable(el));
                 await this.saveModifiedImage(el, resModel, resId);
             }
         );

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -13,7 +13,12 @@ import {
     waitForNone,
 } from "@odoo/hoot-dom";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
-import { defineWebsiteModels, setupWebsiteBuilder, dummyBase64Img } from "./website_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+    dummyBase64Img,
+    setupWebsiteBuilderOeId,
+} from "./website_helpers";
 import { testImg } from "./image_test_helpers";
 import { delay } from "@web/core/utils/concurrency";
 import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
@@ -112,6 +117,8 @@ test("pasted/dropped images are converted to attachments on save in website edit
             params.data ===
                 "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII="
         ).toBe(true);
+        expect(params.res_id).toBe(`${setupWebsiteBuilderOeId}`);
+        expect(params.res_model).toBe("ir.ui.view");
         expect.step("add_data");
         return {
             image_src: "/test_image_url.png",
@@ -278,4 +285,31 @@ describe("Image format/optimize", () => {
 
         expect(img.dataset.quality).toBe("50");
     });
+});
+
+test("Save image with correct parameter", async () => {
+    const originalId = 1;
+    onRpc(`/html_editor/modify_image/${originalId}`, async (request) => {
+        const { params } = await request.json();
+        expect(params.res_id).toBe(setupWebsiteBuilderOeId);
+        expect(params.res_model).toBe("ir.ui.view");
+        expect.step("modify_image");
+        return {
+            image_src: "/test_image_url.png",
+            access_token: "1234",
+            public: false,
+        };
+    });
+    onRpc("ir.ui.view", "save", ({ args }) => true);
+    await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            <img src='${dummyBase64Img}'
+                data-original-id="${originalId}"
+                data-original-src="/website/static/src/img/snippets_demo/s_text_image.jpg"
+                data-mimetype-before-conversion="image/jpeg"
+                class="o_modified_image_to_save"
+            >
+        </div>`);
+    await contains(".o-snippets-top-actions button:contains(Save)").click();
+    expect.verifySteps(["modify_image"]);
 });

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -53,6 +53,8 @@ class IrUiView extends models.Model {
     }
 }
 
+export const setupWebsiteBuilderOeId = 539;
+
 export const exampleWebsiteContent = '<h1 class="title">Hello</h1>';
 
 export const invisibleEl =
@@ -112,7 +114,7 @@ export async function setupWebsiteBuilder(
     let originalIframeLoaded;
     let resolveIframeLoaded = () => {};
     const bodyHTML = `${beforeWrapwrapContent}
-        <div id="wrapwrap">${headerContent} <div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch">${websiteContent}</div></div>`;
+        <div id="wrapwrap">${headerContent} <div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="${setupWebsiteBuilderOeId}" data-oe-field="arch">${websiteContent}</div></div>`;
     const iframeLoaded = new Promise((resolve) => {
         resolveIframeLoaded = (el) => {
             const iframe = el;


### PR DESCRIPTION
[FIX] html_builder, *: save attachment with correct resource info
*: html_editor, website

Steps to reproduce the problem:
- Add a "Text-Image" snippet on the website.
- Replace the image.
- Save.

-> The `/html_editor/modify_image/` is called with the `res_model` and
`res_id` parameter set to `null`.

The problem appeared since the [website refactoring]. To solve the
problem, the `res_model` and `res_id` parameters are set thanks to the
information of the closest savable element from the image.

Related to task-4367641

[website refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

