### PR TITLE
[FIX] hr_holidays: added context to leave multi wizard

### DIFF
--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -102,5 +102,8 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
                 "views": [[self.env.ref('hr_holidays.hr_leave_allocation_view_tree').id, "list"], [self.env.ref('hr_holidays.hr_leave_allocation_view_form_manager').id, "form"]],
                 'view_mode': 'list',
                 'res_model': 'hr.leave.allocation',
-                'domain': [('id', 'in', allocations.ids)]
+                'domain': [('id', 'in', allocations.ids)],
+                'context': {
+                    'active_id': False,
+                },
             }

--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -106,5 +106,8 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
             "views": [[self.env.ref('hr_holidays.hr_leave_view_tree').id, "list"], [self.env.ref('hr_holidays.hr_leave_view_form_manager').id, "form"]],
             'view_mode': 'list',
             'res_model': 'hr.leave',
-            'domain': [('id', 'in', leaves.ids)]
+            'domain': [('id', 'in', leaves.ids)],
+            'context': {
+                'active_id': False,
+            },
         }


### PR DESCRIPTION
Task ID: 5004005

**Description of the issue this PR addresses:** When generating time off or allocations for multiple employees using the wizard, the resulting breadcrumb and navigation incorrectly inherit the active_id from the parent view (a specific leave request) appearing as a child of a specific leave record in the breadcrumb and URL.

