### PR TITLE
[FIX] website: avoid tracking of o_conditional_hidden in the history

### DIFF
--- a/addons/website/static/src/builder/plugins/website_visibility_plugin.js
+++ b/addons/website/static/src/builder/plugins/website_visibility_plugin.js
@@ -10,6 +10,7 @@ export class WebsiteVisibilityPlugin extends Plugin {
     static id = "websiteVisibilityPlugin";
 
     resources = {
+        system_classes: ["o_conditional_hidden"],
         target_show: this.onTargetShow.bind(this),
         target_hide: this.onTargetHide.bind(this),
     };


### PR DESCRIPTION
With the initial [website builder refactor], the class `o_conditional_invisible` was tracked in the history. This class is added/moved when the user toggles the visibility in the "Invisible Elements" panel of a conditionnaly visible element. Just toggling the visibility does not add a step, so that mutation was added on the next added step (and undone with it).

This commit lists `o_conditional_invisible` in the `system_class` so it is not tracked by the history (like `o_snippet_override_invisible`)

Steps to reproduce:
- Open website builder
- Drop a section
- On the section, set "Visibility" to "Conditionally"
- In the "Invisible Elements", hide the section
- Somewhere else, do a change
- Undo the change
- Bug: the section is shown again (and redo hide it again)

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
