### PR TITLE
[FIX] hr_timesheet: update documentation path

### DIFF
--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -27,7 +27,7 @@
                     </block>
                     <div name="section_leaves">
                         <block title="Time Off" name="timesheet_control">
-                            <setting company_dependent="1" documentation="/applications/services/timesheets/overview/time_off.html" help="Generate timesheets for validated time off requests and public holidays" id="timesheet_off_validation_setting">
+                            <setting company_dependent="1" documentation="/applications/services/timesheets/time_off.html" help="Generate timesheets for validated time off requests and public holidays" id="timesheet_off_validation_setting">
                                 <field name="module_project_timesheet_holidays"/>
                             </setting>
                         </block>


### PR DESCRIPTION
**Description:**
- In a recent documentation commit, the overview section was removed from the timesheets path.
commit: odoo/documentation@3bceee836fa8b8edfd8a35c20b21867354f6c078

**Steps to reproduce:**
- In a `v18` runbot
- open settings > Timesheets settings > under Time off
- click on the info icon

<img width="1905" height="944" alt="2025-08-21_18-25" src="https://github.com/user-attachments/assets/34ec76ed-46f7-4b08-8c23-10269e105b43" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
