### PR TITLE
[FIX] website: fix failing standalone test with refreshed registry

### DIFF
--- a/addons/test_website/tests/test_views_during_module_operation.py
+++ b/addons/test_website/tests/test_views_during_module_operation.py
@@ -177,9 +177,22 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
 
     view_website_1, view_website_2, theme_child_view = _simulate_xml_view()
 
+    old_registry = env.registry
+
     # Upgrade the module
     theme_default.button_immediate_upgrade()
     env.transaction.reset()  # clear the set of environments
+
+    # Beware: records do not belong to the correct registry anymore
+    assert env.registry is not old_registry
+    # Therefore we need to re-obtain them
+    View = env['ir.ui.view']
+    ThemeView = env['theme.ir.ui.view']
+    Imd = env['ir.model.data']
+
+    website_1 = env['website'].browse(1)
+    website_2 = env['website'].browse(2)
+    theme_default = env.ref('base.module_theme_default')
 
     # Ensure the theme.ir.ui.view got removed (since there is an IMD but not
     # present in XML files)


### PR DESCRIPTION
Since [1] the `test_02_copy_ids_views_unlink_on_module_update`
standalone test fails because it cannot find the `is_seo_optimized`
field.

This happens because the `env`'s registry is changed when
`button_immediate_upgrade` is called: the types of the used records do
not belong to the correct registry after the first call.

This commit re-obtains the records used in the second part of the test
to avoid this issue.

[1]: https://github.com/odoo/odoo/commit/7f36a94a548f728aa89feb1a4facd59c91fc47bf

task-4422810
runbot-227670