### PR TITLE
[FIX] website: avoid instagram snippet flicker on option change

### DIFF
--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -4,6 +4,7 @@ import { Colibri } from "@web/public/colibri";
 import { Interaction } from "@web/public/interaction";
 import { patch } from "@web/core/utils/patch";
 import { setupIgnoreDOMMutations } from "@website/js/content/auto_hide_menu";
+import { omit } from "@web/core/utils/objects";
 
 export function buildEditableInteractions(builders) {
     const result = [];
@@ -172,7 +173,7 @@ registry.category("services").add("website_edit", {
                         // To be overloaded by edit-mode interactions that need
                         // something more specific.
                         // TODO Sort keys to improve comparison.
-                        const dataset = { ...this.el.dataset };
+                        const dataset = omit(this.el.dataset, "visibility");
                         const style = {};
                         for (const property of this.el.style) {
                             if (property.startsWith("animation")) {

--- a/addons/website/static/src/snippets/s_instagram_page/instagram_page.edit.js
+++ b/addons/website/static/src/snippets/s_instagram_page/instagram_page.edit.js
@@ -8,6 +8,10 @@ const InstagramPageEdit = I => class extends I {
             "t-att-style": () => ({ "pointer-events": "none" }),
         };
     }
+
+    getConfigurationSnapshot() {
+        return this.el.dataset.instagramPage;
+    }
 }
 
 registry


### PR DESCRIPTION
> 2. Instagram Snippet Flickering when changing visibility settings from "Conditionally" to "No Condition" (Firefox Browser)

With the initial [website builder refactor], the instagram snippet's iframe reloaded when an option was changed on its container.

By implementing `shouldStop` to check if the url of the iframe changed, this commit prevents reloads on changes on other options.

Steps to reproduce:
- Open website builder
- Drop the "Instagram Page" snippet (in "Social" category)
- Change the "Visibility" to "Conditional"
- Bug: the snippet becomes blank during a short time

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
