### PR TITLE
[FIX] website_sale: prevent reload on ProductReplaceMainImageAction

### DIFF
--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -120,7 +120,7 @@ class ProductPageOptionPlugin extends Plugin {
 
 export class ProductPageImageWidthAction extends WebsiteConfigAction {
     static id = "productPageImageWidth";
-    static dependencies = ["customizeWebsite", "productPageOption"];
+    static dependencies = [...super.dependencies, "customizeWebsite", "productPageOption"];
     isApplied({ editingElement: productDetailMainEl, value }) {
         return productDetailMainEl.dataset.image_width === value;
     }
@@ -141,7 +141,7 @@ export class ProductPageImageWidthAction extends WebsiteConfigAction {
 }
 export class ProductPageImageLayoutAction extends WebsiteConfigAction {
     static id = "productPageImageLayout";
-    static dependencies = ["customizeWebsite", "productPageOption"];
+    static dependencies = [...super.dependencies, "customizeWebsite", "productPageOption"];
     isApplied({ editingElement: productDetailMainEl, value }) {
         return productDetailMainEl.dataset.image_layout === value;
     }
@@ -349,7 +349,7 @@ export class ProductPageImageGridColumnsAction extends BaseProductPageAction {
 }
 export class ProductReplaceMainImageAction extends BaseProductPageAction {
     static id = "productReplaceMainImage";
-    static dependencies = ["media_website"];
+    static dependencies = [...super.dependencies, "media_website"];
     setup() {
         super.setup();
         this.reload = false;
@@ -365,7 +365,7 @@ export class ProductReplaceMainImageAction extends BaseProductPageAction {
 
 export class ProductAddExtraImageAction extends BaseProductPageAction {
     static id = "productAddExtraImage";
-    static dependencies = ["media"];
+    static dependencies = [...super.dependencies, "media"];
     async apply({ editingElement: el }) {
         // Prompts the user for images, then saves the new images.
         if (this.model === "product.template") {

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -349,12 +349,17 @@ export class ProductPageImageGridColumnsAction extends BaseProductPageAction {
 }
 export class ProductReplaceMainImageAction extends BaseProductPageAction {
     static id = "productReplaceMainImage";
+    static dependencies = ["media_website"];
+    setup() {
+        super.setup();
+        this.reload = false;
+    }
     apply({ editingElement: productDetailMainEl }) {
         // Emulate click on the main image of the carousel.
         const image = productDetailMainEl.querySelector(
             `[data-oe-model="${this.model}"][data-oe-field=image_1920] img`
         );
-        image.dispatchEvent(new Event("dblclick", { bubbles: true }));
+        this.dependencies.media_website.replaceMedia(image);
     }
 }
 

--- a/addons/website_sale/static/tests/builder/product_page_option.test.js
+++ b/addons/website_sale/static/tests/builder/product_page_option.test.js
@@ -1,0 +1,48 @@
+import { expect, test } from "@odoo/hoot";
+import { waitForNone } from "@odoo/hoot-dom";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("Replace Main Image", async () => {
+    onRpc("ir.attachment", "search_read", () => [
+        {
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
+    await setupWebsiteBuilder(`
+        <main>
+            <div class="o_wsale_product_page">
+                <div id="product_detail_main">
+                    <div class="o_wsale_product_images">
+                        <div id="o-carousel-product">
+                            <div class="carousel-item h-100 text-center active o_colored_level" style="min-height: 693px;">
+                                <div name="o_img_with_max_suggested_width"
+                                    class="d-flex align-items-start justify-content-center h-100 oe_unmovable o_editable"
+                                    data-oe-xpath="/t[1]/div[2]/div[1]" data-oe-model="product.product" data-oe-id="13"
+                                    data-oe-field="image_1920" data-oe-type="image"
+                                    data-oe-expression="product_image.image_1920" contenteditable="false">
+                                    <img>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>`);
+
+    await contains(":iframe .o_wsale_product_page").click();
+    await contains("[data-action-id=productReplaceMainImage]").click();
+    await contains(".o_select_media_dialog img").click();
+    await waitForNone(".o_select_media_dialog");
+
+    expect(":iframe #product_detail_main img[src^='data:image/webp;base64,']").toHaveCount(1);
+    expect(":iframe img").toHaveCount(1);
+});

--- a/addons/website_sale/static/tests/builder/product_page_option.test.js
+++ b/addons/website_sale/static/tests/builder/product_page_option.test.js
@@ -1,28 +1,30 @@
 import { expect, test } from "@odoo/hoot";
 import { waitForNone } from "@odoo/hoot-dom";
-import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { contains, dataURItoBlob, onRpc } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
     setupWebsiteBuilder,
+    waitForEndOfOperation,
 } from "@website/../tests/builder/website_helpers";
 
 defineWebsiteModels();
 
-test("Replace Main Image", async () => {
-    onRpc("ir.attachment", "search_read", () => [
-        {
-            mimetype: "image/png",
-            image_src: "/web/static/img/logo2.png",
-            access_token: false,
-            public: true,
-        },
-    ]);
+test("Product page options", async () => {
     await setupWebsiteBuilder(`
         <main>
             <div class="o_wsale_product_page">
-                <div id="product_detail_main">
-                    <div class="o_wsale_product_images">
+                <div id="product_detail_main" data-image_width="66_pc" data-image_layout="carousel">
+                    <div class="o_wsale_product_images" data-image-amount="2">
                         <div id="o-carousel-product">
+                            <div class="carousel-item h-100 text-center active o_colored_level" style="min-height: 693px;">
+                                <div name="o_img_with_max_suggested_width"
+                                    class="d-flex align-items-start justify-content-center h-100 oe_unmovable o_editable"
+                                    data-oe-xpath="/t[1]/div[2]/div[1]" data-oe-model="product.product" data-oe-id="13"
+                                    data-oe-field="image_1920" data-oe-type="image"
+                                    data-oe-expression="product_image.image_1920" contenteditable="false">
+                                    <img>
+                                </div>
+                            </div>
                             <div class="carousel-item h-100 text-center active o_colored_level" style="min-height: 693px;">
                                 <div name="o_img_with_max_suggested_width"
                                     class="d-flex align-items-start justify-content-center h-100 oe_unmovable o_editable"
@@ -38,11 +40,58 @@ test("Replace Main Image", async () => {
             </div>
         </main>`);
 
+    onRpc("/website/theme_customize_data", () => expect.step("theme_customize_data"));
+    onRpc("/website/theme_customize_data_get", () => expect.step("theme_customize_data_get"));
+    onRpc("/shop/config/website", () => expect.step("config"));
+    onRpc("/html_editor/modify_image/1", () => expect.step("modify_image"));
+    onRpc("ir.ui.view", "save", () => {
+        expect.step("save");
+        return [];
+    });
+
+    onRpc("ir.attachment", "search_read", () => [
+        {
+            mimetype: "image/png",
+            image_src: "/web/image/hoot.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
+
+    onRpc("/html_editor/get_image_info", () => {
+        expect.step("get_image_info");
+        return {
+            attachment: { id: 1 },
+            original: { id: 1, image_src: "/web/image/hoot.png", mimetype: "image/png" },
+        };
+    });
+
+    onRpc(
+        "/web/image/hoot.png",
+        () => {
+            const base64Image =
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYIIA" +
+                "A".repeat(1000); // converted image won't be used if original is not larger
+            return dataURItoBlob(base64Image);
+        },
+        { pure: true },
+    );
+
     await contains(":iframe .o_wsale_product_page").click();
     await contains("[data-action-id=productReplaceMainImage]").click();
     await contains(".o_select_media_dialog img").click();
     await waitForNone(".o_select_media_dialog");
 
     expect(":iframe #product_detail_main img[src^='data:image/webp;base64,']").toHaveCount(1);
-    expect(":iframe img").toHaveCount(1);
+    expect(":iframe img").toHaveCount(2);
+    expect.verifySteps(["theme_customize_data_get", "get_image_info"]);
+
+    await contains("[data-action-id=productPageImageWidth]").click();
+    await waitForEndOfOperation();
+    expect.verifySteps(["config", "modify_image", "save", "theme_customize_data_get"]);
+
+    await contains("button#o_wsale_image_layout").click();
+    await contains("[data-action-id=productPageImageLayout]").click();
+    await waitForEndOfOperation();
+    expect.verifySteps(["theme_customize_data", "config", "theme_customize_data_get"]);
 });


### PR DESCRIPTION
__Current behavior before commit:__
When trying to replace the main image on a product page, the iframe reloads before the user can choose an image in the dialog. Therefore, when the user chooses on an image the editing element is already removed, leading to a crash.

__Description of the fix:__
Disable the automatic reload for `ProductReplaceMainImageAction` like it was done in saas-18.3.

__Steps to reproduce the issue:__
1. Go to a product page
2. Open the editor
3. Click on the "Replace" button next to "Main Image"
4. Click on an image in the dialog
5. Traceback: `TypeError: Cannot read properties of null (reading 'getComputedStyle')`

opw-5010040
