### PR TITLE
[FIX] base: should check only the already fully upgraded views at update

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1029,6 +1029,14 @@ actual arch.
                 root = root.inherit_id
         views = self.env['ir.ui.view'].browse(unique(view_id for view_ids in parented for view_id in view_ids))
 
+        # Add inherited views to the list of loading forced views
+        # Otherwise, inherited views could not find elements created in
+        # their direct parents if that parent is defined in the same module
+        # introduce check_view_ids in context
+        if 'check_view_ids' not in views.env.context:
+            views = views.with_context(check_view_ids=[])
+        views.env.context['check_view_ids'].extend(views.ids)
+
         # Map each node to its children nodes. Note that all children nodes are
         # part of a single prefetch set, which is all views to combine.
         all_tree_views = views._get_inheriting_views()
@@ -1036,13 +1044,7 @@ actual arch.
         # During an upgrade, we can only use the views that have been
         # fully upgraded already.
         if self.pool._init and not self.env.context.get('load_all_views'):
-            check_view_ids = self.env.context.get('check_view_ids', [])
-            # Add inherited views to the list of loading forced views
-            # Otherwise, inherited views could not find elements created in
-            # their direct parents if that parent is defined in the same module
-            # introduce check_view_ids in context
-            check_view_ids += views.ids
-            all_tree_views = all_tree_views._filter_loaded_views(set(check_view_ids))
+            all_tree_views = all_tree_views._filter_loaded_views(set(views.env.context['check_view_ids']))
 
         # get the global children views then get hierarchy for each views
         children_views = collections.defaultdict(list)


### PR DESCRIPTION
The previous fix is incomplete and does not properly filter the involved views.
see https://github.com/odoo/odoo/pull/219847/commits/67917b7adc5b7bcc423327bdb3cc84fd76b67196

Issue:
Error occurs when updating `hr_timesheet` after having installed it, if addon timesheet_grid is installed (view: hr_timesheet_line_form_grid).

View source:
```xml
        <record id="hr_timesheet_line_form_grid" model="ir.ui.view">
            <field name="name">account.analytic.line.form.grid</field>
            <field name="model">account.analytic.line</field>
            <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form"/>
            <field name="mode">primary</field>
            <field name="arch" type="xml">
                <header position="replace"/>
            </field>
        </record>
```

Traceback:

odoo.tools.convert.ParseError: while parsing /data/build/odoo/addons/hr_timesheet/views/hr_timesheet_views.xml:155 Error while parsing or validating view:

Element '<header>' cannot be located in parent view

View error context:
{'file': '/data/build/odoo/addons/hr_timesheet/views/hr_timesheet_views.xml',
 'line': 1,
 'name': 'account.analytic.line.form.grid',
 'view': ir.ui.view(918,),
 'view.model': 'account.analytic.line',
 'view.parent': ir.ui.view(852,),
 'xmlid': 'hr_timesheet_line_form'}

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
