### PR TITLE
[FIX] stock: avoid repeating source origin on picking

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1404,14 +1404,11 @@ Please change the quantity done or the rounding precision of your unit of measur
         if any(picking.partner_id != m.partner_id for m in self):
             vals['partner_id'] = False
         if any(picking.origin != m.origin for m in self):
-            current_origins = set(picking.origin.split(',') + [False]) if picking.origin else {False}
-            vals['origin'] = picking.origin
-            for move in self:
-                if move.origin not in current_origins:
-                    if not vals['origin']:
-                        vals['origin'] = move.origin
-                    else:
-                        vals['origin'] += f',{move.origin}'
+            current_origins = picking.origin.split(',') if picking.origin else []
+            new_moves_origins = [move.origin for move in self if move.origin]
+            new_origin = ','.join(OrderedSet(current_origins + new_moves_origins))
+            if picking.origin != new_origin:
+                vals['origin'] = new_origin
         return vals
 
     def _assign_picking_post_process(self, new=False):


### PR DESCRIPTION
### Behavior:


#### Current:
During the assignment of a picking,
if several of its moves have the same origin,
it will repeat that origin in its own origin.

#### Expected:
Only have one time each origin.

### Steps to reproduce:

From Inventory
* Enable two step transfer for the warehouse

From Barcode
* create and validate new receipts with "Product A"
* create and validate a second new receipts with "Product A" and other products 

From Inventory/Operations/Transfers/Receipts
* Open the corresponding receipts
* In "source Document" (Field: origin, Model : stock.picking) we can see that the reference from second receipts is repeated.

### Observation:
In the case of already existing origins it will not duplicate them but it's missing if several item comes from the same origin. https://github.com/odoo/odoo/commit/0caa44ca97d9d197811a03ad2ff227df68d4437a#diff-55c6314416a6a400da6acd5018d161a55eeeb0e3008fec8828121e3dd12be0ebR1410

opw-4970159
