### PR TITLE
[IMP] l10n_tr_nilvera: support for official information codes

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/__manifest__.py
+++ b/addons/l10n_tr_nilvera_einvoice/__manifest__.py
@@ -9,6 +9,7 @@ For sending and receiving electronic invoices to Nilvera.
     'data': [
         'data/cron.xml',
         'data/ubl_tr_templates.xml',
+        'data/res_partner_category_data.xml',
         'views/account_journal_dashboard_views.xml',
         'views/account_move_views.xml',
         'wizard/account_move_send_views.xml',

--- a/addons/l10n_tr_nilvera_einvoice/data/res_partner_category_data.xml
+++ b/addons/l10n_tr_nilvera_einvoice/data/res_partner_category_data.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_partner_category_ticaretsicilno" model="res.partner.category">
+            <field name="name">TICARETSICILNO</field>
+        </record>
+        <record id="res_partner_category_mersisno" model="res.partner.category">
+            <field name="name">MERSISNO</field>
+        </record>
+        <record id="res_partner_category_hizmetno" model="res.partner.category">
+            <field name="name">HIZMETNO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_musterino" model="res.partner.category">
+            <field name="name">MUSTERINO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_tesisatno" model="res.partner.category">
+            <field name="name">TESISATNO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_telefonno" model="res.partner.category">
+            <field name="name">TELEFONNO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_distributorno" model="res.partner.category">
+            <field name="name">DISTRIBUTORNO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_tapdkno" model="res.partner.category">
+            <field name="name">TAPDKNO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_bayino" model="res.partner.category">
+            <field name="name">BAYINO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_aboneno" model="res.partner.category">
+            <field name="name">ABONENO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_sayacno" model="res.partner.category">
+            <field name="name">SAYACNO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_epdkno" model="res.partner.category">
+            <field name="name">EPDKNO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_subeno" model="res.partner.category">
+            <field name="name">SUBENO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_pasaportno" model="res.partner.category">
+            <field name="name">PASAPORTNO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_ureticino" model="res.partner.category">
+            <field name="name">URETICINO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_ciftcino" model="res.partner.category">
+            <field name="name">CIFTCINO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_imalatcino" model="res.partner.category">
+            <field name="name">IMALATCINO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_dosyano" model="res.partner.category">
+            <field name="name">DOSYANO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_hastano" model="res.partner.category">
+            <field name="name">HASTANO</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_aracikurumvkn" model="res.partner.category">
+            <field name="name">ARACIKURUMVKN</field>
+            <field name="active" eval="False"/>
+        </record>
+        <record id="res_partner_category_aracikurumetiket" model="res.partner.category">
+            <field name="name">ARACIKURUMETIKET</field>
+            <field name="active" eval="False"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-16 12:38+0000\n"
-"PO-Revision-Date: 2025-07-16 12:38+0000\n"
+"POT-Creation-Date: 2025-08-15 13:23+0000\n"
+"PO-Revision-Date: 2025-08-15 13:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,33 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_aboneno
+msgid "ABONENO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_aracikurumetiket
+msgid "ARACIKURUMETIKET"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_aracikurumvkn
+msgid "ARACIKURUMVKN"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_move_send
 msgid "Account Move Send"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_bayino
+msgid "BAYINO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_ciftcino
+msgid "CIFTCINO"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -43,11 +68,33 @@ msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "Check tags on company(s)"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_distributorno
+msgid "DISTRIBUTORNO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_dosyano
+msgid "DOSYANO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
 #, python-format
 msgid ""
 "E-Invoice customers must have a tax office name in the partner reference "
 "field."
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_epdkno
+msgid "EPDKNO"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -63,6 +110,21 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_journal_dashboard_kanban_view
 msgid "Fetch from Nilvera"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_hastano
+msgid "HASTANO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_hizmetno
+msgid "HIZMETNO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_imalatcino
+msgid "IMALATCINO"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -83,6 +145,16 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_warnings
 msgid "L10N Tr Nilvera Warnings"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_mersisno
+msgid "MERSISNO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_musterino
+msgid "MUSTERINO"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -131,6 +203,36 @@ msgid ""
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_pasaportno
+msgid "PASAPORTNO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.model,name:l10n_tr_nilvera_einvoice.model_res_partner_category
+msgid "Partner Tags"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid ""
+"Please ensure that your company contact has either the 'MERSISNO' or "
+"'TICARETSICILNO' tag with a value assigned."
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_sayacno
+msgid "SAYACNO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_subeno
+msgid "SUBENO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_einvoice_checkbox_xml
 msgid "Send E-Invoice to Nilvera"
 msgstr ""
@@ -150,6 +252,35 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_einvoice.selection__account_move__l10n_tr_nilvera_send_status__succeed
 msgid "Successful"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_tapdkno
+msgid "TAPDKNO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_telefonno
+msgid "TELEFONNO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_tesisatno
+msgid "TESISATNO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_ticaretsicilno
+msgid "TICARETSICILNO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/res_partner_category.py:0
+#, python-format
+msgid ""
+"The Contact Tag(s) cannot be deleted because it is used in Türkiye "
+"electronic integrations"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -231,6 +362,11 @@ msgid "UBL-TR 1.2"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_ureticino
+msgid "URETICINO"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_uuid
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_move__l10n_tr_nilvera_uuid
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_payment__l10n_tr_nilvera_uuid
@@ -240,6 +376,13 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_einvoice.selection__account_move__l10n_tr_nilvera_send_status__unknown
 msgid "Unknown"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "View Company(s)"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice

--- a/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-16 12:39+0000\n"
-"PO-Revision-Date: 2025-07-16 12:39+0000\n"
+"POT-Creation-Date: 2025-08-15 13:24+0000\n"
+"PO-Revision-Date: 2025-08-15 13:24+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,34 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_aboneno
+msgid "ABONENO"
+msgstr "ABONENO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_aracikurumetiket
+msgid "ARACIKURUMETIKET"
+msgstr "ARACIKURUMETIKET"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_aracikurumvkn
+msgid "ARACIKURUMVKN"
+msgstr "ARACIKURUMVKN"
+
+#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_move_send
 msgid "Account Move Send"
 msgstr "Hesap Hareketi Yollandı"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_bayino
+msgid "BAYINO"
+msgstr "BAYINO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_ciftcino
+msgid "CIFTCINO"
+msgstr "CIFTCINO"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -43,6 +68,23 @@ msgstr "Ortak(lar) üzerindeki referansı kontrol edin"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "Check tags on company(s)"
+msgstr "Şirket(ler) üzerindeki etiketleri kontrol edin"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_distributorno
+msgid "DISTRIBUTORNO"
+msgstr "DISTRIBUTORNO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_dosyano
+msgid "DOSYANO"
+msgstr "DOSYANO"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
 #, python-format
 msgid ""
@@ -51,6 +93,11 @@ msgid ""
 msgstr ""
 "E-Fatura müşterilerinin ortak referans alanında bir vergi dairesi adı "
 "bulunmalıdır."
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_epdkno
+msgid "EPDKNO"
+msgstr "EPDKNO"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_einvoice.selection__account_move__l10n_tr_nilvera_send_status__error
@@ -66,6 +113,21 @@ msgstr "Nilvera fatura durumunu getir"
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_journal_dashboard_kanban_view
 msgid "Fetch from Nilvera"
 msgstr "Nilvera'dan Getir"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_hastano
+msgid "HASTANO"
+msgstr "HASTANO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_hizmetno
+msgid "HIZMETNO"
+msgstr "HIZMETNO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_imalatcino
+msgid "IMALATCINO"
+msgstr "IMALATCINO"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_journal
@@ -86,6 +148,16 @@ msgstr "L10N Tr Nilvera Einvoice Etkinleştir Xml"
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_warnings
 msgid "L10N Tr Nilvera Warnings"
 msgstr "L10N Tr Nilvera Uyarıları"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_mersisno
+msgid "MERSISNO"
+msgstr "MERSISNO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_musterino
+msgid "MUSTERINO"
+msgstr "MUSTERINO"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_uuid
@@ -135,6 +207,37 @@ msgstr ""
 "başka bir API anahtarı deneyin veya Nilvera ile iletişime geçin."
 
 #. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_pasaportno
+msgid "PASAPORTNO"
+msgstr "PASAPORTNO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.model,name:l10n_tr_nilvera_einvoice.model_res_partner_category
+msgid "Partner Tags"
+msgstr "Ortak Etiketleri"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid ""
+"Please ensure that your company contact has either the 'MERSISNO' or "
+"''TICARETSICILNO' tag with a value assigned."
+msgstr "Lütfen şirket kontaktınızda 'MERSISNO' veya "
+"'TICARETSICILNO' etiketinin değerle birlikte ekli olduğundan emin olun."
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_sayacno
+msgid "SAYACNO"
+msgstr "SAYACNO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_subeno
+msgid "SUBENO"
+msgstr "SUBENO"
+
+#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_einvoice_checkbox_xml
 msgid "Send E-Invoice to Nilvera"
 msgstr "Nilvera'ya E-Fatura Gönderin"
@@ -157,6 +260,36 @@ msgid "Successful"
 msgstr "Başarılı"
 
 #. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_tapdkno
+msgid "TAPDKNO"
+msgstr "TAPDKNO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_telefonno
+msgid "TELEFONNO"
+msgstr "TELEFONNO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_tesisatno
+msgid "TESISATNO"
+msgstr "TESISATNO"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_ticaretsicilno
+msgid "TICARETSICILNO"
+msgstr "TICARETSICILNO"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/res_partner_category.py:0
+#, python-format
+msgid ""
+"The Contact Tag(s) cannot be deleted because it is used in Türkiye "
+"electronic integrations."
+msgstr "Kontak Etiket(ler)i silinemez çünkü Türkiye "
+"e-entegrasyonlarında kullanılmaktadır."
+
+#. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
 #, python-format
@@ -164,8 +297,8 @@ msgid ""
 "The following E-Invoice partner(s) must have the reference field set to the "
 "tax office name."
 msgstr ""
-"Aşağıdaki E-Fatura ortaklarının referans alanı vergi dairesi adına ayarlanmış "
-"olmalıdır."
+"Aşağıdaki E-Fatura ortaklarının referans alanı vergi dairesi adına "
+"ayarlanmış olmalıdır."
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -186,8 +319,8 @@ msgid ""
 "The following partner(s) are either not Turkish or are missing one of the "
 "following fields: city, state, or street."
 msgstr ""
-"Aşağıdaki ortaklar ya Türk değil ya da şu alanlardan bir veya daha "
-"fazlası eksik: şehir, eyalet veya sokak."
+"Aşağıdaki ortaklar ya Türk değil ya da şu alanlardan bir veya daha fazlası "
+"eksik: şehir, eyalet veya sokak."
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -225,8 +358,8 @@ msgid ""
 "The invoice(s) need to have the same Start Date and End Date on all their "
 "respective Invoice Lines."
 msgstr ""
-"Fatura(lar)ın tüm Fatura Satırlarında aynı Başlangıç Tarihi ve "
-"Bitiş Tarihi bulunmalıdır."
+"Fatura(lar)ın tüm Fatura Satırlarında aynı Başlangıç Tarihi ve Bitiş Tarihi "
+"bulunmalıdır."
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
@@ -236,13 +369,18 @@ msgid ""
 "To continue sending e-Invoices to Nilvera, please upgrade the 'Türkiye - "
 "Nilvera E-Invoice' module."
 msgstr ""
-"Nilvera’ya e-Fatura göndermeye devam etmek için için lütfen "
-"'Türkiye - Nilvera E-Invoice' modülünü güncelleyin."
+"Nilvera’ya e-Fatura göndermeye devam etmek için için lütfen 'Türkiye - "
+"Nilvera E-Invoice' modülünü güncelleyin."
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_edi_xml_ubl_tr
 msgid "UBL-TR 1.2"
 msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:res.partner.category,name:l10n_tr_nilvera_einvoice.res_partner_category_ureticino
+msgid "URETICINO"
+msgstr "URETICINO"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_uuid
@@ -255,6 +393,13 @@ msgstr "Faturanın evrensel Olarak benzersiz tanımlayıcısı"
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_einvoice.selection__account_move__l10n_tr_nilvera_send_status__unknown
 msgid "Unknown"
 msgstr "Bilinmiyor"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py:0
+#, python-format
+msgid "View Company(s)"
+msgstr "Şirket(ler)i Görüntüle"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python

--- a/addons/l10n_tr_nilvera_einvoice/models/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_edi_xml_ubl_tr
 from . import account_journal
 from . import account_move
+from . import res_partner_category

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -102,6 +102,23 @@ class AccountEdiXmlUblTr(models.AbstractModel):
             },
             'id': partner.vat,
         })
