### PR TITLE
[IMP] l10n_it: Tax Report UI and UX rework

### DIFF
--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -9,13 +9,68 @@
         <field name="availability_condition">country</field>
         <field name="integer_rounding">HALF-UP</field>
         <field name="column_ids">
-            <record id="tax_monthly_report_vat_balance" model="account.report.column">
-                <field name="name">Balance</field>
-                <field name="name@it">Saldo</field>
-                <field name="expression_label">balance</field>
+            <record id="tax_monthly_report_vat_debit" model="account.report.column">
+                <field name="name">Debit</field>
+                <field name="name@it">Debito</field>
+                <field name="expression_label">debit</field>
+            </record>
+            <record id="tax_monthly_report_vat_credit" model="account.report.column">
+                <field name="name">Credit</field>
+                <field name="name@it">Credito</field>
+                <field name="expression_label">credit</field>
             </record>
         </field>
         <field name="line_ids">
+            <record id="tax_monthly_report_line_vp1" model="account.report.line">
+                <field name="name">VP1</field>
+                <field name="name@it">VP1</field>
+                <field name="code">VP1</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="tax_monthly_report_line_vp1_subcontracting" model="account.report.line">
+                        <field name="name">VP1 - Subcontracting</field>
+                        <field name="name@it">VP1 - Subappaltatore</field>
+                        <field name="code">xml_subcontracting</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp1_subcontracting_credit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">external</field>
+                                <field name="formula">most_recent</field>
+                                <field name="subformula">editable</field>
+                                <field name="figure_type">boolean</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp1_exceptional_events" model="account.report.line">
+                        <field name="name">VP1 - Exceptional Events</field>
+                        <field name="name@it">VP1 - Eventi Eccezionali</field>
+                        <field name="code">xml_exceptional_events</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp1_exceptional_events_credit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">external</field>
+                                <field name="formula">most_recent</field>
+                                <field name="subformula">editable</field>
+                                <field name="figure_type">boolean</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp1_extraordinary_operations" model="account.report.line">
+                        <field name="name">VP1 - Extraordinary Operations</field>
+                        <field name="name@it">VP1 - Operazioni Straordinarie</field>
+                        <field name="code">xml_extraordinary_operations</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp1_extraordinary_operations_credit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">external</field>
+                                <field name="formula">most_recent</field>
+                                <field name="subformula">editable</field>
+                                <field name="figure_type">boolean</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
             <record id="tax_monthly_report_line_operazione_imponibile" model="account.report.line">
                 <field name="name">Taxable transactions</field>
                 <field name="name@it">Operazioni imponibili</field>
@@ -26,13 +81,25 @@
                         <field name="name">VP2 - Total active transactions</field>
                         <field name="name@it">VP2 - Totale operazioni attive</field>
                         <field name="code">VP2</field>
-                        <field name="tax_tags_formula">02</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp2_debit" model="account.report.expression">
+                                <field name="label">debit</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">02</field>
+                            </record>
+                        </field>
                     </record>
                     <record id="tax_monthly_report_line_vp3" model="account.report.line">
                         <field name="name">VP3 - Total passive transactions</field>
                         <field name="name@it">VP3 - Totale operazioni passive</field>
                         <field name="code">VP3</field>
-                        <field name="tax_tags_formula">03</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp3_debit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">03</field>
+                            </record>
+                        </field>
                     </record>
                 </field>
             </record>
@@ -46,13 +113,25 @@
                         <field name="name">VP4 - VAT due</field>
                         <field name="name@it">VP4 - IVA esigibile</field>
                         <field name="code">VP4</field>
-                        <field name="tax_tags_formula">4v</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp4_debit" model="account.report.expression">
+                                <field name="label">debit</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">4v</field>
+                            </record>
+                        </field>
                     </record>
                     <record id="tax_monthly_report_line_vp5" model="account.report.line">
                         <field name="name">VP5 - VAT Deductible</field>
                         <field name="name@it">VP5 - IVA detraibile</field>
                         <field name="code">VP5</field>
-                        <field name="tax_tags_formula">5v</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp5_credit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">5v</field>
+                            </record>
+                        </field>
                     </record>
                 </field>
             </record>
