### PR TITLE
[FIX] hr_timesheet: update remaining time with minutes

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -25,7 +25,7 @@ class Project(models.Model):
 
     timesheet_ids = fields.One2many('account.analytic.line', 'project_id', 'Associated Timesheets', export_string_translation=False)
     timesheet_encode_uom_id = fields.Many2one('uom.uom', compute='_compute_timesheet_encode_uom_id', export_string_translation=False)
-    total_timesheet_time = fields.Integer(
+    total_timesheet_time = fields.Float(
         compute='_compute_total_timesheet_time', groups='hr_timesheet.group_hr_timesheet_user',
         string="Total number of time (in the proper UoM) recorded in the project, rounded to the unit.",
         compute_sudo=True, export_string_translation=False)
@@ -141,7 +141,7 @@ class Project(models.Model):
                 total_time += unit_amount * (1.0 if project.encode_uom_in_days else factor)
             # Now convert to the proper unit of measure set in the settings
             total_time *= project.timesheet_encode_uom_id.factor
-            project.total_timesheet_time = int(round(total_time))
+            project.total_timesheet_time = total_time
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -872,4 +872,14 @@ class TestTimesheet(TestCommonTimesheet):
             f"{self.project.account_id.id}": 50,
             f"{another_account.id}": 50,
         }
-        self.assertEqual(line.amount, -5)  # the line is split in 2
+        self.assertEqual(line.amount, -5)  # the line is split in 2b
+
+    def test_total_timesheet_time_minutes(self):
+        line = self.env['account.analytic.line'].create({
+            'name': 'Timesheet',
+            'unit_amount': 0.75,
+            'project_id': self.project.id,
+            'employee_id': self.empl_employee.id,
+        })
+        self.project._compute_total_timesheet_time()
+        self.assertEqual(self.project.total_timesheet_time, line['unit_amount'])


### PR DESCRIPTION
_______________________________________

## Short functional explanation of the error
When a user encodes an amount of minutes below 30, the estimated time remaining for the task doesn't
change. But when the user encodes an amount above 30, but below 1 hour, the estimated time decreases of 1 hour.

## Reproduction Steps
1. Go to the Timesheets application. Click on the Timesheets tab and click on "All timesheets".
2. For any user, click on "Add a line" and create a test project.
3. Click on the project you created and set the allocated time to 8 hours, for example.
4. Go back to all timesheets. You should be able to see the remaining time.
5. For this project, add an entry of 15 or 45 minutes, depending on the case you would like to test.
6. Refresh the page.

### Expected behavior
If the entry was set at 45 minutes, the estimated remaining time should be 7:15. If the entry was set at 15 minutes, the estimated remaining time should be at 7h45.

### Unexpected behavior
If the entry was set at 45 minutes, the estimated remaining time shown is 7:00. If the entry was set at 15 minutes, the estimated remaining time shown is 8h00.

## Origin of the issue
The estimated time was an integer which was rounded in the code.
_________________________________________
opw-4988446

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
