### PR TITLE
[FIX] tools: translate usererrors passed to website

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -514,7 +514,10 @@ class GettextAlias(object):
             if not lang:
                 try:
                     from odoo.http import request
-                    lang = request.env.lang
+                    if request.httprequest.cookies:
+                        lang = request.httprequest.cookies.get('frontend_lang')
+                    if not lang:
+                        lang = request.env.lang
                 except RuntimeError:
                     pass
             if not lang:


### PR DESCRIPTION
Some UserErrors are calculated in the backend, but are returned to users in the website. For public users and users who cannot set their user.lang (e.g. a portal only user), these errors will default to the db's language if a language isn't passed during a http request. Therefore, add in a check if the lang should come from the request's frontend_lang.

Example use case (Using demo data):
- Install `website_sale` (i.e. ecommerce)
- Install French language and set website1 to be translated into French
- Go to Sales > Configuration > Payment Providers > SEPA Direct Debit > Publish + set "State" = "Test Mode" the payment method
- Go to Website > "Shop" > switch to "EUR" pricelist and switch to "French" > "Add to cart" any product (must be in Euros) > "Proceed to Checkout" > "Checkout"
- change billing/shipping address to any country in EU > "Confirm" > Select "SEPA Direct Debit"
- type in an invalid IBAN > Click "Pay Now"

Issue:
The ValidationError: "The IBAN is invalid, it should begin with the country code" appears in English

Expected result:
The error should be translated into the language of the website

opw-4868395

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
