### PR TITLE
[IMP] fleet: add daterange for services

### DIFF
--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -807,7 +807,7 @@
         <field name="vehicle_id" ref="vehicle_2" />
         <field name="amount">650</field>
         <field name="service_type_id" ref="type_service_service_7"/>
-        <field name="date" eval="(DateTime.now() - timedelta(days=60)).strftime('%Y-%m-%d')" />
+        <field name="date_from" eval="(DateTime.now() - timedelta(days=60)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">4586</field>
         <field name="vendor_id" ref="base.res_partner_2" />
@@ -819,7 +819,7 @@
         <field name="vehicle_id" ref="vehicle_2" />
         <field name="amount">350</field>
         <field name="service_type_id" ref="type_service_service_7"/>
-        <field name="date" eval="(DateTime.now() - timedelta(days=30)).strftime('%Y-%m-%d')" />
+        <field name="date_from" eval="(DateTime.now() - timedelta(days=30)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">4814</field>
         <field name="vendor_id" ref="base.res_partner_2" />
@@ -831,7 +831,7 @@
         <field name="vehicle_id" ref="vehicle_1" />
         <field name="amount">513</field>
         <field name="service_type_id" ref="type_service_service_7"/>
-        <field name="date" eval="(DateTime.now() - timedelta(days=15)).strftime('%Y-%m-%d')" />
+        <field name="date_from" eval="(DateTime.now() - timedelta(days=15)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">124</field>
         <field name="vendor_id" ref="base.res_partner_2" />
@@ -843,7 +843,7 @@
         <field name="vehicle_id" ref="vehicle_3" />
         <field name="amount">412</field>
         <field name="service_type_id" ref="type_service_service_7"/>
-        <field name="date" eval="(DateTime.now() - timedelta(days=120)).strftime('%Y-%m-%d')" />
+        <field name="date_from" eval="(DateTime.now() - timedelta(days=120)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">20984</field>
         <field name="vendor_id" ref="base.res_partner_2" />
@@ -855,7 +855,7 @@
         <field name="vehicle_id" ref="vehicle_4" />
         <field name="amount">275</field>
         <field name="service_type_id" ref="type_service_service_7"/>
-        <field name="date" eval="(DateTime.now() - timedelta(days=100)).strftime('%Y-%m-%d')" />
+        <field name="date_from" eval="(DateTime.now() - timedelta(days=100)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">241</field>
         <field name="vendor_id" ref="base.res_partner_2" />
@@ -867,7 +867,7 @@
         <field name="vehicle_id" ref="vehicle_5" />
         <field name="amount">302</field>
         <field name="service_type_id" ref="type_service_service_7"/>
-        <field name="date" eval="(DateTime.now() - timedelta(days=65)).strftime('%Y-%m-%d')" />
+        <field name="date_from" eval="(DateTime.now() - timedelta(days=65)).strftime('%Y-%m-%d')" />
         <field name="purchaser_id" ref="base.res_partner_address_18" />
         <field name="inv_ref">22513</field>
         <field name="vendor_id" ref="base.res_partner_2" />

--- a/addons/fleet/report/fleet_report.py
+++ b/addons/fleet/report/fleet_report.py
@@ -47,10 +47,10 @@ WITH service_costs AS (
         fleet_vehicle_model vem ON vem.id = ve.model_id
     CROSS JOIN generate_series((
             SELECT
-                min(date)
+                min(date_from)
                 FROM fleet_vehicle_log_services), CURRENT_DATE + '1 month'::interval, '1 month') d
         LEFT JOIN fleet_vehicle_log_services se ON se.vehicle_id = ve.id
-            AND date_trunc('month', se.date) = date_trunc('month', d)
+            AND date_trunc('month', se.date_from) = date_trunc('month', d)
     WHERE
         ve.active AND se.active AND se.state != 'cancelled'
     GROUP BY

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -226,7 +226,8 @@
                         <group>
                             <field name="description" />
                             <field name="service_type_id" />
-                            <field name="date" />
+                            <field name="date_from" string="Date" widget="daterange"
+                                options="{'end_date_field': 'date_to'}"/>
                             <field name="amount" widget="monetary"/>
                             <field name="vendor_id" widget="many2one_avatar"/>
                         </group>
@@ -253,7 +254,8 @@
         <field name="model">fleet.vehicle.log.services</field>
         <field name="arch" type="xml">
             <list string="Services Logs" multi_edit="1" expand="1">
-                <field name="date" readonly="1" />
+                <field name="date_from" readonly="1"/>
+                <field name="date_to" readonly="1"/>
                 <field name="description" />
                 <field name="service_type_id" />
                 <field name="vehicle_id" readonly="1" widget="many2one_avatar" />
@@ -291,7 +293,13 @@
                         </div>
                         <div class="text-truncate">
                             <field name="purchaser_id"/>
-                            <field class="float-end" name="date"/>
+                            <div>
+                                <field name="date_from"/>
+                                <t t-if="record.date_to.raw_value">
+                                    <span class="text-muted"> - </span>
+                                    <field name="date_to"/>
+                                </t>
+                            </div>
                         </div>
                         <field class="text-truncate" name="vendor_id"/>
                         <footer class="pt-0">
@@ -309,7 +317,7 @@
        <field name="model">fleet.vehicle.log.services</field>
        <field name="arch" type="xml">
             <graph string="Services Costs Per Month" sample="1">
-                <field name="date"/>
+                <field name="date_from"/>
                 <field name="vehicle_id"/>
                 <field name="amount" type="measure"/>
             </graph>


### PR DESCRIPTION
In the fleet services, earlier we only had date field, now with this commit it has been converted to date-range with the addition of date_from and date_to.

task-4946099



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
