### PR TITLE
[IMP] html_editor, website: link editing behavior when URL is empty

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -216,13 +216,11 @@ export class LinkPopover extends Component {
             this.loadAsyncLinkPreview();
         }
         const onPointerDown = (ev) => {
-            if (!this.state.url) {
-                this.props.onDiscard();
-            } else if (
-                this.editingWrapper?.el &&
-                !this.state.isImage &&
-                !this.editingWrapper.el.contains(ev.target)
-            ) {
+            if (this.state.isImage) {
+                return;
+            }
+            this.state.url ||= "#";
+            if (this.editingWrapper?.el && !this.editingWrapper.el.contains(ev.target)) {
                 this.onClickApply();
             }
         };

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1651,7 +1651,7 @@ describe("link popover with empty URL", () => {
         await animationFrame();
         await expectElementCount(".o-we-linkpopover", 1);
     });
-    test("should close the popover and not create a link when clicking outside the popover when link URL is empty", async () => {
+    test("should close the popover and create a link with href '#' when URL is empty and clicking outside", async () => {
         const { editor, el } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/link");
         await animationFrame();
@@ -1666,10 +1666,19 @@ describe("link popover with empty URL", () => {
         );
         await contains(".o-we-linkpopover input.o_we_href_input_link").clear();
         await click(el);
+        // Simulate click outside
+        const pNode = queryOne("p");
+        setSelection({
+            anchorNode: pNode,
+            anchorOffset: 0,
+            focusNode: pNode,
+            focusOffset: 0,
+        });
+        await tick(); // wait for selection change.
         await waitForNone(".o-we-linkpopover", { timeout: 1500 });
-        expect(getContent(el)).toBe("<p>ab[]</p>");
+        expect(getContent(el)).toBe('<p>[]ab\ufeff<a href="#">\ufefflabel\ufeff</a>\ufeff</p>');
     });
-    test("should close the popover and discard changes when clicking outside the popover when link URL is empty", async () => {
+    test("should close the popover and fallback href to '#' on empty URL when clicking outside", async () => {
         const { el } = await setupEditor("<p>[abc]</p>");
         await waitFor(".o-we-toolbar");
         await click(".o-we-toolbar .fa-link");
@@ -1693,10 +1702,11 @@ describe("link popover with empty URL", () => {
             focusNode: pNode,
             focusOffset: 0,
         });
+        await tick(); // wait for selection change.
         await waitForNone(".o-we-linkpopover", { timeout: 1500 });
-        expect(getContent(el)).toBe("<p>[]abc</p>");
+        expect(getContent(el)).toBe('<p>[]\ufeff<a href="#">\ufeffabcd\ufeff</a>\ufeff</p>');
     });
-    test("when edit a link URL to '', and clicking outside the link popover should discard the changes", async () => {
+    test("when edit a link URL to '', and clicking outside the link popover should set href to '#'", async () => {
         const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");
         await click(".o_we_edit_link");
@@ -1710,9 +1720,31 @@ describe("link popover with empty URL", () => {
             focusNode: pNode,
             focusOffset: 0,
         });
+        await tick(); // wait for selection change.
         await waitForNone(".o-we-linkpopover", { timeout: 1500 });
-        expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p>[]this is a <a href="http://test.com/">link</a></p>'
+        expect(cleanLinkArtifacts(getContent(el))).toBe('<p>[]this is a <a href="#">link</a></p>');
+    });
+    test("when clearing link URL for an image and clicking outside does not change href", async () => {
+        const { el } = await setupEditor(
+            `<p><a href="http://test.test/">[<img src="${base64Img}">]</a></p>`
+        );
+        await waitFor(".o-we-linkpopover", { timeout: 1500 });
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_href_input_link");
+        await contains(".o-we-linkpopover input.o_we_href_input_link").clear();
+        await click(el);
+        // Simulate click outside
+        const pNode = queryOne("p");
+        setSelection({
+            anchorNode: pNode,
+            anchorOffset: 0,
+            focusNode: pNode,
+            focusOffset: 0,
+        });
+        await tick(); // wait for selection change.
+        await waitForNone(".o-we-linkpopover", { timeout: 1500 });
+        expect(getContent(el)).toBe(
+            `<p>[]<a href="http://test.test/"><img src="${base64Img}"></a></p>`
         );
     });
 });

--- a/addons/website/static/src/js/editor/html_editor.js
+++ b/addons/website/static/src/js/editor/html_editor.js
@@ -128,12 +128,16 @@ patch(LinkPopover.prototype, {
 
     onSelect(value) {
         this.state.url = value;
-        this.onChange();
+        if (!this.state.isImage) {
+            this.onChange();
+        }
     },
 
     updateValue(val) {
         this.state.url = val;
-        this.onChange();
+        if (!this.state.isImage) {
+            this.onChange();
+        }
     },
     onClickForcePreviewMode(ev) {
         if (this.props.linkElement.href) {


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- onChange was triggered both while typing in the URL input and when selecting an autocomplete item, causing live preview even for image links.
- When editing a link, removing URL and clicking outside discarded changes.

### Desired behavior after PR is merged:

- Live preview is now applied only for normal text links, not for image links.
- If the URL field is empty and the user clicks outside, the link now default its href to '#'.

task-5028570

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
