### PR TITLE
[FIX] html_builder: make options with BuilderMany2One previewable

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -19,11 +19,12 @@ export function useColorPickerBuilderComponent() {
     const getAction = comp.env.editor.shared.builderActions.getAction;
     const state = useDomState(getState);
     const applyOperation = comp.env.editor.shared.history.makePreviewableAsyncOperation(
-        (applySpecs) => {
+        (applySpecs, isPreviewing) => {
             const proms = [];
             for (const applySpec of applySpecs) {
                 proms.push(
                     applySpec.action.apply({
+                        isPreviewing,
                         editingElement: applySpec.editingElement,
                         params: applySpec.actionParam,
                         value: applySpec.actionValue,

--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
@@ -10,11 +10,23 @@
             domain="props.domain"
             selected="domState.selected ? [domState.selected] : []"
             select="select.bind(this)"
+            preview="hasPreview ? preview.bind(this) : undefined"
+            revert.bind="revert"
             create="props.createAction ? create.bind(this) : undefined"
 
             message="domState.selected?.display_name || props.defaultMessage"
         />
-        <button t-if="domState.selected and props.allowUnselect" type="button" class="btn btn-primary fa fa-fw fa-times" style="min-width: min-content;" t-on-click="() => this.select()"/>
+        <button
+            t-if="domState.selected and props.allowUnselect"
+            type="button"
+            class="btn btn-primary fa fa-fw fa-times"
+            style="min-width: min-content;"
+            t-on-click="() => this.select()"
+            t-on-pointerenter="hasPreview ? () => this.preview() : undefined"
+            t-on-pointerleave="revert"
+            t-on-focusin="hasPreview ? () => this.preview() : undefined"
+            t-on-focusout="revert"
+        />
     </BuilderComponent>
 </t>
 

--- a/addons/html_builder/static/src/core/building_blocks/select_many2x.xml
+++ b/addons/html_builder/static/src/core/building_blocks/select_many2x.xml
@@ -7,6 +7,10 @@
     <SelectMenu
         choices="this.filteredSearchResult().map(e => ({ value: e, label: e.display_name  }))"
         onSelect="props.select"
+        onNavigated.bind="onNavigated"
+        menuRef="menuRef"
+        onOpened.bind="onOpened"
+        onClosed.bind="onClosed"
         searchPlaceholder.translate="Search for records..."
         onInput.bind="onInput"
         class="'o-hb-selectMany2X-wrapper'"

--- a/addons/html_builder/static/tests/many2one_field.test.js
+++ b/addons/html_builder/static/tests/many2one_field.test.js
@@ -1,5 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { setupHTMLBuilder } from "./helpers";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { advanceTime, animationFrame, press } from "@odoo/hoot-dom";
 
 test("should prevent edition in many2one field", async () => {
     await setupHTMLBuilder(
@@ -8,4 +10,46 @@ test("should prevent edition in many2one field", async () => {
         </a>`
     );
     expect(":iframe a").toHaveProperty("isContentEditable", false);
+});
+
+test.tags("desktop"); // NavigationItem only react to mouvemove which is not triggered in test for mobile
+test("Preview changes of many2one option", async () => {
+    onRpc(
+        "ir.qweb.field.contact",
+        "get_record_to_html",
+        ({ args: [[id]], kwargs }) => `<span>The ${kwargs.options.option} of ${id}</span>`
+    );
+
+    await setupHTMLBuilder(`
+        <div>
+            <span class="span-1" data-oe-model="blog.post" data-oe-id="3" data-oe-field="author_id" data-oe-type="contact" data-oe-many2one-id="3" data-oe-many2one-model="res.partner" data-oe-contact-options='{"option": "Name"}'>
+                <span>The Name of 3</span>
+            </span>
+            <span class="span-2" data-oe-model="blog.post" data-oe-id="3" data-oe-field="author_id" data-oe-type="contact" data-oe-many2one-id="3" data-oe-many2one-model="res.partner" data-oe-contact-options='{"option": "Address"}'>
+                <span>The Address of 3</span>
+            </span>
+            <span class="span-3" data-oe-model="blog.post" data-oe-id="6" data-oe-field="author_id" data-oe-type="contact" data-oe-many2one-id="3" data-oe-many2one-model="res.partner" data-oe-contact-options='{"option": "Address"}'>
+                <span>The Address of 3</span>
+            </span>
+            <span class="span-4" data-oe-model="blog.post" data-oe-id="3" data-oe-field="author_id" data-oe-type="other" data-oe-many2one-id="3" data-oe-many2one-model="res.partner">Other</span>
+        <div>
+    `);
+
+    await contains(":iframe .span-1").click();
+    expect("button.btn.dropdown").toHaveCount(1);
+    await contains("button.btn.dropdown").click();
+    // For some reason, SelectMenu does not behave as expected in this test, so we type some text to force a search
+    await contains('input[placeholder="Search for records..."]').fill("H");
+    await advanceTime(250); // debounced input
+    await contains("span.o-dropdown-item.dropdown-item").hover();
+    expect(":iframe span.span-1 > span").toHaveText("The Name of 1");
+    expect(":iframe span.span-2 > span").toHaveText("The Address of 1");
+    expect(":iframe span.span-3 > span").toHaveText("The Address of 3"); // author of other post is not changed
+    expect(":iframe span.span-4").toHaveText("Hermit");
+
+    await press("esc"); // This causes the dropdown to close, and thus the preview to be reverted
+    await animationFrame();
+    expect(":iframe span.span-1 > span").toHaveText("The Name of 3");
+    expect(":iframe span.span-2 > span").toHaveText("The Address of 3");
+    expect(":iframe span.span-4").toHaveText("Other");
 });

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -289,6 +289,7 @@ export class Navigator {
         this.activeItem?.setInactive(false);
         this.activeItem = this.items[index];
         this.activeItemIndex = index;
+        this._options.onItemActivated?.(this.activeItem.el);
     }
 
     /**
@@ -310,6 +311,7 @@ export class Navigator {
  * @property {({{ navigator: Navigator, target: HTMLElement }}) => bool} isNavigationAvailable
  * @property {NavigationHotkeys} hotkeys
  * @property {Function} onUpdated
+ * @property {Function} onItemActivated
  * @property {Boolean} [virtualFocus=false] - If true, items are only visually
  * focused so the actual focus can be kept on another input.
  * @property {Boolean} [shouldFocusChildInput=false] - If true, elements like inputs or buttons

--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -21,6 +21,9 @@ export class SelectMenu extends Component {
         togglerClass: "",
         multiSelect: false,
         onSelect: () => {},
+        onNavigated: () => {},
+        onOpened: () => {},
+        onClosed: () => {},
         required: false,
         searchable: true,
         autoSort: true,
@@ -78,9 +81,13 @@ export class SelectMenu extends Component {
         multiSelect: { type: Boolean, optional: true },
         onInput: { type: Function, optional: true },
         onSelect: { type: Function, optional: true },
+        onNavigated: { type: Function, optional: true },
+        onOpened: { type: Function, optional: true },
+        onClosed: { type: Function, optional: true },
         slots: { type: Object, optional: true },
         disabled: { type: Boolean, optional: true },
         fuzzyLookupFn: { type: Function, optional: true },
+        menuRef: { type: Function, optional: true },
     };
 
     static SCROLL_SETTINGS = {
@@ -97,6 +104,7 @@ export class SelectMenu extends Component {
         });
         this.inputRef = useRef("inputRef");
         this.menuRef = useChildRef();
+        this.props.menuRef?.(this.menuRef);
         this.debouncedOnInput = useDebounced(
             () => this.onInput(this.inputRef.el ? this.inputRef.el.value.trim() : ""),
             250
@@ -135,6 +143,14 @@ export class SelectMenu extends Component {
                         }
                     },
                 },
+            },
+            onItemActivated: (element) => {
+                const index = parseInt(element.dataset.choiceIndex);
+                if (index >= 0 && this.state.displayedOptions[index]) {
+                    this.props.onNavigated(this.state.displayedOptions[index]);
+                } else {
+                    this.props.onNavigated();
+                }
             },
         };
     }
@@ -182,6 +198,9 @@ export class SelectMenu extends Component {
             if (selectedElement) {
                 scrollTo(selectedElement);
             }
+            this.props.onOpened();
+        } else {
+            this.props.onClosed();
         }
     }
 

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -56,6 +56,7 @@
                     <t t-foreach="state.displayedOptions" t-as="choice" t-key="choice_index">
                         <t t-call="{{ this.constructor.choiceItemTemplate }}">
                             <t t-set="choice" t-value="choice" />
+                            <t t-set="choice_index" t-value="choice_index" />
                         </t>
                     </t>
                     <t t-if="props.slots and props.slots.bottomArea" t-slot="bottomArea" data="state"/>
@@ -77,6 +78,7 @@
             t-if="!choice.isGroup"
             onSelected="() => this.onItemSelected(choice.value)"
             class="getItemClass(choice) + ' d-flex align-items-center'"
+            attrs="{ 'data-choice-index': choice_index }"
         >
             <t t-if="props.slots and props.slots.choice" t-slot="choice" data="choice"/>
             <t t-else="">

--- a/addons/website/static/tests/builder/builder_action.test.js
+++ b/addons/website/static/tests/builder/builder_action.test.js
@@ -280,6 +280,21 @@ describe("HTML builder tests", () => {
             await contains("[data-action-id='isPreviewing'] input").edit("truthy");
             expect.verifySteps(["apply true", "apply false"]);
         });
+
+        test("useColorPickerBuilderComponent", async () => {
+            addBuilderOption({
+                selector: ".test-options-target",
+                template: xml`<BuilderColorPicker action="'isPreviewing'"/>`,
+            });
+            await setupHTMLBuilder(`<section class="test-options-target">Homepage</section>`);
+            await contains(":iframe .test-options-target").click();
+
+            // apply
+            await contains(".o_we_color_preview").click();
+            await contains("button:contains(Custom)").click();
+            await contains("button[data-color='600']").click();
+            expect.verifySteps(["apply true", "apply false"]);
+        });
     });
 
     test("reload action: apply, clean save and reload are called in the right order (async)", async () => {

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2one.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_many2one.test.js
@@ -35,6 +35,9 @@ test("many2one: async load", async () => {
     addActionOption({
         testAction: class extends BuilderAction {
             static id = "testAction";
+            setup() {
+                this.preview = false;
+            }
             async load({ value }) {
                 expect.step("load");
                 await defWillLoad;


### PR DESCRIPTION
### [FIX] html_builder, website: pass `isPreviewing` to action with colors

With the commit 4448303436fd2d5afe235263e13a9d5daa2d14e1, the `apply`
method of actions should receive an argument `isPreviewing`. This has
not been done for `BuilderColorPicker`.

This commit adds the argument `isPreviewing` when calling `apply` in
`BuilderColoPicker`.

task-4367641

### [FIX] html_builder, *: make options with BuilderMany2One previewable

*: web, website

With the initial [website builder refactor], the options based on
`BuilderMany2One` were not previewable (they were in the previous
builder).

This commit brings back that behaviour. To do so it adds props to
`SelectMenu` and options to `Navigator` to receive the information
needed for the preview

Steps to reproduce:
- On `/blog`, open website builder
- Click on the author of a blog post
- In the sidebar, click on "Contact" to open the dropdown
- Hover other authors than the current one
- Bug: the hovered author is not previewed in the dom
  (like in was in the previous builder)

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641