### PR TITLE
[FIX] mail: error when translating message in mobile

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -14,7 +14,6 @@ import { renderToElement } from "@web/core/utils/render";
 
 import {
     Component,
-    markup,
     onMounted,
     onPatched,
     onWillDestroy,
@@ -38,7 +37,6 @@ import { setElementContent } from "@web/core/utils/html";
 import { url } from "@web/core/utils/urls";
 import { messageActionsRegistry, useMessageActions } from "./message_actions";
 import { cookie } from "@web/core/browser/cookie";
-import { rpc } from "@web/core/network/rpc";
 import { escape } from "@web/core/utils/strings";
 import { MessageActionMenuMobile } from "./message_action_menu_mobile";
 import { discussComponentRegistry } from "./discuss_component_registry";
@@ -109,7 +107,6 @@ export class Message extends Component {
             isClicked: false,
             expandOptions: false,
             emailHeaderOpen: false,
-            showTranslation: false,
             actionMenuMobileOpen: false,
         });
         /** @type {ShadowRoot} */
@@ -176,7 +173,7 @@ export class Message extends Component {
                     const bodyEl = document.createElement("span");
                     setElementContent(
                         bodyEl,
-                        this.state.showTranslation
+                        this.message.showTranslation
                             ? this.message.translationValue
                             : this.props.messageSearch?.highlight(this.message.body) ??
                                   this.message.body
@@ -189,7 +186,7 @@ export class Message extends Component {
                 }
             },
             () => [
-                this.state.showTranslation,
+                this.message.showTranslation,
                 this.message.translationValue,
                 this.props.messageSearch?.searchTerm,
                 this.message.body,
@@ -492,17 +489,7 @@ export class Message extends Component {
     }
 
     async onClickToggleTranslation() {
-        const message = toRaw(this.message);
-        if (!message.translationValue) {
-            const { error, lang_name, body } = await rpc("/mail/message/translate", {
-                message_id: message.id,
-            });
-            message.translationValue = body && markup(body);
-            message.translationSource = lang_name;
-            message.translationErrors = error;
-        }
-        this.state.showTranslation =
-            !this.state.showTranslation && Boolean(message.translationValue);
+        toRaw(this.props.message).onClickToggleTranslation();
     }
 }
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -91,9 +91,9 @@
                                                     <t t-else="">
                                                         <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
-                                                        <t t-elif="state.showTranslation" t-out="message.translationValue"/>
+                                                        <t t-elif="message.showTranslation" t-out="message.translationValue"/>
                                                         <t t-elif="message.body" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
-                                                        <p class="fst-italic text-muted small" t-if="state.showTranslation">
+                                                        <p class="fst-italic text-muted small" t-if="message.showTranslation">
                                                             <t t-if="message.translationSource" t-esc="translatedFromText"/>
                                                         </p>
                                                         <p class="fst-italic text-muted small" t-if="message.translationErrors">

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -192,11 +192,13 @@ messageActionsRegistry
         sequence: 55,
     })
     .add("toggle-translation", {
-        condition: (component) => component.props.message.isTranslatable(component.props.thread),
+        condition: (component) => component.props.message.isTranslatable(component.message.thread),
         icon: (component) =>
-            `fa fa-language ${component.state.showTranslation ? "o-mail-Message-translated" : ""}`,
-        title: (component) => (component.state.showTranslation ? _t("Revert") : _t("Translate")),
-        onClick: (component) => component.onClickToggleTranslation(),
+            `fa fa-language ${
+                component.message.showTranslation ? "o-mail-Message-translated" : ""
+            }`,
+        title: (component) => (component.message.showTranslation ? _t("Revert") : _t("Translate")),
+        onClick: (component) => component.message.onClickToggleTranslation(),
         sequence: 100,
     })
     .add("copy-link", {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -7,7 +7,7 @@ import {
 } from "@mail/utils/common/format";
 import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
-import { toRaw } from "@odoo/owl";
+import { markup, toRaw } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
 import { stateToUrl } from "@web/core/browser/router";
@@ -183,6 +183,7 @@ export class Message extends Record {
     /** @type {undefined|Boolean} */
     needaction;
     starred = false;
+    showTranslation = false;
 
     /**
      * True if the backend would technically allow edition
@@ -488,6 +489,18 @@ export class Message extends Record {
             rpc("/mail/link_preview", { message_id: this.id }, { silent: true });
         }
         return data;
+    }
+
+    async onClickToggleTranslation() {
+        if (!this.translationValue) {
+            const { error, lang_name, body } = await rpc("/mail/message/translate", {
+                message_id: this.id,
+            });
+            this.translationValue = body && markup(body);
+            this.translationSource = lang_name;
+            this.translationErrors = error;
+        }
+        this.showTranslation = !this.showTranslation && Boolean(this.translationValue);
     }
 
     async react(content) {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -730,7 +730,9 @@ test("rendering of inbox message", async () => {
     await contains("[title='Add a Reaction']");
     await contains("[title='Mark as Todo']");
     await contains("[title='Mark as Read']");
+    await click("[title='Expand']");
     await contains("[title='Reply']");
+    await contains("[title='Translate']");
 });
 
 test("Unfollow message", async function () {
@@ -773,24 +775,24 @@ test("Unfollow message", async function () {
     });
     await contains(".o-mail-Message-moreMenu", { count: 1 });
     await contains("[title='Unfollow']", { count: 1 });
-    await contains(".o-mail-Message:eq(2) [title='Expand']", { count: 0 });
+    await click(".o-mail-Message:eq(2) [title='Expand']");
     await contains(".o-mail-Message:eq(2)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread not followed" }]],
     });
-    await contains(".o-mail-Message:eq(2) [title='Unfollow']", { count: 0 });
+    await contains("[title='Unfollow']", { count: 0 });
     await click(".o-mail-Message:eq(0) [title='Expand']");
     await click("[title='Unfollow']");
     await contains(".o-mail-Message", { count: 2 }); // Unfollowing message 0 marks it as read -> Message removed
     await contains(".o-mail-Message:eq(0)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread followed" }]],
     });
-    await contains(".o-mail-Message:eq(0) [title='Expand']", { count: 0 });
-    await contains(".o-mail-Message:eq(0) [title='Unfollow']", { count: 0 });
+    await click(".o-mail-Message:eq(0) [title='Expand']");
+    await contains("[title='Unfollow']", { count: 0 });
     await contains(".o-mail-Message:eq(1)", {
         contains: [[".o-mail-Message-header small", { text: "on Thread not followed" }]],
     });
-    await contains(".o-mail-Message:eq(1) [title='Expand']", { count: 0 });
-    await contains(".o-mail-Message:eq(1) [title='Unfollow']", { count: 0 });
+    await click(".o-mail-Message:eq(1) [title='Expand']");
+    await contains("[title='Unfollow']", { count: 0 });
 });
 
 test('messages marked as read move to "History" mailbox', async () => {

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -40,8 +40,10 @@ test("reply: discard on reply button toggle", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
+    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer");
+    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer", { count: 0 });
 });
@@ -68,6 +70,7 @@ test("reply: discard on pressing escape", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
+    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer");
     // Escape on emoji picker does not stop replying
@@ -111,6 +114,7 @@ test('"reply to" composer should log note if message replied to is a note', asyn
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
+    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer [placeholder='Log an internal note…']");
     await insertText(".o-mail-Composer-input", "Test");
@@ -143,6 +147,7 @@ test('"reply to" composer should send message if message replied to is not a not
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
+    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer [placeholder='Send a message to followers…']");
     await insertText(".o-mail-Composer-input", "Test");
@@ -588,6 +593,7 @@ test("reply: stop replying button click", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
+    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer");
     await contains("i[title='Stop replying']");
@@ -775,6 +781,7 @@ test("can reply to email message", async () => {
     await start();
     await openDiscuss();
     await contains(".o-mail-Message");
+    await click("[title='Expand']");
     await click("[title='Reply']");
     await contains(".o-mail-Composer", { text: "Replying to md@oilcompany.fr" });
 });

--- a/addons/mail/static/tests/translation/translation.test.js
+++ b/addons/mail/static/tests/translation/translation.test.js
@@ -1,4 +1,5 @@
-import { describe, test } from "@odoo/hoot";
+import { test } from "@odoo/hoot";
+import { mockUserAgent } from "@odoo/hoot-mock";
 import {
     assertSteps,
     click,
@@ -12,9 +13,9 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { serverState } from "@web/../tests/web_test_helpers";
 
-describe.current.tags("desktop");
 defineMailModels();
 
+test.tags("desktop");
 test("Toggle display of original/translated version of chatter message", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
@@ -46,6 +47,7 @@ test("Toggle display of original/translated version of chatter message", async (
     await assertSteps(["Request"]);
 });
 
+test.tags("desktop");
 test("translation of email message", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
@@ -79,5 +81,28 @@ test("translation of email message", async () => {
     await contains("span", {
         text: "Al mal tiempo, buena cara.",
         parent: [".o-mail-Message-body > div", { shadowRoot: true }],
+    });
+});
+
+test.tags("mobile");
+test("Toggle message translation on mobile", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({});
+    pyEnv["mail.message"].create({
+        model: "res.partner",
+        body: "Al mal tiempo, buena cara.",
+        author_id: serverState.odoobotId,
+        res_id: partnerId,
+    });
+    onRpcBefore("/mail/message/translate", () => {
+        return { body: "To bad weather, good face.", lang_name: "Spanish", error: null };
+    });
+    mockUserAgent("Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)");
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click("button[title='Expand']");
+    await click("span", { text: "Translate" });
+    await contains(".o-mail-Message-body", {
+        text: "To bad weather, good face.(Translated from: Spanish)",
     });
 });


### PR DESCRIPTION
Steps to reproduce:

- Open any chatter with a message on mobile
- Try to translate the message using the Translate mobile action
=> Throws traceback

This happens  because the component here is `MessageActionMenuMobile` instead of `Message`, and MessageActionMenuMobile does not have the `onClickToggleTranslation` method.

This PR fixes the issue.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
