### PR TITLE
[FIX] pos_{online_payment_}self_order: enable online payments in kiosk

### DIFF
--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -289,9 +289,14 @@ class PaymentPortal(payment_portal.PaymentPortal):
         tx_sudo._process_pos_online_payment()
 
         rendering_context['state'] = 'success'
+        self._on_payment_successful(pos_order_sudo)
+
         if exit_route:
             return request.redirect(exit_route)
         return self._render_pay_confirmation(rendering_context)
+
+    def _on_payment_successful(self, pos_order):
+        return
 
     def _render_pay_confirmation(self, rendering_context):
         return request.render('pos_online_payment.pay_confirmation', rendering_context)

--- a/addons/pos_online_payment_self_order/models/pos_payment_method.py
+++ b/addons/pos_online_payment_self_order/models/pos_payment_method.py
@@ -7,9 +7,10 @@ class PosPaymentMethod(models.Model):
 
     @api.model
     def _load_pos_self_data_domain(self, data):
-        if data['pos.config']['data'][0]['self_ordering_mode'] == 'kiosk':
+        config = data['pos.config']['data'][0]
+        if config['self_ordering_mode'] == 'kiosk':
             domain = super()._load_pos_self_data_domain(data)
-            domain = expression.OR([[('is_online_payment', '=', True)], domain])
+            domain = expression.OR([[('is_online_payment', '=', True), ('id', 'in', config['payment_method_ids'])], domain])
             return domain
         else:
             return [('is_online_payment', '=', True)]

--- a/addons/pos_online_payment_self_order/static/src/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/self_order_service.js
@@ -47,12 +47,12 @@ patch(SelfOrder.prototype, {
     },
     filterPaymentMethods(pms) {
         const pm = super.filterPaymentMethods(...arguments);
+        const pmIds = this.config.payment_method_ids.map((o) => o.id);
         const online_pms = pms.filter(
             (rec) =>
                 rec.is_online_payment &&
                 (this.config.self_order_online_payment_method_id?.id === rec.id ||
-                    (this.config.self_ordering_mode === "kiosk" &&
-                        this.config.payment_method_ids.includes(rec.id)))
+                    (this.config.self_ordering_mode === "kiosk" && pmIds.includes(rec.id)))
         );
         return [...new Set([...pm, ...online_pms])];
     },


### PR DESCRIPTION
Currently, you are able to see online payment methods in the kiosk if you have at least a terminal method registered. Since you're able to see them you can also select it. Once paid you are redirected to the confirmation screen saying that the order is being prepared but the order is not sent to the preparation display, although the order is paid in the backend.

Steps to reproduce:
-------------------
* Create a payent method using terminal, for easier setup use stripe, you'll only need to setup serial number on the payment method but you do not need to do the whole stripe setup
* Create an online payment method (use demo for example)
* Change the kiosk settings to use those two payment methods
* Change the settings of the preparation display to use the kiosk
* Open preparation display
* Open kiosk, make on order, and select the online payment method
* Scan QR code and pay
> You are redirected to the confirmation page saying that the order
is being prepared while not sent to the preparation display

Why the fix:
------------
The fix to send the order to the backend is in the other part of this fix.

Here we decide to only allow to use the online payment methods that have been set on the config. Previously if two were existing but only one setup you were able to select any of them.

We also make a change to the `filterPaymentMethods` method. This method is called when pressing the pay button and is indirectly responsible for the fact that if there's only one payment method then we directly start the payment process.

Prior to this fix if we only had a terminal method setup and clicked to pay an order we directly had the screen telling us to follow the instructions on the terminal. However if we only had a online payment method, when clicking on pay, we would directly have the screen prompting us to pay at the register, we could never select the payment method.

With the fix, when there's only one payment method and it's online, clicking on pay will show the qr code.

opw-5001998

Enterprise: https://github.com/odoo/enterprise/pull/92825