### PR TITLE
[FIX] mrp: Update MO planning on update BoM action

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2565,7 +2565,7 @@ class MrpProduction(models.Model):
                    any(att_val.id in product_attribute_ids for att_val in record.bom_product_template_attribute_value_ids)
 
         ratio = self._get_ratio_between_mo_and_bom_quantities(bom)
-        _dummy, bom_lines = bom.explode(self.product_id, bom.product_qty)
+        all_boms, bom_lines = bom.explode(self.product_id, bom.product_qty)
         bom_lines_by_id = defaultdict(lambda: [None, 0])
         for line, exploded_values in bom_lines:
             if filter_by_attributes(line, exploded_values['product']):
@@ -2573,7 +2573,7 @@ class MrpProduction(models.Model):
                 bom_lines_by_id[key][0] = line
                 bom_lines_by_id[key][1] += exploded_values['qty'] / exploded_values['original_qty']
         bom_byproducts_by_id = {byproduct.id: byproduct for byproduct in bom.byproduct_ids.filtered(filter_by_attributes)}
-        operations_by_id = {operation.id: operation for operation in bom.operation_ids.filtered(filter_by_attributes)}
+        operations_by_id = {op.id: op for bom, _ in all_boms for op in bom.operation_ids.filtered(filter_by_attributes)}
 
         # Compares the BoM's operations to the MO's workorders.
         for workorder in self.workorder_ids:

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1151,7 +1151,14 @@ class MrpProduction(models.Model):
     def action_update_bom(self):
         for production in self:
             if production.bom_id:
+                old_durations = production.is_planned and production.workorder_ids.mapped('duration_expected')
                 production._link_bom(production.bom_id)
+
+                if production.is_planned:
+                    new_durations = production.workorder_ids.mapped('duration_expected')
+                    if old_durations != new_durations:
+                        production.button_unplan()
+                        production._plan_workorders()
         self.is_outdated_bom = False
 
     def _get_bom_values(self, ratio=1):


### PR DESCRIPTION
## **Issue Before This Commit:**
MO planning was not updated in two cases:  
1. When the duration of an operation was modified
   in the BoM and the MO was updated.  
2. When the quantity to produce of a Manufacturing Order (MO)
   was changed after planning.  

This led to mismatches between the BoM operation/ MO quantity updates
and the scheduled workorders, causing users to see outdated planning.
## **Steps to Reproduce:**
1. Create and plan a Manufacturing Order with workorders.  
2. Case 1: Edit the BoM and change the duration of an operation.  
   - Return to the MO and click 'Update from BoM'.  
   - Check the planning in Production / Work Centers.  
   - Notice the planning is not updated according to the new duration.  
3. Case 2: Update the quantity to produce on the MO.  
   - Check the planning in Production / Work Centers.  
   - Notice the planning does not reflect the new quantity.
## **With This Commit:**
- MO planning is now automatically updated when the BoM is updated.  
- MO planning is also automatically updated when the
  quantity to produce is changed.  

This ensures that planning always stays consistent with the
latest BoM operation settings and MO quantity,
preventing discrepancies and resolving user confusion.


TaskID: 4900557
