### PR TITLE
[FIX] website: fix navbar options icons

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header/header_elements_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_elements_option.xml
@@ -11,9 +11,8 @@
             title.translate="Company Logo"
             className="'flex-grow-1'"
             actionParam="websiteLogoParams"
-        >
-            <Img src="'/website/static/src/img/snippets_options/header_extra_element_logo.svg'"/>
-        </BuilderButton>
+            iconImg="'/website/static/src/img/snippets_options/header_extra_element_logo.svg'"
+        />
         <BuilderButton
             title.translate="Text Elements (e.g. phone number)"
             className="'flex-grow-1'"
@@ -21,9 +20,8 @@
                 views: ['website.header_text_element'],
                 resetViewArch: true,
             }"
-        >
-            <Img src="'/website/static/src/img/snippets_options/header_extra_element_text.svg'"/>
-        </BuilderButton>
+            iconImg="'/website/static/src/img/snippets_options/header_extra_element_text.svg'"
+        />
         <BuilderButton
             title.translate="Social Links"
             className="'flex-grow-1'"
@@ -31,9 +29,8 @@
                 views: ['website.header_social_links'],
                 resetViewArch: true,
             }"
-        >
-            <Img src="'/website/static/src/img/snippets_options/header_extra_element_social.svg'"/>
-        </BuilderButton>
+            iconImg="'/website/static/src/img/snippets_options/header_extra_element_social.svg'"
+        />
     </BuilderRow>
 
     <BuilderRow label.translate="Actions" action="'websiteConfig'">
@@ -69,9 +66,8 @@
                 views: ['website.header_call_to_action'],
                 resetViewArch: true,
             }"
-        >
-            <Img src="'/website/static/src/img/snippets_options/header_extra_element_cta.svg'"/>
-        </BuilderButton>
+            iconImg="'/website/static/src/img/snippets_options/header_extra_element_cta.svg'"
+        />
     </BuilderRow>
 </t>
 


### PR DESCRIPTION
Since commit [1], some icons of the "Show/Hide Elements" buttons in the navbar option are not displayed properly; some appear in black instead of white, and one has no icon at all.

This commit fixes the issue by adapting the XML template of the options, using the "iconImg" attribute to define the image displayed in the buttons.

[1]: https://github.com/odoo/odoo/commit/cc14f919cb05ff45a1f4cd3a501a4a9c9423bdc8
