### PR TITLE
Replace usage of partner_id of ai.agent

### DIFF
--- a/addons/im_livechat/controllers/cors/main.py
+++ b/addons/im_livechat/controllers/cors/main.py
@@ -28,11 +28,11 @@ class CorsLivechatController(LivechatController):
 
     @route("/im_livechat/cors/get_session", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def cors_get_session(
-        self, channel_id, previous_operator_id=None, chatbot_script_id=None, extra_operator_lookup_params=None, persisted=True, **kwargs
+        self, channel_id, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs
     ):
         force_guest_env(kwargs.pop("guest_token", ""), raise_if_not_found=False)
         return self.get_session(
-            channel_id, previous_operator_id, chatbot_script_id, extra_operator_lookup_params, persisted, **kwargs
+            channel_id, previous_operator_id, chatbot_script_id, persisted, **kwargs
         )
 
     @route("/im_livechat/cors/init", type="jsonrpc", auth="public", cors="*")

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -818,7 +818,7 @@ class DiscussChannel(models.Model):
             channel_sudo._action_unfollow(partner=bot_partner_id, post_leave_message=False)
 
             # finally, rename the channel to include the operator's name
-            channel_sudo._update_channel_info(
+            channel_sudo._update_forwarded_channel_data(
                 livechat_failure="no_answer",
                 livechat_operator_id=human_operator.partner_id,
                 operator_name=human_operator.livechat_username if human_operator.livechat_username else human_operator.name,
@@ -861,7 +861,7 @@ class DiscussChannel(models.Model):
             member_params['partners'] = partners
         self._add_members(**member_params)
 
-    def _update_channel_info(self, livechat_failure, livechat_operator_id, operator_name):
+    def _update_forwarded_channel_data(self, /, *, livechat_failure, livechat_operator_id, operator_name):
         self.write(
             {
                 "livechat_failure": livechat_failure,

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -117,8 +117,8 @@ export class LivechatService {
                 channel_id: options.channel_id ?? this.options.channel_id,
                 previous_operator_id: expirableStorage.getItem(OPERATOR_STORAGE_KEY),
                 chatbot_script_id: originThread?.chatbot?.script.id ?? this.store.livechat_rule?.chatbot_script_id?.id,
-                extra_operator_lookup_params: this.getExtraOperatorLookupParams(originThread, options),
                 persisted: options.persist ?? persist,
+                ...this.getSessionExtraParams(originThread, options),
             },
             { silent: true }
         );
@@ -137,7 +137,7 @@ export class LivechatService {
         return thread;
     }
 
-    getExtraOperatorLookupParams(thread, options){
+    getSessionExtraParams(thread, options) {
         return {};
     }
 

--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -103,7 +103,6 @@ test("Only necessary requests are made when creating a new chat", async () => {
         `/im_livechat/get_session - ${JSON.stringify({
             channel_id: livechatChannelId,
             previous_operator_id: null,
-            extra_operator_lookup_params: {},
             persisted: false,
         })}`,
     ]);
@@ -123,7 +122,6 @@ test("Only necessary requests are made when creating a new chat", async () => {
                 `/im_livechat/get_session - ${JSON.stringify({
                     channel_id: livechatChannelId,
                     previous_operator_id: operatorPartnerId,
-                    extra_operator_lookup_params: {},
                     persisted: true,
                 })}`,
                 `/mail/message/post - ${JSON.stringify({

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -213,7 +213,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             channel_data_join["discuss.channel"][0]["livechat_operator_id"] = self.chatbot_script.operator_partner_id.id
             channel_data_join["discuss.channel"][0]["member_count"] = 3
             channel_data_join["discuss.channel"][0]["name"] = "Testing Bot"
-            channel_data_join["discuss.channel"][0]["livechat_with_ai_agent"] = False
             channel_data_join["discuss.channel.member"].insert(0, member_bot_data)
             channel_data_join["discuss.channel.member"][2]["fetched_message_id"] = False
             channel_data_join["discuss.channel.member"][2]["last_seen_dt"] = False
@@ -242,16 +241,9 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             channel_data["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
             channel_data_emp = Store().add(discuss_channel.with_user(self.user_employee)).get_result()
             channel_data_emp["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
-            channel_data_emp["discuss.channel"][0]["livechat_with_ai_agent"] = False
             channel_data_emp["discuss.channel.member"][1]["message_unread_counter_bus_id"] = 0
             channel_data = Store().add(discuss_channel).get_result()
             channel_data["discuss.channel"][0]["message_needaction_counter_bus_id"] = 0
-            channel_data["discuss.channel"][0]["livechat_with_ai_agent"] = False
-            self._filter_channels_fields(
-                channel_data_join['discuss.channel'][0],
-                channel_data_emp['discuss.channel'][0],
-                channel_data['discuss.channel'][0],
-            )
             channels, message_items = (
                 [
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
@@ -363,10 +355,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                                     "write_date": fields.Datetime.to_string(
                                         self.partner_employee.write_date
                                     ),
-                                    **({
-                                        "im_status": "offline",
-                                        "im_status_access_token": self.partner_employee._get_im_status_access_token()
-                                    } if "ai.agent" in self.env else {})
                                 }
                             ),
                         },

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -2012,10 +2012,10 @@ class MailCommon(MailCase):
         """ Remove store channel data dependant on other modules if they are not not installed.
         Not written in a modular way to avoid complex override for a simple test tool.
         """
+        ai_livechat_installed = self.env['ir.module.module']._get('ai_livechat').state == 'installed'
         for data in channels_data:
-            # if 'ai_livechat' module is not installed
-            if "livechat_with_ai_agent" not in self.env["discuss.channel"]._fields:
-                data.pop("livechat_with_ai_agent", None)
+            if "ai.agent" not in self.env or data.get("channel_type") == "livechat" and not ai_livechat_installed:
+                data.pop("ai_agent_id", None)
         return list(channels_data)
 
     def _filter_messages_fields(self, /, *messages_data):

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -848,6 +848,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_1:
             return {
+                "ai_agent_id": False,
                 "channel_type": "livechat",
                 "country_id": self.env.ref("base.in").id,
                 "create_uid": self.users[1].id,
@@ -872,10 +873,10 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "requested_by_operator": False,
                 "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
-                'livechat_with_ai_agent': False,
             }
         if channel == self.channel_livechat_2:
             return {
+                "ai_agent_id": False,
                 "channel_type": "livechat",
                 "country_id": self.env.ref("base.be").id,
                 "create_uid": self.env.ref("base.public_user").id,
@@ -900,7 +901,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "requested_by_operator": False,
                 "rtc_session_ids": [["ADD", []]],
                 "uuid": channel.uuid,
-                'livechat_with_ai_agent': False,
             }
         return {}
 

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -194,6 +194,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             {
                 "discuss.channel": self._filter_channels_fields(
                     {
+                        "ai_agent_id": False,
                         "channel_type": "livechat",
                         "country_id": False,
                         "create_uid": self.user_public.id,
@@ -219,7 +220,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "requested_by_operator": False,
                         "rtc_session_ids": [("ADD", [])],
                         "uuid": channel.uuid,
-                        'livechat_with_ai_agent': False,
                     }
                 ),
                 "discuss.channel.member": [
@@ -314,6 +314,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             data["discuss.channel"],
             self._filter_channels_fields(
                 {
+                    "ai_agent_id": False,
                     "channel_type": "livechat",
                     "country_id": False,
                     "create_uid": self.user_public.id,
@@ -332,7 +333,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                     "requested_by_operator": False,
                     "rtc_session_ids": [("ADD", [])],
                     "uuid": channel.uuid,
-                    'livechat_with_ai_agent': False,
                 },
             )
         )


### PR DESCRIPTION
In the AI app, there are multiple functions that receive the partner_id of the ai.agent as a parameter. This complicates the code and results in unnecessary checks on the partner_id to make sure it is connected to an AI Agent.

This corresponding commit in enterprise replaces the usages of partner_id of ai.agent (unless necessary) with the id of the agent. This commit:
1. Sets ai_agent_id on non persisted livechat channels when they are created.
2. Adapts the test cases.

Enterprise PR: https://github.com/odoo/enterprise/pull/92390
task-4991208
