### PR TITLE
[FIX] account: prevent blocked invoices from being unblocked

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1145,8 +1145,8 @@ class AccountMove(models.Model):
     def _compute_payment_state(self):
         groups = self.grouped(lambda move:
             'legacy' if move.payment_state == 'invoicing_legacy' else
-            'posted_invoice' if move.state == 'posted' and move.is_invoice(True) else
             'blocked' if move.payment_state == 'blocked' else
+            'posted_invoice' if move.state == 'posted' and move.is_invoice(True) else
             'unpaid'
         )
         groups.get('unpaid', self.browse()).payment_state = 'not_paid'


### PR DESCRIPTION
Problem:
When the `payment_state` field on `account.move` is automatically computed, the logic will prioritize whether the move has been posted over whether it has been blocked. The effect is that if an invoice has been marked as blocked, it might be automatically unblocked during reconciliation.

Solution:
The `_compute_payment_state` method will now prioritize a move's `payment_state` being blocked over whether it has been posted. This prevents a blocked move from being unblocked unexpectedly.

Steps to Replicate (Runbot 18)
- Create a product
	- Track inventory
	- Cost > 0
	- Control policy = On ordered quantities
	- Product category is valuated in real-time (Inventory Valuation - Automated) (requires 'Stock Accounting Automatic' group)

1. Create a PO for the product
2. Create a bill, validate it
3. Block the bill using the contextual action
4. Receive the product

If you navigate back to the Vendor Bill, you will see that it has been unblocked.

opw-4981799

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
