### PR TITLE
[FIX] web: datetime deadline was not red

### DIFF
--- a/addons/web/static/src/views/fields/fields.scss
+++ b/addons/web/static/src/views/fields/fields.scss
@@ -14,7 +14,7 @@
 // but bootstrap contextual classes do not work on input/textarea, so we have to
 // explicitely set their color to the one of their parent
 .o_field_widget {
-    input, textarea, select {
+    input, textarea, select, button.o_input {
         color: inherit;
     }
 }


### PR DESCRIPTION
The decoration classes weren't affecting the new datetime field with the system of button acting like an input

TASK-ID: 5017018




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
