### PR TITLE
[FIX] account_edi_ubl_cii: fix error when sending partially paid credit note

### DIFF
--- a/addons/account_edi_ubl_cii/tools/ubl_21_credit_note.py
+++ b/addons/account_edi_ubl_cii/tools/ubl_21_credit_note.py
@@ -51,6 +51,7 @@ CreditNote = {
     'cac:AccountingSupplierParty': cac.SupplierParty,
     'cac:AccountingCustomerParty': cac.CustomerParty,
     'cac:SellerSupplierParty': cac.SupplierParty,
+    'cac:PrepaidPayment': cac.PrepaidPayment,
     'cac:Delivery': cac.Delivery,
     'cac:PaymentMeans': cac.PaymentMeans,
     'cac:PaymentTerms': cac.PaymentTerms,


### PR DESCRIPTION
When User sends the partially paid credit note, A traceback will appear.

Steps to reproduce the error:
- Install ``l10n_co_dian`` module with demo data and switch to CO Company
- Create a Credit note > Confirm > Register a partial payment > Send > Send

Traceback:
``ValueError: The following child node is not defined in the template: CreditNote/cac:PrepaidPayment``

https://github.com/odoo/odoo/blob/7136383f47f3f86bc803efaa3837f4879b211b11/addons/account_edi_ubl_cii/tools/ubl_21_credit_note.py#L26
Here, ``cac:PrepaidPayment`` node is missing in the CreditNote.
So, It will raise the above traceback when sending the credit note.

sentry-6814211355

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
