### PR TITLE
[FIX] website_sale, website_sale_comparison: manage buttons layout on high PPR

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -17,6 +17,13 @@
     --o-wsale-card-btns-btn-font-size: #{$btn-font-size-lg};
 }
 
+@mixin hide-submit-button-label {
+    --o-wsale-card-btn-submit-label-display: none;
+    --o-wsale-card-btn-submit-flex-grow: 0;
+    --o-wsale-card-btn-submit-aspect-ratio: 1;
+    --o-wsale-card-btn-submit-margin: 0 auto 0 0;
+    --o-wsale-card-btn-submit-padding-x: 0;
+}
 
 // Base style for a product card with image/description
 // ============================================================================
@@ -415,21 +422,26 @@
         }
     }
 
-    &:where(.o_wsale_products_opt_wishlist_inline.o_wsale_products_opt_actions_inline) {
-        .o_wsale_product_btn {
-            @container (max-width: 270px) {
-                --o-wsale-comparison-btn-placeholder-display: none;
+    &:where(.o_wsale_products_opt_actions_inline:not(.o_wsale_products_opt_wishlist_fixed):not(.o_wsale_products_opt_wishlist_fixed_onhover)) {
+        &:where(:not(.o_wsale_products_opt_has_wishlist)) {
+            .o_wsale_product_btn:where(:not(:has(.o_add_compare))) {
+                @container (max-width: 180px) {
+                    @include hide-submit-button-label;
+                }
             }
+        }
 
-            &:where(:has(.o_add_wishlist):has(.o_add_compare)) {
-                @include media-breakpoint-up(lg) {
-                    @container (max-width: 250px) {
-                        --o-wsale-card-btn-submit-label-display: none;
-                        --o-wsale-card-btn-submit-flex-grow: 0;
-                        --o-wsale-card-btn-submit-aspect-ratio: 1;
-                        --o-wsale-card-btn-submit-margin: 0 auto 0 0;
-                        --o-wsale-card-btn-submit-padding-x: 0;
-                    }
+        &:where(.o_wsale_products_opt_has_comparison) .o_wsale_product_btn:where(:has(.o_add_compare)),
+        &:where(.o_wsale_products_opt_has_wishlist) .o_wsale_product_btn:where(:has(.o_add_wishlist)) {
+            @container (max-width: 245px) {
+                @include hide-submit-button-label;
+            }
+        }
+
+        &:where(.o_wsale_products_opt_has_wishlist.o_wsale_products_opt_has_comparison) {
+            .o_wsale_product_btn:where(:has(.o_add_wishlist):has(.o_add_compare)) {
+                @container (max-width: 265px) {
+                    @include hide-submit-button-label;
                 }
             }
         }
@@ -1033,11 +1045,6 @@ $_wsale_products_roundness_map: (
             --o-wsale-card-btn-label-display: none;
             --o-wsale-card-btn-padding-x: 0;
             --o-wsale-card-btn-submit-label-display: inline;
-        }
-        @include media-breakpoint-up(lg) {
-            &:where(.o_wsale_products_opt_has_cta.o_wsale_products_opt_has_comparison.o_wsale_products_opt_has_wishlist):where(:not(.o_wsale_products_opt_wishlist_fixed)) {
-                --o-wsale-comparison-btn-placeholder-display: inline-block;
-            }
         }
     }
 }

--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.options.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.options.scss
@@ -13,14 +13,6 @@
         display: var(--o-wsale-comparison-btn-placeholder-display, none);
         order: var(--o-wsale-comparison-btn-order);
     }
-
-    .o_add_compare, .o_add_compare_placeholder {
-        @include media-breakpoint-down(lg) {
-            // Enforce hiding these buttons regardless by options and context.
-            --o-wsale-comparison-btn-display: none !important;
-            --o-wsale-comparison-btn-placeholder-display: none !important;
-        }
-    }
 }
 
 :where(.o_wsale_products_opt_has_comparison) {


### PR DESCRIPTION
This PR displays the comparison button on mobile/tablet devices.
It also improves button management when buttons are displayed inline
for grid-type layouts, based on their container size.

task-5009392

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
