### PR TITLE
[IMP] base, http: detect untrusted locations

### DIFF
--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -76,7 +76,16 @@ class TestXMLRPC(common.HttpCase):
         now = datetime.datetime.now()
         ids = self.xmlrpc(
             'res.device.log', 'create',
-            {'session_identifier': "abc", 'first_activity': now, 'revoked': False}
+            {
+                'session_identifier': 'abc',
+                'user_id': self.env['res.users'].search([], limit=1).id,
+                'user_agent': '',
+                'ip_address': '',
+                'fingerprint': '',
+                'first_activity': now,
+                'last_activity': now,
+                'revoked': False,
+            }
         )
         [r] = self.xmlrpc(
             'res.device.log', 'read',

--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -25,7 +25,7 @@ class DataSet(http.Controller):
                 return method._readonly
         return False
 
-    @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='jsonrpc', auth="user", readonly=_call_kw_readonly)
+    @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='jsonrpc', auth="user", readonly=_call_kw_readonly, fingerprint=True)
     def call_kw(self, model, method, args, kwargs, path=None):
         if path != f'{model}.{method}':
             thread_local.rpc_model_method = f'{model}.{method}'

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import hashlib
+
 import odoo
 from odoo import api, models, fields
 from odoo.http import request, DEFAULT_MAX_CONTENT_LENGTH
