### PR TITLE
 [FIX] web: emoji picker crash for non-English

### DIFF
--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -1,4 +1,4 @@
-import { patchTranslations, preloadBundle } from "@web/../tests/web_test_helpers";
+import { patchTranslations, patchWithCleanup, preloadBundle } from "@web/../tests/web_test_helpers";
 
 import {
     click,
@@ -18,9 +18,10 @@ describe.current.tags("desktop");
 defineMailModels();
 preloadBundle("web.assets_emoji");
 
-test("emoji picker works well with translation with double quotes", async () => {
+test("emoji picker correctly handles translations with special characters", async () => {
     patchTranslations({
         "Japanese “here” button": `Bouton "ici" japonais`,
+        "heavy dollar sign": `Symbole du dollar\nlourd`,
     });
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "" });
@@ -29,6 +30,8 @@ test("emoji picker works well with translation with double quotes", async () => 
     await click("button[aria-label='Emojis']");
     await insertText("input[placeholder='Search emoji']", "ici");
     await contains(`.o-Emoji[title='Bouton "ici" japonais']`);
+    await insertText("input[placeholder='Search emoji']", "dollar");
+    await contains(`.o-Emoji[title*='Symbole du dollar']`);
 });
 
 test("search emoji from keywords", async () => {
@@ -214,4 +217,19 @@ test("selecting an emoji while holding down the Shift key prevents the emoji pic
     await contains(".o-EmojiPicker-navbar [title='Frequently used']");
     await contains(".o-EmojiPicker");
     await contains(".o-mail-Composer-input", { value: "👺" });
+});
+
+test("Emoji picker shows failure to load emojis", async () => {
+    // Simulate failure to load emojis
+    patchWithCleanup(odoo.loader.modules.get("@web/core/emoji_picker/emoji_data"), {
+        getEmojis() {
+            return [];
+        }
+    });
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "" });
+    await start();
+    await openDiscuss(channelId);
+    await click("button[aria-label='Emojis']");
+    await contains(".o-EmojiPicker", { text: "😵‍💫Failed to load emojis..." });
 });

--- a/addons/web/static/src/core/emoji_picker/emoji_data.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_data.js
@@ -55,8 +55,8 @@
 
 import { _t as realT } from "@web/core/l10n/translation";
 
-// replace all double quotes with escaped double quotes
-const _t = (str) => realT(str).replace(/"/g, '\\"')
+// Escape translated strings to prevent parsing errors
+const _t = (str) => JSON.stringify(realT(str)).slice(1, -1);
 
 const _getCategories = () => `[
     {

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -209,12 +209,12 @@ export class EmojiPicker extends Component {
                 : this.categories[0].sortId;
         });
         onMounted(() => {
-            this.navbarResizeObserver = new ResizeObserver(() => this.adaptNavbar());
-            this.navbarResizeObserver.observe(this.navbarRef.el);
-            this.adaptNavbar();
             if (this.emojis.length === 0) {
                 return;
             }
+            this.navbarResizeObserver = new ResizeObserver(() => this.adaptNavbar());
+            this.navbarResizeObserver.observe(this.navbarRef.el);
+            this.adaptNavbar();
             this.highlightActiveCategory();
             if (this.props.storeScroll) {
                 this.gridRef.el.scrollTop = this.props.storeScroll.get();
@@ -274,7 +274,7 @@ export class EmojiPicker extends Component {
             () => [this.searchTerm]
         );
         onWillUnmount(() => {
-            this.navbarResizeObserver.disconnect();
+            this.navbarResizeObserver?.disconnect();
             if (!this.gridRef.el) {
                 return;
             }
@@ -390,6 +390,9 @@ export class EmojiPicker extends Component {
      * navigation of the emoji picker.
      */
     updateEmojiPickerRepr() {
+        if (this.emojis.length === 0) {
+            return;
+        }
         const emojiEls = Array.from(this.gridRef.el.querySelectorAll(".o-Emoji"));
         const emojiRects = emojiEls.map((el) => el.getBoundingClientRect());
         this.emojiMatrix = [];


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------

In some non-English translations, emoji strings include `\n`, which breaks JSON parsing in `emoji_data.js`.

This causes `emojis.length === 0`, so the empty state is displayed instead of the main emoji picker UI.

Some UI logic still executes on missing DOM elements, which triggers errors.

**Current behavior before PR:**
---------------------------------

- Switch to a non-English language  
- Open the emoji picker in Discuss  
- Errors are triggered due to missing DOM elements  

**Desired behavior after PR is merged:**
-----------------------------------------

- Emoji JSON parses correctly  
- The emoji picker opens without errors in non-English languages  
- The emoji picker still opens when `emojis.length === 0`  

**Task:** 4978824