### PR TITLE
[FIX] account: fix partial amount matching

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2345,7 +2345,7 @@ class AccountMoveLine(models.Model):
             amls_results, fully_reconciled_aml_ids = self._prepare_reconciliation_amls(
                 [
                     amls_values_map[aml]
-                    for aml in remaining_amls
+                    for aml in remaining_amls.sorted(lambda line: abs(line.balance))
                 ],
                 shadowed_aml_values=shadowed_aml_values,
             )

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -5532,3 +5532,24 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         self.assertEqual(invoice_line.matching_number, payment_line.matching_number)
         self.assertEqual(payment_line.matching_number, currency_exchange_line.matching_number)
         self.assertEqual(currency_exchange_line.amount_residual, 0)
+
+    def test_partial_reconcile_amounts_of_several_matching_lines(self):
+        """ Test that the amounts of the partial reconcile records are matched together when
+            reconciling several aml that match together.
+        """
+        comp_curr = self.company_data['currency']
+        partner_c = self.partner_a.copy()
+        line_1 = self.create_line_for_reconciliation(1000.0, 1000.0, comp_curr, '2016-01-01', partner=self.partner_a)
+        line_2 = self.create_line_for_reconciliation(1001.0, 1001.0, comp_curr, '2016-01-01', partner=self.partner_b)
+        line_3 = self.create_line_for_reconciliation(1002.0, 1002.0, comp_curr, '2016-01-01', partner=partner_c)
+        line_4 = self.create_line_for_reconciliation(-1002.0, -1002.0, comp_curr, '2016-01-01', partner=partner_c)
+        line_5 = self.create_line_for_reconciliation(-1001.0, -1001.0, comp_curr, '2016-01-01', partner=self.partner_b)
+        line_6 = self.create_line_for_reconciliation(-1000.0, -1000.0, comp_curr, '2016-01-01', partner=self.partner_a)
+        lines = line_1 + line_2 + line_3 + line_4 + line_5 + line_6
+        lines.reconcile()
+        reconciliation_lines = lines.full_reconcile_id.partial_reconcile_ids.sorted('amount')
+        self.assertRecordValues(reconciliation_lines, [
+            {'amount': 1000.0, 'debit_move_id': line_1.id, 'credit_move_id': line_6.id},
+            {'amount': 1001.0, 'debit_move_id': line_2.id, 'credit_move_id': line_5.id},
+            {'amount': 1002.0, 'debit_move_id': line_3.id, 'credit_move_id': line_4.id},
+        ])


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Go to "Accounting / Accounting / Journals / Journal Entries"
- Create the following MISC entries in this order:
 1)
   |      Account       |  Partner  | Debit | Credit |
   | ------------------ | --------- | ----- | ------ |
   | Receivable Account | Partner A |  1000 |    0   |
   |     Account X      | Partner A |    0  |  1000  |

  2)
   |      Account       |  Partner  | Debit | Credit |
   | ------------------ | --------- | ----- | ------ |
   | Receivable Account | Partner B |  1001 |    0   |
   |     Account X      | Partner B |    0  |  1001  |

  3)
   |      Account       |  Partner  | Debit | Credit |
   | ------------------ | --------- | ----- | ------ |
   | Receivable Account | Partner C |  1002 |    0   |
   |     Account X      | Partner C |    0  |  1002  |

  4)
   |      Account       |  Partner  | Debit | Credit |
   | ------------------ | --------- | ----- | ------ |
   | Receivable Account | Partner C |    0  |  1002  |
   |     Account X      | Partner C |  1002 |    0   |

  5)
   |      Account       |  Partner  | Debit | Credit |
   | ------------------ | --------- | ----- | ------ |
   | Receivable Account | Partner B |    0  |  1001  |
   |     Account X      | Partner B |  1001 |    0   |

  6)
   |      Account       |  Partner  | Debit | Credit |
   | ------------------ | --------- | ----- | ------ |
   | Receivable Account | Partner A |    0  |  1000  |
   |     Account X      | Partner A |  1000 |    0   |

- Go to "Accounting / Accounting / Journals / Journal Items"
- Select the 6 created lines linked to the Receivable Account
- Reconcile them

**Issue:**
The 6 lines are fully reconciled, but when checking the amounts of the partial reconcile records (not visible in the UI), the debit and credit amounts are matched by their actual order.
So, the first debit line of 1000 is matched with the first credit line of 1002, which results in a residual credit of 2 that is then matched with the second debit line of 1001, which leads to a residual debit of 999 and so on.
This generates weird amounts in the partial reconcile records.

opw-449356




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
