### PR TITLE
[FIX] hr_attendance: show only employees with attendance

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -674,7 +674,10 @@ class HrAttendance(models.Model):
         if not self.env.user.has_group('hr_attendance.group_hr_attendance_manager'):
             employee_domain = AND([employee_domain, [('attendance_manager_id', '=', self.env.user.id)]])
         if not user_domain:
-            return self.env['hr.employee'].search(employee_domain)
+            # Workaround to make it work only for list view.
+            if 'gantt_start_date' in self.env.context:
+                return self.env['hr.employee'].search(employee_domain)
+            return resources & self.env['hr.employee'].search(employee_domain)
         else:
             employee_name_domain = []
             for leaf in user_domain:


### PR DESCRIPTION
To reproduce:
=============
- Activate the "Attendances" app.
- Go to Attendances > Overview.
- Switch to list view.
- Group by Employee.

Issue:
======
The current domain fetches all employees matching the filter, regardless of whether they have attendance entries in the grouped model. https://github.com/odoo/odoo/blob/5b5f0bf795ca538e91f063f2b3185c12b1d0a992/addons/hr_attendance/models/hr_attendance.py#L677

Fix:
====
Restrict the employee list to only those linked to a resource that
appears in the grouped data
https://github.com/odoo/odoo/blob/5b5f0bf795ca538e91f063f2b3185c12b1d0a992/odoo/models.py#L2360-L2361
The problem is the behavior of gantt view will change it's behavior
So we have to applied only to the list.
there's something unique when we call it from the gantt which is
`gantt_start_date` property that we will use it so we can differentiate
between list and gantt view

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
