### PR TITLE
[FIX] website: fix sign in button size with some header options

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1740,7 +1740,7 @@ header {
         }
     }
 }
-.navbar-nav {
+:where(header#top) .navbar-nav:where([role="menu"]) {
     .nav-link:not(.o_nav-link_secondary) {
         @if o-website-value('header-links-style') == 'outline' {
             // Need to force the padding in this case so that it stays in mobile


### PR DESCRIPTION
Before this commit, using the "outline" or "border bottom" options
for the Link Style (active page link in the header) would make the
sign in button bigger. This was due to the fact the selector was
not precise enough and would also include the button.

This commit improves the selector to avoid impacting the sign in
button.

Steps to reproduce:
- Go to Edit mode
- Click on the header
- Set the Navbar > Links Style option to "Border Bottom"
- Save
- Log Out
