### PR TITLE
Improve translation plugin

### DIFF
--- a/addons/html_builder/static/src/core/builder_content_editable_plugin.js
+++ b/addons/html_builder/static/src/core/builder_content_editable_plugin.js
@@ -25,7 +25,10 @@ export class BuilderContentEditablePlugin extends Plugin {
 
     filterContentEditable(contentEditableEls) {
         return contentEditableEls.filter(
-            (el) => !el.matches("input, [data-oe-readonly]") && el.closest(".o_editable")
+            (el) =>
+                !el.matches("input, [data-oe-readonly]") &&
+                el.closest(".o_editable") &&
+                !el.closest(".o_not_editable")
         );
     }
 }

--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -13,9 +13,6 @@ export class SetupEditorPlugin extends Plugin {
             "#wrap .o_homepage_editor_welcome_message"
         );
         welcomeMessageEl?.remove();
-        if (this.delegateTo("after_setup_editor_handlers")) {
-            return;
-        }
         let editableEls = this.getEditableElements("[data-oe-model]")
             .filter((el) => !el.matches("link, script"))
             .filter((el) => !el.hasAttribute("data-oe-readonly"))
@@ -30,6 +27,9 @@ export class SetupEditorPlugin extends Plugin {
             .filter((el) => !el.hasAttribute("data-oe-sanitize-prevent-edition"));
         editableEls.concat(Array.from(this.editable.querySelectorAll(".o_editable")));
         editableEls.forEach((el) => el.classList.add("o_editable"));
+        if (this.delegateTo("after_setup_editor_handlers")) {
+            return;
+        }
 
         // Add automatic editor message on the editables where we can drag and
         // drop elements.


### PR DESCRIPTION
[IMP] html_builder, *: improve the logic of the translation plugin
*: website

The goal of this commit is to improve the logic of the
`TranslationPlugin` plugin. Indeed, we do not want this plugin to handle
the addition of the `o_editable` class to html elements. Instead we let
this task to `SetupEditorPlugin` as usual. The problem is still that
some html elements have translatable attributes and those elements will
not have the `o_editable` class as they do not have the branding (oe
data information). To handle those, a new `o_editable_attribute` system
class is added on them. Thanks to those classes, we know which nodes are
translatable (elements with the `o_editable` class have a content that
is translatable while elements with the `o_editable_attribute` class
have an attribute that is translatable). The advantage of handling the
translation that way is that we do not add the `o_editable` class on
elements that are not savable. This is better also in order to not add
the `contenteditable` attribute abusively.

Related to task-4367641

