### PR TITLE
[IMP] orm: fetch prefetchable fields when fields are not given

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1536,7 +1536,7 @@ class AccountMoveLine(models.Model):
         return super().invalidate_recordset(fnames, flush)
 
     @api.model
-    def search_fetch(self, domain, field_names, offset=0, limit=None, order=None):
+    def search_fetch(self, domain, field_names=None, offset=0, limit=None, order=None):
         def to_tuple(t):
             return tuple(map(to_tuple, t)) if isinstance(t, (list, tuple)) else t
         order = (order or self._order)

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -877,7 +877,7 @@ class CrmLead(models.Model):
         return result
 
     @api.model
-    def search_fetch(self, domain, field_names, offset=0, limit=None, order=None):
+    def search_fetch(self, domain, field_names=None, offset=0, limit=None, order=None):
         """ Override to support ordering on my_activity_date_deadline.
 
         Ordering through web client calls search_read() with an order parameter

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -761,7 +761,7 @@ class MailMessage(models.Model):
         self.check_access('read')
         return super().read(fields=fields, load=load)
 
-    def fetch(self, field_names):
+    def fetch(self, field_names=None):
         # This freaky hack is aimed at reading data without the overhead of
         # checking that "self" is accessible, which is already done above in
         # methods read() and _search(). It reproduces the existing behavior

--- a/odoo/addons/test_access_rights/models.py
+++ b/odoo/addons/test_access_rights/models.py
@@ -50,7 +50,7 @@ class Test_Access_RightObj_Categ(models.Model):
     name = fields.Char(required=True)
 
     @api.model
-    def search_fetch(self, domain, field_names, offset=0, limit=None, order=None):
+    def search_fetch(self, domain, field_names=None, offset=0, limit=None, order=None):
         if self.env.context.get('only_media'):
             domain += [('name', '=', 'Media')]
         return super().search_fetch(domain, field_names, offset, limit, order)


### PR DESCRIPTION
This changes methods `fetch()` and `search_fetch()` to use prefetchable fields when fields are not given.  The purpose of this change is to combine the SQL query of `search()` with the one that prefetches the fields with `prefetch=True`.  This may save a few SQL queries here and there.

https://github.com/odoo/enterprise/pull/92506