### PR TITLE
[FIX] crm: Set expected revenue

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -146,7 +146,7 @@ class Lead(models.Model):
         help="Classify and analyze your lead/opportunity categories like: Training, Service")
     color = fields.Integer('Color Index', default=0)
     # Revenues
-    expected_revenue = fields.Monetary('Expected Revenue', currency_field='company_currency', tracking=True)
+    expected_revenue = fields.Monetary('Expected Revenue', currency_field='company_currency', tracking=True, default=0.0)
     prorated_revenue = fields.Monetary('Prorated Revenue', currency_field='company_currency', store=True, compute="_compute_prorated_revenue")
     recurring_revenue = fields.Monetary('Recurring Revenues', currency_field='company_currency', tracking=True)
     recurring_plan = fields.Many2one('crm.recurring.plan', string="Recurring Plan")


### PR DESCRIPTION
Issue: Expected revenue is set to null on creation, when we sort opportunities by expected revenue that are null end up on the bottom.

Purpose of this PR: 
To assign a default 0.0 on expected revenue. 

Steps to reproduce on runbot:
install crm
set up mailgate to create a lead and convert to opportunity go to Pipeline list view and sort by expected revenue newly created lead/opp will be at the bottom even though it shows 0.00

opw-4966472

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
