### PR TITLE
[FIX] im_livechat: do not show restart button after forward to agent

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -38,7 +38,7 @@ class LivechatChatbotScriptController(http.Controller):
 
     @http.route("/chatbot/step/trigger", type="jsonrpc", auth="public")
     @add_guest_to_context
-    def chatbot_trigger_step(self, channel_id, chatbot_script_id=None):
+    def chatbot_trigger_step(self, channel_id, chatbot_script_id=None, data_id=None):
         chatbot_language = self.env["chatbot.script"]._get_chatbot_language()
         discuss_channel = request.env["discuss.channel"].with_context(lang=chatbot_language).search([("id", "=", channel_id)])
         if not discuss_channel:
@@ -66,15 +66,22 @@ class LivechatChatbotScriptController(http.Controller):
             chatbot = request.env['chatbot.script'].sudo().browse(chatbot_script_id).with_context(lang=chatbot_language)
             if chatbot.exists():
                 next_step = chatbot.script_step_ids[:1]
-
+        store = Store()
+        store.data_id = data_id
+        partner, guest = self.env["res.partner"]._get_current_persona()
         if not next_step:
             # sudo - discuss.channel: marking the channel as closed as part of the chat bot flow
             discuss_channel.sudo().livechat_active = False
+            store.resolve_data_request()
+            (partner or guest)._bus_send_store(store)
             return None
         # sudo: discuss.channel - updating current step on the channel is allowed
         discuss_channel.sudo().chatbot_current_step_id = next_step.id
         posted_message = next_step._process_step(discuss_channel)
-        store = Store(posted_message, for_current_user=True)
+        store = store.add(posted_message, for_current_user=True)
+        store.resolve_data_request(
+            chatbot_step={"scriptStep": next_step.id, "message": posted_message.id}
+        )
         store.add(next_step)
         store.add_model_values(
             "ChatbotStep",
@@ -100,6 +107,7 @@ class LivechatChatbotScriptController(http.Controller):
                 "thread": Store.One(discuss_channel, [], as_thread=True),
             },
         )
+        (partner or guest)._bus_send_store(store)
         return store.get_result()
 
     @http.route("/chatbot/step/validate_email", type="jsonrpc", auth="public")

--- a/addons/im_livechat/controllers/cors/chatbot.py
+++ b/addons/im_livechat/controllers/cors/chatbot.py
@@ -17,9 +17,9 @@ class CorsLivechatChatbotScriptController(LivechatChatbotScriptController):
         return self.chatbot_save_answer(channel_id, message_id, selected_answer_id)
 
     @route("/chatbot/cors/step/trigger", type="jsonrpc", auth="public", cors="*")
-    def cors_chatbot_trigger_step(self, guest_token, channel_id, chatbot_script_id=None):
+    def cors_chatbot_trigger_step(self, guest_token, channel_id, chatbot_script_id=None, data_id=None):
         force_guest_env(guest_token)
-        return self.chatbot_trigger_step(channel_id, chatbot_script_id)
+        return self.chatbot_trigger_step(channel_id, chatbot_script_id, data_id)
 
     @route("/chatbot/cors/step/validate_email", type="jsonrpc", auth="public", cors="*")
     def cors_chatbot_validate_email(self, guest_token, channel_id):

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -420,6 +420,18 @@ class DiscussChannel(models.Model):
                 question_msg.user_raw_script_answer_id = selected_answer.id
                 if store := self.env.context.get("message_post_store"):
                     store.add(message, for_current_user=True).add(question_msg.mail_message_id)
+                partner, guest = self.env["res.partner"]._get_current_persona()
+                (partner or guest)._bus_send_store(
+                    Store().add_model_values(
+                        "ChatbotStep",
+                        {
+                            "id": (self.chatbot_current_step_id.id, question_msg.mail_message_id.id),
+                            "scriptStep": self.chatbot_current_step_id.id,
+                            "message": question_msg.mail_message_id.id,
+                            "selectedAnswer": selected_answer.id,
+                        },
+                    )
+                )
 
             self.env["chatbot.message"].sudo().create(
                 {

--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -152,16 +152,18 @@ export class Chatbot extends Record {
             return;
         }
         if (this.steps.at(-1)?.eq(this.currentStep)) {
-            const storeData = await rpc("/chatbot/step/trigger", {
+            const dataRequest = this.store.DataResponse.createRequest();
+            await rpc("/chatbot/step/trigger", {
                 channel_id: this.thread.id,
                 chatbot_script_id: this.script.id,
+                data_id: dataRequest.id,
             });
-            if (!storeData) {
+            await dataRequest._resultDef;
+            if (!dataRequest.chatbot_step) {
                 this.currentStep.isLast = true;
                 return;
             }
-            const { ChatbotStep: steps } = this.store.insert(storeData);
-            this.steps.push(steps[0]);
+            this.steps.push(dataRequest.chatbot_step);
         } else {
             const nextStepIndex = this.steps.lastIndexOf(this.currentStep) + 1;
             this.currentStep = this.steps[nextStepIndex];

--- a/addons/im_livechat/static/src/core/common/data_response_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/data_response_model_patch.js
@@ -1,0 +1,11 @@
+import { DataResponse } from "@mail/core/common/data_response_model";
+import { fields } from "@mail/model/misc";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(DataResponse.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.chatbot_step = fields.One("ChatbotStep");
+    },
+});


### PR DESCRIPTION
Before this commit, the restart button was sometimes shown after the conversation was forwarded to an agent which should not happen.

This happens because the state of the chat bot is not sent on the bus, leading to inconsistent state.

This commit ensures each step is sent on the bus to avoid inconsistencies. This commit also ensures the selected answer of a selection step is properly sent to every tab to avoid similar issues.

task-5031990

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
