### PR TITLE
[IMP] auth_passkey: enable autoinstall

### DIFF
--- a/addons/auth_passkey/__manifest__.py
+++ b/addons/auth_passkey/__manifest__.py
@@ -11,6 +11,7 @@ When a user logs in with a Passkey, MFA will not be required.
 """,
     'category': 'Hidden/Tools',
     'depends': ['base_setup', 'web'],
+    'auto_install': True,
     'data': [
         'views/auth_passkey_key_views.xml',
         'views/auth_passkey_login_templates.xml',
@@ -34,5 +35,4 @@ When a user logs in with a Passkey, MFA will not be required.
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
-    'installable': True,
 }


### PR DESCRIPTION
Passkeys are a feature that improve the security of all the users that use it. Just like auth_totp this should be auto installed since it improves the default security configuration of the database.

Task-3663657