### PR TITLE
[FIX] html_editor: fix toolbar test in community

### DIFF
--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -340,11 +340,11 @@ test("should focus the editable area after selecting a font size item", async ()
     const inputEl = iframeEl.contentWindow.document?.querySelector("input");
     await contains(".o-we-toolbar [name='font-size'] .dropdown-toggle").click();
     expect(getActiveElement()).toBe(inputEl);
-    await waitFor(".o_font_size_selector_menu .dropdown-item:contains('34')", { timeout: 1000 });
-    await contains(".o_font_size_selector_menu .dropdown-item:contains('34')").click();
+    await waitFor(".o_font_size_selector_menu .dropdown-item:contains('21')");
+    await contains(".o_font_size_selector_menu .dropdown-item:contains('21')").click();
     expect(getActiveElement()).toBe(editor.editable);
     expect(getActiveElement()).not.toBe(inputEl);
-    expect(getContent(el)).toBe(`<p><span class="h1-fs">[test]</span></p>`);
+    expect(getContent(el)).toBe(`<p><span class="h2-fs">[test]</span></p>`);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
Turns out the test only failed in community and none of my previous fixes could have solved it because the issue is that the sizes are not all the same between community and enterprise. I'm not sure if this is intended but that will be the subject of another task. In this PR I focus in fixing this test that fails deterministically in community.

runbot-230955