### PR TITLE
[IMP] spreadsheet_dashboard: allow multiple access to multiple companies

### DIFF
--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -15,7 +15,7 @@ class SpreadsheetDashboard(models.Model):
     sequence = fields.Integer()
     sample_dashboard_file_path = fields.Char(export_string_translation=False)
     is_published = fields.Boolean(default=True)
-    company_id = fields.Many2one('res.company')
+    company_ids = fields.Many2many('res.company', string="Companies")
     group_ids = fields.Many2many('res.groups', default=lambda self: self.env.ref('base.group_user'))
     favorite_user_ids = fields.Many2many(
         'res.users',

--- a/addons/spreadsheet_dashboard/security/security.xml
+++ b/addons/spreadsheet_dashboard/security/security.xml
@@ -11,7 +11,7 @@
     <record id="spreadsheet_dashboard_rule_company" model="ir.rule">
         <field name="name">Dashboard multi-company</field>
         <field name="model_id" ref="model_spreadsheet_dashboard"/>
-        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="domain_force">[('company_ids', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="res.groups.privilege" id="res_groups_privilege_dashboard">

--- a/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
+++ b/addons/spreadsheet_dashboard/views/spreadsheet_dashboard_views.xml
@@ -9,7 +9,7 @@
                 <field name="sequence" widget="handle" groups="base.group_system"/>
                 <field name="name"/>
                 <field name="group_ids" widget="many2many_tags" required="1"/>
-                <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company" placeholder="Visible to all"/>
+                <field name="company_ids" options="{'no_create': True}" widget="many2many_tags" groups="base.group_multi_company" placeholder="Visible to all"/>
                 <field name="spreadsheet_binary_data" groups="base.group_no_one" widget="binary_spreadsheet" filename="spreadsheet_file_name" string="Data" />
                 <field name="is_published" widget="boolean_toggle"/>
                 <field name="dashboard_group_id" optional="hidden"/>


### PR DESCRIPTION
Allow multiple companies to acces the same dashboard.

Task: 5002672

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
