### PR TITLE
[FIX] base: make tests independent of default user groups

### DIFF
--- a/addons/l10n_ch/tests/test_swissqr.py
+++ b/addons/l10n_ch/tests/test_swissqr.py
@@ -189,6 +189,7 @@ class TestSwissQR(AccountTestInvoicingCommon):
         """
         if 'sale.order' not in self.env:
             self.skipTest('`sale` is not installed')
+        self.env.user.group_ids += self.env.ref('sales_team.group_sale_salesman')
 
         payment_custom = self.env['ir.module.module']._get('payment_custom')
         if payment_custom.state != 'installed':

--- a/addons/l10n_de/tests/test_audit_trail.py
+++ b/addons/l10n_de/tests/test_audit_trail.py
@@ -21,7 +21,7 @@ class TestAuditTrailDE(AccountTestInvoicingHttpCommon):
                 'name': 'folder_test',
                 'type': 'folder',
             })
-            cls.env['documents.account.folder.setting'].create({
+            cls.env['documents.account.folder.setting'].sudo().create({
                 'folder_id': folder_test.id,
                 'journal_id': cls.company_data['default_journal_sale'].id,
             })

--- a/addons/l10n_hu_edi/tests/test_flows_mocked.py
+++ b/addons/l10n_hu_edi/tests/test_flows_mocked.py
@@ -202,6 +202,7 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
 
     def test_invoice_line_currency_rate_from_sale(self):
         if self.env['ir.module.module']._get('sale_stock').state == 'installed':
+            self.env.user.group_ids += self.env.ref('sales_team.group_sale_salesman')
             currency = self.setup_other_currency('HRK', rates=[
                 ('2016-01-01', 3.0),
                 ('2017-01-01', 2.0),

--- a/addons/l10n_hu_edi/tests/test_invoice_xml.py
+++ b/addons/l10n_hu_edi/tests/test_invoice_xml.py
@@ -91,6 +91,7 @@ class L10nHuEdiTestInvoiceXml(L10nHuEdiTestCommon):
         # Skip if sale is not installed
         if 'sale_line_ids' not in self.env['account.move.line']:
             self.skipTest('Sale module not installed, skipping advance invoice tests.')
+        self.env.user.group_ids += self.env.ref('sales_team.group_sale_salesman')
 
         # Issue advance invoice on 2024-01-01.
         with freeze_time('2024-01-01'):

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -208,6 +208,7 @@ class TestEdiZatca(TestSaEdiCommon):
         """Test invoice generation with downpayment scenarios."""
         if 'sale' not in self.env["ir.module.module"]._installed():
             self.skipTest("Sale module is not installed")
+        self.env.user.group_ids += self.env.ref('sales_team.group_sale_salesman')
 
         freeze = datetime(2022, 9, 5, 8, 20, 2, tzinfo=timezone('Etc/GMT-3'))
 

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -89,7 +89,7 @@ class BaseCommon(TransactionCase):
 
     @classmethod
     def get_default_groups(cls):
-        return cls.env['res.users']._default_groups()
+        return cls.env.ref('base.group_user')
 
     @classmethod
     def setup_main_company(cls, currency_code='USD'):


### PR DESCRIPTION
The tests should not be impacted by the demo data however it is currently the case.
Indeed, a lot of groups are added to the default group user when installing the demo data.
Instead, we only take the user group like it is the case when no demo is installed.
