### PR TITLE
[FIX] sale: unit price not recomputed from pricelist on quantity change

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -560,6 +560,10 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
     def _compute_price_unit(self):
+        def has_manual_price(line):
+            return line.currency_id.compare_amounts(line.technical_price_unit, line.price_unit)
+
+        force_recompute = self.env.context.get('force_price_recomputation')
         for line in self:
             # Don't compute the price for deleted lines.
             if not line.order_id:
@@ -567,7 +571,7 @@ class SaleOrderLine(models.Model):
             # check if the price has been manually set or there is already invoiced amount.
             # if so, the price shouldn't change as it might have been manually edited.
             if (
-                (line.technical_price_unit != line.price_unit and not line.env.context.get('force_price_recomputation'))
+                (not force_recompute and has_manual_price(line))
                 or line.qty_invoiced > 0
                 or (line.product_id.expense_policy == 'cost' and line.is_expense)
             ):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -561,7 +561,13 @@ class SaleOrderLine(models.Model):
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
     def _compute_price_unit(self):
         def has_manual_price(line):
-            return line.currency_id.compare_amounts(line.technical_price_unit, line.price_unit)
+            # `line.currency_id` can be False for NewId records
+            currency = (
+                line.currency_id
+                or line.company_id.currency_id
+                or line.env.company.currency_id
+            )
+            return currency.compare_amounts(line.technical_price_unit, line.price_unit)
 
         force_recompute = self.env.context.get('force_price_recomputation')
         for line in self:

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -347,6 +347,53 @@ class TestSalePrices(SaleCommon):
         order_line.product_uom = new_uom
         self.assertEqual(order_line.price_total, 1800, "First pricelist rule not applied")
 
+    def test_pricelist_price_recompute_on_quantity_change(self):
+        """
+        Test price updates correctly when quantity changes with
+        pricelist based on another pricelist.
+        """
+        self._enable_pricelists()
+
+        pricelist_a = self.env['product.pricelist'].create({
+            'name': "Pricelist A",
+            'item_ids': [
+                Command.create({
+                    'applied_on': '3_global',
+                    'compute_price': 'fixed',
+                    'fixed_price': 0.75,
+                    'min_quantity': 0,
+                }),
+                Command.create({
+                    'applied_on': '3_global',
+                    'compute_price': 'fixed',
+                    'fixed_price': 0.50,
+                    'min_quantity': 1000,
+                }),
+            ],
+        })
+
+        pricelist_b = self.env['product.pricelist'].create({
+            'name': "Pricelist B",
+            'item_ids': [
+                Command.create({
+                    'applied_on': '3_global',
+                    'compute_price': 'percentage',
+                    'percent_price': -10,
+                    'base': 'pricelist',
+                    'base_pricelist_id': pricelist_a.id,
+                }),
+            ],
+        })
+
+        with Form(self.env['sale.order']) as order_form:
+            order_form.partner_id = self.partner
+            order_form.pricelist_id = pricelist_b
+            with order_form.order_line.new() as line_form:
+                line_form.product_id = self.product
+                self.assertEqual(line_form.price_unit, 0.83)
+                line_form.product_uom_qty = 1000
+                self.assertEqual(line_form.price_unit, 0.55)
+
     def test_multi_currency_discount(self):
         """Verify the currency used for pricelist price & discount computation."""
         product_1 = self.product

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -394,6 +394,22 @@ class TestSalePrices(SaleCommon):
                 line_form.product_uom_qty = 1000
                 self.assertEqual(line_form.price_unit, 0.55)
 
+    def test_compute_price_unit_no_currency(self):
+        new_order = self.env['sale.order'].new({
+            'currency_id': False,
+            'pricelist_id': False,
+            'order_line': [Command.create({'product_id': self.product.id})],
+        })
+        new_line = new_order.order_line
+        self.assertEqual(new_line.price_unit, self.product.list_price)
+
+        new_line.price_unit = new_price = self.product.list_price + 0.5
+        new_line.product_uom_qty += 1.0
+        self.assertEqual(new_line.price_unit, new_price, "Manual unit price shouldn't change")
+
+        new_order._recompute_prices()
+        self.assertEqual(new_line.price_unit, self.product.list_price)
+
     def test_multi_currency_discount(self):
         """Verify the currency used for pricelist price & discount computation."""
         product_1 = self.product


### PR DESCRIPTION
> [!Note]
> This PR unreverts fc6b9ed22728 with a minor modification to ensure one `res.currency` record to compare amounts.

**Steps to reproduce**:
1. Install the `sale` module.
2. Enable `Pricelists` under `Settings > Sales > Pricing > Pricelists`.
3. Create two pricelists:
   - Pricelist A with two fixed-price rules: - 0.75 for quantity ≥ 0 - 0.50 for quantity ≥ 1000
   - Pricelist B with a -10% discount applied to Pricelist A.
4. Create a Sales Order using Pricelist B.
5. Add a product to the order line.
6. Increase the quantity to 1000.

**Observed behavior**:
- The unit price does not update according to the pricelist rule for quantity ≥ 1000.
- If you switch the pricelist to another and then back again, the `Update prices` button appears and correctly updates the price.

**Root cause**:
- The price is not recomputed when the quantity changes because the `price_unit` is not updated because it does not match the `technical_price_unit`.
- Since e1b22257a714, `price_unit` is rounded (2 decimals), but `technical_price_unit` is not. This causes a mismatch in comparison logic due to rounding differences.

**Solution**:
- Replace direct float comparison with `currency_id.compare_amounts()` to ensure proper comparison with rounding precision.

opw-4944644