### PR TITLE
[FIX] web_editor: prevent traceback when pasting blocks inline

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -339,7 +339,7 @@ export const editorCommands = {
                         const [left, right] = splitElement(currentNode.parentElement, offset);
                         if (isUnbreakable(nodeToInsert) && container.childNodes.length === 1) {
                             fillEmpty(right);
-                        } else if (isEmptyBlock(right)) {
+                        } else if (isEmptyBlock(right) && !insertBefore) {
                             right.remove();
                         }
                         currentNode = insertBefore ? right : left;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -2206,7 +2206,7 @@ export function isEmptyBlock(blockEl) {
     for (const node of nodes) {
         // There is no text and no double BR, the only thing that could make
         // this visible is a "visible empty" node like an image.
-        if (node.nodeName != 'BR' && (isSelfClosingElement(node) || isFontAwesome(node))) {
+        if (node.nodeName != 'BR' && (isSelfClosingElement(node) || isFontAwesome(node) || isZWS(node))) {
             return false;
         }
     }
@@ -2484,6 +2484,15 @@ export function fillEmpty(el) {
         el.appendChild(zws);
         el.setAttribute("data-oe-zws-empty-inline", "");
         fillers.zws = zws;
+        // If the parent was filled with BR and we are filling the `el` here
+        // we should remove the parent `br` otherwise we fill the el twice.
+        // we do that only for visible el as in `cleanForSave` we remove the 
+        // non visible elements (with no classes if they are empty) so we should
+        // keep the br
+        if (el.classList.length && fillers.br) {
+            fillers.br.remove();
+            delete fillers.br;
+        }
         const previousSibling = el.previousSibling;
         if (previousSibling && previousSibling.nodeName === "BR") {
             previousSibling.remove();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -1236,6 +1236,13 @@ X[]
                     contentAfter: '<p>a<span class="style-class">[]\u200B</span>f</p>',
                 });
             });
+            it('should not add a BR', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p><span class="h4-fs">[a]</span></p>',
+                    stepFunction: deleteBackward,
+                    contentAfter: '<p><span class="h4-fs">[]\u200b</span></p>',
+                });
+            });
             it('should delete styling nodes when delete if empty', async () => {
                 // deleteBackward selection
                 await testEditor(BasicEditor, {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
@@ -355,7 +355,6 @@ describe('insert HTML', () => {
                               <p><br>[]</p>
                               <p>
                                 <span class="h4-fs">\u200b</span>
-                                <br>
                               </p>`),
             });
         });

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
@@ -340,6 +340,25 @@ describe('insert HTML', () => {
                 contentAfter: `<p><span class="a">TEST</span>[]</p>`,
             });
         });
+        it("Should properly insert two blocks content with selection in inline", async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: unformat(`
+                                    <p>
+                                        <span class="display-4"></span>
+                                        <span class="h4-fs">[a]</span>
+                                    </p>`),
+                stepFunction: (editor) =>
+                    editor.execCommand("insert", parseHTML(editor.document, `<p></p><p></p>`)),
+                contentAfter: unformat(`<p>
+                                <span class="display-4"></span>
+                              </p>
+                              <p><br>[]</p>
+                              <p>
+                                <span class="h4-fs">\u200b</span>
+                                <br>
+                              </p>`),
+            });
+        });
     });
 });
 describe('insert text', () => {


### PR DESCRIPTION
Problem:
When pasting two blocks inside an inline element, a traceback occurs.

Cause:
During `insert`, when `insertBefore` is `true` and `isEmptyBlock(right)` after `splitElement`, `currentNode` is set to `right`. But `right` may already have been deleted, leading to an invalid reference.

Solution:
Delete `right` if empty, but do not set `currentNode` to `right` in that case.

Steps to reproduce:
It is tricky to reproduce manually (you must copy two blocks and paste them in an inline element). A test has been added to cover the case.

opw-4972695

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
