### PR TITLE
[FIX] pos_online_payment_self_order: update UI after payment process

### DIFF
--- a/addons/pos_online_payment_self_order/controllers/payment_portal.py
+++ b/addons/pos_online_payment_self_order/controllers/payment_portal.py
@@ -18,18 +18,9 @@ class PaymentPortalSelfOrder(PaymentPortal):
 
         if tx_sudo.state not in ('authorized', 'done'):
             self._send_notification_payment_status(pos_order_id, 'fail')
-        else:
-            self._send_notification_payment_status(pos_order_id, 'success')
 
         return result
 
     def _send_notification_payment_status(self, pos_order_id, status):
         pos_order = request.env['pos.order'].sudo().browse(pos_order_id)
-        pos_order.config_id.notify_synchronisation(pos_order.config_id.current_session_id.id, 0)
-        pos_order.config_id._notify("ONLINE_PAYMENT_STATUS", {
-            'status': status, # progress, success, fail
-            'data': {
-                'pos.order': pos_order.read(pos_order._load_pos_self_data_fields(pos_order.config_id.id), load=False),
-                'pos.payment': pos_order.payment_ids.read(pos_order.payment_ids._load_pos_self_data_fields(pos_order.config_id.id), load=False),
-            }
-        })
+        pos_order._send_notification_online_payment_status(status)

--- a/addons/pos_online_payment_self_order/models/__init__.py
+++ b/addons/pos_online_payment_self_order/models/__init__.py
@@ -5,3 +5,4 @@ from . import pos_config
 from . import pos_order
 from . import res_config_settings
 from . import pos_payment_method
+from . import payment_transaction

--- a/addons/pos_online_payment_self_order/models/payment_transaction.py
+++ b/addons/pos_online_payment_self_order/models/payment_transaction.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class PaymentTransaction(models.Model):
+    _inherit = 'payment.transaction'
+
+    def _process_pos_online_payment(self):
+        super()._process_pos_online_payment()
+        for tx in self:
+            if tx and tx.pos_order_id and tx.state in ('authorized', 'done'):
+                tx.pos_order_id._send_notification_online_payment_status('success')

--- a/addons/pos_online_payment_self_order/models/pos_order.py
+++ b/addons/pos_online_payment_self_order/models/pos_order.py
@@ -66,3 +66,13 @@ class PosOrder(models.Model):
             # flow is cancelled, and the default flow is self order if it is configured.
             self.use_self_order_online_payment = tools.float_is_zero(next_online_payment_amount, precision_rounding=self.currency_id.rounding) and self.config_id.self_order_online_payment_method_id
         return res
+
+    def _send_notification_online_payment_status(self, status):
+        self.config_id.notify_synchronisation(self.config_id.current_session_id.id, 0)
+        self.config_id._notify("ONLINE_PAYMENT_STATUS", {
+            'status': status,  # progress, success, fail
+            'data': {
+                'pos.order': self.read(self._load_pos_self_data_fields(self.config_id.id), load=False),
+                'pos.payment': self.payment_ids.read(self.payment_ids._load_pos_self_data_fields(self.config_id.id), load=False),
+            }
+        })


### PR DESCRIPTION
Before this commit, if a user closed the payment page on mobile after finalizing the payment but before the payment was confirmed, the self order UI would not update once the payment was confirmed.

After this commit, the self-order UI is correctly updated after the payment process, even if the payment page was closed.

opw-4911434

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
