### PR TITLE
[FIX] stock: make `test_context_from_warehouse_filter tour deterministic

### DIFF
--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -49,6 +49,10 @@ odoo.define('stock.reports.setup.tour', function (require) {
             run: "click",
         },
         {
+            trigger: ".o_menu_item.dropdown-item.o_indent:contains(Warehouse A)",
+            run: () => {},  // wait until Warehouse A is rendered
+        },   
+        {
             trigger: ".o_menu_item.dropdown-item.o_indent:contains(Warehouse A) a",
             run: "click",
         },
@@ -60,6 +64,10 @@ odoo.define('stock.reports.setup.tour', function (require) {
         {
             trigger: ".o_menu_item.dropdown-item:contains(Warehouse) a.o_expand > i",
             run: "click",
+        },
+        {
+            trigger: ".o_menu_item.dropdown-item.o_indent:contains(Warehouse B)",
+            run: () => {},  // wait until Warehouse B is rendered
         },
         {
             trigger: ".o_menu_item.dropdown-item.o_indent:contains(Warehouse B) a",


### PR DESCRIPTION
The `test_context_from_warehouse_filter` tour was flaky when selecting Warehouse A and Warehouse B. The tour clicked the expand chevron and immediately tried to select a warehouse, but the child entries are rendered asynchronously. As a result, the selection step could run before the entries were visible, causing intermittent failures.

Changes:

Updated the tour steps to add explicit wait steps `(run: () => {})` after expanding the Warehouse group. The tour now waits until Warehouse A or Warehouse B are present in the DOM before clicking them. This ensures the warehouse selection is stable and the tour runs deterministically.

runbot:107951

### Error screenshot:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/82e1045a-a14a-4bcc-96f6-7396f71c29b3" />

### How it should look if we wait after the chevron click
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/4bffa5fe-221b-4306-a2dc-6124b8de7d00" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
