### PR TITLE
[IMP] hr: split contract type and pay category into separate fields

### DIFF
--- a/addons/hr/views/hr_contract_template_views.xml
+++ b/addons/hr/views/hr_contract_template_views.xml
@@ -17,13 +17,9 @@
                             <field name="department_id" groups="hr.group_hr_manager"/>
                         </group>
                         <group name="top_info_right">
-                            <label for="contract_type_id" string="Contract Type"/>
-                            <div class="o_row" name="contract_type">
-                                <field name="contract_type_id" class="oe_inline" nolabel="1"/>
-                                <div class="mx-3 flex-grow-0">─</div>
-                                <field name="structure_type_id" class="oe_inline" nolabel="1"
-                                       domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
-                            </div>
+                            <field name="contract_type_id" string="Contract Type" placeholder="Contract Type"/>
+                            <field name="structure_type_id" string="Pay Category" placeholder="Pay Category"
+                                    domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
                             <field name="resource_calendar_id"/>
                             <field name="hr_responsible_id" widget="many2one_avatar_user" groups="hr.group_hr_user"/>
                         </group>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -295,13 +295,9 @@
                                         <div class="o_row" name="wage">
                                             <field name="wage" class="oe_inline o_hr_narrow_field" nolabel="1"/>
                                         </div>
-                                        <label for="contract_type_id" string="Contract Type"/>
-                                        <div class="o_row" name="contract_type">
-                                            <field name="contract_type_id" class="oe_inline o_hr_narrow_field" nolabel="1" placeholder="Contract Type"/>
-                                            <div class="mx-3 flex-grow-0">─</div>
-                                            <field name="structure_type_id" class="oe_inline" nolabel="1" placeholder="Salary Structure Type"
-                                                    domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
-                                        </div>
+                                        <field name="contract_type_id" string="Contract Type" placeholder="Contract Type"/>
+                                        <field name="structure_type_id" string="Pay Category" placeholder="Pay Category"
+                                                domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
 
                                         <separator name="schedule" string="Schedule"/>
                                         <field name="resource_calendar_id" help="The default working hours are set in configuration."/>


### PR DESCRIPTION
This change ensures that official contract names remain visible while clearly distinguishing them from the salary structure category.

task-5013761