### PR TITLE
[FIX] l10n_it_edi: Format desc as plain text

### DIFF
--- a/addons/l10n_it_edi_withholding/models/account_move.py
+++ b/addons/l10n_it_edi_withholding/models/account_move.py
@@ -7,7 +7,7 @@ from markupsafe import Markup
 
 from odoo import _, api, fields, models
 from odoo.addons.l10n_it_edi.models.account_move import get_float
-from odoo.tools import float_compare
+from odoo.tools import float_compare, html2plaintext
 
 _logger = logging.getLogger(__name__)
 
@@ -131,7 +131,7 @@ class AccountMove(models.Model):
                 'aliquota_iva': grouping_key['vat_tax_amount_field'],
                 'ritenuta': 'SI' if grouping_key['has_withholding'] else None,
                 'natura': grouping_key['l10n_it_exempt_reason'],
-                'riferimento_amministrazione': grouping_key['description'],
+                'riferimento_amministrazione': html2plaintext(grouping_key['description']),
             })
 
         # Enasarco values.


### PR DESCRIPTION
The description field of the tax record was changed from char to html.

This can break the dit functionality, as it now inserts the html tags into the description field.

This PR aims to format the field as plaintext before rendering the XML to avoid such isses.

opw-4985645

