### PR TITLE
[FIX] delivery: fix report template from illegal html

### DIFF
--- a/addons/delivery/report/ir_actions_report_templates.xml
+++ b/addons/delivery/report/ir_actions_report_templates.xml
@@ -5,7 +5,8 @@
         <span name="order_note" position="before">
             <p t-if="doc.carrier_id.carrier_description" id="carrier_description">
                 <strong>Shipping Description</strong>
-                <div t-out="doc.carrier_id.carrier_description"/>
+                <span class="d-block" t-out="doc.carrier_id.carrier_description"/>
+                <div class="d-none" t-out="doc.carrier_id.carrier_description"/>
             </p>
         </span>
     </template>


### PR DESCRIPTION
because of odoo/odoo#169512, there was some illegal html generated in the delivery report. Indeed a <div> in a <p> is not supported.

This created issues in the reportEditor, and possibly elsewhere

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
