### PR TITLE
[FIX] sale_stock: Fix random runbot error 108414

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1953,19 +1953,24 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
         self.env.user.groups_id += self.env.ref('stock.group_adv_location')
         warehouse = self.company_data['default_warehouse']
+        customer_location = self.env.ref('stock.stock_location_customers')
         # Create two child locations.
         parent_location = warehouse.lot_stock_id
         child_location_1 = self.env['stock.location'].create({
                 'name': 'child_1',
-                'location_id': parent_location.id,
+                'location_id': customer_location.id,
         })
         child_location_2 = self.env['stock.location'].create({
                 'name': 'child_2',
-                'location_id': parent_location.id,
+                'location_id': customer_location.id,
         })
         # Enable 2-steps delivery
         with Form(warehouse) as w:
             w.delivery_steps = 'pick_ship'
+        # update the qty available for the products
+        (self.product_a | self.product_b).type = 'product'
+        self.env['stock.quant']._update_available_quantity(self.product_a, parent_location, 10)
+        self.env['stock.quant']._update_available_quantity(self.product_b, parent_location, 1)
         so = self._get_new_sale_order(product=self.product_a)
         self.env['sale.order.line'].create({
             'product_id': self.product_b.id,
@@ -1974,16 +1979,21 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         self.assertEqual(len(so.order_line), 2)
         so.action_confirm()
         self.assertEqual(len(so.picking_ids), 2)
-        so.picking_ids[1].move_ids[0].location_dest_id = child_location_1
-        so.picking_ids[1].move_ids[1].location_dest_id = child_location_2
+        pick_picking = so.picking_ids.filtered(lambda p: p.picking_type_id == warehouse.pick_type_id)
+        self.assertEqual(pick_picking.state, 'assigned')
+        delivery_picking = so.picking_ids - pick_picking
+        self.assertEqual(delivery_picking.state, 'waiting')
+        delivery_picking.move_ids[0].location_dest_id = child_location_1
+        delivery_picking.move_ids[1].location_dest_id = child_location_2
         # Pack the moves of the first picking together.
-        package = so.picking_ids[0].action_put_in_pack()
+        package = pick_picking.action_put_in_pack()
         # a new package is made and done quantities should be in same package
         self.assertTrue(package)
-        so.picking_ids[0].button_validate()
-        self.assertEqual(so.picking_ids[0].state, 'done')
-        self.assertEqual(so.picking_ids[1].move_ids.move_line_ids[0].location_dest_id, child_location_1)
-        self.assertEqual(so.picking_ids[1].move_ids.move_line_ids[1].location_dest_id, child_location_2)
+        pick_picking.button_validate()
+        self.assertEqual(pick_picking.state, 'done')
+        self.assertEqual(delivery_picking.state, 'assigned')
+        self.assertEqual(delivery_picking.move_ids.move_line_ids[0].location_dest_id, child_location_1)
+        self.assertEqual(delivery_picking.move_ids.move_line_ids[1].location_dest_id, child_location_2)
 
     def test_update_sol_quantity_without_packaging(self):
         """


### PR DESCRIPTION
Steps to reproduce the bug:
- Install l10n_ke_edi_oscu_stock -Try to run the test: test_package_with_moves_to_different_location_dest

Problem:
 A user error is raised:
“There is nothing eligible to put in a pack. Either there are no quantities to put in a pack or all products are already in a pack.” This happens because when only sale_stock is installed, the product type is Consumable, so the move gets assigned directly. However, with l10n_ke, the product becomes Storable, and when assigning the move, the system checks whether there is enough quantity available in stock.

Solution:
Force the product to remain Storable in all cases and update its stock quantity accordingly.

[runbot-108414](https://runbot.odoo.com/odoo/runbot.build.error/108414)
