### PR TITLE
[FIX] core: exception handling in JSON-2

### DIFF
--- a/addons/web/controllers/json2.py
+++ b/addons/web/controllers/json2.py
@@ -23,17 +23,6 @@ from odoo.tools import frozendict
 
 _logger = logging.getLogger(__name__)
 
-SESSION_EXPIRED_MSG = """\
-Session Expired
-
-Surely this is because you are using a session_id cookie but that\
- session does no longer exist.
-
-You can get a renewed cookie via the html form at /web/login?db= or the\
- JSONRPC endpoint at /web/session/authenticate with method "call"\
- and params "login", "password" and "db".
-"""
-
 
 class Json2RpcDispatcher(http.Dispatcher):
     routing_type = '/json/2/rpc'
@@ -62,30 +51,28 @@ class Json2RpcDispatcher(http.Dispatcher):
         return self.request.make_json_response(result)
 
     def handle_error(self, exc: Exception) -> Callable:
+        if isinstance(exc, HTTPException) and exc.response:
+            return exc.response
+
         headers = None
-        cookies = None
-        if isinstance(exc, UserError):
-            msg = exc.args[0]
-            status = exc.http_code
+        if isinstance(exc, (UserError, http.SessionExpiredException)):
+            status = exc.http_status
+            body = http.serialize_exception(exc)
         elif isinstance(exc, HTTPException):
-            if res := exc.response:
-                ct = res.headers.get('Content-Type', 'application/octet-stream')
-                if 'json' in ct or not ct.startswith('text/'):
-                    return exc
-                msg = res.get_data(as_text=True)
-                status = exc.code
-                headers = res.headers
-            else:
-                msg = exc.description
-                status = exc.code
-        elif isinstance(exc, http.SessionExpiredException):
-            # needed by auth='user' but not by auth='bearer'
-            msg = SESSION_EXPIRED_MSG
-            status = HTTPStatus.FORBIDDEN
+            status = exc.code
+            body = http.serialize_exception(
+                exc,
+                message=exc.description,
+                arguments=(exc.description, exc.code),
+            )
+            # strip Content-Type but keep the remaining headers
+            ct, *headers = exc.get_headers()
+            assert ct == ('Content-Type', 'text/html; charset=utf-8')
         else:
-            msg = "internal server error"
             status = HTTPStatus.INTERNAL_SERVER_ERROR
-        return self.request.make_json_response(msg, headers, cookies, status)
+            body = http.serialize_exception(exc)
+
+        return self.request.make_json_response(body, headers=headers, status=status)
 
 
 class WebJson2Controller(http.Controller):

--- a/odoo/addons/test_http/tests/test_webjson2.py
+++ b/odoo/addons/test_http/tests/test_webjson2.py
@@ -1,8 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import datetime, timedelta
 from http import HTTPStatus
+from textwrap import dedent
 
-from odoo.tests import Like, get_db_name, new_test_user, tagged
+from odoo.tests import Like, get_db_name, mute_logger, new_test_user, tagged
+from odoo.tools.misc import submap
 
 from .test_common import TestHttpBase
 from odoo.addons.test_http.controllers import CT_JSON
@@ -26,6 +28,16 @@ class TestHttpWebJson_2(TestHttpBase):
             scope='rpc', name='test', expiration_date=datetime.now() + timedelta(days=0.5))
         cls.bearer_header = {"Authorization": f"Bearer {key}"}
 
+    def assertErrorLike(self, response, expected_error):
+        try:
+            body = response.json()
+        except ValueError as exc:
+            exc.add_note(response.text)
+            raise
+        self.assertIsInstance(body, dict, body)
+        self.assertEqual(list(body), ['name', 'message', 'arguments', 'context', 'debug'])
+        self.assertEqual(submap(body, expected_error), expected_error)
+
     def test_webjson2_multi_db_no_header(self):
         res = self.multidb_url_open(
             '/json/2/res.users/search',
@@ -33,7 +45,7 @@ class TestHttpWebJson_2(TestHttpBase):
             headers=CT_JSON | self.bearer_header,
             dblist=(get_db_name(), 'another-database'),
         )
-        self.assertIn("The requested URL was not found on the server.", res.text)
+        self.assertIn("URL was not found in the server-wide controllers.</p>", res.text)
         self.assertEqual(res.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(res.headers.get('Content-Type'), 'text/html; charset=utf-8')
 
@@ -46,7 +58,7 @@ class TestHttpWebJson_2(TestHttpBase):
             },
             dblist=(get_db_name(), 'another-database'),
         )
