### PR TITLE
prevent removal of unremovable links

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -1069,7 +1069,11 @@ export class LinkPlugin extends Plugin {
     }
 
     deleteImageLink(imageToDelete) {
-        if (imageToDelete.parentElement.tagName === "A") {
+        if (
+            imageToDelete.parentElement.tagName === "A" &&
+            !this.isUnremovable(imageToDelete.parentElement) &&
+            imageToDelete.parentElement.parentElement.isContentEditable
+        ) {
             // If the link is empty after removing the image, remove it.
             const cursors = this.dependencies.selection.preserveSelection();
             cursors.update(callbacksForCursorUpdate.remove(imageToDelete));

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -853,7 +853,7 @@ export class LinkPlugin extends Plugin {
             return;
         }
         const cursors = this.dependencies.selection.preserveSelection();
-        if (link && link.isContentEditable) {
+        if (link && link.isContentEditable && link.parentElement.isContentEditable) {
             cursors.update(callbacksForCursorUpdate.unwrap(link));
             unwrapContents(link);
         }

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -207,6 +207,10 @@ export async function unlinkFromPopover() {
     await click(".o_we_remove_link");
 }
 
+export function deleteImage(editor) {
+    execCommand(editor, "deleteImage");
+}
+
 /** @param {Editor} editor */
 export async function keydownTab(editor) {
     await manuallyDispatchProgrammaticEvent.as("keydownTab")(editor.editable, "keydown", {

--- a/addons/html_editor/static/tests/link/delete.test.js
+++ b/addons/html_editor/static/tests/link/delete.test.js
@@ -1,6 +1,6 @@
 import { describe, test } from "@odoo/hoot";
-import { deleteBackward } from "../_helpers/user_actions";
-import { testEditor } from "../_helpers/editor";
+import { deleteBackward, deleteImage } from "../_helpers/user_actions";
+import { base64Img, testEditor } from "../_helpers/editor";
 
 describe("delete selection involving links", () => {
     test("should remove link", async () => {
@@ -30,6 +30,23 @@ describe("delete selection involving links", () => {
             contentAfterEdit:
                 '<p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[]\ufeff</a>\ufeffdef</p>',
             contentAfter: "<p>[]def</p>",
+        });
+    });
+});
+
+describe("delete images in a link", () => {
+    test("should remove link", async () => {
+        await testEditor({
+            contentBefore: `<p>x<a href="http://test.test/">[<img src="${base64Img}">]</a></p>`,
+            stepFunction: deleteImage,
+            contentAfter: `<p>x[]</p>`,
+        });
+    });
+    test("should not remove unremovable link", async () => {
+        await testEditor({
+            contentBefore: `<p>x<a class="oe_unremovable" href="http://test.test/">[<img src="${base64Img}">]</a></p>`,
+            stepFunction: deleteImage,
+            contentAfter: `<p>x<a class="oe_unremovable" href="http://test.test/">[]</a></p>`,
         });
     });
 });

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1493,6 +1493,30 @@ describe("readonly mode", () => {
     });
 });
 
+describe("link in contenteditable=false", () => {
+    test("popover should not display remove button if link is in a contenteditable=false", async () => {
+        await setupEditor(
+            '<p contenteditable="false"><a contenteditable="true" href="http://test.test/">link[]</a></p>'
+        );
+        await waitFor(".o-we-linkpopover");
+        // Copy and edit link button should be available
+        expect(".o-we-linkpopover .o_we_copy_link").toHaveCount(1);
+        expect(".o-we-linkpopover .o_we_edit_link").toHaveCount(1);
+        // Unlink buttons should not be available
+        expect(".o-we-linkpopover .o_we_remove_link").toHaveCount(0);
+    });
+    test("toolbar should not display unlink button if link is in a contenteditable=false", async () => {
+        await setupEditor(
+            '<p contenteditable="false"><a contenteditable="true" href="http://test.test/">l[in]k</a></p>'
+        );
+        await waitFor(".o-we-toolbar");
+        // Link button should be available and active
+        expect(".o-we-toolbar button.active .fa-link").toHaveCount(1);
+        // Unlink button should not be available
+        expect(".o-we-toolbar .fa-unlink").toHaveCount(0);
+    });
+});
+
 describe("upload file via link popover", () => {
     test("should display upload button when url input is empty", async () => {
         const { editor } = await setupEditor("<p>[]<br></p>");

--- a/addons/html_editor/static/tests/link/remove.test.js
+++ b/addons/html_editor/static/tests/link/remove.test.js
@@ -279,6 +279,16 @@ describe("range not collapsed", () => {
                 contentAfter: '<p>[ab<a contenteditable="false" href="exist">cd</a>ef]</p>',
             });
         });
+
+        test("should not unlink editable links with selection in non-editable", async () => {
+            await testEditor({
+                contentBefore:
+                    '<p contenteditable="false">ab<a contenteditable="true" href="http://test.test">[cd]</a>ef</p>',
+                stepFunction: unlinkByCommand,
+                contentAfter:
+                    '<p contenteditable="false">ab<a contenteditable="true" href="http://test.test">[cd]</a>ef</p>',
+            });
+        });
     });
     test("should be able to remove link if selection has FEFF character", async () => {
         const { el } = await setupEditor(

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -225,12 +225,13 @@ test("toolbar link buttons react to selection change", async () => {
     expect(".btn[name='unlink']").toHaveCount(1);
 });
 
-test("toolbar unlink button should not be present when link is unremovable", async () => {
+test("toolbar unlink button should be disabled when link is unremovable", async () => {
     await setupEditor('<p>a<a class="oe_unremovable" href="http://test.test/">bc[d]</a>e</p>');
     await waitFor(".o-we-toolbar");
     expect(".btn[name='link']").toHaveCount(1);
     expect(".btn[name='link']").toHaveClass("active");
-    expect(".btn[name='unlink']").toHaveCount(0);
+    expect(".btn[name='unlink']").toHaveCount(1);
+    expect(".btn[name='unlink']").toHaveClass("disabled");
 });
 
 test("toolbar format buttons should react to format change", async () => {


### PR DESCRIPTION
### [FIX] html_editor: prevent removal of unremovable links with images

The override that remove a link on `deleteImage` command did not check
if the link was unremovable before removing it.

### [FIX] html_editor: prevent removal of links in contenteditable=false

If a link was `contenteditable=true`, but inside a
`contenteditable=false`, it could be removed

### [FIX] html_editor: prevent removal of unremovable links in batch removal

If the selection covers several links, the "unlink" of the toolbar
removes all the links selected. This included the links which were
supposed to be unremovable.

The procedure for removing the links is changed to avoid removing the
unremovable nodes.

The availability of the tool in the toolbar is also changed to better
reflect whether there is links to remove. In case of unremovable links,
the tool is shown as disabled

Steps to reproduce:
- Open website builder
- In the toolbar, insert links just before and after the "Contact Us"
- Select from the link inserted before, to the one after
- In the toolbar, click "Remove Link"
- Bug: the link on "Contact Us" is gone, but it was "unremovable"
  (Saving after these steps currently breaks the toolbar's rendering)

