### PR TITLE
[FIX] pos_loyalty: fix undeterministic issue

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -303,7 +303,7 @@ registry.category("web_tour.tours").add("PosOrderNoPoints", {
         [
             Chrome.startPoS(),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner 2"),
+            ProductScreen.clickCustomer("AAA Test Partner 2"),
             ProductScreen.addOrderline("Desk Organizer", "3"),
             PosLoyalty.isPointsDisplayed(false),
             PosLoyalty.finalizeOrder("Cash", "15.3"),
@@ -374,7 +374,7 @@ registry.category("web_tour.tours").add("test_max_usage_partner_with_point", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner 2"),
+            ProductScreen.clickCustomer("AAA Test Partner 2"),
             ProductScreen.addOrderline("Desk Organizer", "3"),
             PosLoyalty.claimReward("100% on your order"),
             PosLoyalty.finalizeOrder("Cash", "0"),

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2741,7 +2741,7 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_not_create_loyalty_card_max_usage_program(self):
         self.env['loyalty.program'].search([]).write({'active': False})
         self.env['res.partner'].create({'name': 'Test Partner'})
-        self.env['res.partner'].create({'name': 'Test Partner 2'})
+        self.env['res.partner'].create({'name': 'AAA Test Partner 2'})
 
         loyalty_program = self.env['loyalty.program'].create({
             'name': 'Loyalty Program',
@@ -2956,7 +2956,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.env['loyalty.program'].search([]).write({'active': False})
         test_partner = self.env['res.partner'].create({'name': 'Test Partner'})
-        self.env['res.partner'].create({'name': 'Test Partner 2'})
+        self.env['res.partner'].create({'name': 'AAA Test Partner 2'})
 
         loyalty_program = self.env['loyalty.program'].create({
             'name': 'Loyalty Program',


### PR DESCRIPTION
Tours in POS rely on clicking on partners.
But the POS interface does not load ALL records, meaning that depending on the test environment, the tested partner "Test Partner 2" can be too far down the list and not loaded properly.

This commit fixes this by adding "AAA" in front of the name to move it up un the list order.

It's a temporary fix to unblock the runbot and will be investigated more in details.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
