### PR TITLE
[FIX] pos_loyalty: apply discount when last combo item price is zero

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -1020,7 +1020,7 @@ patch(PosOrder.prototype, {
         const orderProducts = orderLines.map((line) => line.product_id.id);
         const remainingAmountPerLine = {};
         for (const line of orderLines) {
-            if (!line.get_quantity() || !line.price_unit) {
+            if (!line.get_quantity() || !line.price_unit || !line.get_price_with_tax()) {
                 continue;
             }
             remainingAmountPerLine[line.uuid] = line.get_price_with_tax();


### PR DESCRIPTION
### Problem:
When creating a product of type combo where the last combo’s price is 0, in certain conditions—such as assigning a high decimal accuracy to the "Product Price"—the discount will not be added to the POS order. This happens because the remaining, containing the rounding difference on this [line](https://github.com/odoo/odoo/blob/18.0/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js#L27), is added to the last product in the combo. This causes the product to be flagged as discountable and will assigns discountablePerTax in this [line](https://github.com/odoo/odoo/blob/18.0/addons/pos_loyalty/static/src/overrides/models/pos_order.js#L1096-L1098) to NaN,since the price per tax is zero.

### How to reproduce
* Create a combo product.
* Add multiple combos to it.
* Set the price of the last combo to 0.
* Set the price of the other combos to a decimal value.
* Set the price of the main product to 100.
* Create a discount promotion and make it specific to this product.
* Set the decimal accuracy of the "Product Price" to 6.
* Open POS session and add the combo product.
* The discount will not be added.

### Solution
Add a safety check to skip products with price near zero.

opw-4996420
