### PR TITLE
[IMP] base: make config parameter list view editable

### DIFF
--- a/odoo/addons/base/views/ir_config_parameter_views.xml
+++ b/odoo/addons/base/views/ir_config_parameter_views.xml
@@ -12,7 +12,7 @@
         <record model="ir.ui.view" id="view_ir_config_list">
             <field name="model">ir.config_parameter</field>
             <field name="arch" type="xml">
-                <list string="System Parameters">
+                <list string="System Parameters" editable="bottom">
                     <field name="key"/>
                     <field name="value"/>
                 </list>


### PR DESCRIPTION
* Currently, when editing value of config parameter manually we need to go to list view click on it to go to form view to edit . This commit reduce one step by allowing to edit on list view directly.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
