### PR TITLE
[IMP] website_sale: add new "List Condensed" product card design

### DIFF
--- a/addons/website_sale/static/src/img/products_entries_design/style_list_condensed.svg
+++ b/addons/website_sale/static/src/img/products_entries_design/style_list_condensed.svg
@@ -1,0 +1,16 @@
+<svg width="325" height="110" viewBox="0 0 325 110" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="path-1-inside-1_7128_81322" fill="white">
+<path d="M16 31.5H309V78.5H16V31.5Z"/>
+</mask>
+<path d="M309 78.5V77.9H16V78.5V79.1H309V78.5Z" fill="white" mask="url(#path-1-inside-1_7128_81322)"/>
+<rect x="16" y="42" width="27" height="26" rx="2" fill="#9CCDE4"/>
+<path d="M29.4233 45.7939H23.4539L19.4517 51.1443L21.7332 54.1629H23.0894V64.235H35.7413V54.1629H37.1182L39.3949 51.1443L35.3927 45.7939H29.4233Z" fill="#3AADAA" stroke="#1A4746"/>
+<path d="M23.0846 54.1637H21.7284L19.4517 51.1443L23.4539 45.7939H35.3927L39.3949 51.1443L37.1134 54.1637H35.7365" stroke="#1A4746" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M35.7375 52.4541V64.2351H23.0856V49.9224" stroke="#1A4746" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M32.4695 46.8169C32.2787 47.4186 31.9237 47.9514 31.4469 48.3519C30.97 48.7524 30.3912 49.0038 29.7793 49.0762C29.1674 49.1486 28.5482 49.039 27.9951 48.7604C27.4421 48.4818 26.9786 48.0459 26.6596 47.5045" stroke="#1A4746" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M35.7347 60.3135H33.7683" stroke="#1A4746" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M35.7365 61.647H30.8959" stroke="#1A4746" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M48 55H143" stroke="white" stroke-width="2.4"/>
+<path d="M237.808 55H263.792" stroke="#E9ECEF" stroke-width="2.4"/>
+<path d="M276.608 55H302.592" stroke="#E9ECEF" stroke-width="2.4"/>
+</svg>

