### PR TITLE
[IMP] mail: disabled scheduled email time rounding

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -596,6 +596,7 @@ export class Composer extends Component {
             const divElement = document.createElement("div");
             divElement.setAttribute("data-o-mail-quote", "1");
             divElement.append(
+                document.createElement("br"),
                 document.createTextNode("-- "),
                 document.createElement("br"),
                 ...createElementWithContent("div", signature).childNodes

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -79,7 +79,7 @@ export class HtmlComposerMessageField extends HtmlMailField {
 
 export const htmlComposerMessageField = {
     ...htmlMailField,
-    additionalClasses: [...htmlMailField.additionalClasses, "ps-0"],
+    additionalClasses: [...htmlMailField.additionalClasses, "ps-0", "o_mail_composer_message"],
     component: HtmlComposerMessageField,
 };
 

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.scss
@@ -1,4 +1,4 @@
-.o_field_html_composer_message {
+.o_mail_composer_message {
     .note-editable {
         min-height: 300px !important;
         padding-left: 0;
@@ -21,7 +21,7 @@
             padding-right: $movenode-horizontal-padding;
             padding-top: var(--#{$prefix}modal-padding);
         }
-        .o_field_html_composer_message {
+        .o_mail_composer_message {
             .note-editable {
                 padding-left: 0;
                 padding-right: 0;

--- a/addons/mail/static/src/views/web/fields/scheduled_date_field/scheduled_date_dialog.js
+++ b/addons/mail/static/src/views/web/fields/scheduled_date_field/scheduled_date_dialog.js
@@ -56,6 +56,7 @@ export class ScheduledDateDialog extends Component {
             onSelect: (value) => (this.state.customDateTime = value),
             type: "datetime",
             value: this.state.customDateTime,
+            rounding: 1,
         };
     }
 

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -52,7 +52,7 @@
                                 options="{'edit_tags': True}"
                                 context="{'force_email': True, 'show_email': True, 'form_view_ref': 'base.view_partner_simple_form', 'forward_mode': True}"/>
                         </div>
-                        <field name="subject" placeholder="Welcome to MyCompany!" required="True"/>
+                        <field name="subject" placeholder="e.g. Welcome to MyCompany!" required="True"/>
                         <field name="reply_to" placeholder='Recipient Followers'
                             invisible="reply_to_mode == 'update'"
                             required="reply_to_mode != 'update'"/>


### PR DESCRIPTION
Previously, it was impossible to schedule an email to be sent at times
such as 9:21 or 15:33; these times' minutes would be rounded to the
nearest multiple of five by default.

This commit disables that rounding for scheduled email messages,
allowing users to schedule emails at any minute.

task-5010871