### PR TITLE
[PERF] core: profiler performance improvements

### DIFF
--- a/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
@@ -28,6 +28,7 @@
                             <select class="profile_param form-select" t-on-change="(ev) => this.changeParam('traces_async_interval', ev)">
                                 <t t-set="interval" t-value="profiling.state.params.traces_async_interval"/>
                                 <option value="">Default</option>
+                                <option value="0.0001" t-att-selected="interval === '0.0001'">0.0001</option>
                                 <option value="0.001" t-att-selected="interval === '0.001'">0.001</option>
                                 <option value="0.01" t-att-selected="interval === '0.01'">0.01</option>
                                 <option value="0.1" t-att-selected="interval === '0.1'">0.1</option>

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -217,11 +217,17 @@ class _BasePeriodicCollector(Collector):
     def run(self):
         self.active = True
         self.last_time = real_time()
-        while self.active:  # maybe add a check on parent_thread state?
+        while self.active:
             self.progress()
-            time.sleep(self.frame_interval)
-
+            self.sleep()
         self._entries.append({'stack': [], 'start': real_time()})  # add final end frame
+
+    def sleep(self):
+        # Note: This may not be very precise. Most systems will sleep at
+        # minimum between 1 and 5 ms. "The suspension time may be longer
+        # than requested by an arbitrary amount, because of the scheduling
+        # of other activity in the system."
+        time.sleep(self.frame_interval)
 
     def stop(self):
         self.active = False

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -244,7 +244,7 @@ class PeriodicCollector(_BasePeriodicCollector):
                 # the call itself does not appear in any of those frames: the duration of the call
                 # is incorrectly attributed to the last frame.
                 self._entries[-1]['stack'].append(('profiling', 0, '⚠ Profiler freezed for %s s' % duration, ''))
-            self.last_frame = None  # skip duplicate detection for the next frame.
+                self.last_frame = None  # skip duplicate detection for the next frame.
         self._last_time = real_time()
 
         frame = frame or get_current_frame(self.profiler.init_thread)


### PR DESCRIPTION
See commit messages for details.

Since performance of the profiler is important to avoid impacting measured code, this PR improves it in multiple ways:

- Adding logging to the PeriodicCollector to estimate gains
- Inlining some methods and avoiding creating objects when possible.
- Forgetting references to `frame` objects. Keeping them changes behaviour as lot of objects are kept in memory instead of being deallocated by reference counting. This is also what made the SyncCollector to fill-up instantly the memory.

Overall, the profiler runs nearly twice as fast and it can be used to profile at sub-millisecond level.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
