### PR TITLE
[FIX] payment: add missing server action for Stripe activation

### DIFF
--- a/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
+++ b/addons/account_payment/static/tests/interactions/portal_invoice_page_payment.test.js
@@ -111,7 +111,18 @@ test("portal_invoice_page_payment is started with #portal_pay", async () => {
                                                                 <p data-oe-model="ir.ui.view" data-oe-id="612" data-oe-field="arch" data-oe-xpath="/t[1]/div[1]/div[2]/p[2]">
                                                                     No payment providers are configured.
                                                                 </p>
-                                                                <a name="activate_stripe" href="/odoo/action-payment.action_activate_stripe" role="button" class="btn btn-primary me-2 d-none" data-oe-model="ir.ui.view" data-oe-id="612" data-oe-field="arch" data-oe-xpath="/t[1]/div[1]/div[2]/a[1]"> ACTIVATE STRIPE </a>
+                                                                <a
+                                                                    name="activate_payment_provider"
+                                                                    href="/odoo/action-payment.action_start_payment_onboarding"
+                                                                    role="button"
+                                                                    class="btn btn-primary me-2 d-none"
+                                                                    data-oe-model="ir.ui.view"
+                                                                    data-oe-id="612"
+                                                                    data-oe-field="arch"
+                                                                    data-oe-xpath="/t[1]/div[1]/div[2]/a[1]"
+                                                                 >
+                                                                     ACTIVATE <t t-out="onboarding_provider.upper()"/>
+                                                                </a>
                                                                 <a role="button" type="action" class="btn-link alert-warning me-2" href="/odoo/action-payment.action_payment_provider" data-oe-model="ir.ui.view" data-oe-id="612" data-oe-field="arch" data-oe-xpath="/t[1]/div[1]/div[2]/a[3]">
                                                                 <strong><i class="oi oi-arrow-right"></i> Payment Providers</strong>
                                                                 </a>

--- a/addons/payment/__manifest__.py
+++ b/addons/payment/__manifest__.py
@@ -8,6 +8,7 @@
     'depends': ['onboarding', 'portal'],
     'data': [
         # Record data.
+        'data/ir_actions_server_data.xml',
         'data/payment_method_data.xml',
         'data/payment_provider_data.xml',
         'data/payment_cron.xml',

--- a/addons/payment/data/ir_actions_server_data.xml
+++ b/addons/payment/data/ir_actions_server_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="action_start_payment_onboarding" model="ir.actions.server">
+        <field name="name"/>
+        <field name="model_id" ref="payment.model_payment_provider"/>
+        <field name="state">code</field>
+        <field name="code">
+action = env['res.config.settings'].sudo().create({})._start_payment_onboarding()
+        </field>
+    </record>
+
+</odoo>

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -419,14 +419,19 @@
                 <p t-else="">
                     No payment providers are configured.
                 </p>
+                <t
+                    t-set="onboarding_provider"
+                    t-value="request.env['res.config.settings'].sudo().new({}).onboarding_payment_module"
+                />
                 <a
-                    t-if="request.env.company.country_id.is_stripe_supported_country
-                          and not providers_sudo"
-                    name="activate_stripe"
-                    href="/odoo/action-payment.action_activate_stripe"
+                    t-if="onboarding_provider and not providers_sudo"
+                    name="start_payment_onboarding"
+                    href="/odoo/action-payment.action_start_payment_onboarding"
                     role="button"
                     class="btn btn-primary me-2"
-                > ACTIVATE STRIPE </a>
+                >
+                    ACTIVATE <t t-out="onboarding_provider.upper()"/>
+                </a>
                 <a
                     t-if="availability_report"
                     role="button"

--- a/addons/payment_stripe/views/payment_templates.xml
+++ b/addons/payment_stripe/views/payment_templates.xml
@@ -7,10 +7,10 @@
         </xpath>
     </template>
 
-    <template id="no_pms_available_warning" inherit_id="payment.no_pms_available_warning">
-        <a name="activate_stripe" position="attributes">
+    <template id="no_pms_available_warning" inherit_id="payment.no_pms_available_warning" active="False">
+        <a name="start_payment_onboarding" position="attributes">
             <!-- Hide 'Activate Stripe' button when the `payment_stripe` module is installed. -->
-            <attribute name="class" separator=" " add="d-none"/>
+            <!--<attribute name="class" separator=" " add="d-none"/>-->
         </a>
     </template>
 


### PR DESCRIPTION
Steps to Reproduce:
1. Go to the website e-commerce shop and add a product to the cart.
2. Proceed to checkout and reach the Payment step.
3. Click the Activate Stripe button.
4. Warning message pop-up: Missing Action – The action 'payment.action_activate_stripe' does not exist.

Description:
This commit fixes the broken Stripe activation flow by adding the missing server action. With this in place, users can activate and set up the available payment provider without warning on the checkout page in e-commerce.
    
Before this commit:
- Clicking Activate Stripe on the checkout page raised a warning: The action 'payment.action_activate_stripe' does not exist.
- The Stripe payment provider could not be activated from the checkout e-commerce.

After this commit:
- Added a server action in `ir_actions_server_data.xml`.
- Clicking Activate Stripe now triggers the payment onboarding process via `res.config.settings._start_payment_onboarding()`.
- Users can correctly activate and configure available payment provider . 

opw:5022767

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
