### PR TITLE
[IMP] l10n_sa_edi: consider 409 as successful submission

### DIFF
--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-26 10:46+0000\n"
-"PO-Revision-Date: 2025-06-26 14:58+0400\n"
+"POT-Creation-Date: 2025-08-22 06:34+0000\n"
+"PO-Revision-Date: 2025-08-22 10:51+0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ar\n"
@@ -1004,9 +1004,23 @@ msgid "The private key used to generate the CSR and obtain certificates"
 msgstr "المفتاح الخاص المستخدَم لإنشاء CSR والحصول على الشهادات"
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid "This invoice was already successfully reported to ZATCA. Please, check the response below:"
+msgstr "تم الإبلاغ عن هذه الفاتورة بنجاح إلى زاتكا. يُرجى مراجعة الرد أدناه:"
+
+#. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_edi_xml_ubl_21_zatca
 msgid "UBL 2.1 (ZATCA)"
 msgstr "UBL 2.1 (زاتكا)"
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid "Unable to retrieve response from ZATCA. Please, check the response below:"
+msgstr "تعذر استلام الرد من ZATCA. يُرجى مراجعة الرد أدناه:"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_serial_number
@@ -1136,6 +1150,20 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid "Warning: Invoice was already successfully reported to ZATCA"
+msgstr "تحذير: تم بالفعل الإبلاغ عن الفاتورة بنجاح إلى زاتكا"
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid "Warning: Unable to Retrieve a Response from ZATCA"
+msgstr "تحذير: غير قادر على استلام الرد من زاتكا"
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 #, python-format
 msgid "Warnings:"
@@ -1181,7 +1209,7 @@ msgstr "عليك طلب CCSID أولاً قبل الاستمرار"
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "ZATCA"
-msgstr "زاتكا"
+msgstr "تحذير: غير قادر على استلام الرد من ZATCA"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form

--- a/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
+++ b/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-26 10:46+0000\n"
-"PO-Revision-Date: 2025-06-26 10:46+0000\n"
+"POT-Creation-Date: 2025-08-22 06:34+0000\n"
+"PO-Revision-Date: 2025-08-22 06:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1034,8 +1034,25 @@ msgid "The private key used to generate the CSR and obtain certificates"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"This invoice was already successfully reported to ZATCA. Please, check the "
+"response below:"
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_edi_xml_ubl_21_zatca
 msgid "UBL 2.1 (ZATCA)"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"Unable to retrieve response from ZATCA. Please, check the response below:"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -1176,6 +1193,20 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-oos
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax_template__l10n_sa_exemption_reason_code__vatex-sa-oos
 msgid "VATEX-SA-OOS Not subject to VAT."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid "Warning: Invoice was already successfully reported to ZATCA"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+#, python-format
+msgid "Warning: Unable to Retrieve a Response from ZATCA"
 msgstr ""
 
 #. module: l10n_sa_edi

--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -186,7 +186,7 @@ class AccountEdiFormat(models.Model):
                 'blocking_level': 'warning' if is_warning else 'error',
                 'status_code': status_code,
             }
-        if not clearance_data.get('error'):
+        if not clearance_data.get('error') and clearance_data.get("status_code") != 409:
             return self._l10n_sa_assert_clearance_status(invoice, clearance_data)
         return clearance_data
 
@@ -353,8 +353,8 @@ class AccountEdiFormat(models.Model):
         if response_data.get('error'):
 
             # If the request was rejected, we save the signed xml content as an attachment
-            if response_data.get('rejected'):
-                invoice._l10n_sa_log_results(submitted_xml, response_data, error=True)
+            # If request timedout, just log note a warning message
+            invoice._l10n_sa_log_results(submitted_xml, response_data, error=response_data.get('rejected'))
 
             # If the request returned an exception (Timeout, ValueError... etc.) it means we're not sure if the
             # invoice was successfully cleared/reported, and thus we keep the Index Chain.

--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -611,7 +611,7 @@ class AccountJournal(models.Model):
             # In the 401+ cases, it is like the server is overloaded e.g. and we still need to resend later.  We do not
             # erase the index chain (excepted) because for ZATCA, one ICV (index chain) needs to correspond to one invoice.
             status_code = ex.response.status_code
-            if status_code != 400:
+            if status_code not in {400, 409}:
                 return {
                     'error': (Markup("<b>[%s]</b>") % status_code) + _("Server returned an unexpected error: %(error)s",
                                error=(request_response.text or str(ex))),
@@ -636,6 +636,9 @@ class AccountJournal(models.Model):
                 'blocking_level': 'error'
             }
         response_data['status_code'] = request_response.status_code
+
+        if status_code == 409:
+            return response_data
 
         val_res = response_data.get('validationResults', {})
         if not request_response.ok and (val_res.get('errorMessages') or val_res.get('warningMessages')):


### PR DESCRIPTION
ZATCA introduced a new response code (409) to handle duplicate invoice submissions for B2C. This is helpful because when the submission timesout, we are left unsure whether ZATCA successfuly received the invoice or not. The next time Odoo tries to send the same invoice, Zatca will respond with a 409 error if it was received earlier. In which case, we mark the invoice as successfully sent.

A similar flow applies for B2B, with a response code of 208 for duplicate invoices. However, for B2B, ZATCA accepts the duplicate with a warning instead of an error, So the invoice gets marked as sent in Odoo, and no changes need to be done there.

task-id: 4745275

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
