### PR TITLE
[FIX] l10n_es_pos: Make settle account due tour dynamic to current year

### DIFF
--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -57,14 +57,16 @@ registry.category("web_tour.tours").add("spanish_pos_tour", {
 });
 
 registry.category("web_tour.tours").add("l10n_es_pos_settle_account_due", {
-    steps: () =>
-        [
+    steps: () => {
+        const todayYear = new Date().getFullYear();
+        const order = `TSJ/${todayYear}/00001`;
+        return [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.clickPartnerButton(),
             PartnerList.clickPartnerOptions("Partner Test 1"),
             PartnerList.clickDropDownItemText("Settle invoices"),
-            PartnerList.clickSettleOrderName("TSJ/2025/00001"),
+            PartnerList.clickSettleOrderName(order),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
@@ -73,7 +75,8 @@ registry.category("web_tour.tours").add("l10n_es_pos_settle_account_due", {
             ReceiptScreen.paymentLineContains("Bank", "10.00"),
             ReceiptScreen.paymentLineContains("Customer Account", "-10.00"),
             Chrome.endTour(),
-        ].flat(),
+        ].flat();
+    },
 });
 
 registry.category("web_tour.tours").add("test_simplified_invoice_not_override_set_pricelist", {


### PR DESCRIPTION
The settle account due tour in l10n_es_pos was failing because the order name was hardcoded to "TSJ/2025/00001". This value includes a date-dependent year and sequence number, which vary based on `context_today`.

this will ensure that the tour dynamically generates the order name based on the current year, making it correct for faketime builds

build_error-230724

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/2b7d0e04-9cd9-45d9-b5f0-32f39f87dd90" />
