### PR TITLE
[IMP] website_{forum|slides_survey}: merge multiple profile tabs into one

### DIFF
--- a/addons/website_forum/static/src/interactions/website_forum_activity.js
+++ b/addons/website_forum/static/src/interactions/website_forum_activity.js
@@ -1,0 +1,43 @@
+import { registry } from "@web/core/registry";
+import { Interaction } from "@web/public/interaction";
+
+export class WebsiteProfileForumActivity extends Interaction {
+    static selector = ".o_wprofile_forum_activity";
+    dynamicContent = {
+        "#o_wprofile_forum_activity_filter li a": {
+            "t-on-click.withTarget": (ev, currentTargetEl) =>
+                this.selectTab(
+                    currentTargetEl.getAttribute("href").split("_").at(-1),
+                    currentTargetEl.text
+                ),
+        },
+        ".o_wprofile_forum_activity_search_question": {
+            "t-att-class": () => ({ "d-none": this.activeTab !== "question" }),
+        },
+        ".o_wprofile_forum_activity_search_answer": {
+            "t-att-class": () => ({ "d-none": this.activeTab !== "answer" }),
+        },
+        ".o_wprofile_forum_activity_filter_label": {
+            "t-out": () => this.activeTabLabel,
+        },
+    };
+
+    setup() {
+        const activeTab = this.el.dataset.activeTab;
+        this.selectTab(
+            activeTab,
+            document.querySelector(
+                `#o_wprofile_forum_activity_filter li a[href='#o_wprofile_forum_activity_tab_${activeTab}']`
+            ).textContent
+        );
+    }
+
+    selectTab(tab, activeTabLabel) {
+        this.activeTab = tab;
+        this.activeTabLabel = activeTabLabel;
+    }
+}
+
+registry
+    .category("public.interactions")
+    .add("website_forum.wprofile_forum_activity", WebsiteProfileForumActivity);

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -100,5 +100,112 @@ registry.category("web_tour.tours").add('forum_question', {
     }, {
         content: "Congratulations! You just created and post your first question and answer.",
         trigger: '.o_wforum_validate_toggler',
-    }]
+    },
+    {
+        content: "Close modal",
+        trigger: ".modal_shown .modal-header:contains('Thanks for posting!') button.btn-close",
+        run: "click",
+    },
+    {
+        content: "Go to profile page",
+        trigger: "aside span:contains('Marc Demo')",
+        run: "click",
+        expectUnloadPage: true,
+    },
+    {
+        content: "Open activity tab",
+        trigger: ".o_wprofile_nav_tabs a[href='#activities']",
+        run: "click",
+    },
+    {
+        content: "Check that the filter is set to 'Activity' (by default)",
+        trigger: "#o_wprofile_forum_activity_filter button:contains('Activity')",
+    },
+    {
+        content: "Check activity: new question",
+        trigger:
+            "#o_wprofile_forum_activity_tab_activity div:contains('First Question Title') span:contains('New question')",
+    },
+    {
+        content: "Check activity: question edited",
+        trigger:
+            "#o_wprofile_forum_activity_tab_activity div:contains('First Question Title') span:contains('Question edited')",
+    },
+    {
+        content: "Check activity: new answer",
+        trigger:
+            "#o_wprofile_forum_activity_tab_activity div:contains('First Question Title') span:contains('New answer')",
+    },
+    {
+        content: "Open dropdown activity filter",
+        trigger: "#o_wprofile_forum_activity_filter button",
+        run: "click",
+    },
+    {
+        content: "Select activity filter: question",
+        trigger: "#o_wprofile_forum_activity_filter a:contains('Questions')",
+        run: "click",
+    },
+    {
+        content: "Check that the filter is set to 'Question'",
+        trigger: "#o_wprofile_forum_activity_filter button:contains('Questions')",
+    },
+    {
+        content: "Check that one posted question is displayed",
+        trigger:
+            "#activities #o_wprofile_forum_activity_tab_question a:contains('First Question Title')",
+    },
+    {
+        content: "Search for 'Second'",
+        trigger:
+            ".o_wprofile_forum_activity_search_question input[name='activity_search_question']",
+        run: "edit Second",
+    },
+    {
+        content: "Submit search",
+        trigger: ".o_wprofile_forum_activity_search_question button[type='submit']",
+        run: "click",
+        expectUnloadPage: true,
+    },
+    {
+        content: "Check that the posted question is not displayed anymore",
+        trigger: "a:not(:has(.modal:contains('First Question Title')))",
+    },
+    {
+        content: "Open dropdown activity filter",
+        trigger: "#o_wprofile_forum_activity_filter button",
+        run: "click",
+    },
+    {
+        content: "Select activity filter: answer",
+        trigger: "#o_wprofile_forum_activity_filter a:contains('Answers')",
+        run: "click",
+    },
+    {
+        content: "Check that the filter is set to 'Answers'",
+        trigger: "#o_wprofile_forum_activity_filter button:contains('Answers')",
+    },
+    {
+        content: "Check posted answer",
+        trigger:
+            "#activities #o_wprofile_forum_activity_tab_answer a:contains('Re: First Question Title')",
+    },
+    {
+        content: "Search for 'First'",
+        trigger:
+            ".o_wprofile_forum_activity_search_answer input[name='activity_search_answer']",
+        run: "edit First",
+    },
+    {
+        content: "Submit search",
+        trigger: ".o_wprofile_forum_activity_search_answer button[type='submit']",
+        run: "click",
+        expectUnloadPage: true,
+    },
+    {
+        content: "Check that posted answer is still displayed",
+        trigger:
+            "#activities #o_wprofile_forum_activity_tab_answer div:contains('Re: First Question Title')",
+    },
+    ],
 });

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -168,23 +168,19 @@
             t-attf-class="badge #{'ms-1' if not question_tag_first else ''} fw-normal o_tag o_color_#{question_tag.color}"
             t-field="question_tag.name"/>
     </div>
