### PR TITLE
[FIX] website: trigger resize on website previewable config

### DIFF
--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -709,6 +709,10 @@ export class WebsiteConfigAction extends BuilderAction {
 export class PreviewableWebsiteConfigAction extends BuilderAction {
     static id = "previewableWebsiteConfig";
     static dependencies = ["customizeWebsite", "history"];
+    setup() {
+        // we need this so autoHideMenu recomputes the layout after our changes
+        this.dispatchResize = () => this.window.dispatchEvent(new Event("resize"));
+    }
     getPriority({ params }) {
         return (params.previewClass || "")?.trim().split(/\s+/).filter(Boolean).length || 0;
     }
@@ -722,6 +726,10 @@ export class PreviewableWebsiteConfigAction extends BuilderAction {
         if (params.previewClass) {
             params.previewClass.split(/\s+/).forEach((cls) => el.classList.add(cls));
         }
+        this.dependencies.history.applyCustomMutation({
+            apply: this.dispatchResize,
+            revert: this.dispatchResize,
+        });
         if (!isPreviewing) {
             const viewsToApply = params["views"] || [];
             let undoApplyCallback;
@@ -742,6 +750,10 @@ export class PreviewableWebsiteConfigAction extends BuilderAction {
         if (params.previewClass) {
             params.previewClass.split(/\s+/).forEach((cls) => el.classList.remove(cls));
         }
+        this.dependencies.history.applyCustomMutation({
+            apply: this.dispatchResize,
+            revert: this.dispatchResize,
+        });
         if (!isPreviewing) {
             const viewsToClean = params["views"] || [];
             let undoCleanCallback;

--- a/addons/website/static/tests/tours/auto_hide_menu.js
+++ b/addons/website/static/tests/tours/auto_hide_menu.js
@@ -1,0 +1,68 @@
+import { animationFrame } from "@odoo/hoot-dom";
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+let numNavChildren;
+
+const getTheLayoutChildren = {
+    content: "Get the number of elements in the navbar",
+    trigger: ":iframe #o_main_nav ul[role='menu']",
+    async run() {
+        await animationFrame();
+        numNavChildren = this.anchor.children.length;
+    },
+};
+
+const checkThatLayoutChanged = {
+    content: "Ensure that the navbar layout has changed",
+    trigger: ":iframe #o_main_nav ul[role='menu']",
+    async run() {
+        await animationFrame();
+        if (this.anchor.children.length === numNavChildren) {
+            throw new Error("Navbar layout should change");
+        }
+    },
+};
+
+registerWebsitePreviewTour(
+    "website_auto_hide_menu",
+    {
+        edition: true,
+        url: "/",
+    },
+    () => [
+        getTheLayoutChildren,
+        {
+            content: "Click on the navbar",
+            trigger: ":iframe nav",
+            run: "click",
+        },
+        {
+            content: "Change content width",
+            trigger: ".hb-row[data-label='Content Width'] .o-hb-btn[title='Small']",
+            run: "click",
+        },
+        checkThatLayoutChanged,
+        {
+            content: "Make content width large",
+            trigger: ".hb-row[data-label='Content Width'] .o-hb-btn[title='Full']",
+            run: "click",
+        },
+        getTheLayoutChildren,
+        {
+            content: "Go to the Theme Tab",
+            trigger: ".o-website-builder_sidebar .o-snippets-tabs [data-name='theme']",
+            run: "click",
+        },
+        {
+            content: "Change the page layout",
+            trigger: ".hb-row[data-label='Page Layout'] .o-dropdown",
+            run: "click",
+        },
+        {
+            content: "Set the page layout to 'boxed'",
+            trigger: ".o-hb-select-dropdown-item[data-action-value='boxed']",
+            run: "click",
+        },
+        checkThatLayoutChanged,
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -723,5 +723,8 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_systray_items_disappear(self):
         self.start_tour("/", "website_systray_items_disappear", login="admin")
 
+    def test_auto_hide_menu(self):
+        self.start_tour("/", "website_auto_hide_menu", login="admin")
+
     def test_editing_awaits_navigation(self):
         self.start_tour("/", "website_editing_awaits_navigation", login="admin")


### PR DESCRIPTION
Following this [commit] and the [html_builder refactoring], when we preview or apply changes that effect the navbar, we wouldn't see the proper layout until a resize event or reload.
Steps to see the issue:
- Open website and start editing
- Click on a navbar
- Change the Content Width to "Small"

=> The navbar isn't centered, and potentially reflowing if we have enough items in the navbar.
Related to task-4367641

[commit]: https://github.com/odoo/odoo/commit/10d727175f5845d6be6fa69f6adaae1126eea826
[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb