### PR TITLE
[FIX] website: enforce file size limit check correctly

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -209,6 +209,7 @@
             applyTo="`input[type='file']`"
             default="1"
             unit="'MB'"
+            applyWithUnit="false"
         />
     </BuilderRow>
     <BuilderRow t-if="state.valueList">


### PR DESCRIPTION
Steps to Reproduce:
- Open the website module.
- Drop a basic form snippet.
- Change the field type of any field to 'File Upload'.
- Set the 'Max File Size' to any value other than the default (1 MB)
and save the changes.
- Attempt to upload a file larger than the specified maximum file size.

It has been observed that a file larger than the allowed size is
successfully uploaded, which is incorrect behaviour.

Before this commit:
The maximum file size limit was stored as a string. As a result,
comparisons faile,d and files larger than the configured limit could
still be uploaded, causing invalid submissions.

After this commit:
The maxFileSize value is now parsed as an integer before comparison.
The file size restriction works as expected: files larger than the
defined limits are blocked upfront with a clear error.