### PR TITLE
[FIX] account: Fix double counting of base amount when dealing with p…

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -924,7 +924,7 @@ class AccountTax(models.Model):
             tax_amount = float_round(tax_amount, precision_rounding=prec)
             factorized_tax_amount = float_round(tax_amount * sum_repartition_factor, precision_rounding=prec)
 
-            if price_include and total_included_checkpoints.get(i) is None:
+            if price_include and total_included_checkpoints.get(i) is None and not tax.include_base_amount:
                 cumulated_tax_included_amount += factorized_tax_amount
 
             # If the tax affects the base of subsequent taxes, its tax move lines must

--- a/addons/account_tax_python/tests/test_tax.py
+++ b/addons/account_tax_python/tests/test_tax.py
@@ -61,7 +61,7 @@ class TestTaxPython(TestTaxCommon):
             res
         )
 
-    def test_price_included_multi_taxes_with_python_tax(self):
+    def test_price_included_multi_taxes_with_python_tax_1(self):
         """ Test multiple price-included taxes with a Python code tax applied last
         to ensure the total matches the price, and cached tax didn't bypassing the rounding correction.
         """
@@ -94,4 +94,36 @@ class TestTaxPython(TestTaxCommon):
                 (440.63, 22.5),
             ],
             res
+        )
+
+    def test_price_included_multi_taxes_with_python_tax_2(self):
+        tax_python = self.env['account.tax'].create({
+            'name': "Python Tax",
+            'amount_type': 'code',
+            'python_compute': "result = 5",
+            'price_include': True,
+            'include_base_amount': True,
+            'sequence': 1,  # Ensure this tax is applied first
+        })
+
+        tax_12_percent = self.env['account.tax'].create({
+            'name': "Tax 12%",
+            'amount_type': 'percent',
+            'amount': 15.0,
+            'price_include': True,
+            'include_base_amount': False,
+            'sequence': 2,  # Ensure this tax is applied after the 12% tax
+        })
+
+        taxes = tax_python + tax_12_percent
+        res = taxes.compute_all(100.00)
+
+        self._check_compute_all_results(
+            total_included=100.0,
+            total_excluded=81.96,
+            taxes=[
+                (81.96, 5.0),
+                (86.96, 13.04),
+            ],
+            res=res,
         )


### PR DESCRIPTION
…ython taxes

- python tax of 5 price included, affect base amount
- percent tax of 15%

If you apply them on 100, a price excluded amount of 81.96 is computed first. For the python tax, everything is ok. You got a base of 81.96 and a tax amount of 5. For the percent tax, since it's the last tax, we are supposed to compute the tax amount as 100 - 81.96 - 5 = 13.04.
However, the base is accounted twice and we do
100 - 86.96 - 5 = 8.04 instead.

github-issue: 221560

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
