### PR TITLE
[FIX] google_gmail, microsoft_outlook: fix incoming mail server connection

### DIFF
--- a/addons/google_gmail/controllers/main.py
+++ b/addons/google_gmail/controllers/main.py
@@ -76,7 +76,7 @@ class GoogleGmailController(http.Controller):
     def _check_email_and_redirect_to_gmail_record(self, access_token, expiration, refresh_token, record):
         # Verify the token information (that the email set on the
         # server is the email used to login on Gmail)
-        if record.owner_user_id or not request.env.user.has_group('base.group_system'):
+        if (record._name == 'ir.mail_server' and (record.owner_user_id or not request.env.user.has_group('base.group_system'))):
             # https://developers.google.com/identity/protocols/oauth2/scopes
             response = requests.get(
                 'https://www.googleapis.com/oauth2/v2/userinfo',

--- a/addons/microsoft_outlook/controllers/main.py
+++ b/addons/microsoft_outlook/controllers/main.py
@@ -75,7 +75,7 @@ class MicrosoftOutlookController(http.Controller):
     def _check_email_and_redirect_to_outlook_record(self, access_token, expiration, refresh_token, record):
         # Verify the token information (that the email set on the
         # server is the email used to login on Outlook)
-        if record.owner_user_id or not request.env.user.has_group('base.group_system'):
+        if (record._name == 'ir.mail_server' and (record.owner_user_id or not request.env.user.has_group('base.group_system'))):
             response = requests.get(
                 "https://outlook.office.com/api/v2.0/me",
                 headers={"Authorization": f"Bearer {access_token}"},


### PR DESCRIPTION
Bug
===
When connecting an incoming mail server using Gmail or Outlook, an error is raised.

We shouldn't check the email address used to login for the incoming mail server, because only the administrator can add such records.

Task-5001172