### PR TITLE
[IMP] html_builder, *: improve the logic of the translation plugin

### DIFF
--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -16,9 +16,6 @@ export class SetupEditorPlugin extends Plugin {
             "#wrap .o_homepage_editor_welcome_message"
         );
         welcomeMessageEl?.remove();
-        if (this.delegateTo("after_setup_editor_handlers")) {
-            return;
-        }
         let editableEls = this.getEditableElements(
             this.getResource("o_editable_selectors").join(", ")
         )
@@ -35,6 +32,9 @@ export class SetupEditorPlugin extends Plugin {
             .filter((el) => !el.hasAttribute("data-oe-sanitize-prevent-edition"));
         editableEls.concat(Array.from(this.editable.querySelectorAll(".o_editable")));
         editableEls.forEach((el) => el.classList.add("o_editable"));
+        if (this.delegateTo("after_setup_editor_handlers")) {
+            return;
+        }
 
         // Add automatic editor message on the editables where we can drag and
         // drop elements.

--- a/addons/website/static/src/builder/plugins/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_plugin.js
@@ -7,17 +7,16 @@ import {
     localStorageNoDialogKey,
     TranslatorInfoDialog,
 } from "../translation_components/translatorInfoDialog";
+import { withSequence } from "@html_editor/utils/resource";
 
-export const translationSavableSelector =
-    "[data-oe-translation-source-sha], " +
-    "[data-oe-model][data-oe-id][data-oe-field], " +
+export const translationAttributeSelector =
     '[placeholder*="data-oe-translation-source-sha="], ' +
     '[title*="data-oe-translation-source-sha="], ' +
     '[value*="data-oe-translation-source-sha="], ' +
     '[alt*="data-oe-translation-source-sha="]';
 
-export function getTranslationEditableEls(rootEl) {
-    const translationSavableEls = rootEl.querySelectorAll(translationSavableSelector);
+export function getTranslationAttributeEls(rootEl) {
+    const translationSavableEls = rootEl.querySelectorAll(translationAttributeSelector);
     const textAreaEls = Array.from(rootEl.querySelectorAll("textarea")).find((el) =>
         el.textContent.includes("data-oe-translation-source-sha")
     );
@@ -31,16 +30,15 @@ export function getTranslationEditableEls(rootEl) {
  */
 function findOEditable(containerEl) {
     const isOEditable = (node) => {
-        while (node) {
-            if (node.className && typeof node.className === "string") {
-                if (node.className.includes("o_not_editable")) {
-                    return false;
-                }
-                if (node.className.includes("o_editable")) {
-                    return true;
-                }
-            }
-            node = node.parentNode;
+        // Ideally, we should entirely rely on the contenteditable mechanism.
+        // The problem is that the translatable attributes are not branded DOM
+        // nodes hence the o_editable_attribute hack.
+        if (
+            node.isContentEditable ||
+            (node.classList.contains("o_editable_attribute") &&
+                (!node.closest(".o_not_editable") || node.classList.contains("o_editable_media")))
+        ) {
+            return true;
         }
         return false;
     };
@@ -56,30 +54,24 @@ export class TranslationPlugin extends Plugin {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         get_dirty_els: this.getDirtyTranslations.bind(this),
         after_setup_editor_handlers: () => {
-            const translationSavableEls = getTranslationEditableEls(
+            const translationSavableEls = getTranslationAttributeEls(
                 this.services.website.pageDocument
             );
             for (const translationSavableEl of translationSavableEls) {
-                if (!translationSavableEl.hasAttribute("data-oe-readonly")) {
-                    translationSavableEl.classList.add("o_editable");
-                }
+                translationSavableEl.classList.add("o_editable_attribute");
             }
-            this.setupServicesIfNotSet();
-            this.prepareTranslation();
             return true;
         },
+        start_edition_handlers: withSequence(5, () => {
+            this.prepareTranslation();
+        }),
+        system_classes: ["o_editable_attribute"],
     };
 
     setup() {
-        this.setupServicesIfNotSet();
-    }
-
-    setupServicesIfNotSet() {
-        if (!this.websiteService) {
-            this.websiteService = this.services.website;
-            this.notificationService = this.services.notification;
-            this.dialogService = this.services.dialog;
-        }
+        this.websiteService = this.services.website;
+        this.notificationService = this.services.notification;
+        this.dialogService = this.services.dialog;
     }
 
     prepareTranslation() {
@@ -111,9 +103,12 @@ export class TranslationPlugin extends Plugin {
         }
 
         // Apply data-oe-readonly on nested data
-        const translationSavableEls = getTranslationEditableEls(this.websiteService.pageDocument);
+        const translatableElSelector = ".o_editable, .o_editable_attribute";
+        const translationSavableEls = [
+            ...this.websiteService.pageDocument.querySelectorAll(translatableElSelector),
+        ];
         for (const translationSavableEl of translationSavableEls) {
-            if (getTranslationEditableEls(translationSavableEl).length) {
+            if (translationSavableEl.querySelectorAll(translatableElSelector).length) {
                 translationSavableEl.setAttribute("data-oe-readonly", "true");
                 translationSavableEl.removeAttribute("contenteditable");
             }
@@ -136,10 +131,13 @@ export class TranslationPlugin extends Plugin {
             });
         };
         for (const translateEl of editableEls) {
-            if (translateEl.closest(".o_not_editable")) {
-                this.addDomListener(translateEl, "click", showNotification);
-            }
             this.handleToC(translateEl);
+        }
+        const savableInsideNotEditableEls = this.editable.querySelectorAll(
+            ".o_not_editable .o_editable, .o_not_editable .o_editable_attribute"
+        );
+        for (const savableInsideNotEditableEl of savableInsideNotEditableEls) {
+            this.addDomListener(savableInsideNotEditableEl, "click", showNotification);
         }
         // Keep the original values of elToTranslationInfoMap so that we know
         // which translations have been updated.
@@ -340,6 +338,9 @@ export class TranslationPlugin extends Plugin {
     }
 
     cleanForSave({ root }) {
+        root.querySelectorAll(".o_editable_attribute").forEach((el) => {
+            el.classList.remove("o_editable_attribute");
+        });
         // Remove the `.o_translation_select` temporary element
         const optionsEl = root.querySelector(".o_translation_select");
         if (optionsEl) {

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -1,7 +1,7 @@
 import { Builder } from "@html_builder/builder";
 import { EditWebsiteSystrayItem } from "@website/client_actions/website_preview/edit_website_systray_item";
 import { setContent, setSelection } from "@html_editor/../tests/_helpers/selection";
-import { deleteForward, insertText } from "@html_editor/../tests/_helpers/user_actions";
+import { insertText } from "@html_editor/../tests/_helpers/user_actions";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, manuallyDispatchProgrammaticEvent, queryAllTexts } from "@odoo/hoot-dom";
 import { contains, mockService, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
@@ -12,6 +12,7 @@ import {
     setupWebsiteBuilder,
 } from "./website_helpers";
 import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
+import { TranslationPlugin } from "@website/builder/plugins/translation_plugin";
 
 defineWebsiteModels();
 
@@ -160,7 +161,7 @@ test("translate attribute", async () => {
 test("translate attribute history", async () => {
     const { getEditableContent } = await setupSidebarBuilderForTranslation({
         websiteContent: `
-            <img src="/web/image/website.s_text_image_default_image" class="img img-fluid o_editable" loading="lazy" title="<span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;544&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;sourceSha&quot;>title</span>" style=""></img>
+            <img src="/web/image/website.s_text_image_default_image" class="img img-fluid" loading="lazy" title="<span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;544&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;sourceSha&quot;>title</span>" style=""></img>
         `,
     });
     const editable = getEditableContent();
@@ -169,7 +170,7 @@ test("translate attribute history", async () => {
     await contains(".modal .modal-body input").edit("titre");
     await contains(".modal .btn:contains(Ok)").click();
     const getImg = ({ titleName, translated }) =>
-        `<img src="/web/image/website.s_text_image_default_image" class="img img-fluid o_editable o_translatable_attribute${
+        `<img src="/web/image/website.s_text_image_default_image" class="img img-fluid o_editable_attribute o_translatable_attribute${
             translated ? " oe_translated" : ""
         }" loading="lazy" title="${titleName}" style="" data-oe-translation-state="to_translate"></img>`;
     expect(editable).toHaveInnerHTML(getImg({ titleName: "titre", translated: true }));
@@ -283,21 +284,83 @@ test("table of content snippet headings' translation updates its navbar items", 
     );
     const titleEl = editor.editable.querySelector("#table_of_content_heading_1_1");
     setSelection({ anchorNode: titleEl });
-    const oldTitleLength = titleEl.textContent.length;
-    for (let i = 0; i < oldTitleLength; i++) {
-        deleteForward(editor);
-    }
     await insertText(editor, "New title");
     expect(":iframe .s_table_of_content_navbar .table_of_content_link:first-child").toHaveText(
-        "New title"
+        `New title${oldTitle}`
     );
 });
 
-function getTranslateEditable({ inWrap, oeId = "526", sourceSha = "sourceSha" }) {
+test("trying to translate an element inside a .o_not_editable should add a notification", async () => {
+    mockService("notification", {
+        add(message, options = {}) {
+            expect(message).toBe("This translation is not editable.");
+        },
+    });
+    await setupSidebarBuilderForTranslation({
+        websiteContent: getTranslateEditable({
+            inWrap: "Hello",
+            oeId: 10,
+            containerEditable: false,
+        }),
+    });
+    await contains(".modal .btn:contains(Ok, never show me this again)").click();
+    await contains(":iframe [data-oe-id='10']").click();
+});
+
+test("trying to translate an attribute of an image inside a .o_not_editable should add a notification", async () => {
+    expect.assertions(2);
+    mockService("notification", {
+        add(message, options = {}) {
+            expect(message).toBe("This translation is not editable.");
+        },
+    });
+    await setupSidebarBuilderForTranslation({
+        websiteContent: `
+            <div class="o_not_editable">
+                <img src="/web/image/website.s_text_image_default_image" class="img img-fluid mx-auto rounded o_editable" loading="lazy" title="<span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;544&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;sourceSha&quot;>title</span>" style=""></img>
+            <div/>
+        `,
+    });
+    await contains(".modal .btn:contains(Ok, never show me this again)").click();
+    await contains(":iframe img").click();
+    expect(".modal .modal-body input").toHaveCount(0);
+});
+
+test("it should be possible to translate the attribute of an image that has the o_editable_media even if it is inside a o_not_editable area", async () => {
+    await setupSidebarBuilderForTranslation({
+        websiteContent: `
+            <div class="o_not_editable">
+                <img src="/web/image/website.s_text_image_default_image" class="img img-fluid mx-auto rounded o_editable_media" loading="lazy" title="<span data-oe-model=&quot;ir.ui.view&quot; data-oe-id=&quot;544&quot; data-oe-field=&quot;arch_db&quot; data-oe-translation-state=&quot;to_translate&quot; data-oe-translation-source-sha=&quot;sourceSha&quot;>title</span>" style=""></img>
+            <div/>
+        `,
+    });
+    await contains(".modal .btn:contains(Ok, never show me this again)").click();
+    await contains(":iframe img").click();
+    expect(".modal .modal-body input").toHaveCount(1);
+});
+
+test("Ensure the contenteditable attributes have been set before the TranslationPlugin checks for the node to be translated", async () => {
+    patchWithCleanup(TranslationPlugin.prototype, {
+        prepareTranslation() {
+            expect(":iframe .translate_branding").toHaveAttribute("contenteditable", "true");
+            super.prepareTranslation();
+        },
+    });
+    await setupSidebarBuilderForTranslation({
+        websiteContent: getTranslateEditable({ inWrap: "Hello" }),
+    });
+});
+
+function getTranslateEditable({
+    inWrap,
+    oeId = "526",
+    sourceSha = "sourceSha",
+    containerEditable = true,
+}) {
     return `
-        <div class="container s_allow_columns">
+        <div class="container s_allow_columns${containerEditable ? "" : " o_not_editable"}">
             <p>
-                <span data-oe-model="ir.ui.view" data-oe-id="${oeId}" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="${sourceSha}" class="o_editable">${inWrap}</span>
+                <span data-oe-model="ir.ui.view" data-oe-id="${oeId}" data-oe-field="arch_db" data-oe-translation-state="to_translate" data-oe-translation-source-sha="${sourceSha}" class="o_editable translate_branding">${inWrap}</span>
             </p>
         </div>`;
 }

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -114,7 +114,11 @@ export async function setupWebsiteBuilder(
     let originalIframeLoaded;
     let resolveIframeLoaded = () => {};
     const bodyHTML = `${beforeWrapwrapContent}
-        <div id="wrapwrap">${headerContent} <div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="${setupWebsiteBuilderOeId}" data-oe-field="arch">${websiteContent}</div></div>`;
+        <div id="wrapwrap">${headerContent} <div id="wrap" class="oe_structure oe_empty" ${
+        translateMode
+            ? ""
+            : `data-oe-model="ir.ui.view" data-oe-id="${setupWebsiteBuilderOeId}" data-oe-field="arch"`
+    }>${websiteContent}</div></div>`;
     const iframeLoaded = new Promise((resolve) => {
         resolveIframeLoaded = (el) => {
             const iframe = el;


### PR DESCRIPTION
[IMP] html_builder, *: improve the logic of the translation plugin
*: website

The goal of this commit is to improve the logic of the
`TranslationPlugin` plugin. Indeed, we do not want this plugin to handle
the addition of the `o_editable` class to html elements. Instead we let
this task to `SetupEditorPlugin` as usual. The problem is still that
some html elements have translatable attributes and those elements will
not have the `o_editable` class as they do not have the branding (oe
data information). To handle those, a new `o_editable_attribute` system
class is added on them. Thanks to those classes, we know which nodes are
translatable (elements that are editable and elements with the
`o_editable_attribute` class have an attribute that is translatable).
The advantage of handling the translation that way is that we do not add
the `o_editable` class on elements that are not savable. This is better
also in order to not add the `contenteditable` attribute abusively.

Related to task-4367641