### PR TITLE
[IMP] website_sale: remove short description truncation

### DIFF
--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -23,7 +23,7 @@ class SaleOrderLine(models.Model):
     #=== BUSINESS METHODS ===#
 
     def get_description_following_lines(self):
-        return self.name.splitlines()[1:]
+        return reversed(self.name.splitlines()[1:])
 
     def _get_combination_name(self):
         return self.product_id.product_template_attribute_value_ids._get_combination_name()

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2809,11 +2809,11 @@
          description_sale. Called in `website_sale.cart_lines`. -->
     <template id="cart_line_description_following_lines" name="Shopping Cart Line Description Following Lines">
         <t t-set="description_lines" t-value="line.get_description_following_lines()"/>
-        <div t-if="description_lines" t-attf-class="text-muted small">
+        <div t-if="description_lines" class="text-muted small">
             <t t-foreach="description_lines" t-as="name_line">
                 <span
                     t-if="name_line"
-                    t-attf-class="o_description_line o_line_clamp #{not name_line_last and 'mb-1'}"
+                    t-attf-class="d-block #{not name_line_last and 'mb-1'}"
                     t-out="name_line"
                 />
             </t>
@@ -3063,7 +3063,7 @@
                 <t t-foreach="description_lines" t-as="description_line">
                     <span
                         t-if="description_line"
-                        class="o_description_line o_line_clamp"
+                        class="d-block"
                         t-out="description_line"
                     />
                 </t>
@@ -3297,7 +3297,7 @@
                                     />
                                 </a>
                                 <div
-                                    class="o_description_line o_line_clamp mb-2 small text-muted"
+                                    class="mb-2 small text-muted"
                                     t-field="product.description_sale"
                                 />
                             </div>


### PR DESCRIPTION
In the `/cart` we were truncating the description to avoid it being to long. The issue is that the truncation might happen on a very important information in the description. Thus we decided to take the tradeoff and always show the full description.

task-5026288

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
