### PR TITLE
[IMP/FIX] account, sale, purchase: Sections, subsections and combo logic cleanup, fixes and improvements

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2774,9 +2774,7 @@ class AccountMove(models.Model):
         """
         move_line = self.line_ids.filtered_domain([
             ('product_id', '=', product_id),
-            '|',
             ('id', 'child_of', selected_section_id),
-            ('parent_id', '=', False),
         ])
         if move_line:
             if quantity != 0:
@@ -4284,6 +4282,9 @@ class AccountMove(models.Model):
 
     @api.onchange('invoice_line_ids')
     def _onchange_quick_edit_line_ids(self):
+        self.invoice_line_ids._conditional_add_to_compute('parent_id', lambda line: (
+            line.display_type in ('line_section', 'line_subsection', 'line_note', 'product')
+        ))
         quick_encode_suggestion = self.env.context.get('quick_encoding_vals')
         if (
             not self.quick_edit_total_amount

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2747,7 +2747,7 @@ class AccountMove(models.Model):
         grouped_lines = defaultdict(lambda: self.env['account.move.line'])
         for line in self.line_ids:
             if (
-                line.section_line_id.id == selected_section_id
+                line.get_parent_section_line().id == selected_section_id
                 and line.display_type == 'product'
                 and line.product_id.id in product_ids
             ):
@@ -2774,7 +2774,9 @@ class AccountMove(models.Model):
         """
         move_line = self.line_ids.filtered_domain([
             ('product_id', '=', product_id),
-            ('section_line_id', '=', selected_section_id),
+            '|',
+            ('id', 'child_of', selected_section_id),
+            ('parent_id', '=', False),
         ])
         if move_line:
             if quantity != 0:

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6842,6 +6842,21 @@ class AccountMove(models.Model):
         # TO OVERRIDE
         return []
 
