### PR TITLE
[FIX] html_editor, website: not fail on gif upload

### DIFF
--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -232,7 +232,10 @@ export class ImagePostProcessPlugin extends Plugin {
     }
     async getProcessedImageSize(img) {
         const processed = await this._processImage({ img });
-        return getDataURLBinarySize(processed.url);
+        if (processed.url) {
+            return getDataURLBinarySize(processed.url);
+        }
+        return undefined;
     }
     async postProcessImage(url, newDataset, processContext) {
         for (const cb of this.getResource("process_image_post_handlers")) {

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -9,14 +9,7 @@ import { READONLY_MAIN_EMBEDDINGS } from "@html_editor/others/embedded_component
 import { normalizeHTML, parseHTML } from "@html_editor/utils/html";
 import { Wysiwyg } from "@html_editor/wysiwyg";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import {
-    click,
-    press,
-    queryAll,
-    queryAllTexts,
-    queryOne,
-    waitFor,
-} from "@odoo/hoot-dom";
+import { click, press, queryAll, queryAllTexts, queryOne, waitFor } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, mockSendBeacon, tick } from "@odoo/hoot-mock";
 import { onWillDestroy, xml } from "@odoo/owl";
 import {
@@ -92,6 +85,22 @@ class IrAttachment extends models.Model {
             public: true,
             access_token: false,
             image_src: "/web/image/123/transparent.png",
+            image_width: 256,
+            image_height: 256,
+        },
+        {
+            id: 456,
+            name: "gif image",
+            description: "",
+            mimetype: "image/gif",
+            checksum: false,
+            url: "/web/image/456/transparent.gif",
+            type: "url",
+            res_id: 0,
+            res_model: false,
+            public: true,
+            access_token: false,
+            image_src: "/web/image/456/transparent.gif",
             image_width: 256,
             image_height: 256,
         },

--- a/addons/website/static/src/builder/plugins/image/image_size.js
+++ b/addons/website/static/src/builder/plugins/image/image_size.js
@@ -30,6 +30,9 @@ export class ImageSize extends BaseOptionComponent {
                 imageCacheSize.set(src, size);
             }
         }
+        if (size === undefined) {
+            return;
+        }
         return `${(size / 1024).toFixed(1)} kB`;
     }
 }

--- a/addons/website/static/tests/builder/image_size.test.js
+++ b/addons/website/static/tests/builder/image_size.test.js
@@ -2,7 +2,7 @@ import { expect, test } from "@odoo/hoot";
 import { waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
-import { testImg, testImgSrc } from "./image_test_helpers";
+import { testImg, testImgSrc, testGifImg, testGifImgSrc } from "./image_test_helpers";
 
 defineWebsiteModels();
 
@@ -38,3 +38,25 @@ function expectAround(value, expected, delta = 0.2) {
     expect(value).toBeGreaterThan(expected - delta);
     expect(value).toBeLessThan(expected + delta);
 }
+
+test("the GIF image should NOT show its size", async () => {
+    const { waitDomUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            ${testGifImg}
+        </div>
+    `);
+    await contains(":iframe .test-options-target img").click();
+    await waitDomUpdated();
+    expect(`[data-label="Image"] [title="Size"]`).toHaveCount(0);
+});
+
+test("the GIF background image should NOT show its size", async () => {
+    const { waitDomUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            <section style="background-image: url(${testGifImgSrc});">text</section>
+        </div>
+    `);
+    await contains(":iframe .test-options-target section").click();
+    await waitDomUpdated();
+    expect(`[data-label="Image"] [title="Size"]`).toHaveCount(0);
+});

--- a/addons/website/static/tests/builder/image_test_helpers.js
+++ b/addons/website/static/tests/builder/image_test_helpers.js
@@ -15,23 +15,47 @@ export const testImg = `
         >
     `;
 
+export const testGifImgSrc = "/web/image/456-test/test.gif";
+
+export const testGifImg = `
+    <img src='/web/image/456-test/test.gif'>
+    `;
+
 export function mockImageRequests() {
     before(() => {
-        onRpc("/html_editor/get_image_info", async (data) => ({
-            attachment: {
-                id: 1,
-            },
-            original: {
-                id: 1,
-                image_src: "/website/static/src/img/snippets_demo/s_text_image.jpg",
-                mimetype: "image/jpeg",
-            },
-        }));
+        onRpc("/html_editor/get_image_info", async (data) => {
+            const body = await data.body.getReader().read();
+            const { src } = JSON.parse(new TextDecoder().decode(body.value)).params;
+            if (src === testGifImgSrc) {
+                return {
+                    attachment: {
+                        id: 456,
+                    },
+                    original: {
+                        id: 456,
+                        image_src:
+                            "/website/static/src/img/snippets_options/header_effect_fade_out.gif",
+                        mimetype: "image/gif",
+                    },
+                };
+            }
+            return {
+                attachment: {
+                    id: 1,
+                },
+                original: {
+                    id: 1,
+                    image_src: "/website/static/src/img/snippets_demo/s_text_image.jpg",
+                    mimetype: "image/jpeg",
+                },
+            };
+        });
         onRpcReal("/html_builder/static/image_shapes/geometric/geo_shuriken.svg");
         onRpcReal("/html_builder/static/image_shapes/pattern/pattern_wave_4.svg");
         onRpcReal("/html_builder/static/image_shapes/geometric/geo_tetris.svg");
         onRpcReal("/web/image/website.s_text_image_default_image");
         onRpcReal("/website/static/src/img/snippets_demo/s_text_image.jpg");
+        onRpcReal("/website/static/src/img/snippets_options/header_effect_fade_out.gif");
         onRpcReal("/web/image/123/transparent.png");
         onRpcReal("/website/static/src/svg/hover_effects.svg");
         onRpcReal("/html_builder/static/image_shapes/geometric/geo_square.svg");


### PR DESCRIPTION
When uploading a gif image file, no transformation occurs and therefore no data URL is being generated. Because of this, trying to compute the size from the data URL fails.

This commit avoids computing the size from non transformed images, and hides the size info when it is unavailable. (vs "NaN kb")

task-4367641