-        self.assertIn("The requested URL was not found on the server.", res.text)
+        self.assertIn("URL was not found in the server-wide controllers.</p>", res.text)
         self.assertEqual(res.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(res.headers.get('Content-Type'), 'text/html; charset=utf-8')
 
@@ -74,6 +86,7 @@ class TestHttpWebJson_2(TestHttpBase):
             ...Request inferred type is compatible with...http...but...
             /json/2...is type=...json...
         """))
+        self.assertIn("Please verify the Content-Type request header and try again.", res.text)
         self.assertEqual(res.status_code, HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
         self.assertEqual(res.headers.get('Content-Type'), 'text/html; charset=utf-8')
 
@@ -83,7 +96,12 @@ class TestHttpWebJson_2(TestHttpBase):
             data=r"not json",
             headers=CT_JSON | self.bearer_header,
         )
-        self.assertEqual(res.text, '"could not parse the body as json: Expecting value: line 1 column 1 (char 0)"')
+        m = "could not parse the body as json: Expecting value: line 1 column 1 (char 0)"
+        self.assertErrorLike(res, {
+            'name': "werkzeug.exceptions.BadRequest",
+            'message': m,
+            'arguments': [m, HTTPStatus.BAD_REQUEST],
+        })
         self.assertEqual(res.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')
 
@@ -93,7 +111,12 @@ class TestHttpWebJson_2(TestHttpBase):
             data=r'null',
             headers=CT_JSON | self.bearer_header,
         )
-        self.assertEqual(res.text, '''"could not parse the body, expecting a json object"''')
+        m = "could not parse the body, expecting a json object"
+        self.assertErrorLike(res, {
+            'name': "werkzeug.exceptions.BadRequest",
+            'message': m,
+            'arguments': [m, HTTPStatus.BAD_REQUEST],
+        })
         self.assertEqual(res.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')
 
@@ -103,7 +126,15 @@ class TestHttpWebJson_2(TestHttpBase):
             data=r'{"domain": []}',
             headers=CT_JSON,
         )
+        m = 'User not authenticated, use the "Authorization" header'
+        self.assertErrorLike(res, {
+            'name': "werkzeug.exceptions.Unauthorized",
+            'message': m,
+            'arguments': [m, HTTPStatus.UNAUTHORIZED],
+        })
         self.assertEqual(res.status_code, HTTPStatus.UNAUTHORIZED)
+        self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')
+        self.assertEqual(res.headers.get('WWW-Authenticate', '').lower().strip(), 'bearer')
 
     def test_webjson2_missing_argument(self):
         res = self.db_url_open(
@@ -111,8 +142,51 @@ class TestHttpWebJson_2(TestHttpBase):
             data=r'{}',
             headers=CT_JSON | self.bearer_header,
         )
-        self.assertEqual(res.text, '''"missing a required argument: 'domain'"''')
+        m = "missing a required argument: 'domain'"
+        self.assertErrorLike(res, {
+            'name': "werkzeug.exceptions.UnprocessableEntity",
+            'message': m,
+            'arguments': [m, HTTPStatus.UNPROCESSABLE_ENTITY],
+        })
         self.assertEqual(res.status_code, HTTPStatus.UNPROCESSABLE_ENTITY)
+        self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')
+
+    def test_webjson2_bad_domain(self):
+        with mute_logger('odoo.http'):
+            res = self.db_url_open(
+                '/json/2/res.users/search',
+                data=r'{"domain": [["bad field", "=", "foo"]]}',
+                headers=CT_JSON | self.bearer_header,
+            )
+        m = "Invalid field res.users.bad field in condition ('bad field', '=', 'foo')"
+        self.assertErrorLike(res, {
+            'name': "builtins.ValueError",
+            'message': m,
+            'arguments': [m],
+        })
+        self.assertEqual(res.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')
+
+    def test_webjson2_access_error(self):
+        with mute_logger('odoo.http'):
+            res = self.db_url_open(
+                '/json/2/ir.cron/search',
+                data=r'{"domain": []}',
+                headers=CT_JSON | self.bearer_header,
+            )
+        m = dedent("""\
+            You are not allowed to access 'Scheduled Actions' (ir.cron) records.
+
+            This operation is allowed for the following groups:
+            \t- Role / Administrator
+
+            Contact your administrator to request access if necessary.""")
+        self.assertErrorLike(res, {
+            'name': "odoo.exceptions.AccessError",
+            'message': m,
+            'arguments': [m],
+        })
+        self.assertEqual(res.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')
 
     def test_webjson2_good(self):
@@ -131,6 +205,11 @@ class TestHttpWebJson_2(TestHttpBase):
             data=r'{"ids": [0]}',
             headers=CT_JSON | self.bearer_header,
         )
-        self.assertEqual(res.text, '''"cannot call res.users.create with ids"''')
+        m = "cannot call res.users.create with ids"
+        self.assertErrorLike(res, {
+            'name': "werkzeug.exceptions.UnprocessableEntity",
+            'message': m,
+            'arguments': [m, HTTPStatus.UNPROCESSABLE_ENTITY],
+        })
         self.assertEqual(res.status_code, HTTPStatus.UNPROCESSABLE_ENTITY)
         self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -150,6 +150,7 @@ import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from hashlib import sha512
+from http import HTTPStatus
 from io import BytesIO
 from os.path import join as opj
 from pathlib import Path
@@ -274,6 +275,16 @@ for more details.
   passing the `csrf=False` parameter to the `route` decorator.
 """
 
+NOT_FOUND_NODB = """\
+<!DOCTYPE html>
+<title>404 Not Found</title>
+<h1>Not Found</h1>
+<p>No database is selected and the requested URL was not found in the server-wide controllers.</p>
+<p>Please verify the hostname, <a href=/web/login>login</a> and try again.</p>
+
+<!-- Alternatively, use the X-Odoo-Database header. -->
+"""
+
 # The @route arguments to propagate from the decorated method to the
 # routing rule.
 ROUTING_KEYS = {
@@ -311,7 +322,7 @@ class RegistryError(RuntimeError):
 
 
 class SessionExpiredException(Exception):
-    pass
+    http_status = HTTPStatus.FORBIDDEN
 
 
 def content_disposition(filename, disposition_type='attachment'):
@@ -430,16 +441,16 @@ def is_cors_preflight(request, endpoint):
     return request.httprequest.method == 'OPTIONS' and endpoint.routing.get('cors', False)
 
 
-def serialize_exception(exception):
+def serialize_exception(exception, *, message=None, arguments=None):
     name = type(exception).__name__
     module = type(exception).__module__
 
     return {
         'name': f'{module}.{name}' if module else name,
-        'debug': traceback.format_exc(),
-        'message': exception_to_unicode(exception),
-        'arguments': exception.args,
+        'message': exception_to_unicode(exception) if message is None else message,
+        'arguments': exception.args if arguments is None else arguments,
         'context': getattr(exception, 'context', {}),
+        'debug': ''.join(traceback.format_exception(exception)),
     }
 
 
@@ -2046,7 +2057,8 @@ class Request:
                 if disp.is_compatible_with(self)
             ]
             e = (f"Request inferred type is compatible with {compatible_dispatchers} "
-                 f"but {routing['routes'][0]!r} is type={routing['type']!r}.")
+                 f"but {routing['routes'][0]!r} is type={routing['type']!r}.\n\n"
+                 "Please verify the Content-Type request header and try again.")
             # werkzeug doesn't let us add headers to UnsupportedMediaType
             # so use the following (ugly) to still achieve what we want
             res = UnsupportedMediaType(e).get_response()
