### PR TITLE
[IMP] account:  Show "To Validate" link for Miscellaneous journals on Dashboard

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -221,13 +221,10 @@
                             </button>
                         </div>
                         <div id="dashboard_general_right" class="col-auto">
-                            <t t-if="dashboard.number_to_check > 0">
+                            <t t-if="dashboard.number_draft > 0">
                                 <div class="row" groups="account.group_account_user">
                                     <div class="col overflow-hidden text-start">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_move_journal_line', 'search_default_to_check': True}"><t t-out="dashboard.number_to_check"/> To Review</a>
-                                    </div>
-                                    <div class="col-auto text-end">
-                                        <span dir="ltr"><t t-out="dashboard.to_check_balance"/></span>
+                                        <a type="object" name="open_action" context="{'search_default_no_auto_post': 1, 'search_default_posted': 0, 'search_default_unposted': 1}"><t t-out="dashboard.number_draft"/> To Validate</a>
                                     </div>
                                 </div>
                             </t>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1586,6 +1586,7 @@
                             groups="account.group_account_secured,base.group_no_one"/>
                     <separator/>
                     <filter string="Reversed" name="reversed" domain="[('payment_state', '=', 'reversed')]"/>
+                    <filter string="Manual" name="no_auto_post" domain="[('auto_post', '=', 'no')]" context="{'default_journal_type': 'general'}"/>
                     <separator/>
                     <filter string="Sales" name="sales" domain="[('journal_id.type', '=', 'sale')]" context="{'default_journal_type': 'sale'}"/>
                     <filter string="Purchases" name="purchases" domain="[('journal_id.type', '=', 'purchase')]" context="{'default_journal_type': 'purchase'}"/>


### PR DESCRIPTION
Before:
- MISC journals can now be configured with an email alias allowing users to 
  send files also (e.g., SODA).
- Imported entries land in Draft with `auto_post = 'no'`, but there 
  was no clear way to see them from the dashboard.
- Users had to manually open the journal and search for Draft entries.
- Also, a "To Review" link was shown, but since posted misc entries are always
  marked checked, it never had a valid use.

After:
- Added a "To Validate" link on the dashboard card of MISC journals when 
  they have Draft entries with `auto_post = 'no'`.
- The link opens a list view showing those Draft entries.
- Removed the "To Review" link from Miscellaneous journals, since it was not
  functionally usable.

Impact:
- Makes it easier to spot and review imported entries directly 
  from the dashboard.
- Removes a misleading link that did not serve a real purpose.

TaskID-4988258
