### PR TITLE
[FIX] web: Mock call to Odoo Fin favorite institution

### DIFF
--- a/addons/web/tests/test_click_everywhere.py
+++ b/addons/web/tests/test_click_everywhere.py
@@ -15,6 +15,17 @@ _logger = logging.getLogger(__name__)
 @odoo.tests.tagged('click_all', 'post_install', '-at_install', '-standard')
 class TestMenusAdmin(odoo.tests.HttpCase):
     allow_end_on_form = True
+
+    @classmethod
+    def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
+        # mock odoofin requests
+        if 'proxy/v1/get_dashboard_institutions' in r.url:
+            r = Response()
+            r.status_code = 200
+            r.json = lambda: {'result': {}}
+            return r
+        return super()._request_handler(s, r, **kw)
+
     def test_01_click_everywhere_as_admin(self):
         menus = self.env['ir.ui.menu'].load_menus(False)
         for app_id in menus['root']['children']:

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -369,7 +369,7 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
                 patcher.stop()
         cls.addClassCleanup(check_remaining_patchers)
         super().setUpClass()
-        if 'standard' in cls.test_tags:
+        if 'standard' in cls.test_tags or 'click_all' in cls.test_tags:
             # if the method is passed directly `patch` discards the session
             # object which we need
             # pylint: disable=unnecessary-lambda


### PR DESCRIPTION
The aim of this commit is making sure that the click all won't try to contact our external server odoo fin when the accounting application is opened. Indeed, the accounting application is displaying the favorite institutions for a particular country in the accounting dashboard which is doing a call to production.odoofin.com.

This commit adds a mock using _request_handler to patch the call to odoo fin.

runbot-error-231151


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
