### PR TITLE
[FIX] web_editor: properly compute inner layer border-radius

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -767,10 +767,10 @@ pre {
     // --box-border-(radius|width) : rounded-XXX classes
     // --border-(radius|width) : theme (+ default bootstrap)
     border-radius:
-        calc(var(--box-border-top-left-radius, 0) - max(var(--box-border-top-width, 0), var(--box-border-left-width, 0)))
-        calc(var(--box-border-top-right-radius, 0) - max(var(--box-border-top-width, 0), var(--box-border-right-width, 0)))
-        calc(var(--box-border-bottom-right-radius, 0) - max(var(--box-border-bottom-width, 0), var(--box-border-right-width, 0)))
-        calc(var(--box-border-bottom-left-radius, 0) - max(var(--box-border-bottom-width, 0), var(--box-border-left-width, 0)))
+        calc(var(--box-border-top-left-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-left-width, 0px)))
+        calc(var(--box-border-top-right-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-right-width, 0px)))
+        calc(var(--box-border-bottom-right-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-right-width, 0px)))
+        calc(var(--box-border-bottom-left-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-left-width, 0px)))
 }
 
 section, .oe_img_bg, [data-oe-shape-data] {


### PR DESCRIPTION
Follow-up of [1], introduced a mistake just before the merge. CSS calc does not support `0` without a unit.

[1]: https://github.com/odoo/odoo/commit/d0daf3990079477ef7552d769b944b55d9be4366

