### PR TITLE
[REF] *: not import directly hoot-dom in tours

### DIFF
--- a/addons/auth_totp/static/tests/apikeys_flow.js
+++ b/addons/auth_totp/static/tests/apikeys_flow.js
@@ -1,4 +1,3 @@
-import { queryAll, queryText } from "@odoo/hoot-dom";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 
@@ -49,7 +48,7 @@ registry.category("web_tour.tours").add('apikeys_tour_setup', {
     content: "Check that we're on the last step & grab key",
     trigger: '.modal p:contains("Here is your new API key")',
     run: async () => {
-        const key = queryText("code [name=key] span");
+        const key = document.querySelector("code [name=key] span").textContent;
         await rpc('/web/dataset/call_kw', {
             model: 'ir.logging', method: 'send_key',
             args: [key],
@@ -110,10 +109,5 @@ registry.category("web_tour.tours").add('apikeys_tour_teardown', {
     run: 'click',
 }, {
     content: "Check that there's no more keys",
-    trigger: '.o_notebook',
-    run: function() {
-        if (queryAll("[name=api_key_ids]:visible", { root: this.anchor }).length) {
-            console.error("Expected API keys to be hidden (because empty), but it's not");
-        }
-    }
+    trigger: "body:not(:has(.o_notebook [name=api_key_ids]))",
 }]});

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -1,4 +1,3 @@
-import { queryAll, waitFor } from "@odoo/hoot-dom";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
@@ -51,16 +50,18 @@ function closeProfileDialog({content, totp_state}) {
 
     return [{
         content,
-        //TODO: remove when PIPU macro PR is merged: https://github.com/odoo/odoo/pull/194508
         trigger: 'a[role=tab]:contains("Account Security").active',
+    }, 
+    {
+        trigger,
         async run(helpers) {
-            await waitFor(trigger, { timeout: 5000 });
             const modal = document.querySelector(".o_dialog");
             if (modal) {
                 modal.querySelector("button[name=preference_cancel]").click();
             }
         }
-    }, {
+    },
+    {
         trigger: 'body',
         async run() {
             while (document.querySelector('.o_dialog')) {
@@ -77,12 +78,11 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
     url: '/odoo',
     steps: () => [...openUserProfileAtSecurityTab(), {
     content: "Open totp wizard",
-    //TODO: remove when PIPU macro PR is merged: https://github.com/odoo/odoo/pull/194508
     trigger: 'a[role=tab]:contains("Account Security").active',
-    async run(actions) {
-        const el = await waitFor('button[name=action_totp_enable_wizard]', { timeout: 5000 });
-        await actions.click(el);
-    }
+},
+{
+    trigger: "button[name=action_totp_enable_wizard]",
+    run: "click",
 },
 {
     trigger: ".modal div:contains(entering your password)",
@@ -368,6 +368,7 @@ registry.category("web_tour.tours").add('totp_admin_disables', {
     content: "Find test_user User",
     trigger: 'td.o_data_cell:contains("test_user")',
     run(helpers) {
+        const { queryAll } = odoo.loader.modules.get("@odoo/hoot-dom");
         const titles = queryAll("tr:first th", { root: this.anchor.closest("table") });
         titles.forEach((el, i) => {
             columns[el.getAttribute('data-name')] = i;

--- a/addons/auth_totp_mail/static/tests/totp_flow.js
+++ b/addons/auth_totp_mail/static/tests/totp_flow.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
-import { queryFirst } from "@odoo/hoot-dom";
 
 function openAccountSettingsTab() {
     return [{
@@ -48,16 +47,7 @@ registry.category("web_tour.tours").add('totp_admin_self_invite', {
     run: "click",
 }, {
     content: "check that user cannot invite themselves to use 2FA.",
-    trigger: "body",
-    run: function () {
-        const inviteBtn = queryFirst('button:contains(Invite to use 2FA)');
-        if (!inviteBtn) {
-            document.body.classList.add('CannotInviteYourself');
-        }
-    }
-}, {
-    content: "check that user cannot invite themself.",
-    trigger: "body.CannotInviteYourself",
+    trigger: "body:not(:has(button:contains(Invite to use 2FA)))",
 }]});
 
 registry.category("web_tour.tours").add('totp_admin_invite', {

--- a/addons/barcodes/static/src/barcode_handlers.js
+++ b/addons/barcodes/static/src/barcode_handlers.js
@@ -2,7 +2,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { getVisibleElements } from "@web/core/utils/ui";
 import { Macro } from "@web/core/macro";
-import { click, edit } from "@odoo/hoot-dom";
 
 function clickOnButton(selector) {
     const button = document.body.querySelector(selector);
@@ -33,12 +32,14 @@ function updatePager(position) {
             {
                 trigger: "span.o_pager_value",
                 async action(trigger) {
+                    const { click } = odoo.loader.modules.get("@odoo/hoot-dom");
                     await click(trigger);
                 },
             },
             {
                 trigger: "input.o_pager_value",
                 async action(trigger) {
+                    const { click, edit } = odoo.loader.modules.get("@odoo/hoot-dom");
                     await click(trigger);
                     await edit(next, { confirm: "blur" });
                 },

--- a/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
@@ -1,6 +1,6 @@
 import { registry } from "@web/core/registry";
+import { delay } from "@web/core/utils/concurrency";
 import { stepUtils } from "@web_tour/tour_utils";
-import { delay } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour", {
     url: "/odoo",
@@ -57,7 +57,7 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
                 // Ensure the system has registered a correct model value before
                 // we try to open the DPH.
                 // It seems that the autocomplete validation can be very slow.
-                await new Promise((r) => setTimeout(r, 200));
+                await delay(200);
             },
         },
         {

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -1,4 +1,4 @@
-import { delay } from "@odoo/hoot-dom";
+import { delay } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
@@ -244,7 +244,10 @@ registry.category("web_tour.tours").add("portal_project_sharing_chatter_mention_
         {
             trigger: "body:not(:has(.o-mail-Composer-suggestion))",
             run: async () => {
-                await delay(odoo.loader.modules.get("@mail/core/common/suggestion_hook").DELAY_FETCH);
+                const delay_fetch = odoo.loader.modules.get(
+                    "@mail/core/common/suggestion_hook"
+                ).DELAY_FETCH;
+                await delay(delay_fetch);
             },
         },
         { trigger: ".o-mail-Composer-input", run: "edit @Georges" },

--- a/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_performance_tour.js
@@ -1,4 +1,3 @@
-import { queryOne } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 
@@ -22,6 +21,7 @@ var registerSteps = [{
     content: "Fill attendees details",
     trigger: 'form[id="attendee_registration"] .btn[type=submit]',
     run: function () {
+        const { queryOne } = odoo.loader.modules.get("@odoo/hoot-dom");
             document.querySelector("input[name*='1-name']").value = "Raoulette Poiluchette";
             document.querySelector("input[name*='1-phone']").value = "0456112233";
             document.querySelector("input[name*='1-email']").value = "raoulette@example.com";

--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -1,4 +1,3 @@
-import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_favorite_management", {
@@ -111,14 +110,14 @@ registry.category("web_tour.tours").add("test_favorite_management", {
         },
         {
             trigger: ".o_favorite_menu .o-dropdown-item:contains(Apps2)",
-            run() {
-                if (queryAll(".o_searchview_facet").length) {
-                    throw new Error("There should not be any facet inside the search bar");
-                }
-                if (queryAll(".o_favorite_menu .o-dropdown-item:contains(Apps1)").length) {
-                    throw new Error("The Apps1 filter should be deleted");
-                }
-            },
+        },
+        {
+            content: "There should not be any facet inside the search bar",
+            trigger: "body:not(:has(.o_searchview_facet))",
+        },
+        {
+            content: "The Apps1 filter should be deleted",
+            trigger: "body:not(:has(.o_favorite_menu .o-dropdown-item:contains(Apps1)))",
         },
     ],
 });

--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 import { WORKER_STATE } from "@bus/workers/websocket_worker";
 import { whenReady } from "@odoo/owl";
-import { animationFrame } from "@odoo/hoot-dom";
 
 function logout() {
     return [
@@ -9,7 +8,7 @@ function logout() {
             trigger: ".o_web_client .o_navbar",
             async run() {
                 await whenReady();
-                await animationFrame();
+                await new Promise((resolve) => requestAnimationFrame(resolve));
                 await new Promise((resolve) => {
                     const bus = odoo.__WOWL_DEBUG__.root.env.services.bus_service;
                     bus.addEventListener("BUS:CONNECT", resolve, { once: true });

--- a/addons/web_tour/static/src/tour_utils.js
+++ b/addons/web_tour/static/src/tour_utils.js
@@ -1,4 +1,3 @@
-import * as hoot from "@odoo/hoot-dom";
 import { _t } from "@web/core/l10n/translation";
 
 export const stepUtils = {
@@ -24,9 +23,10 @@ export const stepUtils = {
             {
                 trigger,
                 run: async () => {
-                    const input = hoot.queryFirst(trigger);
+                    const { queryFirst, edit } = odoo.loader.modules.get("@odoo/hoot-dom");
+                    const input = queryFirst(trigger);
                     input.focus();
-                    await hoot.edit(value);
+                    await edit(value);
                 },
             },
         ];
@@ -68,10 +68,10 @@ export const stepUtils = {
             isActive,
             content: `autoExpandMoreButtons`,
             trigger: ".o-form-buttonbox",
-            run() {
-                const more = hoot.queryFirst(".o-form-buttonbox .o_button_more");
+            async run(helpers) {
+                const more = document.querySelector(".o-form-buttonbox .o_button_more");
                 if (more) {
-                    hoot.click(more);
+                    await helpers.click(more);
                 }
             },
         };
@@ -111,13 +111,14 @@ export const stepUtils = {
             {
                 isActive: ["auto", "mobile"],
                 trigger: ".o_statusbar_buttons",
-                run: (actions) => {
-                    const buttonOutSideDropdownMenu = hoot.queryFirst(
+                async run(helpers) {
+                    const { queryFirst } = odoo.loader.modules.get("@odoo/hoot-dom");
+                    const buttonOutSideDropdownMenu = queryFirst(
                         `.o_statusbar_buttons button:enabled:contains('${innerTextButton}')`
                     );
-                    const node = hoot.queryFirst(".o_statusbar_buttons button:has(.oi-ellipsis-v)");
+                    const node = queryFirst(".o_statusbar_buttons button:has(.oi-ellipsis-v)");
                     if (!buttonOutSideDropdownMenu && node) {
-                        hoot.click(node);
+                        await helpers.click(node);
                     }
                 },
             },


### PR DESCRIPTION
In this commit, we remove import of hoot-dom in tour files in order to lazy load hoot-dom only when a tour is launched.
In most of time, we can replace uses of hoot-dom by simple function. When the use of hoot-dom is really usefull, we can import it with odoo.loader.module.get()