### PR TITLE
[IMP] l10n_us: move the l10n_us_bank_account_type field here

### DIFF
--- a/addons/l10n_us/models/res_partner_bank.py
+++ b/addons/l10n_us/models/res_partner_bank.py
@@ -10,6 +10,15 @@ class ResPartnerBank(models.Model):
     _inherit = 'res.partner.bank'
 
     show_aba_routing = fields.Boolean(compute="_compute_show_aba_routing")
+    l10n_us_bank_account_type = fields.Selection(
+        selection=[
+            ('checking', 'Checking'),
+            ('savings', 'Savings'),
+        ],
+        string='Bank Account Type',
+        default='checking',
+        required=True
+    )
 
     @api.depends('country_code', 'acc_type')
     def _compute_show_aba_routing(self):

--- a/addons/l10n_us/views/res_partner_bank_views.xml
+++ b/addons/l10n_us/views/res_partner_bank_views.xml
@@ -12,6 +12,9 @@
                 <label for="clearing_number" invisible="show_aba_routing"/>
                 <label for="clearing_number" string="ABA/Routing" invisible="not show_aba_routing"/>
             </field>
+            <field name="currency_id" position="after">
+                <field name="l10n_us_bank_account_type" invisible="country_code != 'US'"/>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
It was part of `l10n_us_payment_nacha`, but is useful in other non-accounting modules as well (e.g. payroll).

task-5015755
