### PR TITLE
[FIX] html_builder: apply date input on datepicker apply

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.js
@@ -78,7 +78,6 @@ export class BuilderDateTimePicker extends Component {
             onChange: (value) => {
                 const dateString = this.formatDateTime(value);
                 this.preview(dateString);
-                state.value = this.parseDisplayValue(dateString);
             },
         });
     }

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_datetimepicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_datetimepicker.test.js
@@ -137,22 +137,3 @@ test("selects a date and properly applies it", async () => {
     const dateTimestamp = parseFloat(queryOne(":iframe .test-options-target").dataset.date);
     expect(Math.abs(expectedDateTimestamp - dateTimestamp)).toBeLessThan(TIME_TOLERANCE);
 });
-
-test("selects a date and synchronize the input field, while still in preview", async () => {
-    addOption({
-        selector: ".test-options-target",
-        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`,
-    });
-    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
-    await contains(":iframe .test-options-target").click();
-    await contains(".we-bg-options-container input").click();
-    await contains(".o_date_item_cell.o_today + .o_date_item_cell").click();
-
-    const dateString = queryOne(".we-bg-options-container input").value;
-    const expectedDateTime = DateTime.now().plus({ days: 1 });
-    expect(isExpectedDateTime({ dateString, expectedDateTime })).toBe(true);
-
-    const expectedDateTimestamp = expectedDateTime.toUnixInteger();
-    const dateTimestamp = parseFloat(queryOne(":iframe .test-options-target").dataset.date);
-    expect(Math.abs(expectedDateTimestamp - dateTimestamp)).toBeLessThan(TIME_TOLERANCE);
-});


### PR DESCRIPTION
In [1] the builder date picker was adapted in order to have the text version of the date updated upon date selection preview (without apply).

In [2] that was changed to use the state to reflect the value. But by doing that, on apply, the datetime picker service considered that the applied date was already known and did not call `onApply` anymore, thus not triggering the actual action.

This commit fixes this but not updating the state during preview. However as a side effect, the text version of the date is not updated during previews anymore.

Steps to reproduce:
- Drop a "Countdown" snippet
- Open "Due Date"
- Select a date
- Click on Apply

=> No undo was available, value was lost on repaint or save.

[1]: https://github.com/odoo/odoo/commit/2d1a39f7224495ea04aa8765ae5ac11145a84398
[2]: https://github.com/odoo/odoo/commit/97a49dcec8f2ef7f6b6ec3113fd1b11eb121c610

task-4367641