### PR TITLE
[FIX] hr_attendance: show checkout field in Gantt modal

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -78,7 +78,7 @@
                             <group col="1">
                                 <field name="employee_id" widget="many2one_avatar_user"/>
                                 <field name="check_in" options="{'rounding': 0}"/>
-                                <field name="check_out" options="{'rounding': 0}" placeholder="Currently Working"/>
+                                <field name="check_out" options="{'rounding': 0}" placeholder="Not yet checked out"/>
                             </group>
                             <group col="2">
                                 <field name="worked_hours" string="Worked Time" widget="float_time"/>


### PR DESCRIPTION
The Gantt popup form explicitly set `check_out` invisible when it was empty, which prevented users from manually entering a checkout for an open attendance.

This commit removes the overriding xpath so that the form simply inherits the standard `hr_attendance_view_form` behavior, where the `check_out` field is always visible and editable. Users can now set a manual checkout directly from the Gantt modal.

task-5026978