### PR TITLE
[FIX] html_editor: do not remove background image when switching o_cc

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -597,7 +597,6 @@ function removePresetGradient(element) {
     } else {
         delete parts.gradient;
         const withoutGradient = backgroundImagePartsToCss(parts);
-        element.style["background-image"] =
-            styleWithoutGradient.backgroundImage === "none" ? "" : withoutGradient;
+        element.style["background-image"] = withoutGradient === "none" ? "" : withoutGradient;
     }
 }

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -633,6 +633,24 @@ describe("colorElement", () => {
             contentAfter: `<div style='background-image: url("https://example.com/image.png"), ${greenToBlueGradient};'>a</div>`,
         });
     });
+    test("should keep the background image when switching o_cc class", async () => {
+        await testEditor({
+            contentBefore: `<div style='background-image: url("https://example.com/image.png");'>a</div>`,
+            stepFunction: (editor) => {
+                editor.shared.color.colorElement(
+                    editor.editable.firstChild,
+                    "o_cc2",
+                    "backgroundColor"
+                );
+                editor.shared.color.colorElement(
+                    editor.editable.firstChild,
+                    "o_cc1",
+                    "backgroundColor"
+                );
+            },
+            contentAfter: `<div style='background-image: url("https://example.com/image.png");' class="o_cc o_cc1">a</div>`,
+        });
+    });
     test("should keep custom gradient when switching o_cc class", async () => {
         await testEditor({
             contentBefore: `<div class="">a</div>`,


### PR DESCRIPTION
[FIX] html_editor: do not remove background image when switching o_cc

Steps to reproduce:
- Add a snippet.
- Set a background image.
- Set a color preset (first tab of the colorpicker).
- Change the color preset.

-> The background image is removed

The goal of this commit is to fix a small error introduced by [this one]: `styleWithoutGradient.backgroundImage` is always `none` at this step as we remove the `background-image` property before computing `styleWithoutGradient`.

[this one]: https://github.com/odoo/odoo/commit/d013db1f43a411a8ae32989a4fbe0d9c5b6c54ce

Related to task-4367641
