### PR TITLE
[FIX] website_sale: prevent error when setting rental start date after end date

### DIFF
--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -232,7 +232,9 @@ var VariantMixin = {
         $parent
             .find('option, input, label, .o_variant_pills')
             .removeClass('css_not_available')
+            .not(`#rental_product_start_date, #rental_product_end_date`)
             .removeAttr('disabled')
+            .end()
             .filter('option, input')
             .closest('li')
             .removeAttr('title')


### PR DESCRIPTION
An error currently occurs when an user attempts to change the rental start date to a value later than the end date while a product is already in the cart.

**Steps to replicate:**
* Install `website_sale`, `stock` , `sale_renting` with demo data
* Rental > Products > Printer > Sales > Turn `Out of stock: continue selling` off
* Website > Shop > Printer > Select dates when printer is available
* Add printer to cart > Set start date greater than end date by typing

`ValueError: min() iterable argument is empty`

**Cause:**
This error occurs because [1] causes the `availabilities` list to be empty at [2] when retrieving combination information.

This issue occurs in version `18.4` and later because the date picker remains editable after the product is added to the cart. The changes in [3] remove the `disabled` attribute after the product is added, allowing users to modify the date.

**Solution:**
* Prevent users from editing dates after a product is added to the cart, as done in version `18.3`, since all products must share the same dates as the one already in the cart, as specified in [4].

[1]:
https://github.com/odoo/enterprise/blob/246a49ff3fd2baa636f3e7d80a75a01e77060ee1/website_sale_stock_renting/models/product_product.py#L79 
[2]:
https://github.com/odoo/enterprise/blob/246a49ff3fd2baa636f3e7d80a75a01e77060ee1/website_sale_stock_renting/models/website.py#L14-L19 
[3]:
https://github.com/odoo/odoo/commit/bbb2d98d9ab97ce729d59b9858b63daccf5434e2#diff-39e02d03a8b765b4e3afc68627aeb33f11b587163638fedfb92ed5657c3336e7R230 
[4]:
https://github.com/odoo/enterprise/blob/246a49ff3fd2baa636f3e7d80a75a01e77060ee1/website_sale_renting/views/templates.xml#L100

**Sentry-6803401968**