### PR TITLE
[FIX] l10n_ar: prevent crash when sanitizing invalid VAT values

### DIFF
--- a/addons/l10n_ar/models/res_partner.py
+++ b/addons/l10n_ar/models/res_partner.py
@@ -123,5 +123,5 @@ class ResPartner(models.Model):
             res = int(stdnum.ar.cuit.compact(self.vat))
         else:
             id_number = re.sub('[^0-9]', '', self.vat)
-            res = int(id_number)
+            res = id_number and int(id_number)
         return res

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import common
 from odoo import Command
+from odoo.exceptions import ValidationError
 from odoo.tests import Form, tagged
 from odoo.tools.float_utils import float_split_str
 
@@ -348,3 +349,10 @@ class TestManual(common.TestAr):
         self.assertAlmostEqual(l10n_ar_values['price_unit'], 5470.0)
         self.assertAlmostEqual(l10n_ar_values['price_subtotal'], 124716.0)
         self.assertAlmostEqual(l10n_ar_values['price_net'], 5196.5)
+
+    def test_l10n_ar_vat_with_non_numeric_value(self):
+        with self.assertRaises(ValidationError) as e:
+            with Form(self.partner) as partner_form:
+                partner_form.l10n_latam_identification_type_id = self.env.ref("l10n_ar.it_dni")
+                partner_form.vat = "test"
+        self.assertIn('Only numbers allowed for "DNI"', str(e.exception))


### PR DESCRIPTION
Manual backport of https://github.com/odoo/odoo/commit/b01a6640895c4dd4b5bcf849740aa6b3312e9a54.
This is needed to prevent crashes when trying to sanitize invalid VAT inputs for Argentina
partners due to the assumption that the identification number can always be
safely cast to int().



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