@@ -2084,7 +2096,13 @@ class Request:
         database-free environment.
         """
         router = root.nodb_routing_map.bind_to_environ(self.httprequest.environ)
-        rule, args = router.match(return_rule=True)
+        try:
+            rule, args = router.match(return_rule=True)
+        except NotFound as exc:
+            exc.response = Response(NOT_FOUND_NODB, status=exc.code, headers=[
+                ('Content-Type', 'text/html; charset=utf-8'),
+            ])
+            raise
         self._set_request_dispatcher(rule)
         self.dispatcher.pre_dispatch(rule, args)
         response = self.dispatcher.dispatch(rule.endpoint, args)


### PR DESCRIPTION
This work incorporates several improvements for the error handling in JSON-2.

The goal was to be able to "discover" how the JSON-2 API works with the help of every error message, starting with a simple `GET /json/2`.

1. The response body now holds the result of `http.serialize_exception`: an object with name, message, arguments, context, debug (traceback); instead of only `str(message)`.

2. The order in the `serialize_exception` object nows have the traceback last, this improve the readability of the json response on the wire.

3. Make the 404 - Not Found message more explicit when the database is missing. Make regular users go to /web/login (which is going to redirect to /web/database/selector) and programmers use the X-Odoo-Database header. The latter is for `auth='bearer'` controllers, as it doesn't use the session.

4. Make the 415 - Unsupported Media Type message more explicit. The HTTP stack sends this error when the `Content-Type` of a request is not compatible with the `@route(type=...)` of a controller. For JSON-2 any request that is not `Content-Type: application/json` will receive this message. The message now explicitely states that it is the request `Content-Type` that is likely at fault.

5. There was a complicated conditional in the JSON-2 `_handle_error` to attempt to jsonify the werkzeug's html, or to keep the existing response under some condition. Error handling is not the place to have anything complicated. The code was simplified to: have a response attached already? use it (even if it is not JSON); otherwise, use `serialize_exception` with status code and description.

6. `odoo.http.SessionExpiredException` now has a `http_status` like the other Odoo exceptions. It is 403 - Forbidden, the generic status for anything related to access errors. This simplifies the error handling in JSON-2 a bit. The other dispatchers have dedicated conditions and routines to handle this exception, and are not impacted by this change.

We could (and maybe should) had split this single commit in six, one for every case above... but we were lazy.