+    def _get_move_lines_to_report(self):
+        def show_line(line):
+            return (
+                line.display_type == 'line_section'
+                or (not (
+                    line.parent_id.collapse_composition
+                    or line.parent_id.parent_id.collapse_composition
+                ) and not (
+                    line.parent_id.collapse_prices
+                    or line.parent_id.parent_id.collapse_prices
+                ))
+            )
+
+        return self.invoice_line_ids.filtered(show_line).sorted('sequence')
+
     @staticmethod
     def _can_commit():
         """ Helper to know if we can commit the current transaction or not.

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -350,8 +350,8 @@ class AccountMoveLine(models.Model):
         'account.move.line',
         string="Parent Section Line",
         compute='_compute_parent_id',
-        search='_search_parent_id',
-        copy=False,
+        index='btree_not_null',
+        copy=False, store=True,
     )
     child_ids = fields.One2many(comodel_name='account.move.line', inverse_name='parent_id')
     product_id = fields.Many2one(
@@ -383,11 +383,6 @@ class AccountMoveLine(models.Model):
         tracking=True,
         help="This field is used for payable and receivable journal entries. "
              "You can put the limit date for the payment of this line.",
-    )
-    section_line_id = fields.Many2one(
-        comodel_name='account.move.line',
-        compute='_compute_section_line_id',
-        store=True,
     )
 
     # === Price fields === #
@@ -887,17 +882,6 @@ class AccountMoveLine(models.Model):
                 line.quantity = line.quantity if line.quantity else 1
             else:
                 line.quantity = False
-
-    @api.depends('move_id.line_ids.sequence')
-    def _compute_section_line_id(self):
-        for move, lines in self.grouped('move_id').items():
-            current_section_line = False
-            for line in lines.sorted('sequence'):
-                if line.display_type == 'line_section':
-                    current_section_line = line
-                    line.section_line_id = False
-                else:
-                    line.section_line_id = current_section_line
 
     @api.depends('display_type')
     def _compute_sequence(self):
@@ -3427,6 +3411,12 @@ class AccountMoveLine(models.Model):
     def get_section_subtotal(self):
         section_lines = self.child_ids + self.child_ids.child_ids
         return sum(section_lines.mapped('price_subtotal'))
+
+    def get_parent_section_line(self):
+        if self.display_type == 'product' and self.parent_id.display_type == 'line_subsection':
+            return self.parent_id.parent_id
+
+        return self.parent_id
 
     # -------------------------------------------------------------------------
     # PUBLIC ACTIONS

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -339,12 +339,10 @@ class AccountMoveLine(models.Model):
     collapse_composition = fields.Boolean(
         string="Hide Composition",
         help="If checked, the lines below this section will not be displayed in reports and portal.",
-        compute="_compute_section_visibility_fields", store=True, copy=True,
     )
     collapse_prices = fields.Boolean(
         string="Hide Prices",
         help="If checked, the prices of the lines below this section will not be displayed in reports and portal.",
-        compute="_compute_section_visibility_fields", store=True, copy=True,
     )
     parent_id = fields.Many2one(
         'account.move.line',
@@ -1197,20 +1195,6 @@ class AccountMoveLine(models.Model):
                     last_sub = line
                 elif line in amls:
                     line.parent_id = last_sub or last_section
-
-    @api.depends('parent_id')
-    def _compute_section_visibility_fields(self):
-        for move in self.grouped('move_id'):
-            for line in move.invoice_line_ids.sorted('sequence'):
-                if line.display_type == 'line_section':
-                    continue
-
-                if line.display_type == 'line_subsection':
-                    line.collapse_prices = line.collapse_prices or line.parent_id.collapse_prices
-                    line.collapse_composition = line.collapse_composition or line.parent_id.collapse_composition
-                else:
-                    line.collapse_prices = line.parent_id.collapse_prices
-                    line.collapse_composition = line.parent_id.collapse_composition
 
     @api.depends('move_id.move_type')
     def _compute_no_followup(self):

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -154,7 +154,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async addRowAfterSection(record, addSubSection) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }
@@ -170,7 +170,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async addNoteInSection(record) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }
@@ -186,7 +186,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async addRowInSection(record, addSubSection) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }
@@ -214,7 +214,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
 
     async deleteSection(record) {
         if (this.editedRecord && this.editedRecord !== record) {
-            const left = await this.props.list.leaveEditMode();
+            const left = await this.props.list.leaveEditMode({ canAbandon: false });
             if (!left) {
                 return;
             }
@@ -414,7 +414,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async moveSectionDown(record) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }
@@ -426,7 +426,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     async moveSectionUp(record) {
-        const canProceed = await this.props.list.leaveEditMode();
+        const canProceed = await this.props.list.leaveEditMode({ canAbandon: false });
         if (!canProceed) {
             return;
         }

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -137,6 +137,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         for (const sectionRecord of sectionRecords) {
             commands.push(x2ManyCommands.update(sectionRecord.resId || sectionRecord._virtualId, {
                 collapse_prices: !record.data.collapse_prices,
+                collapse_composition: false,
             }));
         }
         await this.props.list.applyCommands(commands, { sort: true });
@@ -147,6 +148,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         const commands = [];
         for (const sectionRecord of sectionRecords) {
             commands.push(x2ManyCommands.update(sectionRecord.resId || sectionRecord._virtualId, {
+                collapse_prices: false,
                 collapse_composition: !record.data.collapse_composition,
             }));
         }

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -12,7 +12,7 @@
         <xpath expr="//td[hasclass('o_list_record_remove')]" position="after">
             <td t-else="" class="o_list_section_options w-print-0 p-print-0 text-center">
                 <Dropdown position="'bottom-end'" t-if="!props.readonly">
-                    <button class="btn px-1">
+                    <button class="btn px-1 cursor-pointer">
                         <i class="fa fa-ellipsis-v"/>
                     </button>
                     <t t-set-slot="content">

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -24,21 +24,21 @@
                                 <DropdownItem onSelected="() => this.addRowAfterSection(record, false)">
                                     <i class="me-1 fa fa-fw fa-level-down"/><span>Add a section</span>
                                 </DropdownItem>
-                                <t t-if="this.canAddSubSection">
+                                <t t-if="props.subsections">
                                     <DropdownItem onSelected="() => this.addRowInSection(record, true)">
                                         <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
                                     </DropdownItem>
                                 </t>
                             </t>
-                            <t t-elif="this.canAddSubSection">
+                            <t t-elif="props.subsections">
                                 <DropdownItem onSelected="() => this.addRowAfterSection(record, true)">
                                     <i class="me-1 fa fa-fw fa-level-down"/><span>Add a subsection</span>
                                 </DropdownItem>
                             </t>
-                            <DropdownItem t-if="showPricesButton" onSelected="() => this.toggleHidePrices(record)">
+                            <DropdownItem t-if="props.hidePrices and showPricesButton" onSelected="() => this.toggleCollapse(record, 'collapse_prices')">
                                 <i class="me-1 fa fa-fw" t-att-class="hidePrices ? 'fa-eye' : 'fa-eye-slash'"/><span t-out="hidePrices ? 'Show Prices' : 'Hide Prices'"/>
                             </DropdownItem>
-                            <DropdownItem t-if="showCompositionButton" onSelected="() => this.toggleHideComposition(record)">
+                            <DropdownItem t-if="props.hideComposition and showCompositionButton" onSelected="() => this.toggleCollapse(record, 'collapse_composition')">
                                 <i class="me-1 fa fa-fw" t-att-class="hideCompositions ? 'fa-eye' : 'fa-eye-slash'"/><span t-out="hideCompositions ? 'Show Composition' : 'Hide Composition'"/>
                             </DropdownItem>
                             <DropdownItem onSelected="() => this.addNoteInSection(record)">

--- a/addons/account/static/tests/section_and_note.test.js
+++ b/addons/account/static/tests/section_and_note.test.js
@@ -81,7 +81,7 @@ test("can add a line in a section", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -144,7 +144,7 @@ test("can add a line in a subsection", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -207,7 +207,7 @@ test("can add a subsection in a section", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -261,7 +261,7 @@ test("can add a subsection in a section", async () => {
     expect(".o_is_line_subsection:contains(Aa)").toHaveCount(1);
 });
 
-test("can't add a subsection if value not in selection", async () => {
+test("can't add a subsection if value not in options", async () => {
     InvoiceLine._records[10].display_type = "line_section";
     InvoiceLine._fields.display_type = fields.Selection({
         default: false,
@@ -280,7 +280,6 @@ test("can't add a subsection if value not in selection", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
                 >
                     <list editable="bottom">
                         <control>
@@ -310,7 +309,7 @@ test("can add a section after another", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -374,7 +373,7 @@ test("can add a subsection after another", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -438,7 +437,7 @@ test("can delete sections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -484,7 +483,7 @@ test("can delete subsections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -541,7 +540,7 @@ test("can duplicate sections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -607,7 +606,7 @@ test("can duplicate subsections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -690,7 +689,7 @@ test("can resequence records inside sections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -784,7 +783,7 @@ test("resequence can be discarded", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -860,7 +859,7 @@ test("can resequence sections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -901,7 +900,7 @@ test("add a section", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -965,7 +964,7 @@ test("add note", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -1029,7 +1028,7 @@ test("section_and_note_text widget", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -1093,7 +1092,7 @@ test("sections with required content field", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -1163,7 +1162,7 @@ test("sections duplicate with many2many", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>
@@ -1266,7 +1265,7 @@ test("swap sections and subsections", async () => {
                 <field
                     name="invoice_line_ids"
                     widget="section_and_note_one2many"
-                    options="{'display_type_field': 'display_type', 'section_content_field': 'name', 'note_content_field': 'name'}"
+                    options="{'subsections': True}"
                 >
                     <list editable="bottom">
                         <control>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1130,7 +1130,8 @@
                                            'default_display_type': 'product',
                                            'quick_encoding_vals': quick_encoding_vals,
                                        }" readonly="state != 'draft'"
-                                       aggregated_fields="price_subtotal,price_total">
+                                       aggregated_fields="price_subtotal,price_total"
+                                       options="{'hide_composition': True, 'hide_prices': True, 'subsections': True}">
                                     <list name="journal_items" editable="bottom" string="Journal Items" default_order="sequence, id">
                                         <control>
                                             <create name="add_line_control" string="Add a line"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1207,9 +1207,10 @@
                                         <field name="company_id" column_invisible="True"/>
                                         <field name="company_currency_id" column_invisible="True"/>
                                         <field name="display_type" force_save="1" column_invisible="True"/>
-                                        <field name="collapse_prices" column_invisible="True"/>
-                                        <field name="collapse_composition" column_invisible="True"/>
-                                        <field name="parent_id" column_invisible="True"/>
+                                        <!-- Those 3 fields must stay with force save as there are readonly -->
+                                        <field name="collapse_prices" column_invisible="True" force_save="1"/>
+                                        <field name="collapse_composition" column_invisible="True" force_save="1"/>
+                                        <field name="parent_id" column_invisible="True" force_save="1"/>
                                     </list>
                                     <kanban class="o_kanban_mobile">
                                         <!-- Displayed fields -->

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1208,10 +1208,8 @@
                                         <field name="company_id" column_invisible="True"/>
                                         <field name="company_currency_id" column_invisible="True"/>
                                         <field name="display_type" force_save="1" column_invisible="True"/>
-                                        <!-- Those 3 fields must stay with force save as there are readonly -->
-                                        <field name="collapse_prices" column_invisible="True" force_save="1"/>
-                                        <field name="collapse_composition" column_invisible="True" force_save="1"/>
-                                        <field name="parent_id" column_invisible="True" force_save="1"/>
+                                        <field name="collapse_prices" column_invisible="True"/>
+                                        <field name="collapse_composition" column_invisible="True"/>
                                     </list>
                                     <kanban class="o_kanban_mobile">
                                         <!-- Displayed fields -->

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -166,100 +166,170 @@
                                 </tr>
                             </thead>
                             <tbody class="invoice_tbody">
-                                <t t-set="current_subtotal" t-value="0"/>
-                                <t t-set="current_total" t-value="0"/>
                                 <t t-set="lines" t-value="o.invoice_line_ids.sorted(key=lambda l: (-l.sequence, l.date, l.move_name, -l.id), reverse=True)"/>
-                                <t t-set="treated_lines" t-value="[]"/>
+                                <t t-set="lines_to_report" t-value="o._get_move_lines_to_report()"/>
+                                <t t-set="current_section" t-value="None"/>
+                                <t t-set="current_subsection" t-value="None"/>
 
-                                <t t-foreach="lines" t-as="line">
-                                    <t t-set="current_total" t-value="current_total + line.price_total"/>
+                                <t t-foreach="lines_to_report" t-as="line">
+                                    <t t-set="is_note" t-value="line.display_type == 'line_note'"/>
+                                    <t t-set="is_section" t-value="line.display_type == 'line_section'"/>
+                                    <t t-set="is_subsection" t-value="line.display_type == 'line_subsection'"/>
+                                    <t t-set="is_product" t-value="line.display_type == 'product'"/>
+
+                                    <t t-if="is_section">
+                                        <t t-set="current_section" t-value="line"/>
+                                        <t t-set="current_subsection" t-value="None"/>
+                                        <t t-set="line_padding" t-value="0"/>
+                                    </t>
+                                    <t t-elif="is_subsection">
+                                        <t t-set="current_subsection" t-value="line"/>
+                                        <t t-set="line_padding" t-value="2"/>
+                                    </t>
+                                    <t t-else="">
+                                        <t t-set="line_padding"
+                                           t-value="3 if current_subsection else (2 if current_section else 0)"
+                                        />
+                                    </t>
+                                    <t t-set="padding_class" t-value="line_padding and ('px-' + str(line_padding)) or ''"/>
                                     <t t-set="hide_details" t-value="line.collapse_composition"/>
+                                    <t t-set="hide_prices" t-value="line.collapse_prices"/>
 
-                                    <tr t-att-class="'fw-bolder o_line_section' if line.display_type == 'line_section' else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
-                                        <t t-if="line.id in treated_lines"/>
-                                        <t t-elif="hide_details">
-                                            <t t-set="grouped_lines" t-value="line.get_lines_grouped_by_section()"/>
-                                            <t t-set="current_subtotal" t-value="0"/>
-                                            <t t-foreach="grouped_lines" t-as="grouped_line">
-                                                <t t-set="current_subtotal" t-value="current_subtotal + grouped_line['price_subtotal']"/>
-                                                <tr>
-                                                    <t t-set="treated_lines" t-value="treated_lines + grouped_line['ids']"/>
-                                                    <td name="account_invoice_line_name_grouped">
-                                                        <span t-out="grouped_line['name']" t-options="{'widget': 'text'}">Group 1</span>
-                                                    </td>
-                                                    <td name="td_quantity_grouped" class="o_td_quantity text-end">
-                                                        <span>1.00</span>
-                                                    </td>
-                                                    <td name="td_price_unit_grouped" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                                        <span t-if="not line.collapse_prices" t-out="grouped_line['price_subtotal']" t-options="{'widget': 'float', 'decimal_precision': 'Product Price'}" class="text-nowrap">9.00</span>
-                                                    </td>
-                                                    <td name="td_discount_grouped" t-if="display_discount"/>
-                                                    <td name="td_taxes_grouped" t-if="display_taxes" class="text-end">
-                                                        <span t-out="','.join(grouped_line['taxes'])" id="line_tax_ids">Tax 15%</span>
-                                                    </td>
-                                                    <td name="td_subtotal_grouped" class="text-end o_price_total">
-                                                        <span t-if="not line.collapse_prices and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-out="grouped_line['price_subtotal']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>27.00</span>
-                                                        <span t-if="not line.collapse_prices and o.company_price_include == 'tax_included'" class="text-nowrap" t-out="grouped_line['price_total']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>31.05</span>
-                                                    </td>
-                                                </tr>
+                                    <t t-if="not hide_details and not hide_prices">
+                                        <tr t-att-class="
+                                            'fw-bolder o_line_section' if is_section else
+                                            'fw-bold o_line_subsection' if is_subsection else
+                                            'fst-italic o_line_note' if is_note
+                                            else ''">
+                                            <t t-set="line_colspan" t-value="line.get_column_to_exclude_for_colspan_calculation(line.tax_ids)"/>
+                                            <t t-if="is_product" name="account_invoice_line_accountable">
+                                                <td name="account_invoice_line_name" t-att-class="padding_class">
+                                                    <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
+                                                </td>
+                                                <td name="td_quantity" class="o_td_quantity text-end">
+                                                    <span t-field="line.quantity" class="text-nowrap">3.00</span>
+                                                    <span t-field="line.product_uom_id"  groups="uom.group_uom">units</span>
+                                                    <span t-if="line.product_uom_id != line.product_id.uom_id" groups="uom.group_uom" class="text-muted small">
+                                                        <br/>
+                                                        <t t-set="product_uom_qty" t-value="line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)"/>
+                                                        <span t-out="product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" data-oe-demo="3.00"/> <span t-field="line.product_id.uom_id" data-oe-demo="units"/>
+                                                    </span>
+                                                </td>
+                                                <td name="td_price_unit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                                    <span t-if="not hide_prices" class="text-nowrap" t-field="line.price_unit">9.00</span>
+                                                </td>
+                                                <td name="td_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                                    <span class="text-nowrap" t-field="line.discount">0</span>
+                                                </td>
+                                                <t t-set="taxes" t-value="', '.join(tax.tax_label for tax in line.tax_ids if tax.tax_label)"/>
+                                                <td name="td_taxes" t-if="display_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }} {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
+                                                    <span t-if="not hide_prices" t-out="taxes" id="line_tax_ids">Tax 15%</span>
+                                                </td>
+                                                <td name="td_subtotal" class="text-end o_price_total">
+                                                    <span t-if="not hide_prices and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-field="line.price_subtotal">27.00</span>
+                                                    <span t-if="not hide_prices and o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
+                                                </td>
                                             </t>
-                                        </t>
-                                        <t t-elif="line.display_type == 'product'" name="account_invoice_line_accountable">
-                                            <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
-                                            <td name="account_invoice_line_name">
-                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
-                                            </td>
-                                            <td name="td_quantity" class="o_td_quantity text-end">
-                                                <span t-field="line.quantity" class="text-nowrap">3.00</span>
-                                                <span t-field="line.product_uom_id"  groups="uom.group_uom">units</span>
-                                                <span t-if="line.product_uom_id != line.product_id.uom_id" groups="uom.group_uom" class="text-muted small">
-                                                    <br/>
-                                                    <t t-set="product_uom_qty" t-value="line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)"/>
-                                                    <span t-out="product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" data-oe-demo="3.00"/> <span t-field="line.product_id.uom_id" data-oe-demo="units"/>
-                                                </span>
-                                            </td>
-                                            <td name="td_price_unit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                                <span t-if="not line.collapse_prices" class="text-nowrap" t-field="line.price_unit">9.00</span>
-                                            </td>
-                                            <td name="td_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                                <span class="text-nowrap" t-field="line.discount">0</span>
-                                            </td>
-                                            <t t-set="taxes" t-value="', '.join(tax.tax_label for tax in line.tax_ids if tax.tax_label)"/>
-                                            <td name="td_taxes" t-if="display_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }} {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
-                                                <span t-out="taxes" id="line_tax_ids">Tax 15%</span>
-                                            </td>
-                                            <td name="td_subtotal" class="text-end o_price_total">
-                                                <span t-if="not line.collapse_prices and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-field="line.price_subtotal">27.00</span>
-                                                <span t-if="not line.collapse_prices and o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
-                                            </td>
-                                        </t>
-                                        <t t-elif="line.display_type in ('line_section', 'line_subsection')">
-                                            <t t-set="section_subtotal" t-value="line.get_section_subtotal()"/>
-                                            <td colspan="4">
-                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
-                                            </td>
-                                            <td colspan="1" class="text-end o_price_total">
-                                                <span t-out="section_subtotal" class="text-nowrap" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                                            </td>
-                                            <t t-set="current_section" t-value="line"/>
-                                            <t t-set="current_subtotal" t-value="0"/>
-                                        </t>
-                                        <t t-elif="line.display_type == 'line_note'">
-                                            <td colspan="99">
-                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A note, whose content usually applies to the section or product above.</span>
-                                            </td>
-                                        </t>
-                                    </tr>
-                                    <t t-if="not line.collapse_prices and current_section and (line_last or lines[line_index+1].display_type in ('line_section', 'line_subsection'))">
-                                        <tr class="is-subtotal text-end">
-                                            <td colspan="99">
-                                                <strong class="mr16">Subtotal</strong>
-                                                <span
-                                                    t-out="current_subtotal"
-                                                    t-options='{"widget": "monetary", "display_currency": o.currency_id}'
-                                                >31.05</span>
-                                            </td>
+                                            <t t-elif="line.display_type in ('line_section', 'line_subsection')">
+                                                <t t-set="section_subtotal" t-value="line.get_section_subtotal()"/>
+                                                <!-- For desktop -->
+                                                <td name="line_name_td"
+                                                    t-att-colspan="(1 if is_product else 6 if display_discount else 5) - line_colspan"
+                                                    t-attf-class="{{'d-none d-md-table-cell' if report_type == 'html' else ''}} {{padding_class}}">
+                                                    <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
+                                                </td>
+                                                <!-- For mobile -->
+                                                <td colspan="2" t-attf-class="{{'d-md-none d-table-cell' if report_type == 'html' else 'd-none'}} {{padding_class}}">
+                                                    <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
+                                                </td>
+                                                <td colspan="1" class="text-end o_price_total">
+                                                    <span t-out="section_subtotal" class="text-nowrap" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                                </td>
+                                            </t>
+                                            <t t-elif="is_note">
+                                                <td colspan="99">
+                                                    <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A note, whose content usually applies to the section or product above.</span>
+                                                </td>
+                                            </t>
                                         </tr>
+                                    </t>
+                                    <t t-else="">
+                                        <t t-if="hide_details" t-set="grouped_lines" t-value="line._get_child_lines()"/>
+                                        <t t-if="hide_prices" t-set="grouped_lines" t-value="line._get_child_lines(False)"/>
+                                        <t t-foreach="grouped_lines" t-as="grouped_line">
+                                            <t t-if="grouped_line['display_type'] == 'product'">
+                                                <t t-set="line_colspan" t-value="1"/>
+                                            </t>
+                                            <t t-else="">
+                                                <t t-set="line_colspan" t-value="3 + (1 if display_discount else 0) + (1 if display_taxes and not grouped_line.get('taxes') else 0)"/>
+                                            </t>
+                                            <t t-if="hide_prices">
+                                                <t t-set="line_padding"
+                                                   t-value="3 if current_subsection and grouped_line['display_type'] != 'line_subsection' and grouped_line.get('original_display_type') != 'line_subsection' else
+                                                            2 if current_section and grouped_line['display_type'] != 'line_section' and grouped_line.get('original_display_type') != 'line_section' else
+                                                            0"/>
+                                                <t t-set="padding_class" t-value="line_padding and ('px-' + str(line_padding)) or ''"/>
+                                                <t t-if="grouped_line['display_type'] == 'line_subsection'">
+                                                    <t t-set="current_subsection" t-value="grouped_line"/>
+                                                </t>
+                                            </t>
+                                            <tr t-att-class="
+                                                'fw-bolder o_line_section' if grouped_line.get('display_type') == 'line_section' and not hide_details else
+                                                'fw-bold o_line_subsection' if grouped_line.get('display_type') == 'line_subsection' and not hide_details else
+                                                ''">
+                                                <!-- For desktop -->
+                                                <td name="account_invoice_line_name_grouped_desktop"
+                                                    t-att-colspan="line_colspan"
+                                                    t-attf-class="{{'d-none d-md-table-cell' if report_type == 'html' else ''}} {{padding_class}}">
+                                                    <span t-out="grouped_line['name']" t-options="{'widget': 'text'}">Group 1</span>
+                                                </td>
+                                                <!-- For mobile -->
+                                                <td name="account_invoice_line_name_grouped"
+                                                    t-att-colspan="2 if grouped_line['display_type'] != 'product' else 1"
+                                                    t-attf-class="{{'d-md-none d-table-cell' if report_type == 'html' else 'd-none'}} {{padding_class}}">
+                                                    <span t-out="grouped_line['name']" t-options="{'widget': 'text'}">Group 1</span>
+                                                </td>
+                                                <td name="td_quantity_grouped"
+                                                    colspan="1"
+                                                    t-if="hide_details or (hide_prices and grouped_line['display_type'] not in ('line_section', 'line_subsection'))"
+                                                    class="o_td_quantity text-end">
+                                                    <!-- If line is hide composition, always show 1 unit -->
+                                                    <div t-if="hide_details">
+                                                        <span>1.00</span>
+                                                        <span groups="uom.group_uom">Units</span>
+                                                    </div>
+                                                    <!-- Else, show the line quantity -->
+                                                    <div t-if="hide_prices and grouped_line['display_type'] not in ('line_section', 'line_subsection')">
+                                                        <span t-out="grouped_line['quantity']" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}">1.00</span>
+                                                        <t t-if="grouped_line.get('line_uom')">
+                                                            <span t-out="grouped_line['line_uom'].display_name" groups="uom.group_uom">Unit</span>
+                                                            <span t-if="grouped_line.get('product_uom') != grouped_line['line_uom']" groups="uom.group_uom" class="text-muted small">
+                                                                <br/>
+                                                                <t t-set="product_uom_qty" t-value="grouped_line['line_uom']._compute_quantity(grouped_line['quantity'], grouped_line['product_uom'])"/>
+                                                                <span t-out="product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" data-oe-demo="3.00"/> <span t-out="grouped_line['product_uom'].display_name" data-oe-demo="units"/>
+                                                            </span>
+                                                        </t>
+                                                    </div>
+                                                </td>
+                                                <td name="td_price_unit_grouped"
+                                                    t-if="grouped_line['display_type'] not in ('line_section', 'line_subsection')"
+                                                    colspan="1"
+                                                    t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                                    <span t-if="not hide_prices" t-out="grouped_line['price_subtotal']" t-options="{'widget': 'float', 'decimal_precision': 'Product Price'}" class="text-nowrap">9.00</span>
+                                                </td>
+                                                <td name="td_discount_grouped" t-if="display_discount and grouped_line['display_type'] == 'product'" colspan="1" class="d-none d-md-table-cell"/>
+                                                <td name="td_taxes_grouped"
+                                                    colspan="1"
+                                                    t-if="(display_taxes and grouped_line['display_type'] in ('line_section', 'line_subsection') and grouped_line.get('taxes')) or grouped_line['display_type'] == 'product'"
+                                                    t-attf-class="text-end {{'d-none d-md-table-cell' if report_type == 'html' else ''}}">
+                                                    <span t-if="grouped_line.get('taxes')" t-out="','.join(grouped_line['taxes'])" id="grouped_line_tax_ids">Tax 15%</span>
+                                                </td>
+                                                <td name="td_subtotal_grouped" colspan="1" class="text-end o_price_total">
+                                                    <span t-if="(grouped_line.get('display_type') in ('line_section', 'line_subsection') or hide_details) and o.company_price_include == 'tax_excluded'" class="text-nowrap" t-out="grouped_line['price_subtotal']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>27.00</span>
+                                                    <span t-if="(grouped_line.get('display_type') in ('line_section', 'line_subsection') or hide_details) and o.company_price_include == 'tax_included'" class="text-nowrap" t-out="grouped_line['price_total']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>31.05</span>
+                                                </td>
+                                            </tr>
+                                        </t>
                                     </t>
                                 </t>
                             </tbody>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -191,7 +191,7 @@
                                                         <span>1.00</span>
                                                     </td>
                                                     <td name="td_price_unit_grouped" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                                        <span t-if="not line.collapse_prices" t-out="grouped_line['price_subtotal']" class="text-nowrap">9.00</span>
+                                                        <span t-if="not line.collapse_prices" t-out="grouped_line['price_subtotal']" t-options="{'widget': 'float', 'decimal_precision': 'Product Price'}" class="text-nowrap">9.00</span>
                                                     </td>
                                                     <td name="td_discount_grouped" t-if="display_discount"/>
                                                     <td name="td_taxes_grouped" t-if="display_taxes" class="text-end">

--- a/addons/l10n_ar/models/account_move_line.py
+++ b/addons/l10n_ar/models/account_move_line.py
@@ -42,3 +42,10 @@ class AccountMoveLine(models.Model):
             'price_subtotal': invoice.currency_id.round(raw_total),
             'price_net': price_net,
         }
+
+    def get_column_to_exclude_for_colspan_calculation(self, taxes=None):
+        # OVERRIDE OF ACCOUNT
+        if self.move_id.company_id.country_code == 'AR':
+            return 0 if self.display_type == 'product' else 2
+
+        return super().get_column_to_exclude_for_colspan_calculation(taxes)

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -127,7 +127,7 @@
         </td>
 
         <!-- use latam prices (to include/exclude VAT) -->
-        <xpath expr="//t[@t-foreach='lines']/t" position="before">
+        <xpath expr="//t[@t-foreach='lines_to_report']/t" position="before">
             <t t-set="l10n_ar_values" t-value="line._l10n_ar_prices_and_taxes()"/>
         </xpath>
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
@@ -135,12 +135,9 @@
             <attribute name="t-out">l10n_ar_values['price_unit']</attribute>
             <attribute name="t-options">{"widget": "float", "display_currency": o.currency_id, "decimal_precision": "Product Price"}</attribute>
         </xpath>
-        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
-            <attribute name="t-value">current_subtotal + l10n_ar_values['price_subtotal']</attribute>
-        </t>
         <!-- if b2c we still wants the latam subtotal -->
-        <t t-set="current_total" t-value="current_total + line.price_total" position="attributes">
-            <attribute name="t-value">current_subtotal + l10n_ar_values['price_subtotal']</attribute>
+        <t t-set="section_subtotal" t-value="line.get_section_subtotal()" position="attributes">
+            <attribute name="t-value">line.get_section_subtotal() + l10n_ar_values['price_subtotal']</attribute>
         </t>
         <!-- label amount for subtotal column on b2b and b2c -->
         <xpath expr="//th[@name='th_subtotal']/span" position="replace">
@@ -167,6 +164,9 @@
         </xpath>
 
         <xpath expr="//span[@id='line_tax_ids']/.." position="attributes">
+            <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>
+        </xpath>
+        <xpath expr="//span[@id='grouped_line_tax_ids']/.." position="attributes">
             <attribute name="t-if">not o._l10n_ar_include_vat()</attribute>
         </xpath>
         <span id="line_tax_ids" position="attributes">

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -148,7 +148,7 @@
 
         <xpath expr="//t[@t-set='layout_document_title']" position="replace"/>
 
-        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="before">
+        <t t-set="section_subtotal" t-value="line.get_section_subtotal()" position="before">
             <t t-set="line_amounts" t-value="line._l10n_cl_get_line_amounts()"/>
         </t>
 

--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -81,7 +81,7 @@
             <attribute name="t-out">line.price_subtotal * sign</attribute>
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </xpath>
-        <xpath expr="//table[@name='invoice_line_table']//span[@t-out='current_subtotal']" position="attributes">
+        <xpath expr="//table[@name='invoice_line_table']//span[@t-out='section_subtotal']" position="attributes">
             <attribute name="t-out">current_subtotal * sign</attribute>
         </xpath>
         <xpath expr="//div[hasclass('clearfix')]//span[@t-field='o.amount_residual']" position="attributes">

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -230,7 +230,7 @@ class ProductCatalogMixin(models.AbstractModel):
         sections = {}
         no_section_count = 0
         lines = self[child_field]
-        for line in lines:
+        for line in lines.sorted('sequence'):
             if line.display_type == 'line_section':
                 sections[line.id] = {
                     'id': line.id,

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -239,7 +239,7 @@ class ProductCatalogMixin(models.AbstractModel):
                     'line_count': 0,
                 }
             elif self._is_line_valid_for_section_line_count(line):
-                sec_id = line.section_line_id.id
+                sec_id = line.get_parent_section_line().id
                 if sec_id and sec_id in sections:
                     sections[sec_id]['line_count'] += 1
                 else:
@@ -293,13 +293,17 @@ class ProductCatalogMixin(models.AbstractModel):
         move_block = lines.filtered_domain([
             '|',
             ('id', '=', move_section['id']),
-            ('section_line_id', '=', move_section['id']),
+            '|',
+            ('id', 'child_of', move_section['id']),
+            ('parent_id', '=', False),
         ])
 
         target_block = lines.filtered_domain([
             '|',
             ('id', '=', target_section['id']),
-            ('section_line_id', '=', target_section['id']),
+            '|',
+            ('id', 'child_of', target_section['id']),
+            ('parent_id', '=', False),
         ])
 
         remaining_lines = lines - move_block

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -293,17 +293,13 @@ class ProductCatalogMixin(models.AbstractModel):
         move_block = lines.filtered_domain([
             '|',
             ('id', '=', move_section['id']),
-            '|',
             ('id', 'child_of', move_section['id']),
-            ('parent_id', '=', False),
         ])
 
         target_block = lines.filtered_domain([
             '|',
             ('id', '=', target_section['id']),
-            '|',
             ('id', 'child_of', target_section['id']),
-            ('parent_id', '=', False),
         ])
 
         remaining_lines = lines - move_block

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -290,17 +290,15 @@ class ProductCatalogMixin(models.AbstractModel):
         lines = self[child_field].sorted('sequence')
         move_section, target_section = sections
 
-        move_block = lines.filtered_domain([
-            '|',
-            ('id', '=', move_section['id']),
-            ('id', 'child_of', move_section['id']),
-        ])
+        move_block = lines.filtered(
+            lambda line: line.id == move_section['id']
+            or line.parent_id.id == move_section['id'],
+        )
 
-        target_block = lines.filtered_domain([
-            '|',
-            ('id', '=', target_section['id']),
-            ('id', 'child_of', target_section['id']),
-        ])
+        target_block = lines.filtered(
+            lambda line: line.id == target_section['id']
+            or line.parent_id.id == target_section['id'],
+        )
 
         remaining_lines = lines - move_block
         insert_after = move_section['sequence'] < target_section['sequence']

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -363,9 +363,9 @@ class ProductProduct(models.Model):
         if not (order_id and order_model and line_field):
             return []
 
-        product_ids = self.env[order_model].browse(order_id)[line_field].filtered_domain([
-            ('id', 'child_of', ctx.get('selected_section_id')),
-        ]).mapped('product_id').ids
+        product_ids = self.env[order_model].browse(order_id)[line_field].filtered(
+            lambda line: line.get_parent_section_line().id == ctx.get('selected_section_id'),
+        ).mapped('product_id').ids
 
         return [('id', 'in', product_ids)]
 

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -364,9 +364,7 @@ class ProductProduct(models.Model):
             return []
 
         product_ids = self.env[order_model].browse(order_id)[line_field].filtered_domain([
-            '|',
             ('id', 'child_of', ctx.get('selected_section_id')),
-            ('parent_id', '=', False),
         ]).mapped('product_id').ids
 
         return [('id', 'in', product_ids)]

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -364,7 +364,9 @@ class ProductProduct(models.Model):
             return []
 
         product_ids = self.env[order_model].browse(order_id)[line_field].filtered_domain([
-            ('section_line_id', '=', ctx.get('selected_section_id')),
+            '|',
+            ('id', 'child_of', ctx.get('selected_section_id')),
+            ('parent_id', '=', False),
         ]).mapped('product_id').ids
 
         return [('id', 'in', product_ids)]

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1151,7 +1151,7 @@ class PurchaseOrder(models.Model):
             if (
                 line.display_type
                 or line.product_id.id not in product_ids
-                or line.section_line_id.id != selected_section_id
+                or line.get_parent_section_line().id != selected_section_id
             ):
                 continue
             grouped_lines[line.product_id] |= line
@@ -1273,7 +1273,9 @@ class PurchaseOrder(models.Model):
         self.ensure_one()
         pol = self.order_line.filtered_domain([
             ('product_id', '=', product_id),
-            ('section_line_id', '=', selected_section_id),
+            '|',
+            ('id', 'child_of', selected_section_id),
+            ('parent_id', '=', False),
         ])
         if pol:
             if quantity != 0:

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -453,6 +453,11 @@ class PurchaseOrder(models.Model):
         """
         self.order_line._compute_tax_id()
 
