### PR TITLE
[FIX] web_editor: ensure image border visible in emails

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1810,7 +1810,10 @@ function correctBorderAttributes(style) {
         return correctedStyle;
     }
 
-    return style;
+    if (/border-style\s*:/i.test(style)) {
+        return style;
+    }
+    return style.trim().replace(/;?$/, "; border-style: solid;");
 }
 
 export default {


### PR DESCRIPTION
Problem:
When adding a border to an image and sending an email, the border is not visible in the received email.

Solution:
Ensure a `border-style` is set if missing, otherwise keep the existing one.

Steps to reproduce:
- Open email marketing.
- Add an image snippet.
- Add a border to the image.
- Send the email.
- The received image has no border.

opw-5004824

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
