### PR TITLE
[FIX] hr_expense: ensure outstanding line is first

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -812,6 +812,14 @@ class HrExpense(models.Model):
         base_line_data, to_update = tax_data['base_lines_to_update'][0]  # Add base line
         amount_currency = to_update['price_subtotal']
         expense_name = self.name.split("\n")[0][:64]
+        move_lines.append({  # Add outstanding payment line
+            'name': f'{self.employee_id.name}: {expense_name}',
+            'account_id': self.sheet_id._get_expense_account_destination(),
+            'balance': -self.total_amount,
+            'amount_currency': self.currency_id.round(-self.total_amount_currency),
+            'currency_id': self.currency_id.id,
+        })
+        expense_name = self.name.split("\n")[0][:64]
         base_move_line = {
             'name': f'{self.employee_id.name}: {expense_name}',
             'account_id': base_line_data['account'].id,
@@ -843,14 +851,6 @@ class HrExpense(models.Model):
             }
             move_lines.append(tax_line)
         base_move_line['balance'] = self.total_amount - total_tax_line_balance
-        expense_name = self.name.split("\n")[0][:64]
-        move_lines.append({  # Add outstanding payment line
-            'name': f'{self.employee_id.name}: {expense_name}',
-            'account_id': self.sheet_id._get_expense_account_destination(),
-            'balance': -self.total_amount,
-            'amount_currency': self.currency_id.round(-self.total_amount_currency),
-            'currency_id': self.currency_id.id,
-        })
         return {
             **self.sheet_id._prepare_move_vals(),
             'date': self.date,  # Overidden from self.sheet_id._prepare_move_vals() so we can use the expense date for the account move date


### PR DESCRIPTION
When creating a payment for an expense, the outstanding line was added as the last line. This creates an issue in the l10n_de DATEV DATA general ledger report.

- Create an expense for a contact paid by the company and generate the report.

- Approve the expense and post the journal entries.

- In the general ledger, download the DATEV DATA CSV file.

- For the line corresponding to the payment of the expense, there is no BU code (tax).

In _l10n_de_datev_get_csv, the first line of the move is considered the outstanding line, but in the case of expense payments it was actually the last line. As a result, the outstanding line was included instead of the line with the tax.

opw-4904057

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
