### PR TITLE
[IMP] api_doc: use API key to download json files

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -42,6 +42,10 @@ class DocController(http.Controller):
         res.headers['X-Frame-Options'] = 'deny'
         return res
 
+    @http.route('/doc-bearer/index.json', type='http', auth='bearer')
+    def doc_bearer_index(self):
+        return self.doc_index()
+
     @http.route('/doc/index.json', type='http', auth='user')
     def doc_index(self):
         """
@@ -145,6 +149,10 @@ class DocController(http.Controller):
             if (Model := self.env[ir_model.model]).has_access('read')
         ]
         return modules, models
+
+    @http.route('/doc-bearer/<model_name>.json', type='http', auth='bearer', readonly=True)
+    def doc_bearer_modec(self, model_name):
+        return self.doc_model(model_name)
 
     @http.route('/doc/<model_name>.json', type='http', auth='user', readonly=True)
     def doc_model(self, model_name):


### PR DESCRIPTION
This work adds two routes with `auth='bearer'` that are basically aliases for the `/doc/index.json` and `/doc/<model_name>.json`, so it is possible to download those documents using an API key instead of a logged-in session.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
