### PR TITLE
[FIX] web: Correctly place no content message in list view in modal

### DIFF
--- a/addons/web/static/src/views/view.scss
+++ b/addons/web/static/src/views/view.scss
@@ -53,6 +53,7 @@
 // Naive heuristic to leave enough space for the nocontent helper in dialogs
 .o_dialog {
     .o_content:has(.o_view_nocontent) {
+        height: 20rem;
         min-height: 20rem;
     }
 }


### PR DESCRIPTION
In some cases the "See all possible values" message (no content) inside the listview in modals would not be placed correctly. This is because the parent of a `height: 100%` element did not have a defined height.

As the `.o_view_nocontent` element already has a min-height, setting the height to the same value fixes the issue.

Steps to reproduce:
1. Go to Accounting app, menu Accounting -> Journal entries
3. Go to Import action
4. Import file and click on Test
5. On errored line, click on See possible values
6. Search so that no content is shown
7. -> Wrongly placed "See all possible values" message

Task: [4885640](https://www.odoo.com/odoo/project/133/tasks/4885640)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
