### PR TITLE
[IMP] account_edi_ubl_cii: Add Delivery Party under Delivery Information in UBL

### DIFF
--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -264,11 +264,9 @@
                 </cac:Address>
             </cac:DeliveryLocation>
             <cac:DeliveryParty>
-                <cac:Party>
-                    <t t-call="{{PartyType_template}}">
-                        <t t-set="vals" t-value="vals.get('delivery_party_vals', {}).get('party_vals', {})"/>
-                    </t>
-                </cac:Party>
+                <t t-call="{{PartyType_template}}">
+                    <t t-set="vals" t-value="vals.get('delivery_party_vals', {}).get('party_vals', {})"/>
+                </t>
             </cac:DeliveryParty>
         </t>
     </template>

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_a_nz.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_a_nz.py
@@ -38,6 +38,7 @@ class AccountEdiXmlUBLANZ(models.AbstractModel):
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account.edi.xml.ubl_bis3
         vals = super()._get_partner_party_vals(partner, role)
+        vals.setdefault('party_tax_scheme_vals', [])
 
         if partner.country_code == 'AU' and partner.vat:
             vals['endpoint_id'] = partner.vat.replace(" ", "")

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -114,15 +114,30 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account.edi.xml.ubl_21
-        vals = super()._get_partner_party_vals(partner, role)
+        if (
+            role == 'delivery'
+            # If the user hasn't updated the module, we just don't render `DeliveryParty` because the UBL
+            # to avoid generating an invalid UBL.
+            and '<cac:Party>' not in self.env.ref('account_edi_ubl_cii.ubl_20_DeliveryType').arch
+        ):
+            return {
+                'party_vals': {
+                    'party_name_vals': [
+                        {
+                            'name': partner.display_name,
+                        }
+                    ],
+                }
+            }
+        else:
+            vals = super()._get_partner_party_vals(partner, role)
 
-        partner = partner.commercial_partner_id
-        vals.update({
-            'endpoint_id': partner.peppol_endpoint,
-            'endpoint_id_attrs': {'schemeID': partner.peppol_eas},
-        })
-
-        return vals
+            partner = partner.commercial_partner_id
+            vals.update({
+                'endpoint_id': partner.peppol_endpoint,
+                'endpoint_id_attrs': {'schemeID': partner.peppol_eas},
+            })
+            return vals
 
     def _get_partner_party_identification_vals_list(self, partner):
         # EXTENDS account.edi.xml.ubl_21
@@ -163,6 +178,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 'delivery_location_vals': {
                     'delivery_address_vals': self._get_partner_address_vals(partner_shipping),
                 },
+                'delivery_party_vals': self._get_partner_party_vals(invoice.partner_shipping_id, 'delivery') if invoice.partner_shipping_id else {},
             }]
 
         return super()._get_delivery_vals_list(invoice)
@@ -518,18 +534,26 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         invoice = vals['invoice']
         customer = vals['customer']
         supplier = vals['supplier']
+        shipping_partner = vals['partner_shipping']
+
         intracom_delivery = (
             customer.country_id.code in (economic_area := self.env.ref('base.europe').country_ids.mapped('code') + ['NO'])
             and supplier.country_id.code in economic_area
             and supplier.country_id != customer.country_id
         )
-        if intracom_delivery:
-            document_node['cac:Delivery'] = {
-                'cbc:ActualDeliveryDate': {'_text': invoice.invoice_date},
-                'cac:DeliveryLocation': {
-                    'cac:Address': self._get_address_node({'partner': vals['partner_shipping']})
-                },
-            }
+        delivery_date = invoice.invoice_date if intracom_delivery else invoice.delivery_date
+
+        document_node['cac:Delivery'] = {
+            'cbc:ActualDeliveryDate': {'_text': delivery_date},
+            'cac:DeliveryParty': {
+                'cac:PartyName': {
+                    'cbc:Name': {'_text': shipping_partner.name or customer.name},
+                }
+            },
+            'cac:DeliveryLocation': {
+                'cac:Address': self._get_address_node({'partner': shipping_partner})
+            },
+        }
 
     def _add_invoice_payment_means_nodes(self, document_node, vals):
         super()._add_invoice_payment_means_nodes(document_node, vals)

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_dispatch_base_lines_delta.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_dispatch_base_lines_delta.xml
@@ -85,6 +85,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_early_pay_discount_different_taxes.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_early_pay_discount_different_taxes.xml
@@ -88,6 +88,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_early_pay_discount_with_discount_on_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_early_pay_discount_with_discount_on_lines.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_early_pay_discount_with_fixed_tax.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_early_pay_discount_with_fixed_tax.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_financial_account.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_financial_account.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_invoice.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_invoice.xml
@@ -82,6 +82,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_manual_tax_amount_on_invoice.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_manual_tax_amount_on_invoice.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_multiple_fixed_taxes_price_excluded.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_multiple_fixed_taxes_price_excluded.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_price_unit_with_more_decimals.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_price_unit_with_more_decimals.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_product_code_and_barcode.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_product_code_and_barcode.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_single_fixed_tax_price_excluded.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_single_fixed_tax_price_excluded.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_single_fixed_tax_price_excluded_and_discount.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_single_fixed_tax_price_excluded_and_discount.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_single_fixed_tax_price_included.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_single_fixed_tax_price_included.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3/test_taxes_rounding_negative_line_tax_included.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3/test_taxes_rounding_negative_line_tax_included.xml
@@ -85,6 +85,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_example.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_example.xml
@@ -85,6 +85,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice.xml
@@ -95,6 +95,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_refund.xml
@@ -94,6 +94,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case1.xml
@@ -96,6 +96,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case2.xml
@@ -96,6 +96,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case3.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case3.xml
@@ -96,6 +96,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case4.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case4.xml
@@ -96,6 +96,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_export_with_changed_taxes.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_export_with_changed_taxes.xml
@@ -93,6 +93,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice.xml
@@ -94,6 +94,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_cash_rounding_line.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_cash_rounding_line.xml
@@ -98,6 +98,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_cash_rounding_tax.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_cash_rounding_tax.xml
@@ -98,6 +98,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_negative_unit_price.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_negative_unit_price.xml
@@ -98,6 +98,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_1.xml
@@ -94,6 +94,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_public_admin_2.xml
@@ -94,6 +94,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_rounding.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_rounding.xml
@@ -98,6 +98,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+             </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_tax_exempt.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_tax_exempt.xml
@@ -93,6 +93,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
@@ -92,6 +92,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
@@ -98,6 +98,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_discount.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_discount.xml
@@ -95,6 +95,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_ecotax.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term_ecotax.xml
@@ -98,6 +98,11 @@
                 </cac:Country>
             </cac:Address>
         </cac:DeliveryLocation>
