### PR TITLE
[FIX] website: correctly placed the color filter option

### DIFF
--- a/addons/website/static/src/builder/plugins/options/background_option.xml
+++ b/addons/website/static/src/builder/plugins/options/background_option.xml
@@ -13,7 +13,7 @@
         </t>
     </xpath>
     <!-- TODO: change position of the xpath when snippet_options_image_optimization_widgets is converted -->
-    <xpath expr="//BackgroundShapeOption" position="before">
+    <xpath expr="//ImageFormatOption" position="after">
         <ParallaxOption/>
         <t t-call="website.BackgroundVideoOption"/>
     </xpath>


### PR DESCRIPTION
[FIX] website: correctly placed the color filter option

Steps to reproduce:
- Add a "Text-Image" snippet.
- Add a background video.

-> The "Color Filter" option is misplaced.

Since the [website refactoring], the "Color Filter" option is placed
over the "Video" option while it should be under it. This commit fixes
this problem.

Related to task-4367641

[website refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
