### PR TITLE
[IMP] hr: add button to open version form view

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -596,3 +596,16 @@ class HrVersion(models.Model):
                 'version_id': self.id,
             },
         }
+
+    def action_open_version_form_view(self):
+        self.ensure_one()
+        view_id = self.env.ref('hr.hr_contract_template_form_view').id
+
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'hr.version',
+            'res_id': self.id,
+            'views': [[view_id, "form"]],
+            'target': 'current',
+            'context': self.env.context
+        }

--- a/addons/hr/views/hr_version_views.xml
+++ b/addons/hr/views/hr_version_views.xml
@@ -23,6 +23,7 @@
                 <field name="create_date" optional="hide"/>
                 <field name="last_modified_uid" optional="hide" readonly="1"/>
                 <field name="last_modified_date" optional="hide" readonly="1"/>
+                <button name="action_open_version_form_view" type="object" string="View" class="btn-link" groups="base.group_no_one"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
In version list view there is no way to access the form of the version.
Add a button to open the form view of the version in the list view.

task-4992852