### PR TITLE
[IMP] mail: tweak message link open and error handling

### DIFF
--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -86,11 +86,18 @@ export class ChatWindow extends Record {
         this.bypassCompact = false;
     }
 
-    async open({ focus = false, notifyState = true, jumpToNewMessage = false } = {}) {
+    async open({
+        focus = false,
+        notifyState = true,
+        jumpToNewMessage = false,
+        swapOpened = true,
+    } = {}) {
         await this.store.chatHub.initPromise;
         this.store.chatHub.folded.delete(this);
-        this.store.chatHub.opened.delete(this);
-        this.store.chatHub.opened.unshift(this);
+        if (swapOpened || !this.store.chatHub.opened.includes(this)) {
+            this.store.chatHub.opened.delete(this);
+            this.store.chatHub.opened.unshift(this);
+        }
         if (notifyState) {
             this.store.chatHub.save();
         }

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -15,6 +15,7 @@ import { browser } from "@web/core/browser/browser";
 import { loader } from "@web/core/emoji_picker/emoji_picker";
 import { patch } from "@web/core/utils/patch";
 import { isMobileOS } from "@web/core/browser/feature_detection";
+import { getOrigin } from "@web/core/utils/urls";
 
 /**
  * @typedef {{isSpecial: boolean, channel_types: string[], label: string, displayName: string, description: string}} SpecialMention
@@ -386,28 +387,36 @@ export class Store extends BaseStore {
             ev.preventDefault();
             this.openChat({ partnerId: id });
             return true;
-        } else if (link.classList.contains("o_message_redirect_transformed") && id) {
+        } else if (link.classList.contains("o_message_redirect")) {
             const message = this["mail.message"].get(id);
             const targetThread = message?.thread;
+            const showAccessError = () =>
+                this.env.services.notification.add(_t("This conversation isn’t available."), {
+                    type: "danger",
+                });
             if (targetThread) {
                 targetThread.checkReadAccess().then((hasAccess) => {
                     if (hasAccess) {
                         targetThread.highlightMessage = message;
-                        const wasOpen = targetThread.open({ focus: true });
-                        if (!wasOpen) {
+                        let isOpen = targetThread.eq(thread);
+                        if (!isOpen) {
+                            isOpen = targetThread.open({ focus: true, swapOpened: false });
+                        }
+                        if (!isOpen) {
                             window.open(link.href);
                         }
                     } else {
                         if (this.self_partner) {
-                            this.env.services.notification.add(
-                                _t("You do not have the permission to access this thread."),
-                                { type: "warning" }
-                            );
+                            showAccessError();
                         } else {
                             window.open(link.href);
                         }
                     }
                 });
+                ev.preventDefault();
+                return true;
+            } else if (link.getAttribute("href")?.startsWith(getOrigin())) {
+                showAccessError();
                 ev.preventDefault();
                 return true;
             }

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -738,7 +738,7 @@ export class Thread extends Record {
         return false;
     }
 
-    async openChatWindow({ focus = false, fromMessagingMenu, bypassCompact } = {}) {
+    async openChatWindow({ focus = false, fromMessagingMenu, bypassCompact, swapOpened } = {}) {
         const thread = await this.store.Thread.getOrFetch(this);
         if (!thread) {
             return;
@@ -747,7 +747,7 @@ export class Thread extends Record {
         const cw = this.store.ChatWindow.insert(
             assignDefined({ thread: this }, { fromMessagingMenu, bypassCompact })
         );
-        cw.open({ focus: focus });
+        cw.open({ focus, swapOpened });
         return cw;
     }
 

--- a/addons/mail/static/tests/core/common/message.test.js
+++ b/addons/mail/static/tests/core/common/message.test.js
@@ -9,6 +9,8 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 
 import { describe, test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-dom";
+import { getOrigin } from "@web/core/utils/urls";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -35,4 +37,55 @@ test("following internal link from chatter does not open chat window", async () 
     await click("a", { text: "Create Channel" });
     await contains(".o-mail-ChatWindow-header", { text: "abc" });
     await contains(".o-mail-ChatWindow", { count: 1 });
+});
+
+test("message link shows error when the message is not known", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Alice" });
+    const url = `${getOrigin()}/mail/message/999999`;
+    pyEnv["mail.message"].create({
+        body: `Check this out <a class="o_message_redirect" href="${url}" data-oe-model="mail.message" data-oe-id="999999">${url}</a>`,
+        model: "res.partner",
+        res_id: partnerId,
+    });
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click("a.o_message_redirect");
+    await contains(".o_notification:contains(This conversation isn’t available.)");
+});
+
+test("same-thread message link does not open the thread again but highlights the message", async () => {
+    const pyEnv = await startServer();
+    const [aliceId, lenaId] = pyEnv["res.partner"].create([{ name: "Alice" }, { name: "Lena" }]);
+    const helloMessageId = pyEnv["mail.message"].create({
+        body: "Hello",
+        model: "res.partner",
+        res_id: aliceId,
+    });
+    const heyMessageId = pyEnv["mail.message"].create({
+        body: "Hey",
+        model: "res.partner",
+        res_id: lenaId,
+    });
+    const helloUrl = `${getOrigin()}/mail/message/${helloMessageId}`;
+    pyEnv["mail.message"].create({
+        body: `Check this out <a class="o_message_redirect" href="${helloUrl}" data-oe-model="mail.message" data-oe-id="${helloMessageId}">${helloUrl}</a>`,
+        model: "res.partner",
+        res_id: aliceId,
+    });
+    const heyUrl = `${getOrigin()}/mail/message/${heyMessageId}`;
+    pyEnv["mail.message"].create({
+        body: `Another thread <a class="o_message_redirect" href="${heyUrl}" data-oe-model="mail.message" data-oe-id="${heyMessageId}">${heyUrl}</a>`,
+        model: "res.partner",
+        res_id: aliceId,
+    });
+    await start();
+    await openFormView("res.partner", aliceId);
+    await click("a.o_message_redirect:contains(Alice)");
+    await contains(".o-mail-Message.o-highlighted:contains(Hello)");
+    await animationFrame(); // give enough time for the potential breadcrumb item to render
+    await contains(".breadcrumb-item", { count: 0 });
+    await click("a.o_message_redirect:contains(Lena)");
+    await contains(".o-mail-Message.o-highlighted:contains(Hey)");
+    await contains(".breadcrumb-item:contains(Alice)");
 });

--- a/addons/mail/static/tests/discuss/core/common/message.test.js
+++ b/addons/mail/static/tests/discuss/core/common/message.test.js
@@ -1,0 +1,51 @@
+import {
+    click,
+    contains,
+    defineMailModels,
+    setupChatHub,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+
+import { describe, test } from "@odoo/hoot";
+import { getOrigin } from "@web/core/utils/urls";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+test("clicking message link does not swap open chat window", async () => {
+    const pyEnv = await startServer();
+    const [rdId, supportId] = pyEnv["discuss.channel"].create([
+        { name: "R&D" },
+        { name: "Support" },
+    ]);
+    const messageRdId = pyEnv["mail.message"].create({
+        body: "Hello R&D",
+        model: "discuss.channel",
+        res_id: rdId,
+    });
+    const urlRd = `${getOrigin()}/mail/message/${messageRdId}`;
+    const messageSupportId = pyEnv["mail.message"].create({
+        body: `Hello from there <a class="o_message_redirect" href="${urlRd}" data-oe-model="mail.message" data-oe-id="${messageRdId}">${urlRd}</a>`,
+        model: "discuss.channel",
+        res_id: supportId,
+    });
+    const urlSupport = `${getOrigin()}/mail/message/${messageSupportId}`;
+    pyEnv["mail.message"].create({
+        body: `Hello back <a class="o_message_redirect" href="${urlSupport}" data-oe-model="mail.message" data-oe-id="${messageSupportId}">${urlSupport}</a>`,
+        model: "discuss.channel",
+        res_id: rdId,
+    });
+    setupChatHub({ opened: [rdId, supportId] });
+    await start();
+    await contains(".o-mail-ChatWindow:eq(0) .o-mail-ChatWindow-header:contains(R&D)");
+    await contains(".o-mail-ChatWindow:eq(1) .o-mail-ChatWindow-header:contains(Support)");
+    await click("a.o_message_redirect:contains(R&D)");
+    await contains(".o-mail-Message.o-highlighted:contains(Hello R&D)");
+    await contains(".o-mail-ChatWindow:eq(0) .o-mail-ChatWindow-header:contains(R&D)");
+    await contains(".o-mail-ChatWindow:eq(1) .o-mail-ChatWindow-header:contains(Support)");
+    await click("a.o_message_redirect:contains(Support)");
+    await contains(".o-mail-Message.o-highlighted:contains(Hello from there)");
+    await contains(".o-mail-ChatWindow:eq(0) .o-mail-ChatWindow-header:contains(R&D)");
+    await contains(".o-mail-ChatWindow:eq(1) .o-mail-ChatWindow-header:contains(Support)");
+});


### PR DESCRIPTION
Add a standard message for error, in all cases and not only when the thread is known.

Ensure the currently open thread is not opened again, in particular this avoids breadcrumb stacking in chatter and fixes highlighting.

Avoid swapping already opened chat windows.

task-4095328