### PR TITLE
[FIX] mrp: reference correct dest move for split backorders

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1162,7 +1162,7 @@ class MrpProduction(models.Model):
             'origin': self.product_id.partner_ref,
             'group_id': self.procurement_group_id.id,
             'propagate_cancel': self.propagate_cancel,
-            'move_dest_ids': [(4, x.id) for x in self.move_dest_ids if not byproduct_id],
+            'move_dest_ids': [(4, x.id) for x in move_dest_ids if not byproduct_id],
             'cost_share': cost_share,
         }
 

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2719,3 +2719,42 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         # is linked to all moves (this is a known limitation).
         self.assertEqual(exchange_picking.move_ids.bom_line_id, self.bom_kit_1.bom_line_ids[0], "All moves in the exchange picking should be linked to the first BOM line.")
         self.assertEqual(exchange_picking.move_ids.quantity, 2)
+
+    def test_delivery_after_splitting_production(self):
+        """
+        Test that processing the different MOs of a split production correctly
+        updates the picking SM's quantity.
+        """
+        # Set product up with MTO + Manufacture with (empty) BoM
+        product = self._cls_create_product('Split Product', self.uom_unit, routes=[
+            self.company_data['default_warehouse'].mto_pull_id.route_id,
+            self.company_data['default_warehouse'].manufacture_pull_id.route_id,
+        ])
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'product_uom_id': self.env.ref('uom.product_uom_unit').id,
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'name': f"2 of {self.product.name}",
+                'product_id': product.id,
+                'product_uom_qty': 2,
+                'product_uom': product.uom_id.id,
+            })],
+        })
+        sale_order.action_confirm()
+        sale_picking = sale_order.picking_ids
+        self.assertTrue(sale_picking)
+
+        mo = self.env['mrp.production'].search([('product_id', '=', product.id)], limit=1)
+        Form.from_action(self.env, mo.action_split()).save().action_split()
+        self.assertEqual(len(mo.backorder_ids), 2)
+
+        mo.backorder_ids[0].button_mark_done()
+        self.assertEqual(sale_picking.move_ids.quantity, 1)
+        mo.backorder_ids[1].button_mark_done()
+        self.assertEqual(sale_picking.move_ids.quantity, 2)
+        sale_picking.button_validate()
+        self.assertEqual(sale_order.order_line.qty_delivered, 2.0)


### PR DESCRIPTION
Issue
-----
After splitting a MO, the linked delivery's quantity only gets updated when the original MO is validated. Validating the backorder MOs doesn't affect the shown quantity.

Steps to reproduce
-----
- Unarchive MTO route
- Create a stored product
	- Routes MTO & Manufacturing
	- Empty BoM
- Create a Sale Order for 3 units of the product & confirm it
- Go to the linked MO and split it in 2 (quants of 1 and 2)
- Confirm both MOs (and produce)
- Go to the sale's delivery
> The delivery's move only shows 1 unit of the product

Why the move quantity is only 1
-----
After confirming the first of the 2 backorder productions, when we manufacture the product, we go through

https://github.com/odoo/odoo/blob/e6b87a2a37b4550faf60a77981c533d19aa054d4/addons/mrp/models/mrp_production.py#L2054

Since the first backorder kept the existing move, it has the delivery move in `move_dest_ids` so we do

https://github.com/odoo/odoo/blob/e6b87a2a37b4550faf60a77981c533d19aa054d4/addons/stock/models/stock_move.py#L2088-L2091

Which creates a SML for the delivery move when reserving it

https://github.com/odoo/odoo/blob/e6b87a2a37b4550faf60a77981c533d19aa054d4/addons/stock/models/stock_move.py#L1853-L1858

https://github.com/odoo/odoo/blob/e6b87a2a37b4550faf60a77981c533d19aa054d4/addons/stock/models/stock_move.py#L1950-L1971

This in turn triggers the computation of the move's quantity since it depends on the move's lines

https://github.com/odoo/odoo/blob/e6b87a2a37b4550faf60a77981c533d19aa054d4/addons/stock/models/stock_move.py#L382-L383

Our move ends up with a quantity of 1.

When we proceed with the second MO, things are a little different since there is nothing in `moves_todo.move_dest_ids` when we do

https://github.com/odoo/odoo/blob/e6b87a2a37b4550faf60a77981c533d19aa054d4/addons/stock/models/stock_move.py#L2088-L2091

This means we don't create a new SML for the delivery move, so the quantity stays at 1.

Why there is no move_dest_id
-----
When splitting the production, we go through

https://github.com/odoo/odoo/blob/bc22cf5a225a4e7d58548a8d6dedbcd84d771acb/addons/mrp/models/mrp_production.py#L1815-L1829

We create new a MO and SM for the backorder. The SM is created here

https://github.com/odoo/odoo/blob/bc22cf5a225a4e7d58548a8d6dedbcd84d771acb/addons/mrp/models/mrp_production.py#L1894-L1915

When preparing the values, we correctly copy the `move_dest_ids` of the original MO's SM, see

https://github.com/odoo/odoo/blob/bc22cf5a225a4e7d58548a8d6dedbcd84d771acb/addons/mrp/models/stock_move.py#L646-L656

So when the backorder is created, its' SM has a correct `move_dest_ids`. The problem actually comes from what happens after `_split_productions` in `action_split` when we set the `date_start`

https://github.com/odoo/odoo/blob/bc22cf5a225a4e7d58548a8d6dedbcd84d771acb/addons/mrp/wizard/mrp_production_split.py#L68-L78

In the write, we get to a line where we access the production's state

https://github.com/odoo/odoo/blob/bc22cf5a225a4e7d58548a8d6dedbcd84d771acb/addons/mrp/models/mrp_production.py#L931

This triggers a recompute of the field.

https://github.com/odoo/odoo/blob/bc22cf5a225a4e7d58548a8d6dedbcd84d771acb/addons/mrp/models/mrp_production.py#L539-L552

In the compute, we access `move_finished_ids`, which again triggers a recompute. In this compute, we call `_create_update_move_finished`

https://github.com/odoo/odoo/blob/bc22cf5a225a4e7d58548a8d6dedbcd84d771acb/addons/mrp/models/mrp_production.py#L800

The problem is that the move we create gets its' `move_dest_ids` from the MO instead of using the one populated using `group_orders` (098af2f).

https://github.com/odoo/odoo/blob/bc22cf5a225a4e7d58548a8d6dedbcd84d771acb/addons/mrp/models/mrp_production.py#L1142-L1167

-----
Ticket:
opw-4865082