### PR TITLE
[FIX] point_of_sale: fix customer display auto scroll

### DIFF
--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
@@ -59,6 +59,7 @@ export class CustomerDisplayPosAdapter {
                 line.getUnitDisplayPriceBeforeDiscount(),
                 line.currency
             ),
+            isSelected: line.isSelected(),
         };
     }
 

--- a/addons/point_of_sale/static/src/customer_display/customer_display.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.js
@@ -1,4 +1,4 @@
-import { Component, useEffect, whenReady } from "@odoo/owl";
+import { Component, useEffect, whenReady, useRef } from "@odoo/owl";
 import { OdooLogo } from "@point_of_sale/app/components/odoo_logo/odoo_logo";
 import { useSingleDialog } from "@point_of_sale/customer_display/utils";
 import { MainComponentsContainer } from "@web/core/main_components_container";
@@ -18,6 +18,13 @@ export class CustomerDisplay extends Component {
         this.dialog = useService("dialog");
         this.order = useService("customer_display_data");
         const singleDialog = useSingleDialog();
+
+        this.scrollableRef = useRef("scrollable");
+        useEffect(() => {
+            this.scrollableRef.el
+                ?.querySelector(".orderline.selected")
+                ?.scrollIntoView({ behavior: "smooth", block: "start" });
+        });
 
         useEffect(
             (qrPaymentData) => {

--- a/addons/point_of_sale/static/src/customer_display/customer_display.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.xml
@@ -11,7 +11,7 @@
             </div>
             <div class="o_customer_display_main d-flex flex-column flex-grow-1 overflow-auto">
                 <div t-if="Object.keys(order).length and order.lines.length > 0 and !order.finalized" class="d-flex flex-column flex-grow-1 rounded-3 bg-white overflow-hidden">
-                    <div style="scroll-snap-type: y mandatory;" class="gap-0 p-0 mx-2 pb-3 bg-view order-container d-flex flex-column flex-grow-1 overflow-y-auto text-start">
+                    <div t-ref="scrollable" style="scroll-snap-type: y mandatory;" class="gap-0 p-0 mx-2 pb-3 bg-view order-container d-flex flex-column flex-grow-1 overflow-y-auto text-start">
                          <li t-foreach="order.lines" t-as="line" t-key="line_index"  class="orderline position-relative d-flex align-items-center p-2 lh-sm cursor-pointer o_customer_display_orderline bg-white fs-3 rounded-0" t-attf-class="{{ line.comboParent ? 'orderline-combo ms-4 fst-italic' : '' }} {{ line.isSelected ? 'selected' : '' }}">
                             <div class="o_line_container d-flex align-items-center justify-content-center">
                                 <img t-attf-style="border-radius: 1rem;" t-att-src="`/web/image/product.product/${line.productId}/image_128`"/>

--- a/addons/point_of_sale/static/tests/customer_display/customer_display_tour.js
+++ b/addons/point_of_sale/static/tests/customer_display/customer_display_tour.js
@@ -1,6 +1,7 @@
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import { registry } from "@web/core/registry";
 import { run } from "@point_of_sale/../tests/generic_helpers/utils";
+import { isVisible } from "@web/core/utils/ui";
 
 export function postMessage(message, description = "") {
     return run(() => {
@@ -20,6 +21,37 @@ const ADD_PRODUCT =
     '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":false,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
 export const ADD_PRODUCT_SELECTED =
     '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
+export const ADD_MULTI_PRODUCTS = (() => {
+    const count = 20;
+    const lines = Array.from({ length: count }, (_, i) => {
+        const price = (Math.random() * 100 + 1).toFixed(2);
+        return {
+            productName: `Product ${i + 1}`,
+            price: `$${price}`,
+            qty: "1.00",
+            unit: "Units",
+            unitPrice: `$${price}`,
+            customerNote: "",
+            internalNote: "[]",
+            comboParent: "",
+            packLotLines: [],
+            price_without_discount: `$${price}`,
+            isSelected: i === count - 1,
+            imageSrc: "/web/image/product.product/855/image_128",
+        };
+    });
+    const amount = lines
+        .reduce((sum, line) => sum + parseFloat(line.price.replace("$", "")), 0)
+        .toFixed(2);
+    return JSON.stringify({
+        lines,
+        finalized: false,
+        amount,
+        paymentLines: [],
+        change: 0,
+        onlinePaymentData: {},
+    });
+})();
 const PAY_WITH_CASH =
     '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","customerNote":"","internalNote":"[]","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
 export const ORDER_IS_FINALIZED =
@@ -122,6 +154,61 @@ registry.category("web_tour.tours").add("CustomerDisplayTour", {
             {
                 content: "An order line with `isSelected: true` should have 'selected' class",
                 trigger: ".order-container .orderline:last-child.selected",
+            },
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("CustomerDisplayTourScroll", {
+    steps: () =>
+        [
+            {
+                trigger: "div:contains('Welcome.')",
+                run: async () => {
+                    window.customerDisplayChannel = new BroadcastChannel("UPDATE_CUSTOMER_DISPLAY");
+                    postMessage(ADD_MULTI_PRODUCTS, "add 20 products").run();
+                },
+            },
+            {
+                content: "An order line with `isSelected: true` should have 'selected' class",
+                trigger: ".order-container .orderline:last-child.selected",
+                run: async () =>
+                    await new Promise((resolve) => {
+                        const orderLine = document.querySelector(
+                            ".order-container .orderline:last-child.selected"
+                        );
+                        const animationDuration = parseFloat(
+                            getComputedStyle(orderLine).animationDuration
+                        );
+                        if (animationDuration === 0) {
+                            return resolve();
+                        }
+                        orderLine.onanimationend = function (event) {
+                            if (event.target === orderLine && event.animationName === "item_in") {
+                                resolve(event);
+                            }
+                        };
+                    }),
+            },
+            {
+                trigger: ".order-container",
+                run: async () => {
+                    const orderContainer = document.querySelector(".order-container");
+                    const orderLine = document.querySelector(
+                        ".order-container .orderline:last-child.selected"
+                    );
+                    await new Promise((resolve) => {
+                        const checkScroll = () => {
+                            requestAnimationFrame(() => {
+                                if (orderContainer.scrollTop > 0 && isVisible(orderLine)) {
+                                    resolve();
+                                } else {
+                                    setTimeout(checkScroll, 1000);
+                                }
+                            });
+                        };
+                        checkScroll();
+                    });
+                },
             },
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1422,6 +1422,9 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_customer_display(self):
         self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}", 'CustomerDisplayTour', login="pos_user")
 
+    def test_customer_display_scroll(self):
+        self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}", 'CustomerDisplayTourScroll', login="pos_user")
+
     def test_customer_display_with_qr(self):
         self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}", 'CustomerDisplayTourWithQr', login="pos_user")
 


### PR DESCRIPTION
Steps to reproduce:

- Turn on customer display in point of sale
- Add some order lines
- Customer display doesn't auto scroll

Current behavior:

- Customer display doesn't auto scroll

Expected result:

- Customer display should scroll to the selected lines