### PR TITLE
[FIX] pos_online_payment: trigger post_processing

### DIFF
--- a/addons/pos_online_payment/models/payment_transaction.py
+++ b/addons/pos_online_payment/models/payment_transaction.py
@@ -29,6 +29,13 @@ class PaymentTransaction(models.Model):
         super()._post_process()
         self._process_pos_online_payment()
 
+    def _set_done(self, *, state_message=None, extra_allowed_states=()):
+        """ Override to trigger the post_processing for pos order payments.
+            This is usefull in case the user closes the payment page that was responsible to call `/payment/status/poll` """
+        super()._set_done()
+        if self.pos_order_id:
+            self.env.ref('payment.cron_post_process_payment_tx')._trigger()
+
     def _process_pos_online_payment(self):
         for tx in self:
             if tx and tx.pos_order_id and tx.state in ('authorized', 'done') and not tx.payment_id.pos_order_id:


### PR DESCRIPTION

When paying online with the PoS if for some reason the client closes the
web page before receiving the payment confirmation, the PoS would not be
notified that the payment was successful.

Steps to reproduce:
-------------------
* Setup any online payment method in the PoS.
* Open the PoS and create an order.
* Proceed to payment and choose the online payment method.
* Scan the QR code and close the page before receiving the payment
  confirmation.
> Observation: The PoS will need to wait atleast 10 minutes to receive
  the payment notification.

Why the fix:
------------
When using the online payment method, the user that scans the QR code
will open a web page to complete the payment. This webpage is also
responsible to poll the status of the payment. When polling the status
of the payment, if the payment is successful, the server will send a
notification to the PoS to update the order status. If the user closes
the web page before the payment is confirmed, the PoS will not receive
the notification. We will need to wait for the payment transaction
`_cron_post_process` to be executed, which happens every 10 minutes.

So the solution is to trigger the cron when the payment is set as done
to ensure that the PoS receives the payment notification as soon as
possible.

opw-4925349