### PR TITLE
[FIX] test_website: fix issue in TestAutoComplete


### DIFF
--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -119,6 +119,7 @@ class TestAutoComplete(TransactionCase):
         test_page.groups_id = False
 
         # Public user don't see restricted page
+        saved_env = self.env
         self.website.env = self.env = self.env(user=self.website.user_id)
         self._autocomplete_page('testTotallyUnique', 0, "Not found")
 
@@ -137,3 +138,6 @@ class TestAutoComplete(TransactionCase):
 
         test_page.visibility = 'connected'
         self._autocomplete_page('testTotallyUnique', 0, "Not found")
+
+        # restore website env for next tests
+        self.website.env = self.env = saved_env


### PR DESCRIPTION
In commit "[FIX] {test_,}website: avoid restricted page in search
result" (feaece25f22a184a7f1a7c5487e94afcad5f899b), a test was added but
in 18.0 it was causing errors for test that were executed after it because
the test modified a shared class variable.

This is fixed in 18.0 forward-port, but this commit fixes the issue from
16.0 up to 17.0 to avoid unexpected issue if a test was added in these
version in the future.

opw-3964793
opw-4930197