@@ -62,35 +141,23 @@
                 <field name="code">h3</field>
                 <field name="children_ids">
                     <record id="tax_monthly_report_line_vp6" model="account.report.line">
-                        <field name="name">VP6 - VAT due</field>
-                        <field name="name@it">VP6 - IVA dovuta</field>
+                        <field name="name">VP6 - VAT due/deductible</field>
+                        <field name="name@it">VP6 - IVA dovuta o a credito</field>
                         <field name="code">VP6</field>
-                        <field name="children_ids">
-                            <record id="tax_monthly_report_line_vp6a" model="account.report.line">
-                                <field name="name">VP6a - VAT due (payable)</field>
-                                <field name="name@it">VP6a - IVA dovuta (debito)</field>
-                                <field name="code">VP6a</field>
-                                <field name="expression_ids">
-                                    <record id="tax_monthly_report_line_vp6a_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VP4.balance - VP5.balance</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
-                                    </record>
-                                </field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp6_vp6a_debit" model="account.report.expression">
+                                <field name="label">debit</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">VP4.debit - VP5.credit</field>
+                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="blank_if_zero" eval="True"/>
                             </record>
-                            <record id="tax_monthly_report_line_vp6b" model="account.report.line">
-                                <field name="name">VP6b - VAT due (credit)</field>
-                                <field name="name@it">VP6b - IVA dovuta (credito)</field>
-                                <field name="code">VP6b</field>
-                                <field name="expression_ids">
-                                    <record id="tax_monthly_report_line_vp6b_formula" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VP4.balance - VP5.balance</field>
-                                        <field name="subformula">if_below(EUR(0))</field>
-                                    </record>
-                                </field>
+                            <record id="tax_monthly_report_line_vp6_vp6b_credit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">-(VP4.debit - VP5.credit)</field>
+                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="blank_if_zero" eval="True"/>
                             </record>
                         </field>
                     </record>
@@ -105,15 +172,15 @@
                                 <field name="formula">vp7</field>
                             </record>
                             <record id="tax_monthly_report_line_vp7_applied_carryover" model="account.report.expression">
-                                <field name="label">_applied_carryover_balance</field>
+                                <field name="label">_applied_carryover_debit</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_return_period</field>
                             </record>
-                            <record id="tax_monthly_report_line_vp7_balance" model="account.report.expression">
-                                <field name="label">balance</field>
+                            <record id="tax_monthly_report_line_vp7_debit" model="account.report.expression">
+                                <field name="label">debit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">VP7._applied_carryover_balance + VP7.tag</field>
+                                <field name="formula">VP7._applied_carryover_debit + VP7.tag</field>
                             </record>
                         </field>
                     </record>
@@ -128,15 +195,15 @@
                                 <field name="formula">vp8</field>
                             </record>
                             <record id="tax_monthly_report_line_vp8_applied_carryover" model="account.report.expression">
-                                <field name="label">_applied_carryover_balance</field>
+                                <field name="label">_applied_carryover_credit</field>
                                 <field name="engine">external</field>
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_return_period</field>
                             </record>
-                            <record id="tax_monthly_report_line_vp8_balance" model="account.report.expression">
-                                <field name="label">balance</field>
+                            <record id="tax_monthly_report_line_vp8_credit" model="account.report.expression">
+                                <field name="label">credit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">VP8._applied_carryover_balance + VP8.tag</field>
+                                <field name="formula">VP8._applied_carryover_credit + VP8.tag</field>
                             </record>
                         </field>
                     </record>
@@ -156,8 +223,8 @@
                                 <field name="formula">most_recent</field>
                                 <field name="date_scope">previous_return_period</field>
                             </record>
-                            <record id="tax_monthly_report_line_vp9_balance" model="account.report.expression">
-                                <field name="label">balance</field>
+                            <record id="tax_monthly_report_line_vp9_credit" model="account.report.expression">
+                                <field name="label">credit</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">VP9._applied_carryover_balance + VP9.tag</field>
                             </record>
@@ -167,25 +234,49 @@
                         <field name="name">VP10 - EU car payments</field>
                         <field name="name@it">VP10 - Versamenti auto UE</field>
                         <field name="code">VP10</field>
