### PR TITLE
[FIX] hr_work_entry_holidays: Handle singleton error for Fully Flexible employees

### DIFF
--- a/addons/hr_work_entry_holidays/models/hr_contract.py
+++ b/addons/hr_work_entry_holidays/models/hr_contract.py
@@ -31,8 +31,10 @@ class HrContract(models.Model):
         # Overriden in hr_work_entry_contract_holiday to select the
         # global time off first (eg: Public Holiday > Home Working)
         self.ensure_one()
-        if 'work_entry_type_id' in interval[2] and interval[2].work_entry_type_id.code in bypassing_codes:
-            return interval[2].work_entry_type_id
+        if 'work_entry_type_id' in interval[2]:
+            work_entry_types = interval[2].work_entry_type_id
+            if work_entry_types and work_entry_types[:1].code in bypassing_codes:
+                return work_entry_types[:1]
 
         interval_start = interval[0].astimezone(pytz.utc).replace(tzinfo=None)
         interval_stop = interval[1].astimezone(pytz.utc).replace(tzinfo=None)


### PR DESCRIPTION
**Issue:**
Multiple errors occur when processing payroll for "Fully Flexible" employees
and overlapping leave scenarios:

1. ValueError "Expected singleton: hr.work.entry.type(7, 8)" during work entry generation
   when sick leave overlaps with public holiday

**Steps to Reproduce:**
1. Go to the **Employees** app and create a new employee.
   * Set the working hours to **empty (fully flexible)**.
2. Go to **Contracts** and create a new contract.
   * Set the **Work Entry Source** to *Attendance*.
   * Save and make the contract **Running**.
3. Go to **Time Off** → **New**, and create a sick time off for the employee.
   * Example: from **25th to 29th**.
   * Approve the time off.
4. Go to **Configuration** → **Public Holidays**, and create a new public holiday.
   * Example: **27th**, which overlaps with the sick time off.
   * Work Entry Type = **Paid Time Off**.
5. Go to **Payroll** → **Work Entries**.
   * A **traceback** occurs.

**Root Causes:**
- In `_get_interval_leave_work_entry_type()`: Direct access to `interval[2].work_entry_type_id.code` causes singleton violation when overlapping leaves create intervals containing multiple work entry types.

**Fix:**
- Replace direct access to `interval[2].work_entry_type_id.code` with safe recordset slicing `interval[2].work_entry_type_id[:1].code` to prevent singleton violation when interval contains multiple work entry types

This resolves payroll blocking issue for deployments using the
Fully Flexible employee feature, where employees may have
overlapping leave types and no assigned working calendar.

Test : [PR](https://github.com/odoo/enterprise/pull/93902)

opw-4979974