+    @api.onchange('order_line')
+    def _onchange_order_line(self):
+        self.order_line.invalidate_recordset(['parent_id'])
+        self.env.add_to_compute(self.order_line._fields['parent_id'], self.order_line)
+
     # ------------------------------------------------------------
     # MAIL.THREAD
     # ------------------------------------------------------------
@@ -1273,9 +1278,7 @@ class PurchaseOrder(models.Model):
         self.ensure_one()
         pol = self.order_line.filtered_domain([
             ('product_id', '=', product_id),
-            '|',
             ('id', 'child_of', selected_section_id),
-            ('parent_id', '=', False),
         ])
         if pol:
             if quantity != 0:

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import datetime, time
 from dateutil.relativedelta import relativedelta
 from pytz import UTC
@@ -87,12 +86,22 @@ class PurchaseOrderLine(models.Model):
     product_template_attribute_value_ids = fields.Many2many(related='product_id.product_template_attribute_value_ids', readonly=True)
     product_no_variant_attribute_value_ids = fields.Many2many('product.template.attribute.value', string='Product attribute values that do not create variants', ondelete='restrict')
     purchase_line_warn_msg = fields.Text(related='product_id.purchase_line_warn_msg')
+    collapse_composition = fields.Boolean(
+        string="Hide Composition",
+        help="If checked, the lines below this section will not be displayed in reports and portal.",
+        compute="_compute_section_visibility_fields", store=True, copy=True,
+    )
+    collapse_prices = fields.Boolean(
+        string="Hide Prices",
+        help="If checked, the prices of the lines below this section will not be displayed in reports and portal.",
+        compute="_compute_section_visibility_fields", store=True, copy=True,
+    )
     parent_id = fields.Many2one(
         'purchase.order.line',
         string="Parent Section Line",
         compute='_compute_parent_id',
         index='btree_not_null',
-        copy=False, store=True,
+        store=True
     )
     child_ids = fields.One2many(comodel_name='purchase.order.line', inverse_name='parent_id')
     technical_price_unit = fields.Float(help="Technical field for price computation")