-    <div class="ms-auto d-flex">
-        <div>
-            <span t-if="question.child_count" class="small">
-                <t t-out="question.child_count or 0"/>
-                <span class="text-muted">
-                    <t t-if="question.child_count == 1">Reply</t>
-                    <t t-else="">Replies</t>
-                </span>
+    <div class="d-flex">
+        <div t-if="question.child_count" class="ms-2">
+            <span class="small" t-out="question.child_count or 0"/>
+            <span class="text-muted small">
+                <t t-if="question.child_count == 1">Reply</t>
+                <t t-else="">Replies</t>
             </span>
         </div>
-        <div class="mx-3">
-            <span t-if="question.views" class="small">
-                <t t-out="question.views or 0"/>
-                <span class="text-muted">
-                    <t t-if="question.views == 1">View</t>
-                    <t t-else="">Views</t>
-                </span>
+        <div class="ms-2">
+            <span class="small" t-out="question.views or 0"/>
+            <span class="text-muted small">
+                <t t-if="question.views == 1">View</t>
+                <t t-else="">Views</t>
             </span>
         </div>
     </div>

--- a/addons/website_forum/views/website_profile_templates.xml
+++ b/addons/website_forum/views/website_profile_templates.xml
@@ -28,13 +28,7 @@
         <xpath expr="//ul[@id='profile_extra_info_tablist']" position="inside">
             <t t-if="forum">
                 <li class="nav-item">
-                    <a role="tab" aria-controls="questions" href="#questions" class="nav-link o_wprofile_navlink" data-bs-toggle="tab"><t t-out="count_questions"/> Questions</a>
-                </li>
-                <li class="nav-item">
-                    <a role="tab" aria-controls="answers" href="#answers" class="nav-link o_wprofile_navlink" data-bs-toggle="tab"><t t-out="count_answers"/> Answers</a>
-                </li>
-                <li t-if="uid == user.id" class="nav-item">
-                    <a role="tab" aria-controls="activity" href="#activity" class="nav-link o_wprofile_navlink" data-bs-toggle="tab">Activity</a>
+                    <a role="tab" aria-controls="activities" href="#activities" t-attf-class="#{ 'active' if active_tab == 'activities' else '' } nav-link o_wprofile_navlink" data-bs-toggle="tab">Activities</a>
                 </li>
                 <li t-if="uid == user.id" class="nav-item">
                     <a role="tab" aria-controls="votes" href="#votes" class="nav-link o_wprofile_navlink" data-bs-toggle="tab">Votes</a>
@@ -44,100 +38,138 @@
         <xpath expr="//div[@id='profile_extra_info_tabcontent']" position="inside">
             <t t-if="forum">
                 <t t-set="is_profile" t-value="true"/>
