### PR TITLE
[FIX] base: renaming many2many field ends up with inconsistent registry

### DIFF
--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -412,8 +412,14 @@ class Registry(Mapping[str, type["BaseModel"]]):
             self.field_depends_context.clear()
 
         else:
-            # only mark impacted models for setup
-            for model_name in self.descendants(model_names, '_inherit', '_inherits'):
+            # only mark impacted models for setup and invalidate related fields
+            model_names_to_setup = self.descendants(model_names, '_inherit', '_inherits')
+            for fields in self.many2many_relations.values():
+                for pair in list(fields):
+                    if pair[0] in model_names_to_setup:
+                        fields.discard(pair)
+
+            for model_name in model_names_to_setup:
                 self[model_name]._setup_done__ = False
 
             # recursively mark fields to re-setup


### PR DESCRIPTION
Since 6b9df655bb4424302b78cdeec8ed65b7d4106396, when renaming a custom many2many field, the field disappears from its model's `_fields` dict. The field is silently discarded after its setup has crashed, because another field using the same relation is found in `registry.many2many_relations`.  This "other" field is actually the renamed field under its old name!  The fix thus consists in partially invalidating `registry.many2many_relations` before setting up fields.

Co-authored-by: abz-odoo

opw-4937841