### PR TITLE
[IMP] account: partner follow-up UX improvements

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -185,7 +185,7 @@
                     <field name="discount_date" string="Discount Date" optional="hide" />
                     <field name="discount_amount_currency" string="Discount Amount" optional="hide" />
                     <field name="tax_line_id" string="Originator Tax" optional="hide" readonly="1"/>
-                    <field name="date_maturity" readonly="1" optional="hide"/>
+                    <field name="date_maturity" readonly="1" optional="hide" decoration-danger="not reconciled and date_maturity &lt; context_today().strftime('%Y-%m-%d')"/>
                     <field name="balance" sum="Total Balance" optional="hide" readonly="1"/>
                     <field name="matching_number" string="Matching" readonly="1" optional="show"/>
                     <field name="amount_residual" sum="Total Residual" string="Residual" optional="hide" readonly="1" invisible="not is_account_reconcile"/>


### PR DESCRIPTION
Current behavior before PR:
In the Journal Items list view, all entries show their due date (date_maturity) in the same way. Even if the due date has already passed and the item is not reconciled, there is no highlight to warn the user.

Desired behavior after PR is merged:
After this change, the Journal Items list view will show the due date (date_maturity) in red (decoration-danger) when the due date is earlier than today and the item is not reconciled. This makes it easier for users to quickly see which journal items are overdue.

Enterprise PR: https://github.com/odoo/enterprise/pull/92877
task-5026396

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr