### PR TITLE
[FIX] account, sale: Bad unit price in downpayment when global discount

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -3076,6 +3076,7 @@ class AccountTax(models.Model):
                 price_unit=base_line['quantity'] * price_unit_after_discount,
                 quantity=1.0,
                 discount=0.0,
+                manual_tax_amounts=None,
             )
             grouping_key = {
                 'tax_ids': new_base_line['tax_ids'],
@@ -3202,7 +3203,7 @@ class AccountTax(models.Model):
                 base_line = target_factor['base_line']
                 tax_details = base_line['tax_details']
                 taxes_data = tax_details['taxes_data']
-                if delta_currency == currency:
+                if delta_suffix == '_currency':
                     base_line['price_unit'] += amount_to_distribute / abs(base_line['quantity'] or 1.0)
                 if not taxes_data:
                     continue

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -1723,6 +1723,7 @@ export const accountTaxHelpers = {
                 price_unit: base_line.quantity * price_unit_after_discount,
                 quantity: 1.0,
                 discount: 0.0,
+                manual_tax_amounts: null,
             });
             const raw_grouping_key = {
                 tax_ids: new_base_line.tax_ids.map((tax) => tax.id),
@@ -1840,7 +1841,7 @@ export const accountTaxHelpers = {
                 const base_line = target_factor.base_line;
                 const tax_details = base_line.tax_details;
                 const taxes_data = tax_details.taxes_data;
-                if (delta_currency.id === currency.id) {
+                if (delta_suffix === '_currency') {
                     base_line.price_unit +=
                         amount_to_distribute / Math.abs(base_line.quantity || 1.0);
                 }


### PR DESCRIPTION
Steps to reproduce
1. Create a sale order with a product line for 14,990.00 and a 0% tax. Make sure the product's product category has a Downpayment Account set on it.
2. Create a global discount for 990.00.
3. Create an invoice.

Notice how the invoice lines' price_unit are respectively 2909.29 and -70.71, and differ from the lines' subtotals.

Analysis
Propagating the manual tax amounts in `_reduce_base_lines_with_grouping_function` causes a delta amount to be present in `_apply_base_lines_manual_amounts_to_reach` whereas there shouldn't be. 

Solution
Drop manual tax amounts in `_reduce_base_lines_with_grouping_function`.

We also take the opportunity to fix the `delta_currency == currency` condition which caused the price_unit to be adjusted twice if the invoice currency is the same as the company currency.

opw-5001935