### PR TITLE
[IMP] base: Removing ZIP code requirement for Peru

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1115,6 +1115,7 @@
         <record id="pe" model="res.country">
             <field name="name">Peru</field>
             <field name="code">pe</field>
+            <field name='zip_required'>0</field>
             <field name="currency_id" ref="PEN" />
             <field eval="51" name="phone_code" />
             <field name="vat_label">RUC</field>


### PR DESCRIPTION
As ZIP codes are not widely used in Peru, the requirement for a ZIP code to be provided for a Peruvian customer should not be present.

task-5012593


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
