### PR TITLE
[IMP] pos_restaurant: visibility of Payment and Fire Course buttons

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
@@ -44,7 +44,8 @@ patch(ActionpadWidget.prototype, {
         return (
             this.currentOrder?.lines?.length &&
             !this.hasChangesToPrint &&
-            this.hasQuantity(this.currentOrder)
+            this.hasQuantity(this.currentOrder) &&
+            !this.getCourseToFire()
         );
     },
     get displayCategoryCount() {

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -40,7 +40,7 @@
                     </div>
                 </button>
                 <button
-                    class="fire-btn button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center w-50"
+                    class="fire-btn button btn btn-primary btn-lg d-flex flex-row align-items-center justify-content-center w-50"
                     t-on-click="() => this.clickFireCourse()"
                     t-elif="this.displayFireCourseBtn"
                 >

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -247,6 +247,8 @@ registry.category("web_tour.tours").add("test_pos_restaurant_course", {
             {
                 trigger: negate('.order-course-name:eq(2) > span:contains("Course 3")'),
             },
+            ProductScreen.fireCourseButtonHighlighted("Course 2"),
+            ProductScreen.payButtonNotHighlighted(),
             ProductScreen.clickCourseButton(),
             Chrome.clickPlanButton(),
             FloorScreen.isShown(),

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -68,6 +68,23 @@ export function fireCourseButton() {
         },
     ];
 }
+export function fireCourseButtonHighlighted(courseName) {
+    return [
+        {
+            content: "fire course button highlighted",
+            trigger: `.actionpad .fire-btn.btn-primary:contains('Fire ${courseName}')`,
+        },
+    ];
+}
+export function payButtonNotHighlighted() {
+    return [
+        {
+            content: "pay button not highlighted",
+            trigger:
+                ".actionpad .pay-order-button:not('.highlight'):not('.btn-primary'):contains('Payment')",
+        },
+    ];
+}
 export function setTab(name) {
     return [
         {


### PR DESCRIPTION
Before this commit:
=========
- The Payment button was highlighted even when some courses were not yet sent to the kitchen.
- The Fire Course button was not highlighted in that situation.

After this commit:
=========
- The Payment button is highlighted only when all courses have been sent to the kitchen.
- The Fire Course button is highlighted when there are pending courses to be sent.

Related:
- Enterprise: https://github.com/odoo/enterprise/pull/92752

task-4985324