### PR TITLE
[IMP] html_builder: remove font family picker from toolbar

### DIFF
--- a/addons/html_builder/static/src/core/core_plugins.js
+++ b/addons/html_builder/static/src/core/core_plugins.js
@@ -38,6 +38,7 @@ const mainEditorPluginsToRemove = [
     "StarPlugin",
     "BannerPlugin",
     "MoveNodePlugin",
+    "FontFamilyPlugin",
     // Replaced plugins:
     "ColorPlugin",
 ];

--- a/addons/website/static/tests/builder/editor.test.js
+++ b/addons/website/static/tests/builder/editor.test.js
@@ -181,14 +181,6 @@ describe("toolbar dropdowns", () => {
         expect(p).toHaveStyle("text-align: center");
     });
 
-    test("font family dropdown should close only after click", async () => {
-        const { p } = await setup();
-        click(".o-we-toolbar .btn[name='font_family']");
-        await focusAndClick(".dropdown-menu .dropdown-item[name='Arial']");
-        await animationFrame();
-        expect(p.firstChild).toHaveStyle("font-family: Arial, sans-serif");
-    });
-
     test("font style dropdown should close only after click", async () => {
         const { editor } = await setup();
         click(".o-we-toolbar .btn[name='font']");


### PR DESCRIPTION
Because it is quite complex to enable non-websafe fonts in website without impacting the performances, it was decided to remove the possibility to change the font family with the toolbar within website to deter users from requesting this feature.

This commit removes the font family picker from the toolbar when editing the website.

task-4367641
