### PR TITLE
[IMP] mail, crm, *: add rotting logic on stage-based records

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -389,6 +389,15 @@ class CrmLead(models.Model):
             date_close = fields.Datetime.from_string(lead.date_closed)
             lead.day_close = abs((date_close - date_create).days)
 
+    def _get_rotting_depends_fields(self):
+        return super()._get_rotting_depends_fields() + ['won_status', 'type']
+
+    def _get_rotting_domain(self):
+        return super()._get_rotting_domain() & Domain([
+            ('won_status', '=', 'pending'),
+            ('type', '=', 'opportunity'),
+        ])
+
     @api.depends('partner_id')
     def _compute_name(self):
         for lead in self:

--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -37,6 +37,8 @@ class CrmStage(models.Model):
     name = fields.Char('Stage Name', required=True, translate=True)
     sequence = fields.Integer('Sequence', default=1, help="Used to order stages. Lower is better.")
     is_won = fields.Boolean('Is Won Stage?')
+    rotting_threshold_days = fields.Integer('Days to rot', default=0, help='Highlight opportunities that haven\'t been updated for this many days. \
+        Set to 0 to disable. Changing this parameter will not affect the rotting status/date of resources last updated before this change.')
     requirements = fields.Text('Requirements', help="Enter here the internal requirements for this stage (ex: Offer sent to customer). It will appear as a tooltip over the stage's name.")
     team_id = fields.Many2one('crm.team', string='Sales Team', ondelete="set null",
         help='Specific team that uses this stage. Other teams will not be able to see or use this stage.')

--- a/addons/crm/static/src/views/crm_kanban/crm_column_progress.js
+++ b/addons/crm/static/src/views/crm_kanban/crm_column_progress.js
@@ -1,14 +1,10 @@
 import { onWillStart } from "@odoo/owl";
 import { user } from "@web/core/user";
-import { ColumnProgress } from "@web/views/view_components/column_progress";
 import { session } from "@web/session";
 import { getCurrency } from "@web/core/currency";
+import { RottingColumnProgress } from "@mail/js/rotting_mixin/rotting_column_progress";
 
