### PR TITLE
[IMP] hr_employee: added and inherited the signatory fields from template

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -402,7 +402,7 @@ class HrVersion(models.Model):
     def _get_whitelist_fields_from_template(self):
         # Add here any field that you want to copy from a contract template
         # Those fields should have tracking=True in hr.version to see the change
-        return ['job_id', 'department_id', 'contract_type_id', 'structure_type_id', 'wage', 'resource_calendar_id', 'hr_responsible_id']
+        return ['job_id', 'department_id', 'contract_type_id', 'structure_type_id', 'wage', 'resource_calendar_id', 'hr_responsible_id', 'sign_template_id', 'contract_update_template_id']
 
     def get_values_from_contract_template(self, contract_template_id):
         if not contract_template_id:


### PR DESCRIPTION
**Purpose**
- To simplify the contract management UX while ensuring functional consistency across community and enterprise.

**Changes**
See https://github.com/odoo/enterprise/pull/92644
- Removed the Signatories tab from contracts.
- Improved the employee form view for a lighter, cleaner UX.
- Moved the two fields to Settings, as they are already manageable from the offer.
- Added logic to ensure that if a contract template has custom values for these fields, they are correctly inherited when creating a new contract version.

**Impact**
- Reduced UI clutter with fewer tabs.
- Centralized configuration in Settings.
- Fixed missing inheritance of signatory fields when using contract templates.

Task: 5022734
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
