### PR TITLE
[FIX] web: web_save RedirectWarning with action and additionalContext

### DIFF
--- a/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.js
+++ b/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.js
@@ -6,6 +6,7 @@ import { useService } from "@web/core/utils/hooks";
 import { Component } from "@odoo/owl";
 
 export class FormErrorDialog extends Component {
+    static props = ["*"];
     setup() {
         this.action = useService("action");
         this.message = this.props.message;
@@ -13,11 +14,23 @@ export class FormErrorDialog extends Component {
             this.message = this.props.data.arguments[0];
             this.redirectAction = this.props.data.arguments[1];
             this.redirectBtnLabel = this.props.data.arguments[2];
+            this.additionalContext = this.props.data.arguments[3];
         }
     }
 
-    onRedirectBtnClicked() {
-        this.action.doAction(this.redirectAction);
+    async onRedirectBtnClicked() {
+        if (this.props.onRedirect) {
+            await this.props.onRedirect({
+                action: this.redirectAction,
+                additionalContext: this.additionalContext,
+            });
+            this.props.close();
+        } else {
+            await this.action.doAction(this.redirectAction, {
+                additionalContext: this.additionalContext,
+            });
+            this.stay();
+        }
     }
 
     async discard() {


### PR DESCRIPTION
Have a web_save that raises a RedirectWarning which has the ID of an action and an additional context in its parameters.

Trigger the warning in the form view by clicking on the save button in the form view. Before this commit, this feature did not work like at all.
- The additional context was not taken into account
- the path taken by clicking on the form's save button was not able to handle interacting with the main form view
- The error dialog did not handle going into an action in target other than new

After this commit, all this is fixed and the whole flow, that allow an error to be enriched such that the user could do the correct action to correct the error now works.

opw-4742952

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
