### PR TITLE
[IMP] point_of_sale, pos_self_order: improve point of sale dashboard

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -79,6 +79,7 @@
             'point_of_sale/static/src/scss/pos_dashboard.scss',
             'point_of_sale/static/src/backend/tours/point_of_sale.js',
             'point_of_sale/static/src/backend/pos_kanban_view/*',
+            'point_of_sale/static/src/backend/pos_open_session_statistics/*',
             'point_of_sale/static/src/backend/pos_payment_provider_cards/*',
             'point_of_sale/static/src/app/hooks/hooks.js',
             'point_of_sale/static/src/backend/many2many_placeholder_list_view/*',

--- a/addons/point_of_sale/static/src/backend/pos_open_session_statistics/pos_open_session_statistics.js
+++ b/addons/point_of_sale/static/src/backend/pos_open_session_statistics/pos_open_session_statistics.js
@@ -1,0 +1,107 @@
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { Domain } from "@web/core/domain";
+
+export class PosOpenSessionStatistics extends Component {
+    static template = "point_of_sale.pos_open_session_statistics";
+    static props = {
+        ...standardWidgetProps,
+    };
+
+    setup() {
+        this.orm = useService("orm");
+        this.notification = useService("notification");
+    }
+
+    get data() {
+        let data = this.props.record.data.statistics_for_current_session;
+
+        if (!data) {
+            // Demo data
+            data = {
+                session: {
+                    is_open: true,
+                    session_id: false,
+                    demo: true,
+                    nb_orders: 81,
+                    name: "Demo Session/00001",
+                },
+                cash: { cash_control: true, raw_opening_cash: 0, opening_cash: "$ 193.10" },
+                date: {
+                    is_started: true,
+                    is_ended: false,
+                    start_date: "2025-08-12",
+                    end_date: "Not ended yet",
+                },
+                orders: {
+                    paid: { count: 41, total: "$ 999.00" },
+                    refund: { count: 1, total: "$ 62.00" },
+                    draft: { count: 34, total: "$ 860.00" },
+                    cancel: { count: 5, total: "$ 230.00" },
+                },
+            };
+        }
+
+        return data;
+    }
+
+    async actionViewSession() {
+        if (!this.data.session.session_id) {
+            this.notification.add(_t("There are no sessions yet for this configuration."), {
+                type: "warning",
+            });
+            return;
+        }
+
+        this.env.services.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: "pos.session",
+            res_id: this.data.session.session_id,
+            views: [[false, "form"]],
+            target: "current",
+        });
+    }
+
+    async actionViewOrders(type) {
+        if (!this.data.session.session_id) {
+            this.notification.add(_t("There are no sessions yet for this configuration."), {
+                type: "warning",
+            });
+            return;
+        }
+
+        let domain = new Domain([["session_id", "=", this.data.session.session_id]]);
+        switch (type) {
+            case "paid":
+                domain = Domain.and([domain, [["state", "=", "paid"]]]);
+                break;
+            case "refund":
+                domain = Domain.and([domain, [["is_refund", "=", true]]]);
+                break;
+            case "draft":
+                domain = Domain.and([domain, [["state", "=", "draft"]]]);
+                break;
+            case "cancel":
+                domain = Domain.and([domain, [["state", "=", "cancel"]]]);
+                break;
+        }
+
+        this.env.services.action.doAction({
+            name: _t("Point of Sale orders"),
+            type: "ir.actions.act_window",
+            res_model: "pos.order",
+            views: [[false, "list"]],
+            target: "current",
+            domain: domain.toList(),
+        });
+    }
+}
+
+export const posOpenSessionStatistics = {
+    component: PosOpenSessionStatistics,
+};
+
+registry.category("view_widgets").add("pos_open_session_statistics", posOpenSessionStatistics);