-                        <field name="tax_tags_formula">vp10</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp10_credit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">vp10</field>
+                            </record>
+                        </field>
                     </record>
                     <record id="tax_monthly_report_line_vp11" model="account.report.line">
                         <field name="name">VP11 - Tax Credit</field>
                         <field name="name@it">VP11 - Credito d'imposta</field>
                         <field name="code">VP11</field>
-                        <field name="tax_tags_formula">vp11</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp11_credit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">vp11</field>
+                            </record>
+                        </field>
                     </record>
                     <record id="tax_monthly_report_line_vp12" model="account.report.line">
                         <field name="name">VP12 - Interest due for quarterly settlements</field>
                         <field name="name@it">VP12 - Interessi dovuti per liquidazioni trimestrali</field>
                         <field name="code">VP12</field>
-                        <field name="tax_tags_formula">vp12</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp12_debit" model="account.report.expression">
+                                <field name="label">debit</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">vp12</field>
+                            </record>
+                        </field>
                     </record>
                     <record id="tax_monthly_report_line_vp13" model="account.report.line">
                         <field name="name">VP13 - Down payment due</field>
                         <field name="name@it">VP13 - Acconto dovuto</field>
                         <field name="code">VP13</field>
-                        <field name="tax_tags_formula">vp13</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp13_credit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">vp13</field>
+                            </record>
+                        </field>
                     </record>
                 </field>
             </record>
@@ -198,70 +289,45 @@
                         <field name="name">VP14 - VAT payable</field>
                         <field name="name@it">VP14 - IVA da versare</field>
                         <field name="code">VP14</field>
-                        <field name="children_ids">
-                            <record id="tax_monthly_report_line_vp14a" model="account.report.line">
-                                <field name="name">VP14a - VAT payable (debit)</field>
-                                <field name="name@it">VP14a - IVA da versare (debito)</field>
-                                <field name="code">VP14a</field>
-                                <field name="expression_ids">
-                                    <record id="tax_monthly_report_line_vp14a_vp4_vp5_dif_pos" model="account.report.expression">
-                                        <field name="label">vp4_vp5_dif_pos</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VP4.balance - VP5.balance</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
-                                    </record>
-                                    <record id="tax_monthly_report_line_vp14a_vp4_vp5_dif_neg" model="account.report.expression">
-                                        <field name="label">vp4_vp5_dif_neg</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VP4.balance - VP5.balance</field>
-                                        <field name="subformula">if_below(EUR(0))</field>
-                                    </record>
-                                    <record id="tax_monthly_report_line_vp14a_balance" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">(VP14a.vp4_vp5_dif_pos + VP7.balance + VP12.balance) - (-VP14a.vp4_vp5_dif_neg + VP8.balance + VP9.balance + VP10.balance + VP11.balance + VP13.balance)</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
-                                    </record>
-                                    <record id="tax_monthly_report_line_vp14a_carryover" model="account.report.expression">
-                                        <field name="label">_carryover_balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VP14a.balance</field>
-                                        <field name="subformula">if_between(EUR(0), EUR(100.00))</field>
-                                        <field name="carryover_target">VP7._applied_carryover_balance</field>
-                                    </record>
-                                </field>
+
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp14_vp4_vp5_dif_pos" model="account.report.expression">
+                                <field name="label">vp4_vp5_dif_pos</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">VP4.debit - VP5.credit</field>
+                                <field name="subformula">if_above(EUR(0))</field>
                             </record>
