### PR TITLE
[FIX] l10n_latam_checks: compare with payment_date instead of date

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -101,7 +101,7 @@ class AccountPayment(models.Model):
                     date = rec.date or fields.Datetime.now()
 
                     last_operation = check._get_last_operation()
-                    if last_operation and last_operation[0].date > date:
+                    if last_operation and min(last_operation[0].date, check.payment_date) > date:
                         msgs.append(
                             _(
                               "It seems you're trying to move a check with a date (%(date)s) prior to last "


### PR DESCRIPTION
When validating check movements, the system was comparing the operation date against date, which caused false warnings in scenarios such as customer receipts that include checks already issued with past payment dates.

This commit changes the validation to use payment_date, which is the correct reference for ensuring that the payment operation is not prior to the last effective payment of the check.

Description of the issue/feature this PR addresses:
When validating check movements in `l10n_latam_checks`, the system compares the operation date (`date`) of the last check operation against the current payment date.  
This generates false blocking warnings in cases such as customer receipts, where checks can be received with past payment dates (already issued and ready to be deposited).

Current behavior before PR:
The validation uses `last_operation.date` for comparison.  
If the last operation's `date` is greater than the current payment's date, the system raises a warning, even if the check's `payment_date` is already in the past and valid.  

Desired behavior after PR is merged:
The validation uses `last_operation.payment_date` instead of `last_operation.date`.  
This ensures that the comparison is consistent with the effective payment date of the check, avoiding false positives when processing checks in customer receipts.

Video:
https://drive.google.com/file/d/1Ro2NvKGK_uRyBovMuNeA395y-6MUbzu5/view


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
