### PR TITLE
[FIX] website_sale: reorder locked sale orders

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -437,7 +437,7 @@ class SaleOrder(models.Model):
 
     def _is_reorder_allowed(self):
         self.ensure_one()
-        return self.state == 'sale' and any(line._is_reorder_allowed() for line in self.order_line if not line.display_type)
+        return self.state in {'sale', 'done'} and any(line._is_reorder_allowed() for line in self.order_line if not line.display_type)
 
     def _filter_can_send_abandoned_cart_mail(self):
         self.website_id.ensure_one()


### PR DESCRIPTION
Affected versions 16.0

A sale order is locked when we don't want to modify anything else on it but that doesn't mean we can't place a brand new order with the same products.

Description of the issue/feature this PR addresses:

On config settings:

- Set **Re-order From Portal** on
- Set **Lock Confirmed Orders** on

Current behavior before PR:

- The users won't be able to reorder their confirmed orders.

Desired behavior after PR is merged:

- The users are able to reorder either locked or not.

MT-11212 cc @moduon 

fyi @fcvalgar @rafaelbn 

opw-5030545

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
