### PR TITLE
[FIX] auth_timeout: refresh when check identity dialog is displayed

### DIFF
--- a/addons/auth_timeout/static/src/services/check_identity/check_identity.js
+++ b/addons/auth_timeout/static/src/services/check_identity/check_identity.js
@@ -267,24 +267,23 @@ export const checkIdentityService = {
             startInactivityTimer();
         }
 
+        const checkIdentityErrorHandler = (env, error, originalError) => {
+            if (originalError instanceof RPCError) {
+                if (originalError.data.name === "odoo.addons.auth_timeout.models.ir_http.CheckIdentityException") {
+                    run();
+                    return true;
+                }
+            }
+        };
+        registry.category("error_handlers").add("checkIdentityErrorHandler", checkIdentityErrorHandler);
+
         return {
             bus,
             check,
             getInitData,
-            run,
         };
     },
 };
 
-const checkIdentityErrorHandler = (env, error, originalError) => {
-    if (originalError instanceof RPCError) {
-        if (originalError.data.name === "odoo.addons.auth_timeout.models.ir_http.CheckIdentityException") {
-            useService("check_identity").run();
-            return true;
-        }
-    }
-};
-
 registry.category("public_components").add("auth_timeout.check_identity_form", CheckIdentityForm);
 registry.category("services").add("check_identity", checkIdentityService);
-registry.category("error_handlers").add("checkIdentityErrorHandler", checkIdentityErrorHandler);


### PR DESCRIPTION
If the check identity dialog is displayed and the window is refreshed by the user (F5),
the dialog is supposed to be shown again when catching the `CheckIdentityException` from the server following the rpc call, through the error handler `checkIdentityErrorHandler`.

It wasn't because the service `check_identity` was not ready during the loading, with `useService("check_identity")`, it leaded to a javascript error:
```
@web/core/error_service: handler "checkIdentityErrorHandler" failed with "TypeError: Cannot read properties of null (reading 'component')" while trying to handle:
RPC_ERROR: Odoo Session Expired
    RPC_ERROR
        at makeErrorFromResponse (:8069/web/assets/debug/web.assets_web.js:32897:19) (/web/static/src/core/network/rpc.js:48)
        at XMLHttpRequest.<anonymous> (:8069/web/assets/debug/web.assets_web.js:32974:27) (/web/static/src/core/network/rpc.js:125)
```