### PR TITLE
[FIX] account: handle empty string when updating partner contact

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -796,7 +796,7 @@ class ResPartner(models.Model):
         if 'parent_id' in vals:
             partner2moves = self.sudo().env['account.move'].search([('partner_id', 'in', self.ids)]).grouped('partner_id')
             parent_vat = self.env['res.partner'].browse(vals['parent_id']).vat
-            if partner2moves and vals['parent_id'] and {parent_vat} != set(self.mapped('vat')):
+            if partner2moves and vals['parent_id'] and any((partner.vat or '') != (parent_vat or '') for partner in self):
                 raise UserError(_("You cannot set a partner as an invoicing address of another if they have a different %(vat_label)s.", vat_label=self.vat_label))
 
         res = super().write(vals)

--- a/addons/account/tests/test_account_partner.py
+++ b/addons/account/tests/test_account_partner.py
@@ -100,3 +100,19 @@ class TestAccountPartner(AccountTestInvoicingCommon):
         self.partner_b.vat = 'DIFFERENT'
         with self.assertRaisesRegex(UserError, "different Tax ID"):
             self.partner_a.parent_id = self.partner_b
+
+    def test_manually_write_partner_id_empty_string_vs_False(self):
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'invoice_date': '2025-04-29',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({
+                'quantity': 1,
+                'price_unit': 500.0,
+            })],
+        })
+        move.action_post()
+        self.partner_a.vat = ''
+        self.partner_b.vat = False
+
+        self.partner_a.parent_id = self.partner_b


### PR DESCRIPTION
An error exists if we update the parent partner and the the VAT number does not match with the child partner to prenvent inconsistencies between journal item created before the change.

This error is also triggered when one partner vat is '' and the other is False. This commit aims to fix that.

opw-4915851
