### PR TITLE
[IMP] website,*: update configurator features and website menus

### DIFF
--- a/addons/test_website/tests/test_page.py
+++ b/addons/test_website/tests/test_page.py
@@ -18,10 +18,12 @@ class WithContext(HttpCase):
         contactus_url = '/contactus'
         contactus_url_full = website.domain + contactus_url
         contactus_content = b'content="Contact Us | Test Website"'
-        self.env['website.menu'].search([
-            ('website_id', '=', website.id),
-            ('url', '=', contactus_url),
-        ]).sequence = 1
+        self.env['website.menu'].create({
+            'name': "Contact us",
+            'url': contactus_url,
+            'website_id': website.id,
+            'parent_id': website.menu_id.id,
+        }).sequence = 1
 
         # 404 shouldn't be served but fallback on first menu
         # -------------------------------------------

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -55,12 +55,12 @@ registry.category("web_tour.tours").add("configurator_flow", {
         },
         // Features screen
         {
-            content: "select Pricing",
-            trigger: '.card:contains("Pricing")',
+            content: "select Pricing Plan",
+            trigger: '.card:contains("Pricing Plan")',
             run: "click",
         },
         {
-            trigger: '.card.border-success:contains("Pricing")',
+            trigger: '.card.border-success:contains("Pricing Plan")',
         },
         {
             content: "Events should be selected (module already installed)",
@@ -71,11 +71,7 @@ registry.category("web_tour.tours").add("configurator_flow", {
             trigger: '.card.card_installed:contains("eLearning")',
         },
         {
-            trigger: '.card.card_installed:contains("Success Stories")',
-        },
-        {
-            content:
-                "Success Stories (Blog) and News (Blog) should be selected (module already installed)",
+            content:"News (Blog) should be selected (module already installed)",
             trigger: '.card.card_installed:contains("News")',
         },
         {
@@ -113,13 +109,13 @@ registry.category("web_tour.tours").add("configurator_flow", {
             content: `Check footer menu ${menu} is there`,
             trigger: `:iframe footer a:contains(${menu})`,
         })),
-        ...["Home", "Events", "Courses", "Pricing", "News", "Success Stories", "Contact us"].map(
+        ...["Home", "Events", "Courses", "Pricing Plan", "News"].map(
             (menu) => ({
                 content: `Check menu ${menu} is there`,
                 trigger: `:iframe .top_menu a:contains(${menu}):not(:visible)`,
             })
         ),
-        ...["/", "/event", "/slides", "/pricing", "/blog/", "/blog/", "/contactus"].map((url) => ({
+        ...["/", "/event", "/slides", "/pricing", "/blog/"].map((url) => ({
             content: `Check url ${url} is there`,
             trigger: `:iframe .top_menu a[href^='${url}']:not(:visible)`,
         })),

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -392,23 +392,14 @@
         <field name="feature_url">/our-services</field>
     </record>
     <record id="feature_page_pricing" model="website.configurator.feature">
-        <field name="name">Pricing</field>
-        <field name="description">Designed to drive conversion</field>
+        <field name="name">Pricing Plan</field>
+        <field name="description">Useful if you sell subscriptions</field>
         <field name="iap_page_code">pricing</field>
         <field name="sequence">4</field>
         <field name="page_view_id" ref="pricing"/>
         <field name="icon">fa-random</field>
         <field name="menu_sequence">35</field>
         <field name="feature_url">/pricing</field>
-    </record>
-    <record id="feature_page_privacy_policy" model="website.configurator.feature">
-        <field name="name">Privacy Policy</field>
-        <field name="description">Explain how you protect privacy</field>
-        <field name="iap_page_code">privacy_policy</field>
-        <field name="sequence">5</field>
-        <field name="page_view_id" ref="privacy_policy"/>
-        <field name="icon">fa-gavel</field>
-        <field name="feature_url">/privacy</field>
     </record>
 
     <!-- Configurator apps features -->
@@ -421,16 +412,6 @@
         <field name="icon">fa-rss</field>
         <field name="menu_company">True</field>
         <field name="menu_sequence">40</field>
-        <field name="feature_url">/blog</field>
-    </record>
-    <record id="feature_module_success_stories" model="website.configurator.feature">
-        <field name="name">Success Stories</field>
-        <field name="description">Share your best case studies</field>
-        <field name="sequence">7</field>
-        <field name="module_id" ref="base.module_website_blog"/>
-        <field name="icon">fa-star</field>
-        <field name="menu_company">True</field>
-        <field name="menu_sequence">45</field>
         <field name="feature_url">/blog</field>
     </record>
     <record id="feature_module_career" model="website.configurator.feature">
@@ -460,14 +441,6 @@
         <field name="menu_sequence">20</field>
         <field name="feature_url">/event</field>
     </record>
-    <record id="feature_module_forum" model="website.configurator.feature">
-        <field name="name">Forum</field>
-        <field name="description">Give visitors the information they need</field>
-        <field name="sequence">11</field>
-        <field name="module_id" ref="base.module_website_forum"/>
-        <field name="icon">fa-users</field>
-        <field name="feature_url">/forum</field>
-    </record>
     <record id="feature_module_live_chat" model="website.configurator.feature">
         <field name="name">Live Chat</field>
         <field name="description">Chat with visitors to improve traction</field>
@@ -484,13 +457,6 @@
         <field name="icon">fa-graduation-cap</field>
         <field name="menu_sequence">25</field>
         <field name="feature_url">/slides</field>
-    </record>
-    <record id="feature_module_stores_locator" model="website.configurator.feature">
-        <field name="name">Stores Locator</field>
-        <field name="description">A map and a listing of your stores</field>
-        <field name="sequence">15</field>
-        <field name="module_id" ref="base.module_website_google_map"/>
-        <field name="icon">fa-map-marker</field>
     </record>
 
     <data noupdate="1">
@@ -509,6 +475,13 @@
             <field name="track">True</field>
             <field name="website_meta_description">This is the contact us page of the website</field>
         </record>
+        <record id="privacy_policy_page" model="website.page">
+            <field name="url">/privacy</field>
+            <field name="view_id" ref="privacy_policy"/>
+            <field name="is_published">True</field>
+            <field name="track">True</field>
+            <field name="website_meta_description">This is the privacy policy page of the website</field>
+        </record>
 
         <!-- Default Menu to store module menus for new website -->
         <record id="main_menu" model="website.menu">
@@ -521,13 +494,6 @@
             <field name="page_id" ref="website.homepage_page"/>
             <field name="parent_id" ref="website.main_menu"/>
             <field name="sequence" type="int">10</field>
-        </record>
-        <record id="menu_contactus" model="website.menu">
-            <field name="name">Contact us</field>
-            <field name="url">/contactus</field>
-            <field name="page_id" ref="website.contactus_page"/>
-            <field name="parent_id" ref="website.main_menu"/>
-            <field name="sequence" type="int">60</field>
         </record>
 
         <!-- Default Website -->

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -38,7 +38,7 @@ export const ROUTES = {
 
 export const WEBSITE_TYPES = {
     1: {id: 1, label: _t("a website"), name: 'business'},
-    2: {id: 2, label: _t("an online store"), name: 'online_store'},
+    2: {id: 2, label: _t("an eCommerce"), name: 'eCommerce'},
     3: {id: 3, label: _t("a blog"), name: 'blog'},
     4: {id: 4, label: _t("an event website"), name: 'event'},
     5: {id: 5, label: _t("an elearning platform"), name: 'elearning'},

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -79,7 +79,7 @@ function runConfiguratorFlow(industrySearchText, featureOrPageName) {
 registry.category("web_tour.tours").add('configurator_translation', {
     url: '/website/configurator',
     steps: () => [
-    ...runConfiguratorFlow("in fr", "Parseltongue_privacy"),
+    ...runConfiguratorFlow("in fr", "Parseltongue_pricing"),
     {
         content: "Check if the current interface language is active and monkey patch terms",
         trigger: "body",
@@ -108,7 +108,7 @@ registry.category("web_tour.tours").add('configurator_translation', {
 registry.category("web_tour.tours").add("configurator_page_creation", {
     url: "/website/configurator",
     steps: () => [
-        ...runConfiguratorFlow("abbey", "Pricing"),
+        ...runConfiguratorFlow("abbey", "Pricing Plan"),
         // Verify configurator page templates exist in landing pages category.
         {
             content: "Open create content menu",

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -292,8 +292,8 @@ registerWebsitePreviewTour('edit_menus', {
         run: "click",
     },
     {
-        content: `Drag "Contact Us" menu below "Home" menu`,
-        trigger: '.oe_menu_editor li:contains("Contact us") .oi-draggable',
+        content: `Drag "Modnar !!" menu below "Home" menu`,
+        trigger: '.oe_menu_editor li:contains("Modnar !!") .oi-draggable',
         run(helpers) {
             return helpers.drag_and_drop('.oe_menu_editor li:contains("Home")', {
                 position: {
@@ -305,13 +305,13 @@ registerWebsitePreviewTour('edit_menus', {
         },
     },
     {
-        content: "Drag 'Contact Us' item as a child of the 'Home' item",
-        trigger: '.oe_menu_editor li:contains("Contact us") .oi-draggable',
-        run: 'drag_and_drop .oe_menu_editor li:contains("Contact us") .form-control',
+        content: "Drag 'Modnar !!' item as a child of the 'Home' item",
+        trigger: '.oe_menu_editor li:contains("Modnar !!") .oi-draggable',
+        run: 'drag_and_drop .oe_menu_editor li:contains("Modnar !!") .form-control',
     },
     {
         content: "Wait for drop",
-        trigger: '.oe_menu_editor li:contains("Home") ul li:contains("Contact us")',
+        trigger: '.oe_menu_editor li:contains("Home") ul li:contains("Modnar !!")',
     },
     // Drag the Mega menu to the first position.
     {
@@ -344,7 +344,7 @@ registerWebsitePreviewTour('edit_menus', {
     // openable.
     {
         content: "When menu item is opened, child item must appear in the shown menu",
-        trigger: ':iframe .top_menu .nav-item:contains("Home") ul.show li a.dropdown-item:contains("Contact us")[href="/contactus"]',
+        trigger: ':iframe .top_menu .nav-item:contains("Home") ul.show li a.dropdown-item:contains("Modnar !!")',
         run() {
             // Scroll down.
             this.anchor.closest("body").querySelector(".o_footer_copyright_name")
@@ -366,7 +366,7 @@ registerWebsitePreviewTour('edit_menus', {
     {
         content: "Check that the Home menu is opened",
         trigger: ':iframe .top_menu .nav-item:contains("Home") ul.show li' +
-            ' a.dropdown-item:contains("Contact us")[href="/contactus"]',
+            ' a.dropdown-item:contains("Modnar !!")',
     },
     {
         content: "Close the Home menu",
@@ -422,7 +422,7 @@ registerWebsitePreviewTour('edit_menus', {
     {
         // If this step fails, it means that a patch inside bootstrap was lost.
         content: "Press the 'down arrow' key.",
-        trigger: ':iframe .top_menu .nav-item:contains("Home") li:contains("Contact us")',
+        trigger: ':iframe .top_menu .nav-item:contains("Home") li:contains("Modnar !!")',
         run: "press ArrowDown",
     },
     ...clickOnSave(),
@@ -492,7 +492,7 @@ registerWebsitePreviewTour('edit_menus', {
     },
     {
         content: "Drag 'Modnar !!' below 'new_menu'",
-        trigger: '.oe_menu_editor li:contains("Modnar !!") .oi-draggable',
+        trigger: '.oe_menu_editor li:contains("Home") > ul > li:contains("Modnar !!") .oi-draggable',
         async run(helpers) {
             await helpers.drag_and_drop('.oe_menu_editor li:contains("new_menu") .oi-draggable', {
                 position: "bottom",

--- a/addons/website/static/tests/tours/navigation.js
+++ b/addons/website/static/tests/tours/navigation.js
@@ -8,20 +8,11 @@ registerWebsitePreviewTour(
     },
     () => [
         {
-            content: "Navigate to the 'Contact Us' page",
-            trigger: ":iframe .top_menu a[href='/contactus']:not(:visible)",
-            run: "click",
-        },
-        {
             content: "Click on Edit right after that",
             trigger: ".o_menu_systray_item.o_edit_website_container > button",
             run: "click",
         },
         stepUtils.waitIframeIsReady(),
-        {
-            content: "Contact us page appears first before the builder sidebar",
-            trigger: ":iframe section h1:contains('Contact Us'), :not(.o-website-builder_sidebar)",
-        },
         {
             content: "Can insert a snippet",
             trigger: ".o-website-builder_sidebar",

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -116,8 +116,8 @@ class TestConfiguratorTranslation(TestConfiguratorCommon):
             'overwrite': True,
             'lang_ids': [(6, 0, [parseltongue.id])],
         }).lang_install()
-        feature = self.env['website.configurator.feature'].search([('name', '=', 'Privacy Policy')])
-        feature.with_context(lang=parseltongue.code).write({'name': 'Parseltongue_privacy'})
+        feature = self.env['website.configurator.feature'].search([('name', '=', 'Pricing Plan')])
+        feature.with_context(lang=parseltongue.code).write({'name': 'Parseltongue_pricing'})
         self.env.ref('base.user_admin').write({'lang': parseltongue.code})
         website_fr = self.env['website'].create({
             'name': "New website",

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -71,7 +71,7 @@ class TestMenu(common.TransactionCase):
         # Ensure new website got a top menu
         total_menus = Menu.search_count([])
         Website.create({'name': 'new website'})
-        self.assertEqual(total_menus + 4, Menu.search_count([]), "New website's bootstraping should have duplicate default menu tree (Top/Home/Contactus/Sub Default Menu)")
+        self.assertEqual(total_menus + 3, Menu.search_count([]), "New website's bootstraping should have duplicate default menu tree (Top/Home/Sub Default Menu)")
 
     def test_04_specific_menu_translation(self):
         IrModuleModule = self.env['ir.module.module']

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -370,10 +370,12 @@ class WithContext(HttpCase):
         contactus_url = '/contactus'
         contactus_url_full = website.domain + contactus_url
         contactus_content = b'content="Contact Us | Test Website"'
-        contactus_menu = self.env['website.menu'].search([
-            ('website_id', '=', website.id),
-            ('url', '=', contactus_url),
-        ], limit=1)
+        contactus_menu = self.env['website.menu'].create({
+            'name': "Contact us",
+            'url': contactus_url,
+            'website_id': website.id,
+            'parent_id': website.menu_id.id,
+        })
         home_url = '/'
         home_url_full = website.domain + home_url
         home_content = b'content="Home | Test Website"'

--- a/addons/website_sale/views/website_sale_menus.xml
+++ b/addons/website_sale/views/website_sale_menus.xml
@@ -56,12 +56,14 @@
                 action="product.product_combo_action"
                 sequence="6"
             />
-            <menuitem id="product_catalog_product_tags"
-                name="Product Tags"
-                action="product.product_tag_action"/>
+            <menuitem
+                id="product_catalog_product_tags"
+                name="Tags"
+                action="product.product_tag_action"
+            />
             <menuitem
                 id="product_catalog_product_ribbons"
-                name="Product Ribbons"
+                name="Ribbons"
                 action="website_sale.product_ribbon_action"
             />
         </menuitem>


### PR DESCRIPTION
* = [website_sale,spreadsheet_dashboard_website_sale,test_website_modules,test_website]

Description:
- This commit updates website configurator features, menus and related tests/tours to reflect the current functional scope.

After this commit:
- Renamed Pricing to Pricing Plan with updated description
- Moved Privacy Policy to a default website page instead of configurator feature
- Removed Success Stories, Forum and Stores Locator features
- Dropped default Contact us and eCommerce Dashboard menus
- Updated related tours and tests to reflect menu and feature changes
- Cleaned ecommerce_dashboard.json by removing unused menu references 
- Updated indentation for the `website_sale_menus`

SEE ALSO:
Upgrade PR: https://github.com/odoo/upgrade/pull/8320

task-4855511
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
