### PR TITLE
[REV] sale: revert of ced1335c38834d5ac31f27705a2f7a0047ca8cc2

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -560,10 +560,6 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
     def _compute_price_unit(self):
-        def has_manual_price(line):
-            return line.currency_id.compare_amounts(line.technical_price_unit, line.price_unit)
-
-        force_recompute = self.env.context.get('force_price_recomputation')
         for line in self:
             # Don't compute the price for deleted lines.
             if not line.order_id:
@@ -571,7 +567,7 @@ class SaleOrderLine(models.Model):
             # check if the price has been manually set or there is already invoiced amount.
             # if so, the price shouldn't change as it might have been manually edited.
             if (
-                (not force_recompute and has_manual_price(line))
+                (line.technical_price_unit != line.price_unit and not line.env.context.get('force_price_recomputation'))
                 or line.qty_invoiced > 0
                 or (line.product_id.expense_policy == 'cost' and line.is_expense)
             ):

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -347,53 +347,6 @@ class TestSalePrices(SaleCommon):
         order_line.product_uom = new_uom
         self.assertEqual(order_line.price_total, 1800, "First pricelist rule not applied")
 
-    def test_pricelist_price_recompute_on_quantity_change(self):
-        """
-        Test price updates correctly when quantity changes with
-        pricelist based on another pricelist.
-        """
-        self._enable_pricelists()
-
-        pricelist_a = self.env['product.pricelist'].create({
-            'name': "Pricelist A",
-            'item_ids': [
-                Command.create({
-                    'applied_on': '3_global',
-                    'compute_price': 'fixed',
-                    'fixed_price': 0.75,
-                    'min_quantity': 0,
-                }),
-                Command.create({
-                    'applied_on': '3_global',
-                    'compute_price': 'fixed',
-                    'fixed_price': 0.50,
-                    'min_quantity': 1000,
-                }),
-            ]
-        })
-
-        pricelist_b = self.env['product.pricelist'].create({
-            'name': "Pricelist B",
-            'item_ids': [
-                Command.create({
-                    'applied_on': '3_global',
-                    'compute_price': 'percentage',
-                    'percent_price': -10,
-                    'base': 'pricelist',
-                    'base_pricelist_id': pricelist_a.id,
-                }),
-            ]
-        })
-
-        with Form(self.env['sale.order']) as order_form:
-            order_form.partner_id = self.partner
-            order_form.pricelist_id = pricelist_b
-            with order_form.order_line.new() as line_form:
-                line_form.product_id = self.product
-                self.assertEqual(line_form.price_unit, 0.83)
-                line_form.product_uom_qty = 1000
-                self.assertEqual(line_form.price_unit, 0.55)
-
     def test_multi_currency_discount(self):
         """Verify the currency used for pricelist price & discount computation."""
         product_1 = self.product


### PR DESCRIPTION
"line.currency_id" might be empty or contain more than 1 value, resulting in a crash of the method.
This reverts commit ced1335c38834d5ac31f27705a2f7a0047ca8cc2.

Traceback discovered when creating a rental order from a resource (planning flow).
<img width="1607" height="907" alt="image" src="https://github.com/user-attachments/assets/0980b89b-fc2a-4bfe-a4c7-a290c92bb0e4" />

Quick revert needed to unblock the flow and allow a demo of hotel industry rentals. 
