### PR TITLE
[FIX] account_peppol: prevent error in peppol EAS computation of partners

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -61,7 +61,7 @@ class ResPartner(models.Model):
     def _compute_available_peppol_eas(self):
         # EXTENDS 'account_edi_ubl_cii'
         super()._compute_available_peppol_eas()
-        eas_codes = set(self.available_peppol_eas)
+        eas_codes = set(self[:1].available_peppol_eas)
         if self.env.company._get_peppol_edi_mode() != 'demo' and 'odemo' in eas_codes:
             eas_codes.remove('odemo')
             self.available_peppol_eas = list(eas_codes)

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -474,3 +474,15 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             wizard.action_send_and_print()
             self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()
         self.assertEqual(move_1.peppol_move_state, 'error')
+
+    def test_compute_available_peppol_eas_multi_partner(self):
+        """Check _compute_available_peppol_eas works with multiple partners"""
+
+        # Create multiple partners
+        partners = self.env['res.partner'].create([
+            {'name': 'Partner A'},
+            {'name': 'Partner B'},
+        ])
+        partners._compute_available_peppol_eas()
+        for partner in partners:
+            self.assertFalse('odemo' in partner.available_peppol_eas)


### PR DESCRIPTION
**Steps to Reproduce:**
1. Install `account_peppol` and `contacts`.
2. Open the Contacts app (list view).
3. Select any two contacts and click on "Merge" from the "Actions" menu.
4. Open any of the merged contacts in form view.
5. Close the form view and click on "Add a line".
6. Select multiple records.

**Error:**
ValueError - Expected singleton: res.partner(11, 9)

**Cause:**
The method `_compute_available_peppol_eas` accesses `self.available_peppol_eas` directly. When multiple `res.partner` records were involved, it will raised a singleton error.

**Fix:**
Loop over each partner to compute `available_peppol_eas` for each. This prevents the singleton error when multiple records are processed.

sentry-6807787390