### PR TITLE
Master fix preview interactions role

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -1,4 +1,5 @@
 import { Component, markup, useRef } from "@odoo/owl";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { InputConfirmationDialog } from "./input_confirmation_dialog";
@@ -69,6 +70,13 @@ export class SnippetViewer extends Component {
             this.props.snippetModel.installSnippetModule(snippet, this.props.installSnippetModule);
         } else {
             this.props.selectSnippet(snippet);
+        }
+    }
+
+    onPreviewKeydown(ev, snippet) {
+        const hotkey = getActiveHotkey(ev);
+        if (hotkey === "enter" || hotkey === "space") {
+            this.onClick(snippet);
         }
     }
 

--- a/addons/html_builder/static/src/snippets/snippet_viewer.scss
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.scss
@@ -78,22 +78,6 @@
                     }
                 }
             }
-            > [data-snippet][data-preview-interaction-enabled="true"] {
-                > *:first-child {
-                    // Enable pointer events on the snippet when preview
-                    // interaction is enabled to allow mouseenter/mouseleave
-                    // events.
-                    pointer-events: auto;
-                }
-
-                > *:first-child * {
-                    // Disable pointer events for descendants to prevent
-                    // unwanted hover effects.
-                    // Descendants that require interaction can be excluded
-                    // using the :not() selector.
-                    pointer-events: none;
-                }
-            }
             &[data-label]:not([data-label=""])::before {
                 content: attr(data-label);
                 @include o-position-absolute(0, 0);

--- a/addons/html_builder/static/src/snippets/snippet_viewer.xml
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.xml
@@ -7,6 +7,7 @@
         <div class="col-lg-6" t-foreach="this.getSnippetColumns()" t-as="snippetsColumn" t-key="snippetsColumn_index">
             <t t-foreach="snippetsColumn" t-as="snippet" t-key="snippet.id">
                 <div t-on-click="() => this.onClick(snippet)"
+                     t-on-keydown="(ev) => this.onPreviewKeydown(ev, snippet)"
                      t-att-data-snippet-id="snippet.key"
                      t-att-data-label="snippet.label ? snippet.label : ''"
                      t-attf-class="o_snippet_preview_wrap position-relative #{ snippet.isCustom ? 'mb-0' : '' } #{snippet.moduleId ? 'o_snippet_preview_install' : '' }"

--- a/addons/website/static/src/interactions/carousel/carousel_slider.preview.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.preview.js
@@ -5,43 +5,40 @@ const CarouselSliderPreview = (I) =>
     class extends I {
         carouselOptions = { ride: true, pause: true, interval: 500 };
 
-        setup() {
-            // Bind mouse events to the entire section (top-most parent of the
-            // snippet). This ensures events trigger when hovering anywhere on
-            // the snippet, even if the carousel itself is smaller in width.
-            if (this.el.tagName === "SECTION") {
-                this.carouselSnippetEl = this.el;
-            } else {
-                this.carouselSnippetEl = this.el.closest("section");
-            }
-        }
-
-        start() {
-            super.start();
-
-            this.carouselSnippetEl.style.pointerEvents = "auto";
-
-            this.addListener(this.carouselSnippetEl, "mouseenter", this.mouseEnter);
-            this.addListener(this.carouselSnippetEl, "mouseleave", this.mouseLeave);
-        }
+        dynamicSelectors = {
+            ...this.dynamicSelectors,
+            _snippetPreviewWrapEl: () => this.el.closest(".o_snippet_preview_wrap"),
+        };
+        dynamicContent = {
+            ...this.dynamicContent,
+            // Bind events to the entire preview wrap. This ensures events
+            // trigger when hovering anywhere on the snippet, even though the
+            // preview containers are `inert`.
+            _snippetPreviewWrapEl: {
+                "t-on-mouseenter": this.mouseEnter,
+                "t-on-mouseleave": this.mouseLeave,
+                "t-on-focusin": this.mouseEnter,
+                "t-on-focusout": this.mouseLeave,
+            },
+        };
 
         /**
          * Starts the carousel autoplay when the mouse enters the element.
          */
-        mouseEnter = () => {
+        mouseEnter() {
             const carousel = window.Carousel.getOrCreateInstance(this.el);
             carousel.cycle();
-        };
+        }
 
         /**
          * Pauses the carousel and resets it to the first slide when the mouse
          * leaves the element.
          */
-        mouseLeave = () => {
+        mouseLeave() {
             const carousel = window.Carousel.getOrCreateInstance(this.el);
             carousel.pause();
             carousel.to(0);
-        };
+        }
     };
 
 registry.category("public.interactions.preview").add("website.carousel_slider", {

--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_carousel" name="Carousel">
-    <section class="s_carousel_wrapper p-0" data-vxml="001" data-vcss="001" data-preview-interaction-enabled="true">
+    <section class="s_carousel_wrapper p-0" data-vxml="001" data-vcss="001">
         <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
         <div t-attf-id="myCarousel{{uniq}}" class="s_carousel s_carousel_default carousel slide" data-bs-ride="true" data-bs-interval="10000">
             <!-- Content -->

--- a/addons/website/views/snippets/s_carousel_cards.xml
+++ b/addons/website/views/snippets/s_carousel_cards.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_carousel_cards" name="Carousel Cards">
-    <section class="s_carousel_cards_wrapper pt64 pb64" data-preview-interaction-enabled="true">
+    <section class="s_carousel_cards_wrapper pt64 pb64">
         <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
         <div t-attf-id="myCarouselCards{{uniq}}" class="s_carousel_cards s_carousel_cards_with_img s_carousel_boxed container carousel carousel-fade slide" data-bs-interval="10000" data-bs-ride="true" data-option-name="CarouselCards" style="--card-img-size-h: 60%; --CardBody-extra-height: 0px;">
             <!-- Content -->

--- a/addons/website/views/snippets/s_carousel_intro.xml
+++ b/addons/website/views/snippets/s_carousel_intro.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_carousel_intro" name="Carousel Intro">
-    <section class="s_carousel_intro_wrapper p-0" data-preview-interaction-enabled="true">
+    <section class="s_carousel_intro_wrapper p-0">
         <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
         <div t-attf-id="myCarouselIntro{{uniq}}" class="s_carousel_intro s_carousel_default carousel slide carousel-dark" data-bs-ride="true" data-bs-interval="10000">
             <!-- Content -->

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_image_gallery" name="Image Gallery">
-    <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default" data-vcss="002" data-columns="3" data-preview-interaction-enabled="true">
+    <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default" data-vcss="002" data-columns="3">
         <div class="o_container_small overflow-hidden">
             <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="carousel" data-bs-interval="0">
                 <div class="carousel-inner">

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_quotes_carousel" name="Quotes">
-    <section class="s_quotes_carousel_wrapper" data-vxml="001" data-vcss="002" data-preview-interaction-enabled="true">
+    <section class="s_quotes_carousel_wrapper" data-vxml="001" data-vcss="002">
         <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
         <div t-attf-id="myQuoteCarousel{{uniq}}" class="s_quotes_carousel s_carousel_boxed carousel carousel-dark slide o_cc o_cc2" data-bs-ride="true" data-bs-interval="10000">
             <!-- Content -->

--- a/addons/website/views/snippets/s_quotes_carousel_minimal.xml
+++ b/addons/website/views/snippets/s_quotes_carousel_minimal.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_quotes_carousel_minimal" name="Quotes Minimal">
-    <section class="s_quotes_carousel_wrapper" data-vxml="001" data-vcss="002" data-preview-interaction-enabled="true">
+    <section class="s_quotes_carousel_wrapper" data-vxml="001" data-vcss="002">
         <t t-set="uniq" t-value="datetime.datetime.now().microsecond"/>
         <div t-attf-id="myQuoteCarouselMinimal{{uniq}}" class="s_quotes_carousel s_carousel_default carousel carousel-dark slide" data-bs-ride="true" data-bs-interval="10000">
             <!-- Content -->


### PR DESCRIPTION
## [FIX] html_builder: allow to select snippet with keyboard
    
Commit [1] improved the add snippet dialog accessibility, but being
able to select snippets with the keyboard didn't work.

Steps to reproduce:
- Edit a website page
- Click on a category
- Press Tab twice (1: focus the tab, 2: focus the snippet)
- Press "enter" or "space"
=> Nothing happens.

This commit properly implements both enter and space keydowns.


## [FIX] website: trigger carousel slide on interaction preview

Commit [1] added an `inert` attribute on snippet wrappers within the
preview dialog. This prevents the `CarouselSliderPreview` interaction
from working, as the listener was set on the snippet section.

Steps to reproduce:
- Edit a website page
- Click on any snippet category
- Search for "carousel"
- Hover the snippets
=> They don't slide anymore.

This commit changes the target of the event to make it work.
At the same time, for consistency, `focusin` and `focusout` are listened
to and applied the same behavior as `mouseenter` and `mouseleave`.

[1]: https://github.com/odoo/odoo/pull/220517/commits/6811c3d77588c450f4639a550004b4cddecb9ac7