@@ -404,21 +413,38 @@ class PurchaseOrderLine(models.Model):
             price_unit *= self.product_id.uom_id.factor / self.product_uom_id.factor
         return price_unit
 
-    @api.depends('order_id.order_line.sequence', 'order_id')
+    @api.depends('order_id.order_line.order_id')
     def _compute_parent_id(self):
-        for _orders, lines in self.grouped('order_id').items():
-            current_section = None
-            current_subsection = None
-            for line in lines.sorted('sequence'):
+        purchase_order_lines = set(self)
+        for order in self.grouped('order_id'):
+            last_section = False
+            last_sub = False
+            for line in order.order_line.sorted('sequence'):
                 if line.display_type == 'line_section':
-                    line.parent_id = None
-                    current_section = line
-                    current_subsection = None
+                    last_section = line
+                    if line in purchase_order_lines:
+                        line.parent_id = False
+                    last_sub = False
                 elif line.display_type == 'line_subsection':
-                    line.parent_id = current_section
-                    current_subsection = line
+                    if line in purchase_order_lines:
+                        line.parent_id = last_section
+                    last_sub = line
+                elif line in purchase_order_lines:
+                    line.parent_id = last_sub or last_section
+
+    @api.depends('parent_id')
+    def _compute_section_visibility_fields(self):
+        for order in self.grouped('order_id'):
+            for line in order.order_line.sorted('sequence'):
+                if line.display_type == 'line_section':
+                    continue
+
+                if line.display_type == 'line_subsection':
+                    line.collapse_prices = line.collapse_prices or line.parent_id.collapse_prices
+                    line.collapse_composition = line.collapse_composition or line.parent_id.collapse_composition
                 else:
