### PR TITLE
[FIX] base: Unable to import res.groups with '/' due to full_name search

### DIFF
--- a/odoo/addons/base/tests/test_base.py
+++ b/odoo/addons/base/tests/test_base.py
@@ -198,6 +198,21 @@ class TestParentStore(TransactionCase):
 class TestGroups(TransactionCase):
 
     def test_res_groups_fullname_search(self):
+        monkey = self.env['res.groups.privilege'].create({'name': 'Monkey'})
+        self.env['res.groups']._load_records([{
+            'xml_id': 'base.test_monkey_banana',
+            'values': {'name': 'Banana', 'privilege_id': monkey.id},
+        }, {
+            'xml_id': 'base.test_monkey_stuff',
+            'values': {'name': 'Stuff', 'privilege_id': monkey.id},
+        }, {
+            'xml_id': 'base.test_monkey_administrator',
+            'values': {'name': 'Administrator', 'privilege_id': monkey.id},
+        }, {
+            'xml_id': 'base.test_donky',
+            'values': {'name': 'Donky Monkey'},
+        }])
+
         all_groups = self.env['res.groups'].search([])
 
         groups = all_groups.search([('full_name', 'like', 'Sale')])
@@ -208,9 +223,21 @@ class TestGroups(TransactionCase):
         self.assertItemsEqual(groups.ids, [g.id for g in all_groups if 'Master Data' in g.full_name],
                               "did not match search for 'Master Data'")
 
-        groups = all_groups.search([('full_name', 'like', 'Sales /')])
-        self.assertItemsEqual(groups.ids, [g.id for g in all_groups if 'Sales /' in g.full_name],
-                              "did not match search for 'Sales /'")
+        groups = all_groups.search([('full_name', 'like', 'Monkey/Banana')])
+        self.assertItemsEqual(groups.mapped('full_name'), ['Monkey / Banana'],
+                              "did not match search for 'Monkey/Banana'")
+
+        groups = all_groups.search([('full_name', 'like', 'Monkey /')])
+        self.assertItemsEqual(groups.ids, [g.id for g in all_groups if 'Monkey /' in g.full_name],
+                              "did not match search for 'Monkey /'")
+
+        groups = all_groups.search([('full_name', 'like', 'Monk /')])
+        self.assertItemsEqual(groups.ids, [g.id for g in all_groups if 'Monkey /' in g.full_name],
+                              "did not match search for 'Monk /'")
+
+        groups = all_groups.search([('full_name', 'like', 'Monk')])
+        self.assertItemsEqual(groups.ids, [g.id for g in all_groups if 'Monk' in g.full_name],
+                              "did not match search for 'Monk'")
 
         groups = all_groups.search([('full_name', 'in', ['Creation'])])
         self.assertItemsEqual(groups.mapped('full_name'), ['Contact / Creation'])
@@ -222,7 +249,7 @@ class TestGroups(TransactionCase):
         self.assertItemsEqual(groups.mapped('full_name'), [g.full_name for g in all_groups if 'Admin' in g.full_name])
 
         groups = all_groups.search([('full_name', 'not like', 'Role /')])
-        self.assertItemsEqual(groups.mapped('full_name'), [g.full_name for g in all_groups if 'Role' not in g.full_name])
+        self.assertItemsEqual(groups.mapped('full_name'), [g.full_name for g in all_groups if 'Role /' not in g.full_name])
 
         groups = all_groups.search([('full_name', '=', False)])
         self.assertFalse(groups)


### PR DESCRIPTION
If a group does not have privilege id and contains a /, the group search can return a list of group instead of the group itself. The import display an error message "Found multiple matches for..."

opw-4885648