### PR TITLE
[FIX] website_livechat: fix rating tours

### DIFF
--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -1,5 +1,4 @@
-import { queryAll } from "@odoo/hoot-dom";
-import { waitForStable } from "@web/core/macro";
+import { waitFor } from "@odoo/hoot-dom";
 
 /*******************************
  *         Common Steps
@@ -26,30 +25,16 @@ export const start = [
         run: "press Enter",
     },
     {
-        content: "Verify your message has been typed",
-        trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Hello Sir!')",
-        run: "click",
-    },
-    {
-        content: "Verify there is no duplicates",
-        trigger: ".o-livechat-root:shadow .o-mail-Thread",
-        run() {
-            const el = queryAll(".o-mail-Message:contains('Hello Sir!')", { root: this.anchor });
-            if (el.length === 1) {
-                document.querySelector("body").classList.add("no_duplicated_message");
-            }
-        },
-    },
-    {
-        content: "Is your message correctly sent ?",
-        trigger: "body.no_duplicated_message",
-        async run() {
-            await waitForStable(document.body, 1000);
-        },
-    },
-    {
+        content: "Verify the message has been sent",
         trigger:
             ".o-livechat-root:shadow .o-mail-ChatWindow:contains(El Deboulonnator) .o-mail-Thread:not([data-transient])",
+        async run() {
+            await waitFor(".o-mail-Message:contains('Hello Sir!')", {
+                root: this.anchor,
+                only: true,
+                timeout: 5000,
+            });
+        },
     },
 ];
 


### PR DESCRIPTION
The website live chat rating tours share common steps, among them, the `start` steps.

Those steps check if the first message is not duplicated by:
- Waiting for the `.o-mail-Thread` selector.
- Checking if there is only one message.
- Adding a class to this message if that is the case.
- Adding a step that looks for the added class.

This approach is flawed because:
- The thread will be persisted once the first message is sent. If the class is added to the transient message but the next assertion runs after persistence, the message with the class is no longer in the DOM.
- The class can be overridden if the message re-renders before the next assertion.
- There is no guarantee the message is in the DOM when executing `queryAll`.

There is no reliable way to check the state before persistence because the thread may change between "trigger" and "run".

This commit updates the assertions to ensure the message is sent correctly and no duplicates exist once the thread is fully persisted.

fixes runbot-229822

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
