### PR TITLE
[IMP] point_of_sale: do not ask for retry when no retry button

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.xml
@@ -4,7 +4,7 @@
     <t t-name="point_of_sale.RetryPrintPopup">
         <Dialog size="'md'" title="props.title">
             <p t-if="props.message" t-out="props.message" class="text-prewrap"/>
-            <p>Would you like to continue without printing or retry?</p>
+            <p t-if="props.canRetry">Would you like to continue without printing or retry?</p>
             <t t-set-slot="footer">
                 <button class="btn btn-primary btn-lg" t-on-click="props.close">Continue</button>
                 <button t-if="props.canRetry" class="btn btn-lg btn-secondary" t-on-click="onClickRetry">Retry</button>


### PR DESCRIPTION
In the printer retry popup, if the retry option isn't available, we still displayed a message proposing the user to retry. We don't anymore.

Enterprise PR: odoo/enterprise#92760
Task: 4756311