### PR TITLE
[FIX] point_of_sale: align pos with new fiscal position behavior

### DIFF
--- a/addons/point_of_sale/models/account_fiscal_position.py
+++ b/addons/point_of_sale/models/account_fiscal_position.py
@@ -13,4 +13,4 @@ class AccountFiscalPosition(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'name', 'display_name', 'tax_map']
+        return ['id', 'name', 'display_name', 'tax_map', 'tax_ids']

--- a/addons/point_of_sale/static/src/app/models/utils/tax_utils.js
+++ b/addons/point_of_sale/static/src/app/models/utils/tax_utils.js
@@ -67,6 +67,10 @@ export const getTaxesAfterFiscalPosition = (taxes, fiscalPosition, models) => {
         return taxes;
     }
 
+    if (fiscalPosition.tax_ids?.length == 0) {
+        return [];
+    }
+
     const newTaxIds = [];
     for (const tax of taxes) {
         if (fiscalPosition.tax_map[tax.id]) {

--- a/addons/point_of_sale/static/tests/unit/data/account_fiscal_position.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/account_fiscal_position.data.js
@@ -4,7 +4,7 @@ export class AccountFiscalPosition extends models.ServerModel {
     _name = "account.fiscal.position";
 
     _load_pos_data_fields() {
-        return ["id", "name", "display_name", "tax_map"];
+        return ["id", "name", "display_name", "tax_map", "tax_ids"];
     }
 
     _records = [
@@ -12,6 +12,12 @@ export class AccountFiscalPosition extends models.ServerModel {
             id: 1,
             name: "Domestic",
             display_name: "Domestic",
+            tax_ids: [1],
+        },
+        {
+            id: 2,
+            name: "No tax fp",
+            display_name: "No tax fp",
         },
     ];
 }

--- a/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order_line.test.js
@@ -191,4 +191,15 @@ describe("pos.order.line", () => {
         line1.merge(line2);
         expect(line1.qty).toBe(5);
     });
+
+    test("Test taxes after fiscal position", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const dataDict = getAllPricesData();
+        dataDict["pos.order"][0]["fiscal_position_id"] = 2;
+        const data = models.loadConnectedData(dataDict);
+        const orderLine = data["pos.order.line"][0];
+        const lineValues = orderLine.prepareBaseLineForTaxesComputationExtraValues();
+        expect(lineValues.tax_ids.length).toBe(0);
+    });
 });


### PR DESCRIPTION
If a fiscal position is not related to any tax, when selecting said fiscal position in the pos, the tax from the product is kept. When looking at the paid order in the backend the tax is removed on the order line and the price unit and price with taxes are different (although no tax recorder on the line).

Steps to reproduce:
-------------------
* Create a fiscal position and assign no tax to it
* On the pos config, add this fiscal position and the domestic one to the available fiscal positions
* Open pos session
* Select a product that has a 15% tax
* Change the fiscal position to the one just created
> Observation: We still see that the tax is computed based on the 15%
* Pay the order
* Go see the order in backend
> Observation: price unit: 100, no tax, price with taxes 115

Why the fix:
------------
A recent refactoring happened on the accounting side related to fiscal positions: https://github.com/odoo/odoo/commit/9a97157920c845120861dda49d81d3150e015974

https://github.com/odoo/odoo/blob/e284dfd80bde632e6446fc0b8d3276689da35200/addons/account/models/partner.py#L155-L163

The behavior after this refactoring is the following: When changing fiscal position:
- If the original tax is available for the fiscal position, we use it
- If the original tax is not available but the fiscal position has an available tax that is set to be replacement for the original one, we use the replacement tax
- If the original tax is not available but the fiscal position has an available tax which is NOT a replacement for the original one, we keep the original one
- If the fiscal position has no tax available, we remove the tax

In this fix we apply the same logic inside the pos.

Without the fix we would keep the original tax in the frontend but when passed in the backend the tax with fiscal position was recomputed with the logic from accounting. This explained the difference we observed.

opw-4978056
