### PR TITLE
[FIX] point_of_sale: no name popup when default preset

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2161,10 +2161,10 @@ export class PosStore extends WithLazyGetterTrap {
                     await this.editPartner(partner);
                 }
             }
+            order.setPreset(preset);
             if (preset.identification === "name") {
                 await this.handleSelectNamePreset(order);
             }
-            order.setPreset(preset);
 
             if (preset.use_timing && !order.preset_time) {
                 await this.openPresetTiming(order);


### PR DESCRIPTION
Steps to reproduce:
- go to the setting of your pos.config
- set the default preset as takeout (or any other that require the name)
- open your pos
- click on new order
- the slot selection opens (only if set so it's ok)
- but then no dialog to enter the name of the client

Issue:
The handleSelectNamePreset method in the POS Restaurant module attempts to access the selected preset through the order, but the preset has not yet been set on the order at that point.

Fix:
Make sure the preset is set on the order before calling handleSelectNamePreset.

Task-5030520

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
