### PR TITLE
[IMP] pos_loyalty: show loyalty point details on pos receipt

### DIFF
--- a/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/app/screens/receipt_screen/order_receipt/order_receipt.xml
@@ -3,15 +3,39 @@
 
     <t t-name="pos_coupon.OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('pos-receipt')]//div[hasclass('before-footer')]" position="inside">
+            <t t-if="order.models['loyalty.program'].length">
+                <t t-foreach="order.getLoyaltyPoints() or []" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">
+                    <div t-if="_loyaltyStat.program.portal_visible and (_loyaltyStat.points.won || _loyaltyStat.points.spent)" class='pt-3 loyalty'>
+                        <t t-if='_loyaltyStat.points.won'>
+                            <div class="d-flex" style="font-size: 75%;">
+                                <span><t t-out="_loyaltyStat.points.name"/> Won:</span>
+                                <span t-out='_loyaltyStat.points.won' class="ms-auto"/>
+                            </div>
+                        </t>
+                        <t t-if='_loyaltyStat.points.spent'>
+                            <div class="d-flex" style="font-size: 75%;">
+                                <span><t t-out="_loyaltyStat.points.name"/> Spent:</span>
+                                <span t-out='_loyaltyStat.points.spent' class="ms-auto"/>
+                            </div>
+                        </t>
+                        <t t-if='_loyaltyStat.points.balance'>
+                            <div class="d-flex" style="font-size: 75%;">
+                                <span>Balance <t t-out="_loyaltyStat.points.name"/>:</span>
+                                <span t-out='_loyaltyStat.points.balance' class="ms-auto"/>
+                            </div>
+                        </t>
+                    </div>
+                </t>
+            </t>
+            <t t-if="order.partner_id and order.preset_id?.identification != 'address'">
+                <div class="d-flex pt-3" style="font-size: 75%;">
+                    <span>Customer</span>
+                    <span t-out="order.partner_id.name" class="ms-auto fw-bolder"/>
+                </div>
+            </t>
             <t t-if="order.new_coupon_info and order.new_coupon_info.length !== 0">
                 <div class="pos-coupon-rewards pt-3">
                     <t t-foreach="order.new_coupon_info" t-as="coupon_info" t-key="coupon_info.code">
-                        <t t-if="order.partner_id and order.preset_id?.identification != 'address'">
-                            <div class="d-flex pb-1" style="font-size: 75%;">
-                                <span>Customer</span>
-                                <span t-out="order.partner_id.name" class="ms-auto fw-bolder"/>
-                            </div>
-                        </t>
                         <div class="coupon-container">
                             <div class="row g-2">
                                 <div class="col-6">

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -2,6 +2,7 @@ import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util"
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selection_popup_util";
 import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
@@ -231,6 +232,14 @@ registry.category("web_tour.tours").add("PosLoyaltyTour6", {
             ProductScreen.clickControlButton("Reward"),
             SelectionPopup.has("$ 1 per point on your order", { run: "click" }),
             ProductScreen.totalAmountIs("165.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            {
+                content: "Loyalty Points is visible on the receipt",
+                trigger: ".pos-receipt .loyalty",
+            },
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1141,6 +1141,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'trigger': 'auto',
             'applies_on': 'both',
             'pos_ok': True,
+            'portal_visible': True,
             'pos_config_ids': [Command.link(self.main_pos_config.id)],
             'rule_ids': [(0, 0, {
                 'reward_point_mode': 'money',


### PR DESCRIPTION
Before this commit:
===================
- The receipt screen did not display any details about loyalty points won or the current loyalty point balance.

After this commit:
==================
- Loyalty point details (points earned and balance) are now displayed on the receipt screen.

Task: 5022234
| saas-18.3 and above | This PR |
|--------|--------|
| <img width="391" height="844" alt="image" src="https://github.com/user-attachments/assets/c0ca55c0-cd46-468c-bb16-b19da5daa742" /> | <img width="391" height="844" alt="image" src="https://github.com/user-attachments/assets/1dd6d398-693b-4ab7-a598-520d6f8d8c56" /> |
