### PR TITLE
[FIX] html_editor: prevent flicker when rotating images

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -189,7 +189,16 @@ export class ImageTransformation extends Component {
         settings.angle = Math.round(settings.angle);
         settings.translatex = Math.round(settings.translatex);
         settings.translatey = Math.round(settings.translatey);
+
+        // When rotating, the offset used for the rotation center must be stable.
+        // getOffset normally includes CSS transforms, which would move the
+        // transfoCenter on each call and cause flickering.
+        // Temporarily remove the transform to compute the correct static position.
+        const prevImageTransform = this.image.style.transform;
+        this.image.style.transform = "";
         this.transfo.settings.pos = this.getOffset(this.image);
+        this.image.style.transform = prevImageTransform;
+
         this.positionTransfoContainer();
         this.props.onChange();
     }


### PR DESCRIPTION
Problem:
Rotating an image caused a visible flicker.

Cause:
After commit 59653b4, the container position (`this.transfo.settings.pos`) was recomputed on each mouse move using `getOffset()`. However, `getBoundingClientRect()` includes CSS transforms, so the computed center (`transfoCenter`) was shifting during rotation, even though the image’s visual center does not move. This caused the container to "jump" and flicker.

Solution:
Compute the image center without applying its current CSS transform. By temporarily ignoring the `transform`, we get a stable center, so rotation works smoothly without flickering.

Steps to reproduce:
1. Open todo.
2. Insert an image.
3. Rotate the image. → Notice flickering before this fix, smooth rotation after.

opw-5028443

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
