### PR TITLE
[FIX] web: fixes date not visible on calendar yearly render

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_renderer.js
@@ -6,7 +6,7 @@ import { CalendarYearPopover } from "./calendar_year_popover";
 import { makeWeekColumn } from "@web/views/calendar/calendar_common/calendar_common_week_column";
 import { getLocalWeekNumber } from "@web/core/l10n/dates";
 
-import { Component, useEffect, useRef } from "@odoo/owl";
+import { Component, useRef, useExternalListener, onMounted } from "@odoo/owl";
 
 export class CalendarYearRenderer extends Component {
     static components = {
@@ -35,10 +35,8 @@ export class CalendarYearRenderer extends Component {
         this.popover = useCalendarPopover(this.constructor.components.Popover);
         this.rootRef = useRef("root");
         this.onWindowResizeDebounced = useDebounced(this.onWindowResize, 200);
-
-        useEffect(() => {
-            this.updateSize();
-        });
+        useExternalListener(window, "resize", this.onWindowResizeDebounced);
+        onMounted(() => this.updateSize());
     }
 
     get options() {

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -5454,3 +5454,21 @@ test("calendar (year): tap on date switch to day scale", async () => {
     // should open a Quick create modal view in mobile on short tap on date in monthly view
     expect(".modal").toHaveCount(1);
 });
+test("calendar year view resizes correctly on window resize", async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `<calendar mode="year" date_start="start" date_stop="stop"/>`,
+    });
+    const root = queryFirst(".o_calendar_widget");
+    const originalGetBoundingClientRect = root.getBoundingClientRect;
+
+    root.getBoundingClientRect = () => ({ top: 500 });
+    window.innerHeight = 1000;
+    window.dispatchEvent(new window.Event("resize"));
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    expect(root.style.height).toBe("500px");
+    root.getBoundingClientRect = originalGetBoundingClientRect;
+});


### PR DESCRIPTION
Before this commit, when zooming on the screen in the yearly calendar and scrolling down to the bottom, some end dates are not visible.

By merging this commit, resolved dates will be visible on screen when scrolling down to the bottom by responding to window size changes in the DOM.

task-4809668

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