@@ -95,6 +97,7 @@ class IrHttp(models.AbstractModel):
         ))
         is_internal_user = user._is_internal()
         session_info = {
+            'fingerprint_text': hashlib.sha256(f'{session_uid}{int(user.create_date.timestamp())}'.encode()).hexdigest(),
             "uid": session_uid,
             "is_system": user._is_system() if session_uid else False,
             "is_admin": user._is_admin() if session_uid else False,
@@ -171,6 +174,7 @@ class IrHttp(models.AbstractModel):
         user = self.env.user
         session_uid = request.session.uid
         session_info = {
+            'fingerprint_text': hashlib.sha256(f'{session_uid}{int(user.create_date.timestamp())}'.encode()).hexdigest() if session_uid else None,
             'is_admin': user._is_admin() if session_uid else False,
             'is_system': user._is_system() if session_uid else False,
             'is_public': user._is_public(),

--- a/addons/web/static/tests/core/network/rpc.test.js
+++ b/addons/web/static/tests/core/network/rpc.test.js
@@ -141,6 +141,7 @@ test("rpc can send additional headers", async () => {
         expect(settings.headers).toEqual({
             "Content-Type": "application/json",
             Hello: "World",
+            "X-Rpcfingerprint": undefined,
         });
         return { result: true };
     });

--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -6,8 +6,9 @@ import logging
 
 from odoo import api, fields, models, tools
 from odoo.http import GeoIP, request, root, STORED_SESSION_BYTES
-from odoo.tools import SQL, OrderedSet, unique
+from odoo.tools import SQL, str2bool, unique
 from odoo.tools.translate import _
+from odoo.tools._vendor.useragents import UserAgent
 from .res_users import check_identity
 
 _logger = logging.getLogger(__name__)
@@ -16,62 +17,30 @@ _logger = logging.getLogger(__name__)
 class ResDeviceLog(models.Model):
     _name = 'res.device.log'
     _description = 'Device Log'
-    _rec_names_search = ['platform', 'browser']
+    _rec_names_search = ['user_agent', 'ip_address']
 
+    # Fields that identify a session
     session_identifier = fields.Char("Session Identifier", required=True, index='btree')
-    platform = fields.Char("Platform")
-    browser = fields.Char("Browser")
-    ip_address = fields.Char("IP Address")
-    country = fields.Char("Country")
-    city = fields.Char("City")
-    device_type = fields.Selection([('computer', 'Computer'), ('mobile', 'Mobile')], "Device Type")
-    user_id = fields.Many2one("res.users", index='btree')
-    first_activity = fields.Datetime("First Activity")
-    last_activity = fields.Datetime("Last Activity", index='btree')
+    user_id = fields.Many2one("res.users", required=True, index='btree')
+    # Fields that identify a device for a given session (comes from the HTTP request)
+    user_agent = fields.Char("User Agent", required=True)
+    ip_address = fields.Char("IP Address", required=True)
+    fingerprint = fields.Char("Fingerprint", required=True)
+    # Fields representing the device's activity
+    first_activity = fields.Datetime("First Activity", required=True)
+    last_activity = fields.Datetime("Last Activity", required=True, index='btree')
+    # Field that determine the "status" of the session/device on disk
     revoked = fields.Boolean("Revoked",
                             help="""If True, the session file corresponding to this device
                                     no longer exists on the filesystem.""")
-    is_current = fields.Boolean("Current Device", compute="_compute_is_current")
-    linked_ip_addresses = fields.Text("Linked IP address", compute="_compute_linked_ip_addresses")
+    # Fields for reporting suspicious activities
+    suspicious = fields.Boolean("Suspicious",
+                            help="""If True, the session was used with a suspicious device.""")
+    suspicious_fingerprint = fields.Boolean("Suspicious Fingerprint")
+    suspicious_device = fields.Boolean("Suspicious Device")
 
-    _composite_idx = models.Index("(user_id, session_identifier, platform, browser, last_activity, id) WHERE revoked IS NOT TRUE")
+    _composite_idx = models.Index("(session_identifier, user_agent, ip_address, fingerprint) WHERE revoked IS NOT TRUE")
     _revoked_idx = models.Index("(revoked) WHERE revoked IS NOT TRUE")
-
-    def _compute_display_name(self):
-        for device in self:
-            platform = device.platform or _("Unknown")
-            browser = device.browser or _("Unknown")
-            device.display_name = f"{platform.capitalize()} {browser.capitalize()}"
-
-    def _compute_is_current(self):
-        for device in self:
-            device.is_current = request and request.session.sid.startswith(device.session_identifier)
-
-    def _compute_linked_ip_addresses(self):
-        device_group_map = {}
-        for *device_info, ip_array in self.env['res.device.log']._read_group(
-            domain=[('session_identifier', 'in', self.mapped('session_identifier'))],
-            groupby=['session_identifier', 'platform', 'browser'],
-            aggregates=['ip_address:array_agg']
-        ):
-            device_group_map[tuple(device_info)] = ip_array
-        for device in self:
-            device.linked_ip_addresses = '\n'.join(
-                OrderedSet(device_group_map.get(
-                    (device.session_identifier, device.platform, device.browser), []
-                ))
-            )
-
-    def _order_field_to_sql(self, alias, field_name, direction, nulls, query):
-        if field_name == 'is_current' and request and request.session.sid:
-            return SQL("session_identifier = %s DESC", request.session.sid[:STORED_SESSION_BYTES])
-        return super()._order_field_to_sql(alias, field_name, direction, nulls, query)
-
-    def _is_mobile(self, platform):
-        if not platform:
-            return False
-        mobile_platform = ['android', 'iphone', 'ipad', 'ipod', 'blackberry', 'windows phone', 'webos']
-        return platform.lower() in mobile_platform
 
     @api.model
     def _update_device(self, request):
@@ -81,13 +50,38 @@ class ResDeviceLog(models.Model):
 
             :param request: Request or WebsocketRequest object
         """
-        trace = request.session.update_trace(request)
+        session = request.session
+
+        trace, suspicious_reasons = session.update_trace(request)
         if not trace:
             return
+        (user_agent, ip_address, fingerprint), (first_activity, last_activity) = trace
 
-        geoip = GeoIP(trace['ip_address'])
-        user_id = request.session.uid
-        session_identifier = request.session.sid[:STORED_SESSION_BYTES]
+        session_identifier = session.sid[:STORED_SESSION_BYTES]
+        user_id = session.uid
+
+        # Log suspicious activity
+        suspicious_device = False
+        suspicious_fingerprint = False
+        if suspicious_reasons:
+            if 'fingerprint' in suspicious_reasons:
+                suspicious_fingerprint = str2bool(self.env['ir.config_parameter'].sudo().get_param('res_device.enable_fingerprint', default=True))
+                if fingerprint:
+                    _logger.info(
+                        "User %d used untrusted device with fingerprint %s instead of %s for session identifier %s",
+                        user_id, fingerprint, session['_fingerprint'], session_identifier,
+                    )
+                else:
+                    _logger.info(
+                        "User %d used untrusted device without fingerprint for session %s (expected fingerprint: %s)",
+                        user_id, session_identifier, session['_fingerprint'],
+                    )
+            if 'device' in suspicious_reasons:
+                suspicious_device = True
+                _logger.info(
+                    "User %d used untrusted device with user agent: %s and ip address: %s for session identifier %s",
+                    user_id, user_agent, ip_address, session_identifier,
+                )
 
         if self.env.cr.readonly:
             self.env.cr.rollback()
@@ -96,26 +90,29 @@ class ResDeviceLog(models.Model):
             cursor = nullcontext(self.env.cr)
         with cursor as cr:
             cr.execute(SQL("""
-                INSERT INTO res_device_log (session_identifier, platform, browser, ip_address, country, city, device_type, user_id, first_activity, last_activity, revoked)
-                VALUES (%(session_identifier)s, %(platform)s, %(browser)s, %(ip_address)s, %(country)s, %(city)s, %(device_type)s, %(user_id)s, %(first_activity)s, %(last_activity)s, %(revoked)s)
+                INSERT INTO res_device_log (session_identifier, user_id, user_agent, ip_address, fingerprint, first_activity, last_activity, revoked, suspicious, suspicious_fingerprint, suspicious_device)
+                VALUES (%(session_identifier)s, %(user_id)s, %(user_agent)s, %(ip_address)s, %(fingerprint)s, %(first_activity)s, %(last_activity)s, %(revoked)s, %(suspicious)s, %(suspicious_fingerprint)s, %(suspicious_device)s)
             """,
                 session_identifier=session_identifier,
-                platform=trace['platform'],
-                browser=trace['browser'],
-                ip_address=trace['ip_address'],
-                country=geoip.get('country_name'),
-                city=geoip.get('city'),
-                device_type='mobile' if self._is_mobile(trace['platform']) else 'computer',
                 user_id=user_id,
-                first_activity=datetime.fromtimestamp(trace['first_activity']),
-                last_activity=datetime.fromtimestamp(trace['last_activity']),
+                user_agent=user_agent,
+                fingerprint=fingerprint,
+                ip_address=ip_address,
+                first_activity=datetime.fromtimestamp(first_activity),
+                last_activity=datetime.fromtimestamp(last_activity),
                 revoked=False,
+                suspicious=bool(suspicious_fingerprint or suspicious_device),
+                suspicious_fingerprint=suspicious_fingerprint,
+                suspicious_device=suspicious_device,
             ))
-        _logger.info("User %d inserts device log (%s)", user_id, session_identifier)
+            _logger.info("User %d inserts device log for session identifier %s", user_id, session_identifier)
+
+            # TODO: automatic actions if suspicious ? (send email, session logout, ...)
+            # It is necessary to have practical feedback.
 
     @api.autovacuum
     def _gc_device_log(self):
-        # Keep the last device log
+        # Keep the last device log (keep all suspicious logs)
         # (even if the session file no longer exists on the filesystem)
         self.env.cr.execute("""
             DELETE FROM res_device_log log1
@@ -123,11 +120,11 @@ class ResDeviceLog(models.Model):
                 SELECT 1 FROM res_device_log log2
                 WHERE
                     log1.session_identifier = log2.session_identifier
-                    AND log1.platform = log2.platform
-                    AND log1.browser = log2.browser
+                    AND log1.user_agent = log2.user_agent
                     AND log1.ip_address = log2.ip_address
+                    AND log1.fingerprint = log2.fingerprint
                     AND log1.last_activity < log2.last_activity
-            )
+            ) AND log1.suspicious IS NOT TRUE
         """)
         _logger.info("GC device logs delete %d entries", self.env.cr.rowcount)
 
@@ -157,12 +154,211 @@ class ResDeviceLog(models.Model):
         device_logs_to_revoke.sudo().write({'revoked': True})
 
 
+class ResDeviceLine(models.Model):
+    _name = 'res.device.line'
+    _description = 'Device'
+    _auto = False
+
+    session_identifier = fields.Char('Session identifier', readonly=True)
+    user_id = fields.Many2one('res.users', string='User', readonly=True)
+
+    user_agent = fields.Char('User Agent', readonly=True)
+    ip_address = fields.Char('IP Address', readonly=True)
+    first_activity = fields.Datetime('First Activity', readonly=True)
+    last_activity = fields.Datetime('Last Activity', readonly=True)
+    suspicious = fields.Boolean('Suspicious', readonly=True)
+    suspicious_fingerprint = fields.Boolean('Suspicious Fingerprint', readonly=True)
+    suspicious_device = fields.Boolean('Suspicious Device', readonly=True)
+
+    fingerprint = fields.Char('Fingerprint', compute='_compute_fingerprint', readonly=True)
+
+    platform = fields.Char('Platform', compute='_compute_info', readonly=True)
+    browser = fields.Char('Browser', compute='_compute_info', readonly=True)
+    browser_version = fields.Char('Browser Version', compute='_compute_info', readonly=True)
+    browser_language = fields.Char('Browser Language', compute='_compute_info', readonly=True)
+    device_type = fields.Char('Type', compute='_compute_info', readonly=True)
+    country = fields.Char('Country', compute='_compute_info', readonly=True)
+    city = fields.Char('City', compute='_compute_info', readonly=True)
+
+    def _compute_fingerprint(self):
+        device_map = {}
+        for *device_group, fingerprints in self.env['res.device.log']._read_group(
+            domain=[
+                ('session_identifier', 'in', self.mapped('session_identifier')),
+            ],
+            groupby=['user_agent', 'ip_address'],
+            aggregates=['fingerprint:array_agg'],
+        ):
+            fingerprints = set(fingerprints)
+            fingerprints.discard('')
+            device_map[tuple(device_group)] = '\n'.join(fingerprints)
+
+        for device in self:
+            device.fingerprint = device_map[device.user_agent, device.ip_address]
+
+    def _compute_info(self):
+        user_agent_parser = UserAgent._parser
+        mobile_platform = ('android', 'iphone', 'ipad', 'ipod', 'blackberry', 'windows phone', 'webos')
+
+        for device in self:
+            device.platform, device.browser, device.browser_version, device.browser_language = user_agent_parser(device.user_agent)
+            geoip = GeoIP(device.ip_address)
+            device.device_type = 'mobile' if device.platform in mobile_platform else 'computer'
+            device.country = geoip.get('country_name') or _("Unknown")
+            device.city = geoip.get('city') or _("Unknown")
+
+    @property
+    def _query(self):
+        return """
+            SELECT
+                MIN(L.id) as id,
+                L.session_identifier as session_identifier,
+                MIN(L.user_id) as user_id,
+                L.user_agent as user_agent,
+                L.ip_address as ip_address,
+                MIN(L.first_activity) as first_activity,
+                MAX(L.last_activity) as last_activity,
+                bool_or(L.suspicious) as suspicious,
+                bool_or(L.suspicious_fingerprint) as suspicious_fingerprint,
+                bool_or(L.suspicious_device) as suspicious_device
+            FROM
+                res_device_log L
+            WHERE
+                L.revoked IS NOT TRUE
+            GROUP BY
+                session_identifier,
+                user_agent,
+                ip_address
+        """
+
+    def init(self):
+        tools.drop_view_if_exists(self.env.cr, self._table)
+        self.env.cr.execute(SQL("""
+            CREATE or REPLACE VIEW %s as (%s)
+        """,
+            SQL.identifier(self._table),
+            SQL(self._query),
+        ))
+
+    @check_identity
+    def mark_as_not_suspicious(self):
+        return self._mark_as_not_suspicious()
+
+    def _mark_as_not_suspicious(self):
+        self = self.filtered('suspicious')  # noqa: PLW0642
+        if not self:
+            return
+
+        device_map = {}
+        for *device_group, device_log_ids in self.env['res.device.log']._read_group(
+            domain=[
+                ('session_identifier', 'in', self.mapped('session_identifier')),
+                ('suspicious', '=', True),
+            ],
+            groupby=['user_agent', 'ip_address'],
+            aggregates=['id:recordset'],
+        ):
+            device_map[tuple(device_group)] = device_log_ids
+
+        device_log_to_trust = self.env['res.device.log']
+        for device in self:
+            device_log_to_trust += device_map[device.user_agent, device.ip_address]
+
+        device_log_to_trust.sudo().write({'suspicious': False})
+
+
 class ResDevice(models.Model):
     _name = 'res.device'
-    _inherit = ["res.device.log"]
-    _description = "Devices"
+    _description = 'Session Device'
     _auto = False
-    _order = 'last_activity desc'
+
+    session_identifier = fields.Char('Session identifier')
+    user_id = fields.Many2one('res.users', string='User', readonly=True)
+
+    first_activity = fields.Datetime('First Activity', readonly=True)
+    last_activity = fields.Datetime('Last Activity', readonly=True)
+    suspicious = fields.Boolean('Suspicious', readonly=True)
+
+    is_current = fields.Boolean('Current', compute='_compute_is_current', readonly=True)
+
+    device_line_ids = fields.One2many('res.device.line', compute='_compute_info', readonly=True)
+    user_agent = fields.Char('User Agent', compute='_compute_info', search='_search_user_agent', readonly=True)
+    ip_address = fields.Char('IP Address', compute='_compute_info', search='_search_ip_address', readonly=True)
+    platform = fields.Char('Platform', compute='_compute_info', readonly=True)
+    browser = fields.Char('Browser', compute='_compute_info', readonly=True)
+    device_type = fields.Char('Type', compute='_compute_info', readonly=True)
+    country = fields.Char('Country', compute='_compute_info', readonly=True)
+    city = fields.Char('City', compute='_compute_info', readonly=True)
+
+    def _compute_is_current(self):
+        for device in self:
+            device.is_current = request and request.session.sid.startswith(device.session_identifier)
+
+    def _compute_info(self):
+        device_map = {}
+        for session_identifier, device_line_ids in self.env['res.device.line']._read_group(
+            domain=[('session_identifier', 'in', self.mapped('session_identifier'))],
+            groupby=['session_identifier'],
+            aggregates=['id:recordset'],
+        ):
+            device_map[session_identifier] = device_line_ids.sorted('last_activity', reverse=True)
+
+        for device in self:
+            device_line_ids = device_map[device.session_identifier]
+            device.device_line_ids = device_line_ids
+            last_device_line_id = device_line_ids[0]  # because order is `last_activity desc`
+            device.platform = last_device_line_id.platform
+            device.browser = last_device_line_id.browser
+            device.ip_address = last_device_line_id.ip_address
+            device.device_type = last_device_line_id.device_type
+            device.city = last_device_line_id.city
+            device.country = last_device_line_id.country
+
+    def _compute_display_name(self):
+        for device in self:
+            device.display_name = f"{device.platform.capitalize()} {device.browser.capitalize()}"
+
+    def _order_field_to_sql(self, alias, field_name, direction, nulls, query):
+        if field_name == 'is_current' and request and request.session:
+            return SQL("session_identifier = %s DESC", request.session.sid[:STORED_SESSION_BYTES])
+        return super()._order_field_to_sql(alias, field_name, direction, nulls, query)
+
+    def _search_user_agent(self, operator, value):
+        # Search in all device line and retrieve the session identifiers which used this User Agent
+        data = self.env['res.device.line'].search_read([('user_agent', operator, value)], ['session_identifier'])
+        session_identifiers = {dl['session_identifier'] for dl in data}
+        return [('session_identifier', 'in', session_identifiers)]
+
+    def _search_ip_address(self, operator, value):
+        # Search in all device line and retrieve the session identifiers which used this IP address
+        data = self.env['res.device.line'].search_read([('ip_address', operator, value)], ['session_identifier'])
+        session_identifiers = {dl['session_identifier'] for dl in data}
+        return [('session_identifier', 'in', session_identifiers)]
+
+    @property
+    def _query(self):
+        return """
+            SELECT
+                MIN(DL.id) as id,
+                DL.session_identifier as session_identifier,
+                MIN(DL.user_id) as user_id,
+                MIN(DL.first_activity) as first_activity,
+                MAX(DL.last_activity) as last_activity,
+                bool_or(DL.suspicious) as suspicious
+            FROM
+                res_device_line DL
+            GROUP BY
+                session_identifier
+        """
+
+    def init(self):
+        tools.drop_view_if_exists(self.env.cr, self._table)
+        self.env.cr.execute(SQL("""
+            CREATE or REPLACE VIEW %s as (%s)
+        """,
+            SQL.identifier(self._table),
+            SQL(self._query),
+        ))
 
     @check_identity
     def revoke(self):
@@ -179,45 +375,3 @@ class ResDevice(models.Model):
         must_logout = bool(self.filtered('is_current'))
         if must_logout:
             request.session.logout()
-
-    @api.model
-    def _select(self):
-        return "SELECT D.*"
-
-    @api.model
-    def _from(self):
-        return "FROM res_device_log D"
-
-    @api.model
-    def _where(self):
-        return """
-            WHERE
-                NOT EXISTS (
-                    SELECT 1
-                    FROM res_device_log D2
-                    WHERE
-                        D2.user_id = D.user_id
-                        AND D2.session_identifier = D.session_identifier
-                        AND D2.platform IS NOT DISTINCT FROM D.platform
-                        AND D2.browser IS NOT DISTINCT FROM D.browser
-                        AND (
-                            D2.last_activity > D.last_activity
-                            OR (D2.last_activity = D.last_activity AND D2.id > D.id)
-                        )
-                        AND D2.revoked IS NOT TRUE
-                )
-                AND D.revoked IS NOT TRUE
-        """
-
-    @property
-    def _query(self):
-        return "%s %s %s" % (self._select(), self._from(), self._where())
-
-    def init(self):
-        tools.drop_view_if_exists(self.env.cr, self._table)
-        self.env.cr.execute(SQL("""
-            CREATE or REPLACE VIEW %s as (%s)
-        """,
-            SQL.identifier(self._table),
-            SQL(self._query)
-        ))

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -228,14 +228,27 @@
 
         <!-- Record Rules For User Devices -->
         <record id="user_device" model="ir.rule">
-            <field name="name">Users can read only their own devices</field>
+            <field name="name">Users can read only their own session devices</field>
             <field name="model_id" ref="model_res_device"/>
             <field name="domain_force">[('user_id', '=', user.id)]</field>
             <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
         </record>
         <record id="user_device_admin" model="ir.rule">
-            <field name="name">Administrators can read all devices</field>
+            <field name="name">Administrators can read all session devices</field>
             <field name="model_id" ref="model_res_device"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
+        </record>
+
+        <record id="user_device_line" model="ir.rule">
+            <field name="name">Users can read only their own devices</field>
+            <field name="model_id" ref="model_res_device_line"/>
+            <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
+        </record>
+        <record id="user_device_line_admin" model="ir.rule">
+            <field name="name">Administrators can read all devices</field>
+            <field name="model_id" ref="model_res_device_line"/>
             <field name="domain_force">[(1, '=', 1)]</field>
             <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
         </record>

--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -143,5 +143,6 @@ access_res_users_settings_user,res.users.settings,model_res_users_settings,group
 "access_ir_profile","ir_profile","model_ir_profile","group_system",1,1,1,1
 "access_base_enable_profiling_wizard","access.base.enable.profiling.wizard","model_base_enable_profiling_wizard","group_system",1,1,1,0
 "access_res_device",access_res_device,base.model_res_device,base.group_user,1,0,0,0
+"access_res_device_line",access_res_device_line,base.model_res_device_line,base.group_user,1,0,0,0
 "access_res_device_log",access_res_device_log,base.model_res_device_log,base.group_user,1,0,0,0
 "access_properties_base_definition_group_system",access_properties_base_definition,base.model_properties_base_definition,base.group_system,1,1,1,1

--- a/odoo/addons/base/views/res_device_views.xml
+++ b/odoo/addons/base/views/res_device_views.xml
@@ -9,17 +9,25 @@
                 <form>
                     <group>
                         <group>
+                            <field name="session_identifier"/>
                             <field name="user_id"/>
-                            <field name="display_name" string="Name"/>
-                            <field name="ip_address" string="Last IP Address"/>
                         </group>
                         <group>
                             <field name="first_activity"/>
                             <field name="last_activity"/>
                         </group>
-                        <group>
-                            <field name="linked_ip_addresses"/>
-                        </group>
+                        <field name="device_line_ids" mode="list">
+                            <list decoration-danger="suspicious" decoration-success="not suspicious">
+                                <field name="platform"/>
+                                <field name="browser"/>
+                                <field name="ip_address"/>
+                                <field name="country"/>
+                                <field name="city"/>
+                                <field name="first_activity"/>
+                                <field name="last_activity"/>
+                                <button type="object" name="mark_as_not_suspicious" string="Trust" class="btn btn-secondary"/>
+                            </list>
+                        </field>
                     </group>
                 </form>
             </field>
@@ -29,14 +37,13 @@
             <field name="name">res.device.list</field>
             <field name="model">res.device</field>
             <field name="arch" type="xml">
-                <list default_order="last_activity desc">
+                <list>
+                    <!-- Not use computed fields for performance (and not `display_name`) -->
+                    <field name="session_identifier"/>
                     <field name="user_id"/>
-                    <field name="display_name" string="Name"/>
-                    <field name="ip_address"/>
                     <field name="first_activity"/>
                     <field name="last_activity"/>
-                    <field name="country" optional="hidden"/>
-                    <field name="city" optional="hidden"/>
+                    <field name="suspicious"/>
                     <button type="object" name="revoke" string="Revoke" class="btn btn-secondary"/>
                 </list>
             </field>
@@ -46,11 +53,12 @@
             <field name="name">res.device.kanban</field>
             <field name="model">res.device</field>
             <field name="arch" type="xml">
-                <kanban create="0" can_open="0" default_order="is_current desc, last_activity desc">
+                <kanban create="0" can_open="1" default_order="is_current desc, last_activity desc">
                     <field name="id"/>
                     <field name="device_type"/>
                     <field name="last_activity"/>
                     <field name="is_current"/>
+                    <field name="suspicious"/>
                     <templates>
                         <t t-name="card" class="flex-row">
                             <span t-if="record.device_type.raw_value === 'computer'" class="fa fa-laptop fs-1 col-1 mx-auto" title="Computer" role="img" aria-label="Computer"/>
@@ -59,9 +67,8 @@
                                 <div class="d-flex flex-column ms-2">
                                     <div class="d-flex align-items-center">
                                         <field name="display_name" string="Name" class="fw-bolder"/>
-                                        <t t-if="record.is_current.raw_value">
-                                            <span class="ms-2 text-success o_status o_status_green"></span>
-                                        </t>
+                                        <span t-if="record.is_current.raw_value" class="ms-2 text-success o_status o_status_green"/>
+                                        <span t-if="record.suspicious.raw_value" class="ms-2 text-danger fa fa-exclamation-circle" title="This device behaves suspiciously"/>
                                         <span t-out="luxon.DateTime.fromISO(record.last_activity.raw_value).toRelative()"
                                            class="ms-2 text-muted"/>
                                     </div>

--- a/odoo/addons/test_http/tests/test_common.py
+++ b/odoo/addons/test_http/tests/test_common.py
@@ -19,7 +19,7 @@ class TestHttpBase(HttpCaseWithUserDemo):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        geoip_resolver = MemoryGeoipResolver()
+        cls.geoip_resolver = MemoryGeoipResolver()
         session_store = MemorySessionStore(session_class=Session)
 
         reset_cached_properties(odoo.http.root)
@@ -28,8 +28,8 @@ class TestHttpBase(HttpCaseWithUserDemo):
             'server_wide_modules': ['base', 'web', 'rpc', 'test_http']
         }))
         cls.classPatch(odoo.http.Application, 'session_store', session_store)
-        cls.classPatch(odoo.http.Application, 'geoip_city_db', geoip_resolver)
-        cls.classPatch(odoo.http.Application, 'geoip_country_db', geoip_resolver)
+        cls.classPatch(odoo.http.Application, 'geoip_city_db', cls.geoip_resolver)
+        cls.classPatch(odoo.http.Application, 'geoip_country_db', cls.geoip_resolver)
 
     def setUp(self):
         super().setUp()

--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -1,5 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import functools
+import itertools
+
+from datetime import datetime, timedelta
 from freezegun import freeze_time
 from unittest.mock import patch
 
@@ -7,10 +11,10 @@ import odoo
 
 from odoo import Command
 from odoo.addons.test_http.utils import (
-    TEST_IP,
-    USER_AGENT_android_chrome,
     USER_AGENT_linux_chrome,
-    USER_AGENT_linux_firefox
+    USER_AGENT_linux_firefox,
+    TEST_IPv4_locations,
+    TEST_IPv6_locations,
 )
 from .test_common import TestHttpBase
 
@@ -21,8 +25,8 @@ class TestDevice(TestHttpBase):
         super().setUp()
 
         self.Device = self.env['res.device']
+        self.DeviceLine = self.env['res.device.line']
         self.DeviceLog = self.env['res.device.log']
-        self.DeviceLog.search([]).unlink()
 
         self.user_admin = self.env.ref('base.user_admin')
         self.user_internal = self.env['res.users'].create({
@@ -32,396 +36,141 @@ class TestDevice(TestHttpBase):
             'email': 'internal@example.com',
             'group_ids': [Command.set([self.env.ref('base.group_user').id])],
         })
+        self.user_portal = self.env['res.users'].create({
+            'login': 'portal',
+            'password': 'portal',
+            'name': 'Portal',
+            'email': 'portal@example.com',
+            'group_ids': [Command.set([self.env.ref('base.group_portal').id])],
+        })
 
-    def hit(self, time, endpoint, headers=None, ip=None):
-        if ip:
-            headers = headers or {}
-            headers = {
-                **headers,
-                'Host': '',
-                'X-Forwarded-For': ip,
-                'X-Forwarded-Host': 'odoo.com',
-                'X-Forwarded-Proto': 'https'
-            }
-        with freeze_time(time), \
-            patch.dict(odoo.tools.config.options, {'proxy_mode': bool(ip)}):
-            res = self.url_open(url=endpoint, headers=headers)
-        return res
+        self.url_public_readonly = '/test_http/greeting-public'
+        self.url_public_noreadonly = '/test_http/greeting-public?readonly=0'
+        self.url_auth_readonly = '/test_http/greeting-user'
+        self.url_auth_noreadonly = '/test_http/greeting-user?readonly=0'
 
-    def info_trace(self, trace):
-        return {
-            'elapsed_time': trace['last_activity'] - trace['first_activity'],
-            'platform': trace['platform'],
-            'browser': trace['browser'],
-            'ip_address': trace['ip_address'],
+        self.geoip_resolver.add_locations(TEST_IPv4_locations)
+        self.geoip_resolver.add_locations(TEST_IPv6_locations)
+
+        self._clean_env()
+
+    def _clean_env(self):
+        self.DeviceLog.search([]).unlink()
+
+    # --------------------
+    # HELPERS
+    # --------------------
+
+    def hit(self, session_sid, time, endpoint, headers=None, ip=None):
+        # By default: Belgium (Brussels) | Linux Chrome
+        headers = headers or {}
+        ip = ip or TEST_IPv4_locations.Belgium.Brussels
+
+        headers = {
+            **headers,
+            'Host': '',
+            'X-Forwarded-For': ip,
+            'X-Forwarded-Host': 'odoo.com',
+            'X-Forwarded-Proto': 'https',
         }
 
-    def get_devices_logs(self, user=None):
-        domain = [('user_id', '=', user.id)] if user else []
-        devices = self.Device.search(domain)
-        logs = self.DeviceLog.search([
-            ('session_identifier', 'in', devices.mapped('session_identifier')),
-            ('platform', 'in', devices.mapped('platform')),
-            ('browser', 'in', devices.mapped('browser'))
-        ])
-        return devices, logs
+        if 'User-Agent' not in headers:
+            headers['User-Agent'] = USER_AGENT_linux_chrome
+
+        with freeze_time(time), \
+            patch.dict(odoo.tools.config.options, {'proxy_mode': bool(ip)}):
+            return self.url_open(url=endpoint, headers=headers, cookies={'session_id': session_sid})
+
+    def get_trace_info(self, trace):
+        (user_agent, ip_address, _), (first_activity, last_activity) = trace
+        return {
+            'user_agent': user_agent,
+            'ip_address': ip_address,
+            'elapsed_time': last_activity - first_activity,
+        }
+
+    def get_devices(self, user=None, _with=False):
+        self.DeviceLog.flush_model()
+        self.DeviceLine.invalidate_model()
+        self.Device.invalidate_model()
+
+        if _with:
+            device_ids = self.Device.with_user(user).search([])
+            device_line_ids = device_ids.device_line_ids
+            device_log_ids = self.DeviceLog.with_user(user).search([])
+        else:
+            domain = [('user_id', '=', user.id)] if user else []
+            device_ids = self.Device.search(domain)
+            device_line_ids = device_ids.device_line_ids  # To have the order `last_activity desc`
+            device_log_ids = self.DeviceLog.search(domain)
+        return device_ids, device_line_ids, device_log_ids
+
+    def fuzz_user_url(func_test):
+
+        @functools.wraps(func_test)
+        def wrapper(self, *args, **kwars):
+            users = (self.user_admin, self.user_internal, self.user_portal)
+            urls = (self.url_public_readonly, self.url_public_noreadonly, self.url_auth_noreadonly)
+            for user, url in itertools.product(users, urls):
+                self._clean_env()
+                with self.subTest(user=user, url=url):
+                    func_test(self, user, url)
+
+        return wrapper
 
     # --------------------
     # DETECTION
     # --------------------
 
-    def test_detection_device_readonly(self):
-        session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public')
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(len(session['_trace']), 1)
-
-    def test_detection_device_no_readonly(self):
-        session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(len(session['_trace']), 1)
-
-    def test_detection_user_public(self):
-        self.authenticate(None, None)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
-
-        devices, logs = self.get_devices_logs()
-        self.assertEqual(len(devices), 0)
-        self.assertEqual(len(logs), 0)
-
-    def test_detection_device_readonly_then_no_readonly(self):
-        session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public')
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(len(session['_trace']), 1)
-
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(len(session['_trace']), 1)
-
-    def test_detection_device_according_to_time(self):
-        session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(len(session['_trace']), 1)
-        self.assertEqual(self.info_trace(session['_trace'][0])['elapsed_time'], 0)
-
-        self.hit('2024-01-01 08:30:00', '/test_http/greeting-public?readonly=0')
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(len(session['_trace']), 1)
-        self.assertEqual(self.info_trace(session['_trace'][0])['elapsed_time'], 0)  # No trace update (< 3600 sec)
-
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0')
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 2)
-        self.assertEqual(len(session['_trace']), 1)
-        self.assertEqual(self.info_trace(session['_trace'][0])['elapsed_time'], 3600)
-
-        self.hit('2024-01-01 10:00:00', '/test_http/greeting-public?readonly=0')
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 3)
-        self.assertEqual(len(session['_trace']), 1)
-        self.assertEqual(self.info_trace(session['_trace'][0])['elapsed_time'], 7200)
-
-    def test_detection_device_according_to_useragent(self):
-        session = self.authenticate(self.user_admin.login, self.user_admin.login)
-
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(len(session['_trace']), 1)
-        self.assertEqual(self.info_trace(session['_trace'][0])['platform'], 'linux')
-        self.assertEqual(self.info_trace(session['_trace'][0])['browser'], 'chrome')
-
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 2)
-        self.assertEqual(len(logs), 2)
-        self.assertEqual(len(session['_trace']), 2)
-        self.assertEqual(self.info_trace(session['_trace'][1])['platform'], 'linux')
-        self.assertEqual(self.info_trace(session['_trace'][1])['browser'], 'firefox')
-
-    def test_detection_device_according_to_ipaddress(self):
-        session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 1)
-        self.assertEqual(len(session['_trace']), 1)
-
-        self.hit('2024-01-01 08:00:01', '/test_http/greeting-public?readonly=0', ip=TEST_IP)
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 2)
-        self.assertEqual(len(session['_trace']), 2)
-        self.assertNotEqual(self.info_trace(session['_trace'][0])['ip_address'], TEST_IP)
-        self.assertEqual(self.info_trace(session['_trace'][1])['ip_address'], TEST_IP)
-
-        localized_device = devices.filtered(lambda device: device.ip_address == TEST_IP)
-        self.assertEqual(localized_device.country, 'France')
-
-    def test_detection_usurpation_sid(self):
-        session = self.authenticate(self.user_internal.login, self.user_internal.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0')
-
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'session_id': session.sid}, ip=TEST_IP)
-        devices, logs = self.get_devices_logs(self.user_internal)
-        self.assertEqual(len(devices), 1)
-        self.assertEqual(len(logs), 2)
-        self.assertEqual(len(self.user_internal.device_ids), 1)
-
-    def test_detection_devices_according_to_time_useragent(self):
-        self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.assertEqual(len(self.user_admin.device_ids), 1)
-
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.assertEqual(len(self.user_admin.device_ids), 1)
-
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
-        self.assertEqual(len(self.user_admin.device_ids), 2)
-
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
-        self.assertEqual(len(self.user_admin.device_ids), 2)
-
-    def test_detection_devices_according_to_user_or_admin(self):
-        self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0')
-        self.authenticate(self.user_internal.login, self.user_internal.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0')
-
-        devices, logs = self.get_devices_logs()
-        self.assertEqual(len(devices), 2)
-        self.assertEqual(len(logs), 4)
-        self.assertEqual(len(self.user_admin.device_ids), 1)
-        self.assertEqual(len(self.user_internal.device_ids), 1)
-
-        devices_from_admin = self.Device.with_user(self.user_admin).search([])
-        devices_from_internal = self.Device.with_user(self.user_internal).search([])
-        self.assertEqual(len(devices_from_admin), 2)
-        self.assertEqual(len(devices_from_internal), 1)
-
-    def test_differentiate_computer_and_mobile(self):
-        self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_android_chrome})
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 2)
-        self.assertEqual(len(logs), 2)
-
-        laptop_device = devices.filtered(lambda device: device.device_type == 'computer')
-        mobile_device = devices.filtered(lambda device: device.device_type == 'mobile')
-        self.assertEqual(len(laptop_device), 1)
-        self.assertEqual(len(mobile_device), 1)
-
-    def test_retrieve_linked_ip_addresses(self):
-        self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', ip='193.0.3.43')
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', ip='192.0.2.42')
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', ip='191.0.1.41')
-
-        devices, _ = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 1)
-        self.assertIn('193.0.3.43', devices.linked_ip_addresses)
-        self.assertIn('192.0.2.42', devices.linked_ip_addresses)
-        self.assertIn('191.0.1.41', devices.linked_ip_addresses)
-
-    def test_retrieve_linked_ip_addresses_according_to_devices(self):
-        self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome}, ip='193.0.3.43')
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome}, ip='192.0.2.42')
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox}, ip='191.0.1.41')
-
-        devices, _ = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 2)
-        device_chrome = devices.filtered(lambda device: device.browser == 'chrome')
-        device_firefox = devices.filtered(lambda device: device.browser == 'firefox')
-        self.assertIn('193.0.3.43', device_chrome.linked_ip_addresses)
-        self.assertIn('192.0.2.42', device_chrome.linked_ip_addresses)
-        self.assertNotIn('191.0.1.41', device_chrome.linked_ip_addresses)
-        self.assertIn('191.0.1.41', device_firefox.linked_ip_addresses)
-
-    def test_detection_no_trace_mechanism(self):
-        session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        session['_trace_disable'] = True
-        odoo.http.root.session_store.save(session)
-        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
-        self.assertEqual(res.status_code, 200)
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 0)
-        self.assertEqual(len(logs), 0)
-
-    def test_detection_device_default_order(self):
-        self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.hit('2024-01-01 10:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public?readonly=0', headers={'User-Agent': USER_AGENT_android_chrome})
-        devices, _ = self.get_devices_logs(self.user_admin)
-        self.assertEqual(
-            list(zip(devices.mapped('platform'), devices.mapped('browser'))),
-            [('linux', 'firefox'), ('android', 'chrome'), ('linux', 'chrome')],
-            "By default, devices should be found from the most recent to the least recent (according to their last activity)."
-        )
-
-    # --------------------
-    # DELETION
-    # --------------------
-
-    def test_deletion_device(self):
-        """
-            A user is authenticated and the administrator
-            wants to block his device (and therefore its session).
-        """
-        self.authenticate(self.user_internal.login, self.user_internal.login)
-        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0')
-        self.assertNotIn('/web/login', res.url)
-
-        user_internal_device = self.user_internal.device_ids
-        self.assertEqual(len(user_internal_device), 1)
-        self.assertEqual(user_internal_device.revoked, False)
-
-        user_internal_device._revoke()
-
-        res = self.hit('2024-01-01 08:00:01', '/test_http/greeting-user?readonly=0')
-        self.assertIn('/web/login', res.url)
-
-    def test_deletion_invalidate_sid(self):
-        session = self.authenticate(self.user_internal.login, self.user_internal.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0')
-
-        self.user_internal.device_ids._revoke()
-
-        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'session_id': session.sid})
-        self.assertIn('/web/login', res.url)
-
-    def test_deletion_specific_device(self):
-        self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.authenticate(self.user_admin.login, self.user_admin.login)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.hit('2024-01-01 09:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_chrome})
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 3)
-        self.assertEqual(len(logs), 5)
-        self.assertEqual(len(self.user_admin.device_ids), 3)
-
-        self.user_admin.device_ids.filtered(lambda device: 'firefox' in device.browser)._revoke()
-
-        res = self.hit('2024-01-01 08:00:30', '/test_http/greeting-user?readonly=0', headers={'User-Agent': USER_AGENT_linux_firefox})
-        self.assertIn('/web/login', res.url)
-
-    # --------------------
-    # FILESYSTEM REFLEXION
-    # --------------------
-
-    def _create_device_log_for_user(self, session, count):
-        for _ in range(count):
-            self.DeviceLog.create({
-                'session_identifier': odoo.http.root.session_store.generate_key(),
-                'user_id': session.uid,
-                'revoked': False,
-            })
-
-    def test_filesystem_reflexion_user(self):
-        session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self._create_device_log_for_user(session, 10)
-        session = self.authenticate(self.user_internal.login, self.user_internal.login)
-        self._create_device_log_for_user(session, 10)
-
-        devices, logs = self.get_devices_logs(self.user_internal)
-        self.assertEqual(len(devices), 10)
-        self.assertEqual(len(logs), 10)
-        self.assertEqual(len(self.user_internal.device_ids), 10)
-
-        self.DeviceLog.with_user(self.user_internal)._ResDeviceLog__update_revoked()
-        self.DeviceLog.flush_model()  # Because write on ``res.device.log`` and so we have new values in cache
-        self.Device.invalidate_model()  # Because it depends on the ``res.device.log`` model (updated in database)
-
-        devices, _ = self.get_devices_logs(self.user_internal)
-        self.assertEqual(len(devices), 0)  # No file exist on the filesystem (``revoked`` equals to ``False``)
-        self.assertEqual(len(self.user_internal.device_ids), 0)
-
-        # Admin device logs are not updated
-        devices, _ = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 10)
-        self.assertEqual(len(self.user_admin.device_ids), 10)
-
-    def test_filesystem_reflexion_admin(self):
-        session = self.authenticate(self.user_admin.login, self.user_admin.login)
-        self._create_device_log_for_user(session, 10)
-
-        devices, logs = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 10)
-        self.assertEqual(len(logs), 10)
-        self.assertEqual(len(self.user_admin.device_ids), 10)
-
-        session = self.authenticate(self.user_internal.login, self.user_internal.login)
-        self._create_device_log_for_user(session, 10)
-
-        devices, logs = self.get_devices_logs(self.user_internal)
-        self.assertEqual(len(devices), 10)
-        self.assertEqual(len(logs), 10)
-        self.assertEqual(len(self.user_internal.device_ids), 10)
-
-        # Admin can update all device logs
-        self.DeviceLog.with_user(self.user_admin)._ResDeviceLog__update_revoked()
-        self.DeviceLog.flush_model()
-        self.Device.invalidate_model()
-
-        devices, _ = self.get_devices_logs(self.user_admin)
-        self.assertEqual(len(devices), 0)
-        self.assertEqual(len(self.user_admin.device_ids), 0)
-
-        devices, _ = self.get_devices_logs(self.user_internal)
-        self.assertEqual(len(devices), 0)
-        self.assertEqual(len(self.user_internal.device_ids), 0)
-
-    # --------------------
-    # SPECIFIC USE CASE
-    # --------------------
-
-    def test_specific_public_user_write(self):
-        """
-            A public user who hits a non-readonly route
-            does not have to create a session file if there
-            are no changes in the session itself.
-        """
+    @fuzz_user_url
+    def test_detection_session_auth(self, user, url):
+        session1 = self.authenticate(user.login, user.login)
+        time1 = datetime(2025, 1, 1, 8, 0, 0)
+
+        self.hit(session1.sid, time1, url)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (1, 1, 1))
+        self.assertEqual(len(session1['_trace']), 1)
+        self.assertEqual(self.get_trace_info(next(iter(session1['_trace'].values())))['elapsed_time'], 0)
+
+        self.hit(session1.sid, time1 + timedelta(minutes=30), url)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (1, 1, 1), 'Below the activity update frequency')
+        self.assertEqual(len(session1['_trace']), 1)
+        self.assertEqual(self.get_trace_info(next(iter(session1['_trace'].values())))['elapsed_time'], 0)
+
+        self.hit(session1.sid, time1 + timedelta(hours=1), url)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (2, 1, 1))
+        self.assertEqual(len(session1['_trace']), 1)
+        self.assertEqual(self.get_trace_info(next(iter(session1['_trace'].values())))['elapsed_time'], timedelta(hours=1).seconds)
+
+        self.hit(session1.sid, time1 + timedelta(hours=2), url)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (3, 1, 1))
+        self.assertEqual(len(session1['_trace']), 1)
+        self.assertEqual(self.get_trace_info(next(iter(session1['_trace'].values())))['elapsed_time'], timedelta(hours=2).seconds)
+
+        session2 = self.authenticate(user.login, user.login)
+        time2 = datetime(2025, 1, 1, 10, 0, 0)
+
+        self.hit(session2.sid, time2, url)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (4, 2, 2))
+        self.assertEqual(len(session2['_trace']), 1)
+        self.assertEqual(self.get_trace_info(next(iter(session2['_trace'].values())))['elapsed_time'], 0)
+
+        self.hit(session1.sid, time2 + timedelta(hours=1), url)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (5, 2, 2))
+        self.assertEqual(len(session2['_trace']), 1)
+        self.assertEqual(self.get_trace_info(next(iter(session2['_trace'].values())))['elapsed_time'], timedelta(hours=1).seconds)
+
+    def test_detection_session_public(self):
         session = self.authenticate(None, None)
-        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public?readonly=0')
+
+        time = datetime(2025, 1, 1, 8, 0, 0)
+        self.hit(session.sid, time, self.url_public_readonly)
 
         # As we don't have a uid in the session, we shouldn't go through
         # the session check and therefore we won't go through the device update.
@@ -430,4 +179,298 @@ class TestDevice(TestHttpBase):
         # we can check that there is no `_trace`.
         # This means that the device logic will not create a session file
         # (because we are not passing in the `_update_device` logic).
-        self.assertFalse(session['_trace'])
+        self.assertEqual(len(session['_trace']), 0)
+        self.assertFalse(session.is_dirty)
+
+    @fuzz_user_url
+    def test_detection_device_auth(self, user, url):
+        # Different devices for a session is suspicious
+        session = self.authenticate(user.login, user.login)
+        time = datetime(2025, 1, 1, 8, 0, 0)
+
+        self.hit(session.sid, time + timedelta(minutes=1), url,
+            headers={'User-Agent': USER_AGENT_linux_chrome}, ip=TEST_IPv4_locations.Belgium.Brussels)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (1, 1, 1))
+        self.assertEqual(len(session['_trace']), 1)
+        self.assertFalse(devices[0].suspicious)
+        self.assertFalse(device_lines[0].suspicious)
+        self.assertFalse(device_lines[0].suspicious_device)
+
+        self.hit(session.sid, time + timedelta(minutes=2), url,
+            headers={'User-Agent': USER_AGENT_linux_firefox}, ip=TEST_IPv4_locations.Belgium.Brussels)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (2, 2, 1))
+        self.assertEqual(len(session['_trace']), 2)
+        self.assertTrue(devices[0].suspicious, 'A User Agent is suspicious')
+        self.assertTrue(device_lines[0].suspicious)
+        self.assertTrue(device_lines[0].suspicious_device)
+
+        self.hit(session.sid, time + timedelta(minutes=3), url,
+            headers={'User-Agent': USER_AGENT_linux_chrome}, ip=TEST_IPv4_locations.France.Paris)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (3, 3, 1))
+        self.assertEqual(len(session['_trace']), 3)
+        self.assertTrue(devices[0].suspicious, 'An IP address is suspicious')
+        self.assertTrue(device_lines[0].suspicious)
+        self.assertTrue(device_lines[0].suspicious_device)
+
+    @fuzz_user_url
+    def test_detection_device_validity_period_auth(self, user, url):
+        session = self.authenticate(user.login, user.login)
+        time = datetime(2025, 1, 1, 8, 0, 0)
+
+        self.hit(session.sid, time + timedelta(minutes=1), url,
+            headers={'User-Agent': USER_AGENT_linux_chrome}, ip=TEST_IPv4_locations.Belgium.Brussels)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (1, 1, 1))
+
+        self.hit(session.sid, time + timedelta(minutes=1), url,
+            headers={'User-Agent': USER_AGENT_linux_chrome}, ip=TEST_IPv4_locations.France.Paris)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (2, 2, 1))
+
+        # Mark it as no suspicious
+        self.assertTrue(devices[0].suspicious)
+
+        suspicious_device = device_lines.filtered('suspicious')
+        suspicious_device._mark_as_not_suspicious()
+        self.DeviceLog.flush_model()
+        self.DeviceLine.invalidate_model()
+        self.Device.invalidate_model()
+
+        self.assertFalse(devices[0].suspicious)
+
+        time2 = time + timedelta(days=15)
+
+        self.hit(session.sid, time2, url,
+            headers={'User-Agent': USER_AGENT_linux_chrome}, ip=TEST_IPv4_locations.Belgium.Brussels)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (3, 2, 1))
+
+        self.hit(session.sid, time2, url,
+            headers={'User-Agent': USER_AGENT_linux_chrome}, ip=TEST_IPv4_locations.France.Paris)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (4, 2, 1))
+
+        self.assertFalse(devices[0].suspicious)
+
+        time3 = time2 + timedelta(days=31)
+
+        self.hit(session.sid, time3, url,
+            headers={'User-Agent': USER_AGENT_linux_chrome}, ip=TEST_IPv4_locations.France.Paris)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (5, 2, 1))
+
+        self.assertTrue(devices[0].suspicious, 'The device is suspicious because the validity is 30 days.')
+
+    @fuzz_user_url
+    def test_detection_no_trace_mechanism(self, user, url):
+        session = self.authenticate(user.login, user.login)
+        session['_trace_disable'] = True
+        odoo.http.root.session_store.save(session)
+
+        time = datetime(2025, 1, 1, 8, 0, 0)
+        for hour in range(1, 5):
+            self.hit(session.sid, time + timedelta(hours=hour), url, ip=TEST_IPv4_locations.Belgium.Brussels)
+
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (0, 0, 0), 'No log should be inserted.')
+
+        self.hit(session.sid, time + timedelta(hours=hour + 1), url, ip=TEST_IPv4_locations.France.Paris)
+
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (1, 1, 1), 'A log should be inserted because is suspicious.')
+
+        self.hit(session.sid, time + timedelta(hours=hour + 2), url, ip=TEST_IPv4_locations.France.Paris)
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (1, 1, 1), 'No log should be inserted because we match a trace history.')
+
+    def test_detection_devices_according_to_user_or_admin(self):
+        time = datetime(2025, 1, 1, 8, 0, 0)
+
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+        for hour in range(1, 6):
+            self.hit(session.sid, time + timedelta(hours=hour), self.url_public_noreadonly)
+
+        session = self.authenticate(self.user_internal.login, self.user_internal.login)
+        for hour in range(1, 6):
+            self.hit(session.sid, time + timedelta(hours=hour), self.url_public_noreadonly)
+
+        devices, device_lines, logs = self.get_devices()
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (10, 2, 2))
+
+        devices, device_lines, logs = self.get_devices(self.user_admin, _with=True)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (10, 2, 2))
+
+        devices, device_lines, logs = self.get_devices(self.user_internal, _with=True)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (5, 1, 1))
+
+    # --------------------
+    # GARBAGE COLLECTOR
+    # --------------------
+
+    @fuzz_user_url
+    def test_garbage_collector_log(self, user, url):
+        session = self.authenticate(user.login, user.login)
+        time = datetime(2025, 1, 1, 8, 0, 0)
+
+        self.hit(session.sid, time, url)
+        for hour in range(1, 10):
+            self.hit(session.sid, time + timedelta(hours=hour), url)
+
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (10, 1, 1))
+        first_activity = devices[0].first_activity
+        last_activity = devices[0].last_activity
+
+        self.DeviceLog._gc_device_log()
+        self.DeviceLog.flush_model()
+        self.DeviceLine.invalidate_model()
+        self.Device.invalidate_model()
+
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (1, 1, 1))
+        # Check we conserve session information after GC
+        self.assertEqual(devices[0].first_activity, first_activity)
+        self.assertEqual(devices[0].last_activity, last_activity)
+
+    @fuzz_user_url
+    def test_garbage_collector_conserve_suspicious_log(self, user, url):
+        session = self.authenticate(user.login, user.login)
+        time = datetime(2025, 1, 1, 8, 0, 0)
+
+        self.hit(session.sid, time, url, ip=TEST_IPv4_locations.Belgium.Brussels)
+        for hour in range(1, 5):
+            self.hit(session.sid, time + timedelta(hours=hour), url, ip=TEST_IPv4_locations.Belgium.Brussels)
+        self.hit(session.sid, time + timedelta(hours=hour), url, ip=TEST_IPv4_locations.France.Paris)
+        for hour in range(5, 9):
+            self.hit(session.sid, time + timedelta(hours=hour), url, ip=TEST_IPv4_locations.Belgium.Brussels)
+
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (10, 2, 1))
+        self.assertTrue(devices[0].suspicious)
+        first_activity = devices[0].first_activity
+        last_activity = devices[0].last_activity
+
+        self.DeviceLog._gc_device_log()
+        self.DeviceLog.flush_model()
+        self.DeviceLine.invalidate_model()
+        self.Device.invalidate_model()
+
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (2, 2, 1))
+        # Check we conserve session information after GC
+        self.assertTrue(devices[0].suspicious)
+        self.assertEqual(devices[0].first_activity, first_activity)
+        self.assertEqual(devices[0].last_activity, last_activity)
+
+    # --------------------
+    # DELETION
+    # --------------------
+
+    def test_deletion_session(self):
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+        time = datetime(2025, 1, 1, 8, 0, 0)
+
+        res = self.hit(session.sid, time, self.url_auth_noreadonly)
+        self.assertNotIn('/web/login', res.url)
+
+        self.user_admin.device_ids._revoke()
+
+        res = self.hit(session.sid, time, self.url_auth_noreadonly)
+        self.assertIn('/web/login', res.url, 'We must be redirected to the login page because the session has been deleted.')
+
+    # --------------------
+    # FILESYSTEM REFLEXION
+    # --------------------
+
+    def _create_device_log_for_user(self, session, count):
+        now = int(datetime.now().timestamp())
+        for _ in range(count):
+            self.DeviceLog.create({
+                'session_identifier': odoo.http.root.session_store.generate_key(),
+                'user_id': session.uid,
+                'user_agent': '',
+                'ip_address': '',
+                'fingerprint': '',
+                'first_activity': datetime.fromtimestamp(now),
+                'last_activity': datetime.fromtimestamp(now),
+                'revoked': False,
+            })
+
+    @fuzz_user_url
+    def test_filesystem_reflexion(self, user, url):
+        session = self.authenticate(user.login, user.login)
+        self._create_device_log_for_user(session, 10)
+
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (10, 10, 10))
+
+        self.DeviceLog._ResDeviceLog__update_revoked()
+
+        devices, device_lines, logs = self.get_devices(user)
+        self.assertEqual((len(logs), len(device_lines), len(devices)), (10, 0, 0), 'Logs still exist but are no longer used')
+
+    # --------------------
+    # UNTRUSTED LOCATIONS
+    # --------------------
+
+    @fuzz_user_url
+    def test_untrusted_location_device_ipv4(self, user, url):
+        session = self.authenticate(user.login, user.login)
+
+        time = datetime(2025, 1, 1, 8, 0, 0)
+
+        self.hit(session.sid, time, url, ip=TEST_IPv4_locations.Belgium.Bruges)
+        self.hit(session.sid, time, url, ip=TEST_IPv4_locations.France.Paris)  # suspicious
+
+        _, _, logs = self.get_devices(user)
+        self.assertEqual(len(logs.filtered('suspicious')), 1)
+
+        self.hit(session.sid, time, url, ip=TEST_IPv4_locations.United_Kingdom.London)  # suspicious
+
+        _, _, logs = self.get_devices(user)
+        self.assertEqual(len(logs.filtered('suspicious')), 2)
+
+        self.hit(session.sid, time + timedelta(days=15), url, ip=TEST_IPv4_locations.Belgium.Bruges)
+        self.hit(session.sid, time + timedelta(days=15), url, ip=TEST_IPv4_locations.United_Kingdom.London)
+
+        _, _, logs = self.get_devices(user)
+        self.assertEqual(len(logs.filtered('suspicious')), 2)
+
+        self.hit(session.sid, time + timedelta(days=15 + 31), url, ip=TEST_IPv4_locations.United_Kingdom.London)  # suspicious
+
+        _, _, logs = self.get_devices(user)
+        self.assertEqual(len(logs.filtered('suspicious')), 3)
+
+        self.hit(session.sid, time + timedelta(days=30), url, ip=TEST_IPv4_locations.Italy.Rome)  # suspicious
+
+        _, _, logs = self.get_devices(user)
+        self.assertEqual(len(logs.filtered('suspicious')), 4)
+
+    @fuzz_user_url
+    def test_untrusted_location_device_ipv6(self, user, url):
+        session = self.authenticate(user.login, user.login)
+
+        time = datetime(2025, 1, 1, 8, 0, 0)
+
+        self.hit(session.sid, time, url, ip=TEST_IPv6_locations.Belgium.Bruges)
+        self.hit(session.sid, time, url, ip=TEST_IPv6_locations.France.Paris)  # suspicious
+
+        _, _, logs = self.get_devices(user)
+        self.assertEqual(len(logs.filtered('suspicious')), 1)
+
+        self.hit(session.sid, time, url, ip=TEST_IPv6_locations.United_Kingdom.London)  # suspicious
+
+        _, _, logs = self.get_devices(user)
+        self.assertEqual(len(logs.filtered('suspicious')), 2)
+
+        self.hit(session.sid, time + timedelta(days=15), url, ip=TEST_IPv6_locations.Belgium.Bruges)
+        self.hit(session.sid, time + timedelta(days=15), url, ip=TEST_IPv6_locations.United_Kingdom.London)
+
+        # Trust ipv6 on the same network
+        self.hit(session.sid, time + timedelta(days=30), url, ip=TEST_IPv6_locations.Netherlands.Rotterdam)
+
+        _, _, logs = self.get_devices(user)
+        self.assertEqual(len(logs.filtered('suspicious')), 2)

--- a/odoo/addons/test_http/utils.py
+++ b/odoo/addons/test_http/utils.py
@@ -3,6 +3,7 @@
 import geoip2.errors
 import geoip2.models
 from html.parser import HTMLParser
+from types import SimpleNamespace
 from odoo.http import FilesystemSessionStore
 from odoo.tools._vendor.sessions import SessionStore
 
@@ -24,6 +25,49 @@ TEST_IP_GEOIP_COUNTRY = geoip2.models.Country(
      'traits': {'ip_address': TEST_IP, 'prefix_len': 21},
     }, ['en']
 )
+
+
+class Location(dict):
+    """Wrapper around a location dictionary for easy access to IP addresses."""
+
+    def __getattr__(self, name):
+        city_location = SimpleNamespace()
+        for ip, (country, city, *_) in self.items():
+            if country == name:
+                setattr(city_location, city, ip)
+        if not city_location.__dict__:
+            raise AttributeError(f"'Location' object has no attribute '{name}'")
+        return city_location
+
+
+TEST_IPv4_locations = Location({
+    # IP: (Country, Latitude, Longitude, Accuracy radius [km])
+    '192.0.1.1': ('Belgium', 'Bruges', 51.2608836, 3.0573057, 100),
+    '192.0.1.2': ('Belgium', 'Antwerpen', 51.2605815, 4.1929726, 100),
+    '192.0.1.3': ('Belgium', 'Brussels', 50.8552021, 4.2930167, 100),
+    '192.0.2.1': ('Netherlands', 'Rotterdam', 51.9280632, 4.4084283, 100),
+    '192.0.3.1': ('Germany', 'Frankfurt', 50.1213155, 8.4717592, 100),
+    '192.0.4.1': ('France', 'Toulouse', 43.600798, 1.3504423, 100),
+    '192.0.4.2': ('France', 'Paris', 48.8589384, 2.264635, 100),
+    '192.0.5.1': ('Luxembourg', 'Rambrouch', 49.8398831, 5.7814468, 100),
+    '192.0.6.1': ('United_Kingdom', 'London', 51.5287398, -0.266403, 100),
+    '192.0.7.1': ('Italy', 'Rome', 41.9102088, 12.3711918, 100),
+})
+
+TEST_IPv6_locations = Location({
+    # IP: (Country, Latitude, Longitude, Accuracy radius [km])
+    'fe80:0000:0000:0001:abcd:1234:5678:9abc': ('Belgium', 'Bruges', 51.2608836, 3.0573057, 10),
+    'fe80:0000:0000:0001:bcde:2345:6789:abcd': ('Belgium', 'Antwerpen', 51.2605815, 4.1929726, 10),
+    'fe80:0000:0000:0001:cdef:3456:789a:bcde': ('Belgium', 'Brussels', 50.8552021, 4.2930167, 10),
+    'fe80:0000:0000:0001:def1:4567:89ab:cdef': ('Netherlands', 'Rotterdam', 51.9280632, 4.4084283, 10),
+    'fe80:0000:0000:0002:abcd:1234:5678:9abc': ('Germany', 'Frankfurt', 50.1213155, 8.4717592, 10),
+    'fe80:0000:0000:0003:abcd:1234:5678:9abc': ('France', 'Toulouse', 43.600798, 1.3504423, 10),
+    'fe80:0000:0000:0003:bcde:2345:6789:abcd': ('France', 'Paris', 48.8589384, 2.264635, 10),
+    'fe80:0000:0000:0004:abcd:1234:5678:9abc': ('Luxembourg', 'Rambrouch', 49.8398831, 5.7814468, 10),
+    'fe80:0000:0000:0005:abcd:1234:5678:9abc': ('United_Kingdom', 'London', 51.5287398, -0.266403, 10),
+    'fe80:0000:0000:0006:abcd:1234:5678:9abc': ('Italy', 'Rome', 41.9102088, 12.3711918, 10),
+})
+
 USER_AGENT_linux_chrome = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36'
 USER_AGENT_linux_firefox = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0'
 USER_AGENT_android_chrome = 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Mobile Safari/537.36'
@@ -33,6 +77,14 @@ class MemoryGeoipResolver:
     def __init__(self):
         self.country_db = {TEST_IP: TEST_IP_GEOIP_COUNTRY}
         self.city_db = {TEST_IP: TEST_IP_GEOIP_CITY}
+
+    def add_locations(self, locations):
+        for ip, (country, city, latitude, longitude, accuracy_radius) in locations.items():
+            self.city_db[ip] = geoip2.models.City({
+                'country': {'names': {'en': country}},
+                'city': {'names': {'en': city}},
+                'location': {'latitude': latitude, 'longitude': longitude, 'accuracy_radius': accuracy_radius},
+            }, ['en'])
 
     def country(self, ip):
         record = self.country_db.get(ip)


### PR DESCRIPTION
Objective:
----------
Use request information to detect certain types of malicious
behavior and help prevent incidents.
Users should be warned when suspicious behavior is detected,
without blocking their workflow.

Solution:
---------
Maintain two types of information in the session:
`_trace` and `_fingerprint`.
These are extracted from the HTTP request.

Trace:
The `_trace` data structure passively stores device information
using the user agent, IP address, and activity time.
It is possible to determine whether a new trace matches previously
stored traces in the session.

Fingerprint:
This is a string uniquely identifying a device generated from canvas rendering.
It is sent with RPC.
This allows detection of whether a session is being used across
multiple devices.

Thus, we have two ways to detect suspicious behavior:
passive (trace) and active (fingerprint).

It is possible to take action upon detection of suspicious activity by
overriding the `_alert_untrusted_device_in_session` method on
the `res.users` model.

If the `ir.config_parameter` named `auth_signup.alert_untrusted_device_in_session`
is set, a warning email will be sent.

If an unexpected fingerprint is encountered, the user is logged out.

task-4281529