### PR TITLE
[IMP] mail,*: composer text to HTML draftContent

### DIFF
--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -204,8 +204,8 @@ export class Chatbot extends Record {
     async _processAnswer(message) {
         if (
             this.currentStep.step_type === "free_input_multi" &&
-            this.thread.composer.text &&
-            this.tmpAnswer !== this.thread.composer.text
+            this.thread.composer.composerText &&
+            this.tmpAnswer !== this.thread.composer.composerText
         ) {
             return await this._delayThenProcessAnswerAgain(message);
         }
@@ -223,7 +223,7 @@ export class Chatbot extends Record {
     }
 
     async _delayThenProcessAnswerAgain(message) {
-        this.tmpAnswer = this.thread.composer.text;
+        this.tmpAnswer = this.thread.composer.composerText;
         await Promise.resolve(); // Ensure that it's properly debounced when called again
         return this._processAnswerDebounced(message);
     }

--- a/addons/im_livechat/static/src/core/web/composer_patch.js
+++ b/addons/im_livechat/static/src/core/web/composer_patch.js
@@ -9,7 +9,7 @@ patch(Composer.prototype, {
         if (
             ev.key === "Tab" &&
             this.thread?.channel_type === "livechat" &&
-            !this.props.composer.text
+            !this.props.composer.composerText
         ) {
             const threadChanged = this.store.goToOldestUnreadLivechatThread();
             if (threadChanged) {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -62,7 +62,7 @@
                             'o-mail-Composer-inputStyle form-control border-0 o-rounded-bubble': true,
                             'ps-2': partitionedActions.other.length === 0
                         }"/>
-                        <Wysiwyg t-if="composerService.htmlEnabled" class="'w-100 text-break overflow-auto'" config="wysiwygConfig"/>
+                        <Wysiwyg t-if="composerService.htmlEnabled" class="'w-100 text-break overflow-auto'" config="this.wysiwygConfig" onLoad.bind="onLoadWysiwyg"/>
                         <t t-else="">
                                 <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto o-scrollbar-thin text-body user-select-auto"
                                 t-att-class="inputClasses"
@@ -72,7 +72,7 @@
                                 t-on-focusout="onFocusout"
                                 t-on-click="(ev) => markEventHandled(ev, 'composer.onClickTextarea')"
                                 t-on-paste="onPaste"
-                                t-model="props.composer.text"
+                                t-model="props.composer.composerText"
                                 t-on-input="(ev) => this.onInput(ev)"
                                 t-att-placeholder="placeholder"
                                 t-att-readOnly="!state.active"
@@ -86,7 +86,7 @@
                             <textarea
                                 class="o-mail-Composer-fake position-absolute overflow-hidden"
                                 t-att-class="inputClasses"
-                                t-model="props.composer.text"
+                                t-att-value="props.composer.composerText"
                                 t-ref="fakeTextarea"
                                 disabled="1"
                             />

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -1,5 +1,5 @@
 import { fields, OR, Record } from "@mail/core/common/record";
-import { convertBrToLineBreak } from "@mail/utils/common/format";
+import { convertBrToLineBreak, prettifyMessageContent } from "@mail/utils/common/format";
 
 export class Composer extends Record {
     static id = OR("thread", "message");
@@ -7,7 +7,7 @@ export class Composer extends Record {
     clear() {
         this.attachments.length = 0;
         this.replyToMessage = undefined;
-        this.text = "";
+        this.composerHtml = "";
         Object.assign(this.selection, {
             start: 0,
             end: 0,
@@ -24,12 +24,37 @@ export class Composer extends Record {
     mentionedChannels = fields.Many("Thread");
     cannedResponses = fields.Many("mail.canned.response");
     isDirty = false;
-    text = fields.Attr("", {
+    composerText = fields.Attr("", {
         compute() {
             if (this.syncTextWithMessage) {
                 return convertBrToLineBreak(this.message.body || "");
             }
-            return this.text;
+            return this.composerText;
+        },
+        onUpdate() {
+            if (this.updateFromHtml) {
+                return;
+            }
+            const validMentions = this.store.getMentionsFromText(this.composerText, {
+                mentionedChannels: this.mentionedChannels,
+                mentionedPartners: this.mentionedPartners,
+                mentionedRoles: this.mentionedRoles,
+            });
+            prettifyMessageContent(this.composerText, { validMentions }).then((content) => {
+                this.updateFromText = true;
+                this.composerHtml = content;
+                this.updateFromText = false;
+            });
+        },
+    });
+    composerHtml = fields.Html("", {
+        onUpdate() {
+            if (this.updateFromText) {
+                return;
+            }
+            this.updateFromHtml = true;
+            this.composerText = convertBrToLineBreak(this.composerHtml);
+            this.updateFromHtml = false;
         },
     });
     thread = fields.One("Thread");
@@ -55,6 +80,8 @@ export class Composer extends Record {
     });
     autofocus = 0;
     replyToMessage = fields.One("mail.message");
+    updateFromText = false;
+    updateFromHtml = false;
 
     get syncTextWithMessage() {
         return this.message && !this.isDirty;

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -560,7 +560,7 @@ export class Message extends Record {
         }
         this.composer = {
             mentionedPartners: this.partner_ids,
-            text,
+            composerText: text,
             selection: {
                 start: text.length,
                 end: text.length,

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -32,7 +32,11 @@ export class UseSuggestion {
             () => {
                 this.detect();
             },
-            () => [this.composer.selection.start, this.composer.selection.end, this.composer.text]
+            () => [
+                this.composer.selection.start,
+                this.composer.selection.end,
+                this.composer.composerText,
+            ]
         );
     }
     /** @type {import("@mail/core/common/composer").Composer} */
@@ -77,7 +81,7 @@ export class UseSuggestion {
     }
     detect() {
         const { start, end } = this.composer.selection;
-        const text = this.composer.text;
+        const text = this.composer.composerText;
         if (start !== end) {
             // avoid interfering with multi-char selection
             this.clearSearch();
@@ -148,7 +152,7 @@ export class UseSuggestion {
     }
     insert(option) {
         const position = this.composer.selection.start;
-        const text = this.composer.text;
+        const text = this.composer.composerText;
         let before = text.substring(0, this.search.position + 1);
         let after = text.substring(position, text.length);
         if ([":", "::"].includes(this.search.delimiter)) {
@@ -173,7 +177,7 @@ export class UseSuggestion {
             this.composer.cannedResponses.push(option.cannedResponse);
         }
         this.clearSearch();
-        this.composer.text = before + option.label + " " + after;
+        this.composer.composerText = before + option.label + " " + after;
         this.composer.selection.start = before.length + option.label.length + 1;
         this.composer.selection.end = before.length + option.label.length + 1;
         this.composer.forceCursorMove = true;

--- a/addons/mail/static/src/discuss/typing/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.js
@@ -52,7 +52,7 @@ patch(Composer.prototype, {
         this.detectTyping(ev);
     },
     detectTyping() {
-        const value = this.props.composer.text;
+        const value = this.props.composer.composerText;
         if (this.thread?.model === "discuss.channel" && value.startsWith("/")) {
             const [firstWord] = value.substring(1).split(/\s/);
             const command = commandRegistry.get(firstWord, false);

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -24,9 +24,9 @@ export class HtmlComposerMessageField extends HtmlMailField {
                 this.editor.editable.after(elContent);
                 // TODO: the following legacy regex may not have the desired effect as it
                 // agglomerates multiple newLines together.
-                const text = elContent.innerText.replace(/(\t|\n)+/g, "\n");
+                const composerText = elContent.innerText.replace(/(\t|\n)+/g, "\n");
                 elContent.remove();
-                ev.detail.onSaveContent({ text, emailAddSignature });
+                ev.detail.onSaveContent({ composerText, emailAddSignature });
             });
             useBus(this.env.fullComposerBus, "ATTACHMENT_REMOVED", (ev) => {
                 const attachmentElements = this.editor.editable.querySelectorAll(

--- a/addons/mail/static/tests/discuss/core/composer.test.js
+++ b/addons/mail/static/tests/discuss/core/composer.test.js
@@ -1,7 +1,10 @@
+import { insertText as htmlInsertText } from "@html_editor/../tests/_helpers/user_actions";
+
 import {
     click,
     contains,
     defineMailModels,
+    focus,
     insertText,
     onRpcBefore,
     openDiscuss,
@@ -10,7 +13,12 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { Composer } from "@mail/core/common/composer";
 import { beforeEach, describe, test } from "@odoo/hoot";
-import { asyncStep, patchWithCleanup, waitForSteps } from "@web/../tests/web_test_helpers";
+import {
+    asyncStep,
+    getService,
+    patchWithCleanup,
+    waitForSteps,
+} from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -92,4 +100,28 @@ test("add an emoji after a command", async () => {
     await click("button[title='Add Emojis']");
     await click(".o-Emoji", { text: "😊" });
     await contains(".o-mail-Composer-input", { value: "/who 😊" });
+});
+
+test.tags("html composer");
+test("html composer: send a message in a channel", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-input", { value: "" });
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await htmlInsertText(editor, "Hello");
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "Hello" });
+    await click(".o-mail-Composer button[title='Send']:enabled");
+    await click(".o-mail-Message[data-persistent]:contains(Hello)");
+    await contains(".o-mail-Composer-html.odoo-editor-editable", { text: "" });
 });

--- a/addons/portal_rating/static/src/chatter/frontend/composer_patch.js
+++ b/addons/portal_rating/static/src/chatter/frontend/composer_patch.js
@@ -32,7 +32,7 @@ patch(Composer.prototype, {
         this.state.active = false;
         const data = await rpc("/website/rating/comment", {
             rating_id: this.message.rating_id.id,
-            publisher_comment: this.props.composer.text.trim(),
+            publisher_comment: this.props.composer.composerText.trim(),
         });
         this.message.rating_id = data;
         this.props.onPostCallback();


### PR DESCRIPTION
This commit updates the text field in composer model to use HTML instead of plain text. This change is made to ensure that the html composer can share the same field as the text composer.

Also, this commit renames the text field to draftContent in a variety of places.

https://github.com/odoo/enterprise/pull/92669

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
