### PR TITLE
[FIX] spreadsheet: remove print assets from backend bundle

### DIFF
--- a/addons/spreadsheet/__manifest__.py
+++ b/addons/spreadsheet/__manifest__.py
@@ -87,6 +87,7 @@
             'spreadsheet/static/src/assets_backend/**/*',
             ('remove', 'spreadsheet/static/src/public_readonly_app/**/*.scss'),
             ('remove', 'spreadsheet/static/src/**/*.dark.scss'),
+            ('remove', 'spreadsheet/static/src/print_assets/**/*'),
         ],
         "web.assets_web_dark": [
             'spreadsheet/static/src/**/*.dark.scss',


### PR DESCRIPTION
### Reproduction Steps

1. Install `knowledge`, `spreadsheet`, and `planning` modules
2. In the knowledge app on an admin account, ensure an article is publicly available and invite a portal user
3. Log in as the portal user and attempt to print/export the article
4. Also attempt to print/export the same article from the public (unauthenticated) view

**Result**:

* As a portal user: a blank page is displayed instead of the article.
* As a public user: a blank page is also displayed instead of the article.

### Root Cause

The blank print issue comes from multiple problems with CSS asset loading in print mode:

1. **Spreadsheet Conflict (Portal View)**
   The spreadsheet module’s print styles were incorrectly included in the `web.assets_backend` bundle, causing conflicts. These styles are already properly loaded through `spreadsheet.assets_print` and shouldn’t be duplicated in the backend.

2. **Missing Print Assets (Portal View)**
   The knowledge portal template was missing the `web.assets_web_print` bundle, which contains the core print styles needed for proper article formatting.

3. **Planning Conflict (Public View)**
   The planning module’s print styles in the `web.assets_frontend` bundle were globally hiding elements, conflicting with the display of knowledge articles.

4. **Missing Print Assets (Public View)**
   The knowledge public templates were also missing the `web.assets_web_print` bundle, preventing proper article rendering in print mode.

### Fix

This PR addresses the first issue by removing spreadsheet print assets from the `web.assets_backend` bundle, since they're already available through their dedicated `spreadsheet.assets_print` bundle.

The remaining issues are tackled in odoo/enterprise#92665

opw-4816241