-                <div role="tabpanel" class="o_wforum_profile_tab tab-pane" id="questions">
-                    <div class="mb-4">
-                        <h5 class="border-bottom pb-1 d-flex align-items-center justify-content-between">
-                            Questions
-                            <t t-if="count_questions &gt; 0" t-call="website.website_search_box_input">
-                                <t t-set="_form_classes" t-valuef="d-flex flex-row align-items-center flex-wrap float-end"/>
-                                <t t-set="search_type" t-valuef="forums"/>
-                                <t t-if="forum_id" t-set="action" t-value="'/forum/%s%s' % (forum_id, ('/tag/%s/questions' % slug(tag)) if tag else '')"/>
-                                <t t-else="" t-set="action" t-value="'/forum/all%s' % (('/tag/%s/questions' % slug(tag)) if tag else '')"/>
-                                <t t-set="display_description" t-value="true"/>
-                                <t t-set="display_detail" t-valuef="false"/>
-                                <t t-set="placeholder" t-valuef="Search Questions..."/>
-                                <input type="hidden" name="create_uid" t-att-value="user.id"/>
-                                <input t-if="filters" type="hidden" name="filters" t-att-value="filters"/>
-                                <input t-if="my_profile" type="hidden" name="my" t-att-value="mine"/>
-                                <input t-if="sorting" type="hidden" name="sorting" t-att-value="sorting"/>
-                            </t>
-                        </h5>
-                        <t t-call="website_forum.forum_filter_tag"/>
-                        <t t-if="questions">
-                            <div class="mb-1" t-foreach="questions" t-as="question">
-                                <t t-call="website_forum.display_post"/>
+                <div role="tabpanel" t-attf-class="o_wforum_profile_tab tab-pane o_wprofile_forum_activity #{ 'show active' if active_tab == 'activities' else '' }" id="activities"
+                     t-att-data-active-tab="activities_active_tab">
+                    <h5 class="border-bottom pb-1 d-flex align-items-start align-items-md-center justify-content-between">
+                        <div>Activities</div>
+                        <div class="d-flex flex-wrap gap-1">
+                            <div class="m-auto"/>
+                            <div class="dropdown" id="o_wprofile_forum_activity_filter" role="tablist">
+                                <button class="btn btn-light dropdown-toggle" type="button" id="o_wprofile_forum_activity_filter_button"
+                                        data-bs-toggle="dropdown" aria-expanded="false">
+                                    <i class="fa fa-filter"/><span class="o_wprofile_forum_activity_filter_label ms-2"/>
+                                </button>
+                                <ul class="dropdown-menu" aria-labelledby="o_wprofile_forum_activity_filter_button">
+                                    <li t-if="uid == user.id">
+                                        <a role="tab" aria-controls="activity" href="#o_wprofile_forum_activity_tab_activity"
+                                            t-attf-class="#{ 'active' if activities_active_tab =='activity' else '' } dropdown-item o_wprofile_navlink px-3 py-2"
+                                            data-bs-toggle="tab">Activity</a>
+                                    </li>
+                                    <li>
+                                        <a role="tab" aria-controls="questions" href="#o_wprofile_forum_activity_tab_question"
+                                            t-attf-class="#{ 'active' if activities_active_tab =='question' else '' } dropdown-item o_wprofile_navlink px-3 py-2"
+                                            data-bs-toggle="tab" aria-selected="true"><t t-out="count_questions"/> Questions</a>
+                                    </li>
+                                    <li>
+                                        <a role="tab" aria-controls="answers" href="#o_wprofile_forum_activity_tab_answer"
+                                            t-attf-class="#{ 'active' if activities_active_tab =='answer' else '' } dropdown-item o_wprofile_navlink px-3 py-2"
+                                            data-bs-toggle="tab"><t t-out="count_answers"/> Answers</a>
+                                    </li>
+                                </ul>
                             </div>
-                        </t>
-                        <div t-elif="my_profile" class="text-muted">
-                            You have not posted any questions yet. <br />
-                            <a href="/forum/" class="btn btn-link px-0">
-                                <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
-                            </a>
+                            <div class="w-100 d-block d-sm-none"></div>
+                            <form method="post" class="o_wprofile_forum_activity_search_question ms-auto">
+                                <div class="input-group" role="search">
+                                    <input type="text" class="form-control oe_search_box border-0 bg-light"
+                                        name="activity_search_question" t-att-value="activity_search_question"
+                                        placeholder="Search Questions..."/>
+                                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                    <button type="submit" class="btn btn-light" aria-label="Search" title="Search">
+                                        <i class="oi oi-search"/>
+                                    </button>
+                                </div>
+                            </form>
+                            <form method="post" class="o_wprofile_forum_activity_search_answer d-none ms-auto">
+                                <div class="input-group" role="search">
+                                    <input type="text" class="form-control oe_search_box border-0 bg-light"
+                                        name="activity_search_answer" t-att-value="activity_search_answer"
+                                        placeholder="Search Answers..."/>
+                                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                    <button type="submit" class="btn btn-light" aria-label="Search" title="Search">
+                                        <i class="oi oi-search"/>
+                                    </button>
+                                </div>
+                            </form>
                         </div>
