### PR TITLE
[IMP] hr: improve cron for expiring employee contracts and work permits

### DIFF
--- a/addons/hr/models/__init__.py
+++ b/addons/hr/models/__init__.py
@@ -4,6 +4,7 @@ from . import hr_payroll_structure_type
 from . import hr_job
 from . import hr_version
 from . import hr_contract_type
+from . import mail_activity
 from . import hr_employee
 from . import hr_mixin
 from . import hr_employee_category

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1190,32 +1190,68 @@ class HrEmployee(models.Model):
         companies = self.env['res.company'].search([])
         employees_contract_expiring = self.env['hr.employee']
         employees_work_permit_expiring = self.env['hr.employee']
+        today = fields.Date.today()
 
         for company in companies:
+            # Employees with contracts expiring soon
             employees_contract_expiring += self.env['hr.employee'].search([
                 ('company_id', '=', company.id),
                 ('contract_date_start', '!=', False),
-                ('contract_date_start', '<', fields.Date.today()),
-                ('contract_date_end', '=', fields.Date.today() + relativedelta(days=company.contract_expiration_notice_period)),
+                ('contract_date_start', '<', today),
+                ('contract_date_end', '>=', today),
+                ('contract_date_end', '<=', today + relativedelta(days=company.contract_expiration_notice_period)),
             ])
 
+            # Employees with work permits expiring soon
             employees_work_permit_expiring += self.env['hr.employee'].search([
                 ('company_id', '=', company.id),
                 ('work_permit_expiration_date', '!=', False),
-                ('work_permit_expiration_date', '=', fields.Date.today() + relativedelta(days=company.work_permit_expiration_notice_period)),
+                ('work_permit_expiration_date', '>=', today),
+                ('work_permit_expiration_date', '<=', today + relativedelta(days=company.work_permit_expiration_notice_period)),
             ])
 
-        for employee in employees_contract_expiring:
-            employee.with_context(mail_activity_quick_update=True).activity_schedule(
-                'mail.mail_activity_data_todo', employee.contract_date_end,
-                _("The contract of %s is about to expire.", employee.name),
-                user_id=employee.hr_responsible_id.id or self.env.uid)
+        todo_type = self.env.ref('mail.mail_activity_data_todo')
 
+        # Existing activities
+        existing_activities_contract = employees_contract_expiring.activity_ids.filtered(
+            lambda a: a.technical_usage == 'hr_expiring_contract'
+        )
+        existing_activities_permit = employees_work_permit_expiring.activity_ids.filtered(
+            lambda a: a.technical_usage == 'hr_expiring_work_permit'
+        )
+
+        existing_activities_index_contract = {
+            (a.res_id, a.date_deadline, a.user_id.id): a for a in existing_activities_contract
+        }
+        existing_activities_index_permit = {
+            (a.res_id, a.date_deadline, a.user_id.id): a for a in existing_activities_permit
+        }
+
+        # Create contract expiry activities
+        for employee in employees_contract_expiring:
+            activity_responsible = employee.hr_responsible_id.id or self.env.uid
+            key = (employee.id, employee.contract_date_end, activity_responsible)
+            if key not in existing_activities_index_contract:
+                employee.with_context(mail_activity_quick_update=True).activity_schedule(
+                    activity_type_id=todo_type.id,
+                    date_deadline=employee.contract_date_end,
+                    summary=self.env._("The contract of %(employee_name)s is about to expire.", employee_name=employee.name),
+                    user_id=activity_responsible,
+                    technical_usage='hr_expiring_contract',
+                )
+
+        # Create work permit expiry activities
         for employee in employees_work_permit_expiring:
-            employee.with_context(mail_activity_quick_update=True).activity_schedule(
-                'mail.mail_activity_data_todo', employee.work_permit_expiration_date,
-                _("The work permit of %s is about to expire.", employee.name),
-                user_id=employee.hr_responsible_id.id or self.env.uid)
+            activity_responsible = employee.hr_responsible_id.id or self.env.uid
+            key = (employee.id, employee.work_permit_expiration_date, activity_responsible)
+            if key not in existing_activities_index_permit:
+                employee.with_context(mail_activity_quick_update=True).activity_schedule(
+                    activity_type_id=todo_type.id,
+                    date_deadline=employee.work_permit_expiration_date,
+                    summary=self.env._("The work permit of %(employee_name)s is about to expire.", employee_name=employee.name),
+                    user_id=activity_responsible,
+                    technical_usage='hr_expiring_work_permit',
+                )
 
         return True
 

--- a/addons/hr/models/mail_activity.py
+++ b/addons/hr/models/mail_activity.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class MailActivity(models.Model):
+    _inherit = 'mail.activity'
+
+    technical_usage = fields.Selection(selection_add=[
+        ('hr_expiring_contract', 'Expiring Contract'),
+        ('hr_expiring_work_permit', 'Expiring Work Permit')
+    ])

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -79,6 +79,7 @@ class MailActivity(models.Model):
     automated = fields.Boolean(
         'Automated activity', readonly=True,
         help='Indicates this activity has been created automatically and not by any user.')
+    technical_usage = fields.Selection(selection=[('none', 'Non Technical')], default='none', readonly=True, help="Technical identifier")
     # Attachments are linked to a document through model / res_id and to the activity through this field.
     attachment_ids = fields.Many2many(
         'ir.attachment', 'activity_attachment_rel',


### PR DESCRIPTION
Previously, the cron would only create an activity on the exact day `(end_date - notice_period)`. If the server was down or the cron did not run on that day, the activity was never created.

With this commit, the cron now checks every day within the notice period and ensures that the activity is created if it does not already exist.

Task-5022170
