### PR TITLE
[FIX] iot_drivers: print even if can't get printer status

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -239,9 +239,8 @@ class PrinterDriverBase(Driver, ABC):
                 elif paper_status == 1:
                     self.send_status(status='warning', message='WARNING_LOW_PAPER')
         except (escpos.exceptions.Error, OSError, AssertionError):
-            self.send_status(status='error', message='ERROR_UNREACHABLE')
+            self.escpos_device = None
             _logger.warning("Failed to query ESC/POS status")
-            return False
 
         return True
 


### PR DESCRIPTION
If for some reason, the IoT Box can't query the epson printer status, we should still try to print: an escpos lib issue shouldn't prevent cups from sending its job.