### PR TITLE
[IMP] web_studio: multiple improvements in studio

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -52,6 +52,12 @@ const supportedInfoValidation = {
             shape: { label: String, value: String },
             optional: true,
         },
+        /**
+         * If true, the listed fields come from the relation.
+         * e.g.: the field is a relational one like many2many_tags, so
+         * property 'field' will search on the relation.
+         * */
+        isRelationalField: { type: Boolean, optional: false },
     },
     optional: true,
 };

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -229,6 +229,7 @@ export const many2ManyTagsField = {
             label: _t("Color field"),
             name: "color_field",
             type: "field",
+            isRelationalField: true,
             availableTypes: ["integer"],
             help: _t("Set an integer field to use colors with the tags."),
         },


### PR DESCRIPTION
- Removing properties from chatter

- Added related field will take by default the string of the related field

- Correction of the property 'Color field' for the many2many_tags widget. The value wasn't showing.

- A new attribute is available for the supportedOptions. It's 'isRelationalField'. This attribute is used for the options that are type: "field". When it's set to true, the list of fields for the selection will come from the relation model and not from the viewEditor model.

- The techinal name is now normalized

- and other minor UX improvements

TASK-ID: 4936789




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
