### PR TITLE
website*: migrate search forms to POST method to prevent crawler indexing

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2877,9 +2877,12 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
         <attribute name="t-attf-class" remove="s_searchbar_input" separator=" "/>
     </xpath>
     <xpath expr="//div[@role='search']" position="replace">
-        <form t-attf-class="o_searchbar_form s_searchbar_input #{_form_classes}" t-att-action="action" method="get" t-attf-data-snippet="s_searchbar_input">
+        <form t-attf-class="o_searchbar_form s_searchbar_input #{_form_classes}" t-att-action="action" t-att-method="form_method or 'get'" t-attf-data-snippet="s_searchbar_input">
             <t>$0</t>
             <input name="order" type="hidden" class="o_search_order_by" t-att-value="order_by if order_by else 'name asc'"/>
+            <t t-if="form_method and form_method.lower() == 'post'">
+                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+            </t>
             <t t-out="0"/>
         </form>
     </xpath>

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -185,7 +185,8 @@ class WebsiteBlog(http.Controller):
 
         date_begin, date_end = opt.get('date_begin'), opt.get('date_end')
 
-        if tag and request.httprequest.method == 'GET':
+        has_group_designer = request.env.user.has_group('website.group_website_designer')
+        if tag and request.httprequest.method == 'GET' and not has_group_designer:
             # redirect get tag-1,tag-2 -> get tag-1
             tags = tag.split(',')
             if len(tags) > 1:

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -83,6 +83,7 @@
             <!-- 'Search Box' -->
             <t t-call="website.website_search_box_input">
                 <t t-set="_form_classes" t-valuef="#{not len(blogs) &gt; 1 and 'ms-auto'} flex-grow-1 flex-lg-grow-0"/>
