### PR TITLE
[FIX] sale: fix sale order signature issue when confirmation fails

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -278,7 +278,8 @@ class CustomerPortal(payment_portal.PaymentPortal):
                 'signed_on': fields.Datetime.now(),
                 'signature': signature,
             })
-            request.env.cr.commit()
+            # flush now to make signature data available to PDF render request
+            request.env.cr.flush()
         except (TypeError, binascii.Error) as e:
             return {'error': _('Invalid signature data.')}
 


### PR DESCRIPTION
In this bug, sale order signature is commited before confirm, causing sale order not be able to be signed later, if confirm fails.

To reproduce the bug:
1- Create a consumable product with `Buy` and `Dropship` routes enabled in the inventory tab

2- Do not put in any vendors in the purchase tab

3- Create a sale order with this product and uncheck the online payment option.

4- On an incognito browser, sign in as portal user and open the sale order

5- Click on the `Accept & Sign` button and confirm

6- We get an invalid operation error because of not having vendors

7- Reload the order. As you see, it is not possible to sign it

To fix the issue, we use flush instead of commit, so when confirm fails it can rollback.

Note: It is not easy to write a test for this case, because the `action_confirm` fails in a specific case when `purchase_stock` and `stock_dropshipping` are installed.

opw-4864150