+        <cac:DeliveryParty>
+            <cac:PartyName>
+                <cbc:Name>partner_2</cbc:Name>
+            </cac:PartyName>
+        </cac:DeliveryParty>
     </cac:Delivery>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
@@ -98,6 +98,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
@@ -102,6 +102,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode>57</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice.xml
@@ -96,6 +96,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice_without_vat.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_invoice_without_vat.xml
@@ -95,6 +95,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/xrechnung_ubl_out_refund.xml
@@ -95,6 +95,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>

--- a/addons/l10n_anz_ubl_pint/models/account_edi_xml_pint_anz.py
+++ b/addons/l10n_anz_ubl_pint/models/account_edi_xml_pint_anz.py
@@ -27,6 +27,7 @@ class AccountEdiXmlUBLPINTANZ(models.AbstractModel):
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account.edi.xml.ubl_bis3
         vals = super()._get_partner_party_vals(partner, role)
+        vals.setdefault('party_tax_scheme_vals', [])
 
         for party_tax_scheme in vals['party_tax_scheme_vals']:
             party_tax_scheme['tax_scheme_vals'] = {'id': 'GST'}

--- a/addons/l10n_anz_ubl_pint/tests/expected_xmls/invoice.xml
+++ b/addons/l10n_anz_ubl_pint/tests/expected_xmls/invoice.xml
@@ -85,6 +85,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>

--- a/addons/l10n_jp_ubl_pint/tests/expected_xmls/invoice.xml
+++ b/addons/l10n_jp_ubl_pint/tests/expected_xmls/invoice.xml
@@ -87,6 +87,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>

--- a/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes.xml
+++ b/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes.xml
@@ -85,6 +85,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>

--- a/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_with_sst.xml
+++ b/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_with_sst.xml
@@ -86,6 +86,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
@@ -96,6 +96,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>Roasted Romanian Roller</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
@@ -96,6 +96,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>Roasted Romanian Roller</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
@@ -96,6 +96,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>Roasted Romanian Roller</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
@@ -96,6 +96,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>Roasted Romanian Roller</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund_negative_quantity.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund_negative_quantity.xml
@@ -96,6 +96,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>Roasted Romanian Roller</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="standing agreement">57</cbc:PaymentMeansCode>

--- a/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
+++ b/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
@@ -29,6 +29,7 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
     def _get_partner_party_vals(self, partner, role):
         # EXTENDS account_edi_ubl_cii
         vals = super()._get_partner_party_vals(partner, role)
+        vals.setdefault('party_tax_scheme_vals', [])
 
         for party_tax_scheme in vals['party_tax_scheme_vals']:
             party_tax_scheme['tax_scheme_vals'] = {'id': 'GST'}

--- a/addons/l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml
+++ b/addons/l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml
@@ -92,6 +92,11 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:DeliveryParty>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+    </cac:DeliveryParty>
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>


### PR DESCRIPTION
Previously, the Peppol UBL export only covered the mandatory delivery fields and did not include the `delivery party`. This commit adds the `<cac:DeliveryParty>` element under `<cac:Delivery>` to improve the exported information.
- Include `<cac:DeliveryParty>` in the `<cac:Delivery>` section of UBL invoices.
- Use the shipping partner name if set; otherwise, fallback to the customer name
- Keep existing `<cac:DeliveryLocation>` and delivery date logic unchanged.
<img width="766" height="306" alt="image" src="https://github.com/user-attachments/assets/d07c1b37-4c6d-42d1-99b4-66c5abc8e298" />

-----
task-5022404

