### PR TITLE
[FIX] mail: improve grammar in DM and channel welcome messages

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -655,7 +655,7 @@ export class Thread extends Component {
             }
         }
         if (this.props.thread.channel_type === "channel") {
-            return _t("This is the start of #%(channelName)s channel", {
+            return _t("This is the start of the #%(channelName)s channel", {
                 channelName: this.props.thread.name,
             });
         }
@@ -664,7 +664,7 @@ export class Thread extends Component {
                 conversationName: this.props.thread.displayName,
             });
         }
-        return _t("This is the start of direct chat with %(userName)s", {
+        return _t("This is the start of your direct chat with %(userName)s", {
             userName: this.props.thread.displayName,
         });
     }

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -50,7 +50,7 @@ test("No duplicated chat bubbles", async () => {
     await insertText("input[placeholder='Search a conversation']", "John");
     await click(".o_command_name", { text: "John" });
     await contains(".o-mail-ChatWindow", { text: "John" });
-    await contains(".o-mail-ChatWindow", { text: "This is the start of direct chat with John" }); // wait fully loaded
+    await contains(".o-mail-ChatWindow", { text: "This is the start of your direct chat with John" }); // wait fully loaded
     await click("button[title='Fold']");
     await contains(".o-mail-ChatBubble[name='John']");
     // Make bubble of "John" chat again


### PR DESCRIPTION
Description of the issue this PR addresses:
Some welcome messages in direct chats and channels contain minor grammatical errors, making them less natural and slightly confusing for end users.

Current behavior before PR:
Direct chat message: "This is the start of direct chat with %(userName)s"
Channel message: "This is the start of #%(channelName)s channel"

Desired behavior after PR is merged:
Direct chat message: "This is the start of your direct chat with %(userName)s"
Channel message: "This is the start of the #%(channelName)s channel"

This improves readability and ensures the welcome messages are grammatically correct.

task-4952480
