### PR TITLE
[FIX] crm_iap_enrich: do not enrich again if no email

### DIFF
--- a/addons/crm_iap_enrich/models/crm_lead.py
+++ b/addons/crm_iap_enrich/models/crm_lead.py
@@ -68,6 +68,7 @@ class Lead(models.Model):
 
                         normalized_email = tools.email_normalize(lead.email_from)
                         if not normalized_email:
+                            lead.write({'iap_enrich_done': True})
                             lead.message_post_with_source(
                                 'crm_iap_enrich.mail_message_lead_enrich_no_email',
                                 subtype_xmlid='mail.mt_note',


### PR DESCRIPTION
If a lead has no valid email, try to enrich it only once This will avoid infinite loop of errors of "Enrichment could not be done because…"
