### PR TITLE
[FIX] mail: fix race-condition in HtmlMail hoot tests

### DIFF
--- a/addons/mail/static/tests/inline/html_mail_field.test.js
+++ b/addons/mail/static/tests/inline/html_mail_field.test.js
@@ -94,7 +94,7 @@ test("HtmlMail save inline html", async function () {
     expect(".odoo-editor-editable").toHaveInnerHTML("<h1> first </h1>");
 
     await contains(".o_form_button_save").click();
-    expect.verifySteps(["web_save"]);
+    await expect.waitForSteps(["web_save"]);
 });
 
 test("HtmlMail don't have access to column commands", async function () {
@@ -148,5 +148,5 @@ test("HtmlMail add icon and save inline html", async function () {
     await contains("span.fa-glass").click();
 
     await contains(".o_form_button_save").click();
-    expect.verifySteps(["web_save"]);
+    await expect.waitForSteps(["web_save"]);
 });


### PR DESCRIPTION
These tests were failing due to `expect.verifySteps()` being empty rather than the RPC response. The rpc response is asynchronous and awaiting the click doesn't necessarily mean the RPC had time to effectively happen, especially when runbot CPU load is high.

Fixes runbot-error-160954