### PR TITLE
[FIX] http: Typeerror on homepage

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1359,7 +1359,10 @@ __wz_get_response = HTTPException.get_response
 
 
 def get_response(self, environ=None, scope=None):
-    return Response(__wz_get_response(self, environ, scope))
+    if scope is None:  # compatible with werkzeug 0.16.x
+        return Response(__wz_get_response(self, environ))
+    else:
+        return Response(__wz_get_response(self, environ, scope))  # werkzeug 2.0.2
 
 
 HTTPException.get_response = get_response


### PR DESCRIPTION
Recently this fix deployed https://github.com/odoo/odoo/commit/b210017ed089f650f9bec9596ff077decfee54f4
Issue during testing while connecting with odoo for lower version then 3.9 as per [requirement](https://github.com/odoo/odoo/blob/94e84750b46497c49ad7e1d36591f829bd22ce05/requirements.txt#L75-L76) 16.0 version db can use lower then or equal 3.9 python version so according to both Werkzeug version ``get_response`` have the difference in positional argument
[2.0.2](https://github.com/pallets/werkzeug/blob/532479573ab3ecd815795df58a48ae7d68777ee0/src/werkzeug/exceptions.py#L190) vs [0.16.1](https://github.com/pallets/werkzeug/blob/0.16.1/src/werkzeug/exceptions.py#L166)

```
Traceback (most recent call last):
  File "/home/odoo/.odoo-venvs/15.0/lib/python3.8/site-packages/werkzeug/serving.py", line 306, in run_wsgi
    execute(self.server.app)
  File "/home/odoo/.odoo-venvs/15.0/lib/python3.8/site-packages/werkzeug/serving.py", line 294, in execute
    application_iter = app(environ, start_response)
  File "/home/odoo/src/odoo/16.0/odoo/http.py", line 2286, in __call__
    return exc.error_response(environ, start_response)
  File "/home/odoo/.odoo-venvs/15.0/lib/python3.8/site-packages/werkzeug/exceptions.py", line 191, in __call__
    response = self.get_response(environ)
  File "/home/odoo/src/odoo/16.0/odoo/http.py", line 1362, in get_response
    return Response(__wz_get_response(self, environ, scope))
TypeError: get_response() takes from 1 to 2 positional arguments but 3 were given 8 0.008 0.019
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
