### PR TITLE
[FIX] html_builder: apply date input on datepicker apply

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_datetimepicker.js
@@ -1,5 +1,6 @@
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { useDateTimePicker } from "@web/core/datetime/datetime_hook";
+import { effect } from "@web/core/utils/reactive";
 import { ConversionError, formatDate, formatDateTime, parseDateTime } from "@web/core/l10n/dates";
 import { pick } from "@web/core/utils/objects";
 import { BuilderComponent } from "./builder_component";
@@ -39,15 +40,19 @@ export class BuilderDateTimePicker extends Component {
             formatRawValue: this.formatRawValue.bind(this),
             parseDisplayValue: this.parseDisplayValue.bind(this),
         });
-        this.state = state;
-        this.oldValue = this.state.value;
+        this.domState = state;
+        this.state = useState({});
+        effect(
+            ({ value }) => {
+                // State to display in the input.
+                this.state.value = value;
+            },
+            [state]
+        );
 
         this.commit = (userInputValue) => {
             this.isPreviewing = false;
             const result = commit(userInputValue);
-            if (result) {
-                this.oldValue = parseDateTime(result).toUnixInteger().toString();
-            }
             return result;
         };
 
@@ -56,10 +61,12 @@ export class BuilderDateTimePicker extends Component {
             preview(userInputValue);
         };
 
+        const minDate = DateTime.fromObject({ year: 1000 });
+        const maxDate = DateTime.now().plus({ year: 200 });
         const getPickerProps = () => ({
             type: this.props.type,
-            minDate: DateTime.fromObject({ year: 1000 }),
-            maxDate: DateTime.now().plus({ year: 200 }),
+            minDate,
+            maxDate,
             value: this.getCurrentValueDateTime(),
             rounding: 0,
         });
@@ -78,7 +85,7 @@ export class BuilderDateTimePicker extends Component {
             onChange: (value) => {
                 const dateString = this.formatDateTime(value);
                 this.preview(dateString);
-                state.value = this.parseDisplayValue(dateString);
+                this.state.value = this.parseDisplayValue(dateString);
             },
         });
     }
@@ -87,7 +94,7 @@ export class BuilderDateTimePicker extends Component {
      * @returns {DateTime} the current value of the datetime picker
      */
     getCurrentValueDateTime() {
-        return this.state.value ? DateTime.fromSeconds(parseInt(this.state.value)) : false;
+        return this.domState.value ? DateTime.fromSeconds(parseInt(this.domState.value)) : false;
     }
 
     /**
@@ -118,7 +125,7 @@ export class BuilderDateTimePicker extends Component {
                 throw e;
             }
             if (!this.isPreviewing && displayValue !== "") {
-                return this.oldValue;
+                return this.domState.value;
             }
         }
         return this.defaultValue;

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_datetimepicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_datetimepicker.test.js
@@ -60,8 +60,13 @@ test("defaults to last one when invalid date provided", async () => {
         selector: ".test-options-target",
         template: xml`<BuilderDateTimePicker dataAttributeAction="'date'"/>`,
     });
-    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await setupWebsiteBuilder(`<div class="test-options-target" data-date="1554219400">b</div>`);
     await contains(":iframe .test-options-target").click();
+    expect(".we-bg-options-container input").toHaveValue("04/02/2019 16:36:40");
+
+    await contains(".we-bg-options-container input").edit("INVALID DATE");
+    expect(".we-bg-options-container input").toHaveValue("04/02/2019 16:36:40");
+
     await contains(".we-bg-options-container input").edit("04/01/2019 10:00:00");
     expect(".we-bg-options-container input").toHaveValue("04/01/2019 10:00:00");
 
@@ -74,8 +79,13 @@ test("defaults to last one when invalid date provided (date)", async () => {
         selector: ".test-options-target",
         template: xml`<BuilderDateTimePicker type="'date'" dataAttributeAction="'date'"/>`,
     });
-    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await setupWebsiteBuilder(`<div class="test-options-target" data-date="1554219400">b</div>`);
     await contains(":iframe .test-options-target").click();
+    expect(".we-bg-options-container input").toHaveValue("04/02/2019");
+
+    await contains(".we-bg-options-container input").edit("INVALID DATE");
+    expect(".we-bg-options-container input").toHaveValue("04/02/2019");
+
     await contains(".we-bg-options-container input").edit("04/01/2019 10:00:00");
     expect(".we-bg-options-container input").toHaveValue("04/01/2019");
 
@@ -155,4 +165,28 @@ test("selects a date and synchronize the input field, while still in preview", a
     const expectedDateTimestamp = expectedDateTime.toUnixInteger();
     const dateTimestamp = parseFloat(queryOne(":iframe .test-options-target").dataset.date);
     expect(Math.abs(expectedDateTimestamp - dateTimestamp)).toBeLessThan(TIME_TOLERANCE);
+});
+
+test("edit a date with the datetime picker should correctly apply the mutation", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'"/>`,
+    });
+    await setupWebsiteBuilder(`
+        <div class="test-options-target" data-date="1554219400">b</div>
+        <div class="another-target">c</div>`);
+    await contains(":iframe .test-options-target").click();
+    await contains(".we-bg-options-container input").click();
+    await contains(".o_date_item_cell:contains('9')").click();
+    expect(".we-bg-options-container input").toHaveValue("04/09/2019 16:36:40");
+
+    await contains(".o_datetime_buttons .btn:contains('apply')").click();
+    expect(".we-bg-options-container input").toHaveValue("04/09/2019 16:36:40");
+    expect(":iframe .test-options-target").toHaveAttribute("data-date", "1554824200");
+
+    // refresh the Edit tab
+    await contains(":iframe .another-target").click();
+    await contains(":iframe .test-options-target").click();
+    expect(".we-bg-options-container input").toHaveValue("04/09/2019 16:36:40");
+    expect(":iframe .test-options-target").toHaveAttribute("data-date", "1554824200");
 });


### PR DESCRIPTION
In [1] the builder date picker was adapted in order to have the text version of the date updated upon date selection preview (without apply).

In [2] that was changed to use the state to reflect the value. But by doing that, on apply, the datetime picker service considered that the applied date was already known and did not call `onApply` anymore, thus not triggering the actual action.

This commit fixes the issue by adding a state that contains the value to be displayed in the input. So we have two states: one that contains the DOM value (not in preview mode) and the new state that contains the value to be displayed in preview mode.
The datetipicker no longer thinks that the value displayed in the input is the one already applied. So it calls onApply.

Steps to reproduce:
- Drop a "Countdown" snippet
- Open "Due Date"
- Select a date
- Click on Apply

=> No undo was available, value was lost on repaint or save.

[1]: https://github.com/odoo/odoo/commit/2d1a39f7224495ea04aa8765ae5ac11145a84398
[2]: https://github.com/odoo/odoo/commit/97a49dcec8f2ef7f6b6ec3113fd1b11eb121c610

task-4367641

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
