### PR TITLE
[FIX] spreadsheet: correctly give env to model creation

### DIFF
--- a/addons/spreadsheet/static/src/helpers/model.js
+++ b/addons/spreadsheet/static/src/helpers/model.js
@@ -25,7 +25,7 @@ export async function fetchSpreadsheetModel(env, resModel, resId) {
 
 export function createSpreadsheetModel({ env, data, revisions }) {
     const odooDataProvider = new OdooDataProvider(env);
-    const model = new OdooSpreadsheetModel(data, { custom: { odooDataProvider } }, revisions);
+    const model = new OdooSpreadsheetModel(data, { custom: { env, odooDataProvider } }, revisions);
     return model;
 }
 


### PR DESCRIPTION
Steps to reproduce:
 - Install documents_spreadsheet (enterprise)
 - Create a spreadsheet with an Odoo List
 - Open the document view
 - Select the spreadsheet
 - Click on "Freeze and Share" => Boom

Please see the enterprise PR for the test.

Task: 5025331

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
