### PR TITLE
[FIX] pos_sale: fix double picking multiple lots

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -76,6 +76,7 @@ class SaleOrderLine(models.Model):
                 item = sale_line.read(field_names)[0]
                 if sale_line.product_id.tracking != 'none':
                     item['lot_names'] = sale_line.move_ids.move_line_ids.lot_id.mapped('name')
+                    item['lot_qty_by_name'] = {line.lot_id.name: line.quantity for line in sale_line.move_ids.move_line_ids}
                 if product_uom == sale_line_uom:
                     results.append(item)
                     continue

--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -254,6 +254,19 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                             this.pos.get_order().add_orderline(splitted_line);
                             remaining_quantity -= splitted_line.quantity;
                         }
+                    } else if (new_line.get_product().tracking == "lot") {
+                        for (const lot of line.lot_names) {
+                            const splitted_line = new Orderline({ env: this.env }, line_values);
+                            splitted_line.set_quantity(line.lot_qty_by_name[lot] || 0, true);
+                            splitted_line.set_unit_price(line.price_unit);
+                            splitted_line.set_discount(line.discount);
+                            splitted_line.setPackLotLines({
+                                modifiedPackLotLines: [],
+                                newPackLotLines: [{ lot_name: lot }],
+                                setQuantity: false,
+                            });
+                            this.pos.get_order().add_orderline(splitted_line);
+                        }
                     } else {
                         this.pos.get_order().add_orderline(new_line);
                     }

--- a/addons/pos_sale/static/tests/helpers/ProductScreenTourMethods.js
+++ b/addons/pos_sale/static/tests/helpers/ProductScreenTourMethods.js
@@ -28,8 +28,9 @@ export function selectFirstOrder() {
         },
     ];
 }
-export function selectNthOrder(n) {
-    return [
+export function selectNthOrder(n, options = {}) {
+    const { loadSN } = options;
+    const step = [
         {
             content: `select order`,
             trigger: `.order-list .order-row:nth-child(${n})`,
@@ -39,6 +40,20 @@ export function selectNthOrder(n) {
             trigger: `.selection-item:contains('Settle the order')`,
         },
     ];
+    if (loadSN) {
+        step.push(...[
+            {
+            content: `Await confirmation demand popup`,
+            trigger: `.modal-body:contains('Do you want to load the SN/Lots linked to the Sales Order?')`,
+            },
+            {
+            content: `Choose to auto link the lot number to the order line`,
+            trigger: `.button.confirm:contains('Yes')`,
+            run: "click",
+            },
+        ]);
+    }
+    return step;
 }
 export function downPaymentFirstOrder() {
     return [

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -367,3 +367,24 @@ registry.category("web_tour.tours").add("PoSDownPaymentFixedTax", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_multiple_lots_sale_order", {
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.selectNthOrder(1, { loadSN: true }),
+            {
+                'content': 'Ensure first line has lot 1001',
+                'trigger': '.order-container .orderline:nth-child(1):contains(Product):contains(1001)',
+            },
+            {
+                'content': 'Ensure second line has lot 1002',
+                'trigger': '.order-container .orderline:nth-child(2):contains(Product):contains(1002)',
+            },
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});


### PR DESCRIPTION
Backport of [687e2c8](https://github.com/odoo/odoo/commit/687e2c848138e62c8b4df95044e4e88e20803657)

Issue:
------
When settling a SO in PoS, the full quantity is removed from every lot.

Steps to reproduce:
-------------------
* Create a product tracked by lot
* Create 2 lots for that product
  * Lot 1 with 2 of the product
  * Lot 2 with 3 of the product
* Create a sale order for 3 of that product
* Confirm the sale order
* Pay the order in the POS
* Check the picking created for the pos order
> Observation: The picking created for the pos order has double the quantity, with each lot getting 3 units picked from.

Why the fix:
------------
A PoS line can only hold one lot, so when we import a sale order with multiple lots, we need to split the line into multiple lines, each with a single lot.

opw-4977785
