### PR TITLE
[FIX] mail: await page reload in discuss_channel_public_tour

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -112,8 +112,12 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             content: "Reload page (fetch reactions)",
             trigger: ".o-mail-Message",
             run() {
+                document.body.classList.add("before-reload-1");
                 location.reload();
             },
+        },
+        {
+            trigger: "body:not(.before-reload-1)",
         },
         {
             content: "Remove reaction",
@@ -124,8 +128,12 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             content: "Reload page (fetch reactions)",
             trigger: ".o-mail-Message:not(:has(.o-mail-MessageReaction:contains('🙂')))",
             run() {
+                document.body.classList.add("before-reload-2");
                 location.reload();
             },
+        },
+        {
+            trigger: "body:not(.before-reload-2)",
         },
         {
             trigger: ".o-mail-Message:not(:has(.o-mail-MessageReaction:contains('🙂')))",


### PR DESCRIPTION
This test suspiciously fails in various ways in all versions before the following PR: https://github.com/odoo/odoo/pull/214358

This seems to indicate an issue with the page reload. Properly wait for the page to reload before proceeding with the next steps in the tour, hoping it will resolve all the related issues.

https://runbot.odoo.com/odoo/error/111051
https://runbot.odoo.com/odoo/error/223165
https://runbot.odoo.com/odoo/error/227755
https://runbot.odoo.com/odoo/error/227756
https://runbot.odoo.com/odoo/error/227757
https://runbot.odoo.com/odoo/error/227758
https://runbot.odoo.com/odoo/error/229657
https://runbot.odoo.com/odoo/error/229724
https://runbot.odoo.com/odoo/error/229745
https://runbot.odoo.com/odoo/error/229817
https://runbot.odoo.com/odoo/error/230901
