### PR TITLE
[FIX] im_livechat: test in race condition

### DIFF
--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -78,11 +78,11 @@ test("editing livechat note is synced between tabs", async () => {
         target: tab1,
         replace: true,
     });
-    await document.querySelector(".o-livechat-ChannelInfoList textarea").blur(); // Trigger the blur event to save the note
+    await click(".o-mail-ActionPanel-header", { target: tab1 }); // Trigger the blur event to save the note
     await contains(
         ".o-livechat-ChannelInfoList textarea",
         { value: "Updated note" },
-        { target: tab1 }
+        { target: tab2 }
     ); // Note should be synced with bus
 });
 


### PR DESCRIPTION
Fix race condition in livechat note tab syncing test by specifying the tab used in blur event.
This commit also fixes the wrong target chosen for checking the sync value.

ticket-230896


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
