### PR TITLE
[FIX] l10n_tr_nilvera, l10n_tr_nilvera_einvoice: remove redundant data

### DIFF
--- a/addons/l10n_tr_nilvera/i18n/l10n_tr_nilvera.pot
+++ b/addons/l10n_tr_nilvera/i18n/l10n_tr_nilvera.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-28 16:01+0000\n"
-"PO-Revision-Date: 2025-03-28 16:01+0000\n"
+"POT-Creation-Date: 2025-08-22 11:17+0000\n"
+"PO-Revision-Date: 2025-08-22 11:17+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -43,7 +43,6 @@ msgstr ""
 #. module: l10n_tr_nilvera
 #. odoo-python
 #: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
-#, python-format
 msgid "An error occurred. Try again later."
 msgstr ""
 
@@ -133,12 +132,6 @@ msgid "Environment"
 msgstr ""
 
 #. module: l10n_tr_nilvera
-#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_partner__ubl_cii_format
-#: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_users__ubl_cii_format
-msgid "Format"
-msgstr ""
-
-#. module: l10n_tr_nilvera
 #: model:uom.uom,name:l10n_tr_nilvera.product_uom_gt
 msgid "Gross Ton"
 msgstr ""
@@ -220,6 +213,11 @@ msgid "Name"
 msgstr ""
 
 #. module: l10n_tr_nilvera
+#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera.res_config_settings_view_form
+msgid "Nilvera"
+msgstr ""
+
+#. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_account_journal__l10n_tr_nilvera_api_key
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_company__l10n_tr_nilvera_api_key
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_config_settings__l10n_tr_nilvera_api_key
@@ -252,7 +250,6 @@ msgstr ""
 #. module: l10n_tr_nilvera
 #. odoo-python
 #: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
-#, python-format
 msgid ""
 "Nilvera connection successful but the tax number on Nilvera and Odoo doesn't"
 " match. Check Nilvera."
@@ -261,14 +258,12 @@ msgstr ""
 #. module: l10n_tr_nilvera
 #. odoo-python
 #: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
-#, python-format
 msgid "Nilvera connection successful!"
 msgstr ""
 
 #. module: l10n_tr_nilvera
 #. odoo-python
 #: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
-#, python-format
 msgid "Nilvera connection was unsuccessful, check the API key."
 msgstr ""
 
@@ -308,6 +303,11 @@ msgid "Partner"
 msgstr ""
 
 #. module: l10n_tr_nilvera
+#: model:ir.model,name:l10n_tr_nilvera.model_uom_uom
+msgid "Product Unit of Measure"
+msgstr ""
+
+#. module: l10n_tr_nilvera
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera.selection__res_company__l10n_tr_nilvera_environment__production
 msgid "Production"
 msgstr ""
@@ -338,8 +338,8 @@ msgid "Test"
 msgstr ""
 
 #. module: l10n_tr_nilvera
-#: model:ir.model.fields.selection,name:l10n_tr_nilvera.selection__res_partner__ubl_cii_format__ubl_tr
-msgid "UBL TR 1.2"
+#: model:ir.model.fields.selection,name:l10n_tr_nilvera.selection__res_partner__invoice_edi_format__ubl_tr
+msgid "Türkiye (UBL TR 1.2)"
 msgstr ""
 
 #. module: l10n_tr_nilvera

--- a/addons/l10n_tr_nilvera/i18n/tr.po
+++ b/addons/l10n_tr_nilvera/i18n/tr.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-28 16:01+0000\n"
-"PO-Revision-Date: 2025-03-28 16:01+0000\n"
+"POT-Creation-Date: 2025-08-22 11:34+0000\n"
+"PO-Revision-Date: 2025-08-22 11:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -47,7 +47,6 @@ msgstr "Takma ad"
 #. module: l10n_tr_nilvera
 #. odoo-python
 #: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
-#, python-format
 msgid "An error occurred. Try again later."
 msgstr "Bir hata oluştu. Daha sonra tekrar deneyin."
 
@@ -224,6 +223,11 @@ msgid "Name"
 msgstr "İsim"
 
 #. module: l10n_tr_nilvera
+#: model_terms:ir.ui.view,arch_db:l10n_tr_nilvera.res_config_settings_view_form
+msgid "Nilvera"
+msgstr ""
+
+#. module: l10n_tr_nilvera
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_account_journal__l10n_tr_nilvera_api_key
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_company__l10n_tr_nilvera_api_key
 #: model:ir.model.fields,field_description:l10n_tr_nilvera.field_res_config_settings__l10n_tr_nilvera_api_key
@@ -256,7 +260,6 @@ msgstr "Nilvera Durumu"
 #. module: l10n_tr_nilvera
 #. odoo-python
 #: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
-#, python-format
 msgid ""
 "Nilvera connection successful but the tax number on Nilvera and Odoo doesn't"
 " match. Check Nilvera."
