### PR TITLE
[FIX] point_of_sale: prevent error when default preset needs a partner

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.js
@@ -23,7 +23,6 @@ export class OrderTabs extends Component {
     async newFloatingOrder() {
         const order = this.pos.addNewOrder();
         this.pos.showScreen("ProductScreen");
-        this.dialog.closeAll();
         return order;
     }
     selectFloatingOrder(order) {

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -865,11 +865,11 @@ export class PosOrder extends Base {
             newPartnerPricelist = this.config.pricelist_id;
         }
 
-        if (!this.config.use_presets || !this.preset_id.fiscal_position_id) {
+        if (!this.config.use_presets || !this.preset_id?.fiscal_position_id) {
             this.fiscal_position_id = newPartnerFiscalPosition;
         }
 
-        if (!this.config.use_presets || !this.preset_id.pricelist_id) {
+        if (!this.config.use_presets || !this.preset_id?.pricelist_id) {
             this.setPricelist(newPartnerPricelist);
         }
     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -11,7 +11,8 @@
                         class="btn btn-secondary btn-lg flex-shrink-0 border-0"
                         t-attf-class="{{`o_colorlist_item_color_${currentOrder.preset_id?.color}`}}"
                         t-on-click="() => this.pos.selectPreset()">
-                        <span t-esc="currentOrder.preset_id?.name" />
+                        <span t-if="currentOrder.preset_id?.name" t-esc="currentOrder.preset_id?.name" />
+                        <span t-else="">Preset</span>
                     </button>
                     <button class="button mobile-more-button btn btn-secondary btn-lg ms-auto" t-on-click="props.onClickMore">
                         <i class="oi oi-fw oi-ellipsis-v" aria-hidden="true" />

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -7,10 +7,11 @@
             <InternalNoteButton label.translate="Note" class="buttonClass"/>
         </t>
         <button t-if="pos.config.use_presets and !props.showRemainingButtons"
-            class="btn btn-light btn-lg flex-shrink-0 border-0"
-            t-attf-class="{{`o_colorlist_item_color_${currentOrder.preset_id?.color}`}}"
+            class="btn btn-secondary btn-lg flex-shrink-0 border-0"
+            t-attf-class="{{currentOrder.preset_id?.color and `o_colorlist_item_color_${currentOrder.preset_id?.color}`}}"
             t-on-click="() => this.pos.selectPreset()">
-            <span t-esc="currentOrder.preset_id?.name" />
+            <span t-if="currentOrder.preset_id?.name" t-esc="currentOrder.preset_id?.name" />
+            <span t-else="">Preset</span>
         </button>
         <button class="btn btn-secondary btn-lg flex-shrink-0 ms-auto more-btn" t-if="!props.showRemainingButtons and !ui.isSmall and props.onClickMore" t-on-click="props.onClickMore">
             <i class="oi oi-fw oi-ellipsis-v" aria-hidden="true" />

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -625,7 +625,7 @@ export class PosStore extends WithLazyGetterTrap {
         if (!this.config.module_pos_restaurant) {
             this.selectedOrderUuid = openOrders.length
                 ? openOrders[openOrders.length - 1].uuid
-                : this.addNewOrder().uuid;
+                : null;
         }
 
         this.markReady();
@@ -2159,6 +2159,9 @@ export class PosStore extends WithLazyGetterTrap {
                 if (!(partner.street || partner.street2)) {
                     this.notification.add(_t("Customer address is required"), { type: "warning" });
                     await this.editPartner(partner);
+                    if (!(partner.street || partner.street2)) {
+                        return;
+                    }
                 }
             }
             if (preset.identification === "name") {

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -972,3 +972,14 @@ registry.category("web_tour.tours").add("test_pos_ui_round_globally", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_preset_customer_selection", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PartnerList.clickPartner("Test Partner"),
+            ProductScreen.customerIsSelected("Test Partner"),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -51,7 +51,7 @@ describe("pos_store.js", () => {
 
             const noSync = await store.syncAllOrders();
             expect(noSync).toBe(undefined);
-            expect(store.models["pos.order"].length).toBe(2); // One order created during setupPosEnv
+            expect(store.models["pos.order"].length).toBe(1);
         });
 
         test("sync specific order", async () => {
@@ -203,7 +203,7 @@ describe("pos_store.js", () => {
         await getFilledOrder(store);
         store.addNewOrder();
         let openOrders = store.getOpenOrders();
-        expect(openOrders.length).toBe(3);
+        expect(openOrders.length).toBe(2);
         const deletedOrders = await store.deleteOrders(openOrders);
         expect(deletedOrders).toBe(true);
         openOrders = store.getOpenOrders();

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2748,6 +2748,26 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_cross_exclusion_attribute_values')
 
+    def test_preset_customer_selection(self):
+        self.preset_delivery = self.env['pos.preset'].create({
+            'name': 'Delivery',
+            'identification': 'address',
+        })
+        self.env['res.partner'].create({
+            'name': 'Test Partner',
+            'street': '123 Test Street',
+            'city': 'Test City',
+            'zip': '12345',
+            'country_id': self.env['res.country'].search([], limit=1).id,
+        })
+        self.main_pos_config.write({
+            'use_presets': True,
+            'default_preset_id': self.preset_delivery.id,
+            'available_preset_ids': [(6, 0, [self.preset_delivery.id])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_preset_customer_selection')
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):

--- a/addons/pos_hr/static/tests/unit/components/popups/product_info_popup.test.js
+++ b/addons/pos_hr/static/tests/unit/components/popups/product_info_popup.test.js
@@ -9,6 +9,7 @@ definePosModels();
 describe("product_info_popup.js", () => {
     test("allowProductEdition", async () => {
         const store = await setupPosEnv();
+        store.addNewOrder();
         const admin = store.models["hr.employee"].get(2);
         store.setCashier(admin);
         const product = store.models["product.template"].get(5);

--- a/addons/pos_hr/static/tests/unit/components/screens/payment_screen.test.js
+++ b/addons/pos_hr/static/tests/unit/components/screens/payment_screen.test.js
@@ -9,6 +9,7 @@ definePosModels();
 describe("payment_screen.js", () => {
     test("validateOrder", async () => {
         const store = await setupPosEnv();
+        store.addNewOrder();
         const orderUuid = store.getOrder().uuid;
         const comp = await mountWithCleanup(PaymentScreen, {
             props: { orderUuid },

--- a/addons/pos_hr/static/tests/unit/models/pos_order.test.js
+++ b/addons/pos_hr/static/tests/unit/models/pos_order.test.js
@@ -7,6 +7,7 @@ definePosModels();
 describe("pos_order.js", () => {
     test("getCashierName", async () => {
         const store = await setupPosEnv();
+        store.addNewOrder();
         const emp = store.models["hr.employee"].get(3);
         store.setCashier(emp);
         const posOrder = store.getOrder();

--- a/addons/pos_hr/static/tests/unit/services/pos_store.test.js
+++ b/addons/pos_hr/static/tests/unit/services/pos_store.test.js
@@ -7,6 +7,7 @@ definePosModels();
 describe("pos_store.js", () => {
     test("createNewOrder", async () => {
         const store = await setupPosEnv();
+        store.addNewOrder();
         const order = store.getOrder();
         expect(order.employee_id.id).toBe(2);
     });
@@ -38,6 +39,7 @@ describe("pos_store.js", () => {
     });
     test("addLineToCurrentOrder", async () => {
         const store = await setupPosEnv();
+        store.addNewOrder();
         const admin = store.models["hr.employee"].get(2);
         store.setCashier(admin);
         const product_id = store.models["product.product"].get(5);


### PR DESCRIPTION
Before this commit, if the POS default preset required a partner, an error would occur during initialization.

opw-5023987

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
