### PR TITLE
[FIX] mail: fetchmail serialization error on commit

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -335,6 +335,10 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                     _logger.warning('Failed to properly finish %s connection: %s.', *server_type_and_name, exc_info=True)
             _logger.info("Fetched %d email(s) on %s server %s; %d succeeded, %d failed.", count, *server_type_and_name, (count - failed), failed)
             server.write({'date': fields.Datetime.now()})
+            # Commit before updating the progress because progress may be
+            # updated for messages using another transaction. Without a commit
+            # before updating the progress, we would have a serialization error.
+            self.env.cr.commit()
             if not self.env['ir.cron']._commit_progress(remaining=total_remaining):
                 break
         return result_exception


### PR DESCRIPTION
The process of fetching run in a transaction t1 and for each message we do it in a transaction tm. tm commits and updates the progress for each message found on the server. t1 was started before tm and since tm changed the progress, t1 may result in a serialization error. By adding the commit, t1 commits all changes and starts a new transaction to update the progress (at that point tm is committed).




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
