### PR TITLE
[FIX] website: prevent duplicate palette names

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
@@ -18,12 +18,15 @@ export class ThemeColorsOption extends BaseOptionComponent {
     }
 
     getPalettes() {
-        const palettes = [];
+        const palettesByName = {};
         const style = window.getComputedStyle(document.documentElement);
         const allPaletteNames = getCSSVariableValue("palette-names", style)
             .split(", ")
             .map((name) => name.replace(/'/g, ""));
         for (const paletteName of allPaletteNames) {
+            if (palettesByName[paletteName]) {
+                continue;
+            }
             const palette = {
                 name: paletteName,
                 colors: [],
@@ -32,9 +35,9 @@ export class ThemeColorsOption extends BaseOptionComponent {
                 const color = getCSSVariableValue(`o-palette-${paletteName}-o-color-${c}`, style);
                 palette.colors.push(color);
             });
-            palettes.push(palette);
+            palettesByName[paletteName] = palette;
         }
-        return palettes;
+        return Object.values(palettesByName);
     }
 
     getPresets() {


### PR DESCRIPTION
This fix prevents duplicate palette names in `t-foreach` by using an object to store palettes by name, which otherwise made theme editing impossible.

Steps to reproduce:
- Create a website with theme "Anelusia"
- Try to change the theme in the editor
- The "Theme" tab will not appear

This issue occurs because the Anelusia theme from Design-Themes introduces a palette named "default-25", which is already defined in the website module. The same conflict can also arise with other themes.

opw-5020952
opw-5040694