### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: refactor API to include E-Invoices & …

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/data/cron.xml
+++ b/addons/l10n_tr_nilvera_einvoice/data/cron.xml
@@ -1,14 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="ir_cron_nilvera_get_new_documents" model="ir.cron">
-        <field name="name">Nilvera: retrieve new documents</field>
+    <record id="ir_cron_nilvera_get_new_purchase_documents" model="ir.cron">
+        <field name="name">Nilvera: retrieve new purchase documents</field>
         <field name="model_id" ref="model_account_move"/>
         <field name="state">code</field>
-        <field name="code">model._cron_nilvera_get_new_documents()</field>
+        <field name="code">model._cron_nilvera_get_new_einvoice_purchase_documents()</field>
         <field name="interval_number">12</field>
         <field name="interval_type">hours</field>
         <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
-        <field name="active" eval="True"/>
+    </record>
+
+    <record id="ir_cron_nilvera_get_new_einvoice_sale_documents" model="ir.cron">
+        <field name="name">Nilvera: retrieve E-Invoice new sale documents</field>
+        <field name="model_id" ref="model_account_move"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_nilvera_get_new_einvoice_sale_documents()</field>
+        <field name="interval_number">12</field>
+        <field name="interval_type">hours</field>
+        <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
+    </record>
+
+    <record id="ir_cron_nilvera_get_new_earchive_sale_documents" model="ir.cron">
+        <field name="name">Nilvera: retrieve new E-Archive sale documents</field>
+        <field name="model_id" ref="model_account_move"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_nilvera_get_new_earchive_sale_documents()</field>
+        <field name="interval_number">12</field>
+        <field name="interval_type">hours</field>
+        <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
     </record>
 
     <record id="ir_cron_nilvera_get_invoice_status" model="ir.cron">
@@ -19,6 +38,5 @@
         <field name="interval_number">12</field>
         <field name="interval_type">hours</field>
         <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
-        <field name="active" eval="True"/>
     </record>
 </odoo>

--- a/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/l10n_tr_nilvera_einvoice.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-16 12:38+0000\n"
-"PO-Revision-Date: 2025-07-16 12:38+0000\n"
+"POT-Creation-Date: 2025-08-20 09:54+0000\n"
+"PO-Revision-Date: 2025-08-20 09:54+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,21 +23,18 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "Check data on Invoice(s)"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "Check data on Partner(s)"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "Check reference on Partner(s)"
 msgstr ""
 
@@ -48,12 +45,13 @@ msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_journal_dashboard_kanban_view
-msgid "Fetch Nilvera invoice status"
+msgid "Fetch from Nilvera"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
-#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_journal_dashboard_kanban_view
-msgid "Fetch from Nilvera"
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_journal.py:0
+msgid "Fetching bills from Nilvera. This will be ready in a moment."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -67,34 +65,26 @@ msgid "Journal Entry"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_einvoice_enable_xml
-msgid "L10N Tr Nilvera Einvoice Enable Xml"
-msgstr ""
-
-#. module: l10n_tr_nilvera_einvoice
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_warnings
-msgid "L10N Tr Nilvera Warnings"
-msgstr ""
-
-#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_uuid
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move__l10n_tr_nilvera_uuid
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_payment__l10n_tr_nilvera_uuid
 msgid "Nilvera Document UUID"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_send_status
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move__l10n_tr_nilvera_send_status
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_payment__l10n_tr_nilvera_send_status
 msgid "Nilvera Status"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "Nilvera document has been received successfully"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_new_einvoice_sale_documents_ir_actions_server
+msgid "Nilvera: retrieve E-Invoice new sale documents"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -103,8 +93,13 @@ msgid "Nilvera: retrieve invoice status"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
-#: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_new_documents_ir_actions_server
-msgid "Nilvera: retrieve new documents"
+#: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_new_earchive_sale_documents_ir_actions_server
+msgid "Nilvera: retrieve new E-Archive sale documents"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_new_purchase_documents_ir_actions_server
+msgid "Nilvera: retrieve new purchase documents"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
@@ -115,14 +110,14 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid ""
 "Oops, seems like you're unauthorised to do this. Try another API key with "
 "more rights or contact Nilvera."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_einvoice_checkbox_xml
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid "Send E-Invoice to Nilvera"
 msgstr ""
 
@@ -134,7 +129,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "Server error from Nilvera, please try again later."
 msgstr ""
 
@@ -144,9 +138,19 @@ msgid "Successful"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
+#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_journal_dashboard_kanban_view
+msgid "Sync Nilvera Invoices"
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_journal.py:0
+msgid "Syncing Invoices with Nilvera. This will be ready in a moment."
+msgstr ""
+
+#. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid ""
 "The following E-Invoice partner(s) must have the reference field set to the "
 "tax office name."
