### PR TITLE
[FIX] test_mail*: fix tests when magic is installed

### DIFF
--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1201,9 +1201,9 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
         Test the message_main_attachment heuristics with an emphasis on the XML/Octet/PDF types.
         -> we don't want XML nor Octet-Stream files to be set as message_main_attachment
         """
-        xml_attachment, octet_attachment, pdf_attachment = [('List1', b'My xml attachment')], \
-                                                           [('List2', b'My octet-stream attachment')], \
-                                                           [('List3', b'My pdf attachment')]
+        xml_attachment, octet_attachment, pdf_attachment = [('List1', b'<?xml version="1.0"?>My xml attachment<_/>')], \
+                                                           [('List2', b'My octet-stream attachment\20')], \
+                                                           [('List3', b'%PDF-1.0My pdf attachment')]
 
         xml_attachment_data, octet_attachment_data, pdf_attachment_data = self.env['ir.attachment'].create(
             self._generate_attachments_data(3, 'mail.compose.message', 0)
@@ -1217,7 +1217,6 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
             'email_from': 'ignasse@example.com',
         })
         self.assertFalse(test_record.message_main_attachment_id)
-
         # test with xml attachment
         with self.mock_mail_gateway():
             test_record.message_post(

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -9,6 +9,7 @@ from odoo.addons.test_mail.tests.test_performance import BaseMailPerformance
 from odoo.tests.common import users, warmup
 from odoo.tests import tagged
 from odoo.tools import mute_logger
+from odoo.tools.mimetypes import magic
 
 
 @tagged('mail_performance', 'post_install', '-at_install')
@@ -247,6 +248,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
         self.assertEqual(len(res), len(messages_all))
         for format_res, message, record in zip(res, messages_all, self.messages_records):
             self.assertEqual(len(format_res['attachment_ids']), 2)
+            expected_mimetype = 'text/plain' if magic else 'application/octet-stream'
             self.assertEqual(
                 format_res['attachment_ids'],
                 [
@@ -255,7 +257,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
                         'checksum': message.attachment_ids[0].checksum,
                         'filename': 'Test file 1',
                         'id': message.attachment_ids[0].id,
-                        'mimetype': 'application/octet-stream',
+                        'mimetype': expected_mimetype,
                         'name': 'Test file 1',
                         'res_id': record.id,
                         'res_model': record._name,
@@ -264,7 +266,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
                         'checksum': message.attachment_ids[1].checksum,
                         'filename': 'Test file 0',
                         'id': message.attachment_ids[1].id,
-                        'mimetype': 'application/octet-stream',
+                        'mimetype': expected_mimetype,
                         'name': 'Test file 0',
                         'res_id': record.id,
                         'res_model': record._name,


### PR DESCRIPTION
Those tests are failing when python-magic is installed. Since 26f9c82b99 Odoo > saas-18.4 has this lib as a requirement and comes with appropriate fixes.

This commit adapts some test from 17.0 up to saas-18.4 to also work when the python-magic lib is installed.

