### PR TITLE
[ADD] auth_passkey_portal: passkeys for portal users

### DIFF
--- a/addons/auth_passkey/__manifest__.py
+++ b/addons/auth_passkey/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Passkeys',
-    'version': '1.0',
+    'version': '1.1',
     'summary': 'Log in with a Passkey',
     'description': """
 The implementation of Passkeys using the webauthn protocol.

--- a/addons/auth_passkey/security/ir.model.access.csv
+++ b/addons/auth_passkey/security/ir.model.access.csv
@@ -1,4 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 auth_passkey.access_auth_passkey_key,access_auth_passkey_key,model_auth_passkey_key,base.group_user,1,1,0,0
+auth_passkey.access_auth_passkey_key_portal,access_auth_passkey_key_portal,model_auth_passkey_key,base.group_portal,1,1,0,0
 auth_passkey.access_auth_passkey_key_admin,access_auth_passkey_key_admin,model_auth_passkey_key,base.group_erp_manager,1,1,0,1
 auth_passkey.access_auth_passkey_key_create,access_auth_passkey_key_create,model_auth_passkey_key_create,base.group_user,1,1,1,1
+auth_passkey.access_auth_passkey_key_create_portal,access_auth_passkey_key_create_portal,model_auth_passkey_key_create,base.group_portal,1,1,1,1

--- a/addons/auth_passkey/security/security.xml
+++ b/addons/auth_passkey/security/security.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
+<odoo noupdate="1">
     <record model="ir.rule" id="rule_auth_passkey_key_user">
         <field name="name">Passkeys: Users can only access own Passkeys</field>
         <field name="model_id" ref="model_auth_passkey_key"/>
-        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="groups" eval="[
+            (4, ref('base.group_portal')),
+            (4, ref('base.group_user')),
+        ]"/>
         <field name="domain_force">[('create_uid', '=', user.id)]</field>
-        <field name="perm_unlink" eval="1"/>
-        <field name="perm_write" eval="1"/>
-        <field name="perm_read" eval="1"/>
-        <field name="perm_create" eval="1"/>
+    </record>
+
+    <record model="ir.rule" id="rule_auth_passkey_key_create_portal">
+        <field name="name">Passkeys: Users can only modify their own Passkey creation requests</field>
+        <field name="model_id" ref="auth_passkey.model_auth_passkey_key_create"/>
+        <field name="groups" eval="[
+            (4, ref('base.group_portal')),
+            (4, ref('base.group_user')),
+        ]"/>
+        <field name="domain_force">[('create_uid', '=', user.id)]</field>
     </record>
 
     <record model="ir.rule" id="rule_auth_passkey_key_admin">

--- a/addons/auth_passkey_portal/__manifest__.py
+++ b/addons/auth_passkey_portal/__manifest__.py
@@ -1,0 +1,28 @@
+{
+    'name': 'Passkeys Portal',
+    'version': '1.0',
+    'summary': 'Passkeys for portal users',
+    'description': """
+The implementation of Passkeys using the webauthn protocol.
+===========================================================
+
+Passkeys are a secure alternative to a username and a password.
+When a user logs in with a Passkey, MFA will not be required.
+""",
+    'category': 'Hidden/Tools',
+    'depends': ['auth_passkey', 'portal'],
+    'data': [
+        'views/templates.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'auth_passkey_portal/static/src/**',
+        ],
+        'web.assets_tests': [
+            'auth_passkey_portal/static/tests/tours/*.js',
+        ],
+    },
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+    'auto_install': True,
+}

--- a/addons/auth_passkey_portal/static/src/js/passkeys_portal.js
+++ b/addons/auth_passkey_portal/static/src/js/passkeys_portal.js
@@ -1,0 +1,52 @@
+import { handleCheckIdentity } from "@portal/interactions/portal_security";
+import { Interaction } from "@web/public/interaction";
+import { InputConfirmationDialog } from "@portal/js/components/input_confirmation_dialog/input_confirmation_dialog";
+import { registry } from "@web/core/registry";
+import { renderToMarkup } from "@web/core/utils/render";
+import { _t } from "@web/core/l10n/translation";
+
+export class PortalPasskey extends Interaction {
+    static selector = ".o_passkey_portal_entry";
+    dynamicContent = {
+        ".o_passkey_portal_rename": {
+            "t-on-click": this.onRename,
+        },
+        ".o_passkey_portal_delete": {
+            "t-on-click": this.onDelete,
+        },
+    };
+
+    setup() {
+        this.id = parseInt(this.el.attributes.id.value);
+        this.name = this.el.querySelector(".o_passkey_name").innerText;
+        this.dropDown = this.el.querySelector(".o_passkey_dropdown");
+    }
+
+    async onRename() {
+        this.services.dialog.add(InputConfirmationDialog, {
+            title: _t("Passkeys"),
+            body: renderToMarkup("auth_passkey_portal.rename", { oldname: this.name }),
+            confirmLabel: _t("Rename"),
+            confirm: async ({ inputEl }) => {
+                const name = inputEl.value;
+                if (name.length > 0) {
+                    await this.services.orm.write("auth.passkey.key", [this.id], { name })
+                    location.reload();
+                }
+            },
+            cancelLabel: _t("Discard"),
+            cancel: () => {},
+        });
+    }
+
+    async onDelete() {
+        await handleCheckIdentity(
+            this.services.orm.call("auth.passkey.key", "action_delete_passkey", [this.id]),
+            this.services.orm,
+            this.services.dialog
+        );
+        location.reload();
+    }
+}
+
+registry.category("public.interactions").add("auth_passkey_portal.passkey", PortalPasskey);

--- a/addons/auth_passkey_portal/static/src/js/passkeys_portal_create.js
+++ b/addons/auth_passkey_portal/static/src/js/passkeys_portal_create.js
@@ -1,0 +1,59 @@
+import { Interaction } from "@web/public/interaction";
+import { InputConfirmationDialog } from "@portal/js/components/input_confirmation_dialog/input_confirmation_dialog";
+import { registry } from "@web/core/registry";
+import { renderToMarkup } from "@web/core/utils/render";
+import { handleCheckIdentity } from "@portal/interactions/portal_security";
+import { _t } from "@web/core/l10n/translation";
+import * as passkeyLib from "@auth_passkey/../lib/simplewebauthn";
+import { user } from "@web/core/user";
+
+export class PortalPasskeyCreate extends Interaction {
+    static selector = "#portal_passkey_add";
+    dynamicContent = {
+        _root: { "t-on-click": this.startRegistrationFlow },
+    };
+
+    async startRegistrationFlow() {
+        const create_action = await this.waitFor(
+            handleCheckIdentity(
+                this.waitFor(
+                    this.services.orm.call("res.users", "action_create_passkey", [user.userId])
+                ),
+                this.services.orm,
+                this.services.dialog
+            )
+        );
+        const serverOptions = create_action.context.registration;
+        this.services.dialog.add(InputConfirmationDialog, {
+            title: _t("Create Passkey"),
+            body: renderToMarkup("auth_passkey_portal.create"),
+            confirmLabel: _t("Create"),
+            confirm: async ({ inputEl }) => {
+                const name = inputEl.value;
+                if (name.length > 0) {
+                    this.createPasskey(serverOptions, name);
+                }
+            },
+            cancelLabel: _t("Discard"),
+            cancel: () => {},
+        });
+    }
+
+    async createPasskey(serverOptions, name) {
+        const registration = await passkeyLib
+            .startRegistration(serverOptions)
+            .catch((e) => console.error(e));
+        const [new_key] = await this.services.orm.create("auth.passkey.key.create", [{ name }]);
+        await handleCheckIdentity(
+            this.services.orm.call("auth.passkey.key.create", "make_key", [
+                new_key,
+                registration,
+            ]),
+            this.services.orm,
+            this.services.dialog
+        );
+        location.reload();
+    }
+}
+
+registry.category("public.interactions").add("auth_passkey_portal.create", PortalPasskeyCreate);

--- a/addons/auth_passkey_portal/static/src/xml/passkeys_portal_popups.xml
+++ b/addons/auth_passkey_portal/static/src/xml/passkeys_portal_popups.xml
@@ -1,0 +1,14 @@
+<templates>
+    <t t-name="auth_passkey_portal.create">
+        <form string="Key Create">
+            <h3><strong>Name your key</strong></h3>
+            <input type="text" class="form-control col-10 col-md-6" name="keyname" required="required" placeholder="Name"/>
+        </form>
+    </t>
+    <t t-name="auth_passkey_portal.rename">
+        <form string="Key Rename">
+            <h3><strong>Rename your key</strong></h3>
+            <input type="text" class="form-control col-10 col-md-6" name="keyname" required="required" t-attf-value="{{oldname}}" placeholder="Name"/>
+        </form>
+    </t>
+</templates>

--- a/addons/auth_passkey_portal/static/tests/tours/test_passkey_portal.js
+++ b/addons/auth_passkey_portal/static/tests/tours/test_passkey_portal.js
@@ -1,0 +1,166 @@
+import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
+import * as passkeyLib from "@auth_passkey/../lib/simplewebauthn";
+
+let unpatchPasskeyRegistrationPortal;
+
+registry.category("web_tour.tours").add("passkeys_portal_create", {
+    url: "/my/security",
+    steps: () => [
+        {
+            content: "Ensure there are no passkeys already",
+            trigger: 'button:contains("Add Passkey")',
+            run: () => {
+                const amount = document.querySelectorAll(".o_passkey_portal_entry").length;
+                if (amount != 0) {
+                    throw Error("Amount of Passkeys must be 0");
+                }
+            },
+        }, {
+            content: "Add a Passkey",
+            trigger: 'button:contains("Add Passkey")',
+            run: "click",
+        }, {
+            content: "Check that we have to enter enhanced security mode",
+            trigger: "form strong:contains(Please enter your password to confirm you own this account)",
+        }, {
+            content: "Input password",
+            trigger: "form input[name=password]",
+            run: "edit passkey_portal",
+        }, {
+            content: "Confirm",
+            trigger: ".modal-footer button:contains(Confirm Password)",
+            run: "click",
+        }, {
+            content: "Ready to create Passkey",
+            trigger: ".modal-title:contains(Create Passkey)",
+        }, {
+            content: "Input passkey name",
+            trigger: 'input[name="keyname"]',
+            run: "edit test_passkey_one",
+        }, {
+            content: "Override startRegistration",
+            trigger: "body",
+            run: () => {
+                unpatchPasskeyRegistrationPortal = patch(passkeyLib, {
+                    async startRegistration() {
+                        return {
+                            // test-yubikey
+                            "id": "L2p6jvcWuCMTRmkZHKqqvQbz0Dhk3JbJOx1F8ci99nSNjlfx3Z7nkigMdUACLggB",
+                            "rawId": "L2p6jvcWuCMTRmkZHKqqvQbz0Dhk3JbJOx1F8ci99nSNjlfx3Z7nkigMdUACLggB",
+                            "response": {
+                                "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjCSZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2PFAAAAAgAAAAAAAAAAAAAAAAAAAAAAMC9qeo73FrgjE0ZpGRyqqr0G89A4ZNyWyTsdRfHIvfZ0jY5X8d2e55IoDHVAAi4IAaUBAgMmIAEhWCAvanqO9xa4IxNGaRkcMSyBudC-JDZYY9gyMqknP2IkUiJYINqumy9viKCeo_xpFU3XzyssfEReXvMM1_fmZN-wMpDPoWtjcmVkUHJvdGVjdAI",
+                                "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiVW9hNk01akVQN0kzVG95SzlRQTB2ZjhJY3NlemZlSmswcmdzMXBMVVdyTWdGOXZkMC03RHY1aVYzeFc3cjcwLVlxa3dlUlhoQUNtRFBtaEhLdEFJZVEiLCJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwNjkiLCJjcm9zc09yaWdpbiI6ZmFsc2V9",
+                                "transports": [
+                                    "nfc",
+                                    "usb",
+                                ],
+                                "publicKeyAlgorithm": -7,
+                                "publicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEL2p6jvcWuCMTRmkZHDEsgbnQviQ2WGPYMjKpJz9iJFLarpsvb4ignqP8aRVN188rLHxEXl7zDNf35mTfsDKQzw",
+                                "authenticatorData": "SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2PFAAAAAgAAAAAAAAAAAAAAAAAAAAAAMC9qeo73FrgjE0ZpGRyqqr0G89A4ZNyWyTsdRfHIvfZ0jY5X8d2e55IoDHVAAi4IAaUBAgMmIAEhWCAvanqO9xa4IxNGaRkcMSyBudC-JDZYY9gyMqknP2IkUiJYINqumy9viKCeo_xpFU3XzyssfEReXvMM1_fmZN-wMpDPoWtjcmVkUHJvdGVjdAI",
+                            },
+                            "type": "public-key",
+                            "clientExtensionResults": {},
+                            "authenticatorAttachment": "cross-platform",
+                        };
+                    },
+                });
+            },
+        }, {
+            content: "Click the Create button",
+            trigger: ".modal-content button:contains(Create)",
+            run: "click",
+            expectUnloadPage: true,
+        }, {
+            content: "Return startRegistration to original state",
+            trigger: "body",
+            run: () => {
+                if (unpatchPasskeyRegistrationPortal) {
+                    unpatchPasskeyRegistrationPortal();
+                }
+            },
+        }, {
+            content: "Ensure there is one passkey",
+            trigger: ".o_passkey_name",
+            run: () => {
+                const amount = document.querySelectorAll(".o_passkey_portal_entry").length;
+                if (amount != 1) {
+                    throw Error("Amount of Passkeys must be 1");
+                }
+            },
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("passkeys_portal_rename", {
+    url: "/my/security",
+    steps: () => [
+        {
+            content: "Ensure there is one passkey",
+            trigger: 'button:contains("Add Passkey")',
+            run: () => {
+                const amount = document.querySelectorAll(".o_passkey_portal_entry").length;
+                if (amount != 1) {
+                    throw Error("Amount of Passkeys must be 1");
+                }
+            },
+        }, {
+            content: "Click rename",
+            trigger: '.o_passkey_portal_rename',
+            run: "click",
+        }, {
+            content: "Input passkey name",
+            trigger: 'input[name="keyname"]',
+            run: "edit edited_key",
+        }, {
+            content: "Confirm the rename",
+            trigger: ".modal-content button:contains(Rename)",
+            run: "click",
+            expectUnloadPage: true,
+        }, {
+            content: "Ensure the rename occurred",
+            trigger: ".o_passkey_name:contains(edited_key)",
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("passkeys_portal_delete", {
+    url: "/my/security",
+    steps: () => [
+        {
+            content: "Ensure there is one passkey",
+            trigger: 'button:contains("Add Passkey")',
+            run: () => {
+                const amount = document.querySelectorAll(".o_passkey_portal_entry").length;
+                if (amount != 1) {
+                    throw Error("Amount of Passkeys must be 1");
+                }
+            },
+        }, {
+            content: "Click delete",
+            trigger: '.o_passkey_portal_delete',
+            run: "click",
+        }, {
+            content: "Check that we have to enter enhanced security mode",
+            trigger: "form strong:contains(Please enter your password to confirm you own this account)",
+        }, {
+            content: "Input password",
+            trigger: "form input[name=password]",
+            run: "edit passkey_portal",
+        }, {
+            content: "Confirm",
+            trigger: ".modal-footer button:contains(Confirm Password)",
+            run: "click",
+            expectUnloadPage: true,
+        }, {
+            content: "Ensure there are no more passkeys",
+            trigger: 'button:contains("Add Passkey")',
+            run: () => {
+                const amount = document.querySelectorAll(".o_passkey_portal_entry").length;
+                if (amount != 0) {
+                    throw Error("Amount of Passkeys must be 0");
+                }
+            },
+        },
+    ],
+});

--- a/addons/auth_passkey_portal/tests/__init__.py
+++ b/addons/auth_passkey_portal/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_passkey_portal

--- a/addons/auth_passkey_portal/tests/test_passkey_portal.py
+++ b/addons/auth_passkey_portal/tests/test_passkey_portal.py
@@ -1,0 +1,40 @@
+from odoo import Command
+from odoo.exceptions import AccessError
+from odoo.tests import tagged
+from odoo.tools import SQL
+from odoo.addons.auth_passkey.tests.test_passkey_demo import PasskeyTest
+
+
+@tagged('post_install', '-at_install')
+class PasskeyTestPortal(PasskeyTest):
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+        login = 'passkey_portal'
+        self.portal_user = self.env['res.users'].create({
+            'name': login,
+            'login': login,
+            'password': login,
+            'group_ids': [Command.set([self.env.ref('base.group_portal').id])],
+        })
+
+    def test_passkey_portal_create(self):
+        self.env['ir.config_parameter'].sudo().set_param('web.base.url', self.passkeys['test-yubikey']['host'])
+        self.admin_user.auth_passkey_key_ids.unlink()
+        with self.patch_start_registration(self.passkeys['test-yubikey']['registration']['challenge']):
+            self.start_tour("/my/security?debug=tests", 'passkeys_portal_create', login="passkey_portal")
+
+    def test_passkey_portal_rename(self):
+        portal_passkey = self.env['auth.passkey.key'].search([('name', '=', 'test-keepassxc')])
+        self.env.cr.execute(SQL("UPDATE auth_passkey_key SET create_uid = %s WHERE id = %s", self.portal_user.id, portal_passkey.id))
+        self.start_tour("/my/security?debug=tests", 'passkeys_portal_rename', login='passkey_portal')
+
+    def test_passkey_portal_delete(self):
+        portal_passkey = self.env['auth.passkey.key'].search([('name', '=', 'test-keepassxc')])
+        self.env.cr.execute(SQL("UPDATE auth_passkey_key SET create_uid = %s WHERE id = %s", self.portal_user.id, portal_passkey.id))
+        self.start_tour("/my/security?debug=tests", 'passkeys_portal_delete', login='passkey_portal')
+
+    def test_portal_permissions(self):
+        admin_passkey = self.env['auth.passkey.key'].search([('name', '=', 'test-yubikey-nano')])
+        with self.assertRaises(AccessError):
+            admin_passkey.with_user(self.portal_user).write({'name': 'test'})

--- a/addons/auth_passkey_portal/views/templates.xml
+++ b/addons/auth_passkey_portal/views/templates.xml
@@ -1,0 +1,42 @@
+<odoo>
+    <template id="passkeys_portal_hook" name="Passkeys Portal hook" inherit_id="portal.portal_my_security">
+        <xpath expr="//section[@name='portal_revoke_all_devices_popup']" position="before">
+            <section name="portal_passkey_management">
+                <h4>
+                    Passkeys
+                </h4>
+                <div>
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Created</th>
+                                <th>Last Used</th>
+                                <th/>
+                                <th/>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <t t-foreach="user_id.auth_passkey_key_ids" t-as="key">
+                                <tr class="o_passkey_portal_entry" t-att-id="key.id">
+                                    <td><span t-field="key.name" class="o_passkey_name"/></td>
+                                    <td><span t-field="key.create_date" t-options='{"widget": "datetime", "format": "short"}'/></td>
+                                    <td><span t-field="key.write_date" t-options='{"widget": "datetime", "format": "short"}'/></td>
+                                    <td>
+                                        <i class="fa fa-pencil o_passkey_portal_rename" type="button"/>
+                                    </td>
+                                    <td>
+                                        <i class="fa fa-trash text-danger o_passkey_portal_delete" type="button"/>
+                                    </td>
+                                </tr>
+                            </t>
+                        </tbody>
+                    </table>
+                </div>
+                <button type="button" class="btn btn-light mt-1" id="portal_passkey_add">
+                    Add Passkey
+                </button>
+            </section>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/portal/static/src/interactions/portal_security.js
+++ b/addons/portal/static/src/interactions/portal_security.js
@@ -153,6 +153,7 @@ export async function handleCheckIdentity(wrapped, ormService, dialogService) {
     return wrapped.then((r) => {
         if (
             !(
+                r &&
                 r.type &&
                 r.type === "ir.actions.act_window" &&
                 r.res_model === "res.users.identitycheck"


### PR DESCRIPTION
Before this commit passkeys were only supported for internal users. The
plan was always to add in portal user functionality later. However we
wanted to test passkeys and their robustness. I believe that passkeys
are finally ready to be used by all users, including portal users.

Upgrade script: https://github.com/odoo/upgrade/pull/8280

Task-3663657
