### PR TITLE
[FIX] website_sale: prevent adding duplicate zoom event listeners

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -211,7 +211,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
         this.zoomCleanup = [];
         // Zoom on hover (except on mobile)
         if (salePage.dataset.ecomZoomAuto && !uiUtils.isSmall()) {
-            const images = salePage.querySelectorAll("img[data-zoom]");
+            const images = this.el.querySelectorAll('img[data-zoom]');
             for (const image of images) {
                 const $image = $(image);
                 const callback = () => {
@@ -240,7 +240,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
         // Zoom on click
         if (salePage.dataset.ecomZoomClick) {
             // In this case we want all the images not just the ones that are "zoomables"
-            const images = salePage.querySelectorAll(".product_detail_img");
+            const images = this.el.querySelectorAll('.product_detail_img');
             for (const image of images ) {
                 const handler = () => {
                     if (salePage.dataset.ecomZoomAuto) {


### PR DESCRIPTION
Versions
--------
- saas-18.2+

Steps
-----
1. Have a product with extra eCommerce images;
2. enable zoom-on-click on the product page;
3. add a recently-sold product carousel to the page;
4. click on an image to zoom in;
5. attempt to use arrow keys to navigate or using esc to exit zoom.

Issue
-----
Keys don't appear to do anything.

Cause
-----
Commit b8d0ab4275b24 set `oe_website_sale` as `snippet_classes` on the `s_dynamic_snippet_products` snippet, in order to enable the `websiteSaleTracking` widget, which uses this class as `selector`.

Issue is this class also gets used as the selector by the `WebsiteSale` widget which adds zoom-on-click event listeners. As there are two elements with the `oe_website_sale` class now, this widget gets called twice, and because the query selector selects all image elements on the sale page, images get duplicate event listeners assigned to them.

Consequently, clicking on an image opens two lightboxes, and the keys only impact the one hidden behind the other, making it appear as if key presses aren't doing anything.

Solution
--------
Instead of querying all images on the sale page in each call of the widget, only query for images in `this.el`.

opw-4908881