### PR TITLE
[FIX] bus: race condition and correct error in waitForChannels

### DIFF
--- a/addons/bus/static/tests/bus_test_helpers.js
+++ b/addons/bus/static/tests/bus_test_helpers.js
@@ -218,6 +218,7 @@ export async function waitForChannels(channels, { operation = "add" } = {}) {
     const { env } = MockServer;
     const def = new Deferred();
     let done = false;
+    let failTimeout;
 
     /**
      * @param {boolean} crashOnFail
@@ -245,7 +246,7 @@ export async function waitForChannels(channels, { operation = "add" } = {}) {
         if (success) {
             def.resolve();
         } else {
-            def.reject(new Error(message(false, String.raw).join(" ")));
+            def.reject(new Error(message(false)));
         }
         done = true;
     }
@@ -255,7 +256,7 @@ export async function waitForChannels(channels, { operation = "add" } = {}) {
 
     await runAllTimers();
 
-    const failTimeout = setTimeout(() => check(true), TIMEOUT);
+    failTimeout = setTimeout(() => check(true), TIMEOUT);
     check(false);
 
     return def;


### PR DESCRIPTION
This change addresses two issues in the `waitForChannels` test utility:
- Fixes a race condition. The `failTimeout` variable was sometimes accessed before its `setTimeout` declaration had been executed. This happens when a fast bus event triggers the `onWebsocketEvent` handler, resulting in a reference error. The variable is now declared at the beginning of the function, making it available before any access (fixes runbot-223252).
- Corrects error in def.reject. `message` only takes one param, and a string does not have a join method.
