### PR TITLE
[FIX] l10n_tr_nilvera*: UBL structure & compliance errors

### DIFF
--- a/addons/l10n_tr_nilvera/security/ir.model.access.csv
+++ b/addons/l10n_tr_nilvera/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_l10n_tr_nilvera_alias_readonly,l10n_tr.nilvera.alias.readonly,model_l10n_tr_nilvera_alias,account.group_account_readonly,1,0,0,0
+access_l10n_tr_nilvera_alias_invoice,l10n_tr.nilvera.alias.readonly,model_l10n_tr_nilvera_alias,account.group_account_invoice,1,0,0,0
+access_l10n_tr_nilvera_alias_manager,l10n_tr.nilvera.alias,model_l10n_tr_nilvera_alias,account.group_account_manager,1,1,1,1
 access_l10n_tr_nilvera_alias,l10n_tr.nilvera.alias,model_l10n_tr_nilvera_alias,account.group_account_user,1,1,1,1

--- a/addons/l10n_tr_nilvera_einvoice/__manifest__.py
+++ b/addons/l10n_tr_nilvera_einvoice/__manifest__.py
@@ -13,6 +13,11 @@ For sending and receiving electronic invoices to Nilvera.
         'views/account_move_views.xml',
         'wizard/account_move_send_views.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_tr_nilvera_einvoice/static/src/components/**/*',
+        ],
+    },
     'auto_install': ['l10n_tr_nilvera'],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
@@ -245,6 +245,7 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid "View Invoice(s)"
 msgstr ""
@@ -267,4 +268,13 @@ msgstr ""
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
 #, python-format
 msgid "You cannot reset to draft an entry that has been sent to Nilvera."
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid ""
+"Nilvera portal cannot process negative quantity nor negative price on "
+"invoice lines"
 msgstr ""

--- a/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
@@ -259,6 +259,7 @@ msgstr "Bilinmiyor"
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
 msgid "View Invoice(s)"
 msgstr "Fatura(ları) Görüntüle"
@@ -284,3 +285,13 @@ msgid "You cannot reset to draft an entry that has been sent to Nilvera."
 msgstr ""
 "Nilvera'ya gönderilmiş bir girişi taslak haline getirmek için "
 "sıfırlayamazsınız."
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid ""
+"Nilvera portal cannot process negative quantity nor negative price on "
+"invoice lines"
+msgstr ""
+"Nilvera portalı, fatura satırlarında negatif miktar veya negatif fiyat işleyemez."

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -269,6 +269,13 @@ class AccountMove(models.Model):
             lambda aml: (aml.deferred_start_date, aml.deferred_end_date))
         )) > 1
 
+    def _l10n_tr_nilvera_einvoice_check_negative_lines(self):
+        return any(
+            line.display_type not in {'line_note', 'line_section'}
+            and (line.quantity < 0 or line.price_unit < 0)
+            for line in self.invoice_line_ids
+        )
+
     # -------------------------------------------------------------------------
     # CRONS
     # -------------------------------------------------------------------------

--- a/addons/l10n_tr_nilvera_einvoice/static/src/components/actionable_errors/actionable_errors.xml
+++ b/addons/l10n_tr_nilvera_einvoice/static/src/components/actionable_errors/actionable_errors.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="l10n_tr_nilvera_einvoice.ActionableErrors" t-inherit="account.ActionableErrors" t-inherit-mode="extension">
+        <xpath expr="//div[@role='alert']" position="attributes">
+            <attribute name="t-att-class">Object.values(this.props.record.data[this.props.name]).some(e => e.danger) ? 'alert-danger' : 'alert-warning'</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
@@ -81,6 +81,17 @@ class AccountMoveSend(models.TransientModel):
                 "critical": True,
             }
 
+        if invalid_negative_lines := moves_to_check.filtered(
+            lambda move: move._l10n_tr_nilvera_einvoice_check_negative_lines(),
+        ):
+            warnings["critical_invalid_negative_lines"] = {
+                "message": _("Nilvera portal cannot process negative quantity nor negative price on invoice lines"),
+                "action_text": _("View Invoice(s)"),
+                "action": invalid_negative_lines._get_records_action(name=_("Check data on Invoice(s)")),
+                "critical": True,
+                "danger": True,
+            }
+
         return warnings
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR aims to fix certain compliance issues apparent in the UBL structure of Nilvera. an access right issue was also occurring when account is installed but not account_accountant when doing check_nilvera_customer.

Current behavior before PR:
- access right error when doing check_nilvera_customer with account_accountant uninstalled.
- negative lines were allowed in nilvera invoices and were reflected in the xml document.
- StandardItemIdentification displays the products barcode under the invoice line.
- multiplierfactor was not reflecting the discount % of the invoice line

Desired behavior after PR is merged:
- added read access to account module specific groups.
- raise a blocking error if there are discount lines in the invoice.
- remove the StandardItemIdentification node from the xml document
- show discount % in the multiplierfactor 


task-4907751

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
