### PR TITLE
[FIX] html_editor: merge adjacent formatting inline tags

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -8,6 +8,7 @@ import { cleanTextNode, fillEmpty, splitTextNode, unwrapContents } from "../util
 import {
     areSimilarElements,
     isContentEditable,
+    isElement,
     isEmptyBlock,
     isEmptyTextNode,
     isSelfClosingElement,
@@ -25,7 +26,7 @@ import {
     findFurthest,
     selectElements,
 } from "../utils/dom_traversal";
-import { formatsSpecs } from "../utils/formatting";
+import { formatsSpecs, FORMATTABLE_TAGS } from "../utils/formatting";
 import { boundariesIn, boundariesOut, DIRECTIONS, leftPos, rightPos } from "../utils/position";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
@@ -588,7 +589,7 @@ export class FormatPlugin extends Plugin {
      */
     mergeAdjacentInlines(root, { preserveSelection = true } = {}) {
         let selectionToRestore = null;
-        for (const node of [root, ...descendants(root)]) {
+        for (const node of [root, ...descendants(root)].filter(isElement)) {
             if (this.shouldBeMergedWithPreviousSibling(node)) {
                 if (preserveSelection) {
                     selectionToRestore ??= this.dependencies.selection.preserveSelection();
@@ -603,6 +604,7 @@ export class FormatPlugin extends Plugin {
 
     shouldBeMergedWithPreviousSibling(node) {
         const isMergeable = (node) =>
+            FORMATTABLE_TAGS.includes(node.nodeName) &&
             !this.getResource("unsplittable_node_predicates").some((predicate) => predicate(node));
         return (
             !isSelfClosingElement(node) &&

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -25,6 +25,8 @@ export const FONT_SIZE_CLASSES = [
 
 export const TEXT_STYLE_CLASSES = ["display-1", "display-2", "display-3", "display-4", "lead"];
 
+export const FORMATTABLE_TAGS = ["SPAN", "FONT", "B", "STRONG", "I", "EM", "U", "S"];
+
 export const formatsSpecs = {
     italic: {
         tagName: "em",

--- a/addons/html_editor/static/tests/initialization.test.js
+++ b/addons/html_editor/static/tests/initialization.test.js
@@ -2,6 +2,7 @@ import { describe, test } from "@odoo/hoot";
 import { testEditor } from "./_helpers/editor";
 import { unformat } from "./_helpers/format";
 import { BOLD_TAGS } from "./_helpers/tags";
+import { FORMATTABLE_TAGS } from "@html_editor/utils/formatting";
 
 /**
  * content of the "init" sub suite in editor.test.js
@@ -326,5 +327,14 @@ describe("formatting normalization", () => {
                 </p>
             `),
         });
+    });
+
+    test("merges adjacent formattable tags", async () => {
+        for (const tagName of FORMATTABLE_TAGS.map((tag) => tag.toLowerCase())) {
+            await testEditor({
+                contentBefore: `<p><${tagName}>A</${tagName}><${tagName}>B</${tagName}></p>`,
+                contentAfter: `<p><${tagName}>AB</${tagName}></p>`,
+            });
+        }
     });
 });

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2918,6 +2918,17 @@ describe("link", () => {
                 contentAfter: "<pre>http://www.xyz.com[]</pre>",
             });
         });
+        test("should not merge consecutive pastes of the same URL into a single anchor", async () => {
+            await testEditor({
+                contentBefore: "<p>[]</p>",
+                stepFunction: async (editor) => {
+                    pasteText(editor, "http://www.xyz.com");
+                    pasteText(editor, "http://www.xyz.com");
+                },
+                contentAfter:
+                    '<p><a href="http://www.xyz.com">http://www.xyz.com</a><a href="http://www.xyz.com">http://www.xyz.com</a>[]</p>',
+            });
+        });
     });
 
     describe("range not collapsed", () => {


### PR DESCRIPTION
Steps to reproduce:

- Copy a valid hyperlink (e.g., https://example.com).
- Paste it into the editor.
- Without changing the selection or moving the cursor, paste the link again.
- Inspect the DOM: both links are merged into single tag, causing a traceback.

Description of the issue/feature this PR addresses:

- When pasting the same hyperlink multiple times without moving the cursor, editor merged them into a single anchor tag, which triggered a traceback. This appeared after commit [1](https://github.com/odoo/odoo/commit/2752ca733b4feda4ef16eef02fdaba1561ceb6b7), it introduced root-level check for mergeability.

Desired behavior after PR is merged:

- Only formattable inline tags (SPAN, FONT, B, STRONG, I, EM, U, S) are eligible for merging.

task-4965381

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
