### PR TITLE
Master-mail_fix_access_to_store_attr-akha

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -463,11 +463,18 @@ class DiscussChannel(models.Model):
                 return field_description.field_name
             return field_description
 
+        def get_field_value(channel, field_description):
+            if isinstance(field_description, Store.Relation):
+                return field_description._get_value(channel).records
+            if isinstance(field_description, Store.Attr):
+                return field_description._get_value(channel)
+            return channel[field_description]
+
         def get_vals(channel):
             return {
                 subchannel: {
                     get_field_name(field_description): (
-                        channel[get_field_name(field_description)],
+                        get_field_value(channel, field_description),
                         field_description,
                     )
                     for field_description in field_descriptions


### PR DESCRIPTION
Fields are added to '_sync_field_names' method so that they are synced whenever their value changes. Some of these fields are added using 'Store.Attr' which has a 'sudo' parameter. This sudo parameter is not used when the value of the field is retrieved inside the 'write' method of 'discuss.channel'. This commit now uses the 'sudo' property to access the field's value.

Steps to reproduce:
- Whenever 'discuss.channel'.write({...}) is called (without sudo), the values of the fields defined inside `_sync_field_names` method are retrieved. This will raise ACL error if one of these fields has restricted access, for example a field defined with `groups='base.group_system'`.