### PR TITLE
[FIX] account_peppol: user state desync

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -240,7 +240,7 @@ class AccountEdiProxyClientUser(models.Model):
             self.env.ref('account_peppol.ir_cron_peppol_get_message_status')._trigger()
 
     def _cron_peppol_get_participant_status(self):
-        edi_users = self.search([('company_id.account_peppol_proxy_state', 'in', ['pending', 'not_verified', 'sent_verification']), ('proxy_type', '=', 'peppol')])
+        edi_users = self.search([('company_id.account_peppol_proxy_state', '!=', 'not_registered'), ('proxy_type', '=', 'peppol')])
         edi_users._peppol_get_participant_status()
 
     def _peppol_get_participant_status(self):


### PR DESCRIPTION
Registered users state never gets fetched from AP API when the user is already registered. This is not great when user state somehow gets updated by AP server (for whatever reason).

no-task