### PR TITLE
[IMP]: sale_project, project_purchase: keep manual analytic distribution on confirmation

### DIFF
--- a/addons/project_purchase/tests/test_project_purchase.py
+++ b/addons/project_purchase/tests/test_project_purchase.py
@@ -22,6 +22,44 @@ class TestProjectPurchase(TestProjectPurchaseProfitability):
         # Create additional analytic plans at setup to avoid adding fields in project.project between tests
         cls.analytic_plan_1 = cls.env['account.analytic.plan'].create({'name': 'Purchase Project Plan 1'})
         cls.analytic_plan_2 = cls.env['account.analytic.plan'].create({'name': 'Purchase Project Plan 2'})
+        cls.analytic_account_1 = cls.env['account.analytic.account'].create({
+            'name': 'Analytic Account - Plan 1',
+            'plan_id': cls.analytic_plan_1.id,
+        })
+        cls.analytic_account_2 = cls.env['account.analytic.account'].create({
+            'name': 'Analytic Account - Plan 2',
+            'plan_id': cls.analytic_plan_2.id,
+        })
+
+    def test_project_creation_on_po_with_manual_analytic(self):
+        """ Tests the interaction between manually added analytic account, distribution
+            model accounts and the project account created when the PO is confirmed.
+        """
+        self.env['account.analytic.distribution.model'].create({
+            'partner_id': self.partner.id,
+            'analytic_distribution': {self.analytic_account_1.id: 100},
+            'company_id': self.company.id,
+        })
+        analytic_distribution_manual = {str(self.analytic_account.id): 100}
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_order.id,
+                }),
+            ],
+        })
+
+        # Add a manual analytic account and a project
+        purchase_order.order_line.analytic_distribution |= analytic_distribution_manual
+        purchase_order.project_id = self.project1
+        # All accounts should still be in the line after confirmation
+        expected_analytic_distribution = {
+            f"{self.analytic_account.id},{purchase_order.project_id.account_id.id}": 100,
+            f"{self.analytic_account_1.id},{purchase_order.project_id.account_id.id}": 100,
+        }
+        self.assertEqual(purchase_order.order_line.analytic_distribution, expected_analytic_distribution)
 
     def test_project_on_pol_with_analytic_distribution_model(self):
         """ If a line has a distribution coming from an analytic distribution model, and the PO has a project,
@@ -30,17 +68,9 @@ class TestProjectPurchase(TestProjectPurchaseProfitability):
         """
         # We create one distribution model with two accounts in one line, based on product
         # and a second model with a different plan, based on partner