-                    line.parent_id = current_subsection or current_section
+                    line.collapse_prices = line.parent_id.collapse_prices
+                    line.collapse_composition = line.parent_id.collapse_composition
 
     def action_add_from_catalog(self):
         order = self.env['purchase.order'].browse(self.env.context.get('order_id'))

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -242,7 +242,8 @@
                                 widget="product_label_section_and_note_field_o2m"
                                 mode="list,kanban"
                                 context="{'default_state': 'draft'}"
-                                readonly="state == 'cancel' or locked">
+                                readonly="state == 'cancel' or locked"
+                                options="{ 'subsections': True }">
                                 <list string="Purchase Order Lines" editable="bottom" limit="200"
                                       decoration-warning="purchase_line_warn_msg">
                                     <control>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -258,6 +258,10 @@
                                     <field name="state" column_invisible="True"/>
                                     <field name="product_type" column_invisible="True"/>
                                     <field name="invoice_lines" column_invisible="True"/>
+                                    <!-- Those 3 fields must stay with force save as there are readonly -->
+                                    <field name="parent_id" column_invisible="True" force_save="1"/>
+                                    <field name="collapse_prices" column_invisible="True" force_save="1"/>
+                                    <field name="collapse_composition" column_invisible="True" force_save="1"/>
                                     <field name="technical_price_unit" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
                                     <!-- optional="show" allows name (description) to be editable -->

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -259,10 +259,6 @@
                                     <field name="state" column_invisible="True"/>
                                     <field name="product_type" column_invisible="True"/>
                                     <field name="invoice_lines" column_invisible="True"/>
