### PR TITLE
[FIX] payment_paymob: compare date with isoformat

### DIFF
--- a/addons/payment_paymob/models/payment_provider.py
+++ b/addons/payment_paymob/models/payment_provider.py
@@ -38,6 +38,7 @@ class PaymentProvider(models.Model):
     )
     paymob_hmac_key = fields.Char(string="Paymob HMAC Key", required_if_provider='paymob')
     paymob_api_key = fields.Char(string="Paymob API Key", required_if_provider='paymob')
+    # TODO in master, remove paymob_access_token related fields
     paymob_access_token = fields.Char(groups='base.group_system')
     paymob_access_token_expiry = fields.Datetime(default='1970-01-01', groups='base.group_system')
 
@@ -260,20 +261,15 @@ class PaymentProvider(models.Model):
         :rtype: str
         :raise ValidationError: If the access token can not be fetched.
         """
-        if not self.paymob_access_token or fields.Datetime.now() > self.paymob_access_token_expiry:
-            response_content = self._paymob_make_request(
-                '/api/auth/tokens',
-                payload={'api_key': self.paymob_api_key},
-                is_refresh_token_request=True,
-            )
-            access_token = response_content['token']
-            if not access_token:
-                raise ValidationError(_("Could not generate a new access token."))
-            self.write({
-                'paymob_access_token': access_token,
-                'paymob_access_token_expiry': fields.Datetime.now() + timedelta(minutes=55),
-            })
-        return self.paymob_access_token
+        response_content = self._paymob_make_request(
+            '/api/auth/tokens',
+            payload={'api_key': self.paymob_api_key},
+            is_refresh_token_request=True,
+        )
+        access_token = response_content['token']
+        if not access_token:
+            raise ValidationError(_("Could not generate a new access token."))
+        return access_token
 
     def _get_default_payment_method_codes(self):
         """ Override of `payment` to return the default payment method codes. """

--- a/addons/payment_paymob/models/payment_provider.py
+++ b/addons/payment_paymob/models/payment_provider.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import pprint
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import requests
 
@@ -130,7 +130,7 @@ class PaymentProvider(models.Model):
         available_payment_method_codes = self.payment_method_ids.mapped('code')
         sorted_gateways_data = sorted(
             paymob_gateways_data,
-            key=lambda x: datetime.strptime((x['created_at']), "%Y-%m-%dT%H:%M:%S.%f"),
+            key=lambda pm: datetime.fromisoformat(pm['created_at']),
             reverse=True,
         )
         matched_gateways_data = []


### PR DESCRIPTION
Previously, we assumed that the format of created_date provided by paymob was the same for all countries.

However it seems like for countries other than Egypt a timezone field is added to the date.

Therefore we switched to using 'fromisoformat' instead of 'strptime' to avoid specifying the date format if its not consistent throughout the different countries.

Also, if an access token is fetched, then it won't be invalidated when new credentials are given and it might result in faulty behavior.

Since the expiry of the access token is about 60 mins, then there is no value to storing the access token on the payment provider and can be fetched when needed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
