### PR TITLE
[FIX] l10n_es: CoA traceback upon Canary CoA loading

### DIFF
--- a/addons/l10n_es/models/template_es_canary_assoc.py
+++ b/addons/l10n_es/models/template_es_canary_assoc.py
@@ -37,4 +37,7 @@ class AccountChartTemplate(models.AbstractModel):
 
     @template('es_canary_assoc', 'account.asset')
     def _get_es_canary_assoc_account_asset(self):
+        # account_asset is not auto-installed when l10n_es is installed
+        if 'account.asset' not in self.env:
+            return {}
         return self._parse_csv('es_assec', 'account.asset', module='l10n_es')

--- a/addons/l10n_es/models/template_es_canary_full.py
+++ b/addons/l10n_es/models/template_es_canary_full.py
@@ -37,4 +37,7 @@ class AccountChartTemplate(models.AbstractModel):
 
     @template('es_canary_full', 'account.asset')
     def _get_es_canary_full_account_asset(self):
+        # account_asset is not auto-installed when l10n_es is installed
+        if 'account.asset' not in self.env:
+            return {}
         return self._parse_csv('es_full', 'account.asset', module='l10n_es')

--- a/addons/l10n_es/models/template_es_canary_pymes.py
+++ b/addons/l10n_es/models/template_es_canary_pymes.py
@@ -37,4 +37,7 @@ class AccountChartTemplate(models.AbstractModel):
 
     @template('es_canary_pymes', 'account.asset')
     def _get_es_canary_pymes_account_asset(self):
+        # account_asset is not auto-installed when l10n_es is installed
+        if 'account.asset' not in self.env:
+            return {}
         return self._parse_csv('es_pymes', 'account.asset', module='l10n_es')


### PR DESCRIPTION
Steps
---------
1. Install l10n_es
2. Create a new Spanish company
3. Set the CoA to `Canary Islands - SMEs`

-> Traceback saying `key Error for account.asset in env`

Problem
---------
`l10n_es` does not auto-install `account_asset` which is in enterprise. When loading the CoA for the canaries, the `account.asset` template methods are all registered regardless whether or not the model exists, leading to the issue.

Solution
---------
Check that `account_asset` exists before loading the templates.

error-build-230827

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
