### PR TITLE
[FIX] website: restore header border width option

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header_border_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header_border_option.xml
@@ -3,7 +3,7 @@
 
 <t t-name="website.HeaderBorderOption">
     <BuilderContext>
-        <BorderConfigurator label.translate="Border" action="'styleActionHeader'" withRoundCorner="this.domState.withRoundCorner"/>
+        <BorderConfigurator label.translate="Border" action="'styleActionHeader'" withBSClass="false" withRoundCorner="this.domState.withRoundCorner"/>
         <ShadowOption setShadowModeAction="'setShadowModeHeader'" setShadowAction="'setShadowHeader'"/>
     </BuilderContext>
 </t>


### PR DESCRIPTION
Since [1], the header border width option no longer had any effect. This commit restores the ability to change the border width from the header options.

Steps to reproduce:
- Go to Website in edit mode
- Select the header to display its options
- Change the border width (e.g., set to `10px`)
- Bug: no visible change

[1]: https://github.com/odoo/odoo/commit/d0daf3990079477ef7552d769b944b55d9be4366
