### PR TITLE
[FIX] payment_stripe: proceed google pay express checkout when no free delivery

### DIFF
--- a/addons/payment_stripe/static/src/js/express_checkout_form.js
+++ b/addons/payment_stripe/static/src/js/express_checkout_form.js
@@ -186,7 +186,7 @@ paymentExpressCheckoutForm.include({
                             detail: carrier.description ? carrier.description:"",
                             amount: carrier.minorAmount,
                         })),
-                        ...this._getOrderDetails(availableCarriers[0].minorAmount),
+                        ...this._getOrderDetails(availableCarriers[0].minorAmount, 0),
                     });
                 }
             });


### PR DESCRIPTION
## Version
16.0

## Issue
Google Pay express checkout form runs out of time.

## Steps to reproduce
*Requires Chrome with a payment method set up in the browser profile.*
Ensure an eCommerce website is set up.
- Go to "Shipping Methods":
  - Depublish all shipping method;
  - Create a new shipping method with fixed price:
    - Set its fixed price to $10;
    - Leave “Free if order amount is above” box unchecked.
- Go to "Payment Providers":
  - Install Stripe;
  - Set up test credentials ("Publishable Key", "Secret Key" AND generate a webhook);
  - Enable (test mode) and publish the Stripe.
- Log out and open the shop:
  - Add any product to the cart then go to the cart;
  - Click the “Buy with GPay” button (*you may need to manually select an address*).
  - Wait for the process to run out of time.

## Cause
When `shippingaddresschange` (https://github.com/odoo/odoo/blob/9ab62328ee0b119ccc342b3a5c9de856e827c9c7/addons/payment_stripe/static/src/js/express_checkout_form.js#L166-L192)  is triggered, Odoo provides a carrier option with a `minorAmount` set to the shipping price.
Because the shipping method's “Free if order amount is above” is not checked, there is no `free_shipping_lines` (https://github.com/odoo/odoo/blob/9ab62328ee0b119ccc342b3a5c9de856e827c9c7/addons/website_sale_loyalty_delivery/controllers/main.py#L24-L41). 
In this case, the browse does not trigger `shippingoptionchange` (https://github.com/odoo/odoo/blob/9ab62328ee0b119ccc342b3a5c9de856e827c9c7/addons/payment_stripe/static/src/js/express_checkout_form.js#L195-L209) because there is no conditional free shipping to re-evaluate.  
As a result, `_getOrderDetails` is called without a second argument (https://github.com/odoo/odoo/blob/9ab62328ee0b119ccc342b3a5c9de856e827c9c7/addons/payment_stripe/static/src/js/express_checkout_form.js#L189), `amountFreeShipping` remains `undefined`, and the total calculation includes an `undefined` variable.

When the “Free if order amount is above” box is checked, provides a carrier option with a `minorAmount` set to 0 which makes the browser automatically change the option and trigger `shippingoptionchange` ([W3C doc](https://www.w3.org/TR/payment-request/#dom-paymentdetailsbase-shippingoptions)). `_getOrderDetails` is then called with a valid second argument (https://github.com/odoo/odoo/blob/9ab62328ee0b119ccc342b3a5c9de856e827c9c7/addons/payment_stripe/static/src/js/express_checkout_form.js#L204-L207), and the total remains numeric.


opw-4967415