### PR TITLE
remove empty links by default

### DIFF
--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -51,6 +51,8 @@ export class QWebPlugin extends Plugin {
         unremovable_node_predicates: isUnremovableQWebElement,
         unsplittable_node_predicates: isUnsplittableQWebElement,
         clipboard_content_processors: this.clearDataAttributes.bind(this),
+        legit_empty_link_predicates: (linkEl) =>
+            linkEl.getAttributeNames().some((name) => name.startsWith("t-")),
     };
 
     setup() {

--- a/addons/html_editor/static/tests/editor.test.js
+++ b/addons/html_editor/static/tests/editor.test.js
@@ -113,14 +113,14 @@ test("clean_for_save_listeners is done last", async () => {
 test("Convert self closing a elements to opening/closing tags", async () => {
     const { el, editor } = await setupEditor(`
         <ul>
-            <li><a href="xyz" t-out="xyz"/></li>
+            <li><a href="xyz" class="oe_unremovable"/></li>
         </ul>
     `);
     expect(el.innerHTML.trim().replace(/\s+/g, " ")).toBe(
-        `<ul> <li> <a href="xyz" t-out="xyz"> </a> </li> </ul>`
+        `<ul> <li> <a href="xyz" class="oe_unremovable"> </a> </li> </ul>`
     );
     expect(editor.getContent().trim().replace(/\s+/g, " ")).toBe(
-        '<ul> <li><a href="xyz" t-out="xyz"></a></li> </ul>'
+        '<ul> <li><a href="xyz" class="oe_unremovable"></a></li> </ul>'
     );
 });
 

--- a/addons/html_editor/static/tests/qweb.test.js
+++ b/addons/html_editor/static/tests/qweb.test.js
@@ -307,3 +307,20 @@ test("cleaning removes content editable", async () => {
             <t t-raw="test">Hello</t>
         </div>`);
 });
+
+test("cleaning does not remove t-out links", async () => {
+    const { el, editor } = await setupEditor(
+        `
+        <ul>
+            <li><a href="xyz" t-out="xyz"/></li>
+        </ul>
+    `,
+        { config }
+    );
+    expect(el.innerHTML.trim().replace(/\s+/g, " ")).toBe(
+        `<ul> <li> <a href="xyz" t-out="xyz" data-oe-protected="true" contenteditable="false"> </a> </li> </ul>`
+    );
+    expect(editor.getContent().trim().replace(/\s+/g, " ")).toBe(
+        '<ul> <li><a href="xyz" t-out="xyz"></a></li> </ul>'
+    );
+});

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -380,6 +380,20 @@ test("Drag and drop from the page should only mark the concerned elements as dir
     expect(":iframe .o_dirty").toHaveCount(0);
 });
 
+test("empty links with o_translate_inline are removed on save", async () => {
+    setupSaveAndReloadIframe();
+    await setupWebsiteBuilder(
+        `<section><a href="http://test.test" class="o_translate_inline">x</a></section>`
+    );
+    const link = queryOne(":iframe a");
+    link.replaceChildren("");
+    expect(":iframe a").toHaveCount(1);
+    expect(":iframe a").toHaveText("");
+    await contains(".o-snippets-top-actions button:contains(Save)").click();
+    await animationFrame();
+    expect(":iframe a").toHaveCount(0);
+});
+
 function setupSaveAndReloadIframe() {
     const resultSave = [];
     onRpc("ir.ui.view", "save", ({ args }) => {


### PR DESCRIPTION
The link plugin was removing empty links only if they only had classes
that were known or that were system classes. But this limits a lot
the possibility to add other classes to link elements. For example,
website builder adds a class `o_translate_inline` on some links. That
unfortunately prevents their removal by the link plugin.

With this commit, link plugin removes empty links, unless they match a
handler of `unremovable_node_predicates` or `keep_empty_link_predicates`

Steps to reproduce:
- Open website builder
- Create a new link
- Make the link appear as a button to see it easily
- Delete its label (but not the link itself)
- Save
- Bug: the empty link has not been removed

task-4975547