### PR TITLE
[FIX] core: remove Registry.__call__

### DIFF
--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -142,7 +142,7 @@ class TestTracking(MailCommon):
 
         def _track_subtype(self, init_values):
             return self.env.ref('mail.mt_note')
-        self.patch(self.registry('mail.test.ticket'), '_track_subtype', _track_subtype)
+        self.patch(self.registry['mail.test.ticket'], '_track_subtype', _track_subtype)
 
         def _track_template(self, changes):
             if 'email_from' in changes:
@@ -150,7 +150,7 @@ class TestTracking(MailCommon):
             elif 'container_id' in changes:
                 return {'container_id': (mail_templates[1], {'message_type': 'notification'})}
             return {}
-        self.patch(self.registry('mail.test.ticket'), '_track_template', _track_template)
+        self.patch(self.registry['mail.test.ticket'], '_track_template', _track_template)
 
         container = self.env['mail.test.container'].create({'name': 'Container'})
 

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -317,10 +317,6 @@ class Registry(Mapping[str, type["BaseModel"]]):
         """ Return the model with the given name or raise KeyError if it doesn't exist."""
         return self.models[model_name]
 
-    def __call__(self, model_name: str) -> type[BaseModel]:
-        """ Same as ``self[model_name]``. """
-        return self.models[model_name]
-
     def __setitem__(self, model_name: str, model: type[BaseModel]):
         """ Add or replace a model in the registry."""
         self.models[model_name] = model


### PR DESCRIPTION
`BaseModel.pool` was exposed in RPC because it is considered as a public method: it is callable, not prefixed by `_`, not decorated with `@api.private`.

There's no reason to expose this object in RPC, and `__call__` is redundant with `__getitem__`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
