### PR TITLE
[FIX] account: prevent draft invoices to appear in checked dashboard

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -738,6 +738,7 @@ class account_journal(models.Model):
             *self.env['account.move']._check_company_domain(self.env.companies),
             ('journal_id', 'in', self.ids),
             ('checked', '=', False),
+            ('state', '=', 'posted'),
         ])
 
     def _count_results_and_sum_amounts(self, results_dict, target_currency):

--- a/addons/account/tests/test_account_journal_dashboard.py
+++ b/addons/account/tests/test_account_journal_dashboard.py
@@ -323,6 +323,39 @@ class TestAccountJournalDashboard(TestAccountJournalDashboardCommon):
         self.assertEqual(dashboard_data.get('misc_operations_balance', 0), None)
         self.assertEqual(dashboard_data.get('misc_class', ''), 'text-warning')
 
+    def test_to_check_posted(self):
+        """We want to only have the information on posted moves"""
+        journal = self.env['account.journal'].create({
+            'name': 'Test Foreign Currency Journal',
+            'type': 'sale',
+            'code': 'TEST',
+            'currency_id': self.currency.id,
+            'company_id': self.env.company.id,
+            'autocheck_on_post': False,
+        })
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'journal_id': journal.id,
+            'partner_id': self.partner_a.id,
+            'checked': False,
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'tax_ids': [],
+                })
+            ]
+        })
+
+        dashboard_data = journal._get_journal_dashboard_data_batched()[journal.id]
+        self.assertEqual(dashboard_data['to_check_balance'], journal.currency_id.format(0))
+
+        move.action_post()
+
+        dashboard_data = journal._get_journal_dashboard_data_batched()[journal.id]
+        self.assertEqual(dashboard_data['to_check_balance'], journal.currency_id.format(100))
+
     def test_to_check_amount_different_currency(self):
         """
         We want the to_check amount to be displayed in the journal currency
@@ -333,6 +366,7 @@ class TestAccountJournalDashboard(TestAccountJournalDashboardCommon):
 
         => to check = 150 €
         """
+        self.env.ref('base.CHF').write({'active': True})
         self.env['res.currency.rate'].create({
             'currency_id': self.env.ref('base.EUR').id,
             'name': '2024-12-01',
@@ -349,6 +383,7 @@ class TestAccountJournalDashboard(TestAccountJournalDashboardCommon):
             'code': 'TEST',
             'currency_id': self.env.ref('base.EUR').id,
             'company_id': self.env.company.id,
+            'autocheck_on_post': False,
         })
         self.env['account.move'].create([{
             'move_type': 'out_invoice',
@@ -364,7 +399,7 @@ class TestAccountJournalDashboard(TestAccountJournalDashboardCommon):
                     'tax_ids': [],
                 })
             ]
-        } for currency in (self.env.ref('base.EUR'), self.env.ref('base.CHF'))])
+        } for currency in (self.env.ref('base.EUR'), self.env.ref('base.CHF'))]).action_post()
 
         dashboard_data = journal._get_journal_dashboard_data_batched()[journal.id]
         self.assertEqual(dashboard_data['to_check_balance'], journal.currency_id.format(150))


### PR DESCRIPTION
state = posted has been added in 18.0 but removed in https://github.com/odoo/odoo/commit/68fa35faa332615a2862935a82f778e38a2a3041#diff-6e3139ca3c848ecd9159cbee86a94aa51a3c7e0d2b62bbccfac1023c18a1edf5L586

initial opw-4349684
