### PR TITLE
[FIX] website_profile : clear email validation banner after user is validated

### DIFF
--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -299,6 +299,7 @@ class WebsiteProfile(http.Controller):
     def validate_email(self, token, user_id, email, **kwargs):
         done = request.env['res.users'].sudo().browse(int(user_id))._process_profile_validation_token(token, email)
         if done:
+            request.session['validation_email_sent'] = False
             request.session['validation_email_done'] = True
         url = kwargs.get('redirect_url', '/')
         return request.redirect(url)

--- a/addons/website_profile/static/src/js/website_profile.js
+++ b/addons/website_profile/static/src/js/website_profile.js
@@ -7,7 +7,7 @@ publicWidget.registry.websiteProfile = publicWidget.Widget.extend({
     selector: '.o_wprofile_email_validation_container',
     read_events: {
         'click .send_validation_email': 'async _onSendValidationEmailClick',
-        'click .validated_email_close': '_onCloseValidatedEmailClick',
+        'click': '_onCloseValidatedEmailClick',
     },
 
     init() {
@@ -38,8 +38,9 @@ publicWidget.registry.websiteProfile = publicWidget.Widget.extend({
     /**
      * @private
      */
-    _onCloseValidatedEmailClick: function () {
-        this.rpc('/profile/validate_email/close');
+    _onCloseValidatedEmailClick: function (ev) {
+        if (ev.target.classList.contains('validated_email_close'))
+            this.rpc('/profile/validate_email/close');
     },
 });
 

--- a/addons/website_profile/tests/__init__.py
+++ b/addons/website_profile/tests/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import test_website_profile
+from . import test_email_validation

--- a/addons/website_profile/tests/test_email_validation.py
+++ b/addons/website_profile/tests/test_email_validation.py
@@ -1,0 +1,49 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged, HttpCase
+
+
+@tagged('post_install', '-at_install')
+class TestEmailValidationBannerFix(HttpCase):
+
+    def test_congratulations_banner_disappears_after_validation(self):
+        """Test that congratulations banner doesn't persist across page loads"""
+
+        user = self.env['res.users'].create({
+            'name': 'Test User',
+            'login': 'test@example.com',
+            'email': 'test@example.com',
+            'password': 'testpassword',
+            'karma': 0,
+            'groups_id': [(6, 0, [self.env.ref('base.group_portal').id])],
+        })
+
+        self.env['slide.channel'].create({
+            'name': 'Test Course',
+            'website_published': True,
+            'enroll': 'public',
+            'visibility': 'public',
+        })
+
+        self.authenticate(user.login, 'testpassword')
+
+        response = self.url_open('/slides')
+        response_text = response.content.decode()
+        self.assertTrue(
+            'not yet been verified' in response_text.lower(),
+            "Unvalidated users should still see verification banner"
+        )
+
+        user.write({'karma': 3})
+        session = self.session
+        session['validation_email_done'] = True
+
+        self.url_open('/slides')
+        response2 = self.url_open('/slides')
+        response_text2 = response2.content.decode()
+        self.assertNotIn('Congratulations', response_text2.lower(),
+                        "Congratulations banner should NOT reappear on refresh")
+
+        response3 = self.url_open('/slides')
+        response_text3 = response3.content.decode()
+        self.assertNotIn('Congratulations', response_text3.lower(),
+                        "Banner should stay hidden on subsequent visits")


### PR DESCRIPTION
**Description**

External users signing up for e-learning courses. They encounter an "account not validated" banner on the website. After clicking the "Validate Account" button in the email, users are redirected back to the website, and the>


1. **When user validates email**: The system sets `request.session['validation_email_done'] = True`
2. **Template shows banner based on session**: `validation_email_done` from session determines if congratulations banner appears
3. **Session persists but doesn't sync**: Even after user is fully validated, the session flag stays `True`
4. **Page refresh = banner reappears**: Every page reload checks session and shows banner again
5. **Clicking "X" only hides temporarily**: The close button doesn't actually clear the session flag properly

**Cause**:
When clicking on close button, bootstrap detach `.validated_email_close` alert component from the DOM. When jQuery should call `_onCloseValidatedEmailClick` handler, it finds that `.validated_email_close` is not a child of `.o_wprofile_email_validation_container` so it ignores the event.

**Fix**:
Check that the event target was `.validated_email_close` inside `_onCloseValidatedEmailClick` instead of using delegation.

**Result**: The congratulations banner shows once after validation, then automatically disappears forever without requiring logout/login.

**Additional issue identified**: After implementing the frontend fix, the `validation_email_sent` banner persists because this session flag is never reset. This creates a new UX issue where users continue to see "verification email sent" messages inappropriately.

**Solution**: Clear the `validation_email_sent` flag when email validation succeeds. This ensures proper session state cleanup and prevents stale banner messages.

opw-4817084
