### PR TITLE
[FIX] html_builder, html_editor: track image transform only on mouseup

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
@@ -25,6 +25,7 @@ class TransformImageAction extends BuilderAction {
         params: { isImageTransformationOpen, closeImageTransformation },
     }) {
         if (!isImageTransformationOpen()) {
+            let changed = false;
             const deferredTillMounted = new Deferred();
             registry.category("main_components").add("ImageTransformation", {
                 Component: ImageTransformation,
@@ -33,7 +34,15 @@ class TransformImageAction extends BuilderAction {
                     document: this.document,
                     editable: this.editable,
                     destroy: () => closeImageTransformation(),
-                    onChange: () => this.dependencies.history.addStep(),
+                    onChange: () => {
+                        changed = true;
+                    },
+                    onApply: () => {
+                        if (changed) {
+                            changed = false;
+                            this.dependencies.history.addStep();
+                        }
+                    },
                     onComponentMounted: () => {
                         deferredTillMounted.resolve();
                     },

--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -37,6 +37,7 @@ export class ImageTransformation extends Component {
         image: { validate: (p) => p.tagName === "IMG" },
         destroy: { type: Function },
         onChange: { type: Function },
+        onApply: { type: Function, optional: true },
         onComponentMounted: { type: Function, optional: true },
     };
     static defaultProps = {
@@ -64,20 +65,25 @@ export class ImageTransformation extends Component {
         }
         // When a character key is pressed and the image gets deleted,
         // close the image transform via selectionchange.
-        useExternalListener(this.document, "selectionchange", () => this.props.destroy());
+        useExternalListener(this.document, "selectionchange", () => this.destroy());
         // Backspace/Delete don’t trigger selectionchange on image
         // delete in Chrome, so we use keydown event.
         useExternalListener(this.document, "keydown", (ev) => {
             if (["Backspace", "Delete"].includes(ev.key)) {
-                this.props.destroy();
+                this.destroy();
             }
         });
-        useHotkey("escape", () => this.props.destroy());
+        useHotkey("escape", () => this.destroy());
         usePositionHook({ el: this.props.editable }, this.document, () => {
             if (!this.isCurrentlyTransforming) {
                 this.resetHandlers();
             }
         });
+    }
+
+    destroy() {
+        this.props.onApply?.();
+        this.props.destroy();
     }
 
     mouseMove(ev) {
@@ -194,6 +200,7 @@ export class ImageTransformation extends Component {
     mouseUp() {
         this.isCurrentlyTransforming = false;
         this.transfo.active = null;
+        this.props.onApply?.();
     }
 
     mouseDown(ev) {


### PR DESCRIPTION
When using image transform, steps are added to the history for every intermediate change during mouse moves.

This commit adapts this behavior so that only the states reached when releasing the mouse button are recorded in the history.

task-4367641