--- a/addons/point_of_sale/static/src/backend/pos_open_session_statistics/pos_open_session_statistics.scss
+++ b/addons/point_of_sale/static/src/backend/pos_open_session_statistics/pos_open_session_statistics.scss
@@ -1,0 +1,17 @@
+.o_session-statistics {
+    .icon {
+        height: 1.2rem;
+        width: 1.2rem;
+        border-radius: 999px;
+
+        i {
+            font-size: 11px;
+        }
+    }
+
+    .demo-overlay {
+        width: 100%;
+        height: 50px;
+        background: linear-gradient(to top, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
+    }
+}

--- a/addons/point_of_sale/static/src/backend/pos_open_session_statistics/pos_open_session_statistics.xml
+++ b/addons/point_of_sale/static/src/backend/pos_open_session_statistics/pos_open_session_statistics.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="point_of_sale.pos_open_session_statistics">
+        <div class="o_session-statistics position-relative">
+            <div class="my-1" t-att-class="{'opacity-75': !data.date.is_started, 'opacity-25 pe-none': data.session.demo}">
+                <div class="fs-5 pt-2 mb-1 fw-bold cursor-pointer" t-on-click.stop.prevent="() => this.actionViewSession()">
+                    <span>Session <span class="text-action" t-esc="data.session.name" /></span>
+                </div>
+
+                <div class="row gy-1 mb-3">
+                    <t t-set="icon" t-value="'fa fa-usd'" />
+                    <t t-set="iconColor" t-value="'text-bg-secondary'" />
+                    <t t-set="onClick" t-value="() => this.actionViewSession()" />
+                    <t t-set="name" t-value="'Cash Control'" />
+                    <t t-set="value" t-value="data.cash.opening_cash" />
+                    <t t-call="point_of_sale.pos_open_session_statistics-row" />
+
+                    <t t-set="icon" t-value="'fa fa-unlock'" />
+                    <t t-set="iconColor" t-value="'text-bg-secondary'" />
+                    <t t-set="onClick" t-value="() => this.actionViewSession()" />
+                    <t t-set="name" t-value="'Opening Date'" />
+                    <t t-set="value" t-value="data.date.start_date" />
+                    <t t-call="point_of_sale.pos_open_session_statistics-row" />
+                </div>
+
+                <div class="fs-5 mt-2 mb-1 fw-bold">
+                    <span>Orders <t t-esc="data.session.nb_orders" /></span>
+                </div>
+                <div class="row gy-1">
+                    <t t-set="icon" t-value="'fa fa-check'" />
+                    <t t-set="iconColor" t-value="'text-bg-success'" />
+                    <t t-set="onClick" t-value="() => this.actionViewOrders('paid')" />
+                    <t t-set="name" t-value="'Finalized'" />
+                    <t t-set="value" t-value="`${data.orders.paid.total} (${data.orders.paid.count})`" />
+                    <t t-call="point_of_sale.pos_open_session_statistics-row" />
+
+                    <t t-set="icon" t-value="'fa fa-check'" />
+                    <t t-set="iconColor" t-value="'text-bg-secondary'" />
+                    <t t-set="onClick" t-value="() => this.actionViewOrders('draft')" />
+                    <t t-set="name" t-value="'Active'" />
+                    <t t-set="value" t-value="`${data.orders.draft.total} (${data.orders.draft.count})`" />
+                    <t t-call="point_of_sale.pos_open_session_statistics-row" />
+
+                    <t t-set="icon" t-value="'fa fa-times'" />
+                    <t t-set="iconColor" t-value="'text-bg-danger'" />
+                    <t t-set="onClick" t-value="() => this.actionViewOrders('cancel')" />
+                    <t t-set="name" t-value="'Cancelled'" />
+                    <t t-set="value" t-value="`${data.orders.cancel.total} (${data.orders.cancel.count})`" />
+                    <t t-call="point_of_sale.pos_open_session_statistics-row" />
+
+                    <t t-set="icon" t-value="'fa fa-refresh'" />
+                    <t t-set="iconColor" t-value="'text-bg-secondary'" />
+                    <t t-set="onClick" t-value="() => this.actionViewOrders('refund')" />
+                    <t t-set="name" t-value="'Refunded'" />
+                    <t t-set="value" t-value="`${data.orders.refund.total} (${data.orders.refund.count})`" />
+                    <t t-call="point_of_sale.pos_open_session_statistics-row" />
+                </div>
+            </div>
+
+            <div t-if="data.session.demo" class="position-absolute left-0 bottom-0 w-100">
+                <div class="demo-overlay" />
+                <div class="d-flex justify-content-center align-items-center flex-column bg-white py-2">
+                    <span class="fs-4 fw-bold">No data available!</span>
+                    <span class="fs-6">Click the button above to start.</span>
+                </div>
+            </div>
+        </div>
+    </t>
+
+    <t t-name="point_of_sale.pos_open_session_statistics-row">
+        <div class="col-auto d-flex align-items-center justify-content-between fs-6 fw-light cursor-pointer col-12 col-sm-6"
+            t-on-click.stop.prevent="onClick">
+            <div class="d-flex align-items-center gap-2">
+                <div class="icon d-flex justify-content-center align-items-center" t-attf-class="{{iconColor}}">
+                    <i t-attf-class="{{icon}}" />
+                </div>
+                <span t-esc="name" />
+            </div>
+            <span t-esc="value" />
+        </div>
+    </t>
+</templates>

--- a/addons/point_of_sale/views/point_of_sale_dashboard.xml
+++ b/addons/point_of_sale/views/point_of_sale_dashboard.xml
@@ -63,6 +63,7 @@
                 <field name="pos_session_state"/>
                 <field name="pos_session_duration"/>
                 <field name="currency_id"/>
+                <field name="statistics_for_current_session" />
                 <templates>
                     <t t-name="menu">
                         <div class="container dropdown-pos-config">
@@ -96,8 +97,13 @@
                         </div>
                     </t>
                     <t t-name="card">
-                        <div name="card_title" class="mb-4 ms-2">
-                            <field name="name" class="fw-bold fs-4 d-block"/>
+                        <div name="card_title" class="mb-3 mx-2 mt-2">
+                            <div class="d-flex align-items-center justify-content-start gap-2">
+                                <div t-if="record.current_user_id.raw_value">
+                                    <field name="current_user_id" widget="many2one_avatar_user" />
+                                </div>
+                                <field name="name" class="fw-bold fs-4 d-block"/>
+                            </div>
                             <div t-if="!record.current_session_id.raw_value &amp;&amp; record.pos_session_username.value" class="badge text-bg-info d-inline-block">Opened by <field name="pos_session_username"/></div>
                             <div t-if="record.pos_session_state.raw_value == 'opening_control'" class="badge text-bg-info d-inline-block">Opening Control</div>
                             <div t-if="record.pos_session_state.raw_value == 'closing_control'" class="badge text-bg-info d-inline-block">Closing Control</div>
@@ -106,35 +112,23 @@
                                     To Close
                             </div>
                         </div>
-                        <div class="row g-0 pb-4 ms-2 mt-auto">
-                            <div name="card_left" class="col-6 d-flex flex-wrap align-items-center gap-2">
+                        <div class="row g-0 mx-2 mt-auto pb-3" t-att-class="{'pb-4': !record.statistics_for_current_session.raw_value}">
+                            <div name="card_left" class="col-12 col-md-6 d-flex flex-wrap align-items-center gap-2 mb-2 mb-md-0">
                                 <button t-if="record.current_session_state.raw_value != 'closing_control'" class="btn btn-primary" name="open_ui" type="object">
                                     <t t-if="record.current_session_state.raw_value === 'opened'">Continue Selling</t>
                                     <t t-else="">Open Register</t>
                                 </button>
                                 <button t-else="" class="btn btn-secondary" name="open_existing_session_cb" type="object">Close</button>
                             </div>
-                            <div class="col-6">
-                                <div t-if="record.last_session_closing_date.value" class="row">
-                                    <div class="col-6">
-                                        <span>Closing</span>
-                                    </div>
-                                    <field name="last_session_closing_date" class="col-6"/>
-                                </div>
-
-                                <div t-if="record.last_session_closing_date.value" invisible="not cash_control" class="row">
-                                    <div class="col-6">
-                                        <span>Balance</span>
-                                    </div>
-                                    <field name="last_session_closing_cash" widget="monetary" class="col-6"/>
-                                </div>
-
+                            <div class="col-12 col-md-6">
                                 <a t-if="record.number_of_rescue_session.value &gt; 0" class="col-12" name="open_opened_rescue_session_form" type="object">
                                     <field name="number_of_rescue_session" /> outstanding rescue session
                                 </a>
                             </div>
                         </div>
-                        <field name="current_user_id" widget="many2one_avatar_user" class="mt-auto ms-auto"/>
+                        <div class="mx-2 pb-2">
+                            <widget name="pos_open_session_statistics" />
+                        </div>
                     </t>
                 </templates>
             </kanban>

--- a/addons/pos_self_order/views/point_of_sale_dashboard.xml
+++ b/addons/pos_self_order/views/point_of_sale_dashboard.xml
@@ -31,13 +31,6 @@
                         Mobile Menu
                  </button>
             </xpath>
-            <xpath expr="//field[@name='name']" position="after">
-                <field name="self_ordering_mode" invisible="1" />
-                <div class="badge text-bg-info o_kanban_inline_block me-2"
-                    invisible="not self_ordering_mode == 'mobile'">
-                    Self Ordering Enabled
-                </div>
-            </xpath>
             <xpath expr="//div[@name='card_left']" position="after">
                 <field name="self_ordering_mode" invisible="1" />
                 <field name="current_session_id" invisible="1" />


### PR DESCRIPTION
Before this commit, the point of sale dashboard did not provide a
clear overview of the session statistics, particularly regarding
cash control, sold orders, and ongoing restaurant orders.

This commit enhances the dashboard by adding dedicated sections for
each of these statistics, making it easier for users to monitor
the performance of their POS sessions at a glance.

Before:
<img width="626" height="141" alt="image" src="https://github.com/user-attachments/assets/cf62f2ed-e989-4a40-a6ad-9211986f9db2" />

After:
<img width="1192" height="293" alt="image" src="https://github.com/user-attachments/assets/4a6d1b34-dea8-43ac-868c-c1bef4e68855" />
