### PR TITLE
[IMP] mail,*: do not use return value of store.insert

### DIFF
--- a/addons/account/tests/test_portal_attachment.py
+++ b/addons/account/tests/test_portal_attachment.py
@@ -64,7 +64,10 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
                 files={"ufile": file},
             )
         self.assertEqual(res.status_code, 200)
-        create_res = json.loads(res.content.decode('utf-8'))['data']['ir.attachment'][0]
+        data = json.loads(res.content.decode('utf-8'))['data']
+        create_res = next(
+            filter(lambda a: a["id"] == data["attachment_id"], data["store_data"]["ir.attachment"])
+        )
         self.assertTrue(self.env['ir.attachment'].sudo().search([('id', '=', create_res['id'])]))
 
         # Test created attachment is private
@@ -91,7 +94,10 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
             files={"ufile": ("test.svg", b'<svg></svg>', "image/svg+xml")},
         )
         self.assertEqual(res.status_code, 200)
-        create_res = json.loads(res.content.decode('utf-8'))['data']['ir.attachment'][0]
+        data = json.loads(res.content.decode('utf-8'))["data"]
+        create_res = next(
+            filter(lambda a: a["id"] == data["attachment_id"], data["store_data"]["ir.attachment"])
+        )
         self.assertEqual(create_res['mimetype'], 'text/plain')
 
         res_binary = self.url_open(
@@ -287,7 +293,10 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
             files={"ufile": ("final attachment", b'test', "plain/text")},
         )
         self.assertEqual(res.status_code, 200)
