### PR TITLE
[FIX] account_edi_ubl_cii: Fix depends of ubl_cii_xml_id

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -9,7 +9,7 @@ class AccountMove(models.Model):
         comodel_name='ir.attachment',
         string="Attachment",
         compute=lambda self: self._compute_linked_attachment_id('ubl_cii_xml_id', 'ubl_cii_xml_file'),
-        depends=['ubl_cii_xml_id']
+        depends=['ubl_cii_xml_file']
     )
     ubl_cii_xml_file = fields.Binary(
         attachment=True,


### PR DESCRIPTION
In previous PR [1], we renamed field `ubl_xml_id` to `ubl_cii_xml_id`, but failed the compute dependencies.
It has next to no impact since this field it not in views, but could lead to problems if people add it through Studio.

[1]: https://github.com/odoo/odoo/pull/115627/files#diff-5f7f5f6e9c54527b31f7579db7ef63b5b910794e462cd3346e32387900c13efdR12

task-none
