### PR TITLE
[REF] web_tour: add helper to wait for pixel in canvas

### DIFF
--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { redirect } from "@web/core/utils/urls";
-import { waitUntil } from "@odoo/hoot-dom";
 
 // This tour relies on data created on the Python test.
 registry.category("web_tour.tours").add('sale_signature', {
@@ -26,15 +25,7 @@ registry.category("web_tour.tours").add('sale_signature', {
     },
     {
         trigger: ".modal canvas.o_web_sign_signature",
-        async run(helpers) {
-            await waitUntil(() => {
-                const canvas = helpers.anchor;
-                const context = canvas.getContext("2d");
-                const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-                const pixels = new Uint32Array(imageData.data.buffer);
-                return pixels.some((pixel) => pixel !== 0);
-            });
-        },
+        run: "canvasNotEmpty",
     },
     {
         content: "click select style",

--- a/addons/web_tour/static/src/tour_service/tour_helpers.js
+++ b/addons/web_tour/static/src/tour_service/tour_helpers.js
@@ -302,6 +302,23 @@ export class TourHelpers {
     }
 
     /**
+     * Ensures that the given canvas selector **{@link Selector}** contains pixels.
+     * @param {string|Node} selector
+     */
+    async canvasNotEmpty(selector) {
+        const canvas = this._get_action_element(selector);
+        if (canvas.tagName.toLowerCase() !== "canvas") {
+            throw new Error(`canvasNotEmpty is only suitable for canvas elements.`);
+        }
+        await hoot.waitUntil(() => {
+            const context = canvas.getContext("2d");
+            const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+            const pixels = new Uint32Array(imageData.data.buffer);
+            return pixels.some((pixel) => pixel !== 0); // pixel is on
+        });
+    }
+
+    /**
      * Get Node for **{@link Selector}**
      * @param {Selector} selector
      * @returns {Node}


### PR DESCRIPTION
In this commit, we add a helper for tour to ensure the canvas selector contains pixel before continue the tour.
This is quite useful to check that the signature has been loaded before continuing the tour, otherwise we get the "missing signature" error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
