### PR TITLE
[IMP] website_sale_collect: hide option enviroment and debug

### DIFF
--- a/addons/website_sale_collect/data/delivery_carrier_data.xml
+++ b/addons/website_sale_collect/data/delivery_carrier_data.xml
@@ -6,6 +6,7 @@
         <field name="delivery_type">in_store</field>
         <field name="product_id" ref="website_sale_collect.product_pick_up_in_store"/>
         <field name="website_id" ref="website.default_website"/>
+        <field name="prod_environment" eval="True"/>
     </record>
 
 </odoo>

--- a/addons/website_sale_collect/views/delivery_carrier_views.xml
+++ b/addons/website_sale_collect/views/delivery_carrier_views.xml
@@ -28,6 +28,12 @@
                     </field>
                 </page>
             </page>
+            <button name="toggle_prod_environment" position="attributes">
+                <attribute name="invisible" add="delivery_type == 'in_store'" separator=" or "/>
+            </button>
+            <button name="toggle_debug" position="attributes">
+                <attribute name="invisible" add="delivery_type == 'in_store'" separator=" or "/>
+            </button>
         </field>
     </record>
 


### PR DESCRIPTION
* Problem: when choosing In store provider , the toggle button to enable enviroment and debug is present which is not necessary , it should only display for external 3rd provider
* This commit is to hide them

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