--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -208,7 +208,7 @@
         // Only visible in /shop page
         .css_attribute_preview_thumbnail {
             border: $border-width solid $border-color;
-            border-radius: var(--o-wsale-card-attribute-previewer-thumbnail-border-radius, 0);
+            border-radius: var(--o-wsale-card-attribute-previewer-thumbnail-border-radius, #{$border-radius-sm});
             aspect-ratio: var(--o-wsale-card-thumb-aspect-ratio, 1/1);
             transition: border-color 0.05s ease-in-out;
 
@@ -226,9 +226,9 @@
     }
 
     .o_wsale_product_information_text {
-        flex-basis: var(--o-wsale-card-info-text-basis);
+        flex: var(--o-wsale-card-info-text-flex);
         width: var(--o-wsale-card-info-text-width);
-        margin-right: var(--o-wsale-card-info-text-margin-right);
+        margin: var(--o-wsale-card-info-text-margin);
         order: var(--o-wsale-card-info-order, 4);
     }
     .o_wsale_products_item_title {
@@ -497,7 +497,6 @@
     --o-wsale-card-info-padding: #{map-get($spacers, 3)} 0 0;
     --o-wsale-card-border-radius: 0px;
     --o-wsale-card-thumb-border-radius: var(--o-wsale-opt-border-radius);
-    --o-wsale-card-attribute-previewer-thumbnail-border-radius: #{$border-radius-sm};
 
     --o-wsale-card-offset-top: calc(var(--o-wsale-opt-border-radius, 0px) * 0.1);
     --o-wsale-card-offset-x: calc(var(--o-wsale-opt-border-radius, 0px) * 0.2);
@@ -522,7 +521,6 @@
             --o-wsale-card-btn-submit-order: 1;
         }
         @include media-breakpoint-between(md, xl) {
-            --o-wsale-card-info-text-basis: 0 0 200px;
             --o-wsale-card-info-text-width: 200px;
             --o-wsale-card-btn-submit-order: -2;
             --o-wsale-card-btns-flex-direction: column;
@@ -533,7 +531,6 @@
             }
         }
         @include media-breakpoint-up(xl) {
-            --o-wsale-card-info-text-basis: 0 0 360px;
             --o-wsale-card-info-text-width: 360px;
 
             &:where(.o_wsale_products_opt_has_comparison):where(:has(.o_add_compare)) {
@@ -550,7 +547,6 @@
     --o-wsale-card-border-radius: var(--o-wsale-opt-border-radius, 0px);
     --o-wsale-card-pseudobg-y: 0;
     --o-wsale-card-pseudobg-x: 0;
-    --o-wsale-card-attribute-previewer-thumbnail-border-radius: #{$border-radius-sm};
     --o-wsale-card-btns-margin-bottom: 0;
 
     $-br-top: MAX(0px, calc(var(--o-wsale-card-border-radius) - 1px));
@@ -637,6 +633,7 @@
     --o-border-color: #{$gray-300};
     --border-color: #{$gray-300};
     --gap: 0px;
+    --o-wsale-card-attribute-previewer-thumbnail-border-radius: 0;
 
     --o-wsale-card-offset-top: 0px;
     --o-wsale-card-offset-x: 0px;
@@ -659,7 +656,6 @@
             --o-wsale-card-btn-submit-order: -2;
         }
         @include media-breakpoint-up(md) {
-            --o-wsale-card-info-text-basis: 0 0 200px;
             --o-wsale-card-info-text-width: 200px;
             --o-wsale-card-price-flex-basis: 100%;
             --o-wsale-card-info-attributes-justify-content: center;
@@ -670,7 +666,6 @@
         }
         @include media-breakpoint-up(xl) {
             --o-wsale-card-btn-submit-order: 1;
-            --o-wsale-card-info-text-basis: 0 0 280px;
             --o-wsale-card-info-text-width: 280px;
 
             &:where(.o_wsale_products_opt_has_comparison):where(:has(.o_add_compare)) {
@@ -678,14 +673,11 @@
             }
         }
         @include media-breakpoint-up(xxl) {
-            --o-wsale-card-info-text-basis: 0 0 360px;
             --o-wsale-card-info-text-width: 360px;
         }
     }
 }
 .o_wsale_products_opt_design_showcase {
-    --o-wsale-card-padding: 0;
-    --o-wsale-card-flex-direction: column;
     --o-wsale-card-thumb-size: 100%;
     --o-wsale-card-border-radius: var(--o-wsale-opt-border-radius, 0);
     --o-wsale-card-thumb-border-radius: var(--o-wsale-opt-border-radius, 0);
@@ -784,6 +776,53 @@
         }
     }
 }
