### PR TITLE
[FIX] im_livechat: fix session form view embeds thread

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
@@ -3,22 +3,6 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("im_livechat_session_history_open", {
     steps: () => [
         {
-            trigger: "body:has(.o_action_manager)",
-            run: "click && press ctrl+k",
-        },
-        {
-            trigger: ".o_command_palette_search input",
-            run: "fill /",
-        },
-        {
-            trigger: ".o_command_palette_search input",
-            run: "fill Sessions",
-        },
-        {
-            trigger: ".o_command:contains(Live Chat / Sessions)",
-            run: "click",
-        },
-        {
             trigger: ".o_switch_view[data-tooltip='List']",
             run: "click",
         },

--- a/addons/im_livechat/tests/test_session_history_open.py
+++ b/addons/im_livechat/tests/test_session_history_open.py
@@ -14,18 +14,24 @@ class TestImLivechatSessionHistoryOpen(TestImLivechatCommon):
             [{
                 "name": "test 1",
                 "channel_type": "livechat",
-                "livechat_channel_id": 1,
+                "livechat_channel_id": self.livechat_channel.id,
                 "livechat_operator_id": operator.partner_id.id,
                 "channel_member_ids": [Command.create({"partner_id": user_1.id})],
             },
             {
                 "name": "test 2",
                 "channel_type": "livechat",
-                "livechat_channel_id": 1,
+                "livechat_channel_id": self.livechat_channel.id,
                 "livechat_operator_id": operator.partner_id.id,
                 "channel_member_ids": [Command.create({"partner_id": user_2.id})],
             }]
         )
         channel1.message_post(body="Test Channel 1 Msg", message_type="comment", subtype_xmlid="mail.mt_comment")
         channel2.message_post(body="Test Channel 2 Msg", message_type="comment", subtype_xmlid="mail.mt_comment")
-        self.start_tour("/web", "im_livechat_session_history_open", login="operator", step_delay=25)
+        action = self.env.ref("im_livechat.discuss_channel_action_from_livechat_channel")
+        self.start_tour(
+            f"/odoo/livechat/{self.livechat_channel.id}/action-{action.id}",
+            "im_livechat_session_history_open",
+            login="operator",
+            step_delay=25,
+        )


### PR DESCRIPTION
The `test_session_history_open`, in later versions renamed `test_form_view_embed_thread`, ensures that clicking on a live chat session in the list view opens the thread, not the default form view.

To do so, we first access the `/web` url, then open the command palette, and finally find the correct live chat view. However, such tests are known to be non-deterministic as the command palette is not always available at the start of the tour.

Several live chat tours have been updated to directly access the view, providing the correct URL to `start_tour`: command palette part of the tour is meaningless.

fixes runbot-161482

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
