### PR TITLE
[FIX] html_editor: deletion issue when first child is non-editable

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
-import { fillShrunkPhrasingParent } from "@html_editor/utils/dom";
+import { fillShrunkPhrasingParent, fixNonEditableFirstChild } from "@html_editor/utils/dom";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { withSequence } from "@html_editor/utils/resource";
@@ -119,18 +119,12 @@ export class BannerPlugin extends Plugin {
             </div>`
         ).childNodes[0];
         this.dependencies.dom.insert(bannerElement);
+        const baseContainerNodeName = this.dependencies.baseContainer.getDefaultNodeName();
         const nextNode = this.dependencies.baseContainer.isCandidateForBaseContainer(blockEl)
             ? blockEl.nodeName
-            : this.dependencies.baseContainer.getDefaultNodeName();
+            : baseContainerNodeName;
         this.dependencies.dom.setTag({ tagName: nextNode });
-        // If the first child of editable is contenteditable false element
-        // a chromium bug prevents selecting the container.
-        // Add a baseContainer above it so it's no longer the first child.
-        if (this.editable.firstChild === bannerElement) {
-            const firstBaseContainer = this.dependencies.baseContainer.createBaseContainer();
-            firstBaseContainer.append(this.document.createElement("br"));
-            bannerElement.before(firstBaseContainer);
-        }
+        fixNonEditableFirstChild(this.editable, bannerElement, baseContainerNodeName);
         this.dependencies.selection.setCursorEnd(
             bannerElement.querySelector(`.o_editor_banner_content > ${baseContainer.tagName}`)
         );

--- a/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
@@ -5,10 +5,18 @@ import {
     HEADINGS,
     TableOfContentManager,
 } from "@html_editor/others/embedded_components/core/table_of_content/table_of_content_manager";
+import { fixNonEditableFirstChild } from "@html_editor/utils/dom";
 
 export class TableOfContentPlugin extends Plugin {
     static id = "tableOfContent";
-    static dependencies = ["dom", "selection", "embeddedComponents", "link", "history"];
+    static dependencies = [
+        "dom",
+        "selection",
+        "embeddedComponents",
+        "link",
+        "history",
+        "baseContainer",
+    ];
     resources = {
         user_commands: [
             {
@@ -49,6 +57,11 @@ export class TableOfContentPlugin extends Plugin {
     insertTableOfContent() {
         const tableOfContentBlueprint = renderToElement("html_editor.TableOfContentBlueprint");
         this.dependencies.dom.insert(tableOfContentBlueprint);
+        fixNonEditableFirstChild(
+            this.editable,
+            tableOfContentBlueprint,
+            this.dependencies.baseContainer.getDefaultNodeName()
+        );
         this.dependencies.history.addStep();
     }
 

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -291,3 +291,24 @@ export function splitTextNode(textNode, offset, originalNodeSide = DIRECTIONS.RI
     }
     return parentOffset;
 }
+
+/**
+ * Ensures that the first child of the editable container is editable.
+ *
+ * A Chromium bug prevents selecting the container if editable's first child
+ * is contenteditable= false element. To avoid this, a base container is
+ * inserted before the non-editable node so it no longer appears as
+ * the first child.
+ *
+ * @param {HTMLElement} editable
+ * @param {Node} node The non-editable first child of the editable container.
+ * @param {string} baseContainerNodeName
+ */
+export function fixNonEditableFirstChild(editable, node, baseContainerNodeName) {
+    if (editable.firstChild === node) {
+        const ownerDocument = node.ownerDocument;
+        const firstBaseContainer = createBaseContainer(baseContainerNodeName, ownerDocument);
+        firstBaseContainer.append(ownerDocument.createElement("br"));
+        node.before(firstBaseContainer);
+    }
+}

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -2294,3 +2294,30 @@ describe("codeview enabled", () => {
         expect(queryAllTexts(".o-we-command-name")).toEqual(["Video Link"]);
     });
 });
+
+test("should never insert Table of Contents as the first child of the editable", async () => {
+    Partner._records = [
+        {
+            id: 1,
+            txt: `<h1>first</h1>`,
+        },
+    ];
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+    setSelectionInHtmlField("h1");
+    await insertText(htmlEditor, "/tableofcontents");
+    await waitFor(".o-we-powerbox");
+    expect(queryAllTexts(".o-we-command-name")[0]).toBe("Table of Contents");
+    await press("Enter");
+    await animationFrame();
+    const firstChild = htmlEditor.editable.firstChild;
+    expect(firstChild.getAttribute("data-embedded")).not.toBe("tableOfContent");
+    expect(firstChild).toHaveOuterHTML('<div class="o-paragraph"><br></div>');
+});


### PR DESCRIPTION
**Current behavior before PR:**

If the first child of an editable element was `contenteditable="false"`, selecting all content and pressing backspace would not remove everything. This was due to a Chromium bug where non-editable elements as the first child are not fully selected.

**Desired behavior after PR is merged:**

When inserting elements such as a banner or table of contents, a paragraph is added before them. This ensures that the editable element never starts with a non-editable child.

task: 5010666
