### PR TITLE
[FIX] mail, *: always assert uploading state when adding files

### DIFF
--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -73,9 +73,9 @@ test("internal users can upload file to temporary thread", async () => {
     await contains(".o-mail-Composer");
     await contains("button[title='Attach files']");
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [file]);
-    await contains(".o-mail-AttachmentCard", { text: "text.txt", contains: [".fa-check"] });
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading):contains(text.txt) .fa-check");
     await triggerHotkey("Enter");
-    await contains(".o-mail-Message .o-mail-AttachmentCard", { text: "text.txt" });
+    await contains(".o-mail-Message .o-mail-AttachmentCard:contains(text.txt)");
 });
 
 test("Conversation name is operator livechat user name", async () => {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -772,13 +772,14 @@ test("chat window: composer state conservation on toggle discuss", async () => {
     });
     // Set attachments of the composer
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [textFile1, textFile2]);
-    await contains(".o-mail-AttachmentCard .fa-check", { count: 2 });
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading) .fa-check", { count: 2 });
     await openDiscuss();
     await contains(".o-mail-ChatWindow", { count: 0 });
     await openFormView("discuss.channel", channelId);
-    await contains(".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard", {
-        count: 2,
-    });
+    await contains(
+        ".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard:not(.o-isUploading)",
+        { count: 2 }
+    );
     await contains(".o-mail-Composer-input", { value: "XDU for the win !" });
 });
 

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -192,11 +192,11 @@ test("chatter: drop attachments", async () => {
     await contains(".o-Dropzone");
     await contains(".o-mail-AttachmentCard", { count: 0 });
     await dropFiles(".o-Dropzone", files);
-    await contains(".o-mail-AttachmentCard", { count: 2 });
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading)", { count: 2 });
     const extraFiles = [text3];
     await dragenterFiles(".o-mail-Chatter", extraFiles);
     await dropFiles(".o-Dropzone", extraFiles);
-    await contains(".o-mail-AttachmentCard", { count: 3 });
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading)", { count: 3 });
 });
 
 test("chatter: drop attachment should refresh thread data with hasParentReloadOnAttachmentsChange prop", async () => {

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -277,7 +277,7 @@ test("composer text input cleared on message post", async () => {
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "test message");
     await contains(".o-mail-Composer-input", { value: "test message" });
-    await click(".o-mail-Composer-send:not([disabled])");
+    await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message");
     await contains(".o-mail-Composer-input", { value: "" });
 });
@@ -607,11 +607,11 @@ test("composer: drop attachments", async () => {
     await contains(".o-mail-AttachmentCard", { count: 0 });
     await dropFiles(".o-Dropzone", files);
     await contains(".o-Dropzone", { count: 0 });
-    await contains(".o-mail-AttachmentCard", { count: 2 });
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading)", { count: 2 });
     const extraFiles = [text3];
     await dragenterFiles(".o-mail-Composer-input", extraFiles);
     await dropFiles(".o-Dropzone", extraFiles);
-    await contains(".o-mail-AttachmentCard", { count: 3 });
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading)", { count: 3 });
 });
 
 test("composer: add an attachment", async () => {
@@ -621,9 +621,11 @@ test("composer: add an attachment", async () => {
     await start();
     await openDiscuss(channelId);
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
-    await contains(".o-mail-AttachmentCard .fa-check");
+    await contains('.o-mail-AttachmentCard:not(.o-isUploading):contains("text.txt") .fa-check');
     await contains(".o-mail-Composer-footer .o-mail-AttachmentList");
-    await contains(".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard");
+    await contains(
+        ".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard:not(.o-isUploading):contains(text.txt)"
+    );
 });
 
 test("composer: add an attachment in reply to message in history", async () => {
@@ -645,9 +647,11 @@ test("composer: add an attachment in reply to message in history", async () => {
     await openDiscuss("mail.box_history");
     await click("[title='Reply']");
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
-    await contains(".o-mail-AttachmentCard .fa-check");
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading):contains(text.txt) .fa-check");
     await contains(".o-mail-Composer-footer .o-mail-AttachmentList");
-    await contains(".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard");
+    await contains(
+        ".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard:not(.o-isUploading):contains(text.txt)"
+    );
 });
 
 test("composer: send button is disabled if attachment upload is not finished", async () => {
@@ -659,11 +663,11 @@ test("composer: send button is disabled if attachment upload is not finished", a
     await start();
     await openDiscuss(channelId);
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
-    await contains(".o-mail-AttachmentCard.o-isUploading");
+    await contains(".o-mail-AttachmentCard.o-isUploading:contains(text.txt)");
     await contains(".o-mail-Composer-send:disabled");
     // simulates attachment finishes uploading
     attachmentUploadedDef.resolve();
-    await contains(".o-mail-AttachmentCard");
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading):contains(text.txt)");
     await contains(".o-mail-AttachmentCard.o-isUploading", { count: 0 });
     await contains(".o-mail-Composer-send:enabled");
 });
@@ -675,9 +679,8 @@ test("remove an attachment from composer does not need any confirmation", async 
     await start();
     await openDiscuss(channelId);
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
-    await contains(".o-mail-AttachmentCard .fa-check");
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading):contains(text.txt) .fa-check");
     await contains(".o-mail-Composer-footer .o-mail-AttachmentList");
-    await contains(".o-mail-AttachmentList .o-mail-AttachmentCard");
     await click(".o-mail-AttachmentCard-unlink");
     await contains(".o-mail-AttachmentList .o-mail-AttachmentCard", { count: 0 });
 });
@@ -691,7 +694,9 @@ test("composer: paste attachments", async () => {
     await contains(".o-mail-Composer-input");
     await contains(".o-mail-AttachmentList .o-mail-AttachmentCard", { count: 0 });
     await pasteFiles(".o-mail-Composer-input", [text]);
-    await contains(".o-mail-AttachmentList .o-mail-AttachmentCard");
+    await contains(
+        ".o-mail-AttachmentList .o-mail-AttachmentCard:not(.o-isUploading):contains(text.txt)"
+    );
 });
 
 test.tags("focus required");
@@ -721,8 +726,9 @@ test("remove an uploading attachment", async () => {
     await start();
     await openDiscuss(channelId);
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text]);
-    await contains(".o-mail-AttachmentCard.o-isUploading");
-    await click(".o-mail-AttachmentCard-unlink");
+    await click(
+        ".o-mail-AttachmentCard.o-isUploading:contains(text.txt) .o-mail-AttachmentCard-unlink"
+    );
     await contains(".o-mail-Composer .o-mail-AttachmentCard", { count: 0 });
 });
 
