### PR TITLE
[FIX] html_editor: fix non-deterministic toolbar test

### DIFF
--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -340,7 +340,7 @@ test("should focus the editable area after selecting a font size item", async ()
     const inputEl = iframeEl.contentWindow.document?.querySelector("input");
     await contains(".o-we-toolbar [name='font-size'] .dropdown-toggle").click();
     expect(getActiveElement()).toBe(inputEl);
-    await expectElementCount(".o_font_size_selector_menu .dropdown-item:contains('34')", 1);
+    await waitFor(".o_font_size_selector_menu .dropdown-item:contains('34')", { timeout: 1000 });
     await contains(".o_font_size_selector_menu .dropdown-item:contains('34')").click();
     expect(getActiveElement()).toBe(editor.editable);
     expect(getActiveElement()).not.toBe(inputEl);


### PR DESCRIPTION
This is a deparate attempt to fix this test that keeps failing non-deterministically. Previous attempts were [1] and [2].

[1]: https://github.com/odoo/odoo/pull/222583
[2]: https://github.com/odoo/odoo/pull/222828