@@ -155,7 +159,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid ""
 "The following invoice(s) need to have the same Start Date and End Date on "
 "all their respective Invoice Lines."
@@ -164,44 +167,38 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid ""
-"The following partner(s) are either not Turkish or are missing one of the "
-"following fields: city, state, or street."
+"The following partner(s) are either not Turkish or are missing one of those "
+"fields: city, state and street."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "The invoice couldn't be sent due to the following errors:\n"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "The invoice couldn't be sent to the recipient."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "The invoice has been successfully sent to Nilvera."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "The invoice status couldn't be retrieved from Nilvera."
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
-#, python-format
 msgid ""
 "To continue sending e-Invoices to Nilvera, please upgrade the 'Türkiye - "
 "Nilvera E-Invoice' module."
@@ -215,7 +212,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_uuid
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_move__l10n_tr_nilvera_uuid
-#: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_payment__l10n_tr_nilvera_uuid
 msgid "Universally unique identifier of the Invoice"
 msgstr ""
 
@@ -227,16 +223,12 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "View Invoice(s)"
 msgstr ""
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "View Partner(s)"
 msgstr ""
 
@@ -248,7 +240,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "You cannot reset to draft an entry that has been sent to Nilvera."
 msgstr ""
 

--- a/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
+++ b/addons/l10n_tr_nilvera_einvoice/i18n/tr.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-16 12:39+0000\n"
-"PO-Revision-Date: 2025-07-16 12:39+0000\n"
+"POT-Creation-Date: 2025-08-20 09:43+0000\n"
+"PO-Revision-Date: 2025-08-20 09:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,21 +23,19 @@ msgstr "Hesap Hareketi Yollandı"
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "Check data on Invoice(s)"
-msgstr "Fatura(lar)daki Verileri Kontrol Edin"
+msgstr "Fatura(lar) üzerindeki verileri kontrol edin"
+
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "Check data on Partner(s)"
-msgstr "Ortak(lar) hakkındaki verileri kontrol edin"
+msgstr "Ortak(lar) üzerindeki verileri kontrol edin"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "Check reference on Partner(s)"
 msgstr "Ortak(lar) üzerindeki referansı kontrol edin"
 
@@ -48,13 +46,14 @@ msgstr "Hata (konuşmayı kontrol edin)"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_journal_dashboard_kanban_view
-msgid "Fetch Nilvera invoice status"
-msgstr "Nilvera fatura durumunu getir"
-
-#. module: l10n_tr_nilvera_einvoice
-#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_journal_dashboard_kanban_view
 msgid "Fetch from Nilvera"
 msgstr "Nilvera'dan Getir"
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_journal.py:0
+msgid "Fetching bills from Nilvera. This will be ready in a moment."
+msgstr "Nilvera'dan faturalar getiriliyor. Bu birazdan hazır olacak."
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_journal
@@ -67,35 +66,27 @@ msgid "Journal Entry"
 msgstr "Yevmiye Kaydı"
 
 #. module: l10n_tr_nilvera_einvoice
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_einvoice_enable_xml
-msgid "L10N Tr Nilvera Einvoice Enable Xml"
-msgstr "L10N Tr Nilvera Einvoice Etkinleştir Xml"
-
-#. module: l10n_tr_nilvera_einvoice
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_warnings
-msgid "L10N Tr Nilvera Warnings"
-msgstr "L10N Tr Nilvera Uyarıları"
-
-#. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_uuid
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move__l10n_tr_nilvera_uuid
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_payment__l10n_tr_nilvera_uuid
 msgid "Nilvera Document UUID"
 msgstr "Nilvera Belge UUID'si"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_send_status
 #: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move__l10n_tr_nilvera_send_status
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_payment__l10n_tr_nilvera_send_status
 msgid "Nilvera Status"
 msgstr "Nilvera Durumu"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "Nilvera document has been received successfully"
 msgstr "Nilvera belgesi başarıyla alındı"
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_new_einvoice_sale_documents_ir_actions_server
+msgid "Nilvera: retrieve E-Invoice new sale documents"
+msgstr "Nilvera: yeni E-Fatura satış belgelerini al"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_invoice_status_ir_actions_server
@@ -103,9 +94,15 @@ msgid "Nilvera: retrieve invoice status"
 msgstr "Nilvera: fatura durumunu al"
 
 #. module: l10n_tr_nilvera_einvoice
