### PR TITLE
[FIX] point_of_sale: improve traceability when adding lines and payment

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -100,7 +100,11 @@ class PosOrder(models.Model):
             # when vals change the state to 'paid'
             for field in ['lines', 'payment_ids']:
                 if order.get(field):
-                    pos_order.write({field: order.get(field)})
+                    existing_ids = set(pos_order[field].ids)
+                    pos_order.write({field: order[field]})
+                    added_ids = set(pos_order[field].ids) - existing_ids
+                    if added_ids:
+                        _logger.info("Added %s %s to pos.order #%s", field, list(added_ids), pos_order.id)
                     order[field] = []
 
             del order['uuid']


### PR DESCRIPTION
Before this commit, in case of a mismatch it was difficult to identify the root cause since the logs did not show which lines or payments were added to the order.

opw-4954736

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
