### PR TITLE
[IMP] {account, purchase}: Allow Auto-Complete for Vendor Refunds

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -611,7 +611,7 @@ class AccountMove(models.Model):
         store=False,
         check_company=True,
         string='Vendor Bill',
-        help="Auto-complete from a past bill.",
+        help="Auto-complete from a previous bill or refund.",
     )
     invoice_source_email = fields.Char(string='Source Email', tracking=True)
     invoice_partner_display_name = fields.Char(compute='_compute_invoice_partner_display_info', store=True)

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1012,11 +1012,11 @@
                                 <field name="ref" default_focus="1" invisible="move_type != 'entry'"/>
                                 <field name="tax_cash_basis_origin_move_id" invisible="not tax_cash_basis_origin_move_id"/>
                                 <label name="invoice_vendor_bill_id_label" for="invoice_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
-                                       invisible="state != 'draft' or move_type != 'in_invoice'"/>
+                                       invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund')"/>
                                 <field name="invoice_vendor_bill_id" nolabel="1" class="oe_edit_only"
-                                       invisible="state != 'draft' or move_type != 'in_invoice'"
-                                       domain="[('company_id', '=', company_id), ('partner_id','child_of', [partner_id]), ('move_type','=','in_invoice')]"
-                                       placeholder="Select an old vendor bill"
+                                       invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund')"
+                                       domain="[('company_id', '=', company_id), ('partner_id', 'child_of', [partner_id]), ('move_type', '=', move_type)]"
+                                       placeholder="Select an old purchase document"
                                        options="{'no_create': True}" context="{'show_total_amount': True}"/>
                             </group>
                             <group id="header_right_group">

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -18,7 +18,7 @@ class AccountMove(models.Model):
 
     purchase_vendor_bill_id = fields.Many2one('purchase.bill.union', store=False, readonly=False,
         string='Auto-complete',
-        help="Auto-complete from a past bill / purchase order.")
+        help="Auto-complete from a previous bill, refund, or purchase order.")
     purchase_id = fields.Many2one('purchase.order', store=False, readonly=False,
         string='Purchase Order',
         help="Auto-complete from a past purchase order.")

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -498,7 +498,7 @@ class PurchaseOrderLine(models.Model):
             'name': self.env['account.move.line']._get_journal_items_full_name(self.name, self.product_id.display_name),
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom_id.id,
-            'quantity': self.qty_to_invoice,
+            'quantity': -self.qty_to_invoice if move and move.move_type == 'in_refund' else self.qty_to_invoice,
             'discount': self.discount,
             'price_unit': self.currency_id._convert(self.price_unit, aml_currency, self.company_id, date, round=False),
             'tax_ids': [(6, 0, self.tax_ids.ids)],

--- a/addons/purchase/report/purchase_bill.py
+++ b/addons/purchase/report/purchase_bill.py
@@ -31,7 +31,7 @@ class PurchaseBillUnion(models.Model):
                     id as vendor_bill_id, NULL as purchase_order_id
                 FROM account_move
                 WHERE
-                    move_type='in_invoice' and state = 'posted'
+                    move_type in ('in_invoice', 'in_refund') and state = 'posted'
             UNION
                 SELECT
                     -id, name, partner_ref as reference, partner_id, date_order::date as date, amount_untaxed as amount, currency_id, company_id,

--- a/addons/purchase/views/account_move_views.xml
+++ b/addons/purchase/views/account_move_views.xml
@@ -10,13 +10,17 @@
                 <t groups="purchase.group_purchase_user">
                     <field name="purchase_id" invisible="1" readonly="state != 'draft'"/>
                     <label for="purchase_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
-                        invisible="state != 'draft' or move_type != 'in_invoice'" />
+                        invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund')" />
                     <field name="purchase_vendor_bill_id" nolabel="1"
-                        invisible="state != 'draft' or move_type != 'in_invoice'"
+                        invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund')"
                         readonly="state != 'draft'"
                         class="oe_edit_only"
-                        domain="partner_id and [('partner_id.commercial_partner_id', '=', commercial_partner_id)] or []"
-                        placeholder="Select a purchase order or an old bill"
+                        domain = "[('partner_id.commercial_partner_id', '=', commercial_partner_id)] if partner_id else [] + [
+                            	'|',
+    	                    		('vendor_bill_id', '=', False),
+                            		('vendor_bill_id.move_type', '=', move_type)
+                        ]"
+                        placeholder="Select a purchase document"
                         context="{'show_total_amount': True}"
                         options="{'no_create': True, 'no_open': True}"/>
                 </t>


### PR DESCRIPTION
Before:
- Users could auto-complete bills from purchase orders and past bills.
- However, the auto-complete feature was not available for refunds; users had to manually create refunds even if a related purchase document already existed.

After:
- Added auto-complete functionality for vendor refunds.
- Now, users can auto-complete refunds from purchase orders or past refunds.

Impact:
- Improves the user experience for creating vendor bills and refunds.
- Reduces manual work for users when generating bills and refunds.

task-4975196
