### PR TITLE
[IMP] website: new text layout versions for `s_countdown snippet`

### DIFF
--- a/addons/website/static/src/builder/plugins/options/countdown_option.edit.scss
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.edit.scss
@@ -1,7 +1,7 @@
 // s_countdown preview classes
 .o_editable .s_countdown {
     &.s_countdown_enable_preview {
-        &.hide-countdown .s_countdown_canvas_wrapper {
+        &.hide-countdown .s_countdown_canvas_wrapper, &.hide-countdown .s_countdown_inline_wrapper {
             display: none !important;
         }
 

--- a/addons/website/static/src/builder/plugins/options/countdown_option.xml
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.xml
@@ -9,8 +9,8 @@
         <BuilderSelect preview="false" action="'setEndAction'">
             <BuilderSelectItem actionValue="'nothing'" id="'no_end_action_opt'">Nothing</BuilderSelectItem>
             <BuilderSelectItem actionValue="'redirect'" id="'redirect_end_action_opt'">Redirect</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'message_no_countdown'">Show Message and hide countdown</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'message'">Show Message and keep countdown</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'message_no_countdown'">Message only</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'message'">Message + Timer</BuilderSelectItem>
         </BuilderSelect>
         <BuilderButton title.translate="The message will be visible once the countdown ends"
                        t-if="!this.isActiveItem('no_end_action_opt') and !this.isActiveItem('redirect_end_action_opt')"
@@ -22,7 +22,7 @@
                 label.translate="URL">
             <WebsiteUrlPicker placeholder.translate="e.g. /my-awesome-page" dataAttributeAction="'redirectUrl'"/>
     </BuilderRow>
-    <BuilderRow label.translate="Size">
+    <BuilderRow t-if="!this.isActiveItem('text_layout_opt')" label.translate="Size">
         <BuilderSelect dataAttributeAction="'size'">
             <BuilderSelectItem dataAttributeActionValue="'80'">Small</BuilderSelectItem>
             <BuilderSelectItem dataAttributeActionValue="'120'">Medium</BuilderSelectItem>
@@ -37,7 +37,7 @@
         </BuilderSelect>
     </BuilderRow>
 
-    <BuilderRow label.translate="Text Color">
+    <BuilderRow t-if="!this.isActiveItem('text_layout_opt')" label.translate="Text Color">
         <BuilderColorPicker dataAttributeAction="'textColor'" enabledTabs="['solid', 'custom']"/>
     </BuilderRow>
 
@@ -46,11 +46,11 @@
             <BuilderSelectItem actionValue="'circle'" id="'circle_layout_opt'">Circle</BuilderSelectItem>
             <BuilderSelectItem actionValue="'boxes'" id="'boxes_layout_opt'">Boxes</BuilderSelectItem>
             <BuilderSelectItem actionValue="'clean'">Clean</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'text'">Text Inline</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'text'" id="'text_layout_opt'">Text Inline</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
     <t t-if="this.isActiveItem('circle_layout_opt') or this.isActiveItem('boxes_layout_opt')">
-        <BuilderRow label.translate="Layout Background">
+        <BuilderRow label.translate="Layout Background" level="2">
             <BuilderSelect dataAttributeAction="'layoutBackground'">
                 <BuilderSelectItem dataAttributeActionValue="'inner'">Inner</BuilderSelectItem>
                 <BuilderSelectItem dataAttributeActionValue="'plain'">Plain</BuilderSelectItem>
@@ -58,11 +58,11 @@
             </BuilderSelect>
         </BuilderRow>
         <BuilderRow label.translate="Layout Background Color"
-                    t-if="!this.isActiveItem('no_background_layout_opt')">
+                    t-if="!this.isActiveItem('no_background_layout_opt')" level="3">
             <BuilderColorPicker dataAttributeAction="'layoutBackgroundColor'" enabledTabs="['solid', 'custom']"/>
         </BuilderRow>
 
-        <BuilderRow label.translate="Progress Bar Style">
+        <BuilderRow label.translate="Progress Bar Style" level="2">
             <BuilderSelect dataAttributeAction="'progressBarStyle'">
                 <BuilderSelectItem dataAttributeActionValue="'surrounded'">Surrounded</BuilderSelectItem>
                 <BuilderSelectItem dataAttributeActionValue="'disappear'">Disappearing</BuilderSelectItem>
@@ -71,17 +71,113 @@
         </BuilderRow>
 
         <t t-if="!this.isActiveItem('no_progressbar_style_opt')">
-            <BuilderRow label.translate="Progress Bar Weight">
+            <BuilderRow label.translate="Progress Bar Weight" level="3">
                 <BuilderSelect dataAttributeAction="'progressBarWeight'">
                     <BuilderSelectItem dataAttributeActionValue="'thin'">Thin</BuilderSelectItem>
                     <BuilderSelectItem dataAttributeActionValue="'thick'">Thick</BuilderSelectItem>
                 </BuilderSelect>
             </BuilderRow>
-            <BuilderRow label.translate="Progress Bar Color"
-                        t-if="!this.isActiveItem('no_progressbar_style_opt')">
+            <BuilderRow label.translate="Progress Bar Color" level="3">
                 <BuilderColorPicker dataAttributeAction="'progressBarColor'" enabledTabs="['solid', 'custom']"/>
             </BuilderRow>
         </t>
+    </t>
+    <t t-if="this.isActiveItem('text_layout_opt')">
+        <BuilderRow label.translate="Template" level="2">
+            <BuilderSelect id="'countdown_inline_template_opt'" action="'selectCountdownInlineTemplate'" applyTo="'.s_countdown_inline_wrapper'">
+                <BuilderSelectItem
+                    title.translate="Default"
+                    actionParam="{
+                        view: 'website.s_countdown_inline_default_template',
+                        templateClass: 'o_template_default',
+                    }">
+                    Default
+                </BuilderSelectItem>
+                <BuilderSelectItem
+                    id="'template_dominoes_opt'"
+                    title.translate="Dominoes"
+                    actionParam="{
+                        view: 'website.s_countdown_inline_dominoes_template',
+                        templateClass: 'o_template_dominoes',
+                    }">
+                    Dominoes
+                </BuilderSelectItem>
+                <BuilderSelectItem
+                    id="'template_wrapped_numbers_opt'"
+                    title.translate="Wrapped Numbers"
+                    actionParam="{
+                        view: 'website.s_countdown_inline_wrapped_numbers_template',
+                        templateClass: 'o_template_wrapped_numbers',
+                    }">
+                    Wrapped Numbers
+                </BuilderSelectItem>
+                <BuilderSelectItem
+                    id="'template_text_opt'"
+                    title.translate="Text"
+                    actionParam="{
+                        view: 'website.s_countdown_inline_text_template',
+                        templateClass: 'o_template_text',
+                    }">
+                    Text
+                </BuilderSelectItem>
+                <BuilderSelectItem
+                    id="'template_big_numbers_opt'"
+                    title.translate="Big Numbers"
+                    actionParam="{
+                        view: 'website.s_countdown_inline_big_numbers_template',
+                        templateClass: 'o_template_big_numbers',
+                    }">
+                    Big Numbers
+                </BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+        <BuilderRow label.translate="Round Corners" applyTo="'.o_count_item_nbs'" t-if="isActiveItem('template_wrapped_numbers_opt')" level="3">
+            <BuilderNumberInput styleAction="'border-radius'" unit="'px'" min="0"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Color" applyTo="'.s_countdown_inline'" level="2">
+            <BuilderSelect>
+                <BuilderSelectItem id="'color_default_opt'" title.translate="Default" classAction="'o_countdown_default'">Default</BuilderSelectItem>
+                <BuilderSelectItem title.translate="Primary" classAction="'o_countdown_primary'">Primary</BuilderSelectItem>
+                <BuilderSelectItem title.translate="Secondary" classAction="'o_countdown_secondary'">Secondary</BuilderSelectItem>
+                <BuilderSelectItem title.translate="Info" classAction="'o_countdown_info'">Info</BuilderSelectItem>
+                <BuilderSelectItem title.translate="Success" classAction="'o_countdown_success'">Success</BuilderSelectItem>
+                <BuilderSelectItem title.translate="Warning" classAction="'o_countdown_warning'">Warning</BuilderSelectItem>
+                <BuilderSelectItem title.translate="Danger" classAction="'o_countdown_danger'">Danger</BuilderSelectItem>
+                <BuilderSelectItem title.translate="Light" classAction="'o_countdown_light'">Light</BuilderSelectItem>
+                <BuilderSelectItem title.translate="Dark" classAction="'o_countdown_dark'">Dark</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+        <BuilderRow label.translate="Subtle colors" applyTo="'.s_countdown_inline'" level="3">
+            <BuilderCheckbox id="'subtle_colors_opt'" classAction="'o_countdown_subtle'" t-if="!this.isActiveItem('color_default_opt') and !this.isActiveItem('template_text_opt') and !this.isActiveItem('template_big_numbers_opt')"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Label" applyTo="'.s_countdown_inline'" level="2">
+            <BuilderSelect>
+                <BuilderSelectItem title.translate="Default" classAction="''">Default</BuilderSelectItem>
+                <BuilderSelectItem title.translate="Compact" classAction="'o_label_compact'">Compact</BuilderSelectItem>
+                <BuilderSelectItem title.translate="None" classAction="'o_label_none'">None</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+        <BuilderRow label.translate="Alignment" level="2">
+            <BuilderButtonGroup applyTo="'.s_countdown_inline_wrapper'">
+                <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="''"/>
+                <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'align-self-center text-center'"/>
+                <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'align-self-end text-end'"/>
+            </BuilderButtonGroup>
+        </BuilderRow>
+        <BuilderRow label.translate="Font Monospace" applyTo="'.s_countdown_inline'" level="2">
+            <BuilderCheckbox
+                id="'font_monospace_opt'"
+                classAction="'o_count_monospace'"
+                t-if="this.isActiveItem('template_dominoes_opt') or this.isActiveItem('template_wrapped_numbers_opt') or this.isActiveItem('template_big_numbers_opt')"
+                />
+        </BuilderRow>
+        <hr class="mx-3"/>
+        <BuilderRow label.translate="Edge Spacing" applyTo="'.s_countdown_inline_wrapper'">
+            <BuilderRange styleAction="'padding'" min="0" max="200" step="1" displayRangeValue="true" unit="'px'"/>
+        </BuilderRow>
+        <BuilderContext applyTo="'.s_countdown_inline_wrapper'">
+            <BorderConfigurator label.translate="Border"/>
+        </BuilderContext>
     </t>
 </t>
 

