### PR TITLE
[FIX] mrp_subcontracting: keep at least one MO when reducing receipt qty

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -320,6 +320,11 @@ class StockMove(models.Model):
         # Cancel productions until reach new_quantity
         for production in (productions - wip_production):
             if float_compare(quantity_to_remove, production.product_qty, precision_rounding=production.product_uom_id.rounding) >= 0:
+                if len(productions + wip_production) == 1:
+                    production.qty_producing = 0
+                    production.subcontracting_has_been_recorded = False
+                    production._set_qty_producing()
+                    break  # Never cancel the last MO if there's still a subcontracting move
                 quantity_to_remove -= production.product_qty
                 production.with_context(skip_activity=True).action_cancel()
             else:


### PR DESCRIPTION
Steps to reproduce:
- Unarchive subcontracting operation type
- Create a storable product P1 with a BoM:
    - BoM type: Subcontracting
    - Subcontractor: Azure Interior
    - Component C1 (route: Resupply Subcontractor on Order)
- Create a purchase order:
    - Vendor: Azure Interior
    - 10 units of P1
    - Confirm the PO → 2 pickings are created:
        - Resupply of 10 units of C1
        - Receipt of 10 units of P1
- Confirm and validate the resupply of C1
- Components are reserved in the subcontracting MO
- Validate the consumption of 10 units in the receipt
- The MO is updated to 10
- Update the quantity of P1 to 0 in the receipt

Issue:
The manufacturing order is cancelled. As a result, subsequent updates on the receipt cannot recreate MOs.

Fix:
When reducing the receipt quantity, cancel only the extra MOs, but always keep at least one open MO if a subcontracting move is still ongoing.

opw-4792379
