### PR TITLE
[IMP] mail, hr: support res.partner in avatar card popover

### DIFF
--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
@@ -9,10 +9,10 @@ export const patchAvatarCardPopover = {
         this.userInfoTemplate = "hr.avatarCardUserInfos";
     },
     get email() {
-        return this.user?.employee_id?.work_email || this.user?.email;
+        return this.user?.employee_id?.work_email || this.user?.email || this.partner?.email;
     },
     get phone() {
-        return this.user?.employee_id?.work_phone || this.user?.phone;
+        return this.user?.employee_id?.work_phone || this.user?.phone || this.partner?.phone;
     },
     get employeeId() {
         return this.user?.employee_id;

--- a/addons/hr/static/src/components/avatar_card_employee/avatar_card_employee_popover.js
+++ b/addons/hr/static/src/components/avatar_card_employee/avatar_card_employee_popover.js
@@ -3,7 +3,7 @@ import { AvatarCardResourcePopover } from "@resource_mail/components/avatar_card
 export class AvatarCardEmployeePopover extends AvatarCardResourcePopover {
     static defaultProps = {
         ...AvatarCardResourcePopover.defaultProps,
-        recordModel: "hr.employee",
+        resModel: "hr.employee",
     };
     async onWillStart() {
         await super.onWillStart();

--- a/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover_patch.js
+++ b/addons/hr/static/src/components/avatar_card_resource/avatar_card_resource_popover_patch.js
@@ -13,7 +13,7 @@ const patchAvatarCardResourcePopover = {
         return [
             ...super.fieldNames,
             "department_id",
-            this.props.recordModel ? "employee_id" : "employee_ids",
+            this.props.resModel ? "employee_id" : "employee_ids",
             "hr_icon_display",
             "job_title",
             "show_hr_icon_display",

--- a/addons/hr/static/src/components/avatar_employee/avatar_employee.js
+++ b/addons/hr/static/src/components/avatar_employee/avatar_employee.js
@@ -3,11 +3,4 @@ import { AvatarCardEmployeePopover } from "../avatar_card_employee/avatar_card_e
 
 export class AvatarEmployee extends Avatar {
     static components = { ...super.components, Popover: AvatarCardEmployeePopover };
-
-    get popoverProps() {
-        return {
-            ...super.popoverProps,
-            recordModel: this.props.resModel,
-        };
-    }
 }

--- a/addons/hr/static/src/views/fields/employee_field_relation_mixin.js
+++ b/addons/hr/static/src/views/fields/employee_field_relation_mixin.js
@@ -35,7 +35,7 @@ export function EmployeeFieldRelationMixin(fieldClass) {
             if (["hr.employee", "hr.employee.public"].includes(this.relation)) {
                 return {
                     ...originalProps,
-                    recordModel: this.relation,
+                    resModel: this.relation,
                 };
             }
             return originalProps;

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -105,9 +105,18 @@ class WebclientController(ThreadController):
             ]
             store.add(request.env["mail.canned.response"].search(domain))
         if name == "avatar_card":
-            if (
+            if params["res_model"] == "res.partner":
+                if (
+                    partner := request.env["res.partner"]
+                    .with_context(active_test=False)
+                    .search([("id", "=", params["id"])])
+                ):
+                    store.add(partner, partner._get_store_avatar_card_fields(store.target))
+                    if partner.user_id:
+                        store.add(partner.user_id, partner.user_id._get_store_avatar_card_fields(store.target))
+            elif (
                 user := request.env["res.users"]
                 .with_context(active_test=False)
-                .search([("id", "=", params["user_id"])])
+                .search([("id", "=", params["id"])])
             ):
                 store.add(user, user._get_store_avatar_card_fields(store.target))

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -303,6 +303,12 @@ class ResPartner(models.Model):
     def _get_mention_suggestions_domain(self, search):
         return (Domain('name', 'ilike', search) | Domain('email', 'ilike', search)) & Domain('active', '=', True)
 
+    def _get_store_avatar_card_fields(self, target):
+        fields = ["name", "user_id"]
+        if target.is_internal(self.env):
+            fields.extend(["email", "phone"])
+        return fields
+
     @api.model
     def _search_mention_suggestions(self, domain, limit, extra_domain=None):
         domain = Domain(domain)

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -7,34 +7,51 @@ export class AvatarCardPopover extends Component {
 
     static props = {
         id: { type: Number, required: true },
+        resModel: { type: String, required: true },
         close: { type: Function, required: true },
+    };
+    static defaultProps = {
+        resModel: "res.users",
     };
 
     setup() {
         this.actionService = useService("action");
         this.store = useService("mail.store");
         this.openChat = useOpenChat("res.users");
-        this.store.fetchStoreData("avatar_card", { user_id: this.props.id });
+        this.store.fetchStoreData("avatar_card", {
+            id: this.props.id,
+            res_model: this.props.resModel,
+        });
+    }
+
+    get partner() {
+        if (this.props.resModel === "res.partner") {
+            return this.store["res.partner"].get(this.props.id);
+        }
+        return null;
     }
 
     get user() {
-        return this.store["res.users"].get(this.props.id);
+        if (this.partner) {
+            return this.partner.user_id ? this.store["res.users"].get(this.partner.user_id) : null;
+        }
+        return this.store[this.props.resModel].get(this.props.id);
     }
 
     get name() {
-        return this.user?.name;
+        return this.user?.name || this.partner?.name;
     }
 
     get email() {
-        return this.user?.email;
+        return this.user?.email || this.partner?.email;
     }
 
     get phone() {
-        return this.user?.phone;
+        return this.user?.phone || this.partner?.phone;
     }
 
     get showViewProfileBtn() {
-        return this.user;
+        return this.user || this.partner;
     }
 
     get hasFooter() {
@@ -42,11 +59,11 @@ export class AvatarCardPopover extends Component {
     }
 
     async getProfileAction() {
-        if (!this.user?.partner_id) {
-            return this.user?.partner_id;
+        if (!this.user?.partner_id && !this.partner?.id) {
+            return false;
         }
         return {
-            res_id: this.user.partner_id,
+            res_id: this.user?.partner_id || this.partner.id,
             res_model: "res.partner",
             type: "ir.actions.act_window",
             views: [[false, "form"]],

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -7,7 +7,7 @@ export class AvatarCardPopover extends Component {
 
     static props = {
         id: { type: Number, required: true },
-        resModel: { type: String, required: true },
+        resModel: { type: String, optional: true },
         close: { type: Function, required: true },
     };
     static defaultProps = {

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -6,7 +6,7 @@
                 <div class="d-flex align-items-start gap-2 bg-inherit">
                     <span class="o_avatar pt-1 position-relative o_card_avatar bg-inherit">
                         <img t-if="props.id"
-                            t-attf-src="/web/image/res.users/{{props.id}}/avatar_128"
+                            t-attf-src="/web/image/{{props.resModel}}/{{props.id}}/avatar_128"
                             class="rounded"
                         />
                         <span t-if="user?.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center bg-inherit">
@@ -28,7 +28,7 @@
                             <i class="fa fa-fw fa-phone me-1"/><t t-esc="phone"/>
                         </a>
                         <div class="o_avatar_card_buttons d-flex gap-2 mt-2">
-                            <button t-if="!user?.share" class="btn btn-secondary btn-sm" t-on-click.stop="onSendClick">Send message</button>
+                            <button t-if="user and !user?.share" class="btn btn-secondary btn-sm" t-on-click.stop="onSendClick">Send message</button>
                             <button t-if="showViewProfileBtn" class="btn btn-secondary btn-sm" t-custom-click.stop="(ev, isMiddleClick) => this.onClickViewProfile(isMiddleClick)" t-ref="viewProfileBtn">View Profile</button>
                         </div>
                     </div>

--- a/addons/mail/static/src/views/web/fields/avatar/avatar.js
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.js
@@ -29,6 +29,7 @@ export class Avatar extends Component {
     get popoverProps() {
         return {
             id: this.props.resId,
+            resModel: this.props.resModel,
         };
     }
 

--- a/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
+++ b/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
@@ -6,17 +6,9 @@ import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_pop
 export class AvatarCardResourcePopover extends AvatarCardPopover {
     static template = "resource_mail.AvatarCardResourcePopover";
 
-    static props = {
-        ...AvatarCardPopover.props,
-        recordModel: {
-            type: String,
-            optional: true,
-        },
-    };
-
     static defaultProps = {
         ...AvatarCardPopover.defaultProps,
-        recordModel: "resource.resource",
+        resModel: "resource.resource",
     };
 
     setup() {
@@ -27,7 +19,7 @@ export class AvatarCardResourcePopover extends AvatarCardPopover {
     }
 
     async onWillStart() {
-        [this.record] = await this.orm.call(this.props.recordModel, 'get_avatar_card_data', [[this.props.id], this.fieldNames], {});
+        [this.record] = await this.orm.call(this.props.resModel, 'get_avatar_card_data', [[this.props.id], this.fieldNames], {});
         await Promise.all(this.loadAdditionalData());
     }
 

--- a/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
+++ b/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="resource_mail.AvatarCardResourcePopover" t-inherit="mail.AvatarCardPopover">
         <xpath expr="//span[hasclass('o_avatar')]/img" position="attributes">
-            <attribute name="t-attf-src" t-if="displayAvatar">/web/image/{{ props.recordModel }}/{{ props.id }}/avatar_128</attribute>
+            <attribute name="t-attf-src" t-if="displayAvatar">/web/image/{{ props.resModel }}/{{ props.id }}/avatar_128</attribute>
         </xpath>
         <xpath expr="//span[hasclass('o_card_avatar_im_status')]" position="replace">
             <span t-if="record.user_id" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center o_user_im_status bg-inherit">


### PR DESCRIPTION
This commit extends the avatar_card_popover component to handle res.partner records.

- When a partner is linked to a res.users record, the popover behaves as before, showing the user information.
- When no related user is found, the popover now falls back to displaying basic partner information.

This makes the component more flexible and ensures consistent behavior across both users and partners.

task-4868057
