### PR TITLE
[FIX] website: avoid error when replacing form fields without options

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -528,7 +528,7 @@ export class FormOptionPlugin extends Plugin {
 
         // Synchronize the possible values with the fields whose visibility
         // depends on the current field
-        const newValuesText = field.records.map((record) => record.id);
+        const newValuesText = field.records ? field.records.map((record) => record.id) : [];
         const inputEls = oldFieldEl.querySelectorAll(".s_website_form_input, option");
         const inputName = oldFieldEl.querySelector(".s_website_form_input")?.name;
         const formEl = oldFieldEl.closest(".s_website_form");


### PR DESCRIPTION
Steps to reproduce:
1. Open the website form snippet in edit mode.
2. Add a new field and replace it with a field without options (e.g., `email_cc`, `contents`, `reply_to`, `date`, etc.).
3. You will receive a traceback for a TypeError.

Root cause:
Issue started appearing after commit https://github.com/odoo/odoo/commit/69e45976106c93d887d4fe31cdada3a6a2a393c2.
In the `replaceField` method inside `FormOptionPlugin`, there is a refresh-visibility logic where we traverse the records using `field.records.map(...)`.
For backend fields like `datetime`, `html`, or other free-text types, `field.records` is not set because they don’t have predefined option values. Calling `.map()` on `undefined` caused a TypeError.

Fix:
Added a fallback to return an empty array when `field.records` is not defined.

Related to task-4367641