### PR TITLE
[FIX] pos_sale: allow settling order when stock moves are not created

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -169,7 +169,7 @@ patch(PosStore.prototype, {
             }
 
             // Order line can only hold one lot, so we need to split the line if there are multiple lots
-            if (line.product_id.tracking == "lot") {
+            if (line.product_id.tracking == "lot" && converted_line.lot_names.length > 0) {
                 newLine.delete();
                 for (const lot of converted_line.lot_names) {
                     const splitted_line = this.models["pos.order.line"].create({

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -495,11 +495,20 @@ registry.category("web_tour.tours").add("test_sale_order_fp_different_from_partn
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("test_multiple_lots_sale_order", {
+registry.category("web_tour.tours").add("test_multiple_lots_sale_order_1", {
     steps: () =>
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+            PosSale.settleNthOrder(1),
+            Order.hasLine({ productName: "Product", quantity: "3.0" }),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_multiple_lots_sale_order_2", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
             PosSale.settleNthOrder(1, { loadSN: true }),
             PosSale.selectedOrderLinesHasLots("Product", ["1002"]),
             Utils.negateStep(...PosSale.selectedOrderLinesHasLots("Product", ["1001"])),

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1598,9 +1598,10 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
                 'price_unit': self.product.lst_price,
             })],
         })
-        sale_order.action_confirm()
         self.main_pos_config.open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_multiple_lots_sale_order', login="accountman")
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_multiple_lots_sale_order_1', login="accountman")
+        sale_order.action_confirm()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_multiple_lots_sale_order_2', login="accountman")
         self.main_pos_config.current_session_id.action_pos_session_close()
         picking = sale_order.pos_order_line_ids.order_id.picking_ids
         self.assertEqual(picking.move_ids.quantity, 3)


### PR DESCRIPTION
Before this commit, if an order was not confirmed and stock moves were not created, if products are tracked, the order lines would not be added to the PoS.

opw-5026892

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
