### PR TITLE
[FIX] website_sale: hide uom from cart notification

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -400,7 +400,7 @@ class Cart(PaymentPortal):
             ):
                 infos['image_url'] = image_data_uri(combo_item.product_id.image_128)
 
-        if request.env['res.groups']._is_feature_enabled('uom.group_uom'):
+        if line.product_template_id._has_multiple_uoms():
             infos['uom_name'] = line.product_uom_id.name
 
         return infos


### PR DESCRIPTION
If there aren't multiple uoms defined on the product, there is no need to display the uom in the cart notification.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
