### PR TITLE
[FIX] account: readonly amount in currency

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -61,7 +61,8 @@
                                     </group>
                                     <group string="Currency" groups="base.group_multi_currency">
                                         <field name="currency_id" invisible="1"/>
-                                        <field name="amount_currency"/>
+                                        <field name="display_type" invisible="1" />
+                                        <field name="amount_currency" attrs="{'readonly': ['|', ('display_type', '!=', 'tax'), ('parent_state', '!=', 'draft')]}" />
                                     </group>
                                     <group string="Product" attrs="{'invisible': [('product_id', '=', False)]}">
                                         <field name="product_id" readonly="1"/>


### PR DESCRIPTION
- Create an invoice with some products and post it
- Go to Accounting > Journal items and ser for the ones belonging to the invoice.
- Set the checkbox for the product sales one and set whatever tax grid (you'll have to reveal that column).
- Accept the changes.
- Now go back to the invoice.
- You'll see a new tracking message. Something like

Journal Item #1093 updated

- It contains a link and from that link you can go to the journal item form.
- In that form you can edit the *amount in currency* field.

Issue:

- If a user do so, it leaves inconsistent invoice amounts: totals aren't recomputed, analytic lines aren't recomputed either.

How it should behave:

- Amount in currency shouldn't be editable here. Mainly when the journal entry is already posted!

opw-4951629

A vídeo showing the issue:
📹️ https://www.loom.com/share/f7cd1d8f4138458f9b6c190233b0b9df?sid=eec77c17-a4a6-4698-8604-10aaa7e33f47

MT-10887 cc @moduon

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
