### PR TITLE
[FIX] point_of_sale: auto validate force done

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -604,6 +604,16 @@ export class PaymentScreen extends Component {
     }
     async sendForceDone(line) {
         line.set_payment_status("done");
+        const config = this.pos.config;
+        const currency = this.pos.currency;
+        const currentOrder = line.pos_order_id;
+        if (
+            currentOrder.is_paid() &&
+            floatIsZero(currentOrder.get_due(), currency.decimal_places) &&
+            config.auto_validate_terminal_payment
+        ) {
+            this.validateOrder(true);
+        }
     }
 
     check_cash_rounding_has_been_well_applied() {

--- a/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
@@ -1,3 +1,4 @@
+/* global posmodel */
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
@@ -171,5 +172,27 @@ registry.category("web_tour.tours").add("ReceiptTrackingMethodTour", {
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.trackingMethodIsLot(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_auto_validate_force_done", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Whiteboard Pen", "1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            {
+                trigger: "body",
+                run: () => {
+                    posmodel.get_order().payment_ids[0].set_payment_status("force_done");
+                },
+            },
+            {
+                trigger: ".send_force_done",
+                run: "click",
+            },
+            ReceiptScreen.receiptIsThere(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2064,6 +2064,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_barcode_search_attributes_preset', login="pos_user")
 
+    def test_auto_validate_force_done(self):
+        self.main_pos_config.write({
+            'auto_validate_terminal_payment': True
+        })
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_auto_validate_force_done', login="pos_user")
+
     def test_pos_ui_round_globally(self):
         self.main_pos_config.company_id.tax_calculation_rounding_method = 'round_globally'
         tax_16 = self.env['account.tax'].create({


### PR DESCRIPTION
When doing a force done on a terminal payment, if the auto validation was turned on, it would not be triggered after clicking on the force done button.

Steps to reproduce:
-------------------
* Turn on the auto validation for terminal payments
* Create a new order and add a product
* Select a terminal payment method (You can fake the force done state as I did in the tour)
* Click on the "Force Done" button
> Observation: You are not redirected to the receipt screen.

opw-4954406