@@ -267,14 +270,12 @@ msgstr ""
 #. module: l10n_tr_nilvera
 #. odoo-python
 #: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
-#, python-format
 msgid "Nilvera connection successful!"
 msgstr "Nilvera bağlantısı başarılı!"
 
 #. module: l10n_tr_nilvera
 #. odoo-python
 #: code:addons/l10n_tr_nilvera/models/res_config_settings.py:0
-#, python-format
 msgid "Nilvera connection was unsuccessful, check the API key."
 msgstr "Nilvera bağlantısı başarısız oldu, API anahtarını kontrol edin."
 
@@ -314,6 +315,11 @@ msgid "Partner"
 msgstr "Ortak"
 
 #. module: l10n_tr_nilvera
+#: model:ir.model,name:l10n_tr_nilvera.model_uom_uom
+msgid "Product Unit of Measure"
+msgstr "Ürün Ölçü Birimi"
+
+#. module: l10n_tr_nilvera
 #: model:ir.model.fields.selection,name:l10n_tr_nilvera.selection__res_company__l10n_tr_nilvera_environment__production
 msgid "Production"
 msgstr "Üretim"
@@ -344,8 +350,8 @@ msgid "Test"
 msgstr ""
 
 #. module: l10n_tr_nilvera
-#: model:ir.model.fields.selection,name:l10n_tr_nilvera.selection__res_partner__ubl_cii_format__ubl_tr
-msgid "UBL TR 1.2"
+#: model:ir.model.fields.selection,name:l10n_tr_nilvera.selection__res_partner__invoice_edi_format__ubl_tr
+msgid "Türkiye (UBL TR 1.2)"
 msgstr ""
 
 #. module: l10n_tr_nilvera

--- a/addons/l10n_tr_nilvera/models/res_partner.py
+++ b/addons/l10n_tr_nilvera/models/res_partner.py
@@ -13,7 +13,7 @@ class ResPartner(models.Model):
     _name = 'res.partner'
     _inherit = ['res.partner']
 
