### PR TITLE
[FIX] account: to check on statement line

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -423,6 +423,12 @@ class AccountBankStatementLine(models.Model):
         # OVERRIDE
 
         res = super(AccountBankStatementLine, self.with_context(skip_readonly_check=True)).write(vals)
+
+        for statement_line in self:
+            # In case the statement line needed to be checked but is now reconciled, we set the statement line as checked
+            if not statement_line.checked and statement_line.is_reconciled:
+                statement_line.checked = True
+
         self._synchronize_to_moves(set(vals.keys()))
         return res
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5260,15 +5260,7 @@ class AccountMove(models.Model):
             if move.line_ids.account_id.filtered(lambda account: not account.active) and not self._context.get('skip_account_deprecation_check'):
                 validation_msgs.add(_("A line of this move is using a archived account, you cannot post it."))
 
-            # If the field autocheck_on_post is set, we want the checked field on the move to be checked
-            if move.journal_id.autocheck_on_post:
-                move.checked = move.journal_id.autocheck_on_post
-            else:
-                move.sudo().activity_schedule(
-                    activity_type_id=self.env.ref('mail.mail_activity_data_todo').id,
-                    summary=_('To check'),
-                    user_id=move.invoice_user_id.id,
-                )
+            move.checked = move.journal_id.autocheck_on_post
 
         if validation_msgs:
             msg = "\n".join([line for line in validation_msgs])


### PR DESCRIPTION
When reconciling a statement line that needs to be checked, the statement line
will automatically be checked. We do that because the buttons in the dropdown
are not accessible by the user anymore, so to avoid the case where a statement
line will stay as to check forever, we just set is as checked.

Also when auto-check on post was set to false, we created an activity but it
wasn't really easy to use for users. Now they can use the button in the drop
down.

task-5022806



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
