### PR TITLE
[FIX] auth_ldap: fix external dependency name

### DIFF
--- a/addons/auth_ldap/__manifest__.py
+++ b/addons/auth_ldap/__manifest__.py
@@ -11,7 +11,7 @@
         'views/res_config_settings_views.xml',
     ],
     'external_dependencies': {
-        'python': ['ldap'],
+        'python': ['python-ldap'],
     },
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
The wrong package name leads to a warning at install time making unnecessary noise in nighlty builds.

