### PR TITLE
[IMP] mail: using composerHtml to handle messages

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -34,7 +34,12 @@ import {
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { createElementWithContent, htmlJoin, setElementContent } from "@web/core/utils/html";
+import {
+    createElementWithContent,
+    htmlJoin,
+    isHtmlEmpty,
+    setElementContent,
+} from "@web/core/utils/html";
 import { FileUploader } from "@web/views/fields/file_handler";
 import { isEmail } from "@web/core/utils/strings";
 import { isDisplayStandalone, isIOS, isMobileOS } from "@web/core/browser/feature_detection";
@@ -365,7 +370,7 @@ export class Composer extends Component {
         const attachments = this.props.composer.attachments;
         return (
             !this.state.active ||
-            (!this.props.composer.composerText && attachments.length === 0) ||
+            (isHtmlEmpty(this.props.composer.composerHtml) && attachments.length === 0) ||
             attachments.some(({ uploading }) => Boolean(uploading))
         );
     }
@@ -699,7 +704,7 @@ export class Composer extends Component {
                 type: "warning",
             });
         } else if (
-            this.props.composer.composerText.trim() ||
+            !isHtmlEmpty(this.props.composer.composerHtml) ||
             attachments.length > 0 ||
             (this.message && this.message.attachment_ids.length > 0)
         ) {
@@ -707,7 +712,7 @@ export class Composer extends Component {
                 return;
             }
             this.state.active = false;
-            await cb(this.props.composer.composerText);
+            await cb(this.props.composer.composerHtml);
             if (this.props.onPostCallback) {
                 this.props.onPostCallback();
             }
@@ -762,7 +767,7 @@ export class Composer extends Component {
      */
 
     /**
-     * @param {string} value message body
+     * @param {ReturnType<markup>} value message body
      * @param {postData} postData Message meta data info
      * @param {extraData} extraData Message extra meta data info needed by other modules
      */

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -1,5 +1,5 @@
 import { fields, OR, Record } from "@mail/core/common/record";
-import { convertBrToLineBreak, prettifyMessageContent } from "@mail/utils/common/format";
+import { convertBrToLineBreak, prettifyMessageText } from "@mail/utils/common/format";
 import { markup } from "@odoo/owl";
 
 export class Composer extends Record {
@@ -41,11 +41,9 @@ export class Composer extends Record {
                 mentionedPartners: this.mentionedPartners,
                 mentionedRoles: this.mentionedRoles,
             });
-            prettifyMessageContent(this.composerText, { validMentions }).then((content) => {
-                this.updateFromText = true;
-                this.composerHtml = content;
-                this.updateFromText = false;
-            });
+            this.updateFromText = true;
+            this.composerHtml = prettifyMessageText(this.composerText, { validMentions });
+            this.updateFromText = false;
         },
     });
     composerHtml = fields.Html(markup("<p><br></p>"), {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -533,7 +533,11 @@ export class Message extends Record {
         attachments = [],
         { mentionedChannels = [], mentionedPartners = [], mentionedRoles = [] } = {}
     ) {
-        if (convertBrToLineBreak(this.body) === body && attachments.length === 0) {
+        if (
+            createElementWithContent("div", body).textContent ===
+                createElementWithContent("div", this.body).textContent &&
+            attachments.length === 0
+        ) {
             return;
         }
         const validMentions = this.store.getMentionsFromText(body, {
@@ -574,7 +578,7 @@ export class Message extends Record {
         }
         this.composer = {
             mentionedPartners: this.partner_ids,
-            composerText: text,
+            composerHtml: this.body,
             selection: {
                 start: text.length,
                 end: text.length,

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -1,6 +1,6 @@
 import { Store as BaseStore, fields, makeStore, storeInsertFns } from "@mail/core/common/record";
 import { threadCompareRegistry } from "@mail/core/common/thread_compare";
-import { cleanTerm, prettifyMessageContent } from "@mail/utils/common/format";
+import { cleanTerm, generateEmojisOnHtml, prettifyMessageContent } from "@mail/utils/common/format";
 
 import { reactive } from "@odoo/owl";
 
@@ -560,7 +560,7 @@ export class Store extends BaseStore {
             partner_ids.push(...recipientIds);
         }
         postData = {
-            body: await prettifyMessageContent(body, { validMentions }),
+            body: await generateEmojisOnHtml(body),
             email_add_signature: emailAddSignature,
             message_type: "comment",
             subtype_xmlid: subtype,

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
@@ -1,7 +1,7 @@
 import { Composer } from "@mail/core/common/composer";
 import { markEventHandled } from "@web/core/utils/misc";
 
-import { useRef } from "@odoo/owl";
+import { markup, useRef } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
@@ -37,9 +37,13 @@ const composerPatch = {
         markEventHandled(ev, "Composer.onClickAddGif");
     },
     async sendGifMessage(gif) {
-        await this._sendMessage(gif.url, {
-            parentId: this.props.composer.replyToMessage?.id,
-        });
+        const href = encodeURI(gif.url);
+        await this._sendMessage(
+            markup`<a href="${href}" target="_blank" rel="noreferrer noopener">${gif.url}</a>`,
+            {
+                parentId: this.props.composer.replyToMessage?.id,
+            }
+        );
     },
 };
 patch(Composer.prototype, composerPatch);

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -25,11 +25,9 @@ const messageUrlRegExp = new RegExp(`^${escapeRegExp(getOrigin())}/mail/message/
  * @param {string|ReturnType<markup>} rawBody
  * @param {Object} validMentions
  * @param {import("models").Persona[]} validMentions.partners
+ * @returns {string|ReturnType<markup>}
  */
-export async function prettifyMessageContent(
-    rawBody,
-    { validMentions = [], allowEmojiLoading = true } = {}
-) {
+export function prettifyMessageText(rawBody, { validMentions = [] } = {}) {
     let body = htmlTrim(rawBody);
     body = htmlReplace(body, /(\r|\n){2,}/g, () => markup`<br/><br/>`);
     body = htmlReplace(body, /(\r|\n)/g, () => markup`<br/>`);
@@ -42,10 +40,32 @@ export async function prettifyMessageContent(
     // as text internally and only make html enrichment at display time but
     // the current design makes this quite hard to do.
     body = generateMentionsLinks(body, validMentions);
+    body = parseAndTransform(body, addLink);
+    return body;
+}
+
+/**
+ * @param {string|ReturnType<markup>} htmlBody
+ */
+export async function generateEmojisOnHtml(htmlBody, { allowEmojiLoading = true } = {}) {
+    let body = htmlBody;
     if (allowEmojiLoading || odoo.loader.modules.get("@web/core/emoji_picker/emoji_data")) {
         body = await _generateEmojisOnHtml(body);
     }
-    body = parseAndTransform(body, addLink);
+    return body;
+}
+
+/**
+ * @param {string|ReturnType<markup>} rawBody
+ * @param {Object} validMentions
+ * @param {import("models").Persona[]} validMentions.partners
+ */
+export async function prettifyMessageContent(
+    rawBody,
+    { validMentions = [], allowEmojiLoading = true } = {}
+) {
+    let body = prettifyMessageText(rawBody, { validMentions });
+    body = await generateEmojisOnHtml(body, { allowEmojiLoading });
     return body;
 }
 

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1,4 +1,7 @@
-import { insertText as htmlInsertText } from "@html_editor/../tests/_helpers/user_actions";
+import {
+    insertText as htmlInsertText,
+    tripleClick,
+} from "@html_editor/../tests/_helpers/user_actions";
 
 import {
     SIZES,
@@ -1270,4 +1273,24 @@ test("html composer: send a message in a chatter", async () => {
     await htmlInsertText(editor, "Hello");
     await click(".o-mail-Composer-send:enabled");
     await click(".o-mail-Message[data-persistent]:contains(Hello)");
+});
+
+test.tags("html composer");
+test("html composer: send a message with styling", async () => {
+    await startServer();
+    await start();
+    const composerService = getService("mail.composer");
+    await openFormView("res.partner", serverState.partnerId);
+    await click("button", { text: "Send message" });
+    composerService.setHtmlComposer();
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await htmlInsertText(editor, "Hello");
+    await tripleClick(editor.editable.querySelector("p"));
+    await press("Control+b");
+    await click(".o-mail-Composer-send:enabled");
+    await click(".o-mail-Message[data-persistent] strong:contains(Hello)");
 });


### PR DESCRIPTION
Replace composerText with composerHtml when handling message post so that the HTML composer can use the message post as well.

This commit also updates minor issues in the related files, such as send button check and emoji generation.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
