### PR TITLE
[IMP] website: rename the header button option

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header/header_elements_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_elements_option.xml
@@ -60,7 +60,7 @@
             }"
         />
         <BuilderButton
-            title.translate="Contact Us"
+            title.translate="Header Button"
             className="'flex-grow-1'"
             actionParam="{
                 views: ['website.header_call_to_action'],


### PR DESCRIPTION
Before this commit, the option for showing/hiding the header button was labeled "Contact Us." This made sense when the default button text was "Contact Us," but it no longer fits if the button text is changed. For example, users might customize the text, or different apps could set a different default (e.g. With the POS app installed, the button text might be "Book a Table.")

This commit renames the option to "Header Button," making it more general and consistent regardless of the button text.