### PR TITLE
[FIX] account_peppol: email address never updated

### DIFF
--- a/addons/account_peppol/exceptions.py
+++ b/addons/account_peppol/exceptions.py
@@ -41,6 +41,7 @@ STANDARD_EXCEPTION_CODE_MESSAGES_MAP: dict[int, Callable[..., str]] = {
     705: lambda: _('You don\'t have enough credit'),
     706: lambda: _('The document could not be found'),
     707: lambda: _('You have reached the limit of documents you can send today. Retry later. Please contact the support if you think you need to increase that limit.'),
+    708: lambda: _('You are not authorized to change the contact email.'),
 }
 
 

--- a/addons/account_peppol/wizard/peppol_config_wizard.py
+++ b/addons/account_peppol/wizard/peppol_config_wizard.py
@@ -29,7 +29,7 @@ class PeppolConfigWizard(models.TransientModel):
     )
     account_peppol_edi_identification = fields.Char(related='account_peppol_edi_user.edi_identification')
     account_peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state', readonly=False)
-    account_peppol_contact_email = fields.Char(related='company_id.account_peppol_contact_email', readonly=False, required=True)
+    account_peppol_contact_email = fields.Char(default=lambda self: self.env.company.account_peppol_contact_email, required=True)
     account_peppol_migration_key = fields.Char(related='company_id.account_peppol_migration_key', readonly=False)
 
     service_json = fields.Json(
@@ -116,6 +116,7 @@ class PeppolConfigWizard(models.TransientModel):
 
         # Update company details
         if self.account_peppol_contact_email != self.company_id.account_peppol_contact_email:
+            self.company_id.account_peppol_contact_email = self.account_peppol_contact_email
             params = {
                 'update_data': {
                     'peppol_contact_email': self.account_peppol_contact_email,


### PR DESCRIPTION
Due to the config wizard email address field being a related field, and the control flow triggering actual API update only on gets hit when the wizard's email is different from company's email, this control flow never triggered.

The email field in peppol config wizard is a related field to companies peppol email, so the API update ran only if the wizard's email differed from the company's email. Since both were always the same by definition, the update never triggered.

Depends on https://github.com/odoo/iap-apps/pull/1167

no-task