### PR TITLE
[FIX] web_editor: /bus/has_missed_notifications reconnect loop

### DIFF
--- a/addons/web_editor/models/ir_websocket.py
+++ b/addons/web_editor/models/ir_websocket.py
@@ -2,9 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
-
 from odoo import models
-from odoo.exceptions import AccessDenied
+from odoo.exceptions import AccessDenied, AccessError
 
 
 class IrWebsocket(models.AbstractModel):
@@ -30,10 +29,13 @@ class IrWebsocket(models.AbstractModel):
                         if not document.exists():
                             continue
 
-                        document.check_access('read')
-                        document.check_field_access_rights('read', [field_name])
-                        document.check_access('write')
-                        document.check_field_access_rights('write', [field_name])
+                        try:
+                            document.check_access('read')
+                            document.check_field_access_rights('read', [field_name])
+                            document.check_access('write')
+                            document.check_field_access_rights('write', [field_name])
+                        except AccessError:
+                            continue
 
                         channels.append((self.env.registry.db_name, 'editor_collaboration', model_name, field_name, res_id))
         return super()._build_bus_channel_list(channels)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When an exception is raised on the access check, the OutdatedPageWatcherService runs into a reconnect loop, resulting in lots of log entries. 

<img width="1190" height="435" alt="image" src="https://github.com/user-attachments/assets/8634e254-344f-4f4f-a46e-c0b3674de303" />

Each reconnect attempt causes a log entry: 
```
2025-08-22 11:30:17,770 4 INFO db18_test_access odoo.addons.base.models.ir_rule: Access Denied by record rules for operation: write on record ids: [25], uid: 6, model: crm.lead 
2025-08-22 11:30:17,779 4 WARNING db18_test_access odoo.http: Uh-oh! Looks like you have stumbled upon some top-secret records.

Sorry, Marc Demo (id=6) doesn't have 'write' access to:
- Lead/Opportunity, Modern Open Space (crm.lead: 25)

Blame the following rules:
- Personal Leads

If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies. 

```



Current behavior before PR:
Reconnect loop.

Desired behavior after PR is merged:
Do not add channels without sufficient rights.


Related to: https://www.odoo.com/de_DE/my/tasks/5026412

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
