### PR TITLE
[FIX] website: remove duplicate text highlight from ancestors

### DIFF
--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -245,6 +245,11 @@ formatsSpecs.highlight = {
     isFormatted: (node) => closestElement(node)?.classList.contains("o_text_highlight"),
     hasStyle: (node) => closestElement(node)?.classList.contains("o_text_highlight"),
     addStyle: (node, { highlightId, thicknessToRestore, colorToRestore }) => {
+        const styledNode = closestElement(node, ".o_text_highlight");
+        if (styledNode) {
+            formatsSpecs.highlight.removeStyle(styledNode);
+            node = styledNode;
+        }
         node.classList.add("o_text_highlight", `o_text_highlight_${highlightId}`);
         if (colorToRestore && colorToRestore !== "currentColor") {
             node.style.setProperty("--text-highlight-color", colorToRestore);

--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -11,6 +11,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Plugin } from "@html_editor/plugin";
 import { highlightIdToName } from "@website/builder/plugins/highlight/highlight_configurator";
 import { textHighlightFactory } from "@website/js/highlight_utils";
+import { unformat } from "@html_editor/../tests/_helpers/format";
 
 defineMailModels();
 
@@ -191,4 +192,34 @@ test("each highlight has a name", () => {
     highlightWithAName.sort();
     highlightWithAPath.sort();
     expect(highlightWithAPath).toEqual(highlightWithAName);
+});
+
+test("Should override existing highlight", async () => {
+    const { el } = await setupEditor(
+        unformat(
+            `<p>
+                [a
+                <span class="o_text_highlight o_text_highlight_freehand_1" style="--text-highlight-width: 4px;">
+                    <span class="o_animated_text o_animate o_anim_fade_in o_visible o_animated" style="visibility: visible; animation-play-state: running;">b</span>
+                </span>
+                c]
+            </p>`
+        ),
+        { config: { Plugins: [...MAIN_PLUGINS, HighlightPlugin, FakeEditInteractionPlugin] } }
+    );
+    await expandToolbar();
+    await contains(".o-we-toolbar .o-select-highlight").click();
+    await contains("#highlightPicker").click();
+    await contains(".o_popover .o_text_highlight_underline").click();
+    expect(el.innerHTML).toBe(
+        unformat(
+            `<p>
+                <span class="o_text_highlight o_text_highlight_underline" style="--text-highlight-width: 4px;">
+                    a
+                    <span class="o_animated_text o_animate o_anim_fade_in o_visible o_animated" style="visibility: visible; animation-play-state: running;"><span>b</span></span>
+                    c
+                </span>
+            </p>`
+        )
+    );
 });


### PR DESCRIPTION
Problem:
When a text highlight is applied on a node that has an ancestor with the same text highlighted, both highlights remain. The ancestor's highlight should be removed before applying the new one.

Cause:
When applying highlight, it is done on the text node (leaf node). However, one of the ancestors might already have the highlight applied. This is not removed, leading to duplicate highlights.

Solution:
When applying the highlight, check if an ancestor has the same text and highlight style applied. If so, remove it before applying the new highlight.

Steps to reproduce:
1. Add text "ABC".
2. Apply text highlight on "B".
3. Apply animation on "B".
4. Apply text highlight on "ABC".
5. In the DOM, "B" has two highlights (visually noticeable).

opw-5014674

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
