### PR TITLE
[IMP] website_sale: adjust height of shop buttons

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -311,6 +311,8 @@
 
             &:where(:not(.o_wsale_product_btn_primary)) {
                 aspect-ratio: var(--o-wsale-card-btn-aspect-ratio);
+                padding-left: var(--o-wsale-card-btn-padding-x, var(--#{$prefix}btn-padding-x));
+                padding-right: var(--o-wsale-card-btn-padding-x, var(--#{$prefix}btn-padding-x));
             }
             &:where(.o_wsale_product_btn_primary) {
                 display: var(--o-wsale-card-btn-submit-display, none);
@@ -318,6 +320,8 @@
                 flex-grow: var(--o-wsale-card-btn-submit-flex-grow);
                 aspect-ratio: var(--o-wsale-card-btn-submit-aspect-ratio);
                 margin: var(--o-wsale-card-btn-submit-margin);
+                padding-left: var(--o-wsale-card-btn-submit-padding-x, var(--#{$prefix}btn-padding-x));
+                padding-right: var(--o-wsale-card-btn-submit-padding-x, var(--#{$prefix}btn-padding-x));
 
                 .o_label {
                     display: var(--o-wsale-card-btn-submit-label-display,  var(--o-wsale-card-btn-label-display));
@@ -424,6 +428,7 @@
                         --o-wsale-card-btn-submit-flex-grow: 0;
                         --o-wsale-card-btn-submit-aspect-ratio: 1;
                         --o-wsale-card-btn-submit-margin: 0 auto 0 0;
+                        --o-wsale-card-btn-submit-padding-x: 0;
                     }
                 }
             }
@@ -1026,6 +1031,7 @@ $_wsale_products_roundness_map: (
             --o-wsale-card-btns-flex-direction: row;
             --o-wsale-card-btn-aspect-ratio: 1;
             --o-wsale-card-btn-label-display: none;
+            --o-wsale-card-btn-padding-x: 0;
             --o-wsale-card-btn-submit-label-display: inline;
         }
         @include media-breakpoint-up(lg) {


### PR DESCRIPTION
Prior to this commit, the product card buttons could be misaligned across cards when comparison was active.
This is because we enforced a 1/1 aspect ratio on buttons containing only a single icon, creating higher buttons.

This commit adapts these square buttons to correctly match the height of the other buttons in order to fix this misalignment issue.

task-5028598

| Before | After |
|--------|--------|
| <img width="1920" height="833" alt="image" src="https://github.com/user-attachments/assets/6c2b6b25-fc4b-40aa-9a61-f7b0d68b4e68" /> | <img width="1076" height="394" alt="Capture d’écran 2025-08-22 à 11 09 36" src="https://github.com/user-attachments/assets/c5c3b965-d5f8-4b77-8fc3-91fb13236b23" /> | 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
