### PR TITLE
[FIX] mrp: consider archived products on _bom_find

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -311,7 +311,7 @@ class MrpBom(models.Model):
 
         products_ids = set(products.ids)
         for bom in boms:
-            products_implies = bom.product_id or bom.product_tmpl_id.product_variant_ids
+            products_implies = bom.product_id or bom.product_tmpl_id.with_context(active_test=False).product_variant_ids
             for product in products_implies:
                 if product.id in products_ids and product not in bom_by_product:
                     bom_by_product[product] = bom


### PR DESCRIPTION
Steps to reproduce:
- Create a Kit1 (with Comp1) and a Kit2 with (Comp2).
- Create a sales order with 1 unit of each kit.
- Add some variants on Kit1. The main variant without attributes will be archived automatically.
- Confirm the sales order.
- A picking WH/OUT/ will be created only with the Comp2.
- Note that a stock.move for the Comp1 will also be created, but it will not be linked to the WH/OUT/ This happens because the archived product.product is not considered. It should be considered, just like when there's a single Kit.

OPW-4974804

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