--- a/addons/website/static/src/snippets/s_countdown/000.scss
+++ b/addons/website/static/src/snippets/s_countdown/000.scss
@@ -1,0 +1,140 @@
+.s_countdown_inline {
+    font-variant-numeric: tabular-nums;
+
+    .o_skeletton {
+        display: block;
+
+        &:before {
+            content: '\00a0';
+        }
+    }
+
+    .o_colored_item {
+        border: $border-width solid $border-color;
+    }
+
+    // Defines color classes based on $theme-colors
+    @each $-state, $-value in $theme-colors {
+        &.o_countdown_#{$-state} {
+            .o_colored_item {
+                border-color: $-value;
+                background: $-value;
+                color: color-contrast($-value);
+            }
+
+            &.o_countdown_subtle {
+                .o_colored_item {
+                    border-color: var(--#{$prefix}#{$-state}-border-subtle);
+                    background: var(--#{$prefix}#{$-state}-bg-subtle);
+                    color: var(--#{$prefix}#{$-state}-text-emphasis);
+
+                    a {
+                        color: var(--#{$prefix}#{$-state}-text-emphasis);
+                    }
+                }
+            }
+
+            .o_colored_text {
+                color: $-value;
+            }
+        }
+    }
+
+    .o_count_item {
+        display: inline-flex;
+    }
+
+    .o_count_item_nbs {
+        // Force to keep ltr numbers
+        direction: ltr #{"/* rtl:ltr */"};
+    }
+
+    &.o_label_compact .o_count_item_label .o_other_letters, &.o_label_none .o_count_item_label {
+        display: none;
+    }
+
+    &.o_count_monospace .o_count_item_nbs {
+        font-family: $font-family-monospace;
+    }
+
+    // Hide unnecessary separator when changing the display option
+    .o_count_item:where(:has( ~ .o_count_item.d-none)):not(:has(~.o_count_item:not(.d-none))) ~ .o_count_separator {
+        display: none;
+    }
+
+    &:where(:not(.o_label_compact)) {
+        .o_count_inline_text {
+            .o_count_item_label {
+                margin-left: map-get($spacers, 1);
+            }
+        }
+    }
+
+    .o_count_inline_text {
+        .o_count_item_label {
+            text-transform: lowercase;
+        }
+
+        p:last-child {
+            margin-bottom: 0;
+        }
+
+        // Use "," as separator
+        .o_count_item:where(:not(:last-child):not(:has( + .d-none))):after {
+            content: ',\00a0';
+        }
+    }
+
+    &.o_label_none {
+        .o_count_inline_text {
+            .o_count_item {
+                // Replace "," separator with ":" when labels are hidden.
+                &:where(:not(:first-of-type)):before {
+                    content: ':\00a0';
+                }
+
+                &::after {
+                    display: none;
+                }
+            }
+        }
+    }
+
+    .o_template_dominoes {
+        .o_count_item_nbs {
+            gap: 1px;
+        }
+    }
+
+    &.o_countdown_default .o_template_dominoes {
+        .o_count_item_nb {
+            &:after {
+                position: absolute;
+                inset: 50% 0 auto;
+                display: block;
+                border-bottom: $border-width solid $border-color;
+                content: '';
+                z-index: 1;
+            }
+        }
+    }
+
+    &:not(.o_countdown_default) .o_template_dominoes {
+        .o_count_item_nb {
+            // Simulates the horizontal line in the middle of the domino.
+            clip-path: polygon(0 0, 100% 0, 100% calc(50% - 0.5px), 0 calc(50% - 0.5px), 0 calc(50% + 0.5px), 100% calc(50% + 0.5px), 100% 100%, 0 100%);
+        }
+    }
+
+    .o_template_wrapped_numbers {
+        .o_count_item_nbs {
+            width: map-get($spacers, 5);
+            aspect-ratio: 1 / 1;
+        }
+
+        .o_count_separator {
+            display: flex;
+            height: map-get($spacers, 5);
+        }
+    }
+}

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -15,7 +15,7 @@ registerWebsitePreviewTour(
     () => [
         ...insertSnippet({ id: "s_countdown", name: "Countdown", groupName: "Content" }),
         ...clickOnSnippet({ id: "s_countdown", name: "Countdown" }),
-        ...changeOptionInPopover("Countdown", "At The End", "Show Message and keep countdown"),
+        ...changeOptionInPopover("Countdown", "At The End", "Message + Timer"),
         changeOption("Countdown", "previewEndMessage"),
         // The next two steps check that the end message does not disappear when
         // a widgets_start_request is triggered.
@@ -45,7 +45,7 @@ registerWebsitePreviewTour(
         },
         // Next, we change the end action to message and no countdown while the
         // edit message toggle is still activated. It should hide the countdown.
-        ...changeOptionInPopover("Countdown", "At The End", "Show Message and hide countdown"),
+        ...changeOptionInPopover("Countdown", "At The End", "Message only"),
         {
             content: "Check that the countdown is not displayed",
             trigger: ":iframe .s_countdown:has(.s_countdown_canvas_wrapper:not(:visible))",

--- a/addons/website/views/snippets/s_countdown.xml
+++ b/addons/website/views/snippets/s_countdown.xml
@@ -23,13 +23,113 @@
                     <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="175" height="175" class="w-100" viewBox="0 0 175 175"><defs></defs><g><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="43.75px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="87.5" text-anchor="middle" dominant-baseline="central">45</text><text fill="var(--o-color-1)" stroke="none" font-family="Arial" font-size="14.583333333333334px" font-style="normal" font-weight="normal" text-decoration="normal" x="87.5" y="116.66666666666667" text-anchor="middle" dominant-baseline="central">Seconds</text><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 166.25 87.5 A 78.75 78.75 0 1 1 166.24996062500327 87.42125001312495" stroke-miterlimit="10" stroke-width="5" stroke-opacity="0.2" stroke-dasharray=""></path><path fill="none" stroke="var(--o-color-1)" paint-order="fill stroke markers" d=" M 87.5 8.75 A 78.75 78.75 0 1 1 8.75 87.50000000000001" stroke-miterlimit="10" stroke-width="5" stroke-dasharray=""></path></g></svg>
                 </div>
             </div>
+            <div class="s_countdown_inline d-flex flex-column align-items-start o_countdown_default">
+                <div class="s_countdown_inline_wrapper d-none">
+                    <t t-call="website.s_countdown_inline_default_template"/>
+                </div>
+            </div>
         </div>
     </section>
+</template>
+
+<template id="s_countdown_inline_default_template" groups="base.group_user">
+    <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
+    <div class="o_template_default o_count_inline_text o_colored_item alert mb-0">
+        <p>
+            <i class="fa fa-clock-o"/> Sale ends in
+            <span class="o_not_editable oe_unremovable" contenteditable="false">
+                <t t-foreach="metrics" t-as="metric">
+                    <span class="o_count_item">
+                        <span class="o_count_item_nbs d-inline-flex fw-bold"/>
+                        <span class="o_count_item_label fw-bold">
+                            <span class="o_skeletton rounded bg-200 ps-5"/>
+                        </span>
+                    </span>
+                </t>
+            </span>
+        </p>
+    </div>
+</template>
+
+<template id="s_countdown_inline_dominoes_template" groups="base.group_user">
+    <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
+    <div class="o_template_dominoes">
+        <div class="o_not_editable oe_unremovable d-flex gap-1" contenteditable="false">
+            <t t-foreach="metrics" t-as="metric">
+                <span class="o_count_item d-flex gap-1">
+                    <span class="d-flex flex-column align-items-center">
+                        <span class="o_count_item_nbs d-inline-flex">
+                            <span class="o_count_item_nb o_colored_item position-relative rounded py-1 px-2 fs-4 fw-bold"/>
+                            <span class="o_count_item_nb o_colored_item position-relative rounded py-1 px-2 fs-4 fw-bold"/>
+                        </span>
+                        <span class="o_count_item_label small"/>
+                    </span>
+                </span>
+                <span t-if="metric_last == false" class="o_count_separator mt-1 fs-4">:</span>
+            </t>
+        </div>
+    </div>
+</template>
+
+<template id="s_countdown_inline_wrapped_numbers_template" groups="base.group_user">
+    <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
+    <div class="o_template_wrapped_numbers">
+        <div class="o_not_editable oe_unremovable d-inline-flex gap-1" contenteditable="false">
+            <t t-foreach="metrics" t-as="metric">
+                <span class="o_count_item d-flex gap-1">
+                    <span class="d-flex flex-column align-items-center">
+                        <span class="o_count_item_nbs o_colored_item d-flex justify-content-center align-items-center rounded p-2"/>
+                        <span class="o_count_item_label small"/>
+                    </span>
+                </span>
+                <span t-if="metric_last == false" class="o_count_separator align-items-center">:</span>
+            </t>
+        </div>
+    </div>
+</template>
+
+<template id="s_countdown_inline_text_template" groups="base.group_user">
+    <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
+    <div class="o_template_text o_count_inline_text">
+        <p>
+            <i class="fa fa-clock-o"/> Sale ends in
+            <span class="o_not_editable oe_unremovable" contenteditable="false">
+                <t t-foreach="metrics" t-as="metric">
+                    <span class="o_count_item o_colored_text">
+                        <span class="o_count_item_nbs d-inline-flex fw-bold"/>
+                        <span class="o_count_item_label fw-bold"/>
+                    </span>
+                </t>
+            </span>
+        </p>
+    </div>
+</template>
+
+<template id="s_countdown_inline_big_numbers_template" groups="base.group_user">
+    <t t-set="metrics" t-value="[days, hours, minutes, seconds]"/>
+    <div class="o_template_big_numbers">
+        <div class="o_not_editable oe_unremovable d-inline-flex gap-1" contenteditable="false">
+            <t t-foreach="metrics" t-as="metric">
+                <span class="o_count_item d-flex gap-1">
+                    <span class="d-flex flex-column align-items-center">
+                        <span class="o_count_item_nbs o_colored_text fs-3 fw-bold"/>
+                        <span class="o_count_item_label small"/>
+                    </span>
+                </span>
+                <span t-if="metric_last == false" class="o_count_separator fs-3 fw-bold">:</span>
+            </t>
+        </div>
+    </div>
 </template>
 
 <asset id="website.s_countdown_000_xml" name="Countdown 000 XML">
     <bundle>web.assets_frontend</bundle>
     <path>website/static/src/snippets/s_countdown/000.xml</path>
+</asset>
+
+<asset id="website.s_countdown_000_scss" name="Countdown 000 SCSS">
+    <bundle>web.assets_frontend</bundle>
+    <path>website/static/src/snippets/s_countdown/000.scss</path>
 </asset>
 
 </odoo>


### PR DESCRIPTION
Introduce redesigned `text_inline` layouts in `s_countdown`, replacing the old `text_inline` layout.  

Key changes:
- Replace old `text_inline` layout.
- Add 5 inline text templates with `colors` and `labels`.
- Add `border` and `radius` styling to all layouts.

task-4367910

---

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)
