### PR TITLE
[FIX] im_livechat: unwanted behaviour in tab test

### DIFF
--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -80,11 +80,11 @@ test("editing livechat note is synced between tabs", async () => {
         target: tab1,
         replace: true,
     });
-    await document.querySelector(".o-livechat-ChannelInfoList textarea").blur(); // Trigger the blur event to save the note
+    await click(".o-mail-ActionPanel-header", { target: tab1 }); // Trigger the blur event to save the note
     await contains(
         ".o-livechat-ChannelInfoList textarea",
         { value: "Updated note" },
-        { target: tab1 }
+        { target: tab2 }
     ); // Note should be synced with bus
 });
 


### PR DESCRIPTION
Fix the unexpected behavior that the textareas in different tabs were both rendered by specifying the tab used in blur event.

This commit also fixes the wrong target chosen for checking the sync value.

runbot-230896


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
