### PR TITLE
[IMP] website_hr_recruitment: show remote jobs with country filter

### DIFF
--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -52,7 +52,8 @@ class WebsiteHrRecruitment(WebsiteForm):
             )
             if not all_fields or (
                 country_filter and not (
-                    job.address_id and job.address_id.country_id == country
+                    not job.address_id or
+                    (job.address_id and job.address_id.country_id == country)
                 )
             ):
                 return False


### PR DESCRIPTION
Currently, job positions are filtered based on the visitor's IP country. This causes remote jobs to be hidden if they do not match the visitor's country.

This commit ensures that even when jobs are filtered by IP country, all jobs marked as 'Remote' are always displayed.

task-5002673