### PR TITLE
[FIX] html_builder: fix broken `s_popup` preview

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_viewer.scss
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.scss
@@ -51,10 +51,8 @@
             .o_half_screen_height {
                 aspect-ratio: 8 / 3;
             }
-            > [data-snippet] {
+            [inert="inert"] > [data-snippet] {
                 isolation: isolate;
-                pointer-events: none;
-                user-select: none;
 
                 &[data-snippet="s_text_block"] {
                     font-size: 1.6rem;


### PR DESCRIPTION
This PR fixes an issue related to the specific style applied to the popup snippets within the snippet viewer modal.

With Commit [^1], an extra container was added to the structure of the snippet viewer modal items. While this does not cause any issues at first glance, it removes some specific styling that was applied to snippets that were direct children of .o_snippet_preview_wrap.

Since this condition can no longer be matched, the styling was never applied. In the case of the popup snippets, this caused the snippet to be invisible.

This PR updates the selector to include the new div, ensuring that it matches the updated DOM structure.

[^1]: [9ae02d80894d4043e49d8e2cad068f8018e6f113](https://github.com/odoo/odoo/commit/9ae02d80894d4043e49d8e2cad068f8018e6f113)

task-5031664

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
