### PR TITLE
[IMP] im_livechat: add text formatting to chatbot steps

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -845,7 +845,7 @@ class DiscussChannel(models.Model):
     def _post_current_chatbot_step_message(self, chatbot_script_step):
         posted_message = self.env['mail.message']
         if chatbot_script_step and chatbot_script_step.message:
-            posted_message = self._chatbot_post_message(chatbot_script_step.chatbot_script_id, plaintext2html(chatbot_script_step.message))
+            posted_message = self._chatbot_post_message(chatbot_script_step.chatbot_script_id, chatbot_script_step.message)
         return posted_message
 
     def _add_new_members_to_channel(self, create_member_params, inviting_partner, users=None, partners=None):

--- a/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
@@ -10,11 +10,11 @@ function createChatbotSteps(...stepMessages) {
         ...stepMessages
             .map((message) => [
                 {
-                    trigger: ".modal textarea#message_0",
-                    run: `edit ${message}`,
+                    trigger: ".modal .odoo-editor-editable",
+                    run: `editor ${message}`,
                 },
                 {
-                    trigger: `.modal textarea#message_0:value(${message})`,
+                    trigger: `.modal .odoo-editor-editable:contains(${message})`,
                 },
                 {
                     trigger: ".modal button:contains(Save & New)",
@@ -24,7 +24,7 @@ function createChatbotSteps(...stepMessages) {
                     trigger: `tr:contains(${message})`,
                 },
                 {
-                    trigger: ".modal textarea#message_0:empty",
+                    trigger: ".modal .odoo-editor-editable:empty",
                 },
             ])
             .flat(),

--- a/addons/im_livechat/tests/test_chatbot_form_ui.py
+++ b/addons/im_livechat/tests/test_chatbot_form_ui.py
@@ -5,7 +5,7 @@ from odoo import tests
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
 
-@tests.tagged('post_install', '-at_install')
+@tests.tagged("post_install", "-at_install")
 class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
     def test_chatbot_steps_sequence_ui(self):
         """ As sequences are *critical* for the chatbot_script script, let us a run a little tour that
@@ -21,11 +21,11 @@ class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
 
         self.assertEqual(len(chatbot_script.script_step_ids), 3)
 
-        self.assertEqual(chatbot_script.script_step_ids[0].message, 'Step 1')
+        self.assertEqual(chatbot_script.script_step_ids[0].message, "<p>Step 1</p>")
         self.assertEqual(chatbot_script.script_step_ids[0].sequence, 0)
-        self.assertEqual(chatbot_script.script_step_ids[1].message, 'Step 2')
+        self.assertEqual(chatbot_script.script_step_ids[1].message, "<p>Step 2</p>")
         self.assertEqual(chatbot_script.script_step_ids[1].sequence, 1)
-        self.assertEqual(chatbot_script.script_step_ids[2].message, 'Step 3')
+        self.assertEqual(chatbot_script.script_step_ids[2].message, "<p>Step 3</p>")
         self.assertEqual(chatbot_script.script_step_ids[2].sequence, 2)
 
     def test_chatbot_steps_sequence_with_move_ui(self):
@@ -47,15 +47,15 @@ class TestLivechatChatbotFormUI(HttpCaseWithUserDemo):
         # during the test, we create the steps normally and then move 'Step 5'
         # in second position -> check order is correct
 
-        self.assertEqual(chatbot_script.script_step_ids[0].message, 'Step 1')
+        self.assertEqual(chatbot_script.script_step_ids[0].message, "<p>Step 1</p>")
         self.assertEqual(chatbot_script.script_step_ids[0].sequence, 0)
-        self.assertEqual(chatbot_script.script_step_ids[1].message, 'Step 5')
+        self.assertEqual(chatbot_script.script_step_ids[1].message, "<p>Step 5</p>")
         self.assertEqual(chatbot_script.script_step_ids[1].sequence, 1)
-        self.assertEqual(chatbot_script.script_step_ids[2].message, 'Step 2')
+        self.assertEqual(chatbot_script.script_step_ids[2].message, "<p>Step 2</p>")
         self.assertEqual(chatbot_script.script_step_ids[2].sequence, 2)
-        self.assertEqual(chatbot_script.script_step_ids[3].message, 'Step 3')
+        self.assertEqual(chatbot_script.script_step_ids[3].message, "<p>Step 3</p>")
         self.assertEqual(chatbot_script.script_step_ids[3].sequence, 3)
-        self.assertEqual(chatbot_script.script_step_ids[4].message, 'Step 4')
+        self.assertEqual(chatbot_script.script_step_ids[4].message, "<p>Step 4</p>")
         self.assertEqual(chatbot_script.script_step_ids[4].sequence, 4)
-        self.assertEqual(chatbot_script.script_step_ids[5].message, 'Step 6')
+        self.assertEqual(chatbot_script.script_step_ids[5].message, "<p>Step 6</p>")
         self.assertEqual(chatbot_script.script_step_ids[5].sequence, 5)

--- a/addons/im_livechat/views/chatbot_script_step_views.xml
+++ b/addons/im_livechat/views/chatbot_script_step_views.xml
@@ -17,7 +17,7 @@
                     <group>
                         <group>
                             <field name="sequence" invisible="1"/>
-                            <field name="message" widget="text_emojis" placeholder="e.g. 'How can I help you?'"
+                            <field name="message" placeholder="e.g. 'How can I help you?'"
                                 required="not is_forward_operator"/>
                             <field name="chatbot_script_id" invisible="1"/>
                             <field name="step_type"/>


### PR DESCRIPTION
Before this commit, the steps of the livechat bot were stored as a text.

With this commit, we add the support for formatting the text and give a better user experience to both users and guests.

task-4848210

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