-                                    <!-- Those 3 fields must stay with force save as there are readonly -->
-                                    <field name="parent_id" column_invisible="True" force_save="1"/>
-                                    <field name="collapse_prices" column_invisible="True" force_save="1"/>
-                                    <field name="collapse_composition" column_invisible="True" force_save="1"/>
                                     <field name="technical_price_unit" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
                                     <!-- optional="show" allows name (description) to be editable -->

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -901,6 +901,9 @@ class SaleOrder(models.Model):
 
     @api.onchange('order_line')
     def _onchange_order_line(self):
+        self.order_line.invalidate_recordset(['parent_id'])
+        self.env.add_to_compute(self.order_line._fields['parent_id'], self.order_line)
+
         for index, line in enumerate(self.order_line):
             if line.product_type != 'combo':
                 continue
@@ -2136,9 +2139,7 @@ class SaleOrder(models.Model):
         request.update_context(catalog_skip_tracking=True)
         sol = self.order_line.filtered_domain([
             ('product_id', '=', product_id),
-            '|',
             ('id', 'child_of', selected_section_id),
-            ('parent_id', '=', False),
         ])
         if sol:
             if quantity != 0:

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2093,7 +2093,7 @@ class SaleOrder(models.Model):
             if (
                 line.display_type
                 or line.product_id.id not in product_ids
-                or line.section_line_id.id != selected_section_id
+                or line.get_parent_section_line().id != selected_section_id
             ):
                 continue
             grouped_lines[line.product_id] |= line
