### PR TITLE
[FIX] pos_loyalty: keep coupon custom codes

### DIFF
--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -91,6 +91,9 @@ class PosOrder(models.Model):
 
         # Create the coupons that were awarded by the order.
         coupons_to_create = {k: v for k, v in coupon_data.items() if k < 0 and not v.get('giftCardId')}
+        for coupon in coupons_to_create.values():
+            if "gift_code" in coupon:
+                coupon["code"] = coupon.get("gift_code")
         coupon_create_vals = [{
             'program_id': p['program_id'],
             'partner_id': get_partner_id(p.get('partner_id', False)),

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -663,9 +663,10 @@ patch(PosOrder.prototype, {
                                                 points: pointsPerUnit,
                                                 barcode: line._gift_barcode,
                                                 giftCardId: line._gift_card_id.id,
+                                                gift_code: line.gift_code,
                                             };
                                         }
-                                        return { points: pointsPerUnit };
+                                        return { points: pointsPerUnit, gift_code: line.gift_code };
                                     })
                                 );
                             }

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -7,6 +7,7 @@ import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
 import * as PaymentScreen from "@point_of_sale/../tests/tours/utils/payment_screen_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/tours/utils/receipt_screen_util";
+import * as Utils from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("GiftCardProgramTour1", {
     steps: () =>
@@ -201,5 +202,21 @@ registry.category("web_tour.tours").add("test_physical_gift_card_invoiced", {
             PaymentScreen.clickInvoiceButton(),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_coupon_code_stays_set", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Gift Card"),
+            PosLoyalty.createManualGiftCard("Card Name", 20),
+            ProductScreen.clickDisplayedProduct("Gift Card"),
+            Utils.refresh(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });


### PR DESCRIPTION
**Steps to reproduce:**

- Go to PoS
- Buy a gift card, click on the sell physical gift card
- Set a custom code and price
- Reload the page
- Go through with the payment and check the downloaded pdf
- The coupon code is an automatically generated one

**Problem:**
When reloading the coupons after reloading the order, the gift cards lose their custom codes if it was set before.
This means that the coupon will have an automatically generated name in the backend as well as in the pdf that is downloaded once the payment is done.

**Why the fix:**
This happens because we are trying to access the order.get_selected_orderline()?.gift_code to get the coupon code.
https://github.com/odoo/odoo/blob/f13ee41a4a62f7fedbddc4245e52ee8e9dce9e0e/addons/pos_loyalty/static/src/overrides/models/pos_store.js#L230
But when we leave the order to go back in afterwards, there is no selected line anymore, so the gift_code is undefined. We then fallback to the default code, which is to generate one for the user.

The gift_code is still on the orderline, so all we need to do is to link the newly created coupon with the gift_code in the orderline.

Another problem that arises her is that when purchasing a custom gift card AND a default gift card in the same order,
then reloading, the gift codes will be mixed up in the pdf and in the backend as well.
This happens because the custom code's name in the backend is 'code' and we use gift_code in the frontend, so we assign the gift_code to the code in the backend.

opw-4964509