### PR TITLE
[FIX] l10n_gr_edi : neutralize

### DIFF
--- a/addons/l10n_gr_edi/data/neutralize.sql
+++ b/addons/l10n_gr_edi/data/neutralize.sql
@@ -1,0 +1,3 @@
+UPDATE res_company
+   SET l10n_gr_edi_test_env = TRUE;
+


### PR DESCRIPTION
This commit adds the missing neutralization necessary for the l10n_gr_edi
module introduced in [1]

The purpose of the standard neutralization framework is to allow us to
create database copies that will not interact with external systems in
ways that could impact the production database (or if it is not possible
to prevent the interactions, make sure that they are benign or won't
result in actual changes), or impact the customers of the operator of
the production database.

This is mainly useful to allow safe support investigation on database
duplicates.

[1] odoo#203428
