### PR TITLE
[FIX] website: preserve debug mode in website backend

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -167,11 +167,12 @@ class Website(Home):
         """
         path = '/' + path
         mode_edit = bool(kw.pop('enable_editor', False))
+        mode_debug = kw.get('debug', 0)
         if kw:
             path += '?' + werkzeug.urls.url_encode(kw)
 
         if request.env.user._is_internal():
-            path = request.website.get_client_action_url(path, mode_edit)
+            path = request.website.get_client_action_url(path, mode_edit, mode_debug)
 
         return request.redirect(path)
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1716,12 +1716,14 @@ class Website(models.Model):
             return self.env["ir.actions.actions"]._for_xml_id("website.backend_dashboard")
         return self.env["ir.actions.actions"]._for_xml_id("website.action_website")
 
-    def get_client_action_url(self, url, mode_edit=False):
+    def get_client_action_url(self, url, mode_edit=False, mode_debug=0):
         action_params = {
             "path": url,
         }
         if mode_edit:
             action_params["enable_editor"] = 1
+        if mode_debug:
+            action_params["debug"] = mode_debug
         return "/odoo/action-website.website_preview?" + urls.url_encode(action_params)
 
     def get_client_action(self, url, mode_edit=False, website_id=False):


### PR DESCRIPTION
Before this commit, the debug mode was not correctly applied in the website backend when navigating from a website page.
While the `?debug=assets` URL parameter was present, the debug mode was only active within the website's iframe, not the main backend interface itself.

Steps to reproduce:
- Go on a website page
- Enter debug mode by adding `?debug=assets` to the URL (not ctrl+k)
- Click on editor on the top left to navigate to website backend
- Check with `odoo.debug` in console
- Debug is activated in the iframe not in the backend