### PR TITLE
[FIX] im_livechat: fix chat bot step tour

### DIFF
--- a/addons/im_livechat/static/tests/tours/chatbot_step_type_clear_only.js
+++ b/addons/im_livechat/static/tests/tours/chatbot_step_type_clear_only.js
@@ -32,7 +32,8 @@ registry.category("web_tour.tours").add("change_chatbot_step_type", {
             run: "click",
         },
         {
-            trigger: ".o_form_view",
+            // Ensure form is properly saved, in which case the save button is hidden.
+            trigger: ".o_form_button_save:not(:visible)",
         },
     ],
 });


### PR DESCRIPTION
This commit fixes the "change_chatbot_step_type" tour which fails because it doesn't wait for the form to be properly saved.

This commit fixes the issue by waiting until the save button disappears.

fixes runbot-229962

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
