### PR TITLE
[FIX] im_livechat: make session navigation test deterministic

### DIFF
--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -143,3 +143,9 @@ class WebsocketCase(HttpCase):
         if expected_reason:
             # ensure the close reason is the one we expected
             self.assertEqual(payload[2:].decode(), expected_reason)
+
+
+class BusCase:
+    def _reset_bus(self):
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        self.env["bus.bus"].sudo().search([]).unlink()

--- a/addons/im_livechat/tests/common.py
+++ b/addons/im_livechat/tests/common.py
@@ -2,9 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests.common import HttpCase, new_test_user
+from odoo.addons.bus.tests.common import BusCase
 
 
-class TestImLivechatCommon(HttpCase):
+class TestImLivechatCommon(HttpCase, BusCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/addons/im_livechat/tests/test_session_history.py
+++ b/addons/im_livechat/tests/test_session_history.py
@@ -18,6 +18,7 @@ class TestImLivechatSessionHistory(TestImLivechatCommon):
         })
         channel = self.env["discuss.channel"].browse(data["discuss.channel"][0]["id"])
         channel.with_user(operator).message_post(body="Hello, how can I help you?")
+        self._reset_bus()
         action = self.env.ref("im_livechat.discuss_channel_action_from_livechat_channel")
         self.start_tour(
             f"/odoo/livechat/{self.livechat_channel.id}/action-{action.id}",

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -23,6 +23,7 @@ from odoo import tools, fields
 from odoo.addons.base.models.ir_mail_server import IrMail_Server
 from odoo.addons.base.tests.common import MockSmtplibCase
 from odoo.addons.bus.models.bus import BusBus, json_dump
+from odoo.addons.bus.tests.common import BusCase
 from odoo.addons.mail.models import mail_thread
 from odoo.addons.mail.models.mail_mail import MailMail
 from odoo.addons.mail.models.mail_message import MailMessage
@@ -1038,7 +1039,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                 self.assertEqual(1, 0, f'Tracking: unsupported tracking test on {value_type}')
 
 
-class MailCase(MockEmail):
+class MailCase(MockEmail, BusCase):
     """ Tools, helpers and asserts for mail-related tests, including mail
     gateway mock and helpers (see ´´MockEmail´´).
 
@@ -1099,10 +1100,6 @@ class MailCase(MockEmail):
 
     def _init_mock_bus(self):
         self._new_bus_notifs = self.env['bus.bus'].sudo()
-
-    def _reset_bus(self):
-        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
-        self.env["bus.bus"].sudo().search([]).unlink()
 
     @contextmanager
     def mock_mail_app(self):


### PR DESCRIPTION
Before this commit, `test_session_history_navigation_back_and_forth` was sometimes failing.

This test checks that browser history works correctly when navigating between a live chat session and the discuss app.

The test creates a live chat channel via the `/get_session` route, then starts a tour which clicks the related record in the list view to open it in the Discuss app.

However, `/get_session` initially sets `is_pinned` to False for the agent. When the active discuss channel is unpinned, another thread is set as the active thread. According to the timing, it can make the test fail.

The fix resets bus notifications before starting the tour, ensuring consistent results.

fixes runbot-230334,230340

