### PR TITLE
[FIX] http_routing,website: use website lang for dynamic  bundle

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -295,8 +295,12 @@ class IrHttp(models.AbstractModel):
 
         IrHttpModel = request.env['ir.http'].sudo()
         modules = IrHttpModel.get_translation_frontend_modules()
-        user_context = request.session.context if request.session.uid else {}
-        lang = user_context.get('lang')
+        if request.is_frontend:
+            lang = request.lang._get_cached('code')
+            session_info['bundle_params']['lang'] = lang
+        else:
+            user_context = request.session.context if request.session.uid else {}
+            lang = user_context.get('lang')
         translation_hash = request.env['ir.http'].get_web_translations_hash(modules, lang)
 
         session_info.update({

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -5,15 +5,15 @@ import json
 import lxml.html
 from urllib.parse import urlparse
 
+import odoo
 from odoo.addons.http_routing.models.ir_http import url_lang
 from odoo.addons.website.tools import MockRequest
 from odoo.tests import HttpCase, tagged
 
 
-@tagged('-at_install', 'post_install')
-class TestLangUrl(HttpCase):
+class TestLangUrlCommon(HttpCase):
     def setUp(self):
-        super(TestLangUrl, self).setUp()
+        super().setUp()
 
         # Simulate multi lang without loading translations
         self.website = self.env.ref('website.default_website')
@@ -22,6 +22,9 @@ class TestLangUrl(HttpCase):
         self.website.language_ids = self.env.ref('base.lang_en') + self.lang_fr
         self.website.default_lang_id = self.env.ref('base.lang_en')
 
+
+@tagged('-at_install', 'post_install')
+class TestLangUrl(TestLangUrlCommon):
     def test_01_url_lang(self):
         with MockRequest(self.env, website=self.website):
             self.assertEqual(url_lang('', '[lang]'), '/[lang]/mockrequest', "`[lang]` is used to be replaced in the url_return after installing a language, it should not be replaced or removed.")
@@ -63,6 +66,11 @@ class TestLangUrl(HttpCase):
             if match:
                 session_info = json.loads(session_info_str[:-1])
                 self.assertEqual(session_info['user_context']['lang'], 'en_US', "ensure english was loaded")
+                self.assertEqual(session_info['bundle_params']['lang'], 'en_US', "ensure bundle use english")
+                with MockRequest(self.env) as req:
+                    backend_modules = list(req.registry._init_modules) + (odoo.conf.server_wide_modules or [])
+                en_hash = self.env['ir.http'].get_web_translations_hash(modules=backend_modules, lang='en_US')
+                self.assertEqual(session_info['cache_hashes']['translations'], en_hash)
                 break
         else:
             raise ValueError('Session info not found in web page')
@@ -79,6 +87,19 @@ class TestLangUrl(HttpCase):
         if 'lang="fr-FR"' not in r.text:
             doc = lxml.html.document_fromstring(r.text)
             self.assertEqual(doc.get('lang'), 'fr-FR', "Ensure contactus did not soft crash + loaded in correct lang")
+
+        for line in r.text.splitlines():
+            _, match, session_info_str = line.partition('odoo.__session_info__ = ')
+            if match:
+                session_info = json.loads(session_info_str[:-1])
+                self.assertEqual(session_info['bundle_params']['lang'], 'fr_FR', "ensure bundle use french")
+                with MockRequest(self.env):
+                    frontend_modules = self.env['ir.http'].get_translation_frontend_modules()
+                fr_hash = self.env['ir.http'].get_web_translations_hash(modules=frontend_modules, lang='fr_FR')
+                self.assertEqual(session_info['cache_hashes']['translations'], fr_hash)
+                break
+        else:
+            raise ValueError('Session info not found in web page')
 
     def test_05_invalid_ipv6_url(self):
         view = self.env['ir.ui.view'].create({
@@ -113,7 +134,7 @@ class TestLangUrl(HttpCase):
 
 
 @tagged('-at_install', 'post_install')
-class TestControllerRedirect(TestLangUrl):
+class TestControllerRedirect(TestLangUrlCommon):
     def setUp(self):
         self.page = self.env['website.page'].create({
             'name': 'Test View',


### PR DESCRIPTION
Scenario to reproduce from 18.0:

- install right-to-left (eg. arabic) language on website
- open a portal record with chatter (eg. /my/invoices/1)
- switch to right-to-left language
- scroll horizontally to the left

Result: there is a huge amount of whitespace scrollable to the left.

Cause:

In 18.0, the chatter has an hidden textarea .o-mail-Composer-fake with
position "left: -10000px; top: -10000px;".

But the chatter assets (portal.assets_chatter_style) are called
dynamically with getBundle which is using the session lang instead of
the website lang.

So the bundle is gotten with the wrong lang and the CSS is not rtlcss'ed
and this create big whitespace to the left of the page.

Fix: set the website request language when getting bundle for the
frontend.

Note: this PR also create a TestLangUrlCommon to prevent TestLangUrl
tests of being run a second time in TestControllerRedirect.

opw-5013485