### PR TITLE
[FIX] web_editor: s_showcase layout mismatch on large screens

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -237,7 +237,7 @@ function bootstrapToTable(editable) {
             //    by sharing the available space between them.
             const flexColumns = bootstrapColumns.filter(column => !/\d/.test(column.className.match(RE_COL_MATCH)[0] || '0'));
             const colTotalSize = bootstrapColumns.map(child => _getColumnSize(child) + _getColumnOffsetSize(child)).reduce((a, b) => a + b, 0);
-            const colSize = Math.max(1, Math.round((12 - colTotalSize) / flexColumns.length));
+            const colSize = Math.max(1, Math.floor((12 - (colTotalSize)) / flexColumns.length));
             for (const flexColumn of flexColumns) {
                 flexColumn.classList.remove(flexColumn.className.match(RE_COL_MATCH)[0].trim());
                 flexColumn.classList.add(`col-${colSize}`);

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 import convertInline from '@web_editor/js/backend/convert_inline';
 import {getGridHtml, getTableHtml, getRegularGridHtml, getRegularTableHtml, getTdHtml, removeComments} from '@web_editor/../tests/test_utils';
+import { unformat } from '@web_editor/js/editor/odoo-editor/test/utils';
 
 const TEST_WIDTH = 800;
 const TEST_HEIGHT = 600;
@@ -1079,6 +1080,27 @@ QUnit.module('convert_inline', {}, function () {
         assert.strictEqual(convertInline.createMso('<div>ef<!--[if !mso]><div>abcd</div><![endif]-->gh</div>').nodeValue,
             '[if mso]><div>efgh</div><![endif]',
             "Should remove nested mso hide condition");
+    });
+
+    QUnit.test('Should properly calculate colspan', async function (assert) {
+        const editable = document.createElement("div");
+        const container = document.createElement("div");
+        editable.append(container);
+        container.classList.add("container");
+        container.append(document.createElement("div"));
+        container.firstChild.classList.add("row");
+        container.firstChild.innerHTML = `<div class="col-sm">a</div><div class="col-1">b</div><div class="col-sm">c</div>`;
+        convertInline.bootstrapToTable(editable);
+        assert.strictEqual(editable.innerHTML,
+            unformat(`<table cellspacing=\"0\" cellpadding=\"0\" border=\"0\" width=\"100%\" align=\"center\" role=\"presentation\" style=\"width: 100% !important; border-collapse: collapse; text-align: inherit; font-size: unset; line-height: inherit;\">
+                <tr>
+                    <td colspan=\"5\" class=\"o_converted_col\" style=\"max-width: 0px;\">a</td>
+                    <td colspan=\"1\" class=\"o_converted_col\" style=\"max-width: 0px;\">b</td>
+                    <td colspan=\"5\" class=\"o_converted_col\" style=\"max-width: 0px;\">c</td>
+                    <td colspan=\"1\" class=\"o_converted_col\" style=\"max-width: 0px;\"></td>
+                </tr>
+            </table>`),
+            "Should have one row only");
     });
 
     QUnit.test('Correct border attributes for outlook', async function (assert) {


### PR DESCRIPTION
Problem:
On large screens, the `s_showcase` template shows blocks stacked vertically instead of side-by-side as in the editor.

Cause:
After commit 10008b32334152ada1a847b091189d1d9d5aa3d3, `s_showcase` was refactored to fix selection/formatting issues. Mixing relative widths (`col-sm`) with fixed widths (`col-1`) breaks in `convert_inline`, exceeding the 12-column grid.

Solution:
- Use `Math.floor` when calculating the `colSize` to prevent overflow

Before:
<img width="1862" height="948" alt="image" src="https://github.com/user-attachments/assets/35d82103-1f84-4754-862d-50ef3481bcb3" />
After:
<img width="1847" height="955" alt="image" src="https://github.com/user-attachments/assets/20e1b454-dfc4-4ad0-9e6a-3b38c230d0fd" />

Steps to reproduce:
1. Open a new email marketing.
2. Drop the `s_showcase` snippet.
3. Send a test email.
4. Observe the received template is misaligned compared to the editor.

opw-4946126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
