### PR TITLE
[FIX] web_editor, *: header contact us button duplication in undo/redo

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1324,6 +1324,10 @@ export class Wysiwyg extends Component {
                         node.classList.remove(...this.odooEditor.options.renderingClasses);
                     }
                     const html = $(fieldNodeClone).html();
+                    // Prevent recording unnecessary mutations (especially in the header,
+                    // where multiple observers are used to synchronize desktop and mobile views)
+                    // while clearing the uncommitted draft.
+                    this.odooEditor.observerUnactive("undo_redo_header");
                     this.odooEditor.withoutRollback(() => {
                         for (const node of $nodes) {
                             if (node.classList.contains('o_translation_without_style')) {
@@ -1341,6 +1345,7 @@ export class Wysiwyg extends Component {
                             }
                         }
                     });
+                    this.odooEditor.observerActive("undo_redo_header");
                     this._observeOdooFieldChanges();
                 });
                 observer.observe(field, observerOptions);

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -882,6 +882,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         const node = editor.editable.querySelector('p').childNodes[0];
         newHistoryStepPromise();
         node.textContent = 'b';
+        editor.historyStep();
         await historyStepPromise;
 
         assert.equal(editor.editable.children[0].children[0].innerHTML.trim(), '<p>b</p>');
@@ -945,6 +946,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         const node = editor.editable.querySelector('p').childNodes[0];
         newHistoryStepPromise();
         node.textContent = 'b';
+        editor.historyStep();
         await historyStepPromise;
 
         assert.equal(editor.editable.children[0].children[0].innerHTML.trim(), '<p class="oe_unremovable">b</p>');
@@ -1008,6 +1010,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         const node = editor.editable.querySelector('div.oe_unremovable');
         newHistoryStepPromise();
         node.textContent = 'b';
+        editor.historyStep();
         await historyStepPromise;
 
         assert.equal(editor.editable.children[0].children[0].innerHTML.trim(), '<div class="oe_unremovable"><p class="oe_unremovable">a</p></div>');

--- a/addons/website/static/tests/tours/undo_redo_header_issues_tour.js
+++ b/addons/website/static/tests/tours/undo_redo_header_issues_tour.js
@@ -1,0 +1,91 @@
+/** @odoo-module **/
+
+import wTourUtils from "@website/js/tours/tour_utils";
+
+function dropSnippet(id, name, selector) {
+    return [
+        wTourUtils.dragNDrop({ id, name }),
+        {
+            content: `Check ${name} snippet is dropped`,
+            trigger: `iframe #wrapwrap ${selector}`,
+            run() {},
+        },
+    ];
+}
+
+function clickUndoRedo(action, waitSelector) {
+    const btnClass = action === "undo" ? ".fa-undo" : ".fa-repeat";
+    return [
+        wTourUtils.clickOnElement(`${action} Button`, btnClass),
+        {
+            content: `Click ${action} action`,
+            trigger: waitSelector,
+            run() {},
+        },
+    ];
+}
+
+function checkNoBadge(content) {
+    return {
+        content,
+        trigger: "iframe header .navbar:not(:has(.s_badge))",
+        run() {},
+    };
+}
+
+wTourUtils.registerWebsitePreviewTour(
+    "undo_redo_header_oriented_issue",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        // --- Drop multiple snippets ---
+        ...dropSnippet("s_media_list", "Media List", ".s_media_list"),
+        ...dropSnippet("s_three_columns", "Columns", ".s_three_columns"),
+        ...dropSnippet("s_banner", "Banner", ".s_banner"),
+        ...dropSnippet("s_text_image", "Text - Image", ".s_text_image"),
+
+        // --- Scroll to header ---
+        {
+            content: "Scroll to the header",
+            trigger: "iframe #wrapwrap",
+            run() {
+                this.$anchor[0].scrollTo({ top: 0, left: 0 });
+            },
+        },
+
+        // --- Add Badge snippet into header ---
+        {
+            content: "Drag the badge building block and drop it at the bottom of the page header.",
+            trigger: `#oe_snippets .oe_snippet[name="Badge"] .oe_snippet_thumbnail:not(.o_we_already_dragging)`,
+            run: "drag_and_drop_native iframe #wrapwrap > header .navbar",
+        },
+        {
+            content: "Check badge is dropped in the header",
+            trigger: ".oe_snippet_thumbnail:not(.o_we_already_dragging)",
+            run() {},
+        },
+
+        // --- Undo twice ---
+        ...clickUndoRedo("undo", "iframe #wrapwrap > header :not(.s_badge)"),
+        ...clickUndoRedo("undo", "iframe #wrapwrap :not(.s_text_image)"),
+        checkNoBadge("Check that badge is removed after 2 undos."),
+
+        // --- Undo two more (total 4) ---
+        ...clickUndoRedo("undo", "iframe #wrapwrap :not(.s_banner)"),
+        ...clickUndoRedo("undo", "iframe #wrapwrap :not(.s_three_columns)"),
+        checkNoBadge("Check that badge is still removed after 4 undos."),
+
+        // --- Redo steps ---
+        ...clickUndoRedo("redo", "iframe #wrapwrap .s_three_columns"),
+        ...clickUndoRedo("redo", "iframe #wrapwrap .s_banner"),
+        ...clickUndoRedo("redo", "iframe #wrapwrap .s_text_image"),
+        {
+            content: "Check that Contact Us button is not duplicated after 3 redos.",
+            trigger: `iframe header .navbar-nav :has(> .btn.btn-primary.btn_cta) :not(:has(> .btn.btn-primary.btn_cta:nth-of-type(2)))`,
+            run() {},
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -706,3 +706,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_popup_visibility_option(self):
         self.start_tour("/", "website_popup_visibility_option", login="admin")
+
+    def test_header_color_and_undo_redo_issues(self):
+        self.start_tour("/", "undo_redo_header_oriented_issue", login="admin")


### PR DESCRIPTION
*=website

Steps to Reproduce :
 1. Go to `edit` mode.
 2. Drop at least four block snippets.
 3. Drop a badge in the header next to the _Contact Us_ button.
 4. Undo twice → the _Badge_ reappears.
 5. Undo twice more → the _Badge_ reappears again.
 6. Redo three times → the _Contact Us_ button is duplicated.

Issue:
The `Contact Us` button in the header was duplicated after multiple undo/redo actions. Moreover, the `Badge` snippet did not behave as expected during undo/redo.

Reason:
When the uncommitted draft was cleared before undo/redo, the `OdooEditor` observer triggered the `OdooField` observer to roll back and flush mutations. However, this rollback was considered a new mutation by the `OdooEditor` observer. On the next undo, the `OdooField` observer tried to sync with these artificial mutations, causing duplication of buttons and badges.

Fix:
Deactivate the `OdooEditor` observer during undo/redo operations to prevent recording unnecessary mutations. After discarding the draft, reactivate the `OdooEditor` observer. This avoids redundant syncs and resolves the duplication issue.

task-4558376