### PR TITLE
[IMP] account_peppol: Hide things in Advanced Peppol Config if waiting

### DIFF
--- a/addons/account_peppol/wizard/peppol_config_wizard.xml
+++ b/addons/account_peppol/wizard/peppol_config_wizard.xml
@@ -10,7 +10,10 @@
                 <div invisible="account_peppol_proxy_state != 'sender'">
                     You are sending your e-invoices via Odoo with this Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>.
                 </div>
-                <div invisible="account_peppol_proxy_state not in ('smp_registration', 'receiver')">
+                <div invisible="account_peppol_proxy_state != 'smp_registration'">
+                    Your Peppol registration is being processed, it should be active within a day.
+                </div>
+                <div invisible="account_peppol_proxy_state != 'receiver'">
                     You are sending and receiving your e-invoices via Odoo with this Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>.
                 </div>
                 <group string="Company information">


### PR DESCRIPTION
While we're waiting for the SMP registration, it doesn't make sense to be able to modify the Peppol contact e-mail address, or to deregister from Peppol.

We therefore make the 'Primary contact e-mail' field readonly and hide the 'Remove from Peppol' button in this case.

This is a feedback from PMAX while I was doing the self-billing task - see https://app.excalidraw.com/l/65VNwvy7c4X/2krXDb6Kf6h

<img width="1573" height="506" alt="image" src="https://github.com/user-attachments/assets/c6bff00d-2451-4ba7-8509-ca8f3c77189f" />


task-none