### PR TITLE
[IMP] hr_holidays: change default view for management time off to be list view

### DIFF
--- a/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
@@ -36,6 +36,12 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
             run: "click",
         },
         {
+            trigger: "button.o_kanban",
+            content: "Open kanban view",
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
             trigger: "button.o-kanban-button-new",
             content: "Create a new time-off request",
             tooltipPosition: "bottom",

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -812,7 +812,7 @@
         <field name="name">All Time Off</field>
         <field name="res_model">hr.leave</field>
         <field name="path">time-off-approval</field>
-        <field name="view_mode">kanban,list,form,calendar,activity</field>
+        <field name="view_mode">list,kanban,form,calendar,activity</field>
         <field name="search_view_id" ref="hr_holidays.hr_leave_view_search_manager"/>
         <field name="context">{
             'search_default_waiting_for_me': 1,
@@ -848,16 +848,16 @@
         </field>
     </record>
 
-    <record id="action_view_kanban_manager_approve" model="ir.actions.act_window.view">
-        <field name="sequence" eval="1"/>
-        <field name="view_mode">kanban</field>
-        <field name="view_id" ref="hr_leave_view_kanban"/>
-        <field name="act_window_id" ref="hr_leave_action_action_approve_department"/>
-    </record>
     <record id="action_view_tree_manager_approve" model="ir.actions.act_window.view">
-        <field name="sequence" eval="2"/>
+        <field name="sequence" eval="1"/>
         <field name="view_mode">list</field>
         <field name="view_id" ref="hr_leave_view_tree"/>
+        <field name="act_window_id" ref="hr_leave_action_action_approve_department"/>
+    </record>
+    <record id="action_view_kanban_manager_approve" model="ir.actions.act_window.view">
+        <field name="sequence" eval="2"/>
+        <field name="view_mode">kanban</field>
+        <field name="view_id" ref="hr_leave_view_kanban"/>
         <field name="act_window_id" ref="hr_leave_action_action_approve_department"/>
     </record>
     <record id="action_view_form_manager_approve" model="ir.actions.act_window.view">


### PR DESCRIPTION
- Switched the sequence of views for manamgement time off to have the list view before the kanban view

task-5030675

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
