### PR TITLE
[FIX] survey: compute subject when changing template

### DIFF
--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -154,7 +154,7 @@ class SurveyInvite(models.TransientModel):
 
     @api.depends('template_id', 'partner_ids')
     def _compute_subject(self):
-        for invite in self.filtered(lambda inv: not inv.subject):
+        for invite in self:
             if invite.template_id and invite.template_id.subject:
                 invite.subject = invite.template_id.subject
             else:


### PR DESCRIPTION
Changing the template would not change the subject field if there was already a subject in the subject field on the composer. This is not consistent with how the behavior was on 16.0 or in other instances where the mail composer mixin is used.

The expected behavior is to always change the subject to the one on the template unless there is no template in which case it would be false. But in survey invite there is a default which is what we use.

Steps to reproduce:
1. Create a survey
2. Share the survey and send by email
3. Change the template

opw-5005642
