### PR TITLE
[FIX] website_sale_slides: prevent error on installing module

### DIFF
--- a/addons/website_sale_slides/data/product_data.xml
+++ b/addons/website_sale_slides/data/product_data.xml
@@ -8,6 +8,6 @@
         <field name="invoice_policy">order</field>
         <field name="is_published" eval="True"/>
         <field name="image_1920" type="base64" file="website_sale_slides/static/img/default_course_product.svg"/>
-        <field name="categ_id" ref="product.product_category_services"/>
+        <field name="categ_id" eval="ref('product.product_category_services', raise_if_not_found=False)"/>
     </record>
 </data></odoo>


### PR DESCRIPTION
Currently a `ParseError` arises when the user installs the modules after deleting the `Service` Category in Sales.

**Steps to produce:-**
- Install `Sales` module (without demo data).
- Go to `Sales > Configuration > Products > Categories`.
- Delete `Services` category.
- Try to install `website_sale_slides` module.

**Error:-**
```py
ValueError: External ID not found in the system: product.product_category_services

ParseError: while parsing /home/odoo/src/odoo/saas-18.4/addons/website_sale_slides/data/product_data.xml:2, somewhere inside <record id='default_product_course' model='product.product'>
        <field name='name'>Course Access</field>
        <field name='standard_price'>99.99</field>
        <field name='list_price'>99.99</field>
        <field name='type'>service</field>
        <field name='service_tracking'>course</field>
        <field name='invoice_policy'>order</field>
        <field name='is_published' eval='True'/>
        <field name='image_1920' type='base64' file='website_sale_slides/static/img/default_course_product.jpg'/>
        <field name='categ_id' ref='product.product_category_services'/>
    </record>
```
- The error occurs because the user deleted the category, and then installed the modules, that reference the missing product category.

- This commit resolves the error by providing a False value for the field if the product category is missing.

**sentry-6823596992**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
