### PR TITLE
[FIX] stock_account: include accounting date in stock move reference

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -20,6 +20,14 @@ class StockMove(models.Model):
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'stock_move_id')
     analytic_account_line_ids = fields.Many2many('account.analytic.line', copy=False)
 
+    def _compute_reference(self):
+        super()._compute_reference()
+        for move in self:
+            if not move.inventory_name:
+                force_period_date = self.env.context.get('force_period_date', False)
+                if force_period_date:
+                    move.reference += _(' [Accounted on %s]', force_period_date)
+
     def _inverse_picked(self):
         super()._inverse_picked()
         self._account_analytic_entry_move()

--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.tools.misc import groupby
 
 
@@ -87,14 +87,6 @@ class StockQuant(models.Model):
                 inventories.accounting_date = False
             else:
                 super(StockQuant, inventories)._apply_inventory()
-
-    def _get_inventory_move_values(self, qty, location_id, location_dest_id, package_id=False, package_dest_id=False):
-        res_move = super()._get_inventory_move_values(qty, location_id, location_dest_id, package_id, package_dest_id)
-        if not self.env.context.get('inventory_name'):
-            force_period_date = self.env.context.get('force_period_date', False)
-            if force_period_date:
-                res_move['name'] += _(' [Accounted on %s]', force_period_date)
-        return res_move
 
     @api.model
     def _get_inventory_fields_write(self):


### PR DESCRIPTION
Problem: When trying to update a product’s quantity after requesting a count with an accounting date set, you get an error. This error occurs because the name field was removed from the stock move model.

Purpose: To have the accounted on date information set on the stock move’s reference field instead of the name field.

Steps to Reproduce on Runbot:

1. Navigate to Inventory > Operations > Physical Inventory.
2. Select a product in the list view and click on Request a Count.
3. Set the Accounting Date in the wizard.
4. Navigate to the product and try to update the on-hand quantity.
5. Once you save the updated on-hand quantity you will receive an error.

opw-5009967

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
