### PR TITLE
[FIX] html_builder: small optimization for BuilderRow

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_row.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.js
@@ -1,4 +1,4 @@
-import { Component, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, useRef, useState } from "@odoo/owl";
 import {
     useVisibilityObserver,
     useApplyVisibility,
@@ -37,14 +37,12 @@ export class BuilderRow extends Component {
         }
 
         this.labelRef = useRef("label");
-        useEffect(
-            (labelEl) => {
-                if (!this.state.tooltip && labelEl && labelEl.clientWidth < labelEl.scrollWidth) {
-                    this.state.tooltip = this.props.label;
-                }
-            },
-            () => [this.labelRef.el]
-        );
+        onMounted(() => {
+            const labelEl = this.labelRef.el;
+            if (!this.state.tooltip && labelEl && labelEl.clientWidth < labelEl.scrollWidth) {
+                this.state.tooltip = this.props.label;
+            }
+        });
     }
 
     getLevelClass() {


### PR DESCRIPTION
The goal of this commit is to speed up the rerendering of the BuilderRow component. In BuilderRow, we need to calculate whether a row's label is too long or not. If so, we display a tooltip. To do this, we use the clientWidth function to determine the size required for the label. This function is considered computationally expensive. We will therefore avoid calling it at each onPatch, since the length of the label and the right-hand side do not change in size.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
