### PR TITLE
[FIX] sale: onchange on uom should recompute unit price

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1200,7 +1200,7 @@ class SaleOrderLine(models.Model):
                 }
             }
 
-    @api.onchange('product_id')
+    @api.onchange('product_id', 'product_uom')
     def _onchange_product_id(self):
         if not self.product_id:
             return


### PR DESCRIPTION
Problem: When the user changes the UOM on a product more than once, the unit price no longer recomputes. The technical_price_unit and the price_unit are out of sync in which the uom change gets recognized as a manual change from the user. Thus, it no longer recomputes the unit price.

Purpose: The unit price should always recompute when the uom is simply being modified more than once.

Steps to reproduce on Runbot 18:
1. Install Sales and accounting
2. Enable Units of Measure in Settings > Sale
3. Create a product, Soda, whose units is L
4. Create a quotation and add the product Soda
5. Change the uom on the line for the first time --> price_unit changes
6. Change the uom on the line for the second time --> price_unit does not change

opw-4998017

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
