### PR TITLE
[IMP] l10n_ar,*: calculate tax amounts properly

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -1272,7 +1272,7 @@ class AccountTestInvoicingCommon(ProductCommon):
                 for i in range(len(ignore_schema)):
                     cls._apply_json_ignore_schema(data[i], ignore_schema[i])
 
-    def assert_json(self, content_to_assert: dict | list, test_name: str, subfolder=''):
+    def assert_json(self, content_to_assert: dict | list, test_name: str, subfolder='', force_save=False):
         """
         Helper to save/assert a dictionary to a JSON file located in the corresponding module `test_files`.
         By default, this method will assert the dictionary with the JSON content.
@@ -1285,26 +1285,35 @@ class AccountTestInvoicingCommon(ProductCommon):
         :param content_to_assert: dictionary | list to save or assert to the corresponding test file
         :param test_name: the test file name
         :param subfolder: the test file subfolder(s), separated by `/` if there is more than one
+        :param force_save: force the assert method to save the XML to the test file instead of asserting it
         """
         json_path = self._get_test_file_path(f"{test_name}.json", subfolder=subfolder)
         content_to_assert = json.loads(json.dumps(content_to_assert))
         if json_ignore_schema := self._get_json_ignore_schema(subfolder):
             self._apply_json_ignore_schema(content_to_assert, json_ignore_schema)
 
-        if 'SAVE_JSON' in config['test_tags']:
+        if 'SAVE_JSON' in (config['test_tags'] or '').split(',') or force_save:
             with file_open(json_path, 'w') as f:
                 f.write(json.dumps(content_to_assert, indent=4))
             _logger.info("Saved the generated JSON content to %s", json_path)
         else:
             with file_open(json_path, 'rb') as f:
                 expected_content = json.loads(f.read())
-            self.assertDictEqual(content_to_assert, expected_content)
+            try:
+                self.assertDictEqual(content_to_assert, expected_content)
+            except AssertionError:
+                if not force_save and 'SAVE_JSON_ON_FAIL' in config['test_tags']:
+                    self.assert_json(content_to_assert=content_to_assert, test_name=test_name, subfolder=subfolder, force_save=True)
+                else:
+                    raise
 
     def assert_xml(
             self,
             xml_element: str | bytes | etree._Element,
             test_name: str,
             subfolder='',
+            xpath_to_apply='',
+            force_save=False,
     ):
         """
         Helper to save/assert an XML element/string/bytes to an XML file.
@@ -1321,6 +1330,8 @@ class AccountTestInvoicingCommon(ProductCommon):
         :param xml_element: the _Element/str/bytes content to be saved or asserted
         :param test_name: the test file name
         :param subfolder: the test file subfolder(s), separated by `/` if there is more than one
+        :param xpath_to_apply: optional `xpath` string to be applied on the expected file
+        :param force_save: force the assert method to save the XML to the test file instead of asserting it
         :return:
         """
         file_name = f"{test_name}.xml"
@@ -1330,7 +1341,7 @@ class AccountTestInvoicingCommon(ProductCommon):
         if isinstance(xml_element, bytes):
             xml_element = etree.fromstring(xml_element)
 
-        if 'SAVE_XML' in config['test_tags']:
+        if 'SAVE_XML' in (config['test_tags'] or '').split(',') or force_save:
             # Save the XML to tmp folder before modifying some elements with `___ignore___`
             etree.indent(xml_element, space='\t')
             with patch.object(re, 'fullmatch', lambda _arg1, _arg2: True):
@@ -1368,7 +1379,21 @@ class AccountTestInvoicingCommon(ProductCommon):
                 expected_xml_str = f.read()
 
             expected_xml_tree = etree.fromstring(expected_xml_str)
-            self.assertXmlTreeEqual(xml_element, expected_xml_tree)
+            if xpath_to_apply:
+                expected_xml_tree = self.with_applied_xpath(expected_xml_tree, xpath_to_apply)
+            try:
+                self.assertXmlTreeEqual(xml_element, expected_xml_tree)
+            except AssertionError:
+                if not force_save and 'SAVE_XML_ON_FAIL' in config['test_tags']:
+                    self.assert_xml(
+                        xml_element=xml_element,
+                        test_name=test_name,
+                        subfolder=subfolder,
+                        xpath_to_apply=xpath_to_apply,
+                        force_save=True,
+                    )
+                else:
+                    raise
 
     @classmethod
     def _turn_node_as_dict_hierarchy(cls, node, path=''):

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -595,11 +595,30 @@ class TestArCommon(AccountTestInvoicingCommon):
             }
         }
 
-        for invoice_key, invoice_values in test_invoices_map.items():
-            invoice_values.setdefault('invoice_payment_term_id', cls.env.ref("account.account_payment_term_end_following_month"))
-            if use_current_date:
+        if use_current_date:
+            for invoice_key, invoice_values in test_invoices_map.items():
                 invoice_values.pop('invoice_date')
-            cls.demo_invoices[invoice_key] = cls._create_invoice_ar(**invoice_values)
+                cls.demo_invoices[invoice_key] = cls._create_invoice_ar(**invoice_values)
+        else:
+            for key, values in test_invoices_map.items():
+                values['invoice_line_ids'] = [line_data for _, _, line_data in values['invoice_line_ids']]
+                with Form(cls.env['account.move'].with_context(default_move_type=values['move_type'])) as invoice_form:
+                    invoice_form.ref = values['ref']
+                    invoice_form.partner_id = values['partner_id']
+                    invoice_form.invoice_payment_term_id = values['invoice_payment_term_id']
+                    invoice_form.invoice_date = values['invoice_date']
+                    if values.get('invoice_incoterm_id'):
+                        invoice_form.invoice_incoterm_id = values['invoice_incoterm_id']
+                    for line in values['invoice_line_ids']:
+                        with invoice_form.invoice_line_ids.new() as line_form:
+                            line_form.product_id = cls.env['product.product'].browse(line.get('product_id'))
+                            line_form.price_unit = line.get('price_unit')
+                            line_form.quantity = line.get('quantity')
+                            if line.get('tax_ids'):
+                                line_form.tax_ids = cls.env['account.tax'].browse(line.get('tax_ids'))
+                            line_form.name = 'xxxx'
+                            line_form.account_id = cls.company_data['default_account_revenue']
+                cls.demo_invoices[key] = invoice_form.save()
 
     # -------------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
This commit refactors the tax amount calculations on the `_get_vat` and `_l10n_ar_get_amounts` method so that it uses the tax computation engine helpers properly, to prepare for any future fixes done on how Argentina tax calculations differs from all other localizations.

This replaces all move line queries with the proper `base_line` calculation, with the proper aggregating methods.

related-enterprise-PR: https://github.com/odoo/enterprise/pull/92639
task-4891206
