### PR TITLE
[FIX] html_builder: not change id when enabling/disabling a list entry

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -176,8 +176,8 @@ export class BuilderList extends Component {
     handleValueChange(targetInputEl, commitToHistory) {
         const id = targetInputEl.dataset.id;
         const propertyName = targetInputEl.name;
-        const value =
-            targetInputEl.type === "checkbox" ? targetInputEl.checked : targetInputEl.value;
+        const isCheckbox = targetInputEl.type === "checkbox";
+        const value = isCheckbox ? targetInputEl.checked : targetInputEl.value;
 
         const items = this.formatRawValue(this.state.value);
         if (value === true && this.props.itemShape[propertyName] === "exclusive_boolean") {
@@ -187,7 +187,9 @@ export class BuilderList extends Component {
         }
         const item = items.find((item) => item._id === id);
         item[propertyName] = value;
-        item.id = isSmallInteger(value) ? parseInt(value) : value;
+        if (!isCheckbox) {
+            item.id = isSmallInteger(value) ? parseInt(value) : value;
+        }
 
         if (commitToHistory) {
             this.commit(items);

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_list.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_list.test.js
@@ -248,3 +248,85 @@ test("hides hiddenProperties from options", async () => {
         ])
     );
 });
+
+test("do not lose id when adjusting 'selected'", async () => {
+    class Test extends Component {
+        static template = xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                addItemTitle="'Add'"
+                itemShape="{ display_name: 'text', selected: 'boolean' }"
+                default="{ display_name: 'Extra', selected: false }"
+                records="availableRecords" />`;
+        static components = { BuilderList };
+        static props = ["*"];
+        setup() {
+            this.availableRecords = JSON.stringify([
+                { id: 1, display_name: "A" },
+                { id: 2, display_name: "B" },
+            ]);
+        }
+    }
+    addOption({
+        selector: ".test-options-target",
+        Component: Test,
+    });
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await contains(":iframe .test-options-target").click();
+
+    await contains(".we-bg-options-container .bl-dropdown-toggle").click();
+    await contains(".o_popover .o-hb-select-dropdown-item").click();
+    await contains(".we-bg-options-container .bl-dropdown-toggle").click();
+    await contains(".o_popover .o-hb-select-dropdown-item").click();
+    expect(":iframe .test-options-target").toHaveAttribute(
+        "data-list",
+        JSON.stringify([
+            {
+                id: 1,
+                display_name: "A",
+                _id: "0",
+            },
+            {
+                id: 2,
+                display_name: "B",
+                _id: "1",
+            },
+        ])
+    );
+
+    await contains(".we-bg-options-container .o-hb-checkbox input").click();
+    expect(":iframe .test-options-target").toHaveAttribute(
+        "data-list",
+        JSON.stringify([
+            {
+                id: 1,
+                display_name: "A",
+                _id: "0",
+                selected: true,
+            },
+            {
+                id: 2,
+                display_name: "B",
+                _id: "1",
+            },
+        ])
+    );
+
+    await contains(".we-bg-options-container .o-hb-checkbox input").click();
+    expect(":iframe .test-options-target").toHaveAttribute(
+        "data-list",
+        JSON.stringify([
+            {
+                id: 1,
+                display_name: "A",
+                _id: "0",
+                selected: false,
+            },
+            {
+                id: 2,
+                display_name: "B",
+                _id: "1",
+            },
+        ])
+    );
+});


### PR DESCRIPTION
Since [1] the id of list items is lost when clicking on the enable/disable value of builder list.

This commit only updates the id when an actual value is modified.

Steps to reproduce:
- Install website_mass_mailing
- Drop a form
- Add a field for "Mass Mailing"
- No new option can be added, as expected
- Un-default the first value

=> That value could then be added again, and the option value that contained the record id was lost inside the form.

[1]: https://github.com/odoo/odoo/commit/db8be44e1361898af659a28b488b2288ff5b66fc

task-4367641
