### PR TITLE
[FIX] repair: allow adding a kit part to a confirmed repair order

### DIFF
--- a/addons/mrp_repair/models/__init__.py
+++ b/addons/mrp_repair/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import repair
 from . import production
+from . import stock_move

--- a/addons/mrp_repair/models/stock_move.py
+++ b/addons/mrp_repair/models/stock_move.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _prepare_phantom_move_values(self, bom_line, product_qty, quantity_done):
+        vals = super()._prepare_phantom_move_values(bom_line, product_qty, quantity_done)
+        if self.repair_id:
+            vals['repair_id'] = self.repair_id.id
+        return vals


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a repair order with any component.
- Confirm the order.
- Try to add a kit as a component.

Problem:
After saving, the kit disappears. When a kit is added to a confirmed repair order, its move should be confirmed and therefore exploded. However, the moves created from this kit move are just copies of the original move. Fields with copy=False are not copied, including the repair_id field. In this case, repair_id must be added to link the move to the repair order, so it needs to be set manually.

opw-4937817
