### PR TITLE
[FIX] web_editor: no WebP quality change on safari


### DIFF
--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -3541,6 +3541,13 @@ msgstr ""
 
 #. module: web_editor
 #. odoo-javascript
+#: code:addons/web_editor/static/src/js/editor/snippets.options.js:0
+#, python-format
+msgid "WebP compression not supported on this browser"
+msgstr ""
+
+#. module: web_editor
+#. odoo-javascript
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -126,6 +126,7 @@
     <t t-set="quality_label">Quality</t>
     <we-range t-att-string="quality_label"
               t-att-class="indent and 'o_we_sublevel_2'"
+              data-name="quality_range_opt"
               data-set-quality=""/>
 </template>
 


### PR DESCRIPTION
Scenario:

- select a WebP image in the editor
- change the quality with the slider

Result:

- the size and the image quality doesn't change

Cause:

Safari doesn't support HTMLCanvasElement.toDataURL() with WebP, so the
image is exported in PNG instead which is lossless and doesn't support
compression.

Other issue:

If we select in formats a WebP, then a PNG, we still see the quality
option that are meant for the WebP, and inversely if we start with a PNG
the quality option is hidden.

Fix:

Disable the quality for WebP images if this is not supported (in safari
+ iOS webview), and move the code to ImageTools._computeWidgetVisibility
so it is updated when we change image type from/to WebP.

opw-4979378