@@ -2136,7 +2136,9 @@ class SaleOrder(models.Model):
         request.update_context(catalog_skip_tracking=True)
         sol = self.order_line.filtered_domain([
             ('product_id', '=', product_id),
-            ('section_line_id', '=', selected_section_id),
+            '|',
+            ('id', 'child_of', selected_section_id),
+            ('parent_id', '=', False),
         ])
         if sol:
             if quantity != 0:

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1772,8 +1772,7 @@ class SaleOrder(models.Model):
                 )
             return (
                 line.display_type == 'line_section'
-                or (line.display_type == 'line_subsection' and not line.parent_id.collapse_composition)
-                or not line.collapse_composition
+                or not line.parent_id.collapse_composition
             )
 
         return self.order_line.filtered(show_line)

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -119,10 +119,12 @@
                             <t t-set="current_section" t-value="line"/>
                             <t t-set="current_subsection" t-value="None"/>
                             <t t-set="line_padding" t-value="0"/>
+                            <t t-set="collapse_prices" t-value="line.collapse_prices"/>
                         </t>
                         <t t-elif="is_subsection">
                             <t t-set="current_subsection" t-value="line"/>
                             <t t-set="line_padding" t-value="2"/>
+                            <t t-set="collapse_prices" t-value="collapse_prices or line.collapse_prices"/>
                         </t>
                         <t t-else="">
                             <t
@@ -143,14 +145,22 @@
                                 name="tr_section"
                                 t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
                             >
+                                <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
+                                <t
+                                    t-set="section_name_colspan"
+                                    t-value="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                />
+                                <t t-if="not show_section_total">
+                                    <t t-set="section_name_colspan" t-value="99"/>
+                                </t>
                                 <td
                                     name="td_section_name"
-                                    t-att-colspan="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                    t-att-colspan="section_name_colspan"
                                     t-att-class="padding_class"
                                 >
                                     <span t-field="line.name">A section title</span>
                                 </td>
-                                <td name="td_section_price" class="text-end o_price_total">
+                                <td t-if="show_section_total" name="td_section_price" class="text-end o_price_total">
                                     <span
                                         name="price_subtotal_section"
                                         t-out="line._get_section_totals(price_field)"
@@ -196,7 +206,7 @@
                                 </td>
                                 <td name="td_product_priceunit" class="text-end text-nowrap">
                                     <span
-                                        t-if="not line.collapse_prices"
+                                        t-if="not collapse_prices"
                                         t-field="line.price_unit"
                                         t-options="{'widget': 'monetary', 'display_currency': line.currency_id}"
                                     >
@@ -204,7 +214,7 @@
                                     </span>
                                 </td>
                                 <td t-if="display_discount" name="td_product_discount" class="text-end">
-                                    <t t-if="not line.collapse_prices">
+                                    <t t-if="not collapse_prices">
                                         <!-- ! Always check collapse_prices separately; keep discount condition below for XPath -->
                                         <span t-field="line.discount">-</span>
                                     </t>
@@ -214,7 +224,7 @@
                                     <span t-out="taxes">Tax 15%</span>
                                 </td>
                                 <td t-if="not line.is_downpayment" name="td_product_subtotal" class="text-end o_price_total">
-                                    <t t-if="not line.collapse_prices">
+                                    <t t-if="not collapse_prices">
                                         <span
                                             t-if="price_field == 'price_subtotal'"
                                             t-field="line.price_subtotal"

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -16,6 +16,11 @@ import { CharField } from '@web/views/fields/char/char_field';
 export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRender {
     static recordRowTemplate = 'sale.ListRenderer.RecordRow';
 
+    setup(){
+        super.setup();
+        this.priceColumns.push('discount');
+    }
+
     /**
      * Product description widget logic
      */
@@ -88,6 +93,10 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
 
     shouldDuplicateSectionItem(record) {
         return !this.isCombo(record) && !this.isComboItem(record);
+    }
+
+    displayDeleteIcon(record){
+        return super.displayDeleteIcon(record) && !this.isComboItem(record);
     }
 }
 

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
@@ -5,11 +5,51 @@
         t-inherit="account.SectionAndNoteListRenderer.RecordRow"
         t-inherit-mode="primary"
     >
-        <!-- Remove the drag-and-drop handle for combo lines and combo item lines. -->
-        <Field position="attributes">
-            <attribute name="t-if">
-                !((isCombo(record) || isComboItem(record)) &amp;&amp; column.widget === 'handle')
-            </attribute>
-        </Field>
+        <t t-set="isInvisible" position="attributes">
+            <attribute
+                name="t-value"
+                separator=" or "
+                add="isCombo(record) and !this.comboColumns.includes(column.name)"
+            />
+        </t>
+
+        <xpath expr="//td[hasclass('o_list_record_remove')]" position="attributes">
+            <attribute name="t-if" separator=" and " add="!isCombo(record)"/>
+        </xpath>
+
+        <xpath expr="//td[hasclass('o_list_section_options')]" position="before">
+            <td t-elif="isCombo(record)" class="o_list_section_options w-print-0 p-print-0 text-center">
+                <Dropdown position="'bottom-end'" t-if="!props.readonly">
+                    <button class="btn px-1cursor-pointer">
+                        <i class="fa fa-ellipsis-v"/>
+                    </button>
+                    <t t-set-slot="content">
+                        <DropdownItem
+                            t-if="!record.isNew and this.getPreviousRecords(record)"
+                            onSelected="() => this.moveCombo(record, 'up')"
+                        >
+                            <i class="me-1 fa fa-fw fa-arrow-up"/>
+                            <span>Move Up</span>
+                        </DropdownItem>
+                        <DropdownItem
+                            t-if="!record.isNew and this.getNextRecords(record)"
+                            onSelected="() => this.moveCombo(record, 'down')"
+                        >
+                            <i class="me-1 fa fa-fw fa-arrow-down"/>
+                            <span>Move Down</span>
+                        </DropdownItem>
+                        <t t-if="hasDeleteButton">
+                            <DropdownItem
+                                onSelected="() => this.onDeleteRecord(record)"
+                                class="'text-danger'"
+                            >
+                                <i class="me-1 fa fa-fw fa-trash"/>
+                                <span>Delete</span>
+                            </DropdownItem>
+                        </t>
+                    </t>
+                </Dropdown>
+            </td>
+        </xpath>
     </t>
 </templates>

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.xml
@@ -11,9 +11,5 @@
                 !((isCombo(record) || isComboItem(record)) &amp;&amp; column.widget === 'handle')
             </attribute>
         </Field>
-         <!-- Remove the "delete" button for combo item lines. -->
-        <xpath expr="//td[hasclass('o_list_record_remove')]" position="attributes">
-            <attribute name="t-att-class">{'d-none': isComboItem(record)}</attribute>
-        </xpath>
     </t>
 </templates>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -500,6 +500,7 @@
                             mode="list,kanban"
                             readonly="state == 'cancel' or locked"
                             aggregated_fields="price_subtotal,price_total"
+                            options="{'hide_composition': True, 'hide_prices': True, 'subsections': True}"
                         >
                             <form>
                                 <field name="technical_price_unit" invisible="1"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -614,9 +614,10 @@
                                 <field name="selected_combo_items" column_invisible="1"/>
                                 <field name="virtual_id" column_invisible="1"/>
                                 <field name="linked_virtual_id" column_invisible="1"/>
