### PR TITLE
[FIX] l10n_ae:remove duplicate column from invoice report

### DIFF
--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -104,14 +104,6 @@
             </td>
         </xpath>
 
-        <xpath expr="//td[@name='td_subtotal']/span" position="attributes">
-            <attribute name="t-if">o.company_id.country_id.code != 'AE' or o.company_price_include == 'tax_excluded'</attribute>
-        </xpath>
-        
-        <xpath expr="//td[@name='td_subtotal']/span" position="after">
-            <span t-if="o.company_id.country_id.code == 'AE' and o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
-        </xpath>
-
         <xpath expr="//th[@name='th_subtotal']" position="after">
             <th class="text-end" t-if="o.company_id.country_id.code == 'AE' and o.currency_id != o.company_currency_id">
                 <span>Amount (<span t-field="o.company_currency_id"/>)</span>


### PR DESCRIPTION
**Step to reproduce:**
- install account module with localization "UAE"
- go to Settings > Tax Included
- create a invoice (make sure a tax is applied)
- print any invoice (Proforma or Tax)

**Observation:**
- the amount is being displayed twice in the Amount column.

**Cause:**
- A change was introduced in 18.0 to add additional column right after Amount
 column, [1] in l10n_ae module
- Another commit [2] in saas-18.3 introduces same column in main account module
- hence we have two columns printing same information

**Fix:**
- Removed and fixed a faulty xpath from view, as after commit [2]
    base layout provides same logic

[1] https://github.com/odoo/odoo/commit/fe68fa30b18f90411043fc6e2314fd376ddaed0c
[2] https://github.com/odoo/odoo/commit/1bf232c22f430d282aaadd858c5e61fed12f4da6

**Before:**
<img width="774" height="146" alt="image" src="https://github.com/user-attachments/assets/a9eb6af2-81b3-4989-bf6e-6676eafe10f8" />

**After:**
<img width="813" height="143" alt="image" src="https://github.com/user-attachments/assets/fb019516-de7d-4dd3-b7dd-3fd14322b031" />

opw-4976410

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
