### PR TITLE
[IMP] account,base: prevent changing currency decimals

### DIFF
--- a/addons/account/models/res_currency.py
+++ b/addons/account/models/res_currency.py
@@ -20,7 +20,7 @@ class ResCurrency(models.Model):
     @api.depends('rounding')
     def _compute_display_rounding_warning(self):
         for record in self:
-            record.display_rounding_warning = record.id \
+            record.display_rounding_warning = record._origin.id \
                                               and record._origin.rounding != record.rounding \
                                               and record._origin._has_accounting_entries()
 

--- a/addons/account/static/src/components/currency_form/form_controller.js
+++ b/addons/account/static/src/components/currency_form/form_controller.js
@@ -1,0 +1,43 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { registry } from "@web/core/registry";
+import { FormController } from "@web/views/form/form_controller";
+import { formView } from "@web/views/form/form_view";
+
+export class CurrencyFormController extends FormController {
+
+    async onWillSaveRecord(record) {
+        if (record.data.display_rounding_warning &&
+            record._values.rounding !== undefined &&
+            record.data.rounding < record._values.rounding
+        ) {
+            return new Promise((resolve) => {
+                this.dialogService.add(ConfirmationDialog, {
+                    title: _t("Confirmation Warning"),
+                    body: _t(
+                        "You're about to permanently change the decimals for all prices in your database.\n" +
+                        "This change cannot be undone without technical support."
+                    ),
+                    confirmLabel: _t("Confirm"),
+                    cancelLabel: _t("Cancel"),
+                    confirm: () => resolve(true),
+                    cancel: () => {
+                        record.discard();
+                        resolve(false);
+                    },
+                });
+            });
+        }
+
+        return true;
+    }
+}
+
+export const currencyFormView = {
+    ...formView,
+    Controller: CurrencyFormController,
+};
+
+registry.category("views").add("currency_form", currencyFormView);

--- a/addons/account/static/src/components/currency_form/open_decimal_precision_btn.js
+++ b/addons/account/static/src/components/currency_form/open_decimal_precision_btn.js
@@ -1,0 +1,24 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { useService } from "@web/core/utils/hooks";
+import { Component } from "@odoo/owl";
+
+class OpenDecimalPrecisionButton extends Component {
+    static template = "account.OpenDecimalPrecisionButton";
+    static props = { ...standardFieldProps };
+
+    setup() {
+        this.action = useService("action");
+    }
+
+    async discardAndOpen() {
+        await this.props.record.discard();
+        this.action.doAction("base.action_decimal_precision_form");
+    }
+}
+
+registry.category("fields").add("open_decimal_precision_button", {
+    component: OpenDecimalPrecisionButton,
+});

--- a/addons/account/static/src/components/currency_form/open_decimal_precision_btn_template.xml
+++ b/addons/account/static/src/components/currency_form/open_decimal_precision_btn_template.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="account.OpenDecimalPrecisionButton">
+        <button type="button"
+            class="btn btn-link p-0"
+            t-on-click="discardAndOpen">
+            <i class="fa fa-arrow-right text-muted me-1"/>
+             More precision on Product Prices
+        </button>
+    </t>
+</templates>

--- a/addons/account/views/res_currency.xml
+++ b/addons/account/views/res_currency.xml
@@ -7,10 +7,25 @@
             <field name="model">res.currency</field>
             <field name="inherit_id" ref="base.view_currency_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//sheet" position="before">
-                    <div class="alert alert-warning" role="alert" invisible="not display_rounding_warning">
-                        <strong>This currency has already been used to generate accounting entries.</strong> <br/>
-                        Changing its rounding factor now will not change the rounding made on previous entries; possibly causing an inconsistency with the new ones.
+                <form position="attributes">
+                    <attribute name="js_class">currency_form</attribute>
+                </form>
+
+                <xpath expr="//field[@name='decimal_places']" position="after">
+                    <div colspan="2" invisible="not display_rounding_warning" class="alert alert-danger" role="alert">
+                        <p class="m-0">
+                            <strong>WARNING - This change is irreversible</strong>
+                        </p>
+
+                        <p class="mt-1 mb-2">
+                            You are changing decimals in your entire database, including invoices,
+                            tax amounts, accounting amounts, reports. This is probably not intended.
+                        </p>
+
+                        <div>
+                            <field name="display_rounding_warning"
+                               widget="open_decimal_precision_button"/>
+                        </div>
                     </div>
                 </xpath>
             </field>

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -131,9 +131,6 @@
             <field name="model">res.currency</field>
             <field name="arch" type="xml">
                 <form string="Currency">
-                    <div class="alert alert-info text-center" role="alert" groups="base.group_no_one">
-                        You cannot reduce the number of decimal places of a currency already used on an accounting entry.
-                    </div>
                     <div class="alert alert-info text-center" role="alert" invisible="not is_current_company_currency">
                         This is your company's currency.
                     </div>
@@ -148,6 +145,7 @@
                                 <field name="symbol"/>
                                 <field name="currency_unit_label"/>
                                 <field name="currency_subunit_label"/>
+                                <field name="position"/>
                             </group>
                         </group>
 
@@ -155,10 +153,6 @@
                             <group string="Price Accuracy">
                                 <field name="rounding"/>
                                 <field name="decimal_places"/>
-                            </group>
-
-                            <group string="Display">
-                                <field name="position"/>
                             </group>
                         </group>
                         <notebook class="o_currency_rate_list" invisible="is_current_company_currency">


### PR DESCRIPTION
**PURPOSE**
- Changing the currency rounding factor **corrupts accounting data**.
- The change is **irreversible** once applied, making invoices and reports **invalid due to extra decimals**.
- In most cases, users need **price precision**, not **rounding changes**.
- Therefore, users should be **redirected to the correct setting** for changing price precision.

**SPECIFICATION**
- Simplify the form by **hiding the Price Accuracy section**, which is currently **only visible in debug mode**. (Previously, this was handled server-side and required a reload; now it will be handled on the client-side.)
- When the rounding factor is modified, **show a warning message** explaining why this is a bad idea and recommend changing it via **Settings > Technical > Decimal Accuracy**.
- If the user tries to save after the warning, **display a confirmation dialog**. Only upon confirming should the change be saved.

task-4984276