### PR TITLE
[IMP] iot_drivers: ensure scales serial buffer is clean

### DIFF
--- a/addons/iot_drivers/controllers/homepage.py
+++ b/addons/iot_drivers/controllers/homepage.py
@@ -142,7 +142,7 @@ class IotBoxOwlHomePage(http.Controller):
 
         devices = [{
             'name': device.device_name,
-            'value': str(device.data['value']),
+            'value': str(device.data['result']),
             'type': device.device_type,
             'identifier': device.device_identifier,
             'connection': device.device_connection,

--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -23,7 +23,7 @@ class Driver(Thread):
         self.device_connection = ''
         self.device_type = ''
         self.device_manufacturer = ''
-        self.data = {'value': ''}
+        self.data = {'value': '', 'result': ''}  # TODO: deprecate "value"?
         self._actions = {}
         self._stopped = Event()
 

--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -52,17 +52,7 @@ class EventManager:
         :param Driver device: actual device class
         :param dict data: data returned by the device (optional)
         """
-        if data:
-            # Notify via websocket
-            send_to_controller({
-                **device.data,
-                'session_id': data.get('action_args', {}).get('session_id', ''),
-                'iot_box_identifier': helpers.get_identifier(),
-                'device_identifier': device.device_identifier,
-                **data,
-            })
-        else:
-            data = request.params.get('data', {}) if request else {}
+        data = data or request.params.get('data', {}) if request else {}
 
         # Make notification available to longpolling event route
         event = {
@@ -71,6 +61,12 @@ class EventManager:
             'time': time.time(),
             **data,
         }
+        send_to_controller({
+            **event,
+            'session_id': data.get('action_args', {}).get('session_id', ''),
+            'iot_box_identifier': helpers.get_identifier(),
+            **data,
+        })
         webrtc_client.send(event)
         self.events.append(event)
         for session in self.sessions:

--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_service.js
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_service.js
@@ -161,7 +161,7 @@ export class PosScaleService extends Reactive {
     }
 }
 
-const posScaleService = {
+export const posScaleService = {
     dependencies: ["hardware_proxy"],
     start(env, deps) {
         return new PosScaleService(env, deps);


### PR DESCRIPTION
We now use the iot http service to manage scales.
This allows using both webrtc, longpolling or websocket when one protocol or the other is failing.

This commit improves the scale driver to ensure that it uses the new standard "result" key instead of "value". It also ensures that the scale is always detected the first attempt, but cleaning the input buffer.

Enterprise PR: odoo/enterprise#92896
Task: 5031975
