### PR TITLE
[PERF] stock,mrp: optimize _search_product_quantity

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -325,6 +325,7 @@ class MrpBom(models.Model):
 
     @api.model
     def _bom_find_domain(self, products, picking_type=None, company_id=False, bom_type=False):
+        products.fetch(['product_tmpl_id'])
         domain = ['&', '|', ('product_id', 'in', products.ids), '&', ('product_id', '=', False), ('product_tmpl_id', 'in', products.product_tmpl_id.ids), ('active', '=', True)]
         if company_id or self.env.context.get('company_id'):
             domain = AND([domain, ['|', ('company_id', '=', False), ('company_id', '=', company_id or self.env.context.get('company_id'))]])
@@ -343,7 +344,8 @@ class MrpBom(models.Model):
         :rtype: defaultdict(`lambda: self.env['mrp.bom']`)
         """
         bom_by_product = defaultdict(lambda: self.env['mrp.bom'])
-        products = products.filtered(lambda p: p.type != 'service')
+        if not self.env.context.get('skip_products_filter'):
+            products = products.filtered(lambda p: p.type != 'service')
         if not products:
             return bom_by_product
         domain = self._bom_find_domain(products, picking_type=picking_type, company_id=company_id, bom_type=bom_type)


### PR DESCRIPTION
The performance when searching by `qty_available`, `virtual_available`, `free_qty`, `incoming_qty`, or `outgoing_qty` on databases with a large number of `product.product`s is very poor. We improve the performance by moving `_compute_quantities_dict()` up the call stack in `_search_product_quantity()`.

Previously, `_search_product_quantity()` would compute the fields for each product individually in a loop, generating N queries:

Instead, we directly call `_compute_quantities_dict()` on the recordset, which will perform a single read on quants/moves and compute the quantities for all products at once. This results in a constant number of queries relative to the number of products in the database. Some additional optimizations are made in `_compute_quantities_dict()` to avoid additional queries.

Benchmark

| `product.product` count | Before                 | After                 |
| ----------------------- | ---------------------- | --------------------- |
| 5,000                   | 1.48s, 62 queries      | 0.83s, 49 queries     |
| 50,000                  | 13.44s, 351 queries    | 6.47s, 49 queries     |
| 500,000                 | 201.36s, 4,554 queries | 37.86s, 30 queries    |

opw-4930856