### PR TITLE
[FIX] purchase: show both vendor and db name of a product

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -245,7 +245,7 @@
                                         readonly="state in ('purchase', 'to approve', 'done', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
                                         optional="show"
-                                        context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
+                                        context="{'quantity':product_qty, 'company_id': parent.company_id}"
                                         force_save="1" domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"/>
                                     <field name="name" widget="section_and_note_text" optional="show"/>
                                     <field name="date_planned" optional="hide" required="not display_type and not is_downpayment" force_save="1" readonly="is_downpayment"/>


### PR DESCRIPTION
#### Issue:
Only the vendor name of a product is displayed on a purchase order on all pages except the first one.

#### Step to reproduce:
- make sure "Variant grid entries" is disabled in the settings. If you can't disable it, you can disable the view `purchase.order.form.inherit.matrix` to trigger the bug.
- Create a product
- Go to the purchase sheet
- Add a vendor
- Add the field "Vendor Product Name" and "Vendor Product Code" and fill them
- Create a purchase order
- Add your product
- Add your product a second time (on a second line)
- Confirm the PO
- Activate debug mode
- Go to the view and add a limit to have only 1 POL per page
- Return to your PO
- Go to the second page

#### Current behavior:
- Only the vendor name is displayed

#### Expected behavior:
- The vendor name should appear at the top, while the db name should be displayed under as in the first page.

#### Cause of the issue:
On the first page, POLs data are fetch through a `web_read` on the PO, while on other pages data are fetch through `web_read` on the POLs of the page. 
While fetching POL data with a `web_read` the client ask for several informations including: `name` and `product_id.display_name`. If both return the same, the client show only one, else it shows the `display_name` on top and the `name` below.
- `name` return the vendor name 
- `product_id` is fetch with the context `partner_id` which transform the `display_name` from the db_name to the Vendor name
Therefore it fetches twice the vendor name and don't have the name from the db.

#### Solution:
- remove the `partner_id` from the context.

#### Consequence:
- When adding a product to the PO, the name of the product displayed in the dropdown list will be the name from the db instead of the name of the vendor.

PO confirmed that consequence is OK as long as it's still possible to search for product using vendor code, which is still possible.

opw-4737337

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