-                                <field name="parent_id" column_invisible="1"/>
-                                <field name="collapse_prices" column_invisible="1"/>
-                                <field name="collapse_composition" column_invisible="1"/>
+                                <!-- Those 3 fields must stay with force save as there are readonly -->
+                                <field name="parent_id" column_invisible="1" force_save="1"/>
+                                <field name="collapse_prices" column_invisible="1" force_save="1"/>
+                                <field name="collapse_composition" column_invisible="1" force_save="1"/>
 
                                 <!-- Currency, needed for monetary widgets to display the currency symbol -->
                                 <field name="currency_id" column_invisible="True"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -615,10 +615,8 @@
                                 <field name="selected_combo_items" column_invisible="1"/>
                                 <field name="virtual_id" column_invisible="1"/>
                                 <field name="linked_virtual_id" column_invisible="1"/>
-                                <!-- Those 3 fields must stay with force save as there are readonly -->
-                                <field name="parent_id" column_invisible="1" force_save="1"/>
-                                <field name="collapse_prices" column_invisible="1" force_save="1"/>
-                                <field name="collapse_composition" column_invisible="1" force_save="1"/>
+                                <field name="collapse_prices" column_invisible="1"/>
+                                <field name="collapse_composition" column_invisible="1"/>
 
                                 <!-- Currency, needed for monetary widgets to display the currency symbol -->
                                 <field name="currency_id" column_invisible="True"/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -751,7 +751,7 @@
                                 <t t-elif="is_subsection">
                                     <t t-set="current_subsection" t-value="line"/>
                                     <t t-set="line_padding" t-value="2"/>
-                                    <t t-set="collapse_prices" t-value="collapse_prices or line.collapse_prices"/>
+                                    <t t-set="collapse_prices" t-value="current_section.collapse_prices or line.collapse_prices"/>
                                 </t>
                                 <t t-else="">
                                     <t

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -746,10 +746,12 @@
                                     <t t-set="current_section" t-value="line"/>
                                     <t t-set="current_subsection" t-value="None"/>
                                     <t t-set="line_padding" t-value="0"/>
+                                    <t t-set="collapse_prices" t-value="line.collapse_prices"/>
                                 </t>
                                 <t t-elif="is_subsection">
                                     <t t-set="current_subsection" t-value="line"/>
                                     <t t-set="line_padding" t-value="2"/>
+                                    <t t-set="collapse_prices" t-value="collapse_prices or line.collapse_prices"/>
                                 </t>
                                 <t t-else="">
                                     <t
@@ -770,14 +772,26 @@
                                         name="tr_section"
                                         t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
                                     >
+                                        <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
+                                        <t
+                                            t-set="section_name_colspan"
+                                            t-value="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                        />
+                                        <t t-if="not show_section_total">
+                                            <t t-set="section_name_colspan" t-value="99"/>
+                                        </t>
                                         <td
                                             name="td_section_name"
-                                            t-att-colspan="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                            t-att-colspan="section_name_colspan"
                                             t-att-class="padding_class"
                                         >
                                             <span t-field="line.name"/>
                                         </td>
-                                        <td name="td_section_price" class="text-end o_price_total">
+                                        <td
+                                            t-if="show_section_total"
+                                            name="td_section_price"
+                                            class="text-end o_price_total"
+                                        >
                                             <span
                                                 name="price_subtotal_section"
                                                 t-out="line._get_section_totals(price_field)"
@@ -821,7 +835,7 @@
                                             name="td_product_priceunit"
                                             t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}"
                                         >
-                                            <t t-if="not line.collapse_prices">
+                                            <t t-if="not collapse_prices">
                                                 <div
                                                     t-if="line.discount &gt;= 0"
                                                     t-field="line.price_unit"
@@ -838,7 +852,7 @@
                                             </t>
                                         </td>
                                         <td t-if="display_discount" name="td_product_discount" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
-                                            <t t-if="not line.collapse_prices">
+                                            <t t-if="not collapse_prices">
                                                 <!-- ! Always check collapse_prices separately; keep discount condition below for XPath -->
                                                 <strong t-if="line.discount &gt; 0" class="text-info">
                                                     <t t-out="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
@@ -849,14 +863,12 @@
                                             <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
                                         </td>
                                         <td t-if="not line.is_downpayment" name="td_product_subtotal" class="text-end">
-                                            <t t-if="not line.collapse_prices">
+                                            <t t-if="not collapse_prices">
                                                 <span
                                                     t-if="price_field == 'price_subtotal'"
                                                     t-field="line.price_subtotal"
                                                 />
-                                                <span
-                                                    t-else="" t-field="line.price_total"
-                                                />
+                                                <span t-else="" t-field="line.price_total"/>
                                             </t>
                                         </td>
                                     </tr>


### PR DESCRIPTION
### Description:
This PR introduces a bunch of fixes and improvements around (sub)Sections and combo products-related logic in `account`, `sale`, and `purchase`.

### **Improvements / Fixes**:

**[FIX] account, sale, purchase: Remove redundant section_line_id field:**
 - In commit 7f1c1e44a7805ffa50938d8915bfb95b68a41865, we added the 'section_line_id' field, which contains the parent section line. But we already added the 'parent_id' field in commit
0eedc9a702155f22563a44bfedb51b6d2317d371, which does almost the same thing, the only difference is that 'parent_id' could contain a subsection line, where 'section_line_id' only contains the section line.
- We can remove the 'section_line_id' field and add a helper to retrieve the parent section line and change logic like:
  - If 'parent_id' is a subsection, return 'parent_id.parent_id'
  - If 'parent_id' is a section, return 'parent_id'
 - This helper should be temporary, as the catalog feature should support subsections soon.
 - Also, make the 'parent_id' stored so it can work in a domain like ['id', 'child_of', ...].
 - Removed extra "Subtotal:" lines → subtotals now shown directly on section lines.

**[FIX] account, sale, purchase:  parent_id computation:**
- Fixed inconsistent parent_id updates when moving sections/lines.
- Example: dragging a section could leave products pointing to the wrong section.
- Added an onchange on invoice_line_ids to recompute parent_id correctly.

**[IMP] account: Improve PDF report layout with sections:**
- Added better indentation in reports:
  - Section: padding = 0
  - Product in section / Subsection: padding = 2
  - Product in subsection: padding = 4
- Sections/subsections are bold unless in Hide Composition.
- Hide Prices: group by tax, hide taxes on product lines, show only on section line.

**[IMP] account, sale, purchase: Hiding sections/prices logic and sections widget improvements:**
- Added new options { subsections, hide_prices, hide_composition } to the JS widget, to better control collapse/visibility logic.
- Simplified collapse behavior by letting child lines dynamically inherit parent section properties (no redundant recomputations).
- Improved bulk toggle: updating only the parent section, with child states resolved on the fly.
- Fixed issue where subsection prices were still shown when the parent section was hidden.
- Applied options for Sale Order Templates and Purchase Orders to disable collapse logic where not needed.

**[IMP] sale: combo related improvements**
- Enabled resequencing of combo product blocks (moving entire blocks up/down).
- Swapping logic: moving stops at other combo blocks and swapping them as a block.
- Centralized visibility conditions for combo-specific fields → less cluttered XML.
- Used renderer hook to hide the delete icon, replacing XPath-based hacks.
- Fixed dark mode issue for combo product lines.

**[IMP] account, sale, purchase: make `parent_id` non-stored**
- Changed parent_id compute field from stored → non-stored, removing recomputations.
- Changed filter_domain to filtered in catalog-related controllers and methods

See Also:
- https://github.com/odoo/enterprise/pull/92822

task-4966574
task-5009037
