### PR TITLE
[FIX] marketing_card: breakage of uninstallation of a bunch of models

### DIFF
--- a/addons/marketing_card/models/ir_model.py
+++ b/addons/marketing_card/models/ir_model.py
@@ -1,13 +1,12 @@
-from odoo import models
+from odoo import models, api
 
 
 class IrModel(models.Model):
     _inherit = 'ir.model'
 
-    def unlink(self):
+    @api.ondelete(at_uninstall=False)
+    def _delete_linked_campaigns(self):
         """Remove campaigns on removed models."""
         self.env['card.campaign'].search([
             ('res_model', 'in', self.mapped('model'))
         ]).unlink()
-
-        return super().unlink()


### PR DESCRIPTION
Because it overrides the unlink of `IrModel` odoo/odoo#214315 breaks a ton of model uninstall/reinstall (basically all its dependencies, direct or transitive): when `marketing_card` is marked for uninstallation, all its fields get removed first (because that's how `_module_data_uninstall` does things), so all the non-magic columns are dropped.

Then, when trying to `unlink` the `ir.model` records the `unlink` call fails with some sort of "column does not exist" error (on `active` or `res_model`), the unlink fails, which leads the tables to not be removed, leaving a ton of garbage in the database.

This in turns means trying to reinstall the module also fails, as many tables will have a few records left for one reason or another before they are dropped, so new columns which are `required` without a `default` fail to set up their constraint, which logs both errors and warnings on reinstall.

None of this is necessary, if `marketing_card` is being uninstalled we can just ignore the entire issue as the table should be dropped eventually, even if it worked it would be a waste of time.

https://runbot.odoo.com/odoo/error/230837
