### PR TITLE
[FIX] base: prevent Shop Floor being the home action

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -592,8 +592,11 @@ class Users(models.Model):
     @api.constrains('action_id')
     def _check_action_id(self):
         action_open_website = self.env.ref('base.action_open_website', raise_if_not_found=False)
+        action_open_shop_floor = self.env.ref('mrp_workorder.action_mrp_display', raise_if_not_found=False)
         if action_open_website and any(user.action_id.id == action_open_website.id for user in self):
             raise ValidationError(_('The "App Switcher" action cannot be selected as home action.'))
+        if action_open_shop_floor and any(user.action_id.id == action_open_shop_floor.id for user in self):
+            raise ValidationError(_('The "Shop Floor" action cannot be selected as home action.'))
         # We use sudo() because  "Access rights" admins can't read action models
         for user in self.sudo():
             if user.action_id.type == "ir.actions.client":


### PR DESCRIPTION
**PROBLEM**
In debug mode, we can change the default home action of a user (the action he sees when logging in). When the action `action_mrp_display` is set as the home action, there is a traceback after logging in.

**STEP TO REPRODUCE**
1. Go in debug mode
2. Change the home action of a user to the 'Shop Floor' action (in the user form, in the preference tab).
3. log out, and log in with this user.
4. a js traceback should appear.

**CAUSE**
On the js side, the Shop Floor action uses the `menu` service to get the name of the current app. when accessing the 'Shop Floor' action as a home action, the `menu` service app is set after the action is rendered, so the current app during rendering is undefined.

**FIX**
Prevent the user from selection the 'Shop Floor' action as a home action (we already do this for action that doesn't work as home action).

opw-4926317