### PR TITLE
[IMP] website_sale(_*), sale: align product thumbnail design

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -193,7 +193,11 @@
                     <tr t-att-style="'background-color: #f2f2f2' if loop_cycle_number % 2 == 0 else 'background-color: #ffffff'">
                         <t t-set="loop_cycle_number" t-value="loop_cycle_number + 1" />
                         <td style="width: 150px;">
-                            <img t-attf-src="/web/image/product.product/{{ line.product_id.id }}/image_128" style="width: 64px; height: 64px; object-fit: contain;" alt="Product image"></img>
+                            <img
+                                t-attf-src="/web/image/product.product/{{ line.product_id.id }}/image_128"
+                                t-attf-style="width: 64px; height: {{object.website_id and object.website_id._get_product_image_ratio_height() or '64px'}}; object-fit: cover; object-position: center;"
+                                alt="Product image"
+                            />
                         </td>
                         <td align="left" t-out="line.product_id.name or ''">	Taking care of Trees Course</td>
                         <td width="15%" align="center" t-out="line.product_uom_qty or ''">1</td>

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -1007,3 +1007,34 @@ class Website(models.Model):
 
     def _get_snippet_defaults(self, snippet):
         return super()._get_snippet_defaults(snippet) | const.SNIPPET_DEFAULTS.get(snippet, {})
+
+    def _get_product_image_ratio(self):
+        """Get the product image aspect ratio based on the website's design classes.
+
+        Returns:
+            str: The aspect ratio as a string (e.g., '16_9', '4_3', '1_1')
+        """
+        classes = self.shop_opt_products_design_classes or ''
+        ratio_mapping = {
+            'o_wsale_products_opt_thumb_16_9': '16_9',
+            'o_wsale_products_opt_thumb_4_3': '4_3',
+            'o_wsale_products_opt_thumb_6_5': '6_5',
+            'o_wsale_products_opt_thumb_4_5': '4_5',
+            'o_wsale_products_opt_thumb_2_3': '2_3',
+        }
+        for class_name, ratio in ratio_mapping.items():
+            if class_name in classes:
+                return ratio
+        return '1_1'
+
+    def _get_product_image_ratio_height(self):
+        match self._get_product_image_ratio():
+            case '16_9':
+                return '36px'
+            case '4_3':
+                return '48px'
+            case '6_5':
+                return '53px'
+            case '4_5':
+                return '96px'
+        return '64px'

--- a/addons/website_sale/static/src/js/notification/add_to_cart_notification/add_to_cart_notification.xml
+++ b/addons/website_sale/static/src/js/notification/add_to_cart_notification/add_to_cart_notification.xml
@@ -18,11 +18,13 @@
     <t t-name="website_sale.cartLine">
         <div class="d-flex gap-3">
             <div class="position-relative">
-                <img
-                    class="img o_image_64_max rounded mb-2 img-fluid"
-                    t-att-src="line.image_url"
-                    t-att-alt="line.name"
-                />
+                <div class="o_cart_product_image">
+                    <img
+                        class="img o_image_64_max rounded mb-2 img-fluid"
+                        t-att-src="line.image_url"
+                        t-att-alt="line.name"
+                    />
+                </div>
                 <span
                     class="o_cart_item_count badge bg-secondary position-absolute top-0 start-100 translate-middle"
                     t-out="line.quantity"

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1765,28 +1765,6 @@ $-product-radius-map: (
         flex-direction: column;
     }
 
-    #shop_cart {
-        &.o_img_ratio_16_9 {
-            --card-product-img-ratio: 4/3;
-        }
-
-        &.o_img_ratio_4_3 {
-            --card-product-img-ratio: 4/3;
-        }
-
-        &.o_img_ratio_6_5 {
-            --card-product-img-ratio: 6/5;
-        }
-
-        &.o_img_ratio_4_5 {
-            --card-product-img-ratio: 4/5;
-        }
-
-        &.o_img_ratio_2_3 {
-            --card-product-img-ratio: 2/3;
-        }
-    }
-
     #cart_products, .o_wsale_quick_reorder_line_group {
         --cart-product-img-size-lg: 6rem;
 
@@ -1795,10 +1773,6 @@ $-product-radius-map: (
                 @include media-breakpoint-down(md) {
                     --cart-product-img-size-sm: 4rem;
                 }
-
-                aspect-ratio: var(--card-product-img-ratio, 1/1);
-                object-fit: cover;
-                object-position: center;
                 width: var(--cart-product-img-size-sm, var(--cart-product-img-size-lg));
             }
         }
