### PR TITLE
[FIX] sale_timesheet: link timesheet to credit note

### DIFF
--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -75,7 +75,7 @@ class AccountMove(models.Model):
             :param start_date: the start date of the period
             :param end_date: the end date of the period
         """
-        for line in self.filtered(lambda i: i.move_type == 'out_invoice' and i.state == 'draft').invoice_line_ids:
+        for line in self.filtered(lambda i: i.move_type in ['out_invoice', 'out_refund'] and i.state == 'draft').invoice_line_ids:
             sale_line_delivery = line.sale_line_ids.filtered(lambda sol: sol.product_id.invoice_policy == 'delivery' and sol.product_id.service_type == 'timesheet')
             if not start_date and not end_date:
                 start_date, end_date = self._get_range_dates(sale_line_delivery.order_id)


### PR DESCRIPTION
To reproduce:
=============
- create service product based on timesheet that creates project/task
- create sale order with this product with qty of 10h and confirm it
- take advance payment on this sale order of 50% (downpatment invoice)
- record 4h of timesheet entries on the task
- create regular invoice which will be a credit note as we owe the customer 1h
- check that the credit note is linked to the timesheet and we can modify
the timesheet which is not correct for an invoiced timesheet

Problem:
========
when creating invoices and linking them to timesheet we only take into account
the regular invoices, not the credit notes.

Solution:
=========
we should also take into account credit notes when linking timesheet entries

opw-[4850089](https://www.odoo.com/web#id=4850089&view_type=form&model=project.task)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
