### PR TITLE
[FIX] website: restore red on selected device visibility option buttons

### DIFF
--- a/addons/website/static/src/builder/plugins/options/visibility_option.xml
+++ b/addons/website/static/src/builder/plugins/options/visibility_option.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
 <t t-name="website.DeviceVisibility">
-    <BuilderButton className="'btn-danger-color-active'" action="'toggleDeviceVisibility'" actionParam="'no_desktop'" preview="false">
+    <BuilderButton className="'o-hb-btn-has-img-icon btn-danger-color-active'" action="'toggleDeviceVisibility'" actionParam="'no_desktop'" preview="false">
 		<Img src="'/html_builder/static/img/options/desktop_invisible.svg'" style="'width: 12px'"/>
 	</BuilderButton>
-    <BuilderButton className="'btn-danger-color-active'" action="'toggleDeviceVisibility'" actionParam="'no_mobile'" preview="false">
+    <BuilderButton className="'o-hb-btn-has-img-icon btn-danger-color-active'" action="'toggleDeviceVisibility'" actionParam="'no_mobile'" preview="false">
 		<Img src="'/html_builder/static/img/options/mobile_invisible.svg'" style="'width: 12px'" />
 	</BuilderButton>
 </t>


### PR DESCRIPTION
Since [1] bootstrap color is not forwarded from button to nested SVG by default.

This commit restores this by adding the `o-hb-btn-has-img-icon` class. The `iconImg` introduced in [1] cannot be used because we need to specifiy a `style` on the `<Img>`.

[1]: https://github.com/odoo/odoo/pull/213019/commits/eca4d1b1d4ea58959793b0a2cbfa443308759372

task-4367641