@@ -1910,6 +1884,42 @@ $-product-radius-map: (
             }
         }
     }
+}
+
+// Unified product image aspect ratios
+
+%o-wsale-product-img {
+    object-fit: cover;
+    object-position: center;
+}
+
+@mixin o-wsale-product-img-ratio($ratio) {
+    .o_cart_product_image img,
+    .o_sale_product_configurator_img img,
+    .o_wsale_comparison_bottom_bar img,
+    .o_wsale_compare_table_column img,
+    .product-card img {
+        aspect-ratio: $ratio;
+        @extend %o-wsale-product-img;
+    }
+}
+
+.o_wsale_products_opt_thumb_16_9 { @include o-wsale-product-img-ratio(16/9); }
+.o_wsale_products_opt_thumb_4_3 { @include o-wsale-product-img-ratio(4/3); }
+.o_wsale_products_opt_thumb_6_5 { @include o-wsale-product-img-ratio(6/5); }
+.o_wsale_products_opt_thumb_4_5 { @include o-wsale-product-img-ratio(4/5); }
+.o_wsale_products_opt_thumb_2_3 { @include o-wsale-product-img-ratio(2/3); }
+
+.o_cart_product_image img {
+    max-width: 64px;
+    aspect-ratio: 1/1; // Default fallback
+    @extend %o-wsale-product-img;
+}
+
+.o_sale_product_configurator_img img,
+.product-card img {
+    aspect-ratio: 1/1; // Default fallback
+    @extend %o-wsale-product-img;
 }
 
 .oe_website_sale {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -23,6 +23,13 @@
 
         <!-- Insert JSON-LD markup data for SEO. -->
     <template id="website_sale_layout" inherit_id="website.layout" priority="1">
+        <body position="before">
+            <t
+                t-if="website._get_product_image_ratio() != '1_1'"
+                t-set="body_classname"
+                t-value="'o_wsale_products_opt_thumb_' + website._get_product_image_ratio() + (' ' + body_classname if body_classname else '')"
+            />
+        </body>
         <head position="inside">
             <!-- Company markup data, in all pages. -->
             <t t-set="base_url" t-value="website.get_base_url()"/>
@@ -3085,16 +3092,7 @@
                      t-att-id) and each template needs to define a div element. -->
                 <div class="oe_structure" id="oe_structure_website_sale_cart_2"/>
             </t>
-            <div
-                id="shop_cart"
-                t-att-class="'col ' + (
-                        'o_img_ratio_16_9' if 'o_wsale_products_opt_thumb_16_9' in website.shop_opt_products_design_classes else
-                        'o_img_ratio_4_3' if 'o_wsale_products_opt_thumb_4_3' in website.shop_opt_products_design_classes else
-                        'o_img_ratio_6_5' if 'o_wsale_products_opt_thumb_6_5' in website.shop_opt_products_design_classes else
-                        'o_img_ratio_4_5' if 'o_wsale_products_opt_thumb_4_5' in website.shop_opt_products_design_classes else
-                        'o_img_ratio_2_3' if 'o_wsale_products_opt_thumb_2_3' in website.shop_opt_products_design_classes else
-                        '')
-            ">
+            <div id="shop_cart" class="col">
                 <div class="d-flex align-items-center mb-3">
                     <h4 class="mb-0">Order summary</h4>
                     <div class="ms-3 border-start ps-2"><t t-call="website_sale.quick_reorder_button"/></div>
@@ -3899,20 +3897,20 @@
                             t-att-class="line_last and 'border-transparent'"
                         >
                             <td class="td-img ps-0 pt-3">
-                                <div class="position-relative">
+                                <div class="o_cart_product_image position-relative">
                                     <span
                                         t-if="not line._is_sellable() and line.product_id.image_128"
                                     >
                                         <img
                                             t-att-src="image_data_uri(line.product_id.image_128)"
-                                            class="o_image_64_max img rounded"
+                                            class="img rounded"
                                             t-att-alt="line.name_short"
                                         />
                                     </span>
                                     <span
                                         t-else=""
                                         t-field="line.product_id.image_128"
-                                        t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'o_image_64_max rounded'}"
+                                        t-options="{'widget': 'image', 'qweb_img_responsive': False, 'class': 'rounded'}"
                                     />
                                     <span class="o_cart_item_count badge bg-secondary position-absolute top-0 start-100 translate-middle">
                                         <t t-out="int(line.product_uom_qty)" />

