### PR TITLE
[FIX] pos_sale, pos_loyalty: Fix runbot errors

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -249,6 +249,10 @@ patch(PosStore.prototype, {
         let coupon = null;
         // If the code belongs to a loyalty card we just set the partner
         if (partnerId) {
+            if (!this.models["res.partner"].get(partnerId)) {
+                await this.data.read("res.partner", [partnerId]);
+            }
+
             const partner = this.models["res.partner"].get(partnerId);
             order.setPartner(partner);
         } else if (rule) {

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -441,13 +441,14 @@ registry.category("web_tour.tours").add("POSSalePaymentScreenInvoiceOrder", {
             Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Product Test", "1"),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.clickCustomer("AAA - Test Partner invoice"),
             ProductScreen.clickPayButton(),
 
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickInvoiceButton(),
             PaymentScreen.clickValidate(),
             ReceiptScreen.receiptIsThere(),
+            Chrome.waitRequest(),
         ].flat(),
 });
 

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1132,7 +1132,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             })]
         })
         partner_test = self.env['res.partner'].create({
-            'name': 'Test Partner',
+            'name': 'AAA - Test Partner invoice',
             'property_payment_term_id': payment_term.id,
         })
 


### PR DESCRIPTION
In PoS loyalty when activating a barcode we were not checking if the partner was already loaded in the PoS resulting of an undefined var.

Now we check if the partner is loaded before trying to access it.

In PoS sale tour, we were creating a partner called "Test Partner" which was already created in the setup, so sometime the tour was selecting the wrong one.

Now, the name of this partner is changed to "AAA - Test Partner invoice"

Runbot error: 230992, 230995


https://runbot.odoo.com/odoo/runbot.build.error/230992
https://runbot.odoo.com/odoo/runbot.build.error/230995