### PR TITLE
[FIX] hr_attendance: Avoid compute call during onchange

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -137,7 +137,8 @@ class HrAttendance(models.Model):
                     break
                 ot_hours = min(overtime_reserve, att.worked_hours)
                 overtime_reserve -= ot_hours
-                att.overtime_hours = ot_hours
+                if att.overtime_hours != ot_hours:
+                    att.overtime_hours = ot_hours
 
     @api.depends('employee_id', 'overtime_status', 'overtime_hours')
     def _compute_validated_overtime_hours(self):


### PR DESCRIPTION
This fixes a weird behaviour where field that is not triggering the compute on the save because it was already triggered on the onchange

If a user ser the validated_overtime_hours to a value that is not the one in overtime_hours, upon changing the check_out time we will trigger the compute for both those fields. Overtime_hours calculates it's value based on attendance.overtime model, which is not being updated here, hence it will have the same value. Validate_overtime_hours in the other hand will be updated since there is a write in overtime_hours (even though with the same value) and this will mark the field to be updated when a web_save happens. Now when the save happens the overtime_hours is updated but even though validate_overtime_hours depends on it, it won't be updated since it's being writen to, as a field to be updated

This fix aims to prevent writing to overtime_hours when there is no real need to, preventing the described issue

opw-4806193

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
