### PR TITLE
[PERF] mrp: avoid O(n²) recordset operation

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -547,10 +547,7 @@ Please change the quantity done or the rounding precision in your settings.""",
         for warehouse, moves_ids in outgoing_unreserved_moves_per_warehouse.items():
             if not warehouse:  # No prediction possible if no warehouse.
                 continue
-            moves = self.browse(moves_ids)
-            moves_per_location = defaultdict(lambda: self.env['stock.move'])
-            for move in moves:
-                moves_per_location[move.location_id] |= move
+            moves_per_location = self.browse(moves_ids).grouped('location_id')
             for location, mvs in moves_per_location.items():
                 forecast_info = mvs._get_forecast_availability_outgoing(warehouse, location)
                 for move in mvs:


### PR DESCRIPTION
`_compute_forecast_information` can be call with a huge self, because of the hack https://github.com/odoo/odoo/blob/7e21cb9befae0e9ce1eabafc2d5366de5097547c/addons/mrp/models/mrp_production.py#L371 and the for loop + |= on recordset patern is not efficient leading to have poor performance if there are plenty of moves in one location.

e.g. with 20K move in the same location, 12 sec is lost to compute `moves_per_location` (half the request time).

