### PR TITLE
[IMP] website: valid max file size in form upload

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -206,12 +206,11 @@
             min="1"
         />
     </BuilderRow>
-    <BuilderRow label.translate="Max File Size">
+    <BuilderRow label.translate="Max File Size"
+        tooltip.translate="Note that your server has its own upload limit (typically 64 MB on Odoo SaaS), which will take precedence over this value">
         <BuilderNumberInput
-            title.translate="The maximum size (in MB) an uploaded file can have."
             dataAttributeAction="'maxFileSize'"
             applyTo="`input[type='file']`"
-            default="1"
             unit="'MB'"
             applyWithUnit="false"
         />

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -504,7 +504,9 @@ export class Form extends Interaction {
                 this.updateStatus(
                     "error",
                     error.message && error.message === "Content too large"
-                        ? _t("Uploaded file is too large.")
+                        ? _t(
+                              "Your upload is too large for the server to accept. Please choose smaller files."
+                          )
                         : ""
                 );
             });

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -373,7 +373,7 @@
                 t-att="field.maxFilesNumber > 1 and {'multiple': ''} or {}"
                 t-att-id="field.id"
                 t-att-data-max-files-number="field.maxFilesNumber or '1'"
-                t-att-data-max-file-size="field.maxFileSize or '1'"
+                t-att-data-max-file-size="field.maxFileSize or '64'"
             />
         </t>
     </t>


### PR DESCRIPTION
This PR introduces several enhancements and fixes for the file upload field in website forms:

**Website Editor:**

- Updates the default `Max File Size` to 64MB.
- Adds a tooltip when changing the `Max File Size` in the form snippet, guiding users on the appropriate limit.
-  ̶A̶d̶d̶s̶ ̶a̶ ̶n̶e̶w̶ ̶c̶h̶e̶c̶k̶b̶o̶x̶ ̶o̶p̶t̶i̶o̶n̶ ̶R̶e̶s̶t̶r̶i̶c̶t̶ ̶t̶o̶ ̶P̶D̶F̶ ̶f̶o̶r̶ ̶f̶i̶l̶e̶ ̶u̶p̶l̶o̶a̶d̶ ̶f̶i̶e̶l̶d̶s̶.̶ ̶W̶h̶e̶n̶ ̶e̶n̶a̶b̶l̶e̶d̶,̶ ̶o̶n̶l̶y̶ ̶`̶.̶p̶d̶f̶`̶ ̶f̶i̶l̶e̶s̶ ̶a̶r̶e̶ ̶a̶c̶c̶e̶p̶t̶e̶d̶.̶

**Website Visitor:**

- Files larger than the configured `Max File Size` are now blocked upfront with a clear error message.
- If the file is within the configured limit but still exceeds the server’s payload capacity (or fails due to proxy/server limits), a dedicated error message is shown to inform the user.
-  ̶F̶i̶l̶e̶ ̶t̶y̶p̶e̶ ̶v̶a̶l̶i̶d̶a̶t̶i̶o̶n̶ ̶e̶n̶s̶u̶r̶e̶s̶ ̶o̶n̶l̶y̶ ̶P̶D̶F̶s̶ ̶a̶r̶e̶ ̶a̶c̶c̶e̶p̶t̶e̶d̶ ̶w̶h̶e̶n̶ ̶R̶e̶s̶t̶r̶i̶c̶t̶ ̶t̶o̶ ̶P̶D̶F̶ ̶i̶s̶ ̶e̶n̶a̶b̶l̶e̶d̶.̶

TASK - 4626847 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
