### PR TITLE
[FIX] website: fix typo in highlight key names

### DIFF
--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
@@ -24,8 +24,8 @@ export const highlightIdToName = {
     diagonal: "Diagonal",
     strikethrough: "Strikethrough",
     bold: "Bold",
-    bold1: "Bold 1",
-    bold2: "Bold 2",
+    bold_1: "Bold 1",
+    bold_2: "Bold 2",
 };
 
 export class HighlightConfigurator extends Component {

--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -9,6 +9,8 @@ import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { contains } from "@web/../tests/web_test_helpers";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Plugin } from "@html_editor/plugin";
+import { highlightIdToName } from "@website/builder/plugins/highlight/highlight_configurator";
+import { textHighlightFactory } from "@website/js/highlight_utils";
 
 defineMailModels();
 
@@ -173,4 +175,12 @@ test("Can modify multiple highlights", async () => {
     await contains(".o_popover .o_text_highlight_underline").click();
     expect("p>.o_text_highlight_underline").toHaveCount(1);
     expect(".o_text_highlight").toHaveCount(1);
+});
+
+test("each highlight has a name", () => {
+    const highlightWithAName = Object.keys(highlightIdToName);
+    const highlightWithAPath = Object.keys(textHighlightFactory);
+    highlightWithAName.sort();
+    highlightWithAPath.sort();
+    expect(highlightWithAPath).toEqual(highlightWithAName);
 });


### PR DESCRIPTION
With the initial [website builder refactor], there was a typo in the keys for the names of the bold highlights.

This commits fixes the typo, so that the keys in `highlightIdToName` match the ones in `textHighlightFactory`

Steps to reproduce:
- Open website builder
- Select text, in the expended toolbar, add highlight
- Select the "Bold 1" or "Bold 2" highlight (these are the last ones)
- Bug: the picker shows an empty button instead of the highlight's name 

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