-export class CrmColumnProgress extends ColumnProgress {
-    static props = {
-        ...ColumnProgress.props,
-        progressBarState: { type: Object },
-    };
+export class CrmColumnProgress extends RottingColumnProgress {
     static template = "crm.ColumnProgress";
     setup() {
         super.setup();

--- a/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
+++ b/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-name="crm.ColumnProgress" t-inherit="web.ColumnProgress" t-inherit-mode="primary">
+    <t t-name="crm.ColumnProgress" t-inherit="mail.RottingColumnProgress" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_column_progress')]" position="attributes">
             <attribute name="class" remove="w-75" add="w-50" separator=" "/>
         </xpath>

--- a/addons/crm/static/src/views/crm_kanban/crm_kanban_renderer.js
+++ b/addons/crm/static/src/views/crm_kanban/crm_kanban_renderer.js
@@ -1,18 +1,19 @@
 import { CrmColumnProgress } from "./crm_column_progress";
-import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
-import { KanbanHeader } from "@web/views/kanban/kanban_header";
+import { RottingKanbanRecord } from "@mail/js/rotting_mixin/rotting_kanban_record";
+import { RottingKanbanHeader } from "@mail/js/rotting_mixin/rotting_kanban_header";
+import { RottingKanbanRenderer } from "@mail/js/rotting_mixin/rotting_kanban_renderer";
 
-class CrmKanbanHeader extends KanbanHeader {
-    static template = "crm.CrmKanbanHeader";
+class CrmKanbanHeader extends RottingKanbanHeader {
     static components = {
-        ...KanbanHeader.components,
+        ...RottingKanbanHeader.components,
         ColumnProgress: CrmColumnProgress,
     };
 }
 
-export class CrmKanbanRenderer extends KanbanRenderer {
+export class CrmKanbanRenderer extends RottingKanbanRenderer {
     static components = {
-        ...KanbanRenderer.components,
+        ...RottingKanbanRenderer.components,
         KanbanHeader: CrmKanbanHeader,
+        KanbanRecord: RottingKanbanRecord,
     };
 }

--- a/addons/crm/static/src/views/crm_kanban/crm_kanban_view.js
+++ b/addons/crm/static/src/views/crm_kanban/crm_kanban_view.js
@@ -1,14 +1,14 @@
 import { registry } from "@web/core/registry";
-import { kanbanView } from "@web/views/kanban/kanban_view";
 import { CrmKanbanModel } from "@crm/views/crm_kanban/crm_kanban_model";
 import { CrmKanbanArchParser } from "@crm/views/crm_kanban/crm_kanban_arch_parser";
 import { CrmKanbanRenderer } from "@crm/views/crm_kanban/crm_kanban_renderer";
+import { rottingKanbanView } from "@mail/js/rotting_mixin/rotting_kanban_view";
 
 export const crmKanbanView = {
-    ...kanbanView,
+    ...rottingKanbanView,
     ArchParser: CrmKanbanArchParser,
     // Makes it easier to patch
-    Controller: class extends kanbanView.Controller {
+    Controller: class extends rottingKanbanView.Controller {
         get progressBarAggregateFields() {
             const res = super.progressBarAggregateFields;
             const progressAttributes = this.props.archInfo.progressAttributes;

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -15,7 +15,7 @@
                             invisible="won_status != 'lost'"/>
                         <button name="%(crm.crm_lead_lost_action)d" string="Lost" type="action" data-hotkey="l" title="Mark as lost"
                             invisible="won_status != 'pending' or not active"/>
-                        <field name="stage_id" widget="statusbar_duration"
+                        <field name="stage_id" widget="rotting_statusbar_duration"
                             options="{'clickable': '1', 'fold_field': 'fold'}"
                             domain="['|', ('team_id', '=', team_id), ('team_id', '=', False)]"
                             invisible="type == 'lead'" readonly="won_status == 'lost' or not active"/>
@@ -24,6 +24,8 @@
                         <field name="won_status" invisible="1"/>
                         <field name="active" invisible="1"/>
                         <field name="company_id" invisible="1"/>
+                        <field name="is_rotting" invisible="1"/>
+                        <field name="rotting_days" invisible="1"/>
                         <div class="oe_button_box" name="button_box">
                             <button name="action_schedule_meeting" type="object"
                                 class="oe_stat_button" icon="fa-calendar"
@@ -47,8 +49,12 @@
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active or won_status in ['lost', 'won']"/>
                         <widget name="web_ribbon" title="Lost" bg_color="text-bg-danger" invisible="won_status != 'lost'"/>
                         <widget name="web_ribbon" title="Won" invisible="won_status != 'won'"/>
-                        <div class="oe_title">
-                            <h1><field class="text-break" options="{'line_breaks': False}" widget="text" name="name" placeholder="e.g. Product Pricing"/></h1>
+                        <div class="oe_title mw-100">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <h1 class="flex-grow-1">
+                                    <field class="text-break" options="{'line_breaks': False}" widget="text" name="name" placeholder="e.g. Product Pricing"/>
+                                </h1>
+                            </div>
                             <h2 class="row g-0 pb-3 pb-sm-4">
                                 <div class="col-auto pb-2 pb-md-0 w-100 w-sm-auto" invisible="type == 'lead'">
                                     <label for="expected_revenue" class="oe_edit_only"/>
@@ -112,7 +118,6 @@
                                         'default_team_id': team_id,
                                         'default_website': website,
                                         'default_lang': lang_code,
-                                        'show_vat': True
                                     }" invisible="not is_partner_visible"/>
                                 <field name="partner_name"/>
                                 <label for="street" string="Address"/>
@@ -574,7 +579,7 @@
                                     <field name="recurring_plan" groups="crm.group_use_recurring_revenues"/>
                                 </t>
                             </div>
-                            <field name="partner_id" class="text-truncate" />
+                            <field name="partner_id" class="ms-2 text-truncate" />
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                             <field name="lead_properties" widget="properties"/>
                             <footer class="pt-1">
@@ -582,7 +587,11 @@
                                     <field name="priority" widget="priority" groups="base.group_user" class="me-2"/>
                                     <field name="activity_ids" widget="kanban_activity"/>
                                 </div>
-                                <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" class="ms-auto"/>
+                                <div class="ms-auto d-flex">
+                                    <field name="is_rotting" invisible="1"/>
+                                    <field name="rotting_days" class="d-flex" widget="rotting"/>
+                                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" class="ms-2"/>
+                                </div>
                             </footer>
                         </t>
                     </templates>
@@ -775,7 +784,7 @@
                         options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
                     <field name="recurring_plan" optional="hide" groups="crm.group_use_recurring_revenues"/>
                     <field name="stage_id_color" column_invisible="1"/>
-                    <field name="stage_id" optional="show" widget="selection_badge" options="{'color_field': 'stage_id_color'}"/>
+                    <field name="stage_id" optional="show" widget="badge_rotting" options="{'color_field': 'stage_id_color'}"/>
                     <field name="active" column_invisible="True"/>
                     <field name="probability" string="Probability (%)" optional="hide"/>
                     <field name="lost_reason_id" optional="hide"/>
@@ -783,6 +792,8 @@
                     <field name="referred" column_invisible="True"/>
                     <field name="message_needaction" column_invisible="True"/>
                     <field name="lead_properties"/>
+                    <field name="is_rotting" column_invisible="True"/>
+                    <field name="rotting_days" column_invisible="True"/>
                     <widget name="mail_activity_mixin_list_reschedule_dropdown"/>
                     <button name="%(crm.action_lead_mail_compose)d" type="action" string="Email" icon="fa-envelope"/>
                 </list>
@@ -984,6 +995,7 @@
                     <filter string="Won" name="filter_won_status_won" domain="[('won_status', '=', 'won')]"/>
                     <!-- For ongoing: include 'active' as this filter is functional and should filter out archived leads -->
                     <filter string="Ongoing" name="filter_won_status_pending" domain="[('won_status', '=', 'pending'), ('active', '=', True)]"/>
+                    <filter string="Rotting" name="filter_rotting" domain="[('is_rotting', '=', True)]"/>
                     <filter string="Lost" name="filter_won_status_lost" domain="[('won_status', '=', 'lost'), ('active', '=', False)]"/>
                     <separator/>
                     <filter invisible="1" string="Overdue Opportunities" name="overdue_opp" domain="['&amp;', ('date_closed', '=', False), ('date_deadline', '&lt;', 'today')]"/>

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -24,6 +24,7 @@
                 <field name="name" readonly="1"/>
                 <field name="is_won"/>
                 <field name="team_id"/>
+                <field name="rotting_threshold_days" optional="hide"/>
                 <field name="color" optional="hide" widget="color_picker"/>
             </list>
         </field>
@@ -44,10 +45,13 @@
                     </div>
                     <group>
                         <group>
-                            <field name="is_won"/>
                             <field name="fold"/>
                             <field name="color" widget="color_picker"/>
                             <field name="team_id" options='{"no_open": True, "no_create": True}' invisible="team_count &lt;= 1" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
+                        </group>
+                        <group>
+                            <field name="is_won"/>
+                            <field name="rotting_threshold_days" invisible="is_won"/>
                         </group>
                         <field name="team_count" invisible="1"/>
                     </group>

--- a/addons/hr_recruitment/models/hr_recruitment_stage.py
+++ b/addons/hr_recruitment/models/hr_recruitment_stage.py
@@ -24,6 +24,8 @@ class HrRecruitmentStage(models.Model):
         help="This stage is folded in the kanban view when there are no records in that stage to display.")
     hired_stage = fields.Boolean('Hired Stage',
         help="If checked, this stage is used to determine the hire date of an applicant")
+    rotting_threshold_days = fields.Integer('Days to rot', default=0, help='Day count before applicants in this stage become stale. \
+        Set to 0 to disable.  Changing this parameter will not affect the rotting status/date of resources last updated before this change.')
     legend_blocked = fields.Char(
         'Red Kanban Label', default=lambda self: _('Blocked'), translate=True, required=True)
     legend_waiting = fields.Char(

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -34,10 +34,12 @@
                 <field name="email_from" readonly="1" optional="hide"/>
                 <field name="partner_phone" widget="phone" readonly="1" optional="hide"/>
                 <field name="job_id" optional="show" column_invisible="context.get('default_talent_pool_ids')"/>
-                <field name="stage_id" optional="show" column_invisible="context.get('default_talent_pool_ids')"/>
+                <field name="stage_id" widget="badge_rotting" optional="show" column_invisible="context.get('default_talent_pool_ids')"/>
                 <field name="priority" widget="priority" nolabel="1" optional="show"/>
                 <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
                 <field name="user_id" widget="many2one_avatar_user" optional="show"/>
+                <field name="is_rotting" column_invisible="True"/>
+                <field name="rotting_days" column_invisible="True"/>
                 <field name="type_id" column_invisible="True"/>
                 <field name="application_status" optional="hide" invisible="application_status == 'ongoing'"/>
                 <field name="refuse_reason_id" optional='hide'/>
@@ -84,12 +86,14 @@
             <field name="email_normalized" invisible="1"/>
             <field name="partner_phone_sanitized" invisible="1"/>
             <field name="emp_is_active" invisible="1"/>
+            <field name="is_rotting" invisible="1"/>
+            <field name="rotting_days" invisible="1"/>
             <header>
                 <button string="Create Employee" name="create_employee_from_applicant" type="object" data-hotkey="q" groups="hr.group_hr_user"
                         class="o_create_employee" invisible="employee_id or not active or not date_closed"/>
                 <button string="Refuse" name="archive_applicant" type="object" invisible="not active or is_pool_applicant" data-hotkey="d"/>
                 <button string="Restore" name="action_unarchive" type="object" invisible="active" data-hotkey="x"/>
-                <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1'}" invisible="(not active and not employee_id) or is_pool_applicant"/>
+                <field name="stage_id" widget="rotting_statusbar_duration" options="{'clickable': '1'}" invisible="(not active and not employee_id) or is_pool_applicant"/>
                 <button string="Create Applications" name="action_job_add_applicants" type="object" invisible="not is_pool_applicant"/>
                 <button string="Add to Pool" name="action_talent_pool_add_applicants" type="object" invisible="is_pool_applicant or is_applicant_in_pool"/>
             </header>
@@ -279,6 +283,7 @@
                 <filter string="Ready for Next Stage" name="done" domain="[('kanban_state', '=', 'done')]"/>
                 <filter string="Waiting" name="waiting" domain="[('kanban_state', '=', 'waiting')]"/>
                 <filter string="Blocked" name="blocked" domain="[('kanban_state', '=', 'blocked')]"/>
+                <filter string="Rotting" name="filter_rotting" domain="[('is_rotting', '=', True)]"/>
                 <separator/>
                 <filter string="Directly Available" name="applicant_availability" domain="['|',('availability', '&lt;=', 'today'),('availability','=', False)]"/>
                 <separator/>
@@ -363,7 +368,8 @@
         <field name="name">Hr Applicants kanban</field>
         <field name="model">hr.applicant</field>
         <field name="arch" type="xml">
-            <kanban  highlight_color="color" default_group_by="stage_id" class="o_kanban_applicant o_search_matching_applicant" quick_create_view="hr_recruitment.quick_create_applicant_form" sample="1">
+            <kanban  highlight_color="color" default_group_by="stage_id" class="o_kanban_applicant o_search_matching_applicant" quick_create_view="hr_recruitment.quick_create_applicant_form" sample="1" 
+                js_class="rotting_kanban">
                 <header>
                     <button
                         name="action_talent_pool_add_applicants"
@@ -408,6 +414,8 @@
                         <footer>
                             <field name="priority" widget="priority"/>
                             <field class="ms-1 align-items-center" name="activity_ids" widget="kanban_activity"/>
+                            <field name="is_rotting" invisible="1"/>
+                            <field name="rotting_days" class="d-flex" widget="rotting"/>
                             <div class="d-flex ms-auto align-items-center">
                                 <a name="action_open_attachments" type="object">
                                     <i class='fa fa-paperclip' role="img" aria-label="Documents"/>

--- a/addons/hr_recruitment/views/hr_recruitment_stage_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_stage_views.xml
@@ -24,6 +24,7 @@
                 <list string="Stages">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
+                    <field name="rotting_threshold_days" optional="hide"/>
                     <field name="fold"/>
                     <field name="hired_stage"/>
                 </list>
@@ -73,6 +74,7 @@
                                 </span>
                             </span>
                             <field name="job_ids" widget="many2many_tags"/>
+                            <field name="rotting_threshold_days" invisible="hired_stage"/>
                         </group>
                     </group>
                     <group name="tooltips" string="Tooltips">

--- a/addons/mail/static/src/js/rotting_mixin/rotting_column_progress.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_column_progress.js
@@ -5,16 +5,8 @@ export class RottingColumnProgress extends ColumnProgress {
     static props = {
         ...ColumnProgress.props,
         progressBarState: { type: Object },
+        onRotIconClicked: { type: Function },
     };
-
-    setup() {
-        super.setup();
-        const rottingFilter = Object.values(this.env.searchModel.searchItems).find(
-            (filter) =>
-                filter.name === "filter_rotting" || filter.domain === "[('is_rotting', '=', True)]"
-        );
-        this.rottingFilterAvailable = !!rottingFilter;
-    }
 
     getRottingGroupCount(group) {
         const isRottingField = group._config.fields.is_rotting;
@@ -31,13 +23,7 @@ export class RottingColumnProgress extends ColumnProgress {
      * Checks that a filter verifying rotting status exists for the current set view.
      * If that filter exists, it is toggled.
      */
-    async onRotIconClick() {
-        const rottingFilter = Object.values(this.env.searchModel.searchItems).find(
-            (filter) =>
-                filter.name === "filter_rotting" || filter.domain === "[('is_rotting', '=', True)]"
-        );
-        if (rottingFilter) {
-            this.env.searchModel.toggleSearchItem(rottingFilter.id);
-        }
+    async onRottingIconClick() {
+        await this.props.onRotIconClicked(this.props.group);
     }
 }

--- a/addons/mail/static/src/js/rotting_mixin/rotting_column_progress.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_column_progress.js
@@ -1,0 +1,43 @@
+import { ColumnProgress } from "@web/views/view_components/column_progress";
+
+export class RottingColumnProgress extends ColumnProgress {
+    static template = "mail.RottingColumnProgress";
+    static props = {
+        ...ColumnProgress.props,
+        progressBarState: { type: Object },
+    };
+
+    setup() {
+        super.setup();
+        const rottingFilter = Object.values(this.env.searchModel.searchItems).find(
+            (filter) =>
+                filter.name === "filter_rotting" || filter.domain === "[('is_rotting', '=', True)]"
+        );
+        this.rottingFilterAvailable = !!rottingFilter;
+    }
+
+    getRottingGroupCount(group) {
+        const isRottingField = group._config.fields.is_rotting;
+        if (!isRottingField) {
+            return {};
+        }
+        return {
+            title: isRottingField.string,
+            value: group.list.records.filter((record) => record.data.is_rotting).length,
+        };
+    }
+
+    /**
+     * Checks that a filter verifying rotting status exists for the current set view.
+     * If that filter exists, it is toggled.
+     */
+    async onRotIconClick() {
+        const rottingFilter = Object.values(this.env.searchModel.searchItems).find(
+            (filter) =>
+                filter.name === "filter_rotting" || filter.domain === "[('is_rotting', '=', True)]"
+        );
+        if (rottingFilter) {
+            this.env.searchModel.toggleSearchItem(rottingFilter.id);
+        }
+    }
+}

--- a/addons/mail/static/src/js/rotting_mixin/rotting_column_progress.xml
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_column_progress.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="mail.RottingColumnProgress" t-inherit="web.ColumnProgress" t-inherit-mode="primary">
+        <AnimatedNumber position="before">
+            <t t-set="rottingAggregate" t-value="getRottingGroupCount(props.group)"/>
+            <div t-if="rottingAggregate.value > 0" t-on-click="() => onRotIconClick()"
+                t-attf-class="badge rounded-pill o_mail_resource_rotting_bg ms-3 {{ this.rottingFilterAvailable ? 'cursor-pointer' : 'cursor-default' }}"
+                t-att-title="rottingAggregate.title">
+                <div class="text-900 text-nowrap">
+                    <b t-out="rottingAggregate.value"/>
+                </div>
+            </div>
+        </AnimatedNumber>
+    </t>
+</templates>

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_controller.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_controller.js
@@ -1,6 +1,15 @@
+import { patch } from "@web/core/utils/patch";
 import { KanbanController } from "@web/views/kanban/kanban_controller";
+import { rottingProgressBarPatch } from "./rotting_progress_bar_hook";
 
 export class RottingKanbanController extends KanbanController {
+    setup() {
+        super.setup();
+        if (this.progressBarState) {
+            patch(this.progressBarState, rottingProgressBarPatch);
+        }
+    }
+
     get progressBarAggregateFields() {
         const res = super.progressBarAggregateFields;
         if (this.props.fields.is_rotting) {

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_controller.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_controller.js
@@ -1,0 +1,11 @@
+import { KanbanController } from "@web/views/kanban/kanban_controller";
+
+export class RottingKanbanController extends KanbanController {
+    get progressBarAggregateFields() {
+        const res = super.progressBarAggregateFields;
+        if (this.props.fields.is_rotting) {
+            res.push(this.props.fields.is_rotting);
+        }
+        return res;
+    }
+}

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_header.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_header.js
@@ -1,0 +1,10 @@
+import { KanbanHeader } from "@web/views/kanban/kanban_header";
+import { RottingColumnProgress } from "./rotting_column_progress";
+
+export class RottingKanbanHeader extends KanbanHeader {
+    static template = "mail.RottingKanbanHeader";
+    static components = {
+        ...KanbanHeader.components,
+        ColumnProgress: RottingColumnProgress,
+    };
+}

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_header.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_header.js
@@ -7,4 +7,8 @@ export class RottingKanbanHeader extends KanbanHeader {
         ...KanbanHeader.components,
         ColumnProgress: RottingColumnProgress,
     };
+
+    onRotIconClicked(group) {
+        this.props.progressBarState.toggleFilterRotten(group);
+    }
 }

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_header.xml
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_header.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-name="crm.CrmKanbanHeader" t-inherit="web.KanbanHeader" t-inherit-mode="primary">
+    <t t-name="mail.RottingKanbanHeader" t-inherit="web.KanbanHeader" t-inherit-mode="primary">
         <xpath expr="//ColumnProgress" position="attributes">
             <attribute name="progressBarState">props.progressBarState</attribute>
         </xpath>

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_header.xml
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_header.xml
@@ -3,6 +3,7 @@
     <t t-name="mail.RottingKanbanHeader" t-inherit="web.KanbanHeader" t-inherit-mode="primary">
         <xpath expr="//ColumnProgress" position="attributes">
             <attribute name="progressBarState">props.progressBarState</attribute>
+            <attribute name="onRotIconClicked.bind">onRotIconClicked</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_record.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_record.js
@@ -1,0 +1,14 @@
+import { KanbanRecord } from "@web/views/kanban/kanban_record";
+
+export class RottingKanbanRecord extends KanbanRecord {
+    /**
+     * @override
+     */
+    getRecordClasses() {
+        let classes = super.getRecordClasses();
+        if (this.props.record.data.is_rotting) {
+            classes += " oe_kanban_card_rotting";
+        }
+        return classes;
+    }
+}

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_renderer.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_renderer.js
@@ -8,4 +8,14 @@ export class RottingKanbanRenderer extends KanbanRenderer {
         KanbanRecord: RottingKanbanRecord,
         KanbanHeader: RottingKanbanHeader,
     };
+    /**
+     * @override
+     */
+    getGroupClasses(group, isGroupProcessing) {
+        let classes = super.getGroupClasses(group, isGroupProcessing);
+        if (this.props.progressBarState && this.props.progressBarState.rotIsFiltered[group.id]) {
+            classes += " o_kanban_group_show o_kanban_group_show_rotting";
+        }
+        return classes;
+    }
 }

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_renderer.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_renderer.js
@@ -1,0 +1,11 @@
+import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
+import { RottingKanbanRecord } from "./rotting_kanban_record";
+import { RottingKanbanHeader } from "./rotting_kanban_header";
+
+export class RottingKanbanRenderer extends KanbanRenderer {
+    static components = {
+        ...KanbanRenderer.components,
+        KanbanRecord: RottingKanbanRecord,
+        KanbanHeader: RottingKanbanHeader,
+    };
+}

--- a/addons/mail/static/src/js/rotting_mixin/rotting_kanban_view.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_kanban_view.js
@@ -1,0 +1,12 @@
+import { kanbanView } from "@web/views/kanban/kanban_view";
+import { RottingKanbanController } from "./rotting_kanban_controller";
+import { RottingKanbanRenderer } from "./rotting_kanban_renderer";
+import { registry } from "@web/core/registry";
+
+export const rottingKanbanView = {
+    ...kanbanView,
+    Controller: RottingKanbanController,
+    Renderer: RottingKanbanRenderer,
+};
+
+registry.category("views").add("rotting_kanban", rottingKanbanView);

--- a/addons/mail/static/src/js/rotting_mixin/rotting_progress_bar_hook.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_progress_bar_hook.js
@@ -1,0 +1,40 @@
+export const rottingProgressBarPatch = {
+    rotIsFiltered: {},
+    async toggleFilterRotten(group) {
+        if (!this.rotIsFiltered[group.id]) {
+            await this.setFilterRotten(group);
+        } else {
+            await this.unsetFilterRotten(group);
+        }
+        group.model.notify();
+    },
+    async setFilterRotten(group) {
+        await group.applyFilter([["is_rotting", "=", true]]);
+        this.rotIsFiltered[group.id] = group;
+        if (this.activeBars[group.serverValue]) {
+            delete this.activeBars[group.serverValue];
+        }
+    },
+    async unsetFilterRotten(group) {
+        await group.applyFilter(undefined);
+        delete this.rotIsFiltered[group.id];
+    },
+    /**
+     * @override
+     */
+    async selectBar(groupId, bar) {
+        if (this.rotIsFiltered[groupId]) {
+            delete this.rotIsFiltered[groupId];
+        }
+        return super.selectBar(groupId, bar);
+    },
+    /**
+     * @override
+     */
+    getGroupCount(group) {
+        if (this.rotIsFiltered[group.id]) {
+            return group.list.records.filter((record) => record.data.is_rotting).length;
+        }
+        return super.getGroupCount(group);
+    },
+};

--- a/addons/mail/static/src/js/rotting_mixin/rotting_statusbar.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_statusbar.js
@@ -1,0 +1,25 @@
+import {
+    statusBarDurationField,
+    StatusBarDurationField,
+} from "@mail/views/fields/statusbar_duration/statusbar_duration_field";
+import { registry } from "@web/core/registry";
+import { getRottingDaysTitle } from "./rotting_widget";
+
+export class RottingStatusBarDurationField extends StatusBarDurationField {
+    static template = "mail.RottingStatusBarDurationField";
+
+    setup() {
+        super.setup();
+        this.title = getRottingDaysTitle(
+            this.env.model.config.resModel,
+            this.props.record.data.rotting_days
+        );
+    }
+}
+
+export const rottingStatusBarDurationField = {
+    ...statusBarDurationField,
+    component: RottingStatusBarDurationField,
+};
+
+registry.category("fields").add("rotting_statusbar_duration", rottingStatusBarDurationField);

--- a/addons/mail/static/src/js/rotting_mixin/rotting_statusbar.xml
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_statusbar.xml
@@ -1,0 +1,19 @@
+<templates>
+    <t t-name="mail.RottingStatusBarDurationField" t-inherit="mail.StatusBarDurationField" t-inherit-mode="primary">
+        <xpath expr="//*[hasclass('btn btn-secondary o_arrow_button')]" position="attributes">
+            <attribute name="class" add="d-flex align-items-baseline" separator=" "/>
+        </xpath>
+        <xpath expr="//span[@t-att-title='item.fullTimeInStage']" position="attributes">
+            <attribute name="t-if" add="(!props.record.data.is_rotting || !item.isSelected)" separator=" and "/>
+        </xpath>
+                
+        <xpath expr="//span[@t-att-title='item.fullTimeInStage']" position="after">
+            <t t-if="props.record.data.is_rotting and item.isSelected">
+                <span class="badge rounded-pill small o_mail_resource_rotting_bg ms-2"
+                    t-att-title="title" style="pointer-events: all;">
+                    <t t-out="props.record.data.rotting_days"/>d
+                </span>
+            </t>
+        </xpath> 
+    </t>
+</templates>

--- a/addons/mail/static/src/js/rotting_mixin/rotting_widget.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_widget.js
@@ -1,0 +1,67 @@
+import { Component } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import {
+    badgeSelectionField,
+    BadgeSelectionField,
+} from "@web/views/fields/badge_selection/badge_selection_field";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+export function getRottingDaysTitle(modelName, rotDays) {
+    switch (modelName) {
+        case "crm.lead":
+            return _t("This lead has been stuck in this stage for %(numberOfDays)s days.", {
+                numberOfDays: rotDays,
+            });
+        case "hr.applicant":
+            return _t("This applicant has been stuck in this stage for %(numberOfDays)s days.", {
+                numberOfDays: rotDays,
+            });
+        case "project.task":
+            return _t("This task has been stuck in this stage for %(numberOfDays)s days.", {
+                numberOfDays: rotDays,
+            });
+    }
+    return _t("This record has been stuck in this stage for %(numberOfDays)s days.", {
+        numberOfDays: rotDays,
+    });
+}
+
+export class KanbanRottingField extends Component {
+    static props = {
+        ...standardFieldProps,
+    };
+    static template = "mail.KanbanRottingField";
+
+    setup() {
+        // Preprocess all sentences as childless strings so they're easier to format in the DOM
+        this.dayCount = _t("%(numberOfDays)sd", {
+            numberOfDays: this.props.record.data.rotting_days,
+        });
+
+        this.title = getRottingDaysTitle(
+            this.env.model.config.resModel,
+            this.props.record.data.rotting_days
+        );
+    }
+}
+
+export class ListBadgeSelectionRotting extends BadgeSelectionField {
+    static template = "mail.ListBadgeSelectionRotting";
+    setup() {
+        super.setup();
+        // As this widget is appended to another field's value, we display no additional title to prevent title overlap
+        this.dayCount = _t("%(numberOfDays)sd", {
+            numberOfDays: this.props.record.data.rotting_days,
+        });
+    }
+}
+
+registry.category("fields").add("kanban.rotting", {
+    component: KanbanRottingField,
+});
+
+registry.category("fields").add("list.badge_rotting", {
+    ...badgeSelectionField,
+    component: ListBadgeSelectionRotting,
+});

--- a/addons/mail/static/src/js/rotting_mixin/rotting_widget.xml
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_widget.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.KanbanRottingField">
+        <div class="badge rounded-pill o_mail_resource_rotting_bg d-flex align-items-center" t-if="props.record.data.is_rotting"
+            t-att-title="title">
+            <t t-out="dayCount"/>
+        </div>
+    </t>
+
+    <t t-name="mail.ListBadgeSelectionRotting" t-inherit="web.BadgeSelectionField" t-inherit-mode="primary">
+        <t t-else="" position="after">
+            <span class="badge rounded-pill o_mail_resource_rotting_bg ms-2" t-if="props.record.data.is_rotting">
+                <t t-out="dayCount"/>
+        </span>
+        </t>
+    </t>
+</templates>

--- a/addons/mail/static/src/scss/rotting_mixin.scss
+++ b/addons/mail/static/src/scss/rotting_mixin.scss
@@ -1,0 +1,13 @@
+.o_mail_resource_rotting_bg {
+    background-color: #e64980;
+}
+
+.o_kanban_renderer {
+    .o_kanban_group {
+        @include o-kanban-css-filter(rotting, #e64980);
+    }
+
+    .o_kanban_record.oe_kanban_card_rotting {
+        background-color: rgba(255, 201, 201, 0.3);
+    }
+}

--- a/addons/mail/static/src/views/fields/statusbar_duration/statusbar_duration_field.scss
+++ b/addons/mail/static/src/views/fields/statusbar_duration/statusbar_duration_field.scss
@@ -1,3 +1,3 @@
-.o_field_statusbar_duration {
+.o_field_statusbar_duration, .o_field_rotting_statusbar_duration {
     @extend .o_field_statusbar;
 }

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -27,7 +27,6 @@ class ProjectProject(models.Model):
         'portal.mixin',
         'mail.alias.mixin',
         'rating.parent.mixin',
-        'mail.thread',
         'mail.activity.mixin',
         'mail.tracking.duration.mixin',
         'analytic.plan.fields.mixin',

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -405,6 +405,12 @@ class ProjectTask(models.Model):
             return NotImplemented
         return [('state', 'in', searched_states)]
 
+    def _get_rotting_depends_fields(self):
+        return super()._get_rotting_depends_fields() + ['is_closed']
+
+    def _get_rotting_domain(self):
+        return super()._get_rotting_domain() & Domain('is_closed', '=', False)
+
     @property
     def OPEN_STATES(self):
         """ Return a list of the technical names complementing the CLOSED_STATES, a.k.a the open states """

--- a/addons/project/models/project_task_type.py
+++ b/addons/project/models/project_task_type.py
@@ -45,6 +45,8 @@ class ProjectTaskType(models.Model):
             " * Good feedback from the customer will update the state to 'Approved' (green bullet).\n"
             " * Neutral or bad feedback will set the kanban state to 'Changes Requested' (orange bullet).\n")
     disabled_rating_warning = fields.Text(compute='_compute_disabled_rating_warning', export_string_translation=False)
+    rotting_threshold_days = fields.Integer('Days to rot', default=0, help='Day count before tasks in this stage become stale. Set to 0 to disable \
+        Changing this parameter will not affect the rotting status/date of resources last updated before this change.')
 
     user_id = fields.Many2one('res.users', 'Stage Owner', default=_default_user_id, compute='_compute_user_id', store=True, index=True)
 

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.js
@@ -1,11 +1,11 @@
-import { KanbanController } from "@web/views/kanban/kanban_controller";
-
 import { ProjectTaskTemplateDropdown } from "../components/project_task_template_dropdown";
+import { RottingKanbanController } from "@mail/js/rotting_mixin/rotting_kanban_controller";
 
-export class ProjectTaskKanbanController extends KanbanController {
+
+export class ProjectTaskKanbanController extends RottingKanbanController {
     static template = "project.ProjectTaskKanbanView";
     static components = {
-        ...KanbanController.components,
+        ...RottingKanbanController.components,
         ProjectTaskTemplateDropdown,
     };
 

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_header.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_header.js
@@ -1,9 +1,9 @@
-import { KanbanHeader } from "@web/views/kanban/kanban_header";
+import { RottingKanbanHeader } from "@mail/js/rotting_mixin/rotting_kanban_header";
 import { ProjectTaskGroupConfigMenu } from "./project_task_group_config_menu";
 
-export class ProjectTaskKanbanHeader extends KanbanHeader {
+export class ProjectTaskKanbanHeader extends RottingKanbanHeader {
     static components = {
-        ...KanbanHeader.components,
+        ...RottingKanbanHeader.components,
         GroupConfigMenu: ProjectTaskGroupConfigMenu,
     };
 }

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_record.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_record.js
@@ -1,12 +1,12 @@
-import { KanbanRecord } from "@web/views/kanban/kanban_record";
 import { useState } from "@odoo/owl";
 import { ProjectTaskKanbanCompiler } from "./project_task_kanban_compiler";
+import { RottingKanbanRecord } from "@mail/js/rotting_mixin/rotting_kanban_record";
 import { SubtaskKanbanList } from "@project/components/subtask_kanban_list/subtask_kanban_list"
 
-export class ProjectTaskKanbanRecord extends KanbanRecord {
+export class ProjectTaskKanbanRecord extends RottingKanbanRecord {
     static Compiler = ProjectTaskKanbanCompiler;
     static components = {
-        ...KanbanRecord.components,
+        ...RottingKanbanRecord.components,
         SubtaskKanbanList,
     };
 

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.js
@@ -1,12 +1,13 @@
 import { registry } from "@web/core/registry";
-import { kanbanView } from '@web/views/kanban/kanban_view';
+
+import { rottingKanbanView } from "@mail/js/rotting_mixin/rotting_kanban_view";
 import { ProjectTaskKanbanController } from "./project_task_kanban_controller";
 import { ProjectTaskKanbanModel } from "./project_task_kanban_model";
 import { ProjectTaskKanbanRenderer } from './project_task_kanban_renderer';
 import { ProjectTaskControlPanel } from "../project_task_control_panel/project_task_control_panel";
 
 export const projectTaskKanbanView = {
-    ...kanbanView,
+    ...rottingKanbanView,
     ControlPanel: ProjectTaskControlPanel,
     Model: ProjectTaskKanbanModel,
     Renderer: ProjectTaskKanbanRenderer,

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -94,6 +94,11 @@
             <field name="partner_id" position="attributes">
                 <attribute name="column_invisible">0</attribute>
             </field>
+            <field name="is_rotting" position="replace"/>
+            <field name="rotting_days" position="replace"/>
+            <field name="stage_id" position="attributes">
+                <attribute name="widget">selection_badge</attribute>
+            </field>
         </field>
     </record>
 

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -50,6 +50,7 @@
                                 <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color', 'edit_tags': True}"
                                        invisible="user_id"
                                        required="not user_id"/>
+                                <field name="rotting_threshold_days"/>
                             </group>
                         </group>
                     </sheet>
@@ -64,6 +65,7 @@
                 <list string="Task Stage" delete="0" sample="1" multi_edit="1" editable="bottom" open_form_view="True">
                     <field name="sequence" widget="handle" optional="show"/>
                     <field name="name" placeholder="e.g. To Do"/>
+                    <field name="rotting_threshold_days" optional="hide"/>
                     <field name="mail_template_id" optional="hide"/>
                     <field name="project_ids" required="1" optional="show" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="color" optional="hide" widget="color_picker"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -111,6 +111,9 @@
                 <filter name="my_tasks" position="before">
                     <field string="Properties" name="task_properties"/>
                 </filter>
+                <filter name="open_tasks" position="after">
+                    <filter string="Rotting" name="filter_rotting" domain="[('is_rotting', '=', True)]"/>
+                </filter>
                 <filter name="closed_on" position="after">
                     <separator/>
                     <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]" groups="mail.group_mail_notification_type_inbox"/>
@@ -331,8 +334,10 @@
                     <field name="closed_depend_on_count" invisible="1"/>
                     <field name="html_field_history_metadata" invisible="1"/>
                     <field name="is_template" invisible="1"/>
+                    <field name="is_rotting" invisible="1"/>
+                    <field name="rotting_days" invisible="1"/>
                     <header>
-                        <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not project_id and not stage_id"/>
+                        <field name="stage_id" widget="rotting_statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not project_id and not stage_id"/>
                         <field name="state" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="1"/>
                         <field name="personal_stage_type_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="project_id" domain="[('user_id', '=', uid)]" string="Personal Stage"/>
                     </header>
@@ -398,6 +403,8 @@
                         </h1>
                         <div class="d-flex justify-content-end align-items-center px-1" invisible="not active or is_template">
                             <field name="priority" class="h3 pe-2" widget="priority_switch"/>
+                        </div>
+                        <div class="d-flex justify-content-end o_state_container" invisible="not active or is_template">
                             <field name="state" widget="project_task_state_selection" class="o_task_state_widget" />
                         </div>
                         <div class="d-flex justify-content-start align-items-center w-100 w-md-50 w-lg-25" invisible="active and not is_template">
@@ -697,6 +704,8 @@
                                             <widget name="subtask_counter" class="me-1"/>
                                         </t>
                                         <field name="priority" class="pt-1" widget="priority"/>
+                                        <field name="is_rotting" invisible="1"/>
+                                        <field name="rotting_days" widget="rotting" class="ms-1 d-flex"/>
                                     </div>
                                     <div class="d-flex ms-auto">
                                         <field name="user_ids" widget="many2many_avatar_user"/>
@@ -750,7 +759,9 @@
                     <field name="date_last_stage_update" optional="hide" column_invisible="context.get('default_is_template', False)"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
                     <field name="stage_id_color" column_invisible="1"/>
-                    <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show" widget="selection_badge" options="{'color_field': 'stage_id_color'}"/>
+                    <field name="is_rotting" column_invisible="True"/>
+                    <field name="rotting_days" column_invisible="True"/>
+                    <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show" widget="badge_rotting" options="{'color_field': 'stage_id_color'}"/>
                 </list>
             </field>
         </record>

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -173,7 +173,7 @@ class MailTestTrackDurationMixin(models.Model):
     _description = 'Fake model to test the mixin mail.tracking.duration.mixin'
     _name = "mail.test.track.duration.mixin"
     _track_duration_field = 'customer_id'
-    _inherit = ['mail.thread', 'mail.tracking.duration.mixin']
+    _inherit = ['mail.tracking.duration.mixin']
 
     name = fields.Char()
     customer_id = fields.Many2one('res.partner', 'Customer', tracking=True)

--- a/addons/test_mail/models/test_mail_feature_models.py
+++ b/addons/test_mail/models/test_mail_feature_models.py
@@ -1,4 +1,5 @@
 from odoo import api, fields, models
+from odoo.fields import Domain
 
 # ------------------------------------------------------------
 # RECIPIENTS
@@ -53,3 +54,42 @@ class MailTestProperties(models.Model):
     parent_id = fields.Many2one('mail.test.properties', string='Parent')
     properties = fields.Properties('Properties', definition='parent_id.definition_properties')
     definition_properties = fields.PropertiesDefinition('Definitions')
+
+# ------------------------------------------------------------
+# ROTTING RESOURCES
+# ------------------------------------------------------------
+
+
+class MailTestStageField(models.Model):
+    _description = 'Fake model to be a stage to help test rotting implementation'
+    _name = 'mail.test.rotting.stage'
+
+    name = fields.Char()
+    rotting_threshold_days = fields.Integer(default=3)
+    no_rot = fields.Boolean(default=False)
+
+
+class MailTestRottingMixin(models.Model):
+    _description = 'Fake model to test the rotting part of the mixin mail.thread.tracking.duration.mixin'
+    _name = 'mail.test.rotting.resource'
+    _track_duration_field = 'stage_id'
+    _inherit = ['mail.tracking.duration.mixin']
+
+    name = fields.Char()
+    date_last_stage_update = fields.Datetime(
+        'Last Stage Update', compute='_compute_date_last_stage_update', index=True, readonly=True, store=True)
+    stage_id = fields.Many2one('mail.test.rotting.stage', 'Stage')
+    done = fields.Boolean(default=False)
+
+    def _get_rotting_depends_fields(self):
+        return super()._get_rotting_depends_fields() + ['done', 'stage_id.no_rot']
+
+    def _get_rotting_domain(self):
+        return super()._get_rotting_domain() & Domain([
+            ('done', '=', False),
+            ('stage_id.no_rot', '=', False),
+        ])
+
+    @api.depends('stage_id')
+    def _compute_date_last_stage_update(self):
+        self.date_last_stage_update = fields.Datetime.now()

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -62,6 +62,8 @@ access_mail_test_multi_company_with_activity_portal,mail.test.multi.company.with
 access_mail_test_nothread_user,mail.test.nothread.user,model_mail_test_nothread,base.group_user,1,1,1,1
 access_mail_test_nothread_portal,mail.test.nothread.portal,model_mail_test_nothread,base.group_portal,1,0,0,0
 access_mail_test_recipients_user,mail.test.recipients.user,model_mail_test_recipients,base.group_user,1,1,1,1
+access_mail_test_rotting_resource,mail.test.rotting.resource,model_mail_test_rotting_resource,base.group_user,1,1,1,1
+access_mail_test_rotting_stage,mail.test.rotting.stage,model_mail_test_rotting_stage,base.group_user,1,1,1,1
 access_mail_test_thread_customer_user,mail.test.thread.customer.user,model_mail_test_thread_customer,base.group_user,1,1,1,1
 access_mail_test_track_all,mail.test.track.all,model_mail_test_track_all,base.group_user,1,1,1,1
 access_mail_test_track_all_properties_parent,access_mail_test_track_all_properties_parent,model_mail_test_track_all_properties_parent,base.group_user,1,0,0,0

--- a/addons/test_mail/tests/test_mail_thread_mixins.py
+++ b/addons/test_mail/tests/test_mail_thread_mixins.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
 from odoo import exceptions, tools
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tests.common_tracking import MailTrackingDurationMixinCase
@@ -24,6 +25,159 @@ class TestMailTrackingDurationMixin(MailTrackingDurationMixinCase):
 
     def test_queries_batch_mail_tracking_duration(self):
         self._test_queries_batch_duration_tracking()
+
+
+@tagged('mail_thread', 'mail_track')
+class TestMailThreadRottingMixin(MailTrackingDurationMixinCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass('mail.test.rotting.resource')
+
+        [cls.stage_new, cls.stage_qualification, cls.stage_finished] = cls.env['mail.test.rotting.stage'].create([
+            {
+                'name': 'stage_new',
+                'rotting_threshold_days': 3,
+            }, {
+                'name': 'stage_qualification',
+                'rotting_threshold_days': 5,
+            }, {
+                'name': 'stage_finished',
+                'rotting_threshold_days': 1,
+                'no_rot': True,
+            },
+        ])
+
+    def test_resource_rotting(self):
+        # create dates for the test
+        jan1 = datetime(2025, 1, 1)
+        jan5 = datetime(2025, 1, 5)
+        jan7 = datetime(2025, 1, 7)
+        jan12 = datetime(2025, 1, 12)
+        jan28 = datetime(2025, 1, 28)
+
+        # create resources for the test, created on jan 1
+        with self.mock_datetime_and_now(jan1):
+            items = [item1, item2, item3, item_done, item_won] = self.env['mail.test.rotting.resource'].create([
+                {
+                    'name': 'item1',
+                    'stage_id': self.stage_new.id,
+                }, {
+                    'name': 'item2',
+                    'stage_id': self.stage_qualification.id,
+                }, {
+                    'name': 'item3',
+                    'stage_id': self.stage_new.id,
+                }, {
+                    'name': 'item_done',
+                    'stage_id': self.stage_qualification.id,
+                    'done': True,
+                }, {
+                    'name': 'item_wonStage',
+                    'stage_id': self.stage_finished.id,
+                },
+            ])
+            items.flush_recordset(['date_last_stage_update'])  # precalculate stage update()
+
+        with self.mock_datetime_and_now(jan5):
+            # need to invalidate on date change to ensure rotting computations
+            items.invalidate_recordset(['is_rotting'])
+            for item in [item1, item3]:
+                self.assertTrue(
+                    item.is_rotting,
+                    'on jan 5: it\'s been four days, so only items in stage_new should be rotting',
+                )
+                self.assertEqual(item.rotting_days, 4)
+            for item in [item2, item_done, item_won]:
+                self.assertFalse(
+                    item.is_rotting,
+                    'on jan 5: it\'s been four days, so only items in stage_new should be rotting',
+                )
+                self.assertEqual(item.rotting_days, 0)
+
+            item3.name = 'item3 edited'
+            self.assertTrue(
+                item3.is_rotting,
+                'writing to an item doesn\'t affect its rotting status',
+            )
+
+        with self.mock_datetime_and_now(jan7):
+            items.invalidate_recordset(['is_rotting'])
+            self.assertTrue(
+                item2.is_rotting,
+                'on jan 7: items belonging to stage_qualification should be rotting, except if their state forbids it',
+            )
+            self.assertEqual(item2.rotting_days, 6)
+            self.assertFalse(
+                item_done.is_rotting,
+                'item_done is marked as done, it should not be able to rot',
+            )
+
+            self.assertTrue(item1.is_rotting)
+            item1.message_post(body='Message received', message_type='email')
+            self.assertTrue(
+                item1.is_rotting,
+                'Receiving an email should not remove rotting',
+            )
+
+            item1.message_post(body='Message sent', message_type='email_outgoing')
+            self.assertTrue(
+                item1.is_rotting,
+                'Nor should sending an email',
+            )
+
+            self.assertFalse(
+                item_won.is_rotting,
+                'Items in stage_finished cannot rot',
+            )
+            self.stage_finished.no_rot = False
+            self.assertTrue(
+                item_won.is_rotting,
+                'However if the stage no longer disallows rotting, then all items in the stage may once more rot',
+            )
+
+            self.stage_finished.no_rot = True
+            self.assertFalse(
+                item_won.is_rotting,
+                'Disallowing rotting once again should disable rotting once more',
+            )
+
+        with self.mock_datetime_and_now(jan12):
+            items.invalidate_recordset(['rotting_days', 'is_rotting'])
+
+            self.assertTrue(item3.is_rotting)
+            self.stage_new.rotting_threshold_days = 40
+            self.assertFalse(
+                item3.is_rotting,
+                'Changing the threshold should affect the status immediately)',
+            )
+
+            self.stage_new.rotting_threshold_days = 1
+
+            item3.stage_id = self.stage_qualification
+            self.assertFalse(
+                item3.is_rotting,
+                'Changing stages always removes rotting',
+            )
+
+            self.stage_qualification.rotting_threshold_days = 0
+            self.assertFalse(
+                item2.is_rotting,
+                'Setting rotting_threshold_days at 0 on a stage immediately disables rotting for the stage',
+            )
+
+        with self.mock_datetime_and_now(jan28):
+            items.invalidate_recordset(['rotting_days', 'is_rotting'])
+            # After a significant amount of time has passed:
+            self.assertTrue(
+                item1.is_rotting,
+                'Items that are not done or won are rotting',
+            )
+            for item in [item2, item3, item_done, item_won]:
+                self.assertFalse(
+                    item.is_rotting,
+                    'Items that are not done, won, or in a disabled rotting stage are not rotting',
+                )
 
 
 @tagged('mail_thread', 'mail_blacklist')


### PR DESCRIPTION
This PR introduces new logic to the duration tracking mixin.

The rotting logic allows users to get a better sense of when a
resource gets stale. If the logic is activated for a model,
then when its resouces spend too long without seeing activity
based on stage change will be marked as "rotting".

This PR also adds a new custom view for Kanban views; when it is
used in conjunction with the rotting logic, then rotting elements will
appear in a different color in kanban views, highlighting them
and bringing them to attention.

Field widgets for form and kanban views, and view widgets for
list views, also add additional indicators on rotting resources.

This PR makes all necessary modifications to apply the rotting
logic to the crm, project and hr_recruitment modules.

task-5017199