### PR TITLE
[IMP] core: improve jsonb falsy value

### DIFF
--- a/addons/test_import_export/models/models_export_impex.py
+++ b/addons/test_import_export/models/models_export_impex.py
@@ -26,6 +26,7 @@ MODELS = [
     ('date', fields.Date()),
     ('datetime', fields.Datetime()),
     ('text', fields.Text()),
+    ('json', fields.Json()),
     ('selection', fields.Selection([('1', "Foo"), ('2', "Bar"), ('3', "Qux"), ('4', '')])),
     ('selection.function', fields.Selection(selection_fn)),
     # just relate to an integer

--- a/addons/test_import_export/security/ir.model.access.csv
+++ b/addons/test_import_export/security/ir.model.access.csv
@@ -17,6 +17,7 @@ access_export_many2one,access_export_many2one,model_export_many2one,base.group_u
 access_export_one2many,access_export_one2many,model_export_one2many,base.group_user,1,1,1,1
 access_export_many2many,access_export_many2many,model_export_many2many,base.group_user,1,1,1,1
 access_export_function,access_export_function,model_export_function,base.group_user,1,1,1,1
+access_export_json,access_export_json,model_export_json,base.group_user,1,1,1,1
 access_export_reference,access_export_reference,model_export_reference,base.group_user,1,1,1,1
 access_export_one2many_child,access_export_one2many_child,model_export_one2many_child,base.group_user,1,1,1,1
 access_export_one2many_multiple,access_export_one2many_multiple,model_export_one2many_multiple,base.group_user,1,1,1,1

--- a/addons/test_import_export/tests/test_export_impex.py
+++ b/addons/test_import_export/tests/test_export_impex.py
@@ -599,9 +599,9 @@ class test_json_field(CreatorCase):
         """Test export of empty JSON field"""
         self.assertEqual(self.export(None), [['']])
         self.assertEqual(self.export(False), [['']])
-        self.assertEqual(self.export(0), [['']])
-        self.assertEqual(self.export(0.0), [['']])
-        self.assertEqual(self.export(''), [['']])
+        self.assertEqual(self.export(0), [['0']])
+        self.assertEqual(self.export(0.0), [['0.0']])
+        self.assertEqual(self.export(''), [['""']])
         self.assertEqual(self.export([]), [['']])
         self.assertEqual(self.export({}), [['']])
 

--- a/addons/test_import_export/tests/test_export_impex.py
+++ b/addons/test_import_export/tests/test_export_impex.py
@@ -1,4 +1,5 @@
 import itertools
+import json
 import pstats
 from cProfile import Profile
 
@@ -589,6 +590,20 @@ class test_function(CreatorCase):
     def test_value(self):
         """Exports value normally returned by accessing the function field"""
         self.assertEqual(self.export(42), [[3]])
+
+
+class test_json_field(CreatorCase):
+    model_name = 'export.json'
+
+    def test_empty(self):
+        """Test export of empty JSON field"""
+        self.assertEqual(self.export(None), [['']])
+        self.assertEqual(self.export(False), [['']])
+        self.assertEqual(self.export(0), [['']])
+        self.assertEqual(self.export(0.0), [['']])
+        self.assertEqual(self.export(''), [['']])
+        self.assertEqual(self.export([]), [['']])
+        self.assertEqual(self.export({}), [['']])
 
 
 @common.tagged('-standard', 'bench')

--- a/addons/test_import_export/tests/test_load.py
+++ b/addons/test_import_export/tests/test_load.py
@@ -1526,10 +1526,10 @@ class test_json_field(ImporterCase):
             self.assertIs(type(value), type(expected))
 
         test_cases = [
-            ('0', False),
-            ('0.0', False),
+            ('0', 0),
+            ('0.0', 0.0),
             ('', False),
-            ('""', False),
+            ('""', ""),
             ('[]', False),
             ('{}', False),
         ]

--- a/addons/test_import_export/tests/test_load.py
+++ b/addons/test_import_export/tests/test_load.py
@@ -1516,6 +1516,33 @@ class test_datetime(ImporterCase):
         self.assertEqual([fields.Datetime.to_string(value['value']) for value in self.read(domain=[('id', 'in', result['ids'])])], ['2012-02-03 11:11:11'])
 
 
+class test_json_field(ImporterCase):
+    model_name = 'export.json'
+
+    def test_falsy_values(self):
+
+        def check(value, expected):
+            self.assertEqual(value, expected)
+            self.assertIs(type(value), type(expected))
+
+        test_cases = [
+            ('0', False),
+            ('0.0', False),
+            ('', False),
+            ('""', False),
+            ('[]', False),
+            ('{}', False),
+        ]
+
+        for json_data, expected_value in test_cases:           
+            result = self.import_(['value'], [[json_data]])
+            self.assertEqual(len(result['ids']), 1)
+            self.assertFalse(result['messages'])
+            records = self.read(domain=[('id', 'in', result['ids'])])
+            value = values(records)[0]
+            check(value, expected_value)
+
+
 class test_unique(ImporterCase):
     model_name = 'export.unique'
 

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -375,6 +375,7 @@ class TestOrmMixed(models.Model):
     comment3 = fields.Html(sanitize_attributes=True, strip_classes=True)
     comment4 = fields.Html(sanitize_attributes=True, strip_style=True)
     comment5 = fields.Html(sanitize_overridable=True, sanitize_attributes=False)
+    json = fields.Json()
 
     currency_id = fields.Many2one('res.currency', default=lambda self: self.env.ref('base.EUR'))
     amount = fields.Monetary()

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -3215,6 +3215,26 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         self.assertEqual(record.comment0, record_value)
         record.invalidate_recordset()
         self.assertEqual(record.comment0, record_value)
+    
+    def test_json_falsy_values(self):
+
+        def check(value, expected):
+            self.assertEqual(value, expected)
+            self.assertIs(type(value), type(expected))
+
+        record = self.env['test_orm.mixed'].create({})
+        record.json = 0
+        check(record.json, False)
+        record.json = 0.0
+        check(record.json, False)
+        record.json = False
+        check(record.json, False)
+        record.json = ''
+        check(record.json, False)
+        record.json = []
+        check(record.json, False)
+        record.json = {}
+        check(record.json, False)
 
 
 class TestX2many(TransactionExpressionCase):

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -3224,13 +3224,13 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
 
         record = self.env['test_orm.mixed'].create({})
         record.json = 0
-        check(record.json, False)
+        check(record.json, 0)
         record.json = 0.0
-        check(record.json, False)
+        check(record.json, 0.0)
         record.json = False
         check(record.json, False)
         record.json = ''
-        check(record.json, False)
+        check(record.json, '')
         record.json = []
         check(record.json, False)
         record.json = {}

--- a/odoo/addons/test_orm/tests/test_views.py
+++ b/odoo/addons/test_orm/tests/test_views.py
@@ -19,7 +19,7 @@ class TestDefaultView(common.TransactionCase):
         )
         self.assertEqual(
             etree.tostring(self.env['test_orm.mixed']._get_default_form_view()),
-            b'<form><sheet string="Test ORM Mixed"><group><group><field name="foo"/></group></group><group><field name="text"/></group><group><group><field name="truth"/><field name="number"/><field name="date"/><field name="now"/><field name="reference"/></group><group><field name="count"/><field name="number2"/><field name="moment"/><field name="lang"/></group></group><group><field name="comment0"/></group><group><field name="comment1"/></group><group><field name="comment2"/></group><group><field name="comment3"/></group><group><field name="comment4"/></group><group><field name="comment5"/></group><group><group><field name="currency_id"/></group><group><field name="amount"/></group></group><group><separator/></group></sheet></form>',
+            b'<form><sheet string="Test ORM Mixed"><group><group><field name="foo"/></group></group><group><field name="text"/></group><group><group><field name="truth"/><field name="number"/><field name="date"/><field name="now"/><field name="reference"/></group><group><field name="count"/><field name="number2"/><field name="moment"/><field name="lang"/></group></group><group><field name="comment0"/></group><group><field name="comment1"/></group><group><field name="comment2"/></group><group><field name="comment3"/></group><group><field name="comment4"/></group><group><field name="comment5"/></group><group><group><field name="json"/><field name="amount"/></group><group><field name="currency_id"/></group></group><group><separator/></group></sheet></form>',
         )
 
     def test_default_view_with_binaries(self):


### PR DESCRIPTION
save falsy python values
``0``, ``0.0``, ``""``
in json field instead of auto-converting to False

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
