### PR TITLE
[FIX] account_edi_ubl_cii: prevent error when creating invoice for pos order

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
@@ -20,7 +20,7 @@ class AccountEdiXmlUbl_Sg(models.AbstractModel):
 
     def _get_tax_category_code(self, customer, supplier, tax):
         """ https://www.peppolguide.sg/billing/bis/#_gst_category_codes """
-        if tax.amount == 0:
+        if not tax or tax.amount == 0:
             return 'ZR'
         return 'SR'
 


### PR DESCRIPTION
Currently, an error occurs when a user creates the invoice for a POS order.

Steps to Reproduce:

 - Install the `point_of_sale` module.
 - Start a `Point of Sale session`.
 - Go to `Products` > create a product without `Sales Taxes and Purchase Taxes`, and in the `Point of Sale` tab, select your `POS session category`.
 - Go to `Customers` > `create a customer` and In the `Invoicing tab` of the customer, select `Singapore BIS Billing 3.0 SG` in the `eInvoice format` field.
 - Go to the Point of Sale session and validate an order with the newly created product.
 - Go back from the session, open the newly created order in Orders and select the newly created customer in the Customer field, and click the `Invoice button`.

`AttributeError: 'NoneType' object has no attribute 'amount'`

This error occurs after [this commit](https://github.com/odoo/odoo/commit/840bd1832edcc7815b8df70ec52dca10ef978fae), When a user creates an invoice for a POS order, the system calculates the tax_category_code [1], and if the product does not have any type of tax, then an error occurs here [2].

This commit ensures that if the tax is not present, it treats the tax amount as 0 as in [3] and returns the tax_category_code safely.

[1]- https://github.com/odoo/odoo/blob/2627168eea8562477f600c97c42d443a072ddccc/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py#L432

[2]- https://github.com/odoo/odoo/blob/2627168eea8562477f600c97c42d443a072ddccc/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py#L23

[3]- https://github.com/odoo/odoo/blob/9ea122e605366d076a2d6798dce63f1011a579da/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py#L434-L435

sentry-6814145551


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
