### PR TITLE
[FIX] sale_loyalty: use reward description as SOL name for free product

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -144,7 +144,7 @@ class SaleOrder(models.Model):
         claimable_count = float_round(points / reward.required_points, precision_rounding=1, rounding_method='DOWN') if not reward.clear_wallet else 1
         cost = points if reward.clear_wallet else claimable_count * reward.required_points
         return [{
-            'name': _("Free Product - %(product)s", product=product.with_context(display_default_code=False).display_name),
+            'name': reward.description,
             'product_id': product.id,
             'discount': 100,
             'product_uom_qty': reward.reward_product_qty * claimable_count,

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -1045,3 +1045,31 @@ class TestLoyalty(TestSaleCouponCommon):
         rewards = order._get_claimable_rewards()[coupon]
         msg = "Only the free product should be applicable, as the discount was already applied."
         self.assertEqual(rewards, product_reward, msg)
+
+    def test_sol_free_product_description_equals_reward_description(self):
+        """
+        Ensure that if a "Free Product" reward is added to a sale order,
+        its line description matches the reward description.
+        """
+        loyalty_program = self.env['loyalty.program'].create(
+            self.env['loyalty.program']._get_template_values()['buy_x_get_y']
+        )
+        reward = loyalty_program.reward_ids[0]
+        updated_description = f"{reward.description} Adding manual description"
+        reward.description = updated_description
+
+        order = self.empty_order
+        order.write({
+            'order_line': [
+                Command.create({
+                    'product_id': reward.reward_product_id.id,
+                    'name': '1 Product',
+                    'product_uom': self.uom_unit.id,
+                    'product_uom_qty': 4.0,
+                }),
+            ]
+        })
+        order.action_open_reward_wizard()
+
+        self.assertEqual(len(order.order_line.ids), 2)
+        self.assertEqual(order.order_line[1].name, updated_description)


### PR DESCRIPTION
Currently, the reward's product name is used as the SOL name 
for the free product, which can be confusing.

**To reproduce this issue:**

1) Install the sale_loyalty module.
2) Create a loyalty program that grants a free product.
3) Manually update the reward's description.
4) Create a SO with a SOL containing that product
5) Apply the reward and observe the behavior.

**Issue / Cause:**

- The free product's description is taken from the reward product's name instead 
of the manually updated description.
- This is incorrect because, in the point of sale, the name is taken from the reward's 
`discount_line_product_id` rather than the `reward_product_ids`.

https://github.com/odoo/odoo/blob/0abdcd9ef6ad3fc932dc0eb46d8aa973b00c34c2/addons/pos_loyalty/static/src/overrides/models/pos_order.js#L1162

**Solution:**
To resolve this inconsistent behavior, the free product name in the sale order line 
will now be taken from discount_line_product_id.

opw-4982774
