### PR TITLE
[FIX] hr_holidays: allocation warning wrongly displayed for valid future dates

### DIFF
--- a/addons/hr_holidays/static/tests/tours/time_off_allocation_warning_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_allocation_warning_tour.js
@@ -1,0 +1,63 @@
+import { registry } from '@web/core/registry';
+import { stepUtils } from "@web_tour/tour_utils";
+
+registry.category("web_tour.tours").add("time_off_allocation_warning_tour", {
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Click Time Off",
+            trigger: ".o_app[data-menu-xmlid='hr_holidays.menu_hr_holidays_root']",
+            run: "click",
+        },
+        {
+            content: "Open Management menu",
+            trigger: ".o-dropdown[data-menu-xmlid='hr_holidays.menu_hr_holidays_management']",
+            run: "click",
+        },
+        {
+            content: "Go to Allocations",
+            trigger: ".o-dropdown-item[data-menu-xmlid='hr_holidays.hr_holidays_menu_manager_approve_allocations']",
+            run: "click",
+        },
+        {
+            content: "Create a new allocation",
+            trigger: ".o-kanban-button-new",
+            run: "click",
+        },
+        {
+            content: "Click to select a leave type",
+            trigger: ".o_field_widget[name='holiday_status_id'] .o-autocomplete--input",
+            run: "click",
+        },
+        {
+            trigger: ".o-autocomplete--dropdown-item:nth-child(1) > a",
+            run: "click",
+        },
+        {
+            content: "Open the start date picker",
+            trigger: ".o_field_widget[name='date_from'] .o_input",
+            run: "click",
+        },
+        {
+            content: "Choose a start date",
+            trigger: ".o_date_item_cell:nth-child(15) > div",
+            run: "click",
+        },
+        {
+            content: "Open the end date picker",
+            trigger: ".o_field_widget[name='date_to'] .o_input",
+            run: "click",
+        },
+        {
+            content: "Choose a future end date",
+            trigger: ".o_date_item_cell:nth-child(22) > div",
+            run: "click",
+        },
+        ...stepUtils.saveForm(),
+        {
+            trigger: ".o_menu_brand",
+            run: "click",
+        },
+    ],
+});

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -32,4 +32,5 @@ from . import test_hr_leave_type_tour
 from . import test_time_off_graph_view_tour
 from . import test_leave_type_data
 from . import test_multi_contract
+from . import test_time_off_allocation_tour
 from . import test_flexible_resource_calendar

--- a/addons/hr_holidays/tests/test_time_off_allocation_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_allocation_tour.py
@@ -1,0 +1,8 @@
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestTimeOffAllocationTour(HttpCase):
+
+    def test_time_off_allocation_warning_tour(self):
+        self.start_tour("/", "time_off_allocation_warning_tour", login="admin")

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -155,7 +155,7 @@
                                     invisible="not id or date_to or state != 'confirm'">No limit</div>
                             </div>
                             <div colspan="2" class="oe_row alert alert-warning my-2" role="alert"
-                                 invisible="id or not date_to or not (date_to &lt; 'today') or (date_from and (date_to &lt; date_from))">
+                                 invisible="id or not date_to or not (date_to &lt; context_today().strftime('%Y-%m-%d')) or (date_from and (date_to &lt; date_from))">
                                 <span>The allocated days cannot be used, because the allocation is set to finish in the past.</span>
                             </div>
                             <field name="number_of_days" invisible="1"/>


### PR DESCRIPTION
steps to reproduce:
- Go to Time Off > Allocations
- Create new allocation
- Set `date_from` and `date_to` (future dates)
- Notice the warning 'The allocated days cannot be used, because the allocation is set to finish in the past' appears incorrectly

cause:
- The warning visibility condition used literal string `'today'` instead of proper date comparison, causing incorrect evaluation in view expressions.

fix:
- Replace `'today'` string with `context_today().strftime('%Y-%m-%d')` in the invisible condition.
- This ensures the warning only appears when `date_to` is actually in the past.

task-5009365
