### PR TITLE
[FIX] website: make iframe scrollable on undo popup

### DIFF
--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -41,6 +41,7 @@ class PopupOptionPlugin extends Plugin {
         },
         on_cloned_handlers: this.onCloned.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        on_will_remove_handlers: this.onWillRemove.bind(this),
         no_parent_containers: ".s_popup",
     };
 
@@ -57,9 +58,23 @@ class PopupOptionPlugin extends Plugin {
                 apply: () => {
                     this.dependencies.visibility.toggleTargetVisibility(snippetEl, true);
                 },
-                revert: () => {},
+                revert: () => {
+                    this.dependencies.visibility.toggleTargetVisibility(snippetEl, false);
+                },
             });
         }
+    }
+
+    onWillRemove(el) {
+        this.dependencies.visibility.toggleTargetVisibility(el, false);
+        this.dependencies.history.addCustomMutation({
+            apply: () => {
+                this.dependencies.visibility.toggleTargetVisibility(el, false);
+            },
+            revert: () => {
+                this.dependencies.visibility.toggleTargetVisibility(el, true);
+            },
+        });
     }
 
     assignUniqueID(editingElement) {


### PR DESCRIPTION
Following the [html_builder refactoring], commits [1] and [2] removed the functionality that was responsible for toggling the popup's visiblity when we remove it or undo its creation.

Steps to see the issue:
- Have enough content on the page to be able to scroll it
- Start editing and drop the popup
- Undo

=> We can't scroll. The same happens if we just remove the popup. Related to task-4367641

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb
[1]: https://github.com/odoo/odoo/commit/a3722219038fff
[2]: https://github.com/odoo/odoo/commit/06101974532157c521155a7fbb2179aa85b060db