+                <t t-set="form_method" t-value="'post'"/>
                 <t t-set="search_type" t-valuef="blogs"/>
                 <t t-set="action" t-value="blog_url(tag=tag,search=search)"/>
                 <t t-set="display_description" t-valuef="true"/>

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -44,14 +44,13 @@ class WebsiteEventController(http.Controller):
 
     @http.route(['/event', '/event/page/<int:page>', '/events', '/events/page/<int:page>', '/event/tags/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=sitemap_event, list_as_website_content=_lt("Events"))
     def events(self, page=1, slug_tags=None, **searches):
-        if (slug_tags or searches.get('tags', '[]').count(',') > 0) and request.httprequest.method == 'GET' and not searches.get('prevent_redirect'):
+        if (slug_tags or searches.get('tags', '[]').count(',') > 0) and request.httprequest.method == 'GET':
             # Previously, the tags were searched using GET, which caused issues with crawlers (too many hits)
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
             # This permanent redirect is placed to instruct the bots that this page is no longer valid
             # Note: We allow a single tag to be GET, to keep crawlers & indexes on those pages
             # What we really want to avoid is combinatorial explosions
             # (Tags are formed as a JSON array, so we count ',' to keep it simple)
-            # TODO: remove in a few stable versions (v19?), including the "prevent_redirect" param in templates
             return request.redirect('/event', code=301)
 
         Event = request.env['event.event']

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -44,7 +44,8 @@ class WebsiteEventController(http.Controller):
 
     @http.route(['/event', '/event/page/<int:page>', '/events', '/events/page/<int:page>', '/event/tags/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=sitemap_event, list_as_website_content=_lt("Events"))
     def events(self, page=1, slug_tags=None, **searches):
-        if (slug_tags or searches.get('tags', '[]').count(',') > 0) and request.httprequest.method == 'GET':
+        has_group_designer = request.env.user.has_group('website.group_website_designer')
+        if (slug_tags or searches.get('tags', '[]').count(',') > 0) and request.httprequest.method == 'GET' and not has_group_designer:
             # Previously, the tags were searched using GET, which caused issues with crawlers (too many hits)
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
             # This permanent redirect is placed to instruct the bots that this page is no longer valid

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -60,13 +60,13 @@
                             class="badge bg-primary ms-1"/>
                     </button>
                     <div class="dropdown-menu">
-                        <span t-att-data-post="keep_event_url(tags=slugify_tags((search_tags - searched_category_tags).ids), prevent_redirect=True)"
+                        <span t-att-data-post="keep_event_url(tags=slugify_tags((search_tags - searched_category_tags).ids))"
                             t-attf-class="post_link cursor-pointer dropdown-item d-flex align-items-center justify-content-between #{'active' if not searched_category_tags else ''}">
                             All
                         </span>
                         <t t-foreach="category.tag_ids" t-as="tag">
                             <span t-if="tag.color"
-                                t-att-data-post="keep_event_url(tags=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), prevent_redirect=True)"
+                                t-att-data-post="keep_event_url(tags=slugify_tags(search_tags.ids, toggle_tag_id=tag.id))"
                                 t-attf-class="post_link cursor-pointer dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
                                 <t t-out="tag.name"/>
                             </span>
@@ -78,6 +78,7 @@
                 <t t-call="website.website_search_box_input">
                     <t t-set="_form_classes" t-valuef="flex-grow-1"/>
                     <t t-set="_classes" t-valuef="o_wevent_event_searchbar_form"/>
+                    <t t-set="form_method" t-value="'post'"/>
                     <t t-set="search_type">events</t>
                     <t t-set="action" t-value="'/event/'"/>
                     <t t-set="display_description" t-valuef="true"/>
@@ -121,7 +122,7 @@
                                 <ul class="list-group list-group-flush">
                                     <t t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" t-foreach="category.tag_ids" t-as="tag">
                                         <li t-if="tag.color" class="list-group-item border-0 px-0">
-                                            <span t-att-data-post="keep_event_url(tags=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), prevent_redirect=True)"
+                                            <span t-att-data-post="keep_event_url(tags=slugify_tags(search_tags.ids, toggle_tag_id=tag.id))"
                                                 class="post_link text-reset cursor-pointer" t-att-title="tag.name">
                                                 <div class="form-check">
                                                     <input class="form-check-input pe-none" type="checkbox" t-attf-name="#{tag.color}" t-att-checked="tag in search_tags"/>
@@ -145,7 +146,7 @@
         <t t-foreach="search_tags" t-as="tag">
             <span t-attf-class="o_filter_tag d-inline-flex align-items-baseline rounded ps-2 #{'o_color_%s' % tag.color if tag.color else ''}">
                 <t t-out="tag.display_name"/>
-                <span t-att-data-post="keep_event_url(tags=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), prevent_redirect=True)"
+                <span t-att-data-post="keep_event_url(tags=slugify_tags(search_tags.ids, toggle_tag_id=tag.id))"
                     class="post_link cursor-pointer btn border-0 py-1 px-2 text-reset opacity-75-hover">
                     <i class="oi oi-close" role="img"/>
                 </span>

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -69,14 +69,13 @@ class EventTrackController(http.Controller):
           * 'tags': list of tag IDs for filtering;
         """
 
-        if searches.get('tags', '[]').count(',') > 0 and request.httprequest.method == 'GET' and not searches.get('prevent_redirect'):
+        if searches.get('tags', '[]').count(',') > 0 and request.httprequest.method == 'GET':
             # Previously, the tags were searched using GET, which caused issues with crawlers (too many hits)
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
             # This permanent redirect is placed to instruct the bots that this page is no longer valid
             # Note: We allow a single tag to be GET, to keep crawlers & indexes on those pages
             # What we really want to avoid is combinatorial explosions
             # (Tags are formed as a JSON array, so we count ',' to keep it simple)
-            # TODO: remove in a few stable versions (v19?), including the "prevent_redirect" param in templates
             slug = request.env['ir.http']._slug
             return request.redirect(f'/event/{slug(event)}/track', code=301)
         seo_object = event.track_menu_ids.filtered(lambda menu: menu.menu_id.url.endswith('/track'))

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -69,7 +69,8 @@ class EventTrackController(http.Controller):
           * 'tags': list of tag IDs for filtering;
         """
 
-        if searches.get('tags', '[]').count(',') > 0 and request.httprequest.method == 'GET':
+        has_group_designer = request.env.user.has_group('website.group_website_designer')
+        if searches.get('tags', '[]').count(',') > 0 and request.httprequest.method == 'GET' and not has_group_designer:
             # Previously, the tags were searched using GET, which caused issues with crawlers (too many hits)
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
             # This permanent redirect is placed to instruct the bots that this page is no longer valid

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -55,6 +55,7 @@
             <div class="o_wevent_search d-flex w-100 w-lg-auto">
                 <t t-call="website.website_search_box_input">
                     <t t-set="_classes" t-valuef="o_wevent_event_track_searchbar_form flex-grow-1"/>
+                    <t t-set="form_method" t-value="'post'"/>
                     <t t-set="search_type">track</t>
                     <t t-set="action" t-value="'/event/%s/track' % (slug(event))"/>
                     <t t-set="display_detail" t-valuef="false"/>
@@ -124,7 +125,7 @@
                                             <span t-if="tag.color"
                                                 t-att-data-post="'/event/%s/track?%s' % (
                                                     slug(event),
-                                                    keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)
+                                                    keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))
                                                 )"
                                                 t-attf-class="post_link cursot-pointer d-flex align-items-center justify-content-between text-reset #{'active' if tag in search_tags else ''}">
                                                 <t t-out="tag.name"/>
