### PR TITLE
[FIX] event: ensure QR code in email template takes proper height

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -278,7 +278,8 @@
                 </td><td valign="middle" align="right">
                     <t t-if="object.barcode"> 
                         <div style="margin-bottom: 5px;">
-                            <img t-attf-src="/report/barcode/QR/{{object.barcode}}?&amp;width=100&amp;height=100&amp;quiet=0" width="100" height="100" alt="QR Code"/>
+                            <img t-attf-src="/report/barcode/QR/{{object.barcode}}?&amp;width=100&amp;height=100&amp;quiet=0" width="100" height="100" alt="QR Code"
+                            t-att-style="'height: 100px !important;'"/>
                         </div>
                     </t>
                     <t t-if="not object.company_id.uses_default_logo">
@@ -534,7 +535,8 @@
                 </td><td valign="middle" align="right">
                     <t t-if="object.barcode">
                         <div style="margin-bottom: 5px;">
-                            <img t-attf-src="/report/barcode/QR/{{object.barcode}}?&amp;width=100&amp;height=100&amp;quiet=0" width="100" height="100" alt="QR Code"/>
+                            <img t-attf-src="/report/barcode/QR/{{object.barcode}}?&amp;width=100&amp;height=100&amp;quiet=0" width="100" height="100" alt="QR Code"
+                            t-att-style="'height: 100px !important;'"/>
                         </div>
                     </t>
                     <t t-if="not object.company_id.uses_default_logo">


### PR DESCRIPTION
### Steps to reproduce:
1. Set up an event registration with atleast 1 attendee.
2. Go to email templates and search for "Event: Registration Confirmation". (or any with QR code in it)
3. Check the preview of the email template.
4. Edit any text inside the template and check the Preview again. (QR code stop taking the proper height)

### Issue: 
During the rendering of the email template, the QR code image html is changing provoking the QR to not have the proper aspect ratio and look stretched.

### Fix: 
We can make sure we're always taking the 100% height of the container by adding a style attribute to the image tag, thus not losing the aspect ratio of the QR code.

opw-4976893