-        create_res = json.loads(res.content.decode('utf-8'))['data']['ir.attachment'][0]
+        data = json.loads(res.content.decode('utf-8'))['data']
+        create_res = next(
+            filter(lambda a: a["id"] == data["attachment_id"], data["store_data"]["ir.attachment"])
+        )
         self.assertEqual(create_res['name'], "final attachment")
 
         res = self.url_open(

--- a/addons/cloud_storage/controllers/attachment.py
+++ b/addons/cloud_storage/controllers/attachment.py
@@ -27,6 +27,6 @@ class CloudAttachmentController(AttachmentController):
 
         # append upload url to the response to allow the client to directly
         # upload files to the cloud storage
-        attachment = request.env["ir.attachment"].browse(data["data"]["ir.attachment"][0]["id"]).sudo()
+        attachment = request.env["ir.attachment"].browse(data["data"]["attachment_id"]).sudo()
         data["upload_info"] = attachment._generate_cloud_storage_upload_info()
         return request.make_json_response(data)

--- a/addons/cloud_storage/static/src/core/common/attachment_upload_service_patch.js
+++ b/addons/cloud_storage/static/src/core/common/attachment_upload_service_patch.js
@@ -8,7 +8,7 @@ patch(AttachmentUploadService.prototype, {
     setup(env, services) {
         super.setup(env, services);
         this.uploadingCloudFiles = new Map();
-        window.addEventListener('beforeunload', () => 
+        window.addEventListener('beforeunload', () =>
             this.abortByAttachmentId.forEach(abort => abort())
         );
     },
@@ -19,9 +19,10 @@ patch(AttachmentUploadService.prototype, {
             return;
         }
         const removeAttachment = () => {
-            const { "ir.attachment": attachments } = this.store.insert(data);
+            const { store_data, attachment_id } = data;
+            this.store.insert(store_data);
             /** @type {import("models").Attachment} */
-            const attachment = attachments[0];
+            const attachment = this.store["ir.attachment"].get(attachment_id);
             attachment.remove();
         }
         const xhr = new window.XMLHttpRequest();

--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
@@ -54,25 +54,28 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                     json.loads(content),
                     {
                         "data": {
-                            "ir.attachment": [
-                                {
-                                    "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-                                    "create_date": odoo.fields.Datetime.to_string(
-                                        attachment.create_date
-                                    ),
-                                    "file_size": 0,
-                                    "id": attachment.id,
-                                    "mimetype": "text/x-python",
-                                    "name": "__init__.py",
-                                    "ownership_token": attachment._get_ownership_token(),
-                                    "raw_access_token": attachment._get_raw_access_token(),
-                                    "res_name": False,
-                                    "thread": False,
-                                    "voice": False,
-                                    "type": "cloud_storage",
-                                    "url": "[url]",
-                                }
-                            ],
+                            "attachment_id": attachment.id,
+                            "store_data": {
+                                "ir.attachment": [
+                                    {
+                                        "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                                        "create_date": odoo.fields.Datetime.to_string(
+                                            attachment.create_date
+                                        ),
+                                        "file_size": 0,
+                                        "id": attachment.id,
+                                        "mimetype": "text/x-python",
+                                        "name": "__init__.py",
+                                        "ownership_token": attachment._get_ownership_token(),
+                                        "raw_access_token": attachment._get_raw_access_token(),
+                                        "res_name": False,
+                                        "thread": False,
+                                        "voice": False,
+                                        "type": "cloud_storage",
+                                        "url": "[url]",
+                                    }
+                                ],
+                            }
                         },
                         "upload_info": {
                             "headers": {"x-ms-blob-type": "BlockBlob"},

--- a/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
+++ b/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
@@ -39,25 +39,28 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                 json.loads(content),
                 {
                     "data": {
-                        "ir.attachment": [
-                            {
-                                "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-                                "create_date": odoo.fields.Datetime.to_string(
-                                    attachment.create_date
-                                ),
-                                "file_size": 0,
-                                "id": attachment.id,
-                                "mimetype": "text/x-python",
-                                "name": "__init__.py",
-                                "ownership_token": attachment._get_ownership_token(),
-                                "raw_access_token": attachment._get_raw_access_token(),
-                                "res_name": False,
-                                "thread": False,
-                                "voice": False,
-                                "type": "cloud_storage",
-                                "url": "[url]",
-                            }
-                        ],
+                        "attachment_id": attachment.id,
+                        "store_data": {
+                            "ir.attachment": [
+                                {
+                                    "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                                    "create_date": odoo.fields.Datetime.to_string(
+                                        attachment.create_date
+                                    ),
+                                    "file_size": 0,
+                                    "id": attachment.id,
+                                    "mimetype": "text/x-python",
+                                    "name": "__init__.py",
+                                    "ownership_token": attachment._get_ownership_token(),
+                                    "raw_access_token": attachment._get_raw_access_token(),
+                                    "res_name": False,
+                                    "thread": False,
+                                    "voice": False,
+                                    "type": "cloud_storage",
+                                    "url": "[url]",
+                                }
+                            ],
+                        },
                     },
                     "upload_info": {"method": "PUT", "response_status": 200, "url": "[url]"},
                 },

--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -152,16 +152,15 @@ export class Chatbot extends Record {
             return;
         }
         if (this.steps.at(-1)?.eq(this.currentStep)) {
-            const storeData = await rpc("/chatbot/step/trigger", {
+            const res = await rpc("/chatbot/step/trigger", {
                 channel_id: this.thread.id,
                 chatbot_script_id: this.script.id,
             });
-            if (!storeData) {
+            if (!res) {
                 this.currentStep.isLast = true;
                 return;
             }
-            const { ChatbotStep: steps } = this.store.insert(storeData);
-            this.steps.push(steps[0]);
+            this.store.insert(res);
         } else {
             const nextStepIndex = this.steps.lastIndexOf(this.currentStep) + 1;
             this.currentStep = this.steps[nextStepIndex];
@@ -276,12 +275,7 @@ export class Chatbot extends Record {
         const { success, data } = await rpc("/chatbot/step/validate_email", {
             channel_id: this.thread.id,
         });
-        const { "mail.message": messages = [] } = this.store.insert(data);
-        /** @type {import("models").Message} */
-        const message = messages[0];
-        if (message) {
-            this.thread.messages.add(message);
-        }
+        this.store.insert(data);
         return success;
     }
 }

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -159,7 +159,7 @@ class ChatbotCase(common.HttpCase):
                 "/chatbot/step/validate_email", {"channel_id": discuss_channel.id}
             )
         if chatbot_script_answer:
-            message = self.env["mail.message"].browse(data["mail.message"][0]["id"])
+            message = self.env["mail.message"].browse(data["message_id"])
             self.make_jsonrpc_request(
                 "/chatbot/answer/save",
                 {

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -301,7 +301,14 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             data = self.make_jsonrpc_request(
                 "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
             )
-            discuss_channels.append(data["store_data"]["discuss.channel"][0])
+            discuss_channels.append(
+                next(
+                    filter(
+                        lambda c: c["id"] == data["channel_id"],
+                        data["store_data"]["discuss.channel"],
+                    )
+                )
+            )
             # send a message to mark this channel as 'active'
             self.env["discuss.channel"].browse(data["channel_id"]).message_post(body="cc")
         return discuss_channels

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -66,7 +66,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                 "persisted": True,
             },
         )
-        discuss_channel = self.env['discuss.channel'].browse(data["store_data"]["discuss.channel"][0]["id"])
+        discuss_channel = self.env['discuss.channel'].browse(data["channel_id"])
         self._post_answer_and_trigger_next_step(
             discuss_channel,
             self.step_dispatch_buy_software.name,

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -73,7 +73,7 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
                 "livechat_channel_id": livechat_channel.id,
             }
         )
-        data = operator.partner_id.with_user(operator).search_for_channel_invite("fr_FR", channel.id)["data"]
+        data = operator.partner_id.with_user(operator).search_for_channel_invite("fr_FR", channel.id)["store_data"]
         john_data = next(filter(lambda partner: partner["id"] == john.partner_id.id, data["res.partner"]))
         self.assertEqual(
             john_data["user_livechat_username"],

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -69,10 +69,14 @@ class AttachmentController(ThreadController):
             attachment = request.env["ir.attachment"].sudo().create(vals)
             attachment._post_add_create(**kwargs)
             res = {
-                "data": Store().add(
-                    attachment,
-                    extra_fields=request.env["ir.attachment"]._get_store_ownership_fields(),
-                ).get_result()
+                "data": {
+
+                    "store_data": Store().add(
+                        attachment,
+                        extra_fields=request.env["ir.attachment"]._get_store_ownership_fields(),
+                    ).get_result(),
+                    "attachment_id": attachment.id,
+                }
             }
         except AccessError:
             res = {"error": _("You are not allowed to upload an attachment here.")}

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -175,7 +175,11 @@ class ChannelController(http.Controller):
             domain.append(["id", "<", before])
         # sudo: ir.attachment - reading attachments of a channel that the current user can access
         attachments = request.env["ir.attachment"].sudo().search(domain, limit=limit, order="id DESC")
-        return Store().add(attachments).get_result()
+        return {
+
+            "store_data": Store().add(attachments).get_result(),
+            "count": len(attachments),
+        }
 
     @http.route("/discuss/channel/join", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
@@ -192,7 +196,7 @@ class ChannelController(http.Controller):
         if not channel:
             raise NotFound()
         sub_channel = channel._create_sub_channel(from_message_id, name)
-        return {"data": Store().add(sub_channel).get_result(), "sub_channel": sub_channel.id}
+        return {"store_data": Store().add(sub_channel).get_result(), "sub_channel": sub_channel.id}
 
     @http.route("/discuss/channel/sub_channel/fetch", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
@@ -206,4 +210,7 @@ class ChannelController(http.Controller):
         if search_term:
             domain.append(("name", "ilike", search_term))
         sub_channels = request.env["discuss.channel"].search(domain, order="id desc", limit=limit)
-        return Store().add(sub_channels).add(sub_channels._get_last_messages()).get_result()
+        return {
+            "store_data": Store().add(sub_channels).add(sub_channels._get_last_messages()).get_result(),
+            "sub_channel_ids": sub_channels.ids,
+        }

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -230,7 +230,10 @@ class ThreadController(http.Controller):
         message = thread.sudo().message_post(
             **self._prepare_message_data(post_data, thread=thread, from_create=True, **kwargs),
         )
-        return store.add(message).get_result()
+        return {
+            "store_data": store.add(message).get_result(),
+            "message_id": message.id,
+        }
 
     @http.route("/mail/message/update_content", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3316,12 +3316,19 @@ class MailThread(models.AbstractModel):
                 ]
             )
             for user in users:
-                Store(bus_channel=user).add(
+                store = Store(bus_channel=user).add(
                     message.with_user(user).with_context(allowed_company_ids=[]),
                     msg_vals=msg_vals,
                     add_followers=True,
                     followers=followers,
-                ).bus_send("mail.message/inbox")
+                )
+                user._bus_send(
+                    "mail.message/inbox",
+                    {
+                        "message_id": message.id,
+                        "store_data": store.get_result(),
+                    }
+                )
 
     def _notify_thread_by_email(self, message, recipients_data, *, msg_vals=False,
                                 mail_auto_delete=True,  # mail.mail

--- a/addons/mail/static/src/core/common/attachment_upload_service.js
+++ b/addons/mail/static/src/core/common/attachment_upload_service.js
@@ -85,9 +85,10 @@ export class AttachmentUploadService {
     }
 
     _processLoaded(thread, composer, { data }, tmpId, def) {
-        const { "ir.attachment": attachments } = this.store.insert(data);
+        const { store_data, attachment_id } = data;
+        this.store.insert(store_data);
         /** @type {import("models").Attachment} */
-        const attachment = attachments[0];
+        const attachment = this.store["ir.attachment"].get(attachment_id);
         if (composer) {
             const index = composer.attachments.findIndex(({ id }) => id === tmpId);
             if (index >= 0) {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -848,9 +848,9 @@ export class Thread extends Record {
         if (!data) {
             return;
         }
-        const { "mail.message": messages = [] } = this.store.insert(data);
+        this.store.insert(data.store_data);
         /** @type {import("models").Message} */
-        const message = messages[0];
+        const message = this.store["mail.message"].get(data.message_id);
         this.addOrReplaceMessage(message, tmpMsg);
         this.onNewSelfMessage(message);
         // Only delete the temporary message now that seen_message_id is updated

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -37,9 +37,10 @@ export class MailCoreWeb {
             }
         });
         this.busService.subscribe("mail.message/inbox", (payload, { id: notifId }) => {
-            const { "mail.message": messages = [] } = this.store.insert(payload);
+            const { message_id: messageId, store_data } = payload;
+            this.store.insert(store_data);
             /** @type {import("models").Message} */
-            const message = messages[0];
+            const message = this.store["mail.message"].get(messageId);
             const inbox = this.store.inbox;
             if (notifId > inbox.counter_bus_id) {
                 inbox.counter++;

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -121,7 +121,10 @@ export class ChannelInvitation extends Component {
         if (!results) {
             return;
         }
-        const { "res.partner": selectablePartners = [] } = this.store.insert(results.data);
+        this.store.insert(results.store_data);
+        const selectablePartners = results.partner_ids.map((id) =>
+            this.store["res.partner"].get(id)
+        );
         this.selectablePartners = this.suggestionService.sortPartnerSuggestions(
             selectablePartners,
             this.searchStr,

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -321,8 +321,8 @@ const threadPatch = {
                 channel_id: this.id,
                 limit,
             });
-            const { "ir.attachment": attachments = [] } = this.store.insert(data);
-            if (attachments.length < limit) {
+            this.store.insert(data.store_data);
+            if (data.count < limit) {
                 this.areAttachmentsLoaded = true;
             }
         } finally {

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -199,8 +199,7 @@ export class Store extends Record {
     insert(dataByModelName = {}, options = {}) {
         const store = this;
         const ctx = storeInsertFns.makeContext(store);
-        return Record.MAKE_UPDATE(function storeInsert() {
-            const res = {};
+        Record.MAKE_UPDATE(function storeInsert() {
             const recordsDataToDelete = [];
             for (const [pyOrJsModelName, data] of Object.entries(dataByModelName)) {
                 const modelName = storeInsertFns.getActualModelName(store, ctx, pyOrJsModelName);
@@ -224,20 +223,13 @@ export class Store extends Record {
                         insertData.push(vals);
                     }
                 }
-                const records = store[modelName].insert(insertData, options);
-                if (!res[modelName]) {
-                    res[modelName] = records;
-                } else {
-                    const knownRecordIds = new Set(res[modelName].map((r) => r.localId));
-                    res[modelName].push(...records.filter((r) => !knownRecordIds.has(r.localId)));
-                }
+                store[modelName].insert(insertData, options);
             }
             // Delete after all inserts to make sure a relation potentially registered before the
             // delete doesn't re-add the deleted record by mistake.
             for (const [modelName, vals] of recordsDataToDelete) {
                 store[modelName].get(vals)?.delete();
             }
-            return res;
         });
     }
     onChange(record, name, cb) {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -490,14 +490,13 @@ test("receive new needaction messages", async () => {
         res_partner_id: serverState.partnerId,
     });
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
-    pyEnv["bus.bus"]._sendone(
-        partner,
-        "mail.message/inbox",
-        new mailDataHelpers.Store(
+    pyEnv["bus.bus"]._sendone(partner, "mail.message/inbox", {
+        message_id: messageId_1,
+        store_data: new mailDataHelpers.Store(
             pyEnv["mail.message"].browse(messageId_1),
             makeKwArgs({ for_current_user: true, add_followers: true })
-        ).get_result()
-    );
+        ).get_result(),
+    });
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     await contains(".o-mail-Message");
     await contains(".o-mail-Message-content", { text: "not empty 1" });
@@ -515,14 +514,13 @@ test("receive new needaction messages", async () => {
         notification_type: "inbox",
         res_partner_id: serverState.partnerId,
     });
-    pyEnv["bus.bus"]._sendone(
-        partner,
-        "mail.message/inbox",
-        new mailDataHelpers.Store(
+    pyEnv["bus.bus"]._sendone(partner, "mail.message/inbox", {
+        message_id: messageId_2,
+        store_data: new mailDataHelpers.Store(
             pyEnv["mail.message"].browse(messageId_2),
             makeKwArgs({ for_current_user: true, add_followers: true })
-        ).get_result()
-    );
+        ).get_result(),
+    });
     await contains("button", { text: "Inbox", contains: [".badge", { text: "2" }] });
     await contains(".o-mail-Message", { count: 2 });
     await contains(".o-mail-Message-content", { text: "not empty 1" });
@@ -549,14 +547,13 @@ test("receive a message that is not linked to thread", async () => {
         res_partner_id: serverState.partnerId,
     });
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
-    pyEnv["bus.bus"]._sendone(
-        partner,
-        "mail.message/inbox",
-        new mailDataHelpers.Store(
+    pyEnv["bus.bus"]._sendone(partner, "mail.message/inbox", {
+        message_id: messageId_1,
+        store_data: new mailDataHelpers.Store(
             pyEnv["mail.message"].browse(messageId_1),
             makeKwArgs({ for_current_user: true, add_followers: true })
-        ).get_result()
-    );
+        ).get_result(),
+    });
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     await contains(".o-mail-Message");
     await contains(".o-mail-Message-content", { text: "needaction message" });

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -1175,14 +1175,13 @@ test("messaging menu should show new needaction messages from chatter", async ()
         res_partner_id: serverState.partnerId,
     });
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
-    pyEnv["bus.bus"]._sendone(
-        partner,
-        "mail.message/inbox",
-        new mailDataHelpers.Store(
+    pyEnv["bus.bus"]._sendone(partner, "mail.message/inbox", {
+        message_id: messageId,
+        store_data: new mailDataHelpers.Store(
             pyEnv["mail.message"].browse(messageId),
             makeKwArgs({ for_current_user: true, add_followers: true })
-        ).get_result()
-    );
+        ).get_result(),
+    });
     await contains(".o-mail-NotificationItem-text", { text: "Frodo Baggins: @Mitchel Admin" });
 });
 

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -133,7 +133,10 @@ async function mail_attachment_upload(request) {
         DiscussVoiceMetadata.create({ attachment_id: attachmentId });
     }
     return {
-        data: new mailDataHelpers.Store(IrAttachment.browse(attachmentId)).get_result(),
+        data: {
+            attachment_id: attachmentId,
+            store_data: new mailDataHelpers.Store(IrAttachment.browse(attachmentId)).get_result(),
+        },
     };
 }
 
@@ -175,7 +178,10 @@ async function load_attachments(request) {
         .sort()
         .slice(0, limit)
         .map(({ id }) => id);
-    return new mailDataHelpers.Store(IrAttachment.browse(attachmentIds)).get_result();
+    return {
+        count: attachmentIds.length,
+        store_data: new mailDataHelpers.Store(IrAttachment.browse(attachmentIds)).get_result(),
+    };
 }
 
 registerRoute("/mail/rtc/channel/join_call", channel_call_join);
@@ -340,7 +346,10 @@ async function discuss_channel_sub_channel_fetch(request) {
         }
     }
     store.add(MailMessage.browse(lastMessageIds));
-    return store.get_result();
+    return {
+        store_data: store.get_result(),
+        sub_channel_ids: subChannels,
+    };
 }
 
 registerRoute("/discuss/settings/mute", discuss_settings_mute);
@@ -668,10 +677,13 @@ export async function mail_message_post(request) {
             model: thread_model,
         });
     }
-    return new mailDataHelpers.Store(
-        MailMessage.browse(messageIds[0]),
-        makeKwArgs({ for_current_user: true })
-    ).get_result();
+    return {
+        message_id: messageIds[0],
+        store_data: new mailDataHelpers.Store(
+            MailMessage.browse(messageIds[0]),
+            makeKwArgs({ for_current_user: true })
+        ).get_result(),
+    };
 }
 
 registerRoute("/mail/message/reaction", mail_message_reaction);

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -638,7 +638,7 @@ export class DiscussChannel extends models.ServerModel {
             })
         );
         return {
-            data: store.get_result(),
+            store_data: store.get_result(),
             sub_channel: subChannels[0].id,
         };
     }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -481,10 +481,13 @@ export class MailThread extends models.ServerModel {
                         notifications.push([
                             partner,
                             "mail.message/inbox",
-                            new mailDataHelpers.Store(
-                                MailMessage.browse(message.id),
-                                makeKwArgs({ for_current_user: true, add_followers: true })
-                            ).get_result(),
+                            {
+                                message_id: message.id,
+                                store_data: new mailDataHelpers.Store(
+                                    MailMessage.browse(message.id),
+                                    makeKwArgs({ for_current_user: true, add_followers: true })
+                                ).get_result(),
+                            },
                         ]);
                     }
                 }

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -333,13 +333,13 @@ export class ResPartner extends webModels.ResPartner {
     search_for_channel_invite(search_term, channel_id, limit = 30) {
         const kwargs = getKwArgs(arguments, "search_term", "channel_id", "limit");
         const store = new mailDataHelpers.Store();
-        const count = this._search_for_channel_invite(
+        const channel_invites = this._search_for_channel_invite(
             store,
             kwargs.search_term,
             kwargs.channel_id,
             kwargs.limit
         );
-        return { count: count, data: store.get_result() };
+        return { store_data: store.get_result(), ...channel_invites };
     }
 
     /**
@@ -392,11 +392,20 @@ export class ResPartner extends webModels.ResPartner {
                 }
                 return false;
             })
-            .map((user) => user.partner_id);
+            .map((user) => user.partner_id)
+            .reduce((ids, partnerId) => {
+                if (!ids.includes(partnerId)) {
+                    ids.push(partnerId);
+                }
+                return ids;
+            }, []);
         const count = matchingPartnersIds.length;
         matchingPartnersIds.length = Math.min(count, limit);
         this._search_for_channel_invite_to_store(matchingPartnersIds, store, channel_id);
-        return count;
+        return {
+            count,
+            partner_ids: matchingPartnersIds,
+        };
     }
 
     _search_for_channel_invite_to_store(ids, store, channel_id) {

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -756,14 +756,13 @@ test("Opening thread with needaction messages should mark all messages of thread
     });
     // simulate receiving a new needaction message
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
-    pyEnv["bus.bus"]._sendone(
-        partner,
-        "mail.message/inbox",
-        new mailDataHelpers.Store(
+    pyEnv["bus.bus"]._sendone(partner, "mail.message/inbox", {
+        message_id: messageId,
+        store_data: new mailDataHelpers.Store(
             pyEnv["mail.message"].browse(messageId),
             makeKwArgs({ for_current_user: true, add_followers: true })
-        ).get_result()
-    );
+        ).get_result(),
+    });
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     await click("button", { text: "General" });
     await contains(".o-discuss-badge", { count: 0 });

--- a/addons/mail/tests/common_controllers.py
+++ b/addons/mail/tests/common_controllers.py
@@ -148,7 +148,12 @@ class MailControllerAttachmentCommon(MailControllerCommon):
                 files={"ufile": file},
             )
             res.raise_for_status()
-            return json.loads(res.content.decode("utf-8"))["data"]["ir.attachment"][0]["id"]
+            data = json.loads(res.content.decode("utf-8"))["data"]
+            self.assertIn(
+                data["attachment_id"],
+                [a["id"] for a in data["store_data"]["ir.attachment"]]
+            )
+            return data["attachment_id"]
 
     def _delete_attachment(self, attachment, token):
         with mute_logger("odoo.http"):

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -223,7 +223,7 @@ class TestDiscussChannelMember(MailCommon):
         self.public_channel._add_members(guests=guest)
         data = self.env["res.partner"].search_for_channel_invite(
             partner.name, channel_id=self.public_channel.id
-        )["data"]
+        )["store_data"]
         self.assertEqual(len(data["res.partner"]), 1)
         self.assertEqual(data["res.partner"][0]["id"], partner.id)
 

--- a/addons/mail/tests/discuss/test_discuss_res_role.py
+++ b/addons/mail/tests/discuss/test_discuss_res_role.py
@@ -51,7 +51,8 @@ class TestDiscussResRole(TestResRole):
                     },
                 )
                 formatted_partner = user.partner_id.id
+                message = next(filter(lambda m: m["id"] == data["message_id"], data["store_data"]["mail.message"]))
                 if mentionned:
-                    self.assertIn(formatted_partner, data["mail.message"][0]["partner_ids"])
+                    self.assertIn(formatted_partner, message["partner_ids"])
                 else:
-                    self.assertNotIn(formatted_partner, data["mail.message"][0]["partner_ids"])
+                    self.assertNotIn(formatted_partner, message["partner_ids"])

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -95,7 +95,7 @@ class TestMessageController(HttpCaseWithUserDemo):
         self.assertEqual(res2.status_code, 200)
         data1 = res2.json()["result"]
         self.assertEqual(
-            data1["ir.attachment"],
+            data1["store_data"]["ir.attachment"],
             [
                 {
                     "checksum": False,
@@ -121,7 +121,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "message_id": data1["mail.message"][0]["id"],
+                        "message_id": data1["message_id"],
                         "update_data": {
                             "body": "test",
                             "attachment_ids": [self.attachments[1].id],
@@ -144,7 +144,7 @@ class TestMessageController(HttpCaseWithUserDemo):
             data=json.dumps(
                 {
                     "params": {
-                        "message_id": data1["mail.message"][0]["id"],
+                        "message_id": data1["message_id"],
                         "update_data": {
                             "body": "test",
                             "attachment_ids": [self.attachments[1].id],

--- a/addons/mail/tests/test_res_role.py
+++ b/addons/mail/tests/test_res_role.py
@@ -53,7 +53,8 @@ class TestResRole(MailCommon, HttpCase):
                     },
                 },
             )
+            message = next(filter(lambda m: m["id"] == data["message_id"], data["store_data"]["mail.message"]))
             self.assertEqual(
-                data["mail.message"][0]["partner_ids"],
+                message["partner_ids"],
                 expected_users.partner_id.ids
             )

--- a/addons/portal/static/src/interactions/portal_composer.js
+++ b/addons/portal/static/src/interactions/portal_composer.js
@@ -122,7 +122,10 @@ export class PortalComposer extends Interaction {
                             }
                             this.waitFor(post("/mail/attachment/upload", data))
                                 .then((res) => {
-                                    const attachment = res.data["ir.attachment"][0];
+                                    const attachmentId = res.data["attachment_id"];
+                                    const attachment = res.data["store_data"]["ir.attachment"].find(
+                                        (att) => att.id === attachmentId
+                                    );
                                     attachment.state = "pending";
                                     this.attachments.push(attachment);
                                     this.updateAttachments();
@@ -207,8 +210,9 @@ export class PortalComposer extends Interaction {
      */
     async chatterPostMessage(route) {
         const result = await this.waitFor(rpc(route, this.prepareMessageData()));
-        Component.env.bus.trigger("reload_chatter_content", result);
-        return result;
+        const res = result.store_data || result;
+        Component.env.bus.trigger("reload_chatter_content", res);
+        return res;
     }
 }
 

--- a/addons/test_mail/tests/test_controller_thread.py
+++ b/addons/test_mail/tests/test_controller_thread.py
@@ -151,7 +151,8 @@ class TestMessageController(MailControllerThreadCommon):
                 "body": "A great message",
             }
         })
-        self.assertEqual(["markup", "<p>A great message</p>"], data["mail.message"][0]["body"])
+        message = next(filter(lambda m: m["id"] == data["message_id"], data["store_data"]["mail.message"]))
+        self.assertEqual(["markup", "<p>A great message</p>"], message["body"])
 
         # 2. attach a file
         response = self.url_open(

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1509,211 +1509,227 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                     {
                         "type": "mail.message/inbox",
                         "payload": {
-                            "mail.followers": [
-                                {
-                                    "id": follower_1.id,
-                                    "is_active": True,
-                                    "partner_id": self.user_emp_inbox.partner_id.id,
-                                },
-                            ],
-                            "mail.message": self._filter_messages_fields(
-                                {
-                                    "attachment_ids": [],
-                                    "author_guest_id": False,
-                                    "author_id": self.env.user.partner_id.id,
-                                    "body": [
-                                        "markup",
-                                        "<p>Test Post Performances with multiple inbox ping!</p>",
-                                    ],
-                                    "create_date": fields.Datetime.to_string(message.create_date),
-                                    "date": fields.Datetime.to_string(message.date),
-                                    "default_subject": "Test",
-                                    "email_from": '"OdooBot" <odoobot@example.com>',
-                                    "id": message.id,
-                                    "incoming_email_cc": False,
-                                    "incoming_email_to": False,
-                                    "message_link_preview_ids": [],
-                                    "message_type": "comment",
-                                    "model": "mail.test.simple",
-                                    "needaction": True,
-                                    "notification_ids": [notif_1.id, notif_2.id],
-                                    "partner_ids": [],
-                                    "pinned_at": False,
-                                    "rating_id": False,
-                                    "reactions": [],
-                                    "record_name": "Test",
-                                    "res_id": record.id,
-                                    "scheduledDatetime": False,
-                                    "starred": False,
-                                    "subject": False,
-                                    "subtype_id": self.env.ref("mail.mt_comment").id,
-                                    "thread": {"id": record.id, "model": "mail.test.simple"},
-                                    "trackingValues": [],
-                                    "write_date": fields.Datetime.to_string(message.write_date),
-                                },
-                            ),
-                            "mail.message.subtype": [
-                                {"description": False, "id": self.env.ref("mail.mt_comment").id},
-                            ],
-                            "mail.notification": [
-                                {
-                                    "mail_email_address": False,
-                                    "failure_type": False,
-                                    "id": notif_1.id,
-                                    "mail_message_id": message.id,
-                                    "notification_status": "sent",
-                                    "notification_type": "inbox",
-                                    "res_partner_id": self.user_emp_inbox.partner_id.id,
-                                },
-                                {
-                                    "mail_email_address": False,
-                                    "failure_type": False,
-                                    "id": notif_2.id,
-                                    "mail_message_id": message.id,
-                                    "notification_status": "sent",
-                                    "notification_type": "inbox",
-                                    "res_partner_id": self.user_follower_emp_inbox.partner_id.id,
-                                },
-                            ],
-                            "mail.thread": self._filter_threads_fields(
-                                {
-                                    "display_name": "Test",
-                                    "id": record.id,
-                                    "model": "mail.test.simple",
-                                    "module_icon": "/base/static/description/icon.png",
-                                    "selfFollower": follower_1.id,
-                                },
-                            ),
-                            "res.partner": self._filter_partners_fields(
-                                {
-                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
-                                    "id": self.env.user.partner_id.id,
-                                    "is_company": False,
-                                    "main_user_id": self.env.user.id,
-                                    "name": "OdooBot",
-                                    "write_date": fields.Datetime.to_string(
-                                        self.env.user.partner_id.write_date
-                                    ),
-                                },
-                                {
-                                    "email": self.user_emp_inbox.partner_id.email,
-                                    "id": self.user_emp_inbox.partner_id.id,
-                                    "name": "Ignasse Inbox",
-                                },
-                                {
-                                    "email": self.user_follower_emp_inbox.partner_id.email,
-                                    "id": self.user_follower_emp_inbox.partner_id.id,
-                                    "name": "Isabelle Follower Inbox",
-                                },
-                            ),
-                            "res.users": self._filter_users_fields(
-                                {"id": self.env.user.id, "share": False},
-                            ),
+                            "message_id": message.id,
+                            "store_data": {
+                                "mail.followers": [
+                                    {
+                                        "id": follower_1.id,
+                                        "is_active": True,
+                                        "partner_id": self.user_emp_inbox.partner_id.id,
+                                    },
+                                ],
+                                "mail.message": self._filter_messages_fields(
+                                    {
+                                        "attachment_ids": [],
+                                        "author_guest_id": False,
+                                        "author_id": self.env.user.partner_id.id,
+                                        "body": [
+                                            "markup",
+                                            "<p>Test Post Performances with multiple inbox ping!</p>",
+                                        ],
+                                        "create_date": fields.Datetime.to_string(
+                                            message.create_date
+                                        ),
+                                        "date": fields.Datetime.to_string(message.date),
+                                        "default_subject": "Test",
+                                        "email_from": '"OdooBot" <odoobot@example.com>',
+                                        "id": message.id,
+                                        "incoming_email_cc": False,
+                                        "incoming_email_to": False,
+                                        "message_link_preview_ids": [],
+                                        "message_type": "comment",
+                                        "model": "mail.test.simple",
+                                        "needaction": True,
+                                        "notification_ids": [notif_1.id, notif_2.id],
+                                        "partner_ids": [],
+                                        "pinned_at": False,
+                                        "rating_id": False,
+                                        "reactions": [],
+                                        "record_name": "Test",
+                                        "res_id": record.id,
+                                        "scheduledDatetime": False,
+                                        "starred": False,
+                                        "subject": False,
+                                        "subtype_id": self.env.ref("mail.mt_comment").id,
+                                        "thread": {"id": record.id, "model": "mail.test.simple"},
+                                        "trackingValues": [],
+                                        "write_date": fields.Datetime.to_string(message.write_date),
+                                    },
+                                ),
+                                "mail.message.subtype": [
+                                    {
+                                        "description": False,
+                                        "id": self.env.ref("mail.mt_comment").id,
+                                    },
+                                ],
+                                "mail.notification": [
+                                    {
+                                        "mail_email_address": False,
+                                        "failure_type": False,
+                                        "id": notif_1.id,
+                                        "mail_message_id": message.id,
+                                        "notification_status": "sent",
+                                        "notification_type": "inbox",
+                                        "res_partner_id": self.user_emp_inbox.partner_id.id,
+                                    },
+                                    {
+                                        "mail_email_address": False,
+                                        "failure_type": False,
+                                        "id": notif_2.id,
+                                        "mail_message_id": message.id,
+                                        "notification_status": "sent",
+                                        "notification_type": "inbox",
+                                        "res_partner_id": self.user_follower_emp_inbox.partner_id.id,
+                                    },
+                                ],
+                                "mail.thread": self._filter_threads_fields(
+                                    {
+                                        "display_name": "Test",
+                                        "id": record.id,
+                                        "model": "mail.test.simple",
+                                        "module_icon": "/base/static/description/icon.png",
+                                        "selfFollower": follower_1.id,
+                                    },
+                                ),
+                                "res.partner": self._filter_partners_fields(
+                                    {
+                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
+                                        "id": self.env.user.partner_id.id,
+                                        "is_company": False,
+                                        "main_user_id": self.env.user.id,
+                                        "name": "OdooBot",
+                                        "write_date": fields.Datetime.to_string(
+                                            self.env.user.partner_id.write_date
+                                        ),
+                                    },
+                                    {
+                                        "email": self.user_emp_inbox.partner_id.email,
+                                        "id": self.user_emp_inbox.partner_id.id,
+                                        "name": "Ignasse Inbox",
+                                    },
+                                    {
+                                        "email": self.user_follower_emp_inbox.partner_id.email,
+                                        "id": self.user_follower_emp_inbox.partner_id.id,
+                                        "name": "Isabelle Follower Inbox",
+                                    },
+                                ),
+                                "res.users": self._filter_users_fields(
+                                    {"id": self.env.user.id, "share": False},
+                                ),
+                            },
                         },
                     },
                     {
                         "type": "mail.message/inbox",
                         "payload": {
-                            "mail.followers": [
-                                {
-                                    "id": follower_2.id,
-                                    "is_active": True,
-                                    "partner_id": self.user_follower_emp_inbox.partner_id.id,
-                                },
-                            ],
-                            "mail.message": self._filter_messages_fields(
-                                {
-                                    "attachment_ids": [],
-                                    "author_guest_id": False,
-                                    "author_id": self.env.user.partner_id.id,
-                                    "body": [
-                                        "markup",
-                                        "<p>Test Post Performances with multiple inbox ping!</p>",
-                                    ],
-                                    "create_date": fields.Datetime.to_string(message.create_date),
-                                    "date": fields.Datetime.to_string(message.date),
-                                    "default_subject": "Test",
-                                    "email_from": '"OdooBot" <odoobot@example.com>',
-                                    "id": message.id,
-                                    "incoming_email_cc": False,
-                                    "incoming_email_to": False,
-                                    "message_link_preview_ids": [],
-                                    "message_type": "comment",
-                                    "model": "mail.test.simple",
-                                    "needaction": True,
-                                    "notification_ids": [notif_1.id, notif_2.id],
-                                    "partner_ids": [],
-                                    "pinned_at": False,
-                                    "rating_id": False,
-                                    "reactions": [],
-                                    "record_name": "Test",
-                                    "res_id": record.id,
-                                    "scheduledDatetime": False,
-                                    "starred": False,
-                                    "subject": False,
-                                    "subtype_id": self.env.ref("mail.mt_comment").id,
-                                    "thread": {"id": record.id, "model": "mail.test.simple"},
-                                    "trackingValues": [],
-                                    "write_date": fields.Datetime.to_string(message.write_date),
-                                },
-                            ),
-                            "mail.message.subtype": [
-                                {"description": False, "id": self.env.ref("mail.mt_comment").id},
-                            ],
-                            "mail.notification": [
-                                {
-                                    "mail_email_address": False,
-                                    "failure_type": False,
-                                    "id": notif_1.id,
-                                    "mail_message_id": message.id,
-                                    "notification_status": "sent",
-                                    "notification_type": "inbox",
-                                    "res_partner_id": self.user_emp_inbox.partner_id.id,
-                                },
-                                {
-                                    "mail_email_address": False,
-                                    "failure_type": False,
-                                    "id": notif_2.id,
-                                    "mail_message_id": message.id,
-                                    "notification_status": "sent",
-                                    "notification_type": "inbox",
-                                    "res_partner_id": self.user_follower_emp_inbox.partner_id.id,
-                                },
-                            ],
-                            "mail.thread": self._filter_threads_fields(
-                                {
-                                    "display_name": "Test",
-                                    "id": record.id,
-                                    "model": "mail.test.simple",
-                                    "module_icon": "/base/static/description/icon.png",
-                                    "selfFollower": follower_2.id,
-                                },
-                            ),
-                            "res.partner": self._filter_partners_fields(
-                                {
-                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
-                                    "id": self.env.user.partner_id.id,
-                                    "is_company": False,
-                                    "main_user_id": self.env.user.id,
-                                    "name": "OdooBot",
-                                    "write_date": fields.Datetime.to_string(
-                                        self.env.user.partner_id.write_date
-                                    ),
-                                },
-                                {
-                                    "email": self.user_emp_inbox.partner_id.email,
-                                    "id": self.user_emp_inbox.partner_id.id,
-                                    "name": "Ignasse Inbox",
-                                },
-                                {
-                                    "email": self.user_follower_emp_inbox.partner_id.email,
-                                    "id": self.user_follower_emp_inbox.partner_id.id,
-                                    "name": "Isabelle Follower Inbox",
-                                },
-                            ),
-                            "res.users": self._filter_users_fields(
-                                {"id": self.env.user.id, "share": False},
-                            ),
+                            "message_id": message.id,
+                            "store_data": {
+                                "mail.followers": [
+                                    {
+                                        "id": follower_2.id,
+                                        "is_active": True,
+                                        "partner_id": self.user_follower_emp_inbox.partner_id.id,
+                                    },
+                                ],
+                                "mail.message": self._filter_messages_fields(
+                                    {
+                                        "attachment_ids": [],
+                                        "author_guest_id": False,
+                                        "author_id": self.env.user.partner_id.id,
+                                        "body": [
+                                            "markup",
+                                            "<p>Test Post Performances with multiple inbox ping!</p>",
+                                        ],
+                                        "create_date": fields.Datetime.to_string(
+                                            message.create_date
+                                        ),
+                                        "date": fields.Datetime.to_string(message.date),
+                                        "default_subject": "Test",
+                                        "email_from": '"OdooBot" <odoobot@example.com>',
+                                        "id": message.id,
+                                        "incoming_email_cc": False,
+                                        "incoming_email_to": False,
+                                        "message_link_preview_ids": [],
+                                        "message_type": "comment",
+                                        "model": "mail.test.simple",
+                                        "needaction": True,
+                                        "notification_ids": [notif_1.id, notif_2.id],
+                                        "partner_ids": [],
+                                        "pinned_at": False,
+                                        "rating_id": False,
+                                        "reactions": [],
+                                        "record_name": "Test",
+                                        "res_id": record.id,
+                                        "scheduledDatetime": False,
+                                        "starred": False,
+                                        "subject": False,
+                                        "subtype_id": self.env.ref("mail.mt_comment").id,
+                                        "thread": {"id": record.id, "model": "mail.test.simple"},
+                                        "trackingValues": [],
+                                        "write_date": fields.Datetime.to_string(message.write_date),
+                                    },
+                                ),
+                                "mail.message.subtype": [
+                                    {
+                                        "description": False,
+                                        "id": self.env.ref("mail.mt_comment").id,
+                                    },
+                                ],
+                                "mail.notification": [
+                                    {
+                                        "mail_email_address": False,
+                                        "failure_type": False,
+                                        "id": notif_1.id,
+                                        "mail_message_id": message.id,
+                                        "notification_status": "sent",
+                                        "notification_type": "inbox",
+                                        "res_partner_id": self.user_emp_inbox.partner_id.id,
+                                    },
+                                    {
+                                        "mail_email_address": False,
+                                        "failure_type": False,
+                                        "id": notif_2.id,
+                                        "mail_message_id": message.id,
+                                        "notification_status": "sent",
+                                        "notification_type": "inbox",
+                                        "res_partner_id": self.user_follower_emp_inbox.partner_id.id,
+                                    },
+                                ],
+                                "mail.thread": self._filter_threads_fields(
+                                    {
+                                        "display_name": "Test",
+                                        "id": record.id,
+                                        "model": "mail.test.simple",
+                                        "module_icon": "/base/static/description/icon.png",
+                                        "selfFollower": follower_2.id,
+                                    },
+                                ),
+                                "res.partner": self._filter_partners_fields(
+                                    {
+                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
+                                        "id": self.env.user.partner_id.id,
+                                        "is_company": False,
+                                        "main_user_id": self.env.user.id,
+                                        "name": "OdooBot",
+                                        "write_date": fields.Datetime.to_string(
+                                            self.env.user.partner_id.write_date
+                                        ),
+                                    },
+                                    {
+                                        "email": self.user_emp_inbox.partner_id.email,
+                                        "id": self.user_emp_inbox.partner_id.id,
+                                        "name": "Ignasse Inbox",
+                                    },
+                                    {
+                                        "email": self.user_follower_emp_inbox.partner_id.email,
+                                        "id": self.user_follower_emp_inbox.partner_id.id,
+                                        "name": "Isabelle Follower Inbox",
+                                    },
+                                ),
+                                "res.users": self._filter_users_fields(
+                                    {"id": self.env.user.id, "share": False},
+                                ),
+                            },
                         },
                     },
                 ],

--- a/addons/test_mail_full/tests/test_rating.py
+++ b/addons/test_mail_full/tests/test_rating.py
@@ -279,5 +279,10 @@ class TestRatingRoutes(TestRatingCommon):
                 "thread_model": "mail.test.rating.thread.read",
             },
         )