@@ -157,7 +158,7 @@
                     <t t-foreach="tag_category.tag_ids" t-as="tag">
                         <span t-att-data-post="'/event/%s/track?%s' % (
                                 slug(event),
-                                keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)
+                                keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))
                             )"
                             t-if="tag.color"
                             t-attf-class="post_link cursor-pointer dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
@@ -439,7 +440,7 @@
             <span class="align-items-baseline border d-inline-flex rounded">
                 <i class="fa fa-tag mx-2 text-muted"/>
                 <t t-out="tag.display_name"/>
-                <span t-att-data-post="'/event/%s/track?%s' % (slug(event), keep_query('*', tags=str((search_tags - tag).ids), prevent_redirect=True))"
+                <span t-att-data-post="'/event/%s/track?%s' % (slug(event), keep_query('*', tags=str((search_tags - tag).ids)))"
                     class="post_link cursor-pointer btn border-0 py-1">
                     &#215;
                 </span>
@@ -456,14 +457,14 @@
     <span t-if="search_tags"
         t-att-data-post="'/event/%s/track?%s'% (
             slug(event),
-            keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)
+            keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))
         )"
         t-att-class="'post_link cursor-pointer badge rounded-pill text-decoration-none %s' % ('text-bg-primary opacity-75-hover' if tag in search_tags else 'o_badge o_badge_clickable o_color_0')"
         t-out="tag.name"/>
     <span t-else=""
         t-att-data-post="'/event/%s/track?%s'% (
             slug(event),
-            keep_query('*', tags=str(tag.ids), prevent_redirect=True)
+            keep_query('*', tags=str(tag.ids))
         )"
         t-att-class="'post_link cursor-pointer badge rounded-pill text-decoration-none o_badge o_badge_clickable o_color_%s' % (tag.color)"
         t-out="tag.name"/>

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -401,11 +401,10 @@ class WebsiteSlides(WebsiteProfile):
 
     @http.route(['/slides/all', '/slides/all/tag/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=True, readonly=True)
     def slides_channel_all(self, slide_category=None, slug_tags=None, my=False, **post):
-        if slug_tags and slug_tags.count(',') > 0 and request.httprequest.method == 'GET' and not post.get('prevent_redirect'):
+        if slug_tags and slug_tags.count(',') > 0 and request.httprequest.method == 'GET':
             # Previously, the tags were searched using GET, which caused issues with crawlers (too many hits)
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
             # This permanent redirect is placed to instruct the bots that this page is no longer valid
-            # TODO: remove in a few stable versions (v19?), including the "prevent_redirect" param in templates
             # Note: We allow a single tag to be GET, to keep crawlers & indexes on those pages
             # What we really want to avoid is combinatorial explosions
             return request.redirect('/slides/all', code=301)

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -401,7 +401,8 @@ class WebsiteSlides(WebsiteProfile):
 
     @http.route(['/slides/all', '/slides/all/tag/<string:slug_tags>'], type='http', auth="public", website=True, sitemap=True, readonly=True)
     def slides_channel_all(self, slide_category=None, slug_tags=None, my=False, **post):
-        if slug_tags and slug_tags.count(',') > 0 and request.httprequest.method == 'GET':
+        has_group_designer = request.env.user.has_group('website.group_website_designer')
+        if slug_tags and slug_tags.count(',') > 0 and request.httprequest.method == 'GET' and not has_group_designer:
             # Previously, the tags were searched using GET, which caused issues with crawlers (too many hits)
             # We replaced those with POST to avoid that, but it's not sufficient as bots "remember" crawled pages for a while
             # This permanent redirect is placed to instruct the bots that this page is no longer valid

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -25,12 +25,12 @@
                 <nav class="navbar navbar-expand-lg navbar-light shadow-sm">
                     <t t-call="website.website_search_box_input">
                         <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right order-lg-3"/>
+                        <t t-set="form_method" t-value="'post'"/>
                         <t t-set="search_type" t-valuef="slides"/>
                         <t t-set="action" t-valuef="/slides/all"/>
                         <t t-set="display_description" t-valuef="true"/>
                         <t t-set="display_detail" t-valuef="false"/>
                         <t t-set="placeholder">Search courses</t>
-                        <input type="hidden" name="prevent_redirect" value="True"/>
                     </t>
                     <button class="navbar-toggler px-2 order-1" type="button"
                         data-bs-toggle="collapse" data-bs-target="#navbarSlidesHomepage"
@@ -208,6 +208,7 @@
                     <t t-else="" t-call="website.website_search_box_input">
                         <!-- Search box (mobile)-->
                         <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-md-none"/>
+                        <t t-set="form_method" t-value="'post'"/>
                         <t t-set="search_type" t-valuef="slides"/>
                         <!-- No action: remain on same URL -->
                         <t t-set="display_description" t-valuef="true"/>
@@ -216,7 +217,6 @@
                         <t t-set="search" t-value="original_search or search_term"/>
                         <input t-if="search_my" type="hidden" name="my" t-att-value="1"/>
                         <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
-                        <input type="hidden" name="prevent_redirect" value="True"/>
                     </t>
                     <button class="navbar-toggler px-1" type="button"
                         data-bs-toggle="collapse" data-bs-target="#navbarTagGroups"
@@ -238,7 +238,7 @@
                                     <div class="dropdown-menu" t-att-id="'navToogleTagGroup%s' % tag_group.id">
                                         <t t-foreach="group_frontend_tags" t-as="tag">
                                             <span t-att-class="'post_link cursor-pointer dropdown-item %s' % ('active' if tag in search_tags else '')"
-                                                t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
+                                                t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category)"
                                                 t-out="tag.name"/>
                                         </t>
                                     </div>
@@ -254,6 +254,7 @@
                         <!-- Search box (desktop) -->
                         <t t-call="website.website_search_box_input">
                             <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-none d-md-flex"/>
+                            <t t-set="form_method" t-value="'post'"/>
                             <t t-set="search_type" t-valuef="slides"/>
                             <!-- No action: remain on same URL -->
                             <t t-set="display_description" t-valuef="true"/>
@@ -262,7 +263,6 @@
                             <t t-set="search" t-value="original_search or search_term"/>
                             <input t-if="search_my" type="hidden" name="my" t-att-value="1"/>
                             <input t-if="search_slide_category" type="hidden" name="slide_category" t-att-value="search_slide_category" />
-                            <input type="hidden" name="prevent_redirect" value="True"/>
                         </t>
                     </div>
                 </nav>
@@ -278,7 +278,7 @@
                       <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
                       <i class="fa fa-tag me-2 text-muted"/>
                       My Courses
-                      <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), search=search_term, prevent_redirect=True)"
+                      <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), search=search_term)"
                          class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
                     </span>
                 </t>