-                            <record id="tax_monthly_report_line_vp14b" model="account.report.line">
-                                <field name="name">VP14b - VAT payable (credit)</field>
-                                <field name="name@it">VP14b - IVA da versare (credito)</field>
-                                <field name="code">VP14b</field>
-                                <field name="expression_ids">
-                                    <record id="tax_monthly_report_line_vp14b_vp4_vp5_dif_pos" model="account.report.expression">
-                                        <field name="label">vp4_vp5_dif_pos</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VP4.balance - VP5.balance</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
-                                    </record>
-                                    <record id="tax_monthly_report_line_vp14b_vp4_vp5_dif_neg" model="account.report.expression">
-                                        <field name="label">vp4_vp5_dif_neg</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VP4.balance - VP5.balance</field>
-                                        <field name="subformula">if_below(EUR(0))</field>
-                                    </record>
-                                    <record id="tax_monthly_report_line_vp14b_balance" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">(-VP14b.vp4_vp5_dif_neg + VP8.balance + VP9.balance + VP10.balance + VP11.balance + VP13.balance) - (VP14b.vp4_vp5_dif_pos + VP7.balance + VP12.balance)</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
-                                    </record>
-                                    <record id="tax_monthly_report_line_vp14b_carryover" model="account.report.expression">
-                                        <field name="label">_carryover_balance</field>
-                                        <field name="engine">aggregation</field>
-                                        <field name="formula">VP14b.balance</field>
-                                        <field name="subformula">if_above(EUR(0))</field>
-                                        <field name="carryover_target">VP8._applied_carryover_balance</field>
-                                    </record>
-                                </field>
+                            <record id="tax_monthly_report_line_vp14_vp4_vp5_dif_neg" model="account.report.expression">
+                                <field name="label">vp4_vp5_dif_neg</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">VP4.debit - VP5.credit</field>
+                                <field name="subformula">if_below(EUR(0))</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp14_vp14a_debit" model="account.report.expression">
+                                <field name="label">debit</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">(VP14.vp4_vp5_dif_pos + VP7.debit + VP12.debit) - (-VP14.vp4_vp5_dif_neg + VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit)</field>
+                                <field name="subformula">if_above(EUR(0))</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp14_vp14a_carryover" model="account.report.expression">
+                                <field name="label">_carryover_debit</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">VP14.debit</field>
+                                <field name="subformula">if_between(EUR(0), EUR(25.82))</field>
+                                <field name="carryover_target">VP7._applied_carryover_debit</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp14_vp14b_credit" model="account.report.expression">
+                                <field name="label">credit</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">(-VP14.vp4_vp5_dif_neg + VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit) - (VP14.vp4_vp5_dif_pos + VP7.debit + VP12.debit)</field>
+                                <field name="subformula">if_above(EUR(0))</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp14_vp14b_carryover" model="account.report.expression">
+                                <field name="label">_carryover_credit</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">VP14.credit</field>
+                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="carryover_target">VP8._applied_carryover_credit</field>
                             </record>
                         </field>
                     </record>

--- a/addons/l10n_it/models/account_report.py
+++ b/addons/l10n_it/models/account_report.py
@@ -8,10 +8,8 @@ class AccountReportExpression(models.AbstractModel):
     _inherit = "account.report.expression"
 
     def _get_carryover_target_expression(self, options):
-        if self.report_line_id.code == 'VP14b' and fields.Date.from_string(options['date']['date_to']).month == 12:
+        if self.report_line_id.code == 'VP14' and fields.Date.from_string(options['date']['date_to']).month == 12:
             # For this line, if we are between two years, we want to carry over to vp9 instead of the line set in the XML file (vp8)
-            if self.report_line_id == self.env.ref('l10n_it.tax_monthly_report_line_vp14b', raise_if_not_found=False):
-                return self.env.ref('l10n_it.tax_monthly_report_line_vp9_applied_carryover')
-            return self.env.ref('l10n_it.tax_report_line_vp9_applied_carryover')
+            return self.env.ref('l10n_it.tax_monthly_report_line_vp9_applied_carryover')
 
         return super()._get_carryover_target_expression(options)


### PR DESCRIPTION
Improvement on the tax report layout, to make it more like officially documented by the Italian revenue authorities.
See page 12: https://www.agenziaentrate.gov.it/portale/documents/20143/8487117/IVA_Annuale_2025_mod.pdf/f080de03-01f0-c4d6-8c80-8b5573797b89?t=1736949831826

For example, in the official docs some context information fields (those in VP1: Subcontracting, Exceptional Events, Extraordinary Operations) are directly shown on the report.
We moved them in Odoo from our export wizard to the report itself to match that layout.
This way they are also exported to PDF and XLSX.

See the task for screenshots.

enterprise pr: https://github.com/odoo/enterprise/pull/92769
upgrade pr: https://github.com/odoo/upgrade/pull/8253

Task [link](https://www.odoo.com/odoo/project/967/tasks/5000725)
task-5000725