### PR TITLE
[IMP] hr: add tracking on hr.version fields

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -177,6 +177,7 @@ class HrEmployee(models.Model):
         'hr.employee.category', 'employee_category_rel',
         'employee_id', 'category_id', groups="hr.group_hr_user",
         string='Tags')
+    tz = fields.Selection(tracking=True)
     # misc
     color = fields.Integer('Color Index', default=0)
     barcode = fields.Char(string="Badge ID", help="ID used for employee identification.", groups="hr.group_hr_user", copy=False)

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -39,16 +39,16 @@ class HrVersion(models.Model):
         )
 
     company_id = fields.Many2one('res.company', compute='_compute_company_id', readonly=False,
-                                 store=True, default=lambda self: self.env.company)
+                                 store=True, default=lambda self: self.env.company, tracking=True)
     employee_id = fields.Many2one(
         'hr.employee',
         string='Employee',
         tracking=True,
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
         index=True)
-    name = fields.Char()
+    name = fields.Char(tracking=True)
     display_name = fields.Char(compute='_compute_display_name')
-    active = fields.Boolean(default=True)
+    active = fields.Boolean(default=True, tracking=True)
 
     date_version = fields.Date(required=True, default=fields.Date.today, tracking=True, groups="hr.group_hr_user")
     last_modified_uid = fields.Many2one('res.users', string='Last Modified by',
@@ -81,7 +81,7 @@ class HrVersion(models.Model):
 
     distance_home_work = fields.Integer(string="Home-Work Distance", groups="hr.group_hr_user", tracking=True)
     km_home_work = fields.Integer(string="Home-Work Distance in Km", groups="hr.group_hr_user",
-                                  compute="_compute_km_home_work", inverse="_inverse_km_home_work", store=True)
+                                  compute="_compute_km_home_work", inverse="_inverse_km_home_work", store=True, tracking=True)
     distance_home_work_unit = fields.Selection([
         ('kilometers', 'km'),
         ('miles', 'mi'),
@@ -113,7 +113,7 @@ class HrVersion(models.Model):
     job_id = fields.Many2one('hr.job', check_company=True, tracking=True)
     job_title = fields.Char(compute="_compute_job_title", inverse="_inverse_job_title", store=True, readonly=False,
         string="Job Title", tracking=True)
-    is_custom_job_title = fields.Boolean(default=False, groups="hr.group_hr_user")
+    is_custom_job_title = fields.Boolean(default=False, groups="hr.group_hr_user", tracking=True)
     address_id = fields.Many2one(
         'res.partner',
         string='Work Address',
@@ -127,7 +127,7 @@ class HrVersion(models.Model):
 
     departure_reason_id = fields.Many2one("hr.departure.reason", string="Departure Reason",
                                           groups="hr.group_hr_user", copy=False, ondelete='restrict', tracking=True)
-    departure_description = fields.Html(string="Additional Information", groups="hr.group_hr_user", copy=False)
+    departure_description = fields.Html(string="Additional Information", groups="hr.group_hr_user", copy=False, tracking=True)
     departure_date = fields.Date(string="Departure Date", groups="hr.group_hr_user", copy=False, tracking=True)
 
     resource_calendar_id = fields.Many2one('resource.calendar', inverse='_inverse_resource_calendar_id', check_company=True, string="Working Hours", tracking=True)
@@ -141,7 +141,7 @@ class HrVersion(models.Model):
         'Contract End Date', tracking=True, help="End date of the contract (if it's a fixed-term contract).",
         groups="hr.group_hr_manager")
     trial_date_end = fields.Date('End of Trial Period', help="End date of the trial period (if there is one).",
-                                 groups="hr.group_hr_manager")
+                                 groups="hr.group_hr_manager", tracking=True)
     date_start = fields.Date(compute='_compute_dates', groups="hr.group_hr_manager", search="_search_start_date")
     date_end = fields.Date(compute='_compute_dates', groups="hr.group_hr_manager", search="_search_end_date")
     is_current = fields.Boolean(compute='_compute_is_current', groups="hr.group_hr_manager")

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -577,3 +577,62 @@ class TestHrVersion(TransactionCase):
             versions.write({
                 'contract_date_start': '2021-10-10'
             })
+
+    def test_hr_version_fields_tracking(self):
+        tracking_blacklist = {
+            "__last_update",
+            "active_employee",
+            "activity_ids",
+            "company_country_id",
+            "contract_wage",
+            "country_code",
+            "create_date",
+            "create_uid",
+            "currency_id",
+            "date_end",
+            "date_start",
+            "display_name",
+            "id",
+            "is_current",
+            "is_flexible",
+            "is_fully_flexible",
+            "is_future",
+            "is_in_contract",
+            "is_past",
+            "job_title",
+            "last_modified_date",
+            "last_modified_on",
+            "last_modified_uid",
+            "member_of_department",
+            "message_follower_ids",
+            "message_ids",
+            "message_partner_ids",
+            "rating_ids",
+            "template_warning",
+            "tz",
+            "website_message_ids",
+            "work_location_name",
+            "work_location_type",
+            "write_date",
+            "write_uid",
+        }
+
+        hr_version_model = self.env['hr.version']
+        fields_without_tracking = []
+
+        for field_name, field in hr_version_model._fields.items():
+            if field_name in tracking_blacklist:
+                continue
+            if field.compute and not field.inverse:
+                continue
+            if field.related:
+                continue
+            if hasattr(field, 'store') and field.store is False:
+                continue
+            if not (hasattr(field, 'tracking') and field.tracking):
+                fields_without_tracking.append(field_name)
+
+        self.assertFalse(
+            fields_without_tracking,
+            f"The following hr.version fields should have tracking=True: {fields_without_tracking}"
+        )

--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -18,12 +18,12 @@ class HrVersion(models.Model):
 
     date_generated_from = fields.Datetime(string='Generated From', readonly=True, required=True,
         default=lambda self: datetime.now().replace(hour=0, minute=0, second=0, microsecond=0), copy=False,
-        groups="hr.group_hr_user")
+        groups="hr.group_hr_user", tracking=True)
     date_generated_to = fields.Datetime(string='Generated To', readonly=True, required=True,
         default=lambda self: datetime.now().replace(hour=0, minute=0, second=0, microsecond=0), copy=False,
-        groups="hr.group_hr_user")
-    last_generation_date = fields.Date(string='Last Generation Date', readonly=True, groups="hr.group_hr_user")
-    work_entry_source = fields.Selection([('calendar', 'Working Schedule')], required=True, default='calendar', help='''
+        groups="hr.group_hr_user", tracking=True)
+    last_generation_date = fields.Date(string='Last Generation Date', readonly=True, groups="hr.group_hr_user", tracking=True)
+    work_entry_source = fields.Selection([('calendar', 'Working Schedule')], required=True, default='calendar', tracking=True, help='''
         Defines the source for work entries generation
 
         Working Schedule: Work entries will be generated from the working hours below.


### PR DESCRIPTION
Most fields in hr.version represent business-relevant employee data that should be tracked to ensure a complete audit trail. This commit adds `tracking=True` by default on hr.version fields across community and enterprise modules.

task-5022109