### PR TITLE
[FIX] hr_timesheet: fix ValidationError when logging a timesheet

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -212,7 +212,7 @@ class AccountAnalyticLine(models.Model):
             employee_out_id = False
             if employee_per_company:
                 company_id = list(employee_per_company)[0] if len(employee_per_company) == 1\
-                        else vals.get('company_id', self.env.company.id)
+                        else vals.get('company_id') or self.env.company.id
                 employee_out_id = employee_per_company.get(company_id, False)
 
             if employee_out_id:

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -810,3 +810,15 @@ class TestTimesheet(TestCommonTimesheet):
         timesheet.task_id = self.task2
         self.assertEqual(analytic_account, timesheet.account_id)
         self.assertEqual(analytic_account, timesheet[f'{analytic_plan._column_name()}'])
+
+    def test_log_timesheet_with_user_has_two_employees_from_different_companies(self):
+        company_2 = self.env['res.company'].create({'name': 'Company 2'})
+        self.env['hr.employee'].with_company(company_2).create({
+            'name': 'Employee 2',
+            'user_id': self.user_manager.id,
+        })
+        timesheet = self.env['account.analytic.line'].create({
+            'project_id': self.project.id,
+            'user_id': self.user_manager.id,
+        })
+        self.assertEqual(timesheet.company_id, self.env.company)


### PR DESCRIPTION
steps to reproduce:
-------------------
1. Install Employees, Timesheets, Projects
2. Create 2 companies
3. On each company, create an employee for the same related user
4. Create a project without setting a company (making it a global project).
5. Enable both companies in the systray
6. Try to log a timesheet on the global project.

issue:
------
A ValidationError is raised:
"Timesheets must be created with an active employee in the selected companies."

cause:
------
During `vals_list` preparation, the `company_id` value is overwritten here: https://github.com/odoo/odoo/blob/605e47a85561614c17fe2e6f59618610f87c69bb/addons/hr_timesheet/models/hr_timesheet.py#L381

If the project has no company set, `company_id `becomes **False**.

This condition fails if the user has two employees and no company set (or if it is missing): https://github.com/odoo/odoo/blob/d3c7e51e94d98da9086a3817b157c4e125c80790/addons/hr_timesheet/models/hr_timesheet.py#L211-L215

solution:
---------
Use `self.env.company` if company_id is missing(or False) in the vals.

opw-4892449

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
