### PR TITLE
[FIX] im_livechat,*: composer inactive when chatbot expects inputs

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -8,10 +8,9 @@
             </t>
         </xpath>
         <xpath expr="//Composer" position="replace">
-            <t t-if="thread?.composerDisabled and !thread?.isTransient and store.self.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
-            <div t-if="thread?.composerDisabled" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerDisabledContainer">
+            <div t-if="thread?.composerHidden" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerHiddenContainer">
                 <span t-if="!showGiveFeedbackBtn" class="flex-grow-1"/>
-                <span t-esc="thread.composerDisabledText"/>
+                <span>This livechat conversation has ended</span>
                 <span class="flex-grow-1"/>
             </div>
             <t t-else="">$0</t>

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -1,7 +1,6 @@
 import { Record } from "@mail/core/common/record";
 import { Thread } from "@mail/core/common/thread_model";
 
-import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 patch(Thread.prototype, {
@@ -59,15 +58,10 @@ patch(Thread.prototype, {
         return this.channel_type === "livechat" || super.isChatChannel;
     },
 
-    get composerDisabled() {
+    get composerHidden() {
         return this.channel_type === "livechat" && this.livechat_active === false;
     },
 
-    get composerDisabledText() {
-        return this.channel_type === "livechat" && this.livechat_active === false
-            ? _t("This livechat conversation has ended")
-            : null;
-    },
     /**
      * @override
      * @param {import("models").Persona} persona

--- a/addons/im_livechat/static/src/core/public_web/discuss_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_patch.xml
@@ -2,8 +2,9 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Discuss" t-inherit-mode="extension">
         <xpath expr="//Composer" position="replace">
-            <t t-if="thread?.composerDisabled and !thread?.isTransient and store.self.notEq(thread?.livechatVisitorMember?.persona)">$0</t>
-            <span t-if="thread?.composerDisabled" class="bg-200 py-1 text-center fst-italic fw-bold text-muted" t-esc="thread.composerDisabledText"/>
+            <span t-if="thread?.composerHidden" class="bg-200 py-1 text-center fst-italic fw-bold text-muted">
+                This livechat conversation has ended
+            </span>
             <t t-else="">$0</t>
         </xpath>
     </t>

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
@@ -13,10 +13,10 @@
         <xpath expr="//*[hasclass('o-mail-ChatWindow-header')]" position="attributes">
             <attribute name="t-attf-style" add="color: {{ livechatService.options.title_color }}; background-color: {{ livechatService.options.header_background_color }} !important;" separator=" "/>
         </xpath>
-        <xpath expr="//*[@t-ref='composerDisabledContainer']" position="inside">
+        <xpath expr="//*[@t-ref='composerHiddenContainer']" position="inside">
             <button t-if="showGiveFeedbackBtn" class="btn btn-link p-0" title="Give your feedback" t-on-click="() => this.onClickFeedback()">Continue</button>
         </xpath>
-        <xpath expr="//*[@t-ref='composerDisabledContainer']" position="attributes">
+        <xpath expr="//*[@t-ref='composerHiddenContainer']" position="attributes">
             <attribute name="t-attf-class" add="{{ showGiveFeedbackBtn ? 'px-2' : '' }}" separator=" "/>
         </xpath>
     </t>

--- a/addons/im_livechat/static/src/embed/common/composer_patch.js
+++ b/addons/im_livechat/static/src/embed/common/composer_patch.js
@@ -1,10 +1,25 @@
 import { Composer } from "@mail/core/common/composer";
 
+import { useEffect } from "@odoo/owl";
+
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
 patch(Composer.prototype, {
+    setup() {
+        super.setup();
+        useEffect(
+            () => {
+                if (this.thread?.composerDisabled || this.thread?.chatbot?.isProcessingAnswer) {
+                    this.ref.el.blur();
+                } else {
+                    this.ref.el.focus();
+                }
+            },
+            () => [this.thread?.composerDisabled, this.thread?.chatbot?.isProcessingAnswer]
+        );
+    },
     get placeholder() {
         if (this.thread?.channel_type !== "livechat") {
             return super.placeholder;

--- a/addons/im_livechat/static/src/embed/common/composer_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/composer_patch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.Composer" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o-mail-Composer-coreMain')]" position="attributes">
+            <attribute name="t-att-class">{'pe-none': this.thread?.composerDisabled}</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -3,7 +3,6 @@ import { Thread } from "@mail/core/common/thread_model";
 import "@mail/discuss/core/common/thread_model_patch";
 
 import { patch } from "@web/core/utils/patch";
-import { _t } from "@web/core/l10n/translation";
 import { Deferred } from "@web/core/utils/concurrency";
 import { prettifyMessageContent } from "@mail/utils/common/format";
 
@@ -150,7 +149,6 @@ patch(Thread.prototype, {
             return false;
         }
         return (
-            super.composerDisabled ||
             this.chatbot?.isProcessingAnswer ||
             (step &&
                 !step.operatorFound &&
@@ -158,20 +156,10 @@ patch(Thread.prototype, {
         );
     },
 
-    get composerDisabledText() {
-        const text = super.composerDisabledText;
-        if (text || !this.chatbot) {
-            return text;
+    get composerHidden() {
+        if (this.chatbot?.forwarded && this.livechat_active) {
+            return false;
         }
-        if (this.chatbot.completed) {
-            return _t("This livechat conversation has ended");
-        }
-        if (
-            this.chatbot.currentStep?.type === "question_selection" &&
-            !this.chatbot.currentStep.selectedAnswer
-        ) {
-            return _t("Select an option above");
-        }
-        return _t("Say something");
+        return super.composerHidden || this.chatbot?.completed;
     },
 });

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -134,7 +134,6 @@ test("visitor leaving ends the livechat conversation", async () => {
     // simulate visitor leaving
     await withGuest(guestId, () => rpc("/im_livechat/visitor_leave_session", { channel_id }));
     await contains("span", { text: "This livechat conversation has ended" });
-    await contains(".o-mail-Composer-input"); // so that can still `/lead` or last resort send message to visitor
     await click("button[title*='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { count: 0 });
 });

--- a/addons/im_livechat/static/tests/embed/unread_messages.test.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages.test.js
@@ -54,14 +54,13 @@ test("new message from operator displays unread counter", async () => {
             livechatUserId: serverState.publicUserId,
         })
     );
-    setupChatHub({ opened: [channelId] });
+    setupChatHub({ folded: [channelId] });
     onRpc("/mail/data", async (request) => {
         const { params } = await request.json();
         if (params.fetch_params.includes("init_messaging")) {
             asyncStep(`/mail/data - ${JSON.stringify(params)}`);
         }
     });
-    onRpc("/discuss/channel/messages", () => asyncStep("/discuss/channel/message"));
     const userId = serverState.userId;
     await start({
         authenticateAs: { ...pyEnv["mail.guest"].read(guestId)[0], _name: "mail.guest" },
@@ -81,7 +80,6 @@ test("new message from operator displays unread counter", async () => {
                 allowed_company_ids: [1],
             },
         })}`,
-        "/discuss/channel/message",
     ]);
     // send after init_messaging because bus subscription is done after init_messaging
     await withUser(userId, () =>
@@ -91,7 +89,7 @@ test("new message from operator displays unread counter", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatWindow-counter", { text: "1" });
+    await contains(".o-mail-ChatBubble-counter", { text: "1" });
 });
 
 test.tags("focus required");

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -218,7 +218,7 @@ registry.category("web_tour.tours").add('website_form_contactus_submit', {
     // the email
     {
         isActive: ["body:has(.o-livechat-root)"],
-        trigger: ":shadow span:contains(select an option above)",
+        trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
     },
     {
         content: "Fill in the subject",

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -75,11 +75,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 trigger: messagesContain("Can you give us your email please?"),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input ",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus ",
                 run: "edit No, you won't get my email!",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
@@ -89,11 +89,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 ),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit okfine@fakeemail.com",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
@@ -105,11 +105,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 trigger: messagesContain("Would you mind providing your website address?"),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit https://www.fakeaddress.com",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
@@ -119,36 +119,36 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 // should ask for feedback now
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit Yes, actually, I'm glad you asked!",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit I think it's outrageous that you ask for all my personal information!",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit I will be sure to take this to your manager!",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit I want to say...",
             },
             {
                 // Simulate that the user is typing, so the chatbot shouldn't go to the next step
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 async run() {
                     const target = new TourHelpers(this.anchor);
                     chatbotDelayProcessingDef = new Deferred();
@@ -215,11 +215,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 trigger: messagesContain("Would you mind providing your website address?"),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit no",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {
@@ -229,11 +229,11 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 ),
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "edit no, nothing so say",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-Composer-input",
+                trigger: ".o-livechat-root:shadow .o-mail-Composer-input:focus",
                 run: "press Enter",
             },
             {


### PR DESCRIPTION
*=website, website_livechat

Before this commit:
When the chatbot required processing, the composer became inactive. Upon re-enabling for user input, the composer lost focus, forcing users to click on it each time to provide input.

This commit ensures that the composer retains focus, allowing users to immediately start typing without needing to click.

task-4509416

