### PR TITLE
[FIX] pos_loyalty: correctly claim free products with multiple rewards

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -314,7 +314,12 @@ patch(PosOrder.prototype, {
             }
 
             //If there is only one possible reward we try to claim the most possible out of it
-            if (claimedReward.reward.reward_product_ids?.length === 1) {
+            if (
+                claimedReward.reward.reward_product_ids?.length === 1 &&
+                allRewardsMerged.filter(
+                    (reward) => reward.reward.program_id.id === claimedReward.reward.program_id.id
+                ).length === 1
+            ) {
                 delete claimedReward.args["quantity"];
             }
             this._applyReward(claimedReward.reward, claimedReward.coupon_id, claimedReward.args);
@@ -1326,12 +1331,9 @@ patch(PosOrder.prototype, {
                 this._isRewardProductPartOfRules(reward, product) &&
                 reward.program_id.applies_on !== "future"
             ) {
-                const line = this.get_orderlines().find(
-                    (line) => line._reward_product_id?.id === product.id
-                );
                 // Compute the correction points once even if there are multiple reward lines.
                 // This is because _getPointsCorrection is taking into account all the lines already.
-                const claimedPoints = line ? this._getPointsCorrection(reward.program_id) : 0;
+                const claimedPoints = this._getPointsCorrection(reward.program_id);
                 return Math.floor((remainingPoints - claimedPoints) / reward.required_points) > 0
                     ? reward.reward_product_qty
                     : 0;

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -5,6 +5,7 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as SelectionPopup from "@point_of_sale/../tests/tours/utils/selection_popup_util";
 import { registry } from "@web/core/registry";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/utils/product_configurator_util";
+import { negateStep } from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
     steps: () =>
@@ -279,5 +280,30 @@ registry.category("web_tour.tours").add("test_loyalty_reward_with_variant", {
             ProductConfiguratorPopup.pickRadio("Value 1"),
             Dialog.confirm(),
             PosLoyalty.hasRewardLine("Free Product", "-10", "1.00"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_multiple_reward_line_free_product", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            PosLoyalty.hasRewardLine("Free Product - Product A", "-10", "1.00"),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            PosLoyalty.hasRewardLine("Free Product - Product B").map(negateStep),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            PosLoyalty.hasRewardLine("Free Product - Product B", "-5", "1.00"),
+            PosLoyalty.hasRewardLine("Free Product - Product A", "-10", "1.00"),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            ProductScreen.clickDisplayedProduct("Product B"),
+            PosLoyalty.hasRewardLine("Free Product - Product B", "-5", "1.00"),
+            PosLoyalty.hasRewardLine("Free Product - Product A", "-10", "1.00"),
+            ProductScreen.clickDisplayedProduct("Product A"),
+            PosLoyalty.hasRewardLine("Free Product - Product B", "-5", "1.00"),
+            PosLoyalty.hasRewardLine("Free Product - Product A", "-20", "2.00"),
         ].flat(),
 });


### PR DESCRIPTION
Before this commit, when there were multiple reward lines for free products, adding a combination of those products would result in incorrect claimed free product quantities.

opw-4975059

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
