### PR TITLE
[FIX] l10n_in: add missing group to user

### DIFF
--- a/addons/l10n_in/tests/test_tds_tcs_alert.py
+++ b/addons/l10n_in/tests/test_tds_tcs_alert.py
@@ -10,6 +10,8 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
     def setUpClass(cls):
         super().setUpClass()
         ChartTemplate = cls.env['account.chart.template']
+        if cls.env['ir.module.module']._get('l10n_in_pos').state == 'installed':
+            cls.env.user.group_ids |= cls.env.ref("point_of_sale.group_pos_user")
 
         # ==== Chart of Accounts ====
         cls.purchase_account = ChartTemplate.ref('p2107')


### PR DESCRIPTION
steps to reproduce : 
1- install l10n_in,l10n_in_asset,l10n_in_edi,l10n_in_edi_gstr,l10n_in_ewaybill,l10n_in_ewaybill_irn,l10n_in_ewaybill_stock,l10n_in_hr_holidays,l10n_in_hr_payroll,l10n_in_hr_payroll_account,l10n_in_pos_urban_piper,l10n_in_purchase_stock,l10n_in_reports,l10n_in_reports_gstr_document_summary,l10n_in_reports_gstr_pos,l10n_in_sale,l10n_in_sale_stock,l10n_in_stock

2- run test `test_tcs_tds_warning_for_all_lines_do_not_have_taxes`


Add the Point of Sale user group to the test user to ensure that all necessary permissions are granted during testing.

build_error-230964
