### PR TITLE
[FIX] l10n_in: avoid tax return creation for invalid configuration

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -1136,3 +1136,11 @@ class ResCompany(models.Model):
         for company in self:
             self.env['ir.default'].set('product.category', 'property_account_expense_categ_id', company.expense_account_id.id, company_id=company.id)
             self.env['ir.default'].set('product.category', 'property_account_income_categ_id', company.income_account_id.id, company_id=company.id)
+
+    def _check_tax_return_configuration(self):
+        """
+        To override in localizations to check if the company is properly configured for tax returns.
+        or related modules are installed.
+        :raises RedirectWarning: if something is wrong configured.
+        """
+        return

--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -15,3 +15,4 @@ from . import uom_uom
 from . import account_account
 from . import l10n_in_section_alert
 from . import l10n_in_pan_entity
+from . import l10n_in_report_handler

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -2,7 +2,7 @@ import pytz
 from stdnum.in_ import pan, gstin
 
 from odoo import _, api, fields, models 
-from odoo.exceptions import ValidationError
+from odoo.exceptions import RedirectWarning
 
 
 class ResCompany(models.Model):
@@ -166,3 +166,18 @@ class ResCompany(models.Model):
     def action_update_state_as_per_gstin(self):
         self.ensure_one()
         self.partner_id.action_update_state_as_per_gstin()
+
+    def _check_tax_return_configuration(self):
+        """
+        Check if the company is properly configured for tax returns.
+        :raises RedirectWarning: if something is wrong configured.
+        """
+
+        if self.country_code != 'IN':
+            return super()._check_tax_return_configuration()
+
+        is_l10n_in_reports_installed = 'l10n_in_reports' in self.env['ir.module.module']._installed()
+        if not is_l10n_in_reports_installed:
+            msg = _("First enable GST e-Filing feature from configuration for company %s.", (self.name))
+            action = self.env.ref("account.action_account_config")
+            raise RedirectWarning(msg, action.id, _('Go to configuration'))

--- a/addons/l10n_in/models/l10n_in_report_handler.py
+++ b/addons/l10n_in/models/l10n_in_report_handler.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class AccountReport(models.Model):
+    _inherit = 'account.report'
+
+    def _init_options_buttons(self, options, previous_options):
+        super()._init_options_buttons(options, previous_options)
+        company = self.env.company
+        generic_report_id = self.env.ref('account.generic_tax_report').id
+
+        # Remove 'Returns' button from generic report for indian company
+        if company.country_id.code == 'IN' and self.id == generic_report_id and not self.root_report_id:
+            options['buttons'] = [
+                button for button in options['buttons']
+                if button.get('action') != 'action_open_returns'
+            ]


### PR DESCRIPTION
For Indian companies, the GST tax returns (GSTR-1, GSTR-2B ) are provided
by the `l10n_in_reports` module.
This commit fixes issues when adapting the tax returns to the GST return period:

1. Block invalid configuration
   If the l10n_in_reports module is not installed, Indian tax returns should not
   be created. In such cases, users are redirected to enable the e-Filing
   feature from the company configuration.

2. Remove misleading button
   The Returns button on the generic tax report is hidden for Indian companies,
   since GST returns are managed via dedicated reports.

This ensures that tax returns for Indian companies are only available when the
proper localization reports are installed and configured, avoiding confusion in
the generic reports.

Enterprise PR - https://github.com/odoo/enterprise/pull/92173
Upgrade PR - https://github.com/odoo/upgrade/pull/8281

task-4750259
