### PR TITLE
[FIX] crm: fix rainbowman test in faketime mode

### DIFF
--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -1,4 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import os
+
+from unittest import skipIf
 
 from odoo.addons.crm.tests.common import TestCrmCommon
 from odoo.tests import HttpCase
@@ -26,6 +29,7 @@ class TestUi(HttpCase):
         })
         self.start_tour("/web", 'crm_tour', login="admin")
 
+    @skipIf(os.getenv("ODOO_FAKETIME_TEST_MODE"), 'This tour uses CURRENT_DATE which cannot work in faketime mode')
     def test_02_crm_tour_rainbowman(self):
         # we create a new user to make sure they get the 'Congrats on your first deal!'
         # rainbowman message.


### PR DESCRIPTION
When using the faketime mode for testing, the crm_rainbowman tour fails because the underlying SQL query is using `CURRENT_DATE`.

Unfortunately, this SQL keyword cannot be replaced globally by a function easyly (like it was done for the NOW function in faketime mode).

~~With this commit, the SQL query is adapted to use the SQL NOW function instead.~~

With this commit, the tour will be skipped in faketime mode