### PR TITLE
[IMP] hr_appraisal: allow managers to access appraisal campaign wizard.

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -4,7 +4,8 @@
         <record id="base.user_demo" model="res.users">
             <field name="group_ids" eval="[
                 (3, ref('hr.group_hr_user')),
-                (3, ref('hr.group_hr_manager'))]"/>
+                (3, ref('hr.group_hr_manager')),
+                (4, ref('hr.group_hr_responsible'))]"/>
         </record>
 
         <record id="base.default_user_group" model="res.groups">

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -24,6 +24,11 @@
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 
+    <record id="group_hr_responsible" model="res.groups">
+        <field name="name">HR Responsible</field>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+
 <data noupdate="1">
     <record id="hr_employee_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>


### PR DESCRIPTION
To grant managers the access to create appraisal campaigns, new customized group  for employees' managers has been created. Also, views have been modified so that only the managers can see the "Launch Campaign" button.

