### PR TITLE
[FIX] purchase: prevent error if product has no image in portal PO view

### DIFF
--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -338,7 +338,8 @@
                             <tr t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic text-break' if line.display_type == 'line_note' else ''">
                                 <t t-if="not line.display_type">
                                     <td id="product_name" class="d-flex">
-                                        <img t-att-src="image_data_uri(line.product_id.image_128)" alt="Product" class="d-none d-lg-inline o_purchase_portal_product_image"/>
+                                        <img t-att-src="line.product_id.image_128 and image_data_uri(line.product_id.image_128) or '/web/static/img/placeholder.png'"
+                                            alt="Product" class="d-none d-lg-inline o_purchase_portal_product_image"/>
                                         <span t-field="line.name"/>
                                     </td>
                                     <td class="text-end">


### PR DESCRIPTION
In the purchase order portal template
(`purchase.purchase_order_portal_content`),
`image_data_uri(line.product_id.image_128)` was called without checking if the product had an image, leading to a rendering error when `image_128` is False.

Steps to reproduce the bug:
- create a product without an image
- create a purchase order with that product
- partner: portal user (e.g joel)
- connect as portal user
- go to the purchase order
- the portal view will raise an error because it tries to render an image

Solution:
Added a conditional check to only render the `<img>` tag if the product image exists, preventing template evaluation errors.

opw-5013230
