### PR TITLE
[REM] hr: remove versions' computed dates

### DIFF
--- a/addons/hr/models/resource_calendar_leaves.py
+++ b/addons/hr/models/resource_calendar_leaves.py
@@ -22,8 +22,8 @@ class ResourceCalendarLeaves(models.Model):
         )
         for contract, leaves in leaves_by_contract.items():
             tz = timezone(contract.resource_calendar_id.tz or 'UTC')
-            start_dt = date2datetime(contract.date_start, tz)
-            end_dt = date2datetime(contract.date_end, tz) if contract.date_end else datetime.max
+            start_dt = date2datetime(contract.contract_date_start or contract.date_version, tz)
+            end_dt = date2datetime(contract.contract_date_end, tz) if (contract.contract_date_end or contract.get_next_version_start()) else datetime.max
             # only modify leaves that fall under the active contract
             leaves.filtered(
                 lambda leave: start_dt <= leave.date_from < end_dt

--- a/addons/hr/tests/test_calendar_sync.py
+++ b/addons/hr/tests/test_calendar_sync.py
@@ -16,7 +16,7 @@ class TestContractCalendars(TestHrCommon):
 
         cls.contract_cdd_values = {
             'date_version': Date.to_date('2016-01-01'),
-            'date_start': Date.to_date('2016-01-01'),
+            'contract_date_start': Date.to_date('2016-01-01'),
             'name': 'First CDD Contract for Richard',
             'resource_calendar_id': cls.calendar_35h.id,
             'wage': 5000.0,
@@ -24,7 +24,7 @@ class TestContractCalendars(TestHrCommon):
 
         cls.contract_fully_flexible_values = {
             'date_version': Date.to_date('2017-01-01'),
-            'date_start': Date.to_date('2017-01-01'),
+            'contract_date_start': Date.to_date('2017-01-01'),
             'name': 'Fully Flexible Contract for Richard',
             'resource_calendar_id': False,
             'wage': 5000.0,

--- a/addons/hr/wizard/mail_activity_schedule.py
+++ b/addons/hr/wizard/mail_activity_schedule.py
@@ -43,7 +43,7 @@ class MailActivitySchedule(models.TransientModel):
         todo = self.filtered(lambda s: s.res_model == 'hr.employee')
         for scheduler in todo:
             selected_employees = scheduler._get_applied_on_records()
-            start_dates = selected_employees.filtered('date_start').mapped('date_start')
+            start_dates = selected_employees.filtered('contract_date_start').mapped('contract_date_start')
             if start_dates:
                 today = fields.Date.today()
                 planned_due_date = min(start_dates)

--- a/addons/hr_calendar/tests/test_working_hours.py
+++ b/addons/hr_calendar/tests/test_working_hours.py
@@ -349,7 +349,6 @@ class TestWorkingHoursWithVersion(TestHrContractCalendarCommon):
         self.env.user.company_id = self.company_A
         self.env.user.company_ids = [self.company_A.id]
 
-        self.contractB.date_end = datetime(2023, 12, 28)
         self.contractB.contract_date_end = datetime(2023, 12, 28)
         work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
             [self.partnerA.id, self.partnerB.id],

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -360,8 +360,8 @@ class HrLeave(models.Model):
             if not leave.employee_id:
                 continue
             contracts = self.env['hr.version'].search([('employee_id', '=', leave.employee_id.id)]).filtered(
-                lambda c: c.date_start <= leave.request_date_to and
-                          (not c.date_end or c.date_end >= leave.request_date_from))
+                lambda c: (c.contract_date_start or c.date_version) <= leave.request_date_to and
+                          (not (c.contract_date_end or c.get_next_version_start()) or (c.contract_date_end or c.get_next_version_start()) >= leave.request_date_from))
             if contracts:
                 # If there are more than one contract they should all have the
                 # same calendar, otherwise a constraint is violated.
@@ -405,8 +405,8 @@ Versions:
                       versions='\n'.join(_(
                           "- '%(version)s' from %(start_date)s to %(end_date)s",
                           version=version.name or version.employee_id.name,
-                          start_date=format_date(self.env, version.date_start),
-                          end_date=format_date(self.env, version.date_end) if version.date_end else self.env._("undefined"),
+                          start_date=format_date(self.env, version.contract_date_start if version.contract_date_start else version.date_version),
+                          end_date=format_date(self.env, version.contract_date_end) if version.contract_date_end else self.env._("undefined"),
                       ) for version in versions)))
 
     @api.depends('request_date_from_period', 'request_hour_from', 'request_hour_to', 'request_date_from', 'request_date_to',

--- a/addons/hr_holidays/tests/test_multi_contract.py
+++ b/addons/hr_holidays/tests/test_multi_contract.py
@@ -56,7 +56,7 @@ class TestHolidaysMultiContract(TestHolidayContract):
         self.create_leave(start, end, name="Doctor Appointment", employee_id=self.jules_emp.id)
 
         # begins during contract, ends after contract => should not raise
-        self.contract_cdi.date_end = datetime.strptime('2015-11-30', '%Y-%m-%d').date()
+        self.contract_cdi.contract_date_end = datetime.strptime('2015-11-30', '%Y-%m-%d').date()
         start = datetime.strptime('2015-11-25 07:00:00', '%Y-%m-%d %H:%M:%S')
         end = datetime.strptime('2015-12-05 18:00:00', '%Y-%m-%d %H:%M:%S')
         self.create_leave(start, end, name="Doctor Appointment", employee_id=self.jules_emp.id)


### PR DESCRIPTION
There are currently 5 dates used in a version :
- date_version: date at which the version starts to be effective
- contract_date_start: start date of the contract
- date_start (computed): maximum between the start of contract and the start of version
- contract_date_end: end date of the contract
- date_end (computed): minimum between the end of contract and the start of next version - 1 day

This can create a lot of confusion between which fields should be really used, thus the decision was taken to remove the computed dates and create helper methods in their stead.