### PR TITLE
Saas 18.4 fix contenteditables loco

### DIFF
--- a/addons/html_builder/static/src/core/builder_content_editable_plugin.js
+++ b/addons/html_builder/static/src/core/builder_content_editable_plugin.js
@@ -25,7 +25,10 @@ export class BuilderContentEditablePlugin extends Plugin {
 
     filterContentEditable(contentEditableEls) {
         return contentEditableEls.filter(
-            (el) => !el.matches("input, [data-oe-readonly]") && el.closest(".o_editable")
+            (el) =>
+                !el.matches("input, [data-oe-readonly]") &&
+                el.closest(".o_editable") &&
+                !el.closest(".o_not_editable")
         );
     }
 }

--- a/addons/html_builder/static/src/core/media_website_plugin.js
+++ b/addons/html_builder/static/src/core/media_website_plugin.js
@@ -40,14 +40,9 @@ export class MediaWebsitePlugin extends Plugin {
 
     setup() {
         const basicMediaSelector = `${MEDIA_SELECTOR}, img`;
-        // (see isImageSupportedForStyle).
-        const mediaSelector = basicMediaSelector
-            .split(",")
-            .map((s) => `${s}:not([data-oe-xpath])`)
-            .join(",");
 
         this.addDomListener(this.editable, "dblclick", async (ev) => {
-            const targetEl = ev.target.closest(mediaSelector);
+            const targetEl = ev.target.closest(basicMediaSelector);
             if (!targetEl) {
                 return;
             }
@@ -59,7 +54,7 @@ export class MediaWebsitePlugin extends Plugin {
         this.popover = this.services.popover;
         this.removeCurrentTooltip = () => {};
         this.addDomListener(this.editable, "click", (ev) => {
-            const targetEl = ev.target.closest(mediaSelector);
+            const targetEl = ev.target.closest(basicMediaSelector);
             if (!targetEl) {
                 return;
             }

--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -322,7 +322,7 @@ export function shouldEditableMediaBeEditable(mediaEl) {
     // This case is complex and the solution to support it is not
     // perfect: we mark those media with a class and check that they
     // are descendant of a savable.
-    return mediaEl.closest(".o_editable");
+    return mediaEl.parentElement && mediaEl.parentElement.closest(".o_editable");
 }
 /**
  * Returns the label of a link element.

--- a/addons/html_builder/static/tests/contenteditbale.test.js
+++ b/addons/html_builder/static/tests/contenteditbale.test.js
@@ -1,0 +1,23 @@
+import { expect, test } from "@odoo/hoot";
+import { addBuilderPlugin, setupHTMLBuilder } from "./helpers";
+import { Plugin } from "@html_editor/plugin";
+
+test("Do not set contenteditable to true on elements inside o_not_editable", async () => {
+    class TestPlugin extends Plugin {
+        static id = "testPlugin";
+        resources = {
+            force_editable_selector: ".target",
+        };
+    }
+    addBuilderPlugin(TestPlugin);
+    await setupHTMLBuilder(`
+        <section>
+            <div class="o_not_editable">
+                <div class="target">
+                    Hello
+                </div>
+            </div>
+        </section>
+    `);
+    expect(":iframe .target").not.toHaveAttribute("contenteditable", "true");
+});

--- a/addons/html_builder/static/tests/contenteditbale.test.js
+++ b/addons/html_builder/static/tests/contenteditbale.test.js
@@ -1,6 +1,7 @@
-import { expect, test } from "@odoo/hoot";
-import { addBuilderPlugin, setupHTMLBuilder } from "./helpers";
 import { Plugin } from "@html_editor/plugin";
+import { expect, test } from "@odoo/hoot";
+import { contains } from "@web/../tests/web_test_helpers";
+import { addBuilderPlugin, setupHTMLBuilder } from "./helpers";
 
 test("Do not set contenteditable to true on elements inside o_not_editable", async () => {
     class TestPlugin extends Plugin {
@@ -20,4 +21,27 @@ test("Do not set contenteditable to true on elements inside o_not_editable", asy
         </section>
     `);
     expect(":iframe .target").not.toHaveAttribute("contenteditable", "true");
+});
+
+test("Media should not be replaceable if not inside a savable zone", async () => {
+    await setupHTMLBuilder("", {
+        headerContent: `
+        <header id="top" data-anchor="true" data-name="Header">
+            <i class="fa fa-shopping-cart fa-stack target" data-oe-model="ir.ui.view" data-oe-id="786" data-oe-field="arch" data-oe-xpath="/data/xpath/li[1]/a[1]"/>
+        </header>`,
+        styleContent: `
+            .fa {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                width: 0.75rem;
+                height: 0.75rem;
+            }
+        `,
+    });
+    expect(":iframe .target").toHaveClass("o_editable_media");
+    await contains(":iframe #wrapwrap .target").click();
+    expect("span:contains('Double-click to edit')").toHaveCount(0);
+    await contains(":iframe #wrapwrap .target").dblclick();
+    expect(".modal-content:contains(Select a media)").toHaveCount(0);
 });


### PR DESCRIPTION
[FIX] html_builder: avoid setting contenteditable on some elements

The goal of this commit is to prevent the system from setting the
`contenteditable` attribute to true on elements located inside
`.o_not_editable`. This behavior was lost since the
[website refactoring].

Related to task-4367641

[website refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2


-------------------------------------------------------------------------------------------------------------------------------------------------------------------------


[FIX] html_builder: avoid editing non savable media

The goal of this commit is to improve the handling of the `click` and
`dblclick` events on elements inside the editable. The idea is that we
want to do an action to replace the media (open a tooltip to show that
the media is replaceable or open the media dialog) when the user clicks
or double clicks on an editable media. To do so, the `mediaSelector`
selector was built to remove the elements that had the branding
(`data-oe` information) from the list of elements on which we want to do
the action. The idea was that if the element itself had the branding,
it was not savable (its content is savable but the element in itself is
not) so we do not want to replace it. This is true but it is redundant
of the `isReplaceableMedia` method. This commit removes the
`mediaSelector` selector and improves the
`shouldEditableMediaBeEditable` util function; a media that has the
`o_editable_media` class is considered editable if it is a descendant of
a savable element (an element that has the `o_editable` class) but is
not a savable element itself. Indeed, attributes such as `src` are not
saved on savable elements.

Even if there are nothing failing before this commit, a test has been
added for the sake of completeness

Related to task-4367641






