### PR TITLE
[IMP] base: ir_ui_view: auto add filename to arch when binary requests

### DIFF
--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -1066,6 +1066,8 @@ class TestOrmModel_Binary(models.Model):
     _description = 'Test Image field'
 
     binary = fields.Binary()
+    binary_x_filename = fields.Char()
+    binary_x_filename2 = fields.Char()
     binary_related_store = fields.Binary("Binary Related Store", related='binary', store=True, readonly=False)
     binary_related_no_store = fields.Binary("Binary Related No Store", related='binary', store=False, readonly=False)
     binary_computed = fields.Binary(compute='_compute_binary')


### PR DESCRIPTION
A binary field can be included specifying the other field that holds its filename
```
<field name="binary_field" filename="other_field" />
```

Before this commit it was necessary to also put the filename field in the arch.

After this commit, the algorithm that automaticall adds field is leveraged. It is not necessary anymore to explicitly include the filename field in the arch

part-of-task-4991201

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
