### PR TITLE
[FIX] bus: fix non deterministic trigger notification test

### DIFF
--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -214,12 +214,9 @@ class TestWebsocketCaryall(WebsocketCase):
 
         with patch.object(Websocket, 'subscribe', patched_subscribe):
             websocket = self.websocket_connect()
+            bus_last_id = self.env['bus.bus'].sudo().search([], limit=1, order='id desc').id or 0
             self.env['bus.bus']._sendone('my_channel', 'notif_type', 'message')
-            websocket.send(json.dumps({
-                'event_name': 'subscribe',
-                'data': {'channels': ['my_channel'], 'last': 0}
-            }))
-
+            self.subscribe(websocket, ["my_channel"], bus_last_id)
             notifications = json.loads(websocket.recv())
             self.assertEqual(1, len(notifications))
             self.assertEqual(notifications[0]['message']['type'], 'notif_type')


### PR DESCRIPTION
Before this commit, the `test_trigger_notification` test was sometimes failing. This test was already fixed in [1], starting with v16.4.

The issue is that the test sends a message and expects one notification to be received. However, the subscribe is done with 0 as the last id. In such cases, every notification created in the last minute is sent when calling subscribe.

This commit fixes the issue by passing the correct value for `last_id`.

[1]: https://github.com/odoo/odoo/pull/218172

fixes runbot-163224