### PR TITLE
[FIX] sql_db: db_name is a list

### DIFF
--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -100,7 +100,7 @@ def _initialize_db(db_name, demo, lang, user_password, login='admin', country_co
 
 
 def _check_faketime_mode(db_name):
-    if os.getenv('ODOO_FAKETIME_TEST_MODE') and db_name in odoo.tools.config['db_name'].split(','):
+    if os.getenv('ODOO_FAKETIME_TEST_MODE') and db_name in odoo.tools.config['db_name']:
         try:
             db = odoo.sql_db.db_connect(db_name)
             with db.cursor() as cursor:

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -365,7 +365,7 @@ class Cursor(BaseCursor):
         self.connection.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
         self.connection.set_session(readonly=pool.readonly)
 
-        if os.getenv('ODOO_FAKETIME_TEST_MODE') and self.dbname in tools.config['db_name'].split(','):
+        if os.getenv('ODOO_FAKETIME_TEST_MODE') and self.dbname in tools.config['db_name']:
             self.execute("SET search_path = public, pg_catalog;")
             self.commit()  # ensure that the search_path remains after a rollback
 


### PR DESCRIPTION
A fix was introduced in https://github.com/odoo/odoo/pull/222805 to check config['db_name'], but this was replaced by a list in 18.2 and it was missed by the forwardport