### PR TITLE
[REM] auth_timeout: undeterminist tour `auth_timeout_tour_lock_timeout`

### DIFF
--- a/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
+++ b/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
@@ -190,21 +190,3 @@ registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivi
         assertRPC,
     ],
 });
-
-registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout", {
-    url: "/odoo",
-    steps: () => [
-        {
-            content: "Wait 1 second, to reach the session timeout set to 1 second",
-            trigger: "body",
-            run: async function () {
-                await new Promise((r) => setTimeout(r, 1000));
-                await testRPC();
-            },
-        },
-        {
-            content: "The session expired dialog should appear, click the close button to be redirected to the login",
-            trigger: ".modal-dialog:has(.modal-title:contains('Session Expired')) footer .btn:contains('Close')",
-        },
-    ],
-});

--- a/addons/auth_timeout/tests/test_auth_timeout.py
+++ b/addons/auth_timeout/tests/test_auth_timeout.py
@@ -556,13 +556,3 @@ class TestAuthTimeoutHttp(HttpCase):
             },
         ):
             self.start_tour("/odoo", "auth_timeout_tour_lock_timeout_inactivity_2fa", login=self.user.login)
-
-        with patch.object(
-            self.env.registry["res.groups"],
-            "_get_lock_timeouts",
-            return_value={
-                "lock_timeout": [(1, True)],  # 1 second session timeout
-                "lock_timeout_inactivity": [],
-            },
-        ):
-            self.start_tour("/odoo", "auth_timeout_tour_lock_timeout", login=self.user.login)


### PR DESCRIPTION
This test leads to undeterminist unit test fails on runbot:

```
odoo.addons.auth_timeout.tests.test_auth_timeout:568
FAIL: TestAuthTimeoutHttp.test_auth_timeout_tour
Traceback (most recent call last):
  File "/data/build/odoo/addons/auth_timeout/tests/test_auth_timeout.py", line 568, in test_auth_timeout_tour
    self.start_tour("/odoo", "auth_timeout_tour_lock_timeout", login=self.user.login)
  File "/data/build/odoo/odoo/tests/common.py", line 2475, in start_tour
    self.browser_js(url_path=url_path, code=code, ready=ready, timeout=timeout, success_signal="tour succeeded", **kwargs)
  File "/data/build/odoo/odoo/tests/common.py", line 2441, in browser_js
    self.fail('%s\n\n%s' % (message, error))
AssertionError: The test code "odoo.startTour('auth_timeout_tour_lock_timeout', {"stepDelay": 0, "keepWatchBrowser": false, "debug": false, "startUrl": "/odoo", "delayToCheckUndeterminisms": 0})" failed

FAILED: [2/2] Tour auth_timeout_tour_lock_timeout → Step The session expired dialog should appear, click the close button to be redirected to the login (trigger: .modal-dialog:has(.modal-title:contains('Session Expired')) footer .btn:contains('Close')).
Element (.modal-dialog:has(.modal-title:contains('Session Expired')) footer .btn:contains('Close')) has not been found.
TIMEOUT step failed to complete within 10000 ms.
```

The fact the session is disconnected when the session timeout is reached is already tested in the python unit test `test_check_identity_exception`: https://github.com/odoo/odoo/blob/8e0762f6ff1ea7caf3549c2aab4575d84b04bd3c/addons/auth_timeout/tests/test_auth_timeout.py#L307-L312

This tour was just an extra precaution. If it causes a reliability issue, it can be removed.

runbot-buid-error-230824
