### PR TITLE
[ADD] iot_drivers: alter IoT flows while testing

### DIFF
--- a/addons/iot_drivers/main.py
+++ b/addons/iot_drivers/main.py
@@ -7,7 +7,7 @@ from threading import Thread
 import time
 
 from odoo.addons.iot_drivers.tools import certificate, helpers, upgrade, wifi
-from odoo.addons.iot_drivers.tools.system import IS_RPI
+from odoo.addons.iot_drivers.tools.system import IS_RPI, IS_TESTING
 from odoo.addons.iot_drivers.websocket_client import WebsocketClient
 
 if IS_RPI:
@@ -181,4 +181,7 @@ class Manager(Thread):
 
 
 manager = Manager()
-manager.start()
+if not IS_TESTING:
+    # Start the IoT manager if not in test mode
+    # Tests will simulate the IoT manager to avoid extra thread and have full control
+    manager.start()

--- a/addons/iot_drivers/tools/system.py
+++ b/addons/iot_drivers/tools/system.py
@@ -2,6 +2,8 @@
 
 from platform import system, release
 
+from odoo.tools import config
+
 IOT_SYSTEM = system()
 
 IOT_RPI_CHAR, IOT_WINDOWS_CHAR, IOT_TEST_CHAR = "L", "W", "T"
@@ -11,6 +13,9 @@ IS_RPI = 'rpi' in release()
 IS_TEST = not IS_RPI and not IS_WINDOWS
 """IoT system "Test" correspond to any non-Raspberry Pi nor windows system.
 Expected to be Linux or macOS used locally for development purposes."""
+
+IS_TESTING = config['test_enable']
+"""True if odoo is running in test mode"""
 
 IOT_CHAR = IOT_RPI_CHAR if IS_RPI else IOT_WINDOWS_CHAR if IS_WINDOWS else IOT_TEST_CHAR
 """IoT system character used in the identifier and version.


### PR DESCRIPTION
- Define a constant in system.py to know if the IoT is currently being tested
- Prevent the manager to start automatically if testing
