### PR TITLE
[IMP] mail: user notification in messaging menu opens inbox

### DIFF
--- a/addons/hr_gamification/static/src/messaging_menu_patch.js
+++ b/addons/hr_gamification/static/src/messaging_menu_patch.js
@@ -10,11 +10,11 @@ patch(MessagingMenu.prototype, {
         this.orm = useService("orm");
     },
 
-    onClickThread(isMarkAsRead, thread) {
+    onClickThread(isMarkAsRead, thread, message) {
         if (!isMarkAsRead && thread.model === "gamification.badge.user") {
             this.openEmployeeView(thread);
         } else {
-            super.onClickThread(isMarkAsRead, thread);
+            super.onClickThread(...arguments);
         }
     },
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -258,11 +258,7 @@ export class Thread extends Record {
     /** @type {"not_fetched"|"pending"|"fetched"} */
     fetchMembersState = "not_fetched";
     /** @type {integer|null} */
-    highlightMessage = fields.One("mail.message", {
-        onAdd(msg) {
-            msg.thread = this;
-        },
-    });
+    highlightMessage = fields.One("mail.message");
     /** @type {String|undefined} */
     access_token;
     /** @type {String|undefined} */

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -37,7 +37,12 @@ export class MessagingMenu extends Component {
         useExternalListener(window, "keydown", this.onKeydown, true);
     }
 
-    onClickThread(isMarkAsRead, thread) {
+    onClickThread(isMarkAsRead, thread, message) {
+        if (message?.needaction && message.message_type === "user_notification") {
+            this.store.inbox.highlightMessage = message;
+            this.store.inbox.open();
+            return;
+        }
         if (!isMarkAsRead) {
             thread.open({ focus: true, fromMessagingMenu: true, bypassCompact: true });
             this.dropdown.close();

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -20,7 +20,7 @@
                     important="thread.needactionCounter"
                     hasMarkAsReadButton="thread.isUnread"
                     muted="thread.selfMember?.mute_until_dt ? 2 : !thread.isUnread ? 1 : 0"
-                    onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread)"
+                    onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread, message)"
                     onSwipeRight="hasTouch() and thread.isUnread ? { action: () => this.markAsRead(thread), icon: 'fa-check-circle', bgColor: 'bg-success' } : undefined"
                     onSwipeLeft="hasTouch() and canUnpinItem(thread) ? { action: () => thread.unpin(), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
                     nameMaxLine="1"

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -60,12 +60,24 @@ const threadPatch = {
         if (res) {
             return res;
         }
-        this.store.env.services.action.doAction({
-            type: "ir.actions.act_window",
-            res_id: this.id,
-            res_model: this.model,
-            views: [[false, "form"]],
-        });
+        if (this.model === "mail.box") {
+            if (this.store.discuss.isActive) {
+                this.setAsDiscussThread();
+            } else {
+                this.store.env.services.action.doAction({
+                    context: { active_id: `mail.box_${this.id}` },
+                    tag: "mail.action_discuss",
+                    type: "ir.actions.client",
+                });
+            }
+        } else {
+            this.store.env.services.action.doAction({
+                type: "ir.actions.act_window",
+                res_id: this.id,
+                res_model: this.model,
+                views: [[false, "form"]],
+            });
+        }
         return true;
     },
     async unpin() {

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -339,9 +339,6 @@ export function useMessageScrolling(duration = 2000) {
          * @param {import("models").Thread} thread
          */
         async highlightMessage(message, thread) {
-            if (thread.notEq(message.thread)) {
-                return;
-            }
             state.initiated = true;
             let messageScrollDirection;
             if (message.notIn(thread.messages)) {

--- a/addons/rating/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/rating/static/src/core/web/messaging_menu_patch.xml
@@ -3,7 +3,6 @@
     <t t-inherit="mail.MessagingMenu.content" t-inherit-mode="extension">
         <xpath expr="//t[@name='threads']/NotificationItem" position="attributes">
             <attribute name="rating">message?.rating_id</attribute>
-            <attribute name="onClick">(isMarkAsRead) => message?.rating_id and !isMarkAsRead ? this.openThread(thread) : this.onClickThread(isMarkAsRead, thread)</attribute>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Before this commit, clicking a user notification in the messaging menu opened the form view of the related record.
However, the clicked notification was not visible there, since it actually resides in the inbox.

This caused two issues:
- The user could not see the message they had just clicked.
- The thread was not marked as read, adding to the confusion.

With this commit, clicking a user notification now opens the inbox directly at the corresponding message, ensuring the notification is visible.

As a side effect of this commit, it's now possible to jump to messages searched for in `mail.box` channels.

task-4578458
