### PR TITLE
[FIX] l10n_ro_edi: fix invalid field in test case for ubl_ro xml

### DIFF
--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -118,7 +118,6 @@ class TestUBLRO(TestUBLCommon):
                     'quantity': 1.0,
                     'price_unit': 600.0,
                     'tax_ids': [Command.set(self.tax_19.ids)],
-                    'is_downpayment': True,
                 }
             ]
         )


### PR DESCRIPTION
Test case test_export_credit_note_with_negative_quantity in TestUBLRO is failing because it's using "is_downpayment" field when creating move line, which is part of the sales app that isn't installed when doing the single app test for l10n_ro_edi.

The field "is_downpayment" isn't needed for the test case, and the test is functioning fine without it, as the payment can be created as a regular payment without affecting the test flow; hence, it's removed.

build_error-231170