--- a/addons/website_sale_comparison/static/src/js/product_row/product_row.xml
+++ b/addons/website_sale_comparison/static/src/js/product_row/product_row.xml
@@ -11,7 +11,7 @@
             >
                 <img
                     t-att-src="props.image_url"
-                    class="o_image_40_cover border rounded"
+                    class="o_wsale_comparison_bottom_bar_image border rounded"
                     alt="Product Image"
                 />
                 <h6 class="flex-grow-1 mb-0 text-truncate">

--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
@@ -35,22 +35,6 @@
 
         width: var(--o-website-sale-comparison-table-column-width);
         padding: 0 var(--o-website-sale-comparison-table-column-padding-x);
-
-        img {
-            aspect-ratio: var(--card-product-img-ratio, 1/1);
-
-            &.o_img_ratio_4_3 {
-                --card-product-img-ratio: 4/3;
-            }
-
-            &.o_img_ratio_4_5 {
-                --card-product-img-ratio: 4/5;
-            }
-
-            &.o_img_ratio_2_3 {
-                --card-product-img-ratio: 2/3;
-            }
-        }
     }
 
     #o_comparelist_table {
@@ -110,10 +94,6 @@
 }
 
 .o_wsale_comparison_bottom_bar {
-    .o_product_image {
-        width: 2.5rem;
-    }
-
     .btn[data-bs-toggle="collapse"] {
         .oi-chevron-up {
             transition: transform 0.2s ease-in-out;
@@ -136,6 +116,13 @@
         background: $light;
     }
 
+    .o_wsale_comparison_bottom_bar_image {
+        width: 2.5rem;
+        height: fit-content;
+        aspect-ratio: var(--wsale-product-thumb-aspect-ratio, 1/1);
+        object-fit: cover;
+        object-position: center;
+    }
 }
 
 // Style the <main> element when comparison bar is present

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -219,17 +219,6 @@
                 <div class="oe_structure oe_empty" id="oe_structure_website_sale_comparison_product_compare_1"/>
                 <div t-attf-class="oe_website_sale o_wsale_comparison_page pb-5 #{website.shop_page_container == 'fluid' and 'container-fluid' or 'container'}">
                     <h1 class="h4 mt-4 mb-3">Compare Products</h1>
-                    <t
-                        t-set="img_ratio_class"
-                        t-value="
-                           'o_img_ratio_16_9' if 'o_wsale_products_opt_thumb_16_9' in website.shop_opt_products_design_classes else
-                            'o_img_ratio_4_3' if 'o_wsale_products_opt_thumb_4_3' in website.shop_opt_products_design_classes else
-                            'o_img_ratio_6_5' if 'o_wsale_products_opt_thumb_6_5' in website.shop_opt_products_design_classes else
-                            'o_img_ratio_4_5' if 'o_wsale_products_opt_thumb_4_5' in website.shop_opt_products_design_classes else
-                            'o_img_ratio_2_3' if 'o_wsale_products_opt_thumb_2_3' in website.shop_opt_products_design_classes else
-                            ''
-                        "
-                    />
 
                     <!-- Mini sticky product overview (initially hidden) -->
                     <div
@@ -255,7 +244,7 @@
                                             <div class="o_mini_product_img_container flex-shrink-0">
                                                 <img
                                                     t-att-src="product._get_image_1024_url()"
-                                                    t-attf-class="img-fluid flex-shrink-0 w-100 h-100 rounded border object-fit-cover #{img_ratio_class}"
+                                                    class="img-fluid flex-shrink-0 w-100 h-100 rounded border object-fit-cover"
                                                     t-att-alt="combination_info['display_name']"
                                                 />
                                             </div>
@@ -316,7 +305,7 @@
                                     <a t-att-href="product.website_url">
                                         <img
                                             t-att-src="product._get_image_1024_url()"
-                                            t-attf-class="img img-fluid w-100 h-100 object-fit-cover border rounded #{img_ratio_class}"
+                                            class="img img-fluid w-100 h-100 object-fit-cover border rounded"
                                             alt="Product image"
                                         />
                                     </a>


### PR DESCRIPTION
Previously, product image thumbnails were displayed with inconsistent aspect ratios across different areas. In some cases, they followed the image ratio selected by the user for the /shop product list, while in others they defaulted to a fixed 1:1 ratio.

This commit ensures consistency by applying the user-selected image ratio to all product thumbnails (checkout, cart, toast notification, product configurator and email template).

task-4788394

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
