### PR TITLE
[FIX] account: Update move ref when payment memo is changed

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -105,7 +105,7 @@ class AccountPayment(models.Model):
         ('customer', 'Customer'),
         ('supplier', 'Vendor'),
     ], default='customer', tracking=True, required=True)
-    memo = fields.Char(string="Memo", tracking=True)
+    memo = fields.Char(string="Memo", tracking=True, inverse='_inverse_memo')
     payment_reference = fields.Char(string="Payment Reference", copy=False, tracking=True,
         help="Reference of the document used to issue this payment. Eg. check number, file name, etc.")
     currency_id = fields.Many2one(
@@ -817,10 +817,15 @@ class AccountPayment(models.Model):
     # ONCHANGE METHODS
     # -------------------------------------------------------------------------
 
+    def _inverse_memo(self):
+        for payment in self:
+            move = payment.move_id
+            if move:
+                move.ref = payment.memo
+
     def _inverse_partner_id(self):
         # todo: remove in master
         pass
-
 
     # -------------------------------------------------------------------------
     # CONSTRAINT METHODS

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -677,6 +677,25 @@ class TestAccountPayment(AccountTestInvoicingCommon, MailCommon):
         payment.action_post()
         self.assertEqual(payment.state, 'paid')
 
+    def test_payment_memo_account_move_ref_inverse(self):
+        ''' Ensure that when the account payment's memo is updated,
+            the related account move's ref is also updated.
+        '''
+        bank_journal = self.company_data['default_journal_bank']
+        bank_journal.inbound_payment_method_line_ids.payment_account_id = self.inbound_payment_method_line.payment_account_id
+        payment = self.env['account.payment'].create({
+            'payment_type': 'inbound',
+            'partner_type': 'customer',
+            'partner_id': self.partner_a.id,
+            'journal_id': bank_journal.id,
+            'amount': 2629,
+            'memo': 'Test Memo'
+        })
+        payment.action_post()
+        payment.write({'memo': 'Updated Memo'})
+
+        self.assertEqual(payment.move_id.ref, payment.memo)
+
     def test_payment_state_with_unreconciliable_outstanding_account(self):
         unreconciliable_account = self.env['account.account'].create({
             'code': '209.01.01',


### PR DESCRIPTION
Issue: In previous versions, the memo field of account payments and ref field of account move were related Now that payments do not required to have generated account move's when the memo is updated the ref remains unchanged.

Purpose of this PR:
To update the account move ref when the payment memo is updated.

Steps to Reproduce on Runbot:
install accounting
go to bank account and assign outstanding accounts for manual payment methods create a payment -- a related account move should be created update the memo on the payment -- the ref on the related account move is unchanged.

opw-4989260

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
