### PR TITLE
[FIX] html_editor: more complete check for internal and frontend urls

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -596,7 +596,14 @@ class HTML_Editor(http.Controller):
             words = parsed_preview_url.path.strip('/').split('/')
             last_segment = words[-1]
 
-            if not last_segment.isnumeric():
+            if not (
+                last_segment.isnumeric()
+                and (
+                    parsed_preview_url.path.startswith("/odoo")
+                    or parsed_preview_url.path.startswith("/web")
+                    or parsed_preview_url.path.startswith("/@/")
+                )
+            ):
                 # this could be a frontend or an external page
                 link_preview_data = self.link_preview_metadata(preview_url)
                 result = {}

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -456,7 +456,10 @@ export class LinkPopover extends Component {
             if (icon) {
                 this.state.previewIcon.value = icon;
             }
-        } else if (window.location.hostname !== url.hostname) {
+        } else if (
+            window.location.hostname !== url.hostname &&
+            !new RegExp(`^https?://${session.db}\\.odoo\\.com(/.*)?$`).test(url.origin)
+        ) {
             // Preview pages from current website only. External website will
             // most of the time raise a CORS error. To avoid that error, we
             // would need to fetch the page through the server (s2s), involving

--- a/addons/html_editor/tests/test_controller.py
+++ b/addons/html_editor/tests/test_controller.py
@@ -154,7 +154,7 @@ class TestController(HttpCase):
                 return {
                     'og_description': 'Mocked page description',
                 }
-            elif url == _get_full_url("/page-without-description"):
+            elif url == _get_full_url("/page-without-description") or url == _get_full_url("/shop/category/1"):
                 return {
                     'og_description': None,
                 }
@@ -229,6 +229,19 @@ class TestController(HttpCase):
             )
             self.assertEqual(200, response_page_without_desc.status_code)
             self.assertTrue('"result": {}' in response_page_without_desc.text)
+
+            response_page_without_desc = self.url_open(
+                '/html_editor/link_preview_internal',
+                data=json_safe.dumps({
+                    "params": {
+                        "preview_url": _get_full_url("/shop/category/1"),
+                    }
+                }),
+                headers=self.headers
+            )
+            self.assertEqual(200, response_page_without_desc.status_code)
+            self.assertTrue('"result": {}' in response_page_without_desc.text)
+            self.assertFalse('error_msg' in response_page_without_desc.text)
 
             # Check metadata for a URL that points to an invalid/unknown page
             invalid_page = self.url_open(


### PR DESCRIPTION
Before this commit: the condition to check if an url is internal is not complete as the user could user the odoo instance domain instead of the real domain. The check if an internal url is a frontend one is rather naive as there are cases where the url ends with a number but actually not leading to a record.

Reproduction for the second use case:
1. create a link with frontend url for example `/shop/category/16`
2. click on the link, when it loads the preview, a warning pops up

After this commit, the cases explained above are included.

task-4971829

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
