### PR TITLE
[IMP] stock*: show responsible user avatar and availability

### DIFF
--- a/addons/stock/wizard/stock_request_count.xml
+++ b/addons/stock/wizard/stock_request_count.xml
@@ -8,7 +8,7 @@
             <form>
                 <group>
                     <field name="quant_ids" invisible="1"/>
-                    <field name="user_id" placeholder="Anyone"/>
+                    <field name="user_id" placeholder="Anyone" widget="many2one_avatar_user"/>
                     <field name="inventory_date"/>
                     <field name="show_expected_quantity"/>
                 </group>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -135,7 +135,7 @@
                     </div>
                     <group>
                         <group id="batch_delivery_data">
-                            <field name="user_id" readonly="state not in ['draft', 'in_progress']"/>
+                            <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']"/>
                             <field name="picking_type_id" readonly="state != 'draft'"/>
                             <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
                             <field name="description"/>


### PR DESCRIPTION
 *stock_picking_batch

With this commit:
----------------------------------
- Improved the Request a Count form in physical inventory by showing the avatar
  of the selected responsible user, enabling quicker visual identification.
- Applied the same status widget to the Batch/Wave Transfer views, allowing
  users to easily identify employees during transfer and delivery operations.
- These enhancements streamline the assignment process, enabling faster and
  more informed selection of responsible users.

Task Id: 4746426