### PR TITLE
[FIX] pos_viva_com: refund reference lost after refresh

### DIFF
--- a/addons/pos_viva_com/static/src/app/payment_viva_com.js
+++ b/addons/pos_viva_com/static/src/app/payment_viva_com.js
@@ -79,7 +79,7 @@ export class PaymentVivaCom extends PaymentInterface {
         line.viva_com_session_id = order.uuid + " - " + uuidv4();
         var data = {
             sessionId: line.viva_com_session_id,
-            parentSessionId: line.vivaComParentSessionId,
+            parentSessionId: line.uiState.vivaComParentSessionId,
             terminalId: line.payment_method_id.viva_com_terminal_id,
             cashRegisterId: this.pos.getCashier().name,
             amount: roundPrecision(Math.abs(line.amount * 100)),

--- a/addons/pos_viva_com/static/src/overrides/models/pos_payment.js
+++ b/addons/pos_viva_com/static/src/overrides/models/pos_payment.js
@@ -2,8 +2,16 @@ import { PosPayment } from "@point_of_sale/app/models/pos_payment";
 import { patch } from "@web/core/utils/patch";
 
 patch(PosPayment.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.uiState = {
+            ...(this.uiState ?? {}),
+            vivaComParentSessionId: null,
+        };
+    },
+
     updateRefundPaymentLine(refundedPaymentLine) {
         super.updateRefundPaymentLine(refundedPaymentLine);
-        this.vivaComParentSessionId = refundedPaymentLine?.viva_com_session_id;
+        this.uiState.vivaComParentSessionId = refundedPaymentLine?.viva_com_session_id;
     },
 });


### PR DESCRIPTION
Steps to reproduce:
1. Configure a PoS with a Viva payment terminal
2. Complete an order using the Viva payment method
3. Start to refund the order, and get to the Payment screen
4. At this point, refresh the page
5. Now continue with the refund, using the Viva payment method

**Expected behaviour**: The refund is referenced to the original payment, meaning it can be automatically completed without a card.
**Actual behaviour**: The refund reference is lost after refreshing, so an unreferenced refund is performed, requiring a card to be presented.

The fix is to store the refund reference in the `uiState`, not just on the plain JS object. This way it is saved to the indexedDB.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
