### PR TITLE
[FIX] website_sale_{stock,mrp}: update product availability from kit in cart

### DIFF
--- a/addons/website_sale_mrp/__init__.py
+++ b/addons/website_sale_mrp/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers
+from . import models

--- a/addons/website_sale_mrp/__manifest__.py
+++ b/addons/website_sale_mrp/__manifest__.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Kit Availability',
+    'version': '1.0',
+    'category': 'Website/Website',
+    'summary': 'Manage Kit product inventory & availability',
+    'description': """
+Manage the inventory of your Kit products and display their availability status in your eCommerce store.
+    """,
+    'depends': [
+        'website_sale_stock',
+        'sale_mrp',
+    ],
+    'auto_install': True,
+    'assets': {
+        'web.assets_frontend': [
+            'website_sale_mrp/static/src/js/**/*',
+        ],
+        'web.assets_tests': [
+            'website_sale_mrp/static/tests/tours/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/website_sale_mrp/controllers/__init__.py
+++ b/addons/website_sale_mrp/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import variant

--- a/addons/website_sale_mrp/controllers/variant.py
+++ b/addons/website_sale_mrp/controllers/variant.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import request, route
+
+from odoo.addons.website_sale_stock.controllers.variant import WebsiteSaleStockVariantController
+
+
+class WebsiteSaleMrpVariantController(WebsiteSaleStockVariantController):
+
+    @route('/website_sale_mrp/get_unavailable_qty_from_kits', type='json', auth='public', website=True)
+    def get_unavailable_qty_from_kits(self, product_id=None, *args, **kwargs):
+        so = request.website.sale_get_order()
+        if not so:
+            return 0
+        product = request.env['product.product'].browse(product_id)
+        return so._get_unavailable_quantity_from_kits(product)

--- a/addons/website_sale_mrp/models/__init__.py
+++ b/addons/website_sale_mrp/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import sale_order

--- a/addons/website_sale_mrp/models/sale_order.py
+++ b/addons/website_sale_mrp/models/sale_order.py
@@ -1,0 +1,60 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+
+from odoo import models
+from odoo.tools import float_is_zero
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _get_unavailable_quantity_from_kits(self, product):
+        """
+        If any line of the order refers to a kit product, the availability of the product
+        might be impacted (if the product is a kit or a component of one).
+
+        This method computes the quantity that becomes unavailable for the product because
+        of the order lines that do not refer to it directly.
+
+        :param ProductProduct product: the product for which the unavailability is computed.
+        :param float free_qty: the free_qty of the product
+        """
+        self.ensure_one()
+        unavailable_qty = 0
+        if product.is_kits:
+            # Explode the kit to fetch the set of relevant components to track.
+            kit_bom = self.env['mrp.bom'].sudo()._bom_find(product, company_id=self.company_id.id, bom_type='phantom')[product]
+            _, bom_sub_lines = kit_bom.explode(product, quantity=1.0)
+            unavailable_component_qties = {}
+            qty_per_kit = defaultdict(float)
+            for bom_line, bom_line_data in bom_sub_lines:
+                if bom_line.product_id.type != 'product':
+                    # Relevant only for storable components.
+                    continue
+                if float_is_zero(bom_line_data['qty'], precision_rounding=bom_line.product_uom_id.rounding):
+                    # As BoMs allow components with a quantity of 0 (i.e., optional components), we
+                    # skip those to avoid a division by zero.
+                    continue
+                component = bom_line.product_id
+                unavailable_component_qties[component] = sum(self.order_line.filtered(lambda sol: sol.product_id == component).mapped('product_uom_qty'))
+                uom_qty_per_kit = bom_line_data['qty'] / bom_line_data['original_qty']
+                qty_per_kit[component] += bom_line.product_uom_id._compute_quantity(uom_qty_per_kit / kit_bom.product_qty, component.uom_id, round=False)
+
+        for line in self.order_line.filtered(lambda sol: sol.product_id.is_kits and sol.product_id != product):
+            # Other kit lines might influence the availability of the product.
+            line_kit_bom = self.env['mrp.bom'].sudo()._bom_find(line.product_id, company_id=self.company_id.id, bom_type='phantom')[line.product_id]
+            component_qties = line._get_bom_component_qty(line_kit_bom)
+            unavailable_qty += component_qties.get(product.id, {}).get('qty', 0) * line.product_uom_qty / line_kit_bom.product_qty
+            if product.is_kits:
+                # If the product is a kit, the availability of its components can be influenced by other kits.
+                for component, _ in unavailable_component_qties.items():
+                    unavailable_component_qties[component] += component_qties.get(component.id, {}).get('qty', 0) * line.product_uom_qty / line_kit_bom.product_qty
+
+        if product.is_kits:
+            # If the product is a kit, recompute availability based on the availability of its components.
+            max_free_kit_qty = free_qty = product.sudo().free_qty
+            for component, unavailable_component_qty in unavailable_component_qties.items():
+                max_free_kit_qty = min(max_free_kit_qty, (component.free_qty - unavailable_component_qty) // qty_per_kit[component])
+            unavailable_qty += free_qty - max_free_kit_qty
+        return unavailable_qty

--- a/addons/website_sale_mrp/static/src/js/variant_mixin.js
+++ b/addons/website_sale_mrp/static/src/js/variant_mixin.js
@@ -1,0 +1,19 @@
+/** @odoo-module **/
+
+import { jsonrpc } from "@web/core/network/rpc_service";
+import VariantMixin from "@website_sale_stock/js/variant_mixin";
+
+const oldGetUnavailableQty = VariantMixin._getUnavailableQty;
+
+/**
+ * Get unavailable stock related to kit products of the cart.
+ * @override
+ */
+VariantMixin._getUnavailableQty = async function (combination) {
+    const unavailableQty = await oldGetUnavailableQty.apply(this, arguments);
+    const kitUnavailableQty = await jsonrpc(
+        "/website_sale_mrp/get_unavailable_qty_from_kits",
+        combination
+    );
+    return unavailableQty + kitUnavailableQty;
+};

--- a/addons/website_sale_mrp/static/tests/tours/test_website_sale_product_availability.js
+++ b/addons/website_sale_mrp/static/tests/tours/test_website_sale_product_availability.js
@@ -1,0 +1,34 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import tourUtils from "@website_sale/js/tours/tour_utils";
+import wTourUtils from "@website/js/tours/tour_utils";
+
+registry.category("web_tour.tours").add("test_website_sale_availability_kit", {
+    test: true,
+    url: "/shop",
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "Consumable Component" }),
+        ...tourUtils.addToCart({ productName: "Component A" }),
+        { trigger: ".availability_messages:contains(99)", isCheck: true },
+        ...tourUtils.searchProduct("Super Kit Product"),
+        wTourUtils.clickOnElement("Super Kit Product", `a:contains('Super Kit Product')`),
+        { trigger: ".availability_messages:contains(19)", isCheck: true }, // 20 - 1 (Comp A)
+        wTourUtils.clickOnElement("Add to cart", "#add_to_cart"),
+        { trigger: ".availability_messages:contains(18)", isCheck: true }, // 20 - 1 (Comp A) - 1 (in cart)
+        ...tourUtils.searchProduct("Kit Product"),
+        wTourUtils.clickOnElement("Kit Product", `a:contains('Kit Product')`),
+        { trigger: ".availability_messages:contains(19)", isCheck: true }, // 20 - 1 (Super Kit)
+        wTourUtils.clickOnElement("Add to cart", "#add_to_cart"),
+        { trigger: ".availability_messages:contains(18)", isCheck: true }, // 20 - 1 (Super Kit) - 1 (in cart)
+        ...tourUtils.addToCart({ productName: "Component A" }),
+        { trigger: ".availability_messages:contains(92)", isCheck: true },
+        ...tourUtils.searchProduct("Component B"),
+        wTourUtils.clickOnElement("Component B", `a:contains('Component B')`),
+        wTourUtils.clickOnElement("Add to cart", "#add_to_cart"),
+        { trigger: ".availability_messages:contains(89)", isCheck: true },
+        ...tourUtils.searchProduct("Super Kit Product"),
+        wTourUtils.clickOnElement("Super Kit Product", `a:contains('Super Kit Product')`),
+        { trigger: ".availability_messages:contains(17)", isCheck: true }, // 20 - 1 (Comp A and Kit) - 1 (Comp B) - 1 (in cart)
+    ],
+});

