### PR TITLE
[IMP] website,website_sale,test_website_modules: post onboarding improvement

### DIFF
--- a/addons/spreadsheet_dashboard_website_sale/data/files/ecommerce_dashboard.json
+++ b/addons/spreadsheet_dashboard_website_sale/data/files/ecommerce_dashboard.json
@@ -727,12 +727,5 @@
     }
   ],
   "lists": {},
-  "listNextId": 1,
-  "chartOdooMenusReferences": {
-    "0c5e3c79-3754-41a9-83df-b185003ce0b1": "website.menu_website_dashboard",
-    "a761d77e-17d1-4d7a-ac85-5494c07dd360": "website.menu_website_dashboard",
-    "7db1cb48-a155-4984-b8dd-de155db2b65f": "website.menu_website_dashboard",
-    "1bfef494-7090-4263-8e07-83f14f43c0e7": "website.menu_website_dashboard",
-    "79d91c01-7aeb-4845-aa82-5a41895b74af": "website.menu_website_dashboard"
-  }
+  "listNextId": 1
 }

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -77,9 +77,6 @@ registry.category("web_tour.tours").add("configurator_flow", {
             trigger: '.card.card_installed:contains("eLearning")',
         },
         {
-            trigger: '.card.card_installed:contains("Success Stories")',
-        },
-        {
             content:
                 "Success Stories (Blog) and News (Blog) should be selected (module already installed)",
             trigger: '.card.card_installed:contains("News")',
@@ -119,7 +116,7 @@ registry.category("web_tour.tours").add("configurator_flow", {
             content: `Check footer menu ${menu} is there`,
             trigger: `:iframe footer a:contains(${menu})`,
         })),
-        ...["Home", "Events", "Courses", "Pricing", "News", "Success Stories", "Contact us"].map(
+        ...["Home", "Events", "Courses", "Pricing", "News", "Contact us"].map(
             (menu) => ({
                 content: `Check menu ${menu} is there`,
                 trigger: `:iframe .top_menu a:contains(${menu}):not(:visible)`,

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -383,23 +383,14 @@
         <field name="feature_url">/our-services</field>
     </record>
     <record id="feature_page_pricing" model="website.configurator.feature">
-        <field name="name">Pricing</field>
-        <field name="description">Designed to drive conversion</field>
+        <field name="name">Pricing Plan</field>
+        <field name="description">Useful if you sell subscriptions</field>
         <field name="iap_page_code">pricing</field>
         <field name="sequence">4</field>
         <field name="page_view_id" ref="pricing"/>
         <field name="icon">fa-random</field>
         <field name="menu_sequence">35</field>
         <field name="feature_url">/pricing</field>
-    </record>
-    <record id="feature_page_privacy_policy" model="website.configurator.feature">
-        <field name="name">Privacy Policy</field>
-        <field name="description">Explain how you protect privacy</field>
-        <field name="iap_page_code">privacy_policy</field>
-        <field name="sequence">5</field>
-        <field name="page_view_id" ref="privacy_policy"/>
-        <field name="icon">fa-gavel</field>
-        <field name="feature_url">/privacy</field>
     </record>
 
     <!-- Configurator apps features -->
@@ -412,16 +403,6 @@
         <field name="icon">fa-rss</field>
         <field name="menu_company">True</field>
         <field name="menu_sequence">40</field>
-        <field name="feature_url">/blog</field>
-    </record>
-    <record id="feature_module_success_stories" model="website.configurator.feature">
-        <field name="name">Success Stories</field>
-        <field name="description">Share your best case studies</field>
-        <field name="sequence">7</field>
-        <field name="module_id" ref="base.module_website_blog"/>
-        <field name="icon">fa-star</field>
-        <field name="menu_company">True</field>
-        <field name="menu_sequence">45</field>
         <field name="feature_url">/blog</field>
     </record>
     <record id="feature_module_career" model="website.configurator.feature">
@@ -451,14 +432,6 @@
         <field name="menu_sequence">20</field>
         <field name="feature_url">/event</field>
     </record>
-    <record id="feature_module_forum" model="website.configurator.feature">
-        <field name="name">Forum</field>
-        <field name="description">Give visitors the information they need</field>
-        <field name="sequence">11</field>
-        <field name="module_id" ref="base.module_website_forum"/>
-        <field name="icon">fa-users</field>
-        <field name="feature_url">/forum</field>
-    </record>
     <record id="feature_module_live_chat" model="website.configurator.feature">
         <field name="name">Live Chat</field>
         <field name="description">Chat with visitors to improve traction</field>
@@ -475,13 +448,6 @@
         <field name="icon">fa-graduation-cap</field>
         <field name="menu_sequence">25</field>
         <field name="feature_url">/slides</field>
-    </record>
-    <record id="feature_module_stores_locator" model="website.configurator.feature">
-        <field name="name">Stores Locator</field>
-        <field name="description">A map and a listing of your stores</field>
-        <field name="sequence">15</field>
-        <field name="module_id" ref="base.module_website_google_map"/>
-        <field name="icon">fa-map-marker</field>
     </record>
 
     <data noupdate="1">
@@ -500,7 +466,13 @@
             <field name="track">True</field>
             <field name="website_meta_description">This is the contact us page of the website</field>
         </record>
-
+        <record id="privacy_policy_page" model="website.page">
+            <field name="is_published">True</field>
+            <field name="url">/privacy</field>
+            <field name="view_id" ref="privacy_policy"/>
+            <field name="track">True</field>
+            <field name="website_meta_description">This is the privacy policy page of the website</field>
+        </record>
         <!-- Default Menu to store module menus for new website -->
         <record id="main_menu" model="website.menu">
           <field name="name">Default Main Menu</field>
@@ -512,13 +484,6 @@
             <field name="page_id" ref="website.homepage_page"/>
             <field name="parent_id" ref="website.main_menu"/>
             <field name="sequence" type="int">10</field>
-        </record>
-        <record id="menu_contactus" model="website.menu">
-            <field name="name">Contact us</field>
-            <field name="url">/contactus</field>
-            <field name="page_id" ref="website.contactus_page"/>
-            <field name="parent_id" ref="website.main_menu"/>
-            <field name="sequence" type="int">60</field>
         </record>
 
         <!-- Default Website -->

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -35,7 +35,7 @@ export const ROUTES = {
 
 export const WEBSITE_TYPES = {
     1: {id: 1, label: _t("a business website"), name: 'business'},
-    2: {id: 2, label: _t("an online store"), name: 'online_store'},
+    2: {id: 2, label: _t("an eCommerce"), name: 'ecommerce'},
     3: {id: 3, label: _t("a blog"), name: 'blog'},
     4: {id: 4, label: _t("an event website"), name: 'event'},
     5: {id: 5, label: _t("an elearning platform"), name: 'elearning'},

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -70,7 +70,7 @@ class TestMenu(common.TransactionCase):
         # Ensure new website got a top menu
         total_menus = Menu.search_count([])
         Website.create({'name': 'new website'})
-        self.assertEqual(total_menus + 4, Menu.search_count([]), "New website's bootstraping should have duplicate default menu tree (Top/Home/Contactus/Sub Default Menu)")
+        self.assertEqual(total_menus + 3, Menu.search_count([]), "New website's bootstraping should have duplicate default menu tree (Top/Home/Contactus/Sub Default Menu)")
 
     def test_04_specific_menu_translation(self):
         IrModuleModule = self.env['ir.module.module']

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -398,13 +398,6 @@
             sequence="30"
             parent="website.menu_website_configuration"/>
 
-        <menuitem id="menu_website_dashboard"
-            name="eCommerce"
-            sequence="20"
-            parent="menu_reporting"
-            action="website.ir_actions_server_website_dashboard"
-            active="0"/>
-
         <menuitem id="menu_website_analytics"
             name="Analytics"
             sequence="10"

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -92,7 +92,7 @@ goBackToBlocks(),
     tooltipPosition: "bottom",
     run: "click",
 }, {
-    trigger: "a[data-menu-xmlid='website.menu_website_dashboard'], a[data-menu-xmlid='website.menu_website_analytics']",
+    trigger: "a[data-menu-xmlid='website.menu_website_analytics']",
     content: _t("Let's now take a look at your eCommerce dashboard to get your eCommerce website ready in no time."),
     tooltipPosition: "bottom",
     // Just check during test mode. Otherwise, clicking it will result to random error on loading the Chart.js script.

--- a/addons/website_sale/views/website_sale_menus.xml
+++ b/addons/website_sale/views/website_sale_menus.xml
@@ -57,11 +57,11 @@
                 sequence="6"
             />
             <menuitem id="product_catalog_product_tags"
-                name="Product Tags"
+                name="Tags"
                 action="product.product_tag_action"/>
             <menuitem
                 id="product_catalog_product_ribbons"
-                name="Product Ribbons"
+                name="Ribbons"
                 action="website_sale.product_ribbon_action"
             />
         </menuitem>


### PR DESCRIPTION
- Replaced "an online store" with "an eCommerce" in business type selection
- Updated default selected pages:
  - Removed: Success Stories, Stores Locator, Privacy Policy
- Improved CTA logic: removed top-nav "Contact Us" when it's already the main CTA
- Cleaned up menus:
- Renamed  from eCommerce menu: Product Tags, Product Ribbons
- Removed  "eCommerce" from Reporting submenu 
  task:4855511

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