+.o_wsale_products_opt_design_condensed {
+    $_padding_min: MIN(#{map-get($spacers, 1)}, 1vw);
+    --o-wsale-card-border-width: 0 0 1px;
+    --o-wsale-card-padding: #{$_padding_min} 0 calc(#{$_padding_min} + var(--o-wsale-products-grid-gap));
+    --o-wsale-card-thumb-size: 3.375rem;
+    --o-wsale-card-thumb-border-radius: var(--o-wsale-opt-border-radius, 0);
+    --o-wsale-card-info-padding: 0 0 0 #{map-get($spacers, 2)};
+    --o-wsale-card-info-text-width: auto;
+    --o-wsale-card-info-text-margin: 0 auto 0 0;
+    --o-wsale-card-info-description-margin-bottom: 0;
+    --o-wsale-card-price-display: flex;
+    --o-wsale-card-price-flex-direction: column;
+    --o-wsale-card-price-justify-content: end;
+    --o-wsale-card-price-min-width: MAX(9ch, 12cqw);
+    --o-wsale-card-price-font-size: 1rem;
+    --o-wsale-card-attribute-previewer-width: min(40%, 360px);
+    --o-wsale-card-attribute-previewer-justify-content: end;
+    --o-wsale-card-sub-align-items: center;
+    --o-wsale-card-sub-wrap: nowrap;
+    --o-wsale-card-btn-label-display: none;
+    --o-wsale-card-btn-submit-label-display: none;
+    --o-wsale-card-btn-submit-order: 1;
+
+    --o-wsale-card-offset-top: calc(var(--o-wsale-opt-border-radius, 0px) * 0.1);
+    --o-wsale-card-offset-x: calc(var(--o-wsale-opt-border-radius, 0px) * 0.2);
+
+    @include media-breakpoint-down(md) {
+        --o-wsale-card-info-text-width: 100%;
+        --o-wsale-card-info-text-margin: 0 0 #{map-get($spacers, 2)} 0;
+        --o-wsale-card-attribute-previewer-justify-content: start;
+        --o-wsale-card-sub-align-items: center;
+    }
+
+    @include media-breakpoint-up(md) {
+        .o_wsale_product_information_text {
+            --o-wsale-card-info-text-flex: 0 1 40%;
+        }
+
+        &:where(.o_wsale_products_opt_has_comparison):where(:has(.o_add_compare)) {
+            --o-wsale-comparison-btn-placeholder-display: inline-block;
+        }
+    }
+
+    .product_price del {
+        margin-right: 0 !important;
+    }
+}
 
 // ==== Products list decorations
 $_wsale_products_roundness_map: (
@@ -803,20 +842,16 @@ $_wsale_products_roundness_map: (
 
 // ==== Card Hover Effects
 .o_wsale_products_opt_hover_background, .o_wsale_products_opt_hover_background_zoom {
-    &:where(.o_wsale_products_opt_design_thumbs) {
-        --o-wsale-card-pseudobg: "";
-        --o-wsale-card-pseudobg-color: var(--100);
-        --o-wsale-card-pseudobg-opacity-hover: 1;
-        --o-wsale-card-pseudobg-opacity: 0;
-    }
+    --o-wsale-card-pseudobg: "";
+    --o-wsale-card-pseudobg-color: var(--100);
+    --o-wsale-card-pseudobg-opacity-hover: 1;
+    --o-wsale-card-pseudobg-opacity: 0;
 }
 .o_wsale_products_opt_hover_background_zoom {
-    &:where(.o_wsale_products_opt_design_thumbs) {
-        --o-wsale-card-pseudobg-transform-hover: scale(.8);
-        --o-wsale-card-pseudobg-transition-hover: all .1s;
-        --o-wsale-card-pseudobg-transform: scale(1);
-        --o-wsale-card-pseudobg-transition: all cubic-bezier(0.645, 0.045, 0.355, 1) .25s;
-    }
+    --o-wsale-card-pseudobg-transform-hover: scale(.8);
+    --o-wsale-card-pseudobg-transition-hover: all .1s;
+    --o-wsale-card-pseudobg-transform: scale(1);
+    --o-wsale-card-pseudobg-transition: all cubic-bezier(0.645, 0.045, 0.355, 1) .25s;
 }
 .o_wsale_products_opt_hover_border_primary {
     &:where(.o_wsale_products_opt_design_cards), &:where(.o_wsale_products_opt_design_chips) {

--- a/addons/website_sale/static/src/website_builder/products_design_panel.xml
+++ b/addons/website_sale/static/src/website_builder/products_design_panel.xml
@@ -29,7 +29,7 @@
         <t t-set="suggestedClassesListDefault">
             o_wsale_products_opt_name_color_regular o_wsale_products_opt_thumb_cover
             o_wsale_products_opt_has_cta
-            o_wsale_products_opt_has_wishlist o_wsale_products_opt_has_description
+            o_wsale_products_opt_has_wishlist
             o_wsale_products_opt_actions_inline
         </t>
 
@@ -76,7 +76,7 @@
                 label: thumbnailsLabel,
                 className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_thumbs',
                 img: '/website_sale/static/src/img/products_entries_design/style_list_thumbs.svg',
-                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_rounded_2 o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote o_wsale_products_opt_thumb_4_5',
+                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_rounded_2 o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote o_wsale_products_opt_thumb_4_5 o_wsale_products_opt_has_description',
                 gap: 16,
             },
             {
@@ -85,7 +85,7 @@
                 label: cardsLabel,
                 className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_cards',
                 img: '/website_sale/static/src/img/products_entries_design/style_list_cards.svg',
-                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_rounded_2 o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote',
+                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_rounded_2 o_wsale_products_opt_has_description o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote',
                 gap: 8,
             },
             {
@@ -94,7 +94,7 @@
                 label: gridLabel,
                 className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_grid',
                 img: '/website_sale/static/src/img/products_entries_design/style_list_grid.svg',
-                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_name_size_body o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote o_wsale_products_opt_thumb_4_3',
+                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_name_size_body o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote o_wsale_products_opt_thumb_4_3 o_wsale_products_opt_has_description',
                 gap: 0,
             },
             {
@@ -103,8 +103,17 @@
                 type: 'list',
                 className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_showcase',
                 img: '/website_sale/static/src/img/products_entries_design/style_list_showcase.svg',
-                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc5 o_wsale_products_opt_name_color_regular o_wsale_products_opt_actions_theme o_wsale_products_opt_thumb_4_3',
+                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc5 o_wsale_products_opt_name_color_regular o_wsale_products_opt_actions_theme o_wsale_products_opt_thumb_4_3 o_wsale_products_opt_has_description',
                 gap: 0,
+            },
+            {
+                id: 'wsale_design_condensed_list',
+                label: 'Condensed',
+                type: 'list',
+                className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_condensed',
+                img: '/website_sale/static/src/img/products_entries_design/style_list_condensed.svg',
+                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_rounded_1 o_wsale_products_opt_actions_promote o_wsale_products_opt_name_size_body',
+                gap: 4,
             },
         ]"/>
 
@@ -226,10 +235,14 @@
                 t-set="catalogChips"
                 t-value="this.isActiveItem('wsale_design_chips_catalog')"
             />
+            <t
+                t-set="listCondensed"
+                t-value="this.isActiveItem('wsale_design_condensed_list')"
+            />
 
             <BuilderRow
                 label.translate="Hover Effect"
-                t-if="anyThumb || anyCard || catalogThumb || catalogChips"
+                t-if="anyThumb || anyCard || catalogThumb || catalogChips || listCondensed"
                 >
                 <BuilderSelect>
                     <BuilderSelectItem
@@ -237,12 +250,12 @@
                         None
                     </BuilderSelectItem>
                     <BuilderSelectItem
-                        t-if="anyThumb"
+                        t-if="anyThumb || listCondensed"
                         classAction="'o_wsale_products_opt_hover_background'">
                         Background
                     </BuilderSelectItem>
                     <BuilderSelectItem
-                        t-if="anyThumb"
+                        t-if="anyThumb || listCondensed"
                         classAction="'o_wsale_products_opt_hover_background o_wsale_products_opt_hover_background_zoom'">
                         Background Zoom
                     </BuilderSelectItem>
@@ -293,7 +306,7 @@
                 label.translate="Colors"
                 tooltip.translate="Color combinations are defined in the Theme Tab"
             >
-                <BuilderSelect t-if="!anyThumb">
+                <BuilderSelect t-if="!anyThumb and !this.isActiveItem('wsale_design_condensed_list')">
                     <BuilderSelectItem
                         classAction="'.o_wsale_products_opt_cc o_wsale_products_opt_cc1'"
                     >


### PR DESCRIPTION
This commit adds a new preset of option for the `/shop` page.

It also:
- Set default border-radius of `.css_attribute_preview_thumbnail` to `$border-radius-sm` so it is rounded except in grid layout
- Remove invalid `flex-basis` rule on `o_wsale_product_information_text`
- Remove two unused variable declarations in `.o_wsale_products_opt_design_showcase` that matched fallback values

task-4924430

----

<img width="1712" height="839" alt="Screenshot 2025-08-14 at 14 23 18" src="https://github.com/user-attachments/assets/79dd6777-8f0d-42e1-98b3-15e1911c3530" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