-#: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_new_documents_ir_actions_server
-msgid "Nilvera: retrieve new documents"
-msgstr "Nilvera: yeni belgeler alın"
+#: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_new_earchive_sale_documents_ir_actions_server
+msgid "Nilvera: retrieve new E-Archive sale documents"
+msgstr "Nilvera: yeni E-Arşiv satış belgelerini al"
+
+
+#. module: l10n_tr_nilvera_einvoice
+#: model:ir.actions.server,name:l10n_tr_nilvera_einvoice.ir_cron_nilvera_get_new_purchase_documents_ir_actions_server
+msgid "Nilvera: retrieve new purchase documents"
+msgstr "Nilvera: yeni satın alma belgelerini al"
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera_einvoice.selection__account_move__l10n_tr_nilvera_send_status__not_sent
@@ -115,7 +112,6 @@ msgstr "Gönderilmedi"
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid ""
 "Oops, seems like you're unauthorised to do this. Try another API key with "
 "more rights or contact Nilvera."
@@ -124,7 +120,8 @@ msgstr ""
 "başka bir API anahtarı deneyin veya Nilvera ile iletişime geçin."
 
 #. module: l10n_tr_nilvera_einvoice
-#: model:ir.model.fields,field_description:l10n_tr_nilvera_einvoice.field_account_move_send__l10n_tr_nilvera_einvoice_checkbox_xml
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid "Send E-Invoice to Nilvera"
 msgstr "Nilvera'ya E-Fatura Gönderin"
 
@@ -136,7 +133,6 @@ msgstr "Gönderildi ve yanıt bekleniyor"
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "Server error from Nilvera, please try again later."
 msgstr "Nilvera'dan sunucu hatası, lütfen daha sonra tekrar deneyin."
 
@@ -146,20 +142,29 @@ msgid "Successful"
 msgstr "Başarılı"
 
 #. module: l10n_tr_nilvera_einvoice
+#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera_einvoice.account_journal_dashboard_kanban_view
+msgid "Sync Nilvera Invoices"
+msgstr "Nilvera Faturalarını Senkronize Et"
+
+#. module: l10n_tr_nilvera_einvoice
 #. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
-msgid ""
-"The following E-Invoice partner(s) must have the reference field set to the "
-"tax office name."
-msgstr ""
-"Aşağıdaki E-Fatura ortaklarının referans alanı vergi dairesi adına ayarlanmış "
-"olmalıdır."
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_journal.py:0
+msgid "Syncing Invoices with Nilvera. This will be ready in a moment."
+msgstr "Nilvera ile faturalar senkronize ediliyor. Bu birazdan hazır olacak."
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
+msgid ""
+"The following E-Invoice partner(s) must have the reference field set to the "
+"tax office name."
+msgstr ""
+"Aşağıdaki E-Fatura ortaklarının referans alanı vergi dairesi adı olarak "
+"ayarlanmalıdır."
+
+#. module: l10n_tr_nilvera_einvoice
+#. odoo-python
+#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
 msgid ""
 "The following invoice(s) need to have the same Start Date and End Date on "
 "all their respective Invoice Lines."
@@ -170,7 +175,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid ""
 "The following partner(s) are either not Turkish or are missing one of the "
 "following fields: city, state, or street."
@@ -181,41 +185,34 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "The invoice couldn't be sent due to the following errors:\n"
 msgstr "Fatura aşağıdaki hatalar nedeniyle gönderilemedi:\n"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "The invoice couldn't be sent to the recipient."
 msgstr "Fatura alıcıya gönderilemedi."
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "The invoice has been successfully sent to Nilvera."
 msgstr "Fatura Nilvera'ya başarıyla gönderildi."
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "The invoice status couldn't be retrieved from Nilvera."
 msgstr "Fatura durumu Nilvera'dan alınamadı."
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py:0
-#, python-format
 msgid ""
 "To continue sending e-Invoices to Nilvera, please upgrade the 'Türkiye - "
 "Nilvera E-Invoice' module."
 msgstr ""
-"Nilvera’ya e-Fatura göndermeye devam etmek için için lütfen "
-"'Türkiye - Nilvera E-Invoice' modülünü güncelleyin."
 
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model,name:l10n_tr_nilvera_einvoice.model_account_edi_xml_ubl_tr
@@ -225,7 +222,6 @@ msgstr ""
 #. module: l10n_tr_nilvera_einvoice
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_bank_statement_line__l10n_tr_nilvera_uuid
 #: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_move__l10n_tr_nilvera_uuid
-#: model:ir.model.fields,help:l10n_tr_nilvera_einvoice.field_account_payment__l10n_tr_nilvera_uuid
 msgid "Universally unique identifier of the Invoice"
 msgstr "Faturanın evrensel Olarak benzersiz tanımlayıcısı"
 
