### PR TITLE
[FIX] website_sale: re-scope sidebar dropzone selector

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -44,6 +44,16 @@
             width: 0;
             height: 0;
         }
+
+        #oe_structure_website_sale_sidebar_top {
+            &:where(:not(:has(div.oe_dropzone))) .s_text_block p:only-child {
+                margin-bottom: 0;
+            }
+
+            &:where(:has(.s_text_block p:not(:only-child))) {
+                padding-top: map-get($spacers, 3);
+            }
+        }
     }
 
 
@@ -493,16 +503,6 @@
                 --_livechat-gap: calc(3vw + 80px);
 
                 right: calc(0px - calc(var(--_offset) - var(--_livechat-gap)));
-            }
-        }
-
-        & #oe_structure_website_sale_sidebar_top {
-            &:where(:not(:has(div.oe_dropzone))) .s_text_block p:only-child {
-                margin-bottom: 0;
-            }
-
-            &:where(:has(.s_text_block p:not(:only-child))) {
-                padding-top: map-get($spacers, 3);
             }
         }
     }


### PR DESCRIPTION
The SCSS applying the margin 0 on the sidebar dropzone was moved inside the wrong selector. Probably a side effect of 4502098 from auto conflict resolving.

task-5025951

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