@@ -286,7 +286,7 @@
                       <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
                       <i class="fa fa-tag me-2 text-muted"/>
                       <t t-out="search_term"/>
-                      <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, slide_category=search_slide_category, prevent_redirect=True)"
+                      <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids), my=search_my, slide_category=search_slide_category)"
                          class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
                     </span>
                 </t>
@@ -294,7 +294,7 @@
                     <span class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
                         <i class="fa fa-tag me-2 text-muted"/>
                         <t t-out="tag.display_name"/>
-                        <span t-att-data-post='slide_query_url(tag=slugify_tags(search_tags.ids, tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)'
+                        <span t-att-data-post='slide_query_url(tag=slugify_tags(search_tags.ids, tag.id), my=search_my, search=search_term, slide_category=search_slide_category)'
                             class="post_link cursor-pointer btn border-0 py-1">&#215;</span>
                     </span>
                 </t>
@@ -350,11 +350,11 @@
                 <div t-if="channel_frontend_tags" class="mt-auto pt-1 o_wslides_desc_truncate_2_badges">
                     <t t-foreach="channel_frontend_tags" t-as="tag">
                         <t t-if="search_tags">
-                            <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
+                            <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category)"
                                 t-attf-class="post_link cursor-pointer badge o_badge_clickable #{'o_color_'+str(tag.color) if tag in search_tags else 'o_wslides_channel_tag o_color_0'}" t-out="tag.name"/>
                         </t>
                         <t t-else="">
-                            <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
+                            <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category)"
                                 t-attf-class="post_link cursor-pointer badge o_badge_clickable o_wslides_channel_tag #{'o_color_'+str(tag.color)}" t-out="tag.name"/>
                         </t>
                     </t>


### PR DESCRIPTION
This PR migrates some website search forms to POST method and removes the `prevent_redirect` parameter workaround to definitively prevent crawler indexing of combinatorial search pages.

Crawlers have been indexing pages with `prevent_redirect=True` parameters as these links get shared by users and learned by bots. To prevent combinatorial explosion of indexed search pages, this PR:

1. **Migrates all multi-tag search forms to POST method** in website_slides, website_event, website_event_track, and website_blog
2. **Removes all `prevent_redirect` parameter usage** from templates and controllers 
3. **Allows website designers GET access** to preserve editing workflow when the website editor performs full page refreshes

