### PR TITLE
[IMP] website_*: fine-tune actions buttons design

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -49,7 +49,7 @@
                         <div t-if="is_sample" class="o_ribbon_right small text-bg-primary">Sample</div>
                     </div>
                     <button t-if="data.get('_latest_viewed')"
-                        class="btn o_carousel_product_remove js_remove"
+                        class="btn o_carousel_product_remove js_remove rounded-pill lh-1"
                         t-att-data-product-id="product_id"
                         t-att-data-product-template-id="product_template_id"
                         t-att-data-product-selected="record.is_product_variant"

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -160,7 +160,7 @@
         justify-content: var(--o-wsale-card-info-attributes-justify-content);
         flex-direction: column;
         padding: map-get($spacers, 2) 0;
-        margin-right: auto;
+        margin-right: var(--o-wsale-card-info-attributes-margin-right, auto);
     }
     .o_wsale_product_information {
         display: flex;
@@ -308,7 +308,7 @@
         font-size: var(--o-wsale-card-btns-font-size, #{unquote("clamp(12px, 9cqw, 1rem)")});
 
         .btn {
-            --btn-padding-x: var(--o-wsale-card-btns-btn-padding-x, 0.8em);
+            --btn-padding-x: 0.8em;
 
             flex-grow: var(--o-wsale-card-btns-btn-flex-grow);
             font-size: var(--o-wsale-card-btns-btn-font-size, var(--btn-font-size));
@@ -357,20 +357,22 @@
         display: var(--o-wsale-card-btn-label-display);
     }
     .o_carousel_product_remove {
-        @include o-position-absolute(7%, 50%);
-        transform: translateX(50%);
-        display: inline-flex;
-        aspect-ratio: 1;
-        align-items: center;
-        justify-content: center;
-        transition: none;
+        --btn-padding-x: #{map-get($spacers, 2)};
+        --btn-padding-y: var(--btn-padding-x);
 
-        --btn-hover-color: #{$danger};
-        --btn-hover-border-color: #{$danger};
-        --btn-padding-x: #{map-get($spacers, 1)};
-    }
-    &:where(:not(:hover)):where(:not(:focus-visible)) .o_carousel_product_remove {
-        display: none;
+        --o-wsale-wishlist-card-offset-top: calc(var(--o-wsale-card-offset-top) + var(--btn-padding-y));
+        --o-wsale-wishlist-card-offset-x: calc(var(--o-wsale-card-offset-x) + var(--btn-padding-x));
+
+        --o-wsale-wishlist-btn-offset-top-default: calc(var(--o-wsale-card-border-radius, 0px) * 0.1 + var(--btn-padding-y));
+        --o-wsale-wishlist-btn-offset-end-default: calc(var(--o-wsale-card-border-radius, 0px) * 0.2 + var(--btn-padding-x));
+
+        @include o-position-absolute(
+            $top: var(--o-wsale-wishlist-card-offset-top, var(--o-wsale-wishlist-btn-offset-top-default)),
+            $right: var(--o-wsale-wishlist-card-offset-x, var(--o-wsale-wishlist-btn-offset-end-default))
+        );
+        @include o-wsale-card-btn-design-subtle($body-bg, $body-color);
+
+        aspect-ratio: 1;
     }
 }
 
@@ -536,7 +538,8 @@
             --o-wsale-card-info-text-basis: 0 0 360px;
             --o-wsale-card-info-text-width: 360px;
 
-            &:where(.o_wsale_products_opt_has_comparison):where(:has(.o_add_compare)) {
+            &:where(.o_wsale_products_opt_has_comparison):where(:has(.o_add_compare)),
+            &:where(:has(.o_add_to_compare)) {
                 --o-wsale-comparison-btn-placeholder-display: inline-block;
             }
         }
@@ -596,7 +599,6 @@
         --o-wsale-card-attribute-previewer-order: 7;
         --o-wsale-card-attribute-previewer-padding: 0 0 #{map-get($spacers, 2)};
         --o-wsale-card-attribute-previewer-thumbnail-width: MIN(14%, 3rem);
-        --o-wsale-card-btns-btn-padding-x: #{$btn-padding-x};
         --o-wsale-card-btn-label-display: none;
         --o-wsale-card-btn-submit-label-display: inline;
         --o-wsale-card-btn-submit-order: -2;
@@ -619,6 +621,7 @@
     --o-wsale-card-border-radius: var(--o-wsale-opt-border-radius, 0px);
     --o-wsale-card-info-padding: #{map-get($spacers, 2)} 0 0 0;
     --o-wsale-card-padding: var(--_padding-base);
+    --o-wsale-card-btns-row-padding: 0;
     --o-wsale-card-btns-margin-bottom: 0;
     --o-wsale-card-pseudobg-y: 0;
     --o-wsale-card-pseudobg-x: 0;
@@ -700,7 +703,8 @@
             --o-wsale-card-info-text-basis: 0 0 280px;
             --o-wsale-card-info-text-width: 280px;
 
-            &:where(.o_wsale_products_opt_has_comparison):where(:has(.o_add_compare)) {
+            &:where(.o_wsale_products_opt_has_comparison):where(:has(.o_add_compare)),
+            &:where(:has(.o_add_to_compare)) {
                 --o-wsale-comparison-btn-placeholder-display: inline-block;
             }
         }
@@ -727,6 +731,10 @@
     --o-wsale-card-thumb-border-radius: calc(var(--o-wsale-card-border-radius, 1px) - 1px);
     --o-wsale-card-btn-submit-order: -1;
     --o-wsale-card-btn-label-display: none;
+    --o-wsale-card-btn-aspect-ratio: 1;
+    --o-wsale-card-btns-align-items: baseline;
+    --o-wsale-card-btns-btn-min-height: calc(1em + 1.6em);
+    --o-wsale-card-btn-padding-x: 0;
     --o-wsale-card-offset-top: 3%;
     --o-wsale-card-offset-x: 3%;
     --o-wsale-card-overlay: "";
@@ -1161,7 +1169,7 @@ $_wsale_products_roundness_map: (
             .o_wsale_product_action_row {
                 display: flex;
                 gap: map-get($spacers, 2);
-                transform: translateX(var(--o-wsale-card-offset-x));
+                transform: translateX(var(--o-wsale-card-offset-x)) translateY(calc(var(--o-wsale-card-offset-top) * -1));
 
                 .btn {
                     opacity: 0;
@@ -1187,16 +1195,12 @@ $_wsale_products_roundness_map: (
                 }
                 .o_wsale_product_action_row .btn {
                     opacity: 1;
-                    transform: translate(0, (map-get($spacers, 2) * -1));
+                    transform: translate(0, 0);
                     transition: transform .15s ease-out, opacity .35s ease-out;
 
                     &.o_add_compare {
                         transition-delay: .1s;
                     }
-                }
-
-                &.o_has_variations .o_wsale_product_action_row .btn {
-                    transform: translate(0, 0);
                 }
             }
         }

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -283,7 +283,7 @@
         order: var(--o-wsale-card-sub-order, 6);
         flex-grow: var(--o-wsale-card-sub-flex-grow);
     }
-    .product_price {
+    .product_price, .o_wish_price {
         display: var(--o-wsale-card-price-display);
         flex-direction: var(--o-wsale-card-price-flex-direction);
         flex-basis: var(--o-wsale-card-price-flex-basis);
@@ -530,7 +530,7 @@
             --o-wsale-card-btns-flex-direction: column;
         }
         @include media-breakpoint-up(md) {
-            .product_price {
+            .product_price, .o_wish_price {
                 margin: auto;
             }
         }
@@ -694,7 +694,7 @@
             --o-wsale-card-price-flex-basis: 100%;
             --o-wsale-card-info-attributes-justify-content: center;
 
-            .product_price {
+            .product_price, .o_wish_price {
                 margin: auto;
             }
         }

--- a/addons/website_sale/views/product_tile_templates.xml
+++ b/addons/website_sale/views/product_tile_templates.xml
@@ -229,6 +229,8 @@
                     <t t-else="" t-call="website_sale.shop_product_buttons"/>
                 </div>
             </div>
+            <!-- Extra actions (wishlist remove, ...) -->
+            <t t-if="extra_actions" t-out="extra_actions"/>
         </div>
     </form>
 </template>

--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.options.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.options.scss
@@ -4,12 +4,12 @@
 // entry. Show them when `o_wsale_products_opt_has_comparison` is applied.
 :where(.oe_product_cart) {
 
-    .o_add_compare {
+    .o_add_compare, .o_add_to_compare {
         display: var(--o-wsale-comparison-btn-display, none);
         order: var(--o-wsale-comparison-btn-order);
     }
 
-    .o_add_compare_placeholder {
+    .o_add_compare_placeholder, .o_add_to_compare_placeholder {
         display: var(--o-wsale-comparison-btn-placeholder-display, none);
         order: var(--o-wsale-comparison-btn-order);
     }

--- a/addons/website_sale_comparison_wishlist/views/templates.xml
+++ b/addons/website_sale_comparison_wishlist/views/templates.xml
@@ -1,16 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="product_wishlist" inherit_id="website_sale_wishlist.product_wishlist">
-        <xpath expr="//button[hasclass('o_wish_rm')]" position="after">
+        <xpath expr="//div[hasclass('o_wsale_product_action_row')]" position="inside">
             <t t-set="categories" t-value="wish.product_id.product_tmpl_id.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
             <t t-set="product_variant_id" t-value="wish.product_id.product_tmpl_id._get_first_possible_variant_id()"/>
-            <button
-                t-if="is_view_active('website_sale_comparison.add_to_compare') and product_variant_id and categories"
-                type="button"
-                class="btn btn-light btn-sm o_add_to_compare"
-                t-att-data-product-id='wish.product_id.id'>
-                <small><i t-attf-class="fa fa-exchange small"></i></small>
-            </button>
+
+            <t t-if="is_view_active('website_sale_comparison.add_to_compare')">
+                <button
+                    t-if="product_variant_id and categories"
+                    type="button"
+                    class="btn btn-light o_add_to_compare d-inline-flex"
+                    t-att-data-product-id='wish.product_id.id'
+                    aria-label="Add to compare"
+                >
+                    <i class="fa fa-fw fa-exchange" role="presentation"/>
+                </button>
+
+                <!-- Render placeholder when product is not comparable to ensure alignment -->
+                <div t-else="" class="o_add_to_compare_placeholder btn btn-light pe-none opacity-0">
+                    <i class="fa fa-exchange fa-fw" aria-hidden="true"/>
+                </div>
+            </t>
         </xpath>
     </template>
 </odoo>

--- a/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
+++ b/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
@@ -35,19 +35,91 @@
         grid-column: auto/span 12;
     }
 
-    &.o_wsale_products_opt_layout_catalog article {
-        position: relative;
-        grid-column: auto/span 6;
+    &.o_wsale_products_opt_layout_catalog {
+        --o-wsale-card-info-position: none;
+        --o-wsale-card-btns-flex-direction: row;
 
-        @include media-breakpoint-up(md) {
-            grid-column: auto/span 4;
+        article {
+            position: relative;
+            grid-column: auto/span 6;
+
+            @include media-breakpoint-up(md) {
+                grid-column: auto/span 4;
+            }
+
+            @include media-breakpoint-up(lg) {
+                grid-column: auto/span 3;
+            }
+            @include media-breakpoint-up(xxl) {
+                grid-column: auto/span 2;
+            }
+
+            .o_wish_rm {
+                @include o-wsale-card-btn-design-subtle($body-bg, $body-color);
+            }
         }
+    }
+
+    &.o_wsale_products_opt_actions_inline .o_wsale_product_btn:where(:has(.o_add_to_compare)) {
+        @container (max-width: 180px) {
+            @include hide-submit-button-label;
+        }
+    }
+}
+
+.o_wish_rm {
+    --btn-padding-x: #{map-get($spacers, 2)};
+    --btn-padding-y: var(--btn-padding-x);
+
+    --o-wsale-wishlist-card-offset-top: calc(var(--o-wsale-card-offset-top) + var(--btn-padding-x));
+    --o-wsale-wishlist-card-offset-x: calc(var(--o-wsale-card-offset-x) + var(--btn-padding-x));
+
+    --o-wsale-wishlist-btn-offset-top-default: calc(var(--o-wsale-card-border-radius, 0px) * 0.1 + var(--btn-padding-y));
+    --o-wsale-wishlist-btn-offset-end-default: calc(var(--o-wsale-card-border-radius, 0px) * 0.2 + var(--btn-padding-x));
+
+    @include o-position-absolute(
+        $top: var(--o-wsale-wishlist-card-offset-top, var(--o-wsale-wishlist-btn-offset-top-default)),
+        $right: var(--o-wsale-wishlist-card-offset-x, var(--o-wsale-wishlist-btn-offset-end-default))
+    );
+
+    aspect-ratio: 1;
+
+    :where(.o_wsale_products_opt_design_showcase) & {
+        --o-wsale-wishlist-card-offset-x: 3%;
+        --o-wsale-wishlist-card-offset-top: 2.5%;
 
         @include media-breakpoint-up(lg) {
-            grid-column: auto/span 3;
+            @include o-wsale-card-btn-lg();
+            --btn-padding-x: var(--btn-padding-y);
+            --o-wsale-wishlist-card-offset-x: 5%;
         }
-        @include media-breakpoint-up(xxl) {
-            grid-column: auto/span 2;
+    }
+}
+
+
+// List view styles
+:where(#o_comparelist_table.o_wsale_products_opt_layout_list) {
+    // List view except cards and showcase
+    &:where(:not(.o_wsale_products_opt_design_cards, .o_wsale_products_opt_design_showcase)) {
+        .o_wish_rm {
+            --o-wsale-wishlist-card-offset-x: 0;
+            --o-wsale-wishlist-btn-offset-top-default: .5rem;
+            --o-wsale-wishlist-btn-offset-end-default: 0;
+
+            --btn-padding-x: .7rem;
+
+            @include media-breakpoint-up(md) {
+                position: static;
+                align-self: center;
+            }
+
+            order: map-get($order-array, "last");
+        }
+    }
+
+    .o_wsale_product_information_text {
+        @include media-breakpoint-down(md) {
+            --o-wsale-card-info-text-margin-right: calc((var(--btn-padding-x) * 2) + #{$btn-font-size * .5});
         }
     }
 }

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -318,15 +318,6 @@
                                     t-att-data-wish-id="wish.id"
                                     t-att-data-product-id="wish.product_id.id"
                                 >
-                                    <div class="d-flex gap-2 position-absolute start-50 translate-middle-x z-3">
-                                        <button
-                                            type="button"
-                                            class="btn btn-light btn-sm o_wish_rm rounded-top-0"
-                                            title="Remove from wishlist"
-                                        >
-                                            <i class='fa fa-trash-o small' role="presentation"/>
-                                        </button>
-                                    </div>
                                     <t t-call="website_sale.products_item">
                                         <t t-set="product" t-value="wish.product_id.product_tmpl_id"/>
                                         <t t-set="product_variant" t-value="wish.product_id"/>
@@ -383,6 +374,17 @@
                                                     <span class="o_label small ms-1">Add to Cart</span>
                                                 </button>
                                             </div>
+                                        </t>
+                                        <t
+                                            t-set="extra_actions"
+                                        >
+                                            <button
+                                                type="button"
+                                                class="btn btn-light o_wish_rm z-3 rounded-pill lh-1"
+                                                title="Remove from wishlist"
+                                            >
+                                                <i class="oi oi-close" role="presentation"/>
+                                            </button>
                                         </t>
                                     </t>
                                 </article>


### PR DESCRIPTION
*: sale, sale_wishlist, sale_comparison_wishlist, sale_comparison

## eCommerce buttons design

### Main goal
This PR fine-tunes the design of the action buttons (add to compare, remove from wishlist, remove from recently viewed) in the following places:

- Dynamic product snippets (with the recently viewed option)
- Shop page
- Wishlist page

Previously, these buttons used a temporary design. They are now adjusted to match the overall style of /shop.

To improve consistency, we:

- Apply the “glass effect” style in grid mode to match other buttons
- Position the button on the far right in list view, or in the top corner in grid view

### Additional fixes included :
- Correcting minor alignment issues in button positioning on both shop and wishlist pages
- Rendering the comparison placeholder, already present on the shop page, on the wishlist page as well
- Aligning certain design elements of the wishlist page with those of the shop page for consistency

task-4997342
part of task-4252024

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