@@ -798,8 +804,8 @@ test("Uploading multiple files in the composer create multiple temporary attachm
     await start();
     await openDiscuss(channelId);
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text1, text2]);
-    await contains(".o-mail-AttachmentCard", { text: "text1.txt" });
-    await contains(".o-mail-AttachmentCard", { text: "text2.txt" });
+    await contains(".o-mail-AttachmentCard.o-isUploading:contains(text1.txt)");
+    await contains(".o-mail-AttachmentCard.o-isUploading:contains(text2.txt)");
     await contains(".o-mail-AttachmentCard-aside div[title='Uploading']", { count: 2 });
 });
 
@@ -817,14 +823,14 @@ test("[technical] does not crash when an attachment is removed before its upload
     await start();
     await openDiscuss(channelId);
     await inputFiles(".o-mail-Composer-coreMain .o_input_file", [text1, text2]);
-    await contains(".o-mail-AttachmentCard.o-isUploading", { text: "text1.txt" });
-    await click(".o-mail-AttachmentCard-unlink", {
-        parent: [".o-mail-AttachmentCard.o-isUploading", { text: "text2.txt" }],
-    });
+    await contains(".o-mail-AttachmentCard.o-isUploading:contains(text1.txt)");
+    await click(
+        ".o-mail-AttachmentCard.o-isUploading:contains(text2.txt) .o-mail-AttachmentCard-unlink"
+    );
     await contains(".o-mail-AttachmentCard", { count: 0, text: "text2.txt" });
     // Simulates the completion of the upload of the first attachment
     uploadDef.resolve();
-    await contains(".o-mail-AttachmentCard:not(.o-isUploading)", { text: "text1.txt" });
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading):contains(text1.txt)");
 });
 
 test("Message is sent only once when pressing enter twice in a row", async () => {

--- a/addons/mail/static/tests/composer/suggested_recipients.test.js
+++ b/addons/mail/static/tests/composer/suggested_recipients.test.js
@@ -237,7 +237,7 @@ test("suggest recipient on 'Send message' composer (all checked by default)", as
     let partners = pyEnv["res.partner"].search_read([["email", "=", "john@test.be"]]);
     expect(partners).toHaveLength(0);
     await insertText(".o-mail-Composer-input", "Dummy Message");
-    await click(".o-mail-Composer-send");
+    await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Followers-counter", { text: "2" });
     partners = pyEnv["res.partner"].search_read([["email", "=", "john@test.be"]]);
     expect(partners).toHaveLength(1);
@@ -262,7 +262,7 @@ test("suggest recipient on 'Send message' composer (recipient checked/unchecked)
     const partners = pyEnv["res.partner"].search_read([["email", "=", "john@test.be"]]);
     expect(partners).toHaveLength(1);
     await insertText(".o-mail-Composer-input", "Dummy Message");
-    await click(".o-mail-Composer-send");
+    await click(".o-mail-Composer-send:enabled");
     await tick();
     await contains(".o-mail-Followers-counter", { text: "1" });
 });

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -147,7 +147,9 @@ test("Adding attachments", async () => {
         attachment_ids: [attachmentId],
         message_id: messageId,
     });
-    await contains(".o-mail-AttachmentCard", { target: env2, text: "test.txt" });
+    await contains(".o-mail-AttachmentCard:not(.o-isUploading):contains(test.txt)", {
+        target: env2,
+    });
 });
 
 test("Remove attachment from message", async () => {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1776,8 +1776,7 @@ test("warning on send with shortcut when attempting to post message with still-u
     const file = new File(["hello, world"], "text.txt", { type: "text/plain" });
     await insertText(".o-mail-Composer-input", "Dummy Message");
     await editInput(document.body, ".o-mail-Composer input[type=file]", [file]);
-    await contains(".o-mail-AttachmentCard");
-    await contains(".o-mail-AttachmentCard .fa.fa-spinner");
+    await contains(".o-mail-AttachmentCard.o-isUploading:contains(text.txt) .fa.fa-spinner");
     await contains(".o-mail-Composer-send:disabled");
     // Try to send message
     triggerHotkey("Enter");
@@ -1823,13 +1822,11 @@ test("failure on loading more messages should display error and prompt retry but
         name: "General",
     });
     const messageIds = pyEnv["mail.message"].create(
-        [...Array(60).keys()].map(() => {
-            return {
-                body: "coucou",
-                model: "discuss.channel",
-                res_id: channelId,
-            };
-        })
+        [...Array(60).keys()].map(() => ({
+            body: "coucou",
+            model: "discuss.channel",
+            res_id: channelId,
+        }))
     );
     const [selfMember] = pyEnv["discuss.channel.member"].search_read([
         ["partner_id", "=", serverState.partnerId],
@@ -1864,13 +1861,11 @@ test("Retry loading more messages on failed load more messages should load more 
         name: "General",
     });
     const messageIds = pyEnv["mail.message"].create(
-        [...Array(90).keys()].map(() => {
-            return {
-                body: "coucou",
-                model: "discuss.channel",
-                res_id: channelId,
-            };
-        })
+        [...Array(90).keys()].map(() => ({
+            body: "coucou",
+            model: "discuss.channel",
+            res_id: channelId,
+        }))
     );
     const [selfMember] = pyEnv["discuss.channel.member"].search_read([
         ["partner_id", "=", serverState.partnerId],
@@ -1911,7 +1906,10 @@ test("composer state: attachments save and restore", async () => {
         ".o-mail-Composer:has(textarea[placeholder='Message #General…']) input[type=file]",
         [file]
     );
-    await contains(".o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)");
+    await contains(
+        ".o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading):contains(text.txt)"
+    );
+    await contains(".o-mail-Composer .o-mail-AttachmentCard");
     // Switch to #special
     await click("button", { text: "Special" });
     // Attach files in a message for #special
@@ -1929,10 +1927,11 @@ test("composer state: attachments save and restore", async () => {
         files
     );
     await contains(".o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)", { count: 3 });
+    await contains(".o-mail-Composer .o-mail-AttachmentCard", { count: 3 });
     // Switch back to #general
     await click("button", { text: "General" });
     await contains(".o-mail-Composer .o-mail-AttachmentCard");
-    await contains(".o-mail-AttachmentCard", { text: "text.txt" });
+    await contains(".o-mail-Composer .o-mail-AttachmentCard:contains(text.txt)");
     // Switch back to #special
     await click("button", { text: "Special" });
     await contains(".o-mail-Composer .o-mail-AttachmentCard", { count: 3 });

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -63,6 +63,6 @@ test("enter key should create a newline in composer", async () => {
     await insertText(".o-mail-Composer-input", "Test\n");
     await press("Enter");
     await insertText(".o-mail-Composer-input", "Other");
-    await click(".o-mail-Composer-send");
+    await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message-body:has(br)", { textContent: "TestOther" });
 });

--- a/addons/mail/static/tests/thread/file_upload.test.js
+++ b/addons/mail/static/tests/thread/file_upload.test.js
@@ -37,6 +37,12 @@ test("no conflicts between file uploads", async () => {
     await inputFiles(".o-mail-ChatWindow .o-mail-Composer input[type=file]", [text2]);
     await contains(".o-mail-Chatter .o-mail-AttachmentCard");
     await contains(".o-mail-ChatWindow .o-mail-AttachmentCard");
+    await contains(
+        ".o-mail-Chatter .o-mail-AttachmentCard:not(.o-isUploading):contains(text1.txt)"
+    );
+    await contains(
+        ".o-mail-ChatWindow .o-mail-AttachmentCard:not(.o-isUploading):contains(text2.txt)"
+    );
 });
 
 test("Attachment shows spinner during upload", async () => {
@@ -47,5 +53,5 @@ test("Attachment shows spinner during upload", async () => {
     await start();
     await openDiscuss(channelId);
     await inputFiles(".o-mail-Composer input[type=file]", [text2]);
-    await contains(".o-mail-AttachmentCard .fa-spinner");
+    await contains(".o-mail-AttachmentCard.o-isUploading:contains(text2.txt) .fa-spinner");
 });

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -43,11 +43,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             },
         },
         {
-            trigger: ".o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
-        },
-        {
-            content: "Check the text attachment is listed",
-            trigger: '.o-mail-AttachmentCard[title="text.txt"]',
+            trigger: ".o-mail-AttachmentCard:not(.o-isUploading):contains(text.txt)",
         },
         {
             content: "Add an image file in composer",
@@ -69,11 +65,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             },
         },
         {
-            trigger: ".o-mail-AttachmentImage:not(.o-isUploading)",
-        },
-        {
-            content: "Check the image attachment is listed",
-            trigger: '.o-mail-AttachmentImage[title="image.png"]',
+            trigger: '.o-mail-AttachmentImage:not(.o-isUploading)[title="image.png"]',
             async run() {
                 const store = odoo.__WOWL_DEBUG__.root.env.services["mail.store"];
                 if (store.self.type === "guest") {
@@ -162,11 +154,8 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
             },
         },
         {
-            trigger: ".o-mail-Message .o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
-        },
-        {
-            content: "Check the earlier provided extra attachment is listed",
-            trigger: '.o-mail-Message .o-mail-Composer .o-mail-AttachmentCard[title="extra.txt"]',
+            trigger:
+                ".o-mail-Message .o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading):contains(extra.txt)",
         },
         {
             content: "Save edited message",

--- a/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
@@ -109,8 +109,11 @@ registry.category("web_tour.tours").add("create_thread_for_attachment_without_bo
             },
         },
         {
+            trigger: '.o-mail-AttachmentCard:not(.o-isUploading):contains("file2.txt")',
+        },
+        {
             content: "Click on send button",
-            trigger: ".o-mail-Composer-send",
+            trigger: ".o-mail-Composer-send:enabled",
             run: "click",
         },
         {

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -40,7 +40,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             },
         },
         {
-            trigger: ".o-mail-AttachmentCard:not(.o-isUploading)", // waiting the attachment to be uploaded
+            trigger: '.o-mail-AttachmentCard:not(.o-isUploading):contains("file1.txt")',
         },
         {
             content: "Open full composer",
@@ -105,7 +105,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
                 const files = [new File(["hi there"], "file2.txt", { type: "text/plain" })];
                 await dragenterFiles(".o_mail_composer_form_view .o_form_renderer", files);
                 await dropFiles(".o-Dropzone", files);
-            }
+            },
         },
         {
             content: "Check the attachment is listed",
@@ -125,10 +125,13 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             content: "Verify admin template is NOT listed",
             trigger: ".mail-composer-template-dropdown.popover",
             run() {
-                const hasAdminTemplate = [...document.querySelectorAll('.o-dropdown-item')]
-                    .some(item => item.textContent.includes("Test template for admin"));
+                const hasAdminTemplate = [...document.querySelectorAll(".o-dropdown-item")].some(
+                    (item) => item.textContent.includes("Test template for admin")
+                );
                 if (hasAdminTemplate) {
-                    console.error("Template assigned to the admin is visible to a non-assigned user! This should not happen.");
+                    console.error(
+                        "Template assigned to the admin is visible to a non-assigned user! This should not happen."
+                    );
                 }
             },
         },
@@ -184,7 +187,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
                 if ((bodyContent.match(/--\nErnest/g) || []).length !== 1) {
                     console.log("Full composer should contain the user's signature once.");
                 }
-            }
+            },
         },
         {
             content: "Write something in full composer",
@@ -231,7 +234,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
                 if ((bodyContent.match(/--\nErnest/g) || []).length !== 0) {
                     console.error("The composer should not contain the user's signature.");
                 }
-            }
+            },
         },
         {
             content: "Close full composer",
@@ -245,8 +248,8 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Send message from chatter",
-            trigger: ".o-mail-Composer-send",
-            run: "click"
+            trigger: ".o-mail-Composer-send:enabled",
+            run: "click",
         },
         {
             content: "Check message is shown",
@@ -266,8 +269,8 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Send message from chatter",
-            trigger: ".o-mail-Composer-send",
-            run: "click"
+            trigger: ".o-mail-Composer-send:enabled",
+            run: "click",
         },
         {
             content: "Check message is shown",

--- a/addons/website_slides/static/tests/tours/slides_course_review_modification.js
+++ b/addons/website_slides/static/tests/tours/slides_course_review_modification.js
@@ -129,11 +129,7 @@ registry.category("web_tour.tours").add("course_review_modification", {
         },
         {
             trigger:
-                "#chatterRoot:shadow .o-mail-Message .o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)",
-        },
-        {
-            trigger:
-                "#chatterRoot:shadow .o-mail-Message .o-mail-Composer .o-mail-AttachmentCard[title='test.txt']",
+                "#chatterRoot:shadow .o-mail-Message .o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading):contains(test.txt)",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message a:contains(save)",


### PR DESCRIPTION
\* = im_livechat, website_slides

Not waiting for the uploading state to be resolved can lead to unexpected behavior, such as deleting the attachment immediately when clicking on the delete button rather than showing the confirm dialog.

This might also prevent the composer from being sent if the attachment is still uploading. This is checked when checking the enabled state of the send button when clicking on it, but it is not checked when pressing enter directly.

Some tests also checked uploading was finished but didn't target the correct attachment.

https://runbot.odoo.com/odoo/error/230901

https://github.com/odoo/enterprise/pull/92620