### PR TITLE
[FIX] website_sale: translate checkout steps

### DIFF
--- a/addons/website_sale/models/__init__.py
+++ b/addons/website_sale/models/__init__.py
@@ -5,6 +5,7 @@ from . import crm_team
 from . import delivery_carrier
 from . import digest
 from . import ir_http
+from . import ir_module_module
 from . import payment_token
 from . import product_attribute
 from . import product_document

--- a/addons/website_sale/models/ir_module_module.py
+++ b/addons/website_sale/models/ir_module_module.py
@@ -1,0 +1,61 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+from odoo.tools import SQL, split_every
+
+
+class IrModuleModule(models.Model):
+    _inherit = 'ir.module.module'
+
+    @api.model
+    def _load_module_terms(self, modules, langs, overwrite=False, imported_module=False):
+        # Add missing website_sale-specific translations
+
+        super()._load_module_terms(
+            modules, langs, overwrite=overwrite, imported_module=imported_module,
+        )
+
+        to_langs = [lang for lang in langs if lang != 'en_US']
+        if not (to_langs and modules):
+            return  # nothing to translate
+
+        def set_field(fname):
+            lang_items = (
+                SQL('%(lang)s, o_step.%(fname)s->>%(lang)s', lang=lang, fname=fname)
+                for lang in to_langs
+            )
+            # PSQL functions take 100 args max, and we're generating 2 per lang
+            batched_lang_items = split_every(50, lang_items)
+            update_jsonb = SQL(' || ').join(
+                SQL('jsonb_build_object(%s)', SQL(', ').join(batch))
+                for batch in batched_lang_items
+            )
+            ordered = reversed if overwrite else iter
+            src = SQL(' || ').join(ordered([
+                SQL('jsonb_strip_nulls(%s)', update_jsonb),  # gets updated translation
+                SQL('jsonb_strip_nulls(step.%s)', fname),  # keeps current translation
+            ]))
+            return SQL('%(fname)s = %(src)s', fname=fname, src=src)
+
+        WebsiteCheckoutStep = self.env['website.checkout.step']
+        to_translate = [
+            SQL.identifier(field.name)
+            for field in WebsiteCheckoutStep._fields.values()
+            if field.translate is True  # more correct in case of `callable(field.translate)`
+        ]
+        set_fields = SQL(', ').join(set_field(fname) for fname in to_translate)
+
+        WebsiteCheckoutStep.invalidate_model()
+        self.env.cr.execute(SQL(
+            '''
+            UPDATE website_checkout_step step
+               SET %(set_fields)s
+              FROM website_checkout_step o_step
+              JOIN website_checkout_step s_step
+                ON o_step.step_href = s_step.step_href
+             WHERE o_step.website_id IS NULL
+               AND s_step.website_id IS NOT NULL
+               AND step.id = s_step.id
+            ''',
+            set_fields=set_fields,
+        ))

--- a/addons/website_sale/tests/test_website_sale_checkout_steps.py
+++ b/addons/website_sale/tests/test_website_sale_checkout_steps.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from odoo.tests import tagged
+
 from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
 
 
@@ -30,3 +32,55 @@ class TestWebsiteSaleCheckoutSteps(WebsiteSaleCommon):
         my_settings.execute()
         self.assertEqual(extra_step.is_published, False)
         self.assertEqual(extra_step_view.active, False)
+
+    def test_translate_checkout_steps(self):
+        """Verify that loading languages correctly translates website-specific steps."""
+        CheckoutStep = self.env['website.checkout.step']
+        IrModuleModule = self.env['ir.module.module']
+
+        if self.env['website'].search_count([]) == 1:
+            self.env['website'].create({'name': "My Website 2"})
+
+        default_payment_step = self.env.ref('website_sale.checkout_step_payment')
+        default_payment_step_FR = default_payment_step.with_context(lang='fr_FR')
+        website_1_step_FR, website_2_step_FR = CheckoutStep.with_context(lang='fr_FR').search([
+            ('website_id', '!=', False),
+            ('step_href', '=', default_payment_step.step_href),
+        ], limit=2)
+
+        # Activate French
+        if not (lang_fr := self.env.ref('base.lang_fr')).active:
+            lang_fr.active = True
+        for fname, field in CheckoutStep._fields.items():
+            if field.translate and default_payment_step[fname]:
+                default_payment_step_FR[fname] = f"{default_payment_step[fname]} (FR)"
+
+        # Have a different translation for a specific website
+        website_1_step_FR.name = "Pay in French"
+
+        # Load translations without overwrite
+        IrModuleModule._load_module_terms(['website_sale'], ['fr_FR'])
+        CheckoutStep.invalidate_model(['name'])
+        self.assertEqual(
+            website_1_step_FR.name, "Pay in French",
+            "Loading translations without overwrite should keep existing translation",
+        )
+        self.assertIn(
+            website_2_step_FR.name,
+            ("Payment (FR)", "Paiement"),  # "Paiement" in case translation was already loaded
+            "Loading translations should add missing term from default step",
+        )
+
+        # Load translations with overwrite
+        IrModuleModule._load_module_terms(['website_sale'], ['fr_FR'], overwrite=True)
+        CheckoutStep.invalidate_model(['name'])
+        self.assertEqual(
+            website_1_step_FR.name, "Payment (FR)",
+            "Loading translations with overwrite should update existing term from template",
+        )
+
+        # Ensure all translatable fields were updated
+        for fname, field in CheckoutStep._fields.items():
+            if field.translate:
+                self.assertEqual(website_1_step_FR[fname], default_payment_step_FR[fname])
+                self.assertEqual(website_2_step_FR[fname], default_payment_step_FR[fname])


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Have a website;
2. enable a new language (other than English);
3. use website in this language;
4. go to checkout.

Issue
-----
The checkout steps on the top-left aren't translated.

Cause
-----
Commit dbd22d93183f2 added the `website.checkout.step` model. Like `website.menu`, they have a default record that gets set on initialization, which is then gets used to create a new record per website.

The issue is that when enabling a new language, it only translates the default records. The records that are website-specific remain unchanged.

Solution
--------
Because they function the same we as `website.menu`, we can use the same approach that was taken to translate website menus, and add a `_load_module_terms` override to `ir.module.module`, constructing a SQL query that copies the translations from the default records to the website-specific records.

opw-4985676