### PR TITLE
[IMP] html_editor: show focus when navigating link popover with keyboard

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -314,6 +314,16 @@ export class LinkPopover extends Component {
             ev.preventDefault();
             ev.stopImmediatePropagation();
             this.onClickApply();
+        } else if (ev.key == "Tab") {
+            ev.preventDefault();
+            const focusableElements = [
+                ...this.editingWrapper.el.querySelectorAll("input, select, button:not([disabled])"),
+            ];
+            const currentIndex = focusableElements.indexOf(document.activeElement);
+            const nextIndex =
+                (currentIndex + (ev.shiftKey ? -1 : 1) + focusableElements.length) %
+                focusableElements.length;
+            focusableElements[nextIndex].focus();
         }
     }
 

--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -21,6 +21,15 @@
             }
         }
     }
+
+    .form-control:focus, .form-select:focus, .form-check-input:focus {
+        border-color: $input-focus-border-color !important;
+        box-shadow: 0 0 0 $focus-ring-width rgba($input-focus-border-color, $focus-ring-opacity);
+    }
+
+    .o_we_discard_link:focus {
+        opacity: .8;
+    }
 }
 
 .custom-border {

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -12,7 +12,7 @@
                 </div>
                 <div t-else="" class="d-flex">
                     <div class="col p-2" style="max-width: 270px;">
-                        <div class="input-group mb-1" t-att-class="{'d-none': !state.showLabel}">
+                        <div class="input-group mb-2" t-att-class="{'d-none': !state.showLabel}">
                             <input t-ref="label"
                                 class="o_we_label_link border-dark-subtle form-control form-control-sm"
                                 t-model="state.label"
@@ -20,7 +20,7 @@
                                 placeholder="Add a label for your link"
                                 t-on-input="onChange"/>
                         </div>
-                        <div class="input-group mb-1">
+                        <div class="input-group mb-2">
                             <input t-ref="url"
                                 name="o_linkpopover_url"
                                 class="o_we_href_input_link border-dark-subtle form-control form-control-sm"

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1095,6 +1095,37 @@ describe("shortcut", () => {
             '<p><a href="https://test.com">li[]nk</a></p>'
         );
     });
+    test("should trap focus within link popover when using Tab and Shift+Tab", async () => {
+        await setupEditor(`<p><a>li[]nk</a></p>`);
+        await expectElementCount(".o-we-linkpopover", 1);
+
+        // Tab through all focusable elements
+        await press("Tab");
+        await animationFrame();
+        expect(".o_we_href_input_link").toBeFocused();
+        await press("Tab");
+        await animationFrame();
+        expect(".btn-light").toBeFocused();
+        await press("Tab");
+        await animationFrame();
+        expect("select[name='link_type']").toBeFocused();
+        await press("Tab");
+        await animationFrame();
+        expect(".form-check-input").toBeFocused();
+        await press("Tab");
+        await animationFrame();
+        expect(".o_we_discard_link").toBeFocused();
+
+        // One more Tab should wrap to first element
+        await press("Tab");
+        await animationFrame();
+        expect(".o_we_label_link").toBeFocused();
+
+        // Shift+Tab should wrap to Last element
+        await press(["Shift", "Tab"]);
+        await animationFrame();
+        expect(".o_we_discard_link").toBeFocused();
+    });
 });
 
 describe("link preview", () => {


### PR DESCRIPTION
Steps to Reproduce:

- Select a word in the editor.
- Press Ctrl + K and Enter to open the link popover.
- Use the Tab key to move between the fields and buttons.

Current behavior before PR:

- It was not clear which field had the focus.
- The border was always overridden by the `border-dark-subtle` class with `!important`, so users had no visual feedback when tabbing.
- When tabbing, focus could escape the link popover instead of looping inside it.

Desired behavior after PR is merged:

- Inputs and selects now use the correct border color on focus, aslo discard button changes opacity when focused.
- The link popover traps focus: pressing Tab/Shift+Tab will cycle through focusable elements without leaving the popover.

task-4965566

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
