### PR TITLE
[FIX] - #222778  While creation it is giving issue via external API

### DIFF
--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -109,7 +109,7 @@ class MailTracking(models.Model):
         elif col_info['type'] == 'selection':
             values.update({
                 'old_value_char': initial_value and dict(col_info['selection']).get(initial_value, initial_value) or '',
-                'new_value_char': new_value and dict(col_info['selection'])[new_value] or ''
+                'new_value_char': new_value and dict(col_info['selection']).get(new_value, new_value) or ''
             })
         elif col_info['type'] == 'many2one':
             values.update({


### PR DESCRIPTION
During the mail tracking value creation in the new value and looks up using direct dictionary access which throws a KeyError when the value doesn't exist in the selection options, we can  use .get() method with a fallback.
after changes, the tracking will still work and display the raw value when the selection option is missing.