-                        <t t-else="">
-                            <div class="text-muted">This user hasn't posted any questions yet.<br/>
-                                <a href="/forum/" class="btn btn-link px-0">
-                                    <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
-                                </a>
-                            </div>
-                        </t>
-                    </div>
-                    <t t-if="favourite">
-                        <div class="mb-4">
-                            <h5 class="border-bottom pb-1">Favourite Questions</h5>
-                            <div class="mb-1" t-foreach="favourite" t-as="question">
-                                <t t-call="website_forum.display_post">
-                                    <t t-set="hide_fav_icon" t-value="True"/>
+
+                    </h5>
+                    <t t-call="website_forum.forum_filter_tag"/>
+
+                    <div class="tab-content mt-2" id="profile_extra_info_tabcontent_activities">
+                        <div role="tabpanel" t-attf-class="#{ 'show active' if activities_active_tab =='question' else '' } o_wforum_profile_tab tab-pane" id="o_wprofile_forum_activity_tab_question">
+                            <div class="mb-4">
+                                <t t-if="questions">
+                                    <div class="mb-1" t-foreach="questions" t-as="question">
+                                        <t t-call="website_forum.display_post"/>
+                                    </div>
+                                </t>
+                                <div t-elif="my_profile" class="text-muted">
+                                    <t t-if="activity_search_question">No results.</t>
+                                    <t t-else="">You have not posted any questions yet.</t>
+                                    <br />
+                                    <a href="/forum/" class="btn btn-link px-0">
+                                        <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
+                                    </a>
+                                </div>
+                                <t t-else="">
+                                    <div class="text-muted">
+                                        <t t-if="activity_search_question">No results.</t>
+                                        <t t-else="">This user hasn't posted any questions yet.</t>
+                                        <br/>
+                                        <a href="/forum/" class="btn btn-link px-0">
+                                            <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
+                                        </a>
+                                    </div>
                                 </t>
                             </div>
-                        </div>
-                    </t>
-                    <t t-if="followed">
-                        <div class="mb-4">
-                            <h5 class="border-bottom pb-1">Followed Questions</h5>
-                            <div class="mb-1" t-foreach="followed" t-as="question">
-                                <t t-call="website_forum.display_post"/>
-                            </div>
-                        </div>
-                    </t>
-                </div>
-                <div role="tabpanel" class="o_wforum_profile_tab tab-pane" id="answers">
-                    <div class="mb-4">
-                        <h5 class="border-bottom pb-1 d-flex align-items-center justify-content-between">
-                            Answers
-                            <t t-if="count_questions &gt; 0" t-call="website.website_search_box_input">
-                                <t t-set="_form_classes" t-valuef="d-flex flex-row align-items-center flex-wrap float-end"/>
-                                <t t-set="search_type" t-valuef="forums"/>
-                                <t t-if="forum_id" t-set="action" t-value="'/forum/%s%s' % (forum_id, '/tag/%s/questions' % slug(tag)) if tag else ''"/>
-                                <t t-else="" t-set="action" t-value="'/forum/all%s' % (('/tag/%s/questions' % slug(tag)) if tag else '')"/>
-                                <t t-set="display_description" t-value="true"/>
-                                <t t-set="display_detail" t-valuef="false"/>
-                                <t t-set="placeholder" t-valuef="Search Answers..."/>
-                                <input type="hidden" name="author" t-att-value="user.id"/>
-                                <input t-if="filters" type="hidden" name="filters" t-att-value="filters"/>
-                                <input t-if="my_profile" type="hidden" name="my" t-att-value="mine"/>
-                                <input t-if="sorting" type="hidden" name="sorting" t-att-value="sorting"/>
-                                <input type="hidden" name="include_answers" t-att-value="True"/>
+                            <t t-if="favourite">
+                                <div class="mb-4">
+                                    <h5 class="border-bottom pb-1">Favourite Questions</h5>
+                                    <div class="mb-1" t-foreach="favourite" t-as="question">
+                                        <t t-call="website_forum.display_post">
+                                            <t t-set="hide_fav_icon" t-value="True"/>
+                                        </t>
+                                    </div>
+                                </div>
                             </t>
