### PR TITLE
[FIX] mail: more natural position of message more action menu

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -179,7 +179,7 @@
                 <t t-set="quickActions" t-value="messageActions.actions.slice(0, messageActions.actions.length gt quickActionCount ? quickActionCount - 1 : quickActionCount)"/>
                 <ActionList actions="quickActions" inline="true"/>
                 <div t-if="messageActions.actions.length gt quickActionCount" class="d-flex rounded-0">
-                    <Dropdown state="optionsDropdown" position="props.message.threadAsNewest  ? 'top-start' : 'bottom-start'" menuClass="'d-flex flex-column o-mail-Message-moreMenu o-discuss-dropdownMenu border-secondary'" >
+                    <Dropdown state="optionsDropdown" position="isAlignedRight ? (message.threadAsNewest ? 'left-end' : 'left-start') : (message.threadAsNewest ? 'right-end' : 'right-start')" menuClass="'d-flex flex-column o-mail-Message-moreMenu o-discuss-dropdownMenu border-secondary'" >
                         <t t-call="mail.Message.expandAction"/>
                         <t t-set-slot="content">
                             <ActionList actions="messageActions.actions.slice(quickActionCount - 1)" dropdown="true"/>


### PR DESCRIPTION
Before this commit, message more menu action was placed top or bottom of "..." more button.

The top-bottom position made slightly sense when the icon had ellipsis horizontal, but this was changed to ellipsis vertical for better look and this feels off for its placement not being next to icon horizontally.

This commit changes preferred position of message more action menu to the right of icon rather than bottom. In case there's no place in bottom, it attempts placement at bottom and then top. This ordering is the best.

This commit also fixes the position when message is aligned right, for which the same behaviour but horizontally mirrored is expected: on the left is preferred, then attempt bottom then top.

The exception on newest message to unfold actions towards the top is kept. As a reminder, this exists as a quick-and-dirty workaround to prevent overlap with composer when in practice the composer is sometimes filled with content and user is sometimes tempted to open more actions on most recent message.

Before / After
<img width="350" height="250" alt="Screenshot 2025-08-19 at 17 16 56" src="https://github.com/user-attachments/assets/1a30f49b-3c4c-444d-8982-7ab648d438ed" /> <img width="366" height="250" alt="Screenshot 2025-08-19 at 17 16 38" src="https://github.com/user-attachments/assets/47326e69-e05d-46d8-8c8c-a6a0e1f4610b" />

