### PR TITLE
[FIX] website_blog, website_event: fix dynamic snippets filter domains

### DIFF
--- a/addons/website_blog/data/blog_snippet_template_data.xml
+++ b/addons/website_blog/data/blog_snippet_template_data.xml
@@ -6,7 +6,7 @@
             <field name="name">Latest Blog Posts</field>
             <field name="model_id">blog.post</field>
             <field name="user_ids" eval="False" />
-            <field name="domain">[('post_date', '&lt;=', 'today')]</field>
+            <field name="domain">[('post_date', '&lt;=', 'now')]</field>
             <field name="sort">["post_date desc"]</field>
             <field name="action_id" ref="website.action_website"/>
         </record>
@@ -14,7 +14,7 @@
             <field name="name">Most Viewed Blog Posts</field>
             <field name="model_id">blog.post</field>
             <field name="user_ids" eval="False" />
-            <field name="domain">[('post_date', '&lt;=', 'today'), ('visits', '!=', False)]</field>
+            <field name="domain">[('post_date', '&lt;=', 'now'), ('visits', '!=', False)]</field>
             <field name="sort">["visits desc"]</field>
             <field name="action_id" ref="website.action_website"/>
         </record>

--- a/addons/website_event/data/website_snippet_data.xml
+++ b/addons/website_event/data/website_snippet_data.xml
@@ -7,7 +7,7 @@
         <field name="model_id">event.event</field>
         <field name="user_ids" eval="False" />
         <field name="domain">[
-            ('date_begin', '&gt;=', 'today'),
+            ('date_begin', '&gt;=', 'now'),
             ('is_visible_on_website', '=', True)
         ]</field>
         <field name="sort">["date_begin asc"]</field>


### PR DESCRIPTION
Steps to reproduce (master):

1. Create a DB with `website_blog` without demo data.

2. Add an email to the administrator (required to publish the blog post).

3. Create a blog post, publish it.

4. Go to your homepage, add a blog post dynamic snippet: it is empty,
and the blog post does not appear.

Starting from [1], a new simplified dates syntax (introduced in [2]) was
used in dynamic filter domains, and domain expressions like
`context_today()` were replaced by `'today'`.

The `'today'` syntax refers to midnight of the current day (00:00:00),
while `context_today()` returns the "current date and time".
This mismatch caused recent records to be ignored.

This commit replaces `'today'` with `'now'` to preserve the intended
behavior of `context_today()`.

[1]: https://github.com/odoo/odoo/commit/493f231f70c3d831cf85676f45fe3c0356c3203b
[2]: https://github.com/odoo/odoo/commit/d1ea43f6721116914762ea323d8a5987f043e87f

linked to task-4868324