### PR TITLE
[FIX] account_payment: get the correct partial payment amount from link

### DIFF
--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -14,7 +14,7 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
     def _invoice_get_page_view_values(self, invoice, access_token, payment=False, amount=None, **kwargs):
         # EXTENDS account
 
-        values = super()._invoice_get_page_view_values(invoice, access_token, **kwargs)
+        values = super()._invoice_get_page_view_values(invoice, access_token, amount=amount, **kwargs)
 
         if not invoice._has_to_be_paid():
             # Do not compute payment-related stuff if given invoice doesn't have to be paid.


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have an unpaid invoice;
2. generate a partial payment link;
3. open partial payment link;
4. click the Pay button.

Issue
-----
The invoice's full amount gets requested.

Cause
-----
Commit 5697493e0091 added `amount` as a named keyword parameter in an `_invoice_get_page_view_values` override, but failed to pass it along to the call to `super`. As the base method no longer receives an `amount` parameter, it defaults to the invoice total.

Solution
--------
Pass `amount` to the `super` call.

opw-5013044