### PR TITLE
[FIX] html_builder: fix drop clone not working as expected sometimes

### DIFF
--- a/addons/html_builder/static/src/core/drag_and_drop_plugin.js
+++ b/addons/html_builder/static/src/core/drag_and_drop_plugin.js
@@ -198,9 +198,11 @@ export class DragAndDropPlugin extends Plugin {
                     (el) => el !== this.overlayTarget && isVisible(el)
                 );
                 if (parentEl.children.length === 1 || !visibleSiblingEl) {
-                    const dropCloneEl = document.createElement("div");
+                    const dropCloneEl = this.overlayTarget.cloneNode();
                     dropCloneEl.classList.add("oe_drop_clone");
                     dropCloneEl.style.visibility = "hidden";
+                    dropCloneEl.style.height = `${targetRect.height}px`;
+                    dropCloneEl.style.width = `${targetRect.width}px`;
                     this.overlayTarget.after(dropCloneEl);
                     this.dragState.dropCloneEl = dropCloneEl;
                 }


### PR DESCRIPTION
Steps to reproduce:
- Drop the "Banner" snippet.
- Click on the "Blockquote".
- Start to drag it. => No dropzone appears where it was so we cannot drop it back.

When starting the drag and drop of an element that is the only (visible) child of its parent, an invisible clone is created and added where the element was, in order to have a dropzone to drop it where it was. The issue here is that this clone is a simple `<div>`, and inner snippets cannot be dropped next to `<div>` elements, which is why no dropzone is appearing despite the clone being present.

This commit fixes that by making this clone a real clone of the dragged element, so it always has valid classes and tagname to make the dropzone appear. In addition, by giving the clone the same dimensions as the element, it allows to have better looking dropzones (e.g. a vertical one when dragging the last column of the "Steps" snippet instead of a big horizontal one).

task-4367641