### PR TITLE
[FIX] html_editor: preview custom button style

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -113,9 +113,7 @@ export class LinkPopover extends Component {
             imgSrc: "",
             type:
                 this.props.type ||
-                linkElement.className
-                    .match(/btn(-[a-z0-9_-]*)(primary|secondary|custom)/)
-                    ?.pop() ||
+                linkElement.className.match(/btn(-[a-z0-9_-]*)(primary|secondary|custom)/)?.pop() ||
                 "",
             linkTarget: linkElement.target === "_blank" ? "_blank" : "",
             directDownload: true,
@@ -170,6 +168,7 @@ export class LinkPopover extends Component {
                         },
                         applyColorPreview: (colorValue) => {
                             this[colorStateRef].selectedColor = colorValue;
+                            this.onChange();
                         },
                         applyColorResetPreview: () => {
                             this[colorStateRef].selectedColor = this[resetValueRef];
@@ -310,6 +309,10 @@ export class LinkPopover extends Component {
             ev.stopImmediatePropagation();
             this.onClickApply();
         }
+    }
+
+    onInput() {
+        this.onChange();
     }
 
     onClickReplaceTitle() {
@@ -527,8 +530,10 @@ export class LinkPopover extends Component {
 
     get classes() {
         let classes = [...this.props.linkElement.classList]
-            .filter((value) =>
-                !value.match(/^(btn.*|rounded-circle|flat|(text|bg)-(o-color-\d$|\d{3}$))$/))
+            .filter(
+                (value) =>
+                    !value.match(/^(btn.*|rounded-circle|flat|(text|bg)-(o-color-\d$|\d{3}$))$/)
+            )
             .join(" ");
 
         let stylePrefix = "";

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -3,7 +3,7 @@
     <t t-name="html_editor.linkPopover">
         <div class="o-we-linkpopover d-flex bg-light overflow-auto shadow" t-on-keydown="onKeydown">
             <div t-if="state.editing" class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper">
-                <div t-if="state.isImage" class="col p-2" style="max-width: 250px;">
+                <div t-if="state.isImage" class="col p-2" style="max-width: 270px;">
                     <div class="input-group mb-1">
                         <input name="o_linkpopover_url_img" t-ref="url" class="o_we_href_input_link border-dark-subtle form-control form-control-sm" t-model="state.url" title="URL" placeholder="Type your URL"
                             t-on-keydown="onKeydownEnter"/>
@@ -11,7 +11,7 @@
                     </div>
                 </div>
                 <div t-else="" class="d-flex">
-                    <div class="col p-2" style="max-width: 250px;">
+                    <div class="col p-2" style="max-width: 270px;">
                         <div class="input-group mb-1" t-att-class="{'d-none': !state.showLabel}">
                             <input t-ref="label"
                                 class="o_we_label_link border-dark-subtle form-control form-control-sm"
@@ -62,9 +62,9 @@
                             </div>
                             <div class="d-flex mb-1 custom-border">
                                 <div class="input-group">
-                                    <input t-ref="customBoderSize" type="text" pattern="[0-9]*"
+                                    <input t-ref="customBorderSize" type="number" min="0"
                                            class="form-control form-control-sm custom-border-size" t-model="state.customBorderSize"
-                                           placeholder="Border Size"  t-on-keydown="onKeydownEnter"/>
+                                           placeholder="Border Size" t-on-keydown="onKeydownEnter" t-on-input="onInput"/>
                                     <span class="input-group-text">px</span>
                                 </div>
                                 <select name="link_style_border" class="form-select form-select-sm custom-border-style" t-model="state.customBorderStyle" t-on-change="onChange">


### PR DESCRIPTION
When adjusting custom button colors or border width, the in-page preview is not updated.

This commit updates the in-page preview upon color preview and border width modification.

task-4367641
