### PR TITLE
[FIX] fleet: don't change existing car status when new request

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -412,8 +412,9 @@ class FleetVehicle(models.Model):
         if 'future_driver_id' in vals and vals['future_driver_id']:
             future_driver = vals['future_driver_id']
             state_waiting_list = self.env.ref('fleet.fleet_vehicle_state_waiting_list', raise_if_not_found=False)
+            state_new_request = self.env.ref('fleet.fleet_vehicle_state_new_request', raise_if_not_found=False)
             vehicle_types = set(self.filtered(lambda vehicle: not state_waiting_list or\
-                                state_waiting_list.id != vals.get('state_id', vehicle.state_id.id)).mapped('vehicle_type'))
+                                vals.get('state_id', vehicle.state_id.id) not in [state_waiting_list.id, state_new_request.id]).mapped('vehicle_type'))
             if vehicle_types:
                 vehicle_read_group = dict(self.env['fleet.vehicle']._read_group(
                     domain=[('driver_id', '=', future_driver), ('vehicle_type', 'in', vehicle_types)],


### PR DESCRIPTION
When a new car is ordered through the belgian salary configurator, a car is created in the stage 'New Request'.

At this state, nothing is planned to change the car so we don't want to set the existing employee car as available for someone else.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
