### PR TITLE
[FIX] website: s_floating_blocks new card grid resizable


### DIFF
--- a/addons/website/static/src/snippets/s_floating_blocks/options.xml
+++ b/addons/website/static/src/snippets/s_floating_blocks/options.xml
@@ -12,7 +12,7 @@
     <section data-name="Card" class="s_floating_blocks_block s_col_no_resize position-sticky d-flex py-5 o_cc o_cc1">
         <div class="container-fluid align-self-end">
             <div class="s_floating_blocks_block_grid row mx-0 o_grid_mode" data-row-count="8">
-                <div class="o_grid_item g-height-4 col-lg-8 order-lg-0" style="z-index: 1; grid-area: 1 / 1 / 5 / 9;">
+                <div class="o_grid_item g-height-4 g-col-lg-8 col-lg-8 order-lg-0" style="z-index: 1; grid-area: 1 / 1 / 5 / 9;">
                     <p class="lead">A great subtitle</p>
                     <h2 class="display-4-fs">Card Title</h2>
                 </div>


### PR DESCRIPTION

Scenario:

- add a "Cards" snippet (s_floating_blocks)
- click on "Add New" cards
- resize vertically the grid containing "Card Title"

Result: traceback error is shown

  TypeError: Cannot read properties of undefined (reading 'substring')
   at iframeWindowMouseUp (snippets.options.js:4799:1)

Cause: the code assume that there is always a g-col-* class and it is
there on demo cards, as well as if the grid is resized horizontally, but
it's not there when adding a new card.

Fix: adding the class the the new card template.

opw-5027818
