### PR TITLE
[FIX] hr_holidays_attendance: Add well formatted Extra hours on dashb…

### DIFF
--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -108,6 +108,24 @@ export class TimeOffCard extends Component {
         onWillRender(this.updateWarning);
     }
 
+
+    // e.g.: Input: 9.5 Output: 9:30
+    formatHour(hoursFloat) {
+        const hours = Math.floor(hoursFloat);
+        const minutes = Math.round((hoursFloat - hours) * 60);
+        // Pad minutes with leading zero if needed
+        const formattedMinutes = minutes < 10 ? `0${minutes}` : minutes;
+        return `${hours}:${formattedMinutes}`;
+    }
+
+    formatDuration(duration) {
+        if (this.props.data.request_unit === 'hour') {
+            return this.formatHour(duration);
+        }
+        return formatNumber(this.lang, duration);
+    }
+
+
     updateWarning() {
         const { data } = this.props;
         const errorLeavesSignificant = data.allows_negative

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -3,7 +3,7 @@
     <div t-name="hr_holidays.TimeOffCard" class="o_timeoff_card py-3 text-primary">
         <t t-set="data" t-value="props.data"/>
         <t t-set="duration" t-value="props.requires_allocation ? data.virtual_remaining_leaves : data.virtual_leaves_taken"/>
-        <t t-set="parsed_duration" t-value="formatNumber(this.lang, duration)"/>
+        <t t-set="parsed_duration" t-value="formatDuration(duration)"/>
         <t t-set="show_popover" t-value="true"/>
 
         <strong class="o_timeoff_name cursor-pointer btn-link" t-on-click="navigateTimeOffType"><t t-esc="props.name"/></strong>


### PR DESCRIPTION
…oard when needed

To add the possibility to show the Extra Hours section on the dashboard, we had to change the filtering logic of leave_types in the API to make it only depend on:
- Hide in dashboard
- max_leaves Since those are related, it would be more intuitive to have "Hide in Dashboard" automatically change according to overtime_deductible and requires_allocation. But we still let the user change it if they need to override this behavior. Thus the computed field is stored. Since overtime (Extra Hours) card was not well formatted (shown as a float instead of the hour format), we also had to change that to avoid some confusion (e.g.: 9:30 instead of 9.50)

task-5026228


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