-    invoice_edi_format = fields.Selection(selection_add=[('ubl_tr', "Turkyie (UBL TR 1.2)")])
+    invoice_edi_format = fields.Selection(selection_add=[('ubl_tr', "Türkiye (UBL TR 1.2)")])
     l10n_tr_nilvera_customer_status = fields.Selection(
         selection=[
             ('not_checked', "Not Checked"),

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -117,14 +117,29 @@ class AccountEdiXmlUblTr(models.AbstractModel):
 
     def _get_partner_party_tax_scheme_vals_list(self, partner, role):
         # EXTENDS account.edi.xml.ubl_21
+        # Cleans the PartyTaxScheme node values for Turkey (TR).
+        #
+        # Expected XML structure:
+        # <cac:PartyTaxScheme t-foreach="vals.get('party_tax_scheme_vals', [])" t-as="foreach_vals">
+        #     <cac:TaxScheme>
+        #         <cbc:Name>TAX OFFICE NAME</cbc:Name>
+        #     </cac:TaxScheme>
+        # </cac:PartyTaxScheme>
+        #
+        # Note: Adding any extra nodes may cause blocking validation errors on Nilvera's side
+        # when tax office is not set on E-Archive Invoice.
+
         vals_list = super()._get_partner_party_tax_scheme_vals_list(partner, role)
         for vals in vals_list:
             vals.pop('registration_address_vals', None)
+            vals.pop('registration_name', None)
+            vals.pop('company_id', None)
+            vals.pop('tax_level_code', None)
             vals["tax_scheme_vals"].update(
                 {
                     "id": "",
                     "name": partner.ref,
-                }
+                },
             )
         return vals_list
 

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive.xml
@@ -40,8 +40,6 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-        <cbc:CompanyID>3297552117</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:Name>Ulus</cbc:Name>
         </cac:TaxScheme>
@@ -64,7 +62,7 @@
         <cbc:ID schemeID="TCKN">17291716060</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
-        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Name>earchive_partner</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
@@ -76,26 +74,19 @@
           <cbc:Name>Türkiye</cbc:Name>
         </cac:Country>
       </cac:PostalAddress>
-      <cac:PartyTaxScheme>
-        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>17291716060</cbc:CompanyID>
-        <cac:TaxScheme>
-          <cbc:Name>Ulus</cbc:Name>
-        </cac:TaxScheme>
-      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:RegistrationName>earchive_partner</cbc:RegistrationName>
         <cbc:CompanyID>17291716060</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Name>earchive_partner</cbc:Name>
         <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
         <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
       </cac:Contact>
       <cac:Person>
-        <cbc:FirstName>partner_1</cbc:FirstName>
-        <cbc:FamilyName>​</cbc:FamilyName>
+        <cbc:FirstName>earchive_partner</cbc:FirstName>
+        <cbc:FamilyName>___ignore___</cbc:FamilyName>
       </cac:Person>
     </cac:Party>
   </cac:AccountingCustomerParty>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml
@@ -43,8 +43,6 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-        <cbc:CompanyID>3297552117</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:Name>Ulus</cbc:Name>
         </cac:TaxScheme>
@@ -67,7 +65,7 @@
         <cbc:ID schemeID="TCKN">17291716060</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
-        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Name>earchive_partner</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
@@ -79,26 +77,19 @@
           <cbc:Name>Türkiye</cbc:Name>
         </cac:Country>
       </cac:PostalAddress>
-      <cac:PartyTaxScheme>
-        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>17291716060</cbc:CompanyID>
-        <cac:TaxScheme>
-          <cbc:Name>Ulus</cbc:Name>
-        </cac:TaxScheme>
-      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:RegistrationName>earchive_partner</cbc:RegistrationName>
         <cbc:CompanyID>17291716060</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Name>earchive_partner</cbc:Name>
         <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
         <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
       </cac:Contact>
       <cac:Person>
-        <cbc:FirstName>partner_1</cbc:FirstName>
-        <cbc:FamilyName>​</cbc:FamilyName>
+        <cbc:FirstName>earchive_partner</cbc:FirstName>
+        <cbc:FamilyName>___ignore___</cbc:FamilyName>
       </cac:Person>
     </cac:Party>
   </cac:AccountingCustomerParty>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice.xml
@@ -35,8 +35,6 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-        <cbc:CompanyID>3297552117</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:Name>Ulus</cbc:Name>
         </cac:TaxScheme>
@@ -56,10 +54,10 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="TCKN">17291716060</cbc:ID>
+        <cbc:ID schemeID="TCKN">1729171602</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
-        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Name>einvoice_partner</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
@@ -72,25 +70,23 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>17291716060</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:Name>Ulus</cbc:Name>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>17291716060</cbc:CompanyID>
+        <cbc:RegistrationName>einvoice_partner</cbc:RegistrationName>
+        <cbc:CompanyID>1729171602</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Name>einvoice_partner</cbc:Name>
         <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
         <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
       </cac:Contact>
       <cac:Person>
-        <cbc:FirstName>partner_1</cbc:FirstName>
-        <cbc:FamilyName>​</cbc:FamilyName>
+        <cbc:FirstName>einvoice_partner</cbc:FirstName>
+        <cbc:FamilyName>___ignore___</cbc:FamilyName>
       </cac:Person>
     </cac:Party>
   </cac:AccountingCustomerParty>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice_multicurrency.xml
@@ -38,8 +38,6 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-        <cbc:CompanyID>3297552117</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:Name>Ulus</cbc:Name>
         </cac:TaxScheme>
@@ -59,10 +57,10 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="TCKN">17291716060</cbc:ID>
+        <cbc:ID schemeID="TCKN">1729171602</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
-        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Name>einvoice_partner</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
         <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
@@ -75,25 +73,23 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>17291716060</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:Name>Ulus</cbc:Name>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>17291716060</cbc:CompanyID>
+        <cbc:RegistrationName>einvoice_partner</cbc:RegistrationName>
+        <cbc:CompanyID>1729171602</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:ID>___ignore___</cbc:ID>
-        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Name>einvoice_partner</cbc:Name>
         <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
         <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
       </cac:Contact>
       <cac:Person>
-        <cbc:FirstName>partner_1</cbc:FirstName>
-        <cbc:FamilyName>​</cbc:FamilyName>
+        <cbc:FirstName>einvoice_partner</cbc:FirstName>
+        <cbc:FamilyName>___ignore___</cbc:FamilyName>
       </cac:Person>
     </cac:Party>
   </cac:AccountingCustomerParty>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
Nilvera rejects E-Archive invoices if extra fields are present under
`PartyTaxScheme` when no tax office is set. In addition, the
`invoice_edi_format` selection name for TR was incorrect.  

### Current behavior before PR:
When generating E-Archive invoices, Odoo includes extra nodes such as
`registration_address_vals`, `registration_name`, and `company_id`
under the `PartyTaxScheme` element. Nilvera’s validation fails if
these nodes are present while no tax office is configured. At the same
time, the TR value for `invoice_edi_format` was using the wrong name,
which caused inconsistencies. These issues result in blocking
validation errors on Nilvera’s side and prevent the invoices from
being accepted.  

### Desired behavior after PR is merged:
After this fix, the `PartyTaxScheme` is cleaned up only to include the
expected XML structure:

```xml
<cac:PartyTaxScheme>
    <cac:TaxScheme>
        <cbc:Name>TAX OFFICE NAME</cbc:Name>
    </cac:TaxScheme>
</cac:PartyTaxScheme>
```
And the invoice_edi_format selection name for TR will be corrected
to display Türkiye rather than Turkyie.

task-5017223
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
