### PR TITLE
[FIX] base: parse `.eml` attachments as Message

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -14,6 +14,7 @@ import smtplib
 import ssl
 import sys
 import threading
+from email.parser import BytesParser
 
 from socket import gaierror, timeout
 from OpenSSL import crypto as SSLCrypto
@@ -540,8 +541,7 @@ class IrMailServer(models.Model):
             for (fname, fcontent, mime) in attachments:
                 maintype, subtype = mime.split('/') if mime and '/' in mime else ('application', 'octet-stream')
                 if maintype == 'message' and subtype == 'rfc822':
-                    #  Use binary encoding for "message/rfc822" attachments (see RFC 2046 Section 5.2.1)
-                    msg.add_attachment(fcontent, maintype, subtype, filename=fname, cte='binary')
+                    msg.add_attachment(BytesParser().parsebytes(fcontent), filename=fname)
                 else:
                     msg.add_attachment(fcontent, maintype, subtype, filename=fname)
         return msg

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -463,7 +463,7 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
                 )
 
     def test_eml_attachment_encoding(self):
-        """Test that message/rfc822 attachments are encoded using 7bit, 8bit, or binary encoding."""
+        """Test that message/rfc822 attachments are encoded using 7bit, 8bit, or binary encoding per RFC."""
         IrMailServer = self.env['ir.mail_server']
 
         # Create a sample .eml file content
@@ -479,12 +479,43 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
             attachments=attachments,
         )
 
-        # Verify that the attachment is correctly encoded
         acceptable_encodings = {'7bit', '8bit', 'binary'}
+        found_rfc822_part = False
+
         for part in message.iter_attachments():
             if part.get_content_type() == 'message/rfc822':
+                found_rfc822_part = True
+                # Get Content-Transfer-Encoding, defaulting to '7bit' if not present (per RFC)
+                encoding = part.get('Content-Transfer-Encoding', '7bit').lower()
+
                 self.assertIn(
-                    part.get('Content-Transfer-Encoding'),
+                    encoding,
                     acceptable_encodings,
-                    "The message/rfc822 attachment should be encoded using 7bit, 8bit, or binary encoding.",
+                    f"RFC violation: message/rfc822 attachment has Content-Transfer-Encoding '{encoding}'. "
+                    f"Only 7bit, 8bit, or binary encoding is permitted per RFC 2046 Section 5.2.1."
                 )
+
+        self.assertTrue(found_rfc822_part, "No message/rfc822 attachment found in the built email")
+
+    def test_eml_message_serialization_with_non_ascii(self):
+        """Ensure an email with a message/rfc822 attachment containing non-ASCII chars can be serialized."""
+        IrMailServer = self.env['ir.mail_server']
+
+        # .eml content with non-ASCII character
+        eml_content = "From: user@example.com\nTo: user2@example.com\nSubject: Test\n\nBody with é"
+        attachments = [('test.eml', eml_content.encode(), 'message/rfc822')]
+
+        message = IrMailServer.build_email(
+            email_from='john.doe@from.example.com',
+            email_to='destinataire@to.example.com',
+            subject='Serialization test',
+            body='This email contains a .eml attachment.',
+            attachments=attachments,
+        )
+
+        try:
+            serialized = message.as_string().encode('utf-8')
+        except UnicodeEncodeError as e:
+            raise AssertionError("Email with non-ASCII .eml attachment could not be serialized") from e
+
+        self.assertIsInstance(serialized, bytes)


### PR DESCRIPTION

The previous fix for `message/rfc822` attachments forced binary encoding (`cte='binary'`) to comply with RFC 2046. However it also introduced a new issue: emails containing `.eml` attachments with non-ASCII characters could not be serialized

### Steps to reproduce

1. Send an email via the chatter with a `.eml` file attached containing non-ASCII characters (e.g., "é") in its body.

The sending of that email will fail with a `UnicodeEncodeError` error

### Cause

Commit 6197233ef1611ddd974cfdb06ae2568e4af369de attempted to fix an issue where `.eml` (`message/rfc822`) attachments were not RFC-compliant. It did this by forcing the `Content-Transfer-Encoding` to `binary` for the raw byte content of the attachment.

While this worked for simple ASCII attachments, it failed for attachments containing non-ASCII characters. When Python's `email` library later tried to serialize the entire message, it treated the attachment's content as an opaque binary blob. It did not understand the character encoding within that blob, leading to a `UnicodeEncodeError` during the final serialization process.

### Fix

Instead of attaching the raw bytes, we now:
* Parse `.eml` contents using `email.parser.BytesParser`, producing a proper `Message` object.
* Attach the parsed message directly, letting the email library handle correct encoding and transfer settings automatically.

opw-4655868