-                        </h5>
-                        <t t-call="website_forum.forum_filter_tag"/>
-
-                        <t t-if="answers">
-                            <div class="mb-1" t-foreach="answers" t-as="answer">
-                                <t t-call="website_forum.display_post_answer"/>
-                            </div>
-                        </t>
-                        <div t-elif="my_profile" class="text-muted">
-                            You have not answered any questions yet. <br />
-                            <a href="/forum/" class="btn btn-link px-0">
-                                <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
-                            </a>
+                            <t t-if="followed">
+                                <div class="mb-4">
+                                    <h5 class="border-bottom pb-1">Followed Questions</h5>
+                                    <div class="mb-1" t-foreach="followed" t-as="question">
+                                        <t t-call="website_forum.display_post"/>
+                                    </div>
+                                </div>
+                            </t>
                         </div>
-                        <div t-else="" class="text-muted">
-                            This user hasn't answered any questions yet. <br/>
-                            <a href="/forum/" class="btn btn-link px-0">
-                                <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
-                            </a>
+                        <div role="tabpanel" t-attf-class="#{ 'show active' if activities_active_tab =='answer' else '' } o_wforum_profile_tab tab-pane" id="o_wprofile_forum_activity_tab_answer">
+                            <div class="mb-4">
+                                <t t-if="answers">
+                                    <div class="mb-1" t-foreach="answers" t-as="answer">
+                                        <t t-call="website_forum.display_post_answer"/>
+                                    </div>
+                                </t>
+                                <div t-elif="my_profile" class="text-muted">
+                                    <t t-if="activity_search_answer">No results.</t>
+                                    <t t-else="">You have not answered any questions yet.</t>
+                                    <br />
+                                    <a href="/forum/" class="btn btn-link px-0">
+                                        <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
+                                    </a>
+                                </div>
+                                <div t-else="" class="text-muted">
+                                    <t t-if="activity_search_answer">No results.</t>
+                                    <t t-else="">This user hasn't answered any questions yet.</t>
+                                    <br/>
+                                    <a href="/forum/" class="btn btn-link px-0">
+                                        <i class="oi oi-arrow-right d-inline-block"/> Go to Forums
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                        <div t-if="uid == user.id" role="tabpanel" t-attf-class="#{ 'show active' if activities_active_tab =='activity' else '' } o_wforum_profile_tab tab-pane" id="o_wprofile_forum_activity_tab_activity">
+                            <div class="mb-4">
+                                <t t-call="website_forum.display_activities"/>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -160,15 +192,6 @@
                         </h5>
                         <t t-call="website_forum.forum_filter_tag"/>
                         <t t-call="website_forum.user_votes"/>
-                    </div>
-                </div>
-                <div role="tabpanel" class="o_wforum_profile_tab tab-pane" id="activity" t-if="uid == user.id">
-                    <div class="mb-4">
-                        <h5 class="border-bottom pb-1 d-flex align-items-center justify-content-between" style="height:43px;">
-                            Activities
-                        </h5>
-                        <t t-call="website_forum.forum_filter_tag"/>
-                        <t t-call="website_forum.display_activities"/>
                     </div>
                 </div>
             </t>

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -21,12 +21,13 @@
             <div t-if="show_certification_tab" role="tabpanel" t-attf-class="tab-pane #{ 'show active' if active_tab == 'certification' else '' }" id="profile_tab_content_certification">
                 <h5 class="d-flex justify-content-between align-items-end border-bottom pb-1">
                     Certification Attempts
-                    <form method="get">
+                    <form method="post">
                         <div class="input-group" role="search">
-                            <input type="text" class="form-control" name="certification_search" t-att-value="certification_search_terms or ''" placeholder="Search Attempts..."/>
+                            <input type="text" class="form-control oe_search_box border-0 bg-light" name="certification_search" t-att-value="certification_search_terms or ''" placeholder="Search Attempts..."/>
+                            <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                             <div class="input-group-append">
-                                <button type="submit" class="btn btn-primary" aria-label="Search" title="Search">
-                                    <i class="fa fa-search"/>
+                                <button type="submit" class="btn btn-light" aria-label="Search" title="Search">
+                                    <i class="oi oi-search"/>
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
We merge the profile tabs questions, answers and activities into one (activities).
And within this new tab, the users can now filter their questions and answers without leaving the profile page instead of being redirected to the forum.

Technical notes:
- the boostrap tabs (questions, answers and activities) are controlled by a dropdown. But as the bootstrap dropdown has no label by default, we use a widget to set it. That same widget also display the corresponding search field (respectively either question search, answer search or nothing).
- we use post for the search form to keep the URL parameters (ex.: forum_id).

Task-3893028