### PR TITLE
[FIX] marketing_card: avoid false duplicates

### DIFF
--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -29,6 +29,21 @@ def _extract_values_from_document(rendered_document):
 
 class TestMarketingCardMail(MailCase, MarketingCardCommon):
 
+    def assertSentMailCorrectCard(self, sent_mails, cards):
+        IrHttp = self.env['ir.http']
+        sent_cards = self.env['card.card']
+        for sent_mail in self._mails:
+            record_id = int(sent_mail['object_id'].split('-')[0])
+            card = cards.filtered(lambda card: card.res_id == record_id)
+            self.assertEqual(len(card), 1)
+            sent_cards += card
+            campaign_base_url = card.campaign_id.get_base_url()
+            preview_url = f"{campaign_base_url}/cards/{IrHttp._slug(card)}/preview"
+            image_url = f"{campaign_base_url}/cards/{IrHttp._slug(card)}/card.jpg"
+            self.assertIn(f'<a href="{preview_url}"', sent_mail['body'])
+            self.assertIn(f'<img src="{image_url}"', sent_mail['body'])
+        self.assertEqual(sent_cards, cards)
+
     @users('marketing_card_user')
     @warmup
     @mute_logger('odoo.addons.mail.models.mail_mail')
@@ -88,18 +103,41 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
 
         cards = self.env['card.card'].search([('campaign_id', '=', campaign.id)])
         self.assertEqual(len(cards), 6)
-        self.assertEqual(len(cards.filtered(lambda card: not card.requires_sync)), 5)
+        sent_cards = cards.filtered(lambda card: not card.requires_sync)
+        self.assertEqual(len(sent_cards), 5)
         self.assertEqual(len(self._mails), 5)
 
-        IrHttp = self.env['ir.http']
-        for sent_mail in self._mails:
-            record_id = int(sent_mail['object_id'].split('-')[0])
-            card = cards.filtered(lambda card: card.res_id == record_id)
-            self.assertEqual(len(card), 1)
-            preview_url = f"{campaign.get_base_url()}/cards/{IrHttp._slug(card)}/preview"
-            image_url = f"{campaign.get_base_url()}/cards/{IrHttp._slug(card)}/card.jpg"
-            self.assertIn(f'<a href="{preview_url}"', sent_mail['body'])
-            self.assertIn(f'<img src="{image_url}"', sent_mail['body'])
+        self.assertSentMailCorrectCard(self._mails, sent_cards)
+
+    @users('marketing_card_user')
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_campaign_send_mailing_with_duplicates(self):
+        # set a low batch size to make sure mailing "seen list" does not affect card mailings
+        # as it is based on traces existing with some email -> traces created in batches with mail.mail
+        self.env['ir.config_parameter'].sudo().set_param('mail.batch_size', 5)
+
+        campaign = self.campaign.with_user(self.env.user)
+        self.env.user.sudo().groups_id += self.env.ref('mass_mailing.group_mass_mailing_user')
+        partners = self.env['res.partner'].sudo().create([{'name': f'Part{n}', 'email': f'email{n % 3}@test.lan'} for n in range(10)])
+        mailing_context = campaign.action_share().get('context') | {
+            'default_email_from': 'test@test.lan',
+            'default_mailing_domain': [('id', 'in', partners.ids)],
+            'default_reply_to': 'test@test.lan',
+        }
+        mailing = Form(self.env['mailing.mailing'].with_context(mailing_context)).save()
+        mailing.body_html = mailing.body_arch  # normally the js html_field would fill this in
+
+        with self.mock_image_renderer():
+            mailing.action_update_cards()
+
+        cards = self.env['card.card'].search([('campaign_id', '=', campaign.id)])
+        self.assertEqual(len(cards), 10)
+
+        with self.mock_mail_gateway():
+            mailing._action_send_mail()
+        self.assertEqual(len(self._mails), 10)
+
+        self.assertSentMailCorrectCard(self._mails, cards)
 
 
 class TestMarketingCardRender(MarketingCardCommon):

--- a/addons/marketing_card/wizards/mail_compose_message.py
+++ b/addons/marketing_card/wizards/mail_compose_message.py
@@ -26,9 +26,17 @@ class MailComposeMessage(models.TransientModel):
             ])
             for mail_values, body in zip(mail_values_all.values(), processed_bodies):
                 if body is not None:
+                    # in a mailing these are the same
+                    mail_values['body'] = body
                     mail_values['body_html'] = body
 
         return mail_values_all
+
+    def _get_done_emails(self, mail_values_dict):
+        """Consider every target gets a different card, hence we don't want unique message per email address."""
+        if self.mass_mailing_id.card_campaign_id:
+            return []
+        return super()._get_done_emails(mail_values_dict)
 
     @api.model
     def _process_generic_card_url_body(self, card_body_pairs: list[tuple[models.Model, str]]) -> list[str]:


### PR DESCRIPTION
When sending a card mailing to recipients with duplicate emails, they are always considered duplicate emails.

This is because:

1) We use "body" to detect duplicate emails, but "body" is never updated with the individualized card url.
We now update the "body" as in the context of a mailing, "body_html" is just a copy of "body".

2) Mailings consider that all emails are always the same, meaning if it's detected that a mail was already sent to an email address during the mailing (in a previous batch) it would skip the actual duplicate body check.
We disable that feature for card mailings.

task-5009229
