### PR TITLE
[FIX] account: prevent valueError with onchange trigger

### DIFF
--- a/addons/account/tests/test_account_move_duplicate.py
+++ b/addons/account/tests/test_account_move_duplicate.py
@@ -74,6 +74,24 @@ class TestAccountMoveDuplicate(AccountTestInvoicingCommon):
             {'duplicated_ref_ids': (invoice_1 + invoice_2).ids},
         ])
 
+    def test_in_invoice_multiple_duplicate_reference_batch_in_edit_mode(self):
+        """
+            Ensure duplicated ref are computed correctly even when updated in batch
+            when they are in edit mode
+        """
+        invoice_1 = self.invoice
+        invoice_1.ref = 'a unique supplier reference that will be copied'
+        invoice_2 = invoice_1.copy(default={'invoice_date': invoice_1.invoice_date})
+        invoices_new = self.env['account.move'].browse([
+            self.env['account.move'].new(origin=inv).id for inv in (invoice_1, invoice_2)
+        ])
+        # reassign to trigger the compute method
+        invoices_new.ref = invoice_1.ref
+        self.assertRecordValues(invoices_new, [
+            {'duplicated_ref_ids': []},
+            {'duplicated_ref_ids': (invoices_new[0]).ids},
+        ])
+
     def test_in_invoice_single_duplicate_reference_diff_date(self):
         """ Ensure duplicated ref are computed correctly for different dates"""
         bill1 = self.invoice.copy({'invoice_date': self.invoice.invoice_date})


### PR DESCRIPTION
**Step to reproduce**
- create a SO
- link 2+ invoices to it
- using studio, add invoice_ids to the SO Form
- trigger a onchange (ex. change the product from SOL)
- we receive a traceback

**Traceback:**
```ValueError: Expected singleton: account.move(<NewId origin=35>, <NewId origin=31>, <NewId origin=32>, <NewId origin=33>, <NewId origin=34>)```

**Issue:**
- from `onchange` triggers chain,`_compute_duplicated_ref_ids` is invoked calling `_fetch_duplicate_reference` for the related moves (invoice_ids) such that as they are in create/edit mode
- at this time `convert_to_write(moves[field_name], moves)` fails as moves has more than 1 record and `recordset[field]` is not valid syntax in such case
https://github.com/odoo/odoo/blob/3966753eb5a8534c8b5b8a16e626f5250c9013cf/addons/account/models/account_move.py#L1868-L1884

- hence, we receive valueError, expecting a singleton

**Fix;**
- we adapt the method to accept multiple moves which may be in
create/edit mode

opw-4959528

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
