### PR TITLE
[FIX] website_sale_collect: hide delivery truck if it's `in_store` only

### DIFF
--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -27,6 +27,7 @@ class ProductTemplate(models.Model):
             available_delivery_methods_sudo = self.env['delivery.carrier'].sudo().search([
                 '|', ('website_id', '=', website.id), ('website_id', '=', False),
                 ('website_published', '=', True),
+                ('delivery_type', '!=', 'in_store'),
             ])
             if available_delivery_methods_sudo:
                 res['delivery_stock_data'] = utils.format_product_stock_values(

--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
@@ -38,12 +38,12 @@
                     </a>
                 </div>
             </div>
-            <hr />
             <div
                 name="delivery_availability"
-                t-if="this.state.deliveryStockData"
+                t-if="Object.keys(this.state.deliveryStockData || {}).length !== 0"
                 class="flex-row cursor-default"
             >
+                <hr/>
                 <h6>
                     <i class="fa fa-fw fa-truck text-muted"/>
                     Delivery


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Disable all delivery methods except for "Pick up in store";
2. go to a product page.

Issue
-----
A delivery truck is shown with its delivery status, even though delivery is not supported.

Cause
-----
The `delivery_stock_data` info looks for all published "delivery" carriers, including `in_store` types, which is already covered by `in_store_stock_data`.

Solution
--------
- Exclude `in_store` delivery types when looking for delivery carriers.
- If the `deliveryStockData` object is empty, don't render the truck.

opw-5010081