-        self.assertEqual(len(res["rating.rating"]), 1)
-        self.assertEqual(res["rating.rating"][0]["rating"], 5)
+        message = next(
+            m for m in res["store_data"]["mail.message"] if m["id"] == res["message_id"]
+        )
+        rating = next(
+            r for r in res["store_data"]["rating.rating"] if r["id"] == message["rating_id"]
+        )
+        self.assertEqual(rating["rating"], 5)

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -390,10 +390,15 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         """Test livechat_visitor_id is sent with livechat channels data even when there is no
         visitor."""
         self.target_visitor = None
-        channel_info = self.make_jsonrpc_request(
+        channel_data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {"channel_id": self.livechat_channel.id},
-        )["store_data"]["discuss.channel"][0]
+        )
+        channel_info = next(
+            c
+            for c in channel_data["store_data"]["discuss.channel"]
+            if c["id"] == channel_data["channel_id"]
+        )
         self.assertEqual(channel_info["livechat_visitor_id"], False)
 
 


### PR DESCRIPTION
*: cloud_storage,im_livechat,portal

Before this commit, results of the insertion of data in the store were used, this could lead to issues later on, since the insertion does not keep the order of the data.

To avoid this, we send back in the result of the rpc's the IDs linked to the request.

In the future, we could use this to batch requests together and retrieve the result of the request with the given ID.

task-4982525


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
