### PR TITLE
[FIX] html_builder, html_editor: background color for font size input in dark mode

### DIFF
--- a/addons/html_builder/static/src/plugins/font/font_size_selector.xml
+++ b/addons/html_builder/static/src/plugins/font/font_size_selector.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="html_builder.FontSizeSelector" t-inherit="html_editor.FontSizeSelector">
         <xpath expr="//DropdownItem" position="inside">
-            <span class="badge text-bg-secondary ms-3 float-end"><t t-out="fontSizeTags[item.variableName]"/></span>
+            <span class="badge o-we-font-size-item-bg ms-3 float-end"><t t-out="fontSizeTags[item.variableName]"/></span>
         </xpath>
     </t>
 </templates>

--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -46,6 +46,7 @@ This addon provides an extensible, maintainable editor.
             ('remove', 'html_editor/static/src/main/toolbar/toolbar.dark.scss'),
             ('remove', 'html_editor/static/src/main/chatgpt/language_selector.dark.scss'),
             ('remove', 'html_editor/static/src/main/table/table_align_selector.dark.scss'),
+            ('remove', 'html_editor/static/src/main/font/font_size_selector.dark.scss'),
         ],
         'html_editor.assets_media_dialog': [
             # Bundle to use the media dialog in the backend and the frontend
@@ -69,6 +70,7 @@ This addon provides an extensible, maintainable editor.
             'html_editor/static/src/main/toolbar/toolbar.dark.scss',
             'html_editor/static/src/main/chatgpt/language_selector.dark.scss',
             'html_editor/static/src/main/table/table_align_selector.dark.scss',
+            'html_editor/static/src/main/font/font_size_selector.dark.scss',
         ],
         'web.assets_tests': [
             'html_editor/static/tests/tours/**/*',

--- a/addons/html_editor/static/src/main/font/font_size_selector.dark.scss
+++ b/addons/html_editor/static/src/main/font/font_size_selector.dark.scss
@@ -1,0 +1,3 @@
+.o-we-font-size-item-bg {
+    background-color: $gray-200;
+}

--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -46,7 +46,7 @@ export class FontSizeSelector extends Component {
 
                 this.fontSizeInput = iframeDoc.createElement("input");
                 const isDarkMode = cookie.get("color_scheme") === "dark";
-                const htmlStyle = getHtmlStyle(this.props.document);
+                const htmlStyle = getHtmlStyle(document);
                 const backgroundColor = getCSSVariableValue(
                     isDarkMode ? "gray-200" : "white",
                     htmlStyle

--- a/addons/html_editor/static/src/main/font/font_size_selector.scss
+++ b/addons/html_editor/static/src/main/font/font_size_selector.scss
@@ -1,3 +1,6 @@
 .o_font_size_selector_menu {
     --dropdown-min-width: none;
 }
+.o-we-font-size-item-bg {
+    background-color: $gray-300;
+}


### PR DESCRIPTION
### Steps to reproduce:

**Issue 1:**
- Switch the interface to Dark Mode.
- Navigate to the website and drag & drop a snippet.
- Select any text to open the toolbar.
- Observe the font size input field's background color.

**Issue 2:**
- Enable dark mode
- Open the Website module
- Drag and drop any text snippet and select the text
- Click on font size input in the toolbar and observe badge background color.

### Description of the issue/feature this PR addresses:

- The font size input field displayed a white background in Dark Mode.
- This occurred because the code used the editor's document for htmlStyle, but in contexts like the website, the element's ownerDocument differs, leading to incorrect style resolution.
- The badge shown next to the font size in the dropdown had same background color as the dropdown in dark mode, making it indistinguishable.

### Desired behavior after PR is merged:

- Use the correct ownerDocument of the element to access its htmlStyle.
- The badge background color is now darker in dark mode.

task-5027790

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