+
+        mandatory_categories = self.env["res.partner.category"]._get_l10n_tr_official_mandatory_categories()
+        tr_companies = self.env.companies.filtered(lambda company: company.country_code == 'TR' and company.l10n_tr_nilvera_api_key)
+        if partner in tr_companies.partner_id and not (mandatory_categories & partner.category_id.parent_id):
+            raise UserError(_("Please ensure that your company contact has either the 'MERSISNO' or 'TICARETSICILNO' tag with a value assigned."))
+
+        official_categories = partner.category_id._get_l10n_tr_official_categories()
+        for category in partner.category_id:
+            if category.parent_id not in official_categories:
+                continue
+            vals.append({
+                'id_attrs': {
+                    'schemeID': category.parent_id.name,
+                },
+                'id': category.name,
+            })
+
         return vals
 
     def _get_partner_address_vals(self, partner):

--- a/addons/l10n_tr_nilvera_einvoice/models/res_partner_category.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/res_partner_category.py
@@ -1,0 +1,54 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+l10n_tr_official_code_categories = [
+    "res_partner_category_hizmetno",
+    "res_partner_category_mersisno",
+    "res_partner_category_tesisatno",
+    "res_partner_category_telefonno",
+    "res_partner_category_distributorno",
+    "res_partner_category_ticaretsicilno",
+    "res_partner_category_tapdkno",
+    "res_partner_category_bayino",
+    "res_partner_category_aboneno",
+    "res_partner_category_sayacno",
+    "res_partner_category_epdkno",
+    "res_partner_category_subeno",
+    "res_partner_category_pasaportno",
+    "res_partner_category_ureticino",
+    "res_partner_category_ciftcino",
+    "res_partner_category_imalatcino",
+    "res_partner_category_dosyano",
+    "res_partner_category_hastano",
+    "res_partner_category_musterino",
+    "res_partner_category_aracikurumvkn",
+    "res_partner_category_aracikurumetiket",
+]
+
+l10n_tr_official_mandatory_code_categories = [
+    "res_partner_category_mersisno",
+    "res_partner_category_ticaretsicilno",
+]
+
+
+class PartnerCategory(models.Model):
+    _inherit = "res.partner.category"
+
+    def _get_categories_from_xml_ids(self, xml_ids_list):
+        categories = self.env["res.partner.category"]
+        for xml_id in xml_ids_list:
+            categories |= self.env.ref(f"l10n_tr_nilvera_einvoice.{xml_id}", raise_if_not_found=False)
+        return categories
+
+    def _get_l10n_tr_official_categories(self):
+        return self._get_categories_from_xml_ids(l10n_tr_official_code_categories)
+
+    def _get_l10n_tr_official_mandatory_categories(self):
+        return self._get_categories_from_xml_ids(l10n_tr_official_mandatory_code_categories)
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_l10n_tr_official_category(self):
+        """Prevent the deletion of Nilvera official TR categories"""
+        official_categories = self._get_l10n_tr_official_categories()
+        if any(rec in official_categories for rec in self):
+            raise UserError(_("The Contact Tag(s) cannot be deleted because it is used in Türkiye electronic integrations."))

