### PR TITLE
[PERF] website_sale: disable prefetcher for sitemap products

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -170,7 +170,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ProductTemplate = env['product.template']
         dom = sitemap_qs2dom(qs, '/shop', ProductTemplate._rec_name)
         dom += website.sale_product_domain()
-        for product in ProductTemplate.search(dom):
+        for product in ProductTemplate.with_context(prefetch_fields=False).search(dom):
             loc = '/shop/%s' % env['ir.http']._slug(product)
             if not qs or qs.lower() in loc:
                 yield {'loc': loc}


### PR DESCRIPTION
### Issue
Server crashes with MemoryErrors when a database has a large product catalogs.

### Solution
This commit disables the prefetcher to avoid MemoryErrors when generating the sitemap for large product catalogs as web crawlers would continously crash the server when requesting the sitemap.


### References
opw-5001680
opw-4955333

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
