### PR TITLE
[FIX] hr: fix access to field related to hr.employee in hr.employee.p…

### DIFF
--- a/addons/hr/tests/__init__.py
+++ b/addons/hr/tests/__init__.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_attendances
 from . import test_calendar_sync
 from . import test_hr_employee
+from . import test_hr_employee_public
 from . import test_channel
 from . import test_self_user_access
 from . import test_mail_activity_plan

--- a/addons/hr/tests/test_hr_employee_public.py
+++ b/addons/hr/tests/test_hr_employee_public.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.hr.tests.common import TestHrCommon
+
+
+class TestHrEmployee(TestHrCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.res_users_without_hr_right = mail_new_test_user(
+            cls.env,
+            email='nhr@example.com',
+            login='nhr',
+            groups='base.group_user,base.group_partner_manager',
+            name='No HR Right',
+        )
+
+    def test_access_related_field_to_hr_employee(self):
+        # Check if a related field related to hr_employee is accessible.
+        self.env['hr.employee.public'].with_user(self.res_users_without_hr_right).search([("email", "!=", False)])


### PR DESCRIPTION
…ublic

STEP TO REPRODUCE:
==================
    0- Log as Marc Demo (so without hr right)
    1- Go on Employees
    2- Click on the search bar
    3- Click on custom filter
    4- Search employee with email ([('email', '!=', False)])

REASON:
=======
    Due to some hacks, when a user without hr right search on hr.employee,
    his search will be redirected to hr.employee.public.

    Steps of a search on hr.employee.public with this domain = [('email', '!=', False)] (for employee without hr right):
        1- The field email on hr.employee.public is related to hr.employee:
            So (during the call to the method `condition_to_sql` defined in fields_relational.py)
            the domain [('email', '!=', False)]
            become
            [('employee_id', 'any!', [('email', '!=', False)]), ('employee_id', '!=', False)]
        2- A search method in defined for 'employee_id':
            the domain [('employee_id', 'any!', [('email', '!=', False)]), ('employee_id', '!=', False)]
            become
            [('id', 'any!', [('email', '!=', False)]), ('employee_id', '!=', False)]
        3- But this domain have a 'any' operator so the method `_optimize_any_domain` defined in domains.py will be called:
            the domain [('id', 'any!', [('email', '!=', False)]), ('employee_id', '!=', False)]
            will be simplify in this method and will become
            [(email', '!=', False), ('employee_id', '!=', False)]

        You can see an infinite loop, because the first part of the domain is the same as the initial domain.

SOLUTION:
=========
    Store the field employee_id.
task-

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
