### PR TITLE
[FIX] base_import: fix traceback when clicking on cancel in import records

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -98,6 +98,10 @@ export class ImportAction extends Component {
     }
 
     exit(resIds) {
+        if (!resIds) {
+            this.env.config.historyBack();
+            return;
+        }
         this.actionService.doAction({
             type: "ir.actions.act_window",
             name: _t("Imported records"),

--- a/addons/base_import/static/tests/import_action.test.js
+++ b/addons/base_import/static/tests/import_action.test.js
@@ -536,6 +536,21 @@ describe("Import view", () => {
         expect(".o_list_view").toHaveCount(1);
     });
 
+    test("cancel in import view", async () => {
+        await mountWebClient();
+        await getService("action").doAction({
+            name: "Fall back",
+            type: "ir.actions.client",
+            tag: "import",
+            params: { active_model: "partner" },
+        });
+        expect(".o_last_breadcrumb_item span").toHaveText("Fall back");
+        await getService("action").doAction(1);
+        expect(".o_last_breadcrumb_item span").toHaveText("Import Data");
+        await contains(".o_control_panel_main_buttons button:contains(Cancel)").click();
+        expect(".o_last_breadcrumb_item span").toHaveText("Fall back");
+    })
+
     test("additional options in debug", async () => {
         serverState.debug = "1";
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install a module(ex: helpdesk/contacts) and open contacts.
2. Select the Cog Menu > import records
3. Click on the Cancel button

Error:
-----
```python
InvalidDomainError: Invalid domain representation: id,in,
```

Cause:
------
The dc05253 changes the behavior to display the imported records instead of redirecting the user to the action from which the import was launched. However, when the user clicks the Cancel button(resIds = undefined in this case) , it leads to an `InvalidDomainError`.
https://github.com/odoo/odoo/blob/2627168eea8562477f600c97c42d443a072ddccc/addons/base_import/static/src/import_action/import_action.js#L100-L113

Solution:
---------
Used `historyBack` to fall back to the originating action when the user clicks the Cancel button.

opw-4985218


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
