### PR TITLE
[FIX] web: trigger refresh with cache and debug mode

### DIFF
--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -86,6 +86,9 @@ export const viewService = {
             if (env.isSmall) {
                 loadViewsOptions.mobile = true;
             }
+            if (env.debug) {
+                loadViewsOptions.debug = true;
+            }
             const filteredContext = Object.fromEntries(
                 Object.entries(context || {}).filter(
                     ([k, v]) => k == "lang" || k.endsWith("_view_ref")

--- a/addons/web/static/tests/views/view.test.js
+++ b/addons/web/static/tests/views/view.test.js
@@ -1147,3 +1147,47 @@ test("react to prop 'domain' changes", async function () {
     parent.state.domain = [["type", "=", "herbivorous"]];
     await animationFrame();
 });
+
+////////////////////////////////////////////////////////////////////////////
+// cache
+////////////////////////////////////////////////////////////////////////////
+
+test("Cache: refresh with debug mode", async () => {
+    const env = await makeMockEnv();
+
+    onRpc("get_views", ({ kwargs }) => {
+        expect.step("Fetch, debug = " + !!kwargs.options.debug);
+        return {
+            models: {
+                "res.partner": {
+                    fields: {},
+                },
+            },
+            views: {},
+        };
+    });
+
+    const services = env.services;
+
+    const context = {
+        context: {},
+        resModel: "res.partner",
+        views: [],
+    };
+
+    const expected = {
+        fields: {},
+        relatedModels: {
+            "res.partner": {
+                fields: {},
+            },
+        },
+        views: {},
+    };
+
+    env.debug = "";
+    expect(await services.view.loadViews(context)).toEqual(expected);
+    env.debug = "1";
+    expect(await services.view.loadViews(context)).toEqual(expected);
+    expect.verifySteps(["Fetch, debug = false", "Fetch, debug = true"]);
+});


### PR DESCRIPTION
**Steps to reproduce:**
- Go to Calendar app
- Go to any meeting
- Invitations tab should be hidden (no debug mode)
- Trigger developer mode (`?debug=1`)
- Invitations tab should be displayed
- The tab only appears after a second refresh

**Issue:**
The new caching process uses a key based on the RPC parameters. In the
case of the 'get_views' function, it produces a different result with
the same parameters depending on whether debug mode is enabled.
This means that two browser refreshes are needed to have the correct
view.
The first refresh renders the cached view (without the invitation tab)
and updates the cache with the view returned by the RPC
(with the invitation tab). The new cached view with the invitation tab
will be rendered on the second browser refresh.

**Fix:**
Add the debug option to the RPC parameters to cache the different views
separately (with and without the invitation tab).

opw-4986038

related: https://github.com/odoo/odoo/commit/f3d955b3235cb256bda79e834df38da0f6a4ac1a