### PR TITLE
[FIX] account_edi_ubl_cii: AllowanceChargeReason needed in NLCIUS

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_nlcius.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_nlcius.py
@@ -63,6 +63,8 @@ class AccountEdiXmlUBLNL(models.AbstractModel):
         # Careful ! [BR-42]-Each Invoice line allowance (BG-27) shall have an Invoice line allowance reason (BT-139)
         # or an Invoice line allowance reason code (BT-140).
         for vals in vals_list:
+            if vals['allowance_charge_reason_code'] == 95:
+                vals['allowance_charge_reason'] = 'Discount'
             if vals.get('allowance_charge_reason'):
                 vals.pop('allowance_charge_reason_code')
         return vals_list

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
@@ -126,7 +126,7 @@
     <cbc:LineExtensionAmount currencyID="USD">1782.00</cbc:LineExtensionAmount>
     <cac:AllowanceCharge>
       <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-      <cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+      <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
       <cbc:Amount currencyID="USD">198.00</cbc:Amount>
     </cac:AllowanceCharge>
     <cac:Item>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
@@ -130,7 +130,7 @@
     <cbc:LineExtensionAmount currencyID="USD">1782.00</cbc:LineExtensionAmount>
     <cac:AllowanceCharge>
       <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-      <cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+      <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
       <cbc:Amount currencyID="USD">198.00</cbc:Amount>
     </cac:AllowanceCharge>
     <cac:Item>


### PR DESCRIPTION
NLCIUS rule BR-NL-32 triggers a warning if the AllowanceChargeReasonCode rather than the AllowanceChargeReason is present on an invoice line AllowanceCharge.

We don't handle this correctly at the moment for discounts, because in that case the UBL 2.0 builder adds an reason code but not a reason.

This commit ensures that the reason rather than the reason code is specified in NLCIUS in the case of a discount.

opw-4997704