### PR TITLE
[FIX] website: prevent error on invalid domain

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -402,6 +402,14 @@ class Website(models.Model):
         if homepage_url:
             vals['homepage_url'] = homepage_url.rstrip('/')
 
+    @api.constrains('domain')
+    def _check_domain(self):
+        for record in self:
+            try:
+                urlparse(record.domain)
+            except ValueError:
+                raise ValidationError(_("The provided website domain is not a valid URL."))
+
     @api.constrains('homepage_url')
     def _check_homepage_url(self):
         for website in self.filtered('homepage_url'):

--- a/addons/website/tests/test_base_url.py
+++ b/addons/website/tests/test_base_url.py
@@ -3,6 +3,7 @@
 from lxml.html import document_fromstring
 
 import odoo.tests
+from odoo.exceptions import ValidationError
 
 
 class TestUrlCommon(odoo.tests.HttpCase):
@@ -148,3 +149,11 @@ class TestGetBaseUrl(odoo.tests.TransactionCase):
         with self.assertRaises(ValueError):
             # if more than one record, an error we should be raised
             Attachment.search([], limit=2).get_base_url()
+
+    def test_03_invalid_website_domain(self):
+        website = self.env['website'].create({
+            'name': 'Website Test 2',
+        })
+
+        with self.assertRaises(ValidationError):
+            website.write({'domain': 'https://my-website.net['})


### PR DESCRIPTION
Currently, an error occurs when user tries to save an invalid domain.

Steps to replicate:
- Install `website_sale`.
- Go to `Settings > Website`.
- In the domain field, give value as `[`.
  (any normal URL with a square bracket will also work).
- Save and error will occur.

Error:
`ValueError: Invalid IPv6 URL`

Cause:
- The error happens because `config.get_base_url()` returns a 
malformed URL (like containing stray `[`), which makes urljoin [1] 
raise the error.

Solution:
- The solution prevents error by adding a constraint and raising a
user-friendly `ValidationError` if the URL is invalid.

[1]: https://github.com/odoo/odoo/blob/77398aefc291d33264b039e38681f0cd8f65483f/addons/website_sale/models/res_config_settings.py#L135

sentry-6805151048
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
