### PR TITLE
[IMP] point_of_sale: allow grouping orders by hour

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -81,7 +81,14 @@
             'point_of_sale/static/src/backend/pos_payment_provider_cards/*',
             'point_of_sale/static/src/app/hooks/hooks.js',
             'point_of_sale/static/src/backend/many2many_placeholder_list_view/*',
+            'point_of_sale/static/src/backend/views/**/*',
+            ('remove', 'point_of_sale/static/src/backend/views/pivot/*'),
+            ('remove', 'point_of_sale/static/src/backend/views/graph/*'),
             'point_of_sale/static/src/backend/test_epos/*',
+        ],
+        'web.assets_backend_lazy': [
+            'point_of_sale/static/src/backend/views/pivot/*',
+            'point_of_sale/static/src/backend/views/graph/*',
         ],
         "web.assets_web_dark": [
             'point_of_sale/static/src/scss/pos_dashboard.dark.scss',
@@ -104,6 +111,7 @@
             # Adding error handler back since they are removed in the prod bundle
             'web/static/src/core/errors/error_handlers.js',
             'web/static/src/core/dialog/dialog.scss',
+            'point_of_sale/static/src/backend/views/**/*',
         ],
         'web.assets_unit_tests': [
             'point_of_sale/static/tests/unit/**/*',

--- a/addons/point_of_sale/static/src/backend/views/graph/graph_view.js
+++ b/addons/point_of_sale/static/src/backend/views/graph/graph_view.js
@@ -1,0 +1,10 @@
+import { registry } from "@web/core/registry";
+import { graphView } from "@web/views/graph/graph_view";
+import { PosSearchModel } from "@point_of_sale/backend/views/pos_search_model";
+
+export const posGraphView = {
+    ...graphView,
+    SearchModel: PosSearchModel,
+};
+
+registry.category("views").add("pos_graph_view", posGraphView);

--- a/addons/point_of_sale/static/src/backend/views/kanban/kanban_view.js
+++ b/addons/point_of_sale/static/src/backend/views/kanban/kanban_view.js
@@ -1,0 +1,10 @@
+import { registry } from "@web/core/registry";
+import { kanbanView } from "@web/views/kanban/kanban_view";
+import { PosSearchModel } from "@point_of_sale/backend/views/pos_search_model";
+
+export const posKanbanView = {
+    ...kanbanView,
+    SearchModel: PosSearchModel,
+};
+
+registry.category("views").add("pos_kanban_view", posKanbanView);

--- a/addons/point_of_sale/static/src/backend/views/list/list_view.js
+++ b/addons/point_of_sale/static/src/backend/views/list/list_view.js
@@ -1,0 +1,10 @@
+import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
+import { PosSearchModel } from "@point_of_sale/backend/views/pos_search_model";
+
+export const posListView = {
+    ...listView,
+    SearchModel: PosSearchModel,
+};
+
+registry.category("views").add("pos_list_view", posListView);

--- a/addons/point_of_sale/static/src/backend/views/pivot/pivot_view.js
+++ b/addons/point_of_sale/static/src/backend/views/pivot/pivot_view.js
@@ -1,0 +1,10 @@
+import { registry } from "@web/core/registry";
+import { pivotView } from "@web/views/pivot/pivot_view";
+import { PosSearchModel } from "@point_of_sale/backend/views/pos_search_model";
+
+export const posPivotView = {
+    ...pivotView,
+    SearchModel: PosSearchModel,
+};
+
+registry.category("views").add("pos_pivot_view", posPivotView);

--- a/addons/point_of_sale/static/src/backend/views/pos_search_model.js
+++ b/addons/point_of_sale/static/src/backend/views/pos_search_model.js
@@ -1,0 +1,29 @@
+import { _t } from "@web/core/l10n/translation";
+import { SearchModel } from "@web/search/search_model";
+
+const HOUR_OPTION = { id: "hour", description: _t("Hour"), groupNumber: 1 };
+const MODELS = { "pos.order": ["date_order"], "report.pos.order": ["date"] };
+
+export class PosSearchModel extends SearchModel {
+    _getIntervalOptions(searchItem) {
+        const intervalOptions = super._getIntervalOptions(searchItem);
+        if (MODELS[this.resModel]?.includes(searchItem.fieldName)) {
+            return [...intervalOptions, HOUR_OPTION];
+        }
+        return intervalOptions;
+    }
+
+    _getIntervalOptionByIntervalId(intervalId) {
+        if (this.resModel in MODELS && intervalId === HOUR_OPTION.id) {
+            return HOUR_OPTION;
+        }
+        return super._getIntervalOptionByIntervalId(intervalId);
+    }
+
+    _rankInterval(intervalOptionId) {
+        if (this.resModel in MODELS && intervalOptionId === HOUR_OPTION.id) {
+            return super._rankInterval("day") + 1;
+        }
+        return super._rankInterval(intervalOptionId);
+    }
+}

--- a/addons/point_of_sale/static/tests/unit/backend/pos_search_model.test.js
+++ b/addons/point_of_sale/static/tests/unit/backend/pos_search_model.test.js
@@ -1,0 +1,48 @@
+import { expect, test, describe } from "@odoo/hoot";
+import { mountWithSearch } from "@web/../tests/web_test_helpers";
+import { definePosModels } from "../data/generate_model_definitions";
+import { SearchBar } from "@web/search/search_bar/search_bar";
+import { PosSearchModel } from "@point_of_sale/backend/views/pos_search_model";
+
+definePosModels();
+
+describe("SearchModel", () => {
+    test("pos orders can be grouped by hour", async () => {
+        odoo.pos_session_id = 1;
+        odoo.pos_config_id = 1;
+        odoo.info = {
+            db: "pos",
+            isEnterprise: true,
+        };
+        const component = await mountWithSearch(SearchBar, {
+            resModel: "pos.order",
+            searchMenuTypes: ["groupBy"],
+            SearchModel: PosSearchModel,
+            searchViewId: false,
+            searchViewFields: {
+                date_order: {
+                    string: "Order Date",
+                    type: "datetime",
+                    store: true,
+                    sortable: true,
+                    groupable: true,
+                },
+            },
+            searchViewArch: `
+            <search>
+                <filter name="date_groupBy" string="Date Order" context="{'group_by': 'date_order:hour'}"/>
+            </search>
+        `,
+        });
+
+        const filterId = Object.keys(component.env.searchModel.searchItems).map((key) =>
+            Number(key)
+        )[0];
+        component.env.searchModel.toggleDateGroupBy(filterId);
+        expect(component.env.searchModel.groupBy).toEqual(["date_order:hour"]);
+        component.env.searchModel.toggleDateGroupBy(filterId, "day");
+        expect(component.env.searchModel.groupBy).toEqual(["date_order:day", "date_order:hour"]);
+        component.env.searchModel.toggleDateGroupBy(filterId, "hour");
+        expect(component.env.searchModel.groupBy).toEqual(["date_order:day"]);
+    });
+});

--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -4,7 +4,7 @@
             <field name="name">report.pos.order.pivot</field>
             <field name="model">report.pos.order</field>
             <field name="arch" type="xml">
-                <pivot string="Point of Sale Analysis" sample="1">
+                <pivot string="Point of Sale Analysis" sample="1" js_class="pos_pivot_view">
                     <field name="product_categ_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
                     <field name="order_id" type="measure"/>
@@ -18,7 +18,7 @@
             <field name="name">report.pos.order.graph</field>
             <field name="model">report.pos.order</field>
             <field name="arch" type="xml">
-                <graph string="Point of Sale Analysis" sample="1">
+                <graph string="Point of Sale Analysis" sample="1" js_class="pos_graph_view">
                     <field name="product_categ_id"/>
                     <field name="price_total" type="measure"/>
                 </graph>
@@ -29,7 +29,7 @@
             <field name="name">report.pos.order.view.list</field>
             <field name="model">report.pos.order</field>
             <field name="arch" type="xml">
-                <list string="Point of Sale Analysis">
+                <list string="Point of Sale Analysis" js_class="pos_list_view">
                     <field name="date"/>
                     <field name="order_id" optional="hide"/>
                     <field name="partner_id" optional="hide"/>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -216,7 +216,7 @@
         <field name="name">pos.order.kanban</field>
         <field name="model">pos.order</field>
         <field name="arch" type="xml">
-            <kanban class="o_kanban_mobile" create="0" sample="1">
+            <kanban class="o_kanban_mobile" create="0" sample="1" js_class="pos_kanban_view">
                 <field name="currency_id"/>
                 <templates>
                     <t t-name="card">
@@ -244,7 +244,7 @@
         <field name="name">pos.order.pivot</field>
         <field name="model">pos.order</field>
         <field name="arch" type="xml">
-            <pivot string="PoS Orders" sample="1">
+            <pivot string="PoS Orders" sample="1" js_class="pos_pivot_view">
                 <field name="date_order" type="row"/>
                 <field name="margin"/>
                 <field name="margin_percent" invisible="1"/>
@@ -287,7 +287,7 @@
         <field name="name">pos.order.list</field>
         <field name="model">pos.order</field>
         <field name="arch" type="xml">
-            <list string="POS Orders" create="0" sample="1" decoration-info="state == 'draft'" decoration-muted="state == 'cancel'" duplicate="0">
+            <list string="POS Orders" create="0" sample="1" decoration-info="state == 'draft'" decoration-muted="state == 'cancel'" duplicate="0" js_class="pos_list_view">
                 <header>
                     <button name="action_create_invoices" type="object" string="Create Invoices"/>
                 </header>

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1372,7 +1372,7 @@ export class SearchModel extends EventBus {
                 break;
             case "dateGroupBy":
                 enrichSearchItem.options = _enrichOptions(
-                    this.intervalOptions,
+                    this._getIntervalOptions(searchItem),
                     queryElements.map((queryElem) => queryElem.intervalId)
                 );
                 break;
@@ -1662,7 +1662,7 @@ export class SearchModel extends EventBus {
                     case "dateGroupBy": {
                         type = "groupBy";
                         for (const intervalId of activeItem.intervalIds) {
-                            const { description } = INTERVAL_OPTIONS[intervalId];
+                            const { description } = this._getIntervalOptionByIntervalId(intervalId);
                             values.push(`${searchItem.description}: ${description}`);
                         }
                         break;
@@ -1723,7 +1723,7 @@ export class SearchModel extends EventBus {
                     const [fieldName, interval] = gb.split(":");
                     const { string } = this.searchViewFields[fieldName];
                     if (interval) {
-                        const { description } = INTERVAL_OPTIONS[interval];
+                        const { description } = this._getIntervalOptionByIntervalId(interval);
                         return `${string}:${description}`;
                     }
                     return string;
@@ -1957,7 +1957,9 @@ export class SearchModel extends EventBus {
             }
             for (const activeItem of activeItems) {
                 if ("intervalIds" in activeItem) {
-                    activeItem.intervalIds.sort((g1, g2) => rankInterval(g1) - rankInterval(g2));
+                    activeItem.intervalIds.sort(
+                        (g1, g2) => this._rankInterval(g1) - this._rankInterval(g2)
+                    );
                 }
             }
             groups.push({ id, activeItems });
@@ -1965,6 +1967,17 @@ export class SearchModel extends EventBus {
         return groups;
     }
 
+    _getIntervalOptions(searchItem) {
+        return this.intervalOptions;
+    }
+
+    _getIntervalOptionByIntervalId(intervalId) {
+        return INTERVAL_OPTIONS[intervalId];
+    }
+
+    _rankInterval(intervalOptionId) {
+        return rankInterval(intervalOptionId);
+    }
     /**
      *
      * @private


### PR DESCRIPTION
After this commit:
==
- Views of `Orders` and `Order analysis` can be grouped by hour.

task: 5022973
