### PR TITLE
[FIX] pos_self_order: avoid highlighting order button after sending for prep

### DIFF
--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_multi_table_order.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_multi_table_order.js
@@ -5,6 +5,7 @@ import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as ProductScreenPos from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/product_screen_util";
+import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import { registry } from "@web/core/registry";
 
 const Chrome = { ...ChromePos, ...ChromeRestaurant };
@@ -28,5 +29,19 @@ registry.category("web_tour.tours").add("OnlinePaymentWithMultiTables", {
             ProductScreen.clickPayButton(),
             PaymentScreen.validateButtonIsHighlighted(true),
             PaymentScreen.clickValidate(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_online_payment_pos_self_order_preparation_changes", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Chrome.clickOrders(),
+            TicketScreen.checkStatus("Self-order", "Ongoing"),
+            TicketScreen.selectOrder("Self-order"),
+            TicketScreen.loadSelectedOrder(),
+            ProductScreen.isShown(),
+            ProductScreen.clickReview(),
+            ProductScreen.clickOrderButton(),
         ].flat(),
 });

--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
@@ -27,3 +27,20 @@ registry.category("web_tour.tours").add("self_mobile_online_payment_meal_table",
         Utils.clickBtn("Pay"),
     ],
 });
+
+registry
+    .category("web_tour.tours")
+    .add("test_online_payment_mobile_self_order_preparation_changes", {
+        steps: () =>
+            [
+                Utils.checkIsNoBtn("My Order"),
+                Utils.clickBtn("Order Now"),
+                ProductPage.clickProduct("Coca-Cola"),
+                ProductPage.clickProduct("Fanta"),
+                Utils.clickBtn("Order"),
+                CartPage.checkProduct("Fanta", "2.53", "1"),
+                CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+                Utils.clickBtn("Pay"),
+                CartPage.selectTable("3"),
+            ].flat(),
+    });

--- a/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
@@ -42,3 +42,28 @@ class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "self_mobile_online_payment_meal_table")
+
+    def test_online_payment_mobile_self_order_preparation_changes(self):
+        """
+        Ensure that the Order button in the POS UI remains enabled when an online payment method
+        is configured for mobile self-ordering and the order has not yet been paid.
+        """
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'table',
+            'self_order_online_payment_method_id': self.online_payment_method.id,
+            'use_presets': False,
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+
+        # create self-order from mobile
+        self.start_tour(self.pos_config._get_self_order_route(), 'test_online_payment_mobile_self_order_preparation_changes')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.state, 'draft')
+        self.assertEqual(len(order.lines), 2)
+
+        # Check self-order in pos-terminal order button remains enabled
+        self.start_tour('/pos/ui?config_id=%d' % self.pos_config.id, 'test_online_payment_pos_self_order_preparation_changes', login='pos_user')

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -85,8 +85,11 @@
         # Assets tests
         "pos_self_order.assets_tests": [
             ("include", "point_of_sale.base_tests"),
-            "pos_self_order/static/tests/**/*",
+            "pos_self_order/static/tests/tours/**/*",
             "point_of_sale/static/tests/generic_helpers/numpad_util.js",
+        ],
+        'web.assets_tests': [
+            'pos_self_order/static/tests/pos/**/*',
         ],
     },
     "license": "LGPL-3",

--- a/addons/pos_self_order/static/src/overrides/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_self_order/static/src/overrides/screens/ticket_screen/ticket_screen.js
@@ -1,0 +1,19 @@
+import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
+import { patch } from "@web/core/utils/patch";
+
+patch(TicketScreen.prototype, {
+    getFilteredOrderList() {
+        const orders = super.getFilteredOrderList();
+        orders.forEach((order) => {
+            if (
+                (order.pos_reference.includes("Self-Order") ||
+                    order.pos_reference.includes("Kiosk")) &&
+                !order.online_payment_method_id &&
+                !Object.keys(order.last_order_preparation_change.lines).length
+            ) {
+                order.updateLastOrderChange();
+            }
+        });
+        return orders;
+    },
+});

--- a/addons/pos_self_order/static/tests/pos/pos_self_order_tour.js
+++ b/addons/pos_self_order/static/tests/pos/pos_self_order_tour.js
@@ -1,0 +1,19 @@
+import * as ProductScreenPos from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/product_screen_util";
+const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
+import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_pos_self_order_preparation_changes", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Chrome.clickOrders(),
+            TicketScreen.checkStatus("Self-order", "Ongoing"),
+            TicketScreen.selectOrder("Self-order"),
+            TicketScreen.loadSelectedOrder(),
+            ProductScreen.isShown(),
+            ProductScreen.orderlinesHaveNoChange(),
+        ].flat(),
+});

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -321,3 +321,20 @@ registry.category("web_tour.tours").add("self_order_mobile_0_price_order", {
             Utils.clickBtn("My Order"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_mobile_self_order_preparation_changes", {
+    steps: () =>
+        [
+            Utils.checkIsNoBtn("My Order"),
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Coca-Cola"),
+            ProductPage.clickProduct("Fanta"),
+            Utils.clickBtn("Order"),
+            CartPage.checkProduct("Fanta", "2.53", "1"),
+            CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+            Utils.clickBtn("Pay"),
+            CartPage.selectTable("3"),
+            ConfirmationPage.isShown(),
+            Utils.clickBtn("Ok"),
+        ].flat(),
+});

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -158,3 +158,23 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
 
         order = self.env['pos.order'].search([], limit=1)
         self.assertEqual(order.picking_count, 1)
+
+    def test_mobile_self_order_preparation_changes(self):
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'table',
+            'use_presets': False,
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+
+        # create self-order from mobile
+        self.start_tour(self.pos_config._get_self_order_route(), 'test_mobile_self_order_preparation_changes')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.state, 'draft')
+        self.assertEqual(len(order.lines), 2)
+
+        # Check self-order in pos-terminal are not prompted for Send-for-Preparation
+        self.start_tour('/pos/ui?config_id=%d' % self.pos_config.id, 'test_pos_self_order_preparation_changes', login='pos_user')


### PR DESCRIPTION
In the POS UI, the "Order" button was wrongly highlighted when loading a self-order, even though it had already been sent

Steps to reproduce:
- Create an order using self-order mobile (or kiosk).
- Open the related POS terminal.
- Load the self-order from the ticket screen.
- Notice the "Order" button remains highlighted.

Fix:
- Ensure the last order changes updated when loading self-order in pos

Task: 5005161