### PR TITLE
[FIX] point_of_sale: refund lot valuated pos

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -290,7 +290,7 @@ class StockMove(models.Model):
         mls_qties = []
         if are_qties_done:
             for move in moves_remaining:
-                move.move_line_ids.quantity = 0
+                move.move_line_ids.unlink()
                 for line in lines_data[move.product_id.id]['order_lines']:
                     sum_of_lots = 0
                     for lot in line.pack_lot_ids.filtered(lambda l: l.lot_name):


### PR DESCRIPTION
When refunding a product that was lot valuated, the picking would not be validated automatically.

Steps to reproduce:
-------------------
* Create a product tracked by lot, and valuated by lot
* Open PoS and create an order with this product
* Validate the order and create a refund for it
* Validate the refund
* Close the session, and go to the picking of the session
> Observation: The picking is not validated automatically.

Why the fix:
------------
It was happening because the line that was put to 0 here (https://github.com/odoo/odoo/blob/eab97bed9c55a9057c7af7450ae1a09c6383a7b5/addons/point_of_sale/models/stock_picking.py#L249) has no lot assigned and should be deleted instead of just put to 0 quanity. It would then raise an error here (https://github.com/odoo/odoo/blob/2d933b83613ad52d76ab457201adecac6fcf184b/addons/stock_account/models/stock_move_line.py#L94) and cancel the validation of the picking.

opw-4769042