### PR TITLE
[FIX] point_of_sale: fix offline mode search product traceback

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -557,12 +557,13 @@ export class PosStore extends WithLazyGetterTrap {
      * @returns {Promise<Object>}
      */
     async loadNewProducts(domain, offset = 0, limit = 0) {
-        const result = await this.data.callRelated("product.template", "load_product_from_pos", [
-            odoo.pos_config_id,
-            domain,
-            offset,
-            limit,
-        ]);
+        const result = await this.data.callRelated(
+            "product.template",
+            "load_product_from_pos",
+            [odoo.pos_config_id, domain, offset, limit],
+            {},
+            false
+        );
         this.productAttributesExclusion = this.computeProductAttributesExclusion();
         return result;
     }


### PR DESCRIPTION
- Fix issue that was causing a traceback when searching for products in offline mode. Now when we search a product in offline mode, we get the `ConnectionLostError` as before instead of a traceback.

task-id: 5008058



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
