### PR TITLE
[FIX] html_editor: fix non-deterministic test failure

### DIFF
--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -338,7 +338,8 @@ test("should focus the editable area after selecting a font size item", async ()
     await expectElementCount(".o-we-toolbar", 1);
     const iframeEl = queryOne(".o-we-toolbar [name='font-size'] iframe");
     const inputEl = iframeEl.contentWindow.document?.querySelector("input");
-    await click(inputEl);
+    await contains(".o-we-toolbar [name='font-size'] .dropdown-toggle").click();
+    expect(getActiveElement()).toBe(inputEl);
     await expectElementCount(".o_font_size_selector_menu .dropdown-item:contains('34')", 1);
     await contains(".o_font_size_selector_menu .dropdown-item:contains('34')").click();
     expect(getActiveElement()).toBe(editor.editable);


### PR DESCRIPTION
The fix at [1] fixed the case when the dropdown had not yet opened, but that was not really the cause of the issue here. It's unclear to me what is the issue exactly, but I've noticed this particular test did open the font size dropdown in a slightly different way than other tests which do not have the same non-deterministic issue.

runbot-230945

[1]: https://github.com/odoo/odoo/pull/222583
