### PR TITLE
[FIX] web: Hoot - log missing URL IDs

### DIFF
--- a/addons/web/static/lib/hoot/core/runner.js
+++ b/addons/web/static/lib/hoot/core/runner.js
@@ -1927,20 +1927,24 @@ export class Runner {
         let remaining = $keys(idSpecs);
         while (remaining.length) {
             const id = remaining.shift();
-            if ($abs(idSpecs[id]) !== INCLUDE_LEVEL.url) {
+            const value = idSpecs[id];
+            if ($abs(value) !== INCLUDE_LEVEL.url) {
                 continue;
             }
             const item = this.suites.get(id) || this.tests.get(id);
             if (!item) {
-                const applied = this._include(idSpecs, [id], 0);
-                if (applied) {
-                    logger.warn(
-                        `Test runner did not find job with ID "${id}": it has been removed from the URL`
-                    );
-                } else {
-                    logger.warn(
-                        `Test runner did not find job with ID "${id}": it has been ignored from the current run`
-                    );
+                const couldRemove = this._include(idSpecs, [id], 0);
+                if (value > 0) {
+                    // Only log warning for not-found *included* jobs
+                    if (couldRemove) {
+                        logger.warn(
+                            `Test runner did not find job with ID "${id}": it has been removed from the URL`
+                        );
+                    } else {
+                        logger.warn(
+                            `Test runner did not find job with ID "${id}": it has been ignored from the current run`
+                        );
+                    }
                 }
                 hasChanged = true;
             }


### PR DESCRIPTION
Before this commit, URL test/suite IDs were warned in the console if they didn't match any test/suite registered by the test runner.

This is an issue for Runbot which runs sub-builds with the same URL parameters regardless of the installed addons, which repeatedly fails such builds.

This commit changes the warning to a regular log, so that these builds stop failing, while still allowing a developer to get the information that an ID has been removed/ignored.

runbot [230082](https://runbot.odoo.com/odoo/runbot.build.error/230082)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
