### PR TITLE
[FIX] payment{_razorpay,_stripe}: pass extracted arguments to super

### DIFF
--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -236,7 +236,9 @@ class PaymentProvider(models.Model):
 
     def _build_request_url(self, endpoint, *, api_version='v1', is_proxy_request=False, **kwargs):
         if self.code != 'razorpay':
-            return super()._build_request_url(endpoint, **kwargs)
+            return super()._build_request_url(
+                endpoint, api_version=api_version, is_proxy_request=is_proxy_request, **kwargs
+            )
         if is_proxy_request:
             return f'{const.OAUTH_URL}{endpoint}'
         return f'https://api.razorpay.com/{api_version}/{endpoint}'
@@ -269,5 +271,7 @@ class PaymentProvider(models.Model):
 
     def _parse_response_content(self, response, *, is_proxy_request=False, **kwargs):
         if self.code != 'razorpay' or not is_proxy_request:
-            return super()._parse_response_content(response)
+            return super()._parse_response_content(
+                response, is_proxy_request=is_proxy_request, **kwargs
+            )
         return self._parse_proxy_response(response)

--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -444,7 +444,9 @@ class PaymentProvider(models.Model):
 
     def _build_request_url(self, endpoint, *, is_proxy_request=False, version=1, **kwargs):
         if self.code != 'stripe':
-            return super()._build_request_url(endpoint, **kwargs)
+            return super()._build_request_url(
+                endpoint, is_proxy_request=is_proxy_request, version=version, **kwargs
+            )
         if is_proxy_request:
             return url_join(const.PROXY_URL, f'{version}/{endpoint}')
         return url_join('https://api.stripe.com/v1/', endpoint)
@@ -480,7 +482,9 @@ class PaymentProvider(models.Model):
 
     def _parse_response_content(self, response, *, is_proxy_request=False, **kwargs):
         if self.code != 'stripe' or not is_proxy_request:
-            return super()._parse_response_content(response, **kwargs)
+            return super()._parse_response_content(
+                response, is_proxy_request=is_proxy_request, **kwargs
+            )
         return self._parse_proxy_response(response)
 
     def _get_stripe_extra_request_headers(self):


### PR DESCRIPTION
If more than one provider with 'is_proxy_request' in _build_request_url was installed, during the call to super, the parameter was not passed further which resulted in wrongly calling non-proxy route.

Now, all extracted parameters are passed to super.
