### PR TITLE
[FIX] html_editor: clear previously selected files in upload service

### DIFF
--- a/addons/html_editor/static/src/services/upload_local_files_service.js
+++ b/addons/html_editor/static/src/services/upload_local_files_service.js
@@ -17,6 +17,7 @@ export const uploadLocalFileService = {
         async function selectLocalFiles({ multiple, accept }) {
             input.multiple = multiple;
             input.accept = accept;
+            input.value = ""; // clear previously selected files
 
             // Open system's file selector
             input.click();


### PR DESCRIPTION
Currently, the upload local files service does not reset the file input it uses to handle file uploads. As a result, two consecutive uses of the `/file` command can produce undesirable side effects:

Steps to reproduce:
1. Use the `/file` command
2. In the OS file picker, select a file and click on the "open" button.
3. Use the `/file` command
4. In the OS file picker, click on the "cancel" button

=> The system re-uploads the file loaded at step 2 and inserts a file block for that file in the editor. When clicking on the "cancel" button, we should not insert or upload any attachment.

This commit fixes this issue by clearing the file input of the upload local file service before re-prompting the user to select a file. This should guarantee that we do not re-upload the previously selected file.

Task-4989809

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