-        analytic_account_1 = self.env['account.analytic.account'].create({
-            'name': 'Analytic Account - Plan 1',
-            'plan_id': self.analytic_plan_1.id,
-        })
-        analytic_account_2 = self.env['account.analytic.account'].create({
-            'name': 'Analytic Account - Plan 2',
-            'plan_id': self.analytic_plan_2.id,
-        })
         distribution_model_product = self.env['account.analytic.distribution.model'].create({
             'product_id': self.product_order.id,
-            'analytic_distribution': {','.join([str(analytic_account_1.id), str(analytic_account_2.id)]): 100},
+            'analytic_distribution': {','.join([str(self.analytic_account_1.id), str(self.analytic_account_2.id)]): 100},
             'company_id': self.company.id,
         })
         distribution_model_partner = self.env['account.analytic.distribution.model'].create({
@@ -63,7 +93,7 @@ class TestProjectPurchase(TestProjectPurchaseProfitability):
         # When we add a project to the PO, it should keep the previous accounts + the project account
         purchase_order.project_id = self.project1
         expected_distribution_project = {
-            f"{analytic_account_1.id},{analytic_account_2.id},{self.project1.account_id.id}": 100,
+            f"{self.analytic_account_1.id},{self.analytic_account_2.id},{self.project1.account_id.id}": 100,
             f"{self.analytic_account.id},{self.project1.account_id.id}": 100,
         }
         self.assertEqual(purchase_order.order_line.analytic_distribution, expected_distribution_project)

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -114,6 +114,14 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         # Create additional analytic plans at setup to avoid adding fields in project.project between tests
         cls.analytic_plan_1 = cls.env['account.analytic.plan'].create({'name': 'Sale Project Plan 1'})
         cls.analytic_plan_2 = cls.env['account.analytic.plan'].create({'name': 'Sale Project Plan 2'})
+        cls.analytic_account_1 = cls.env['account.analytic.account'].create({
+            'name': 'Analytic Account - Plan 1',
+            'plan_id': cls.analytic_plan_1.id,
+        })
+        cls.analytic_account_2 = cls.env['account.analytic.account'].create({
+            'name': 'Analytic Account - Plan 2',
+            'plan_id': cls.analytic_plan_2.id,
+        })
 
     def test_task_create_sol_ui(self):
         self.start_tour('/odoo', 'task_create_sol_tour', login='admin')
@@ -539,10 +547,16 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         self.assertEqual(self.env.company, sale_order.project_ids.company_id, "The project created for the SO should have the same company as its account.")
 
     def test_project_creation_on_so_with_manual_analytic(self):
-        """ Tests that the manually added analytic account (of a plan other than projects) and the project account
-            created when SO is confirmed are both still in the line after confirmation.
+        """ Tests the interaction between manually added analytic account (of a plan other than projects), distribution
+            model accounts and the project account created when SO is confirmed.
         """
+        self.env['account.analytic.distribution.model'].create({
+            'partner_id': self.partner.id,
+            'analytic_distribution': {self.analytic_account_1.id: 100},
+            'company_id': self.company.id,
+        })
         analytic_distribution_manual = {str(self.analytic_account_sale.id): 100}
+
         sale_order = self.env['sale.order'].create({
             'partner_id': self.partner.id,
             'partner_invoice_id': self.partner.id,
@@ -550,13 +564,16 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_order_service3.id,
-                    'analytic_distribution': analytic_distribution_manual,
                 }),
             ],
         })
-        self.assertEqual(sale_order.order_line.analytic_distribution, analytic_distribution_manual)
+        sale_order.order_line.analytic_distribution |= analytic_distribution_manual
         sale_order.action_confirm()
-        expected_analytic_distribution = {f"{self.analytic_account_sale.id},{sale_order.order_line.project_id.account_id.id}": 100}
+        # All accounts (manually added, from distribution model and project account) are in the line after confirmation
+        expected_analytic_distribution = {
+            f"{self.analytic_account_sale.id},{sale_order.project_id.account_id.id}": 100,
+            f"{self.analytic_account_1.id},{sale_order.project_id.account_id.id}": 100,
+        }
         self.assertEqual(sale_order.order_line.analytic_distribution, expected_analytic_distribution)
 
     def test_project_on_sol_with_analytic_distribution_model(self):
@@ -566,17 +583,9 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         """
         # We create one distribution model with two accounts in one line, based on product
         # and a second model with a different plan, based on partner
-        analytic_account_1 = self.env['account.analytic.account'].create({
-            'name': 'Analytic Account - Plan 1',
-            'plan_id': self.analytic_plan_1.id,
-        })
-        analytic_account_2 = self.env['account.analytic.account'].create({
-            'name': 'Analytic Account - Plan 2',
-            'plan_id': self.analytic_plan_2.id,
-        })
         distribution_model_product = self.env['account.analytic.distribution.model'].create({
             'product_id': self.product_a.id,
-            'analytic_distribution': {','.join([str(analytic_account_1.id), str(analytic_account_2.id)]): 100},
+            'analytic_distribution': {','.join([str(self.analytic_account_1.id), str(self.analytic_account_2.id)]): 100},
             'company_id': self.company.id,
         })
         distribution_model_partner = self.env['account.analytic.distribution.model'].create({
@@ -594,19 +603,18 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
             'partner_id': self.partner.id,
             'partner_invoice_id': self.partner.id,
             'partner_shipping_id': self.partner.id,
-            'project_id': project.id,
             'order_line': [
                 Command.create({'product_id': self.product_a.id}),
             ],
         })
-
+        sale_order.project_id = project.id
         expected_analytic_distribution = {
-            f"{analytic_account_1.id},{analytic_account_2.id},{project.account_id.id}": 100,
+            f"{self.analytic_account_1.id},{self.analytic_account_2.id},{project.account_id.id}": 100,
             f"{self.analytic_account_sale.id},{project.account_id.id}": 100,
         }
         self.assertEqual(sale_order.order_line.analytic_distribution, expected_analytic_distribution)
 
-        # If the project is removed from the SO, only the product's analytic distribution is still in the line
+        # If the project is removed from the SO, only the analytic distribution is still in the line
         sale_order.project_id = None
         self.assertEqual(
             sale_order.order_line.analytic_distribution,


### PR DESCRIPTION
To reproduce:
1. Create a product of type service that creates a project on confirmation
2. Create an Analytic Distribution Model for that same product
3. Create a Sales Order with the same product
4. Add another analytic account on the same line
5. Confirm the Sales Order

The manually added account (step 4) is no longer in the sale order line.

Cause:
When the project is added at confirmation, `_compute_analytic_distribution()` is triggered and leads to the existing analytic distribution to be overwritten, using only the accounts of the matching distribution models and the project account.

Solution:
Instead of calling `super()._compute_analytic_distribution()` whenever the order_id.project_id changes, now the call is only performed if there is no project set in the order. If there is a project, the existing distribution is kept, and the project account is added, if there is no account of the project plan.

This means that if the project is added before any lines, the distribution model accounts won't be added. Also, if the project is removed after the lines have been added, the compute will be triggered, still leading to the overwrite of any analytic distribution manually added.

The same happens in Purchase Orders with projects, so this commit also handles project_purchase.

no-task


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
