### PR TITLE
[REM] account, l10n_es: remove filter_analytic

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -146,11 +146,6 @@ class AccountReport(models.Model):
         compute=lambda x: x._compute_report_option_filter('filter_journals'), readonly=False,
         precompute=True, store=True, depends=['root_report_id', 'section_main_report_ids'],
     )
-    filter_analytic = fields.Boolean(
-        string="Analytic Filter",
-        compute=lambda x: x._compute_report_option_filter('filter_analytic'), readonly=False,
-        precompute=True, store=True, depends=['root_report_id', 'section_main_report_ids'],
-    )
     filter_hierarchy = fields.Selection(
         string="Account Groups",
         selection=[('by_default', "Enabled by Default"), ('optional', "Optional"), ('never', "Never")],

--- a/addons/l10n_es/data/mod111.xml
+++ b/addons/l10n_es/data/mod111.xml
@@ -5,7 +5,6 @@
         <field name="name">Tax Report (Mod 111)</field>
         <field name="name@es">Informe de Impuestos (Mod 111)</field>
         <field name="sequence">111</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_unfold_all" eval="True"/>

--- a/addons/l10n_es/data/mod115.xml
+++ b/addons/l10n_es/data/mod115.xml
@@ -5,7 +5,6 @@
         <field name="name">Tax Report (Mod 115)</field>
         <field name="name@es">Informe de Impuestos (Mod 115)</field>
         <field name="sequence">115</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_unfold_all" eval="True"/>

--- a/addons/l10n_es/data/mod130.xml
+++ b/addons/l10n_es/data/mod130.xml
@@ -5,7 +5,6 @@
             <field name="name">Tax Report(Mod 130)</field>
             <field name="name@es">Informe de impuestos (Mod 130)</field>
             <field name="sequence">130</field>
-            <field name="filter_analytic" eval="False"/>
             <field name="filter_date_range" eval="False"/>
             <field name="filter_period_comparison" eval="False"/>
             <field name="filter_unfold_all" eval="True"/>

--- a/addons/l10n_es/data/mod303.xml
+++ b/addons/l10n_es/data/mod303.xml
@@ -5,7 +5,6 @@
         <field name="name">Tax Report (Mod 303)</field>
         <field name="name@es">Informe de impuestos (Mod 303)</field>
         <field name="sequence">303</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_unfold_all" eval="True"/>

--- a/addons/l10n_es/data/mod390/mod390.xml
+++ b/addons/l10n_es/data/mod390/mod390.xml
@@ -5,7 +5,6 @@
         <field name="name">Tax Report (Mod 390)</field>
         <field name="name@es">Informe de impuestos (Mod 390)</field>
         <field name="sequence">390</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_journals" eval="True"/>

--- a/addons/l10n_es/data/mod390/mod390_section1.xml
+++ b/addons/l10n_es/data/mod390/mod390_section1.xml
@@ -4,7 +4,6 @@
     <record id="mod_390_section_1" model="account.report">
         <field name="name">IVA Devengado</field>
         <field name="name@es">IVA Devengado</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_journals" eval="True"/>

--- a/addons/l10n_es/data/mod390/mod390_section2.xml
+++ b/addons/l10n_es/data/mod390/mod390_section2.xml
@@ -4,7 +4,6 @@
     <record id="mod_390_section_2" model="account.report">
         <field name="name">IVA Deducible</field>
         <field name="name@es">IVA Deducible</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_journals" eval="True"/>

--- a/addons/l10n_es/data/mod390/mod390_section3.xml
+++ b/addons/l10n_es/data/mod390/mod390_section3.xml
@@ -4,7 +4,6 @@
     <record id="mod_390_section_3" model="account.report">
         <field name="name">Resultado Liquidación Anual</field>
         <field name="name@es">Resultado Liquidación Anual</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_journals" eval="True"/>

--- a/addons/l10n_es/data/mod390/mod390_section4.xml
+++ b/addons/l10n_es/data/mod390/mod390_section4.xml
@@ -4,7 +4,6 @@
     <record id="mod_390_section_4" model="account.report">
         <field name="name">Resultado de las Liquidaciones</field>
         <field name="name@es">Resultado de las Liquidaciones</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_journals" eval="True"/>

--- a/addons/l10n_es/data/mod390/mod390_section5.xml
+++ b/addons/l10n_es/data/mod390/mod390_section5.xml
@@ -4,7 +4,6 @@
     <record id="mod_390_section_5" model="account.report">
         <field name="name">Volumen de Operaciones</field>
         <field name="name@es">Volumen de Operaciones</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_journals" eval="True"/>

--- a/addons/l10n_es/data/mod390/mod390_section6.xml
+++ b/addons/l10n_es/data/mod390/mod390_section6.xml
@@ -4,7 +4,6 @@
     <record id="mod_390_section_6" model="account.report">
         <field name="name">Operaciones Específicas</field>
         <field name="name@es">Operaciones Específicas</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_journals" eval="True"/>

--- a/addons/l10n_es/data/mod390/mod390_section7.xml
+++ b/addons/l10n_es/data/mod390/mod390_section7.xml
@@ -4,7 +4,6 @@
     <record id="mod_390_section_7" model="account.report">
         <field name="name">Actividades con Regímenes de Deducción Diferenciados</field>
         <field name="name@es">Actividades con Regímenes de Deducción Diferenciados</field>
-        <field name="filter_analytic" eval="False"/>
         <field name="filter_date_range" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="filter_journals" eval="True"/>

--- a/addons/l10n_es/data/mod420.xml
+++ b/addons/l10n_es/data/mod420.xml
@@ -5,7 +5,6 @@
             <field name="name">Tax Report (Mod 420) Canary Islands</field>
             <field name="name@es">Informe de impuestos Canarias (Mod 420)</field>
             <field name="sequence">420</field>
-            <field name="filter_analytic" eval="False"/>
             <field name="filter_date_range" eval="True"/>
             <field name="filter_period_comparison" eval="True"/>
             <field name="filter_unfold_all" eval="True"/>


### PR DESCRIPTION
Removing `filter_analytic`, as `filter_analytic_groupby` does the job
better and considers the analytic distribution.

Enteprise PR: https://github.com/odoo/enterprise/pull/92598

task-4819486