### PR TITLE
[IMP] web: display imported records in the correct view

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -26,7 +26,7 @@
                         <button t-if="isPreviewing" type="button" class="btn btn-secondary">Load Data File</button>
                         <button t-else="" type="button" class="btn btn-primary o_import_file">Upload Data File</button>
                     </FileInput>
-                    <button t-on-click="() => this.exit()" type="button" class="btn btn-secondary">Cancel</button>
+                    <button t-on-click="cancel" type="button" class="btn btn-secondary">Cancel</button>
                 </t>
                 <t t-if="isPreviewing">
                     <ImportDataSidepanel

--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -78,13 +78,12 @@ const strftimeToHumanFormat = memoize(function strftimeToHumanFormat(value) {
  *
  */
 export class BaseImportModel {
-    constructor({ env, resModel, context, orm }) {
+    constructor({ env, context, orm }) {
         this.id = 1;
         this.env = env;
         this.orm = orm;
         this.handleInterruption = false;
 
-        this.resModel = resModel;
         this.context = context || {};
 
         this.fields = [];
@@ -228,6 +227,10 @@ export class BaseImportModel {
 
     unblock() {
         mainComponentRegistry.remove("ImportBlockUI");
+    }
+
+    setResModel(resModel) {
+        this.resModel = resModel;
     }
 
     async init() {
@@ -863,6 +866,7 @@ export class BaseImportModel {
 /**
  * @returns {BaseImportModel}columns
  */
-export function useImportModel({ env, resModel, context, orm }) {
-    return useState(new BaseImportModel({ env, resModel, context, orm }));
+export function useImportModel({ env, context }) {
+    const orm = useService("orm");
+    return useState(new BaseImportModel({ env, context, orm }));
 }

--- a/addons/base_import/static/src/import_records/import_records.js
+++ b/addons/base_import/static/src/import_records/import_records.js
@@ -27,11 +27,9 @@ export class ImportRecords extends Component {
     //---------------------------------------------------------------------
 
     importRecords() {
-        const { context, resModel } = this.env.searchModel;
         this.action.doAction({
             type: "ir.actions.client",
             tag: "import",
-            params: { active_model: resModel, context },
         });
     }
 }

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -327,6 +327,36 @@ export function makeActionManager(env, router = _router) {
     }
 
     /**
+     * Returns the current action, which is the action of the last controller in the stack.
+     *
+     * @returns {Action|null}
+     */
+
+    async function _getCurrentAction() {
+        const currentController = _getCurrentController();
+        let action = null;
+        if (currentController) {
+            if (currentController.virtual) {
+                try {
+                    action = await _loadAction(currentController.action.id);
+                } catch (error) {
+                    if (
+                        error.exceptionName ===
+                        "odoo.addons.web.controllers.action.MissingActionError"
+                    ) {
+                        action = null;
+                    } else {
+                        throw error;
+                    }
+                }
+            } else {
+                action = JSON.parse(currentController.action._originalAction);
+            }
+        }
+        return action;
+    }
+
+    /**
      * Given an id, xmlid, tag (key of the client action registry) or directly an
      * object describing an action.
      *
@@ -1821,6 +1851,9 @@ export function makeActionManager(env, router = _router) {
         },
         get currentController() {
             return _getCurrentController();
+        },
+        get currentAction() {
+            return _getCurrentAction();
         },
     };
 }

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -225,6 +225,20 @@ describe(`new urls`, () => {
         ]);
     });
 
+    test(`action loading, when action not found, load previous`, async () => {
+        redirect("/odoo/action-1001/action-666");
+        logHistoryInteractions();
+
+        await mountWebClient();
+        expect(`.test_client_action`).toHaveCount(1);
+        expect(`.o_menu_brand`).toHaveText("App1");
+        expect(browser.sessionStorage.getItem("menu_id")).toBe("1");
+        expect(browser.location.href).toBe("http://example.com/odoo/action-1001", {
+            message: "url changed",
+        });
+        expect.verifySteps(["pushState http://example.com/odoo/action-1001"]);
+    });
+
     test(`menu loading`, async () => {
         redirect("/odoo?menu_id=2");
         logHistoryInteractions();


### PR DESCRIPTION
This commit introduces two improvements to the import client action.

1 - The import client action will now automatically deduce the current action.
This means that the active model is no longer needs to be included in the URL
or in the client action parameters.

2 - The import client action will now display the imported records in the
correct view. The views used are those of the current action.

part-of task-id 5013848
