### PR TITLE
[FIX] sql_db: only enable faketime on current_database

### DIFF
--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -99,7 +99,7 @@ def _initialize_db(id, db_name, demo, lang, user_password, login='admin', countr
 
 
 def _check_faketime_mode(db_name):
-    if os.getenv('ODOO_FAKETIME_TEST_MODE') and db_name != 'postgres':
+    if os.getenv('ODOO_FAKETIME_TEST_MODE') and db_name in odoo.tools.config['db_name'].split(','):
         try:
             db = odoo.sql_db.db_connect(db_name)
             with db.cursor() as cursor:

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -276,7 +276,7 @@ class Cursor(BaseCursor):
 
         self.cache = {}
         self._now = None
-        if self.dbname != 'postgres' and os.getenv('ODOO_FAKETIME_TEST_MODE'):
+        if os.getenv('ODOO_FAKETIME_TEST_MODE') and self.dbname in tools.config['db_name'].split(','):
             self.execute("SET search_path = public, pg_catalog;")
             self.commit()  # ensure that the search_path remains after a rollback
 

--- a/odoo/tests/test_module_operations.py
+++ b/odoo/tests/test_module_operations.py
@@ -206,7 +206,7 @@ def test_standalone(args):
 if __name__ == '__main__':
     args = parse_args()
 
-    config['dbname'] = threading.current_thread().dbname = args.database
+    config['db_name'] = threading.current_thread().dbname = args.database
     # handle paths option
     if args.addons_path:
         odoo.tools.config['addons_path'] = ','.join([args.addons_path, odoo.tools.config['addons_path']])


### PR DESCRIPTION
Filtering the postgres database was not enough, the log_db was also affected. Since only the order was impacted, this was creating strange side effect in databases like the log-db where it was only modified when the function exists.

Checking the -d is more reliable and safer to avoid any side effect when testing with faketime.

