### PR TITLE
[FIX] pos_loyalty: fix random tour failure

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -379,7 +379,7 @@ registry.category("web_tour.tours").add("test_max_usage_partner_with_point", {
             PosLoyalty.claimReward("100% on your order"),
             PosLoyalty.finalizeOrder("Cash", "0"),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.clickCustomer("AAA Test Partner 3"),
             ProductScreen.addOrderline("Desk Organizer", "3"),
             PosLoyalty.isRewardButtonHighlighted(false),
         ].flat(),

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2955,7 +2955,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         partners that already have points in the loyalty program cannot claim rewards anymore."""
 
         self.env['loyalty.program'].search([]).write({'active': False})
-        test_partner = self.env['res.partner'].create({'name': 'Test Partner'})
+        test_partner = self.env['res.partner'].create({'name': 'AAA Test Partner 3'})
         self.env['res.partner'].create({'name': 'AAA Test Partner 2'})
 
         loyalty_program = self.env['loyalty.program'].create({


### PR DESCRIPTION
This commit make sure that the partner is always at the top of the list

runbot-230704