@@ -237,16 +233,12 @@ msgstr "Bilinmiyor"
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "View Invoice(s)"
 msgstr "Fatura(ları) Görüntüle"
 
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
 msgid "View Partner(s)"
 msgstr "Ortak(lar)ı Görüntüle"
 
@@ -258,18 +250,7 @@ msgstr "Bekliyorum"
 #. module: l10n_tr_nilvera_einvoice
 #. odoo-python
 #: code:addons/l10n_tr_nilvera_einvoice/models/account_move.py:0
-#, python-format
 msgid "You cannot reset to draft an entry that has been sent to Nilvera."
 msgstr ""
 "Nilvera'ya gönderilmiş bir girişi taslak haline getirmek için "
 "sıfırlayamazsınız."
-
-#. module: l10n_tr_nilvera_einvoice
-#. odoo-python
-#: code:addons/l10n_tr_nilvera_einvoice/models/account_move_send.py:0
-#, python-format
-msgid ""
-"Nilvera portal cannot process negative quantity nor negative price on "
-"invoice lines"
-msgstr ""
-"Nilvera portalı, fatura satırlarında negatif miktar veya negatif fiyat işleyemez."

--- a/addons/l10n_tr_nilvera_einvoice/models/account_journal.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_journal.py
@@ -5,12 +5,17 @@ class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
     def l10n_tr_nilvera_get_documents(self):
-        self.env['account.move']._l10n_tr_nilvera_get_documents()
+        """ Fetches bills from Nilvera."""
+        self.env['account.move']._cron_nilvera_get_new_einvoice_purchase_documents()
 
     def l10n_tr_nilvera_get_message_status(self):
-        """ Gets the status from Nilvera for all processing invoices in this journal. """
+        """Gets the status from Nilvera for all processing invoices in
+        this journal and fetches E-Invoice, & E-Archive invoices from nilvera
+        """
         invoices_to_update = self.env['account.move'].search([
             ('journal_id', '=', self.id),
             ('l10n_tr_nilvera_send_status', 'in', ['waiting', 'sent']),
         ])
         invoices_to_update._l10n_tr_nilvera_get_submitted_document_status()
+        self.env['account.move']._cron_nilvera_get_new_einvoice_sale_documents()
+        self.env['account.move']._cron_nilvera_get_new_earchive_sale_documents()

--- a/addons/l10n_tr_nilvera_einvoice/views/account_journal_dashboard_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_journal_dashboard_views.xml
@@ -15,7 +15,7 @@
                     <t t-if="record.l10n_tr_nilvera_api_key and record.l10n_tr_nilvera_api_key.raw_value">
                         <t t-if="journal_type == 'sale'">
                             <div class="w-100">
-                                <a type="object" name="l10n_tr_nilvera_get_message_status" groups="account.group_account_invoice">Fetch Nilvera invoice status</a>
+                                <a type="object" name="l10n_tr_nilvera_get_message_status" groups="account.group_account_invoice">Sync Nilvera Invoices</a>
                             </div>
                         </t>
                         <t t-elif="journal_type == 'purchase' and record.is_nilvera_journal.raw_value">

--- a/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
@@ -5,13 +5,11 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
-
             <xpath expr="//div[@name='journal_div']" position="after">
-                <label for="l10n_tr_nilvera_send_status"
-                       invisible="country_code != 'TR' or state == 'draft' or move_type in ['in_invoice', 'in_refund']"/>
+                <label for="l10n_tr_nilvera_send_status" invisible="country_code != 'TR' or state == 'draft' or move_type not in ['out_invoice', 'in_invoice']"/>
                 <div name="nilvera_div"
                      class="d-flex"
-                     invisible="country_code != 'TR' or state == 'draft' or move_type in ['in_invoice', 'in_refund']">
+                     invisible="country_code != 'TR' or state == 'draft' or move_type not in ['out_invoice', 'in_invoice']">
                     <field name="l10n_tr_nilvera_send_status" class="oe_inline"/>
                 </div>
             </xpath>


### PR DESCRIPTION
[IMP] l10n_tr_nilvera_einvoice: refactor API to include E-Invoices & E-Archive

Fixed bugs in API calls triggered during fetch requests and added support for fetching the status of E-Archive files. Updated the action button label to "Sync with Nilvera", which now fetches invoice statuses, retrieves PDFs for both E-Archive and E-Invoices, and includes invoices generated directly in Nilvera, enabling support for additional invoice types currently not supported in Odoo. Invoices/Bills are marked as "Successful" once retrieved. Retrieved PDFs are displayed in the preview and automatically attached to the chatter. The original limit of fetching a maximum of 30 records (status and PDFs) is maintained.

task-4714467
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
