### PR TITLE
[FIX] account: handle error on uploading empty file

### DIFF
--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -109,7 +109,7 @@ def split_etree_on_tag(tree, tag):
 
 
 def extract_pdf_embedded_files(filename, content):
-    with io.BytesIO(content) as buffer:
+    with io.BytesIO(content or b'') as buffer:
         try:
             pdf_reader = OdooPdfFileReader(buffer, strict=False)
         except Exception as e:  # noqa: BLE001

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -937,3 +937,13 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
                 }
             },
         )
+
+    def test_75_journal_upload_empty_pdf(self):
+        empty_pdf_vals = {'name': 'empty.pdf', 'raw': False, 'type': 'binary', 'mimetype': 'application/pdf'}
+        self.assert_attachment_import(
+            origin='journal',
+            attachments_vals=[empty_pdf_vals],
+            expected_invoices={
+                1: {'empty.pdf': {'on_invoice': True, 'on_message': True, 'is_decoded': True, 'is_new': True}},
+            },
+        )


### PR DESCRIPTION
Currently, an error occurs when uploading zero-byte files as attachments.

**Steps to Reproduce:**
1. Install the **Invoicing** app.
2. In Customer **Invoices**, try uploading [this file](https://drive.google.com/file/d/1iWO1pKT9XJbeUPNpqJdbN_Ahea3lK68o/view?usp=drive_link).

**Error:**
`TypeError - a bytes-like object is required, not 'bool'`

**Cause:**
An empty file has no raw data. So at [1], the value of `file_data['raw']` is `False`, leading to an error when attempting to extract the embedded PDF file at [2].

**Fix:**
This commit ensures that if the raw data is False, it passes the empty byte data to prevent the error.

[1] - https://github.com/odoo/odoo/blob/69c8348d5f99e653b31f02b46663dc8ba887bade/addons/account/models/account_document_import_mixin.py#L506
[2] - https://github.com/odoo/odoo/blob/69c8348d5f99e653b31f02b46663dc8ba887bade/addons/account/models/account_document_import_mixin.py#L112

sentry-6820233764, 6781383914, 6930502625