### PR TITLE
[FIX] {test_,}website: search redirect to last page if over


### DIFF
--- a/addons/test_website/tests/test_website_controller_page.py
+++ b/addons/test_website/tests/test_website_controller_page.py
@@ -156,6 +156,13 @@ class TestWebsiteControllerPage(HttpCase):
         self.assertEqual(len(rec_nodes), 1)
         self.assertEqual(rec_nodes[0].get("href"), f"/model/{self.single_controller_page.name_slugified}/{slug(self.exposed_records[1])}")
 
+        response = self.url_open(f"/model/{self.listing_controller_page.name_slugified}/page/2?search={self.exposed_records[0].name}")
+        self.assertEqual(response.url.partition('/model/')[2], f"exposed-model?search={self.exposed_records[0].name}&order=create_date+desc")
+        tree = html.fromstring(response.content.decode())
+        rec_nodes = tree.xpath("//a[@class='test_record_listing']")
+        self.assertEqual(len(rec_nodes), 1)
+        self.assertEqual(rec_nodes[0].get("href"), f"/model/{self.single_controller_page.name_slugified}/{slug(self.exposed_records[0])}")
+
     def test_default_layout(self):
         self.assertEqual(self.listing_controller_page.default_layout, 'grid')
         self.start_tour('/model/exposed-model', 'website_controller_page_listing_layout', login='admin')

--- a/addons/website/controllers/model_page.py
+++ b/addons/website/controllers/model_page.py
@@ -117,6 +117,9 @@ class ModelPageController(Controller):
             step=self.pager_step,
             scope=5,
         )
+        # if we are after the last page, redirect to last page
+        if search_count <= self.pager_step * (page_number - 1) > 0:
+            return request.redirect(pager['page_last']['url'])
 
         records = Model.search(AND(domains), limit=self.pager_step, offset=self.pager_step * (page_number - 1), order=searches["order"])
 


### PR DESCRIPTION

Scenario:

- enable website_studio
- go to contact -> open studio -> website
- add a listing and open it on website
- go to page 2 and search a specific terms with less than 20 results

Result: we see "5 results" in the search bar, but no result are shown
and the pager is hidden.

Cause: the pager is hidden since there is only one page, and we are
currently displaying the records of page 2 that do not exist.

Fix: if we detect that we are on a page over the last page, redirect to
the last page. Eg. if there is 2 pages and we are in page 500, redirect
to page 2.

opw-5008556
