### PR TITLE
[FIX] sale_timesheet: link timesheet to downpayment invoice

### DIFF
--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
@@ -48,4 +48,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 timesheet_end_date=self.date_end_invoice_timesheet
             )._create_invoices(final=self.deduct_down_payments, grouped=not self.consolidated_billing)
 
-        return super()._create_invoices(sale_orders)
+        moves = super()._create_invoices(sale_orders)
+        moves._link_timesheets_to_invoice()
+        return moves


### PR DESCRIPTION
To reproduce:
=============
- create service product based on timesheet that creates project/task
- create sale order with this product
- confirm sale order
- record couple hours on the task
- go back to sale order and create downpayment invoice
- go back to timesheet and group by invoice
- you will see that the timesheet is not linked to the downpayment invoice

Problem:
========
- before this commit, we only link timesheet to regular invoices, not to downpayment invoices.
- the `_link_timesheets_to_invoice` method fetches timesheets from the SOL linked to the created invoice, which is in case of downpayment a different SOL than the one linked to the timesheet.

Solution:
=========
we call `_link_timesheets_to_invoice` in case of downpayment invoices and we also ensure that the method fetches the timesheets from all SOLs on the whole sale order.

opw-4850089

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
