### PR TITLE
[FIX] base: source maps

### DIFF
--- a/odoo/tools/js_transpiler.py
+++ b/odoo/tools/js_transpiler.py
@@ -261,7 +261,7 @@ def convert_t(url, content):
             renamed_import = match_.group(0).replace("_t", "__not_defined__")
         else:
             renamed_import = match_.group(0).replace("_t", "appTranslateFn")
-        renamed_import += f"""\nconst _t = (str, ...args) => appTranslateFn(str, "{module_name}", ...args);"""
+        renamed_import += f"""const _t = (str, ...args) => appTranslateFn(str, "{module_name}", ...args);"""
         return renamed_import
 
     return GETTEXT_RE.sub(rename_gettext, content)


### PR DESCRIPTION
In js_transpiler.py, the purpose of convert_t is to transform an import of _t into a const declaration of _t using appTranslateFn. That declaration has to be at the end of the line of the import declaration. If not, each const declaration brings a shift of 1 line and the source maps become invalid.