--- a/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/wizard/account_move_send.py
@@ -36,8 +36,17 @@ class AccountMoveSend(models.TransientModel):
 
     def _l10n_tr_nilvera_check_invoices(self):
         moves_to_check = self.move_ids.filtered(self._get_default_l10n_tr_nilvera_einvoice_enable_einvoice)
+        mandatory_category_codes = self.env["res.partner.category"]._get_l10n_tr_official_mandatory_categories()
 
         warnings = {}
+
+        if tr_companies_missing_required_codes := moves_to_check.company_id.filtered(lambda c: not (c.partner_id.category_id.parent_id & mandatory_category_codes)):
+            warnings["tr_companies_missing_required_codes"] = {
+                "message": _("Please ensure that your company contact has either the 'MERSISNO' or 'TICARETSICILNO' tag with a value assigned."),
+                "action_text": _("View Company(s)"),
+                "action": tr_companies_missing_required_codes.partner_id._get_records_action(name=_("Check tags on company(s)")),
+                "critical": True,
+            }
 
         if invalid_records := moves_to_check.partner_id.filtered(
             lambda p: p.country_code != "TR"


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
Nilvera requires official codes on company contacts for submission to be compliant.

Current behavior before PR:
Invoices may be sent to Nilvera without the required codes, resulting in non-compliance. Currently, only the VKN and TCKN codes are sent, while other required codes are not supported.

Desired behavior after PR is merged: 
Official codes are added as non-deletable tags (non-mandatory ones archived). An error is raised when required tags are missing or empty. Invoices cannot be sent to Nilvera without valid codes. Codes are always reflected in both PDF and XML.

[IMP] l10n_tr_nilvera: support for official information codes

Added codes as tags from the official list and archived non-mandatory ones. These tags cannot be deleted, and an error is shown on attempt. Invoices are blocked from being sent to Nilvera if either MERSISNO or TICARETSICILNO is missing, or if assigned but without a value. Codes are reflected in both PDF and XML. 

task-4992049 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
