### PR TITLE
[ADD] test_stock: Add test_stock test module for concurrent tests

### DIFF
--- a/addons/test_stock/__manifest__.py
+++ b/addons/test_stock/__manifest__.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Stock Test',
+    'version': '1.0',
+    'category': 'Hidden/Tests',
+    'summary': 'Stock tests module for tests needing speficic data',
+    'description': "Stock tests module for tests needing speficic data",
+    'depends': ['stock'],
+    'data': [
+        'data/test_stock_data.xml',
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/addons/test_stock/data/test_stock_data.xml
+++ b/addons/test_stock/data/test_stock_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="test_stock_simple_product" model="product.product">
+            <field name="name">Simple Product</field>
+            <field name="type">product</field>
+        </record>
+        <record id="test_stock_simple_product_quant" model="stock.quant">
+            <field name="product_id" ref="test_stock_simple_product"/>
+            <field name="location_id" ref="stock.stock_location_stock"/>
+            <field name="quantity">1.0</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/test_stock/tests/__init__.py
+++ b/addons/test_stock/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_quant_concurrence

--- a/addons/test_stock/tests/test_quant_concurrence.py
+++ b/addons/test_stock/tests/test_quant_concurrence.py
@@ -1,0 +1,48 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from contextlib import closing
+
+from odoo.tests.common import TransactionCase
+
+
+class ConcurrentStockQuant(TransactionCase):
+
+    def gather_relevant(self, product_id, location_id, lot_id=None, package_id=None, owner_id=None, strict=False):
+        quants = self.env['stock.quant']._gather(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=strict)
+        return quants.filtered(lambda q: not (q.quantity == 0 and q.reserved_quantity == 0))
+
+    def test_concurrent_increase_available_quantity(self):
+        """ Increase the available quantity when a concurrent transaction is already increasing
+        the reserved quanntity for the same product.
+        """
+        location = self.env.ref('stock.stock_location_stock')
+        quant = self.env['stock.quant'].search([('location_id', '=', location.id)], limit=1)
+        product = quant.product_id
+        available_quantity = self.env['stock.quant']._get_available_quantity(product, location, allow_negative=True)
+        # opens a new cursor and SELECT FOR UPDATE the quant, to simulate another concurrent reserved
+        # quantity increase
+        with closing(self.registry.cursor()) as cr:
+            cr.execute("SELECT id FROM stock_quant WHERE product_id=%s AND location_id=%s", (product.id, location.id))
+            quant_id = cr.fetchone()
+            cr.execute("SELECT 1 FROM stock_quant WHERE id=%s FOR UPDATE", quant_id)
+            self.env['stock.quant']._update_available_quantity(product, location, 1.0)
+
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(product, location, allow_negative=True), available_quantity + 1)
+        self.assertEqual(len(self.gather_relevant(product, location, strict=True)), 2)
+
+    def test_concurent_decrease_available_quantity(self):
+        """ Decrease the available quantity when a concurrent transaction is already increasing
+        the reserved quanntity for the same product.
+        """
+        location = self.env.ref('stock.stock_location_stock')
+        quant = self.env['stock.quant'].search([('location_id', '=', location.id)], limit=1)
+        product = quant.product_id
+        available_quantity = self.env['stock.quant']._get_available_quantity(product, location, allow_negative=True)
+        # opens a new cursor and SELECT FOR UPDATE the quant, to simulate another concurrent reserved
+        # quantity increase
+        with closing(self.registry.cursor()) as cr:
+            cr.execute("SELECT 1 FROM stock_quant WHERE id = %s FOR UPDATE", quant.ids)
+            self.env['stock.quant']._update_available_quantity(product, location, -1.0)
+
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(product, location, allow_negative=True), available_quantity - 1)
+        self.assertEqual(len(self.gather_relevant(product, location, strict=True)), 2)


### PR DESCRIPTION
Currently the tests `test_increase_available_quantity_3` and `test_decrease_available_quantity_3` are failing when running with no-demo. Both tests checks if a stock.quant is properly created when another transaction is locking the same rows on the stock_quant table. As there are no quants nor product in the data files of the stock module, making these tests passed in no-demo is non-trivial.

Being in `REPEATABLE READ`, the database SNAPSHOT is taken just after the `BEGIN` statement. This means that even if we open a new cursor, create a product/quant pair and commit during the test, it won't be visible to the test transaction. We need `self.env.cr` + 3 cursors in total to make the tests passed in no-demo. The intermediate commits make it difficult to properly tearDown the tests afterwards.

Instead, this commit moves both tests in a new test_stock module. This new module contains a small data file that has a few records needed to run the concurrent tests easily. Thanks to that both tests now only need `self.env.cr` + 1 cursor to run in no-demo and the tearDown is properly carried out.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
