### PR TITLE
[FIX] website: fix silent rendering error in theme tab

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
@@ -20,9 +20,8 @@ export class ThemeColorsOption extends BaseOptionComponent {
     getPalettes() {
         const palettes = [];
         const style = window.getComputedStyle(document.documentElement);
-        const allPaletteNames = getCSSVariableValue("palette-names", style)
-            .split(", ")
-            .map((name) => name.replace(/'/g, ""));
+        const uniquePaletteNames = new Set(getCSSVariableValue("palette-names", style).split(", "));
+        const allPaletteNames = [...uniquePaletteNames].map((name) => name.replace(/'/g, ""));
         for (const paletteName of allPaletteNames) {
             const palette = {
                 name: paletteName,


### PR DESCRIPTION
Since website refactor [1],a silent error would occur while rendering the theme tab, leading to nothing being displayed depending of the theme.
This was caused by a duplicate key in the
`$o-selected-color-palettes-names` scss variable, added by some theme, which would crash the `t-foreach` template loop.

Steps to reproduce:
- Create a website using theme_real_estate, through the wizard
- Enter edit mode
- Click on theme tab
- Nothing is rendered

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
