### PR TITLE
[FIX] account_payment: payment link generation based on amount

### DIFF
--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -11,7 +11,7 @@ from odoo.addons.payment.controllers.portal import PaymentPortal
 
 class PortalAccount(portal.PortalAccount, PaymentPortal):
 
-    def _invoice_get_page_view_values(self, invoice, access_token, payment=False, amount=None, **kwargs):
+    def _invoice_get_page_view_values(self, invoice, access_token, payment=False, **kwargs):
         # EXTENDS account
 
         values = super()._invoice_get_page_view_values(invoice, access_token, **kwargs)
@@ -39,7 +39,7 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
             access_token=access_token,
             **kwargs)
 
-        amount_custom = float(amount or 0.0)
+        amount_custom = float(kwargs.get('amount') or 0.0)
         values |= {
             **common_view_values,
             'amount_custom': amount_custom,
@@ -117,6 +117,7 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
         invoice_company = invoices_data['company'] or request.env.company
 
         availability_report = {}
+        kwargs.pop('amount', None)  # Prevent crash `_get_compatible_providers`
         # Select all the payment methods and tokens that match the payment context.
         providers_sudo = request.env['payment.provider'].sudo()._get_compatible_providers(
             invoice_company.id,


### PR DESCRIPTION
Steps to reproduce:
1. Create an invoice with an amount.
2. Post the invoice.
3. Generate a payment link with a custom amount.
4. Open the link.

Issue:
The generated link did not respect the amount provided.

Cause:
In `account`, the method `_invoice_get_page_view_values` retrieves
`amount` from `kwargs`. However, in `account_payment`, the
overridden `_invoice_get_page_view_values` was incorrectly declaring
`amount` as a method parameter instead of leaving it in `kwargs`.
As a result, it was not passed to `super()`. This caused the amount
from the link to be ignored.

Solution:
Remove `amount` from the method parameters, keep it inside
`kwargs`, and then clean it up in `_get_common_page_view_values`
to avoid multiple arguments error when retrieving the payment providers.

Note:
This issue was found while preparing the Pull Request 
[#218243](https://github.com/odoo/odoo/pull/218243).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
