### PR TITLE
[FIX] hr_expense: fix expense name not being set by OCR

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1189,6 +1189,11 @@ class HrExpense(models.Model):
         self._message_set_main_attachment_id(self.env["ir.attachment"].browse(kwargs['attachment_ids'][-1:]), force=True)
 
     @api.model
+    def _get_untitled_expense_name(self, *args):
+        """ Done in a specific function to be called by hr_expense_extract to keep the same translation """
+        return _("Untitled Expense %s", *args)
+
+    @api.model
     def create_expense_from_attachments(self, attachment_ids=None, view_type='list'):
         """
             Create the expenses from files.
@@ -1211,7 +1216,7 @@ class HrExpense(models.Model):
 
         for attachment in attachments:
             vals = {
-                'name': _("Untitled Expense %s", format_date(self.env, fields.Date.context_today(self))),
+                'name': self._get_untitled_expense_name(format_date(self.env, fields.Date.context_today(self))),
                 'price_unit': 0,
                 'product_id': product.id,
             }


### PR DESCRIPTION
Introduces the function `_get_untitled_expense_name` that will be used by the OCR to check whether the expense still has its default name, in which case it can be overwritten.

task-[4684825](https://www.odoo.com/odoo/project/967/tasks/4684825)
