### PR TITLE
[FIX] pos_order: prevent duplicate invoices generation

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -7722,6 +7722,12 @@ msgid "Stripe"
 msgstr ""
 
 #. module: point_of_sale
+#. odoo-python
+#: code:addons/point_of_sale/models/pos_order.py:0
+msgid "Some orders are already being invoiced. Please try again later."
+msgstr ""
+
+#. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_res_config_settings__module_pos_stripe
 msgid "Stripe Payment Terminal"
 msgstr ""


### PR DESCRIPTION
This fix prevents multiple users from generating separate invoices for the same POS order simultaneously.

Steps to reproduce:
1. Create a new POS order.
2. Open two tabs (or two POS sessions).
3. Generate an invoice in the first tab.
4. Immediately try to generate an invoice in the second tab.
5. Two invoices will be generated.

With this fix:
- If a user attempts to generate an invoice while another is already in progress, an error message is shown.
- If the invoice has already been generated, the existing invoice view is opened instead of creating a duplicate.

opw-5004504