### PR TITLE
[FIX] web: enable select from SelectCreateDialog when grouped with domain selection

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -186,12 +186,9 @@ export class ListController extends Component {
 
         useEffect(
             () => {
-                if (this.props.onSelectionChanged) {
-                    const resIds = this.model.root.selection.map((record) => record.resId);
-                    this.props.onSelectionChanged(resIds);
-                }
+                this.onSelectionChanged();
             },
-            () => [this.model.root.selection.length]
+            () => [this.model.root.selection.length, this.model.root.isDomainSelected]
         );
         this.searchBarToggler = useSearchBarToggler();
         this.firstLoad = true;
@@ -260,6 +257,13 @@ export class ListController extends Component {
      * @param {Record} record
      */
     async onRecordSaved(record) {}
+
+    async onSelectionChanged() {
+        if (this.props.onSelectionChanged) {
+            const resIds = await this.model.root.getResIds(true);
+            this.props.onSelectionChanged(resIds);
+        }
+    }
 
     /**
      * onWillSaveRecord is a callBack that will be executed before the
@@ -431,10 +435,6 @@ export class ListController extends Component {
 
     async onSelectDomain() {
         await this.model.root.selectDomain(true);
-        if (this.props.onSelectionChanged) {
-            const resIds = await this.model.root.getResIds(true);
-            this.props.onSelectionChanged(resIds);
-        }
     }
 
     onUnselectAll() {

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -536,3 +536,34 @@ test("SelectCreateDialog with open action", async () => {
     expect("input").toHaveValue("Instrument 10");
     expect.verifySteps([]);
 });
+
+test("SelectCreateDialog: enable select when grouped with domain selection", async () => {
+    Partner._views["list"] = `
+        <list string="Partner">
+            <field name="name"/>
+            <field name="foo"/>
+        </list>
+    `;
+    Partner._views["search"] = `
+        <search>
+            <group expand="0" string="Group By">
+                <filter name="groupby_bar" context="{'group_by' : 'bar'}"/>
+            </group>
+        </search>
+    `;
+
+    await mountWithCleanup(WebClient);
+    getService("dialog").add(SelectCreateDialog, {
+        noCreate: true,
+        resModel: "partner",
+        domain: [["name", "like", "a"]],
+        context: {
+            search_default_groupby_bar: true,
+        },
+    });
+    await animationFrame();
+    await contains("thead .o_list_record_selector input").click();
+
+    await animationFrame();
+    expect(".o_select_button:not([disabled])").toHaveCount(1);
+});


### PR DESCRIPTION
Steps to reproduce
==================

- Enable debug
- Go to Settings / User & Companies / Groups
- Open a record
- Switch to the Views notebook tab
- Add a line
- Group by Model
- Click on the o_list_record_selector checkbox

=> The Select button is disabled

Cause of the issue
==================

The list_controller onSelectionChanged props is only called when we select records manually, but not when using the domain selection

Solution
========

Backport part of
https://github.com/odoo/odoo/commit/1d761ac90d027f1448381391104d20f0e1693407

This calls the onSelectionChanged when this.model.root.isDomainSelected changes

opw-4856528