### PR TITLE
[FIX] mail: do not unlink the same member twice

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -294,6 +294,7 @@ class DiscussChannelMember(models.Model):
         # always unlink members of sub-channels as well
         domains = [
             [
+                ("id", "not in", self.ids),
                 ("partner_id", "=", member.partner_id.id),
                 ("guest_id", "=", member.guest_id.id),
                 ("channel_id", "in", member.channel_id.sub_channel_ids.ids),


### PR DESCRIPTION
When a user leaves a channel, it also leaves every of its sub channels. To do so, the `unlink` channel member method is extended.

However, the current approach can lead to the same member being unlinked twice, leading to errors.

This commit fixes the issue by ensuring the domain looking for sub channel members excludes the members currently being unlinked.

fixes runbot-230830

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