--- a/addons/website_sale_mrp/tests/__init__.py
+++ b/addons/website_sale_mrp/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_website_sale_product_availability

--- a/addons/website_sale_mrp/tests/test_website_sale_product_availability.py
+++ b/addons/website_sale_mrp/tests/test_website_sale_product_availability.py
@@ -1,0 +1,76 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.sale.tests.test_sale_product_attribute_value_config import TestSaleProductAttributeValueCommon
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleMrpAvailability(HttpCase, TestSaleProductAttributeValueCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Run the tests in another company, so the tests do not rely on the
+        # database state (eg the default company's warehouse)
+        cls.company = cls.env['res.company'].create({'name': 'Kit Company'})
+        cls.env = cls.env['base'].with_company(cls.company).env
+        cls.env.user.company_id = cls.company
+        cls.website = cls.env.ref('website.default_website')
+        cls.website.company_id = cls.env.company
+        cls.warehouse = cls.env['stock.warehouse'].search([('company_id', '=', cls.company.id)], limit=1)
+
+        # Create two storable products
+        cls.super_kit_product, cls.kit_product, cls.component_A, cls.component_B = cls.env['product.product'].create([
+            {
+                'name': product_name,
+                'allow_out_of_stock_order': False,
+                'type': 'product',
+                'website_published': True,
+                'show_availability': True,
+                'available_threshold': 100,
+            } for product_name in ("Super Kit Product", "Kit Product", "Component A", "Component B")
+        ])
+
+        cls.consumable_component = cls.env['product.product'].create({
+                'name': "Consumable Component",
+                'allow_out_of_stock_order': False,
+                'type': 'consu',
+                'website_published': True,
+                'show_availability': True,
+                'available_threshold': 100,
+        })
+
+        cls.super_kit_bom, cls.kit_bom = cls.env['mrp.bom'].create([
+            {
+                'product_tmpl_id': cls.super_kit_product.product_tmpl_id.id,
+                'type': 'phantom',
+                'product_qty': 2,
+                'bom_line_ids': [
+                    Command.create({'product_id': cls.component_A.id, 'product_qty': 8}),
+                    Command.create({'product_id': cls.kit_product.id, 'product_qty': 2}),
+                    Command.create({'product_id': cls.consumable_component.id, 'product_qty': 1}),
+                ],
+            },
+            {
+                'product_tmpl_id': cls.kit_product.product_tmpl_id.id,
+                'type': 'phantom',
+                'product_qty': 1,
+                'bom_line_ids': [
+                    Command.create({'product_id': cls.component_A.id, 'product_qty': 1}),
+                    Command.create({'product_id': cls.component_B.id, 'product_qty': 5}),
+                    Command.create({'product_id': cls.consumable_component.id, 'product_qty': 1}),
+                ],
+            },
+        ])
+
+        # Add 100 Component A and Component B in stock
+        cls.env['stock.quant']._update_available_quantity(cls.component_A, cls.warehouse.lot_stock_id, 100)
+        cls.env['stock.quant']._update_available_quantity(cls.component_B, cls.warehouse.lot_stock_id, 100)
+
+    def test_website_sale_availability_kit(self):
+        """
+        Check that the website availability of products is influenced by kits present in the cart.
+        """
+        self.start_tour("/shop", 'test_website_sale_availability_kit', login="")

--- a/addons/website_sale_stock/static/src/js/variant_mixin.js
+++ b/addons/website_sale_stock/static/src/js/variant_mixin.js
@@ -24,7 +24,7 @@ import { markup } from "@odoo/owl";
  * @param {$.Element} $parent
  * @param {Array} combination
  */
-VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
+VariantMixin._onChangeCombinationStock = async function (ev, $parent, combination) {
     let product_id = 0;
     // needed for list view of variants
     if ($parent.find('input.product_id:checked').length) {
@@ -47,7 +47,8 @@ VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
     ctaWrapper.classList.remove('out_of_stock');
 
     if (combination.product_type === 'product' && !combination.allow_out_of_stock_order) {
-        combination.free_qty -= parseInt(combination.cart_qty);
+        const unavailableQty = await VariantMixin._getUnavailableQty(combination);
+        combination.free_qty -= unavailableQty;
         $addQtyInput.data('max', combination.free_qty || 1);
         if (combination.free_qty < 0) {
             combination.free_qty = 0;
@@ -84,6 +85,10 @@ VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
         'website_sale_stock.product_availability',
         combination
     ));
+};
+
+VariantMixin._getUnavailableQty = async function (combination) {
+    return parseInt(combination.cart_qty);
 };
 
 publicWidget.registry.WebsiteSale.include({


### PR DESCRIPTION
### Steps to reproduce:

- In the settings website > Shop:
    - Disable `Out-of-Stock: Continue Selling`.
    - Enable `Show Available Qty` if below 5 units.
- Create 2 storable products published on the website:
    - COMP, put 1 unit in stock.
    - KIT with bom of type Kit using 1 x COMP.
- With a private window go to the shop.
- Add 1 x COMP or KIT to the chart.
#### > This is not reflected on the available quantity in stock of the other product

### Cause of the issue:

The availability on the website is computed from the product availability using the `free_qty` fetched because of this override: https://github.com/odoo/odoo/blob/d358542c9159f325b4e2ff184ed1f5cdb6b8c5a9/addons/website_sale_stock/controllers/variant.py#L10-L13 from which the cart quantity of the product itself is deduced before re-render:
https://github.com/odoo/odoo/blob/d358542c9159f325b4e2ff184ed1f5cdb6b8c5a9/addons/website_sale_stock/static/src/js/variant_mixin.js#L49-L51 https://github.com/odoo/odoo/blob/d358542c9159f325b4e2ff184ed1f5cdb6b8c5a9/addons/website_sale_stock/static/src/js/variant_mixin.js#L83-L86 While the `free_qty` is correctly computed from kit products based on the component availability:
https://github.com/odoo/odoo/blob/d358542c9159f325b4e2ff184ed1f5cdb6b8c5a9/addons/mrp/models/product.py#L211-L221 The qties in the virtual cart quantities are not recomputed base on kits.

opw-4889956
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
