### PR TITLE
[FIX] hr_holidays_attendance: Add well formatted Extra hours on dashb…

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -498,6 +498,23 @@ class HrEmployee(models.Model):
 
         for employee in employees:
             for leave_type in leave_types:
+                if not leave_type.requires_allocation:
+                    # Ensure that leave types that do not require allocation are
+                    # still stored in the consumed allocation leaves.
+                    # False is the special key used for this type of leave
+                    allocations_leaves_consumed[employee][
+                        leave_type
+                    ][False].update(
+                        {
+                            "max_leaves": 0,
+                            "accrual_bonus": 0,
+                            "virtual_remaining_leaves": 0,
+                            "remaining_leaves": 0,
+                            "leaves_taken": 0,
+                            "virtual_leaves_taken": 0,
+                        }
+                    )
+
                 allocations_with_date_to = self.env['hr.leave.allocation']
                 allocations_without_date_to = self.env['hr.leave.allocation']
                 for leave_allocation in allocations_per_employee_type[employee][leave_type]:
@@ -574,9 +591,9 @@ class HrEmployee(models.Model):
                         else:
                             allocated_time = leave.number_of_days
                         leave_type_data[False]['virtual_leaves_taken'] += allocated_time
-                        leave_type_data[False]['virtual_remaining_leaves'] = 0
-                        leave_type_data[False]['remaining_leaves'] = 0
+                        leave_type_data[False]['virtual_remaining_leaves'] -= allocated_time
                         if leave.state == 'validate':
+                            leave_type_data[False]['remaining_leaves'] -= allocated_time
                             leave_type_data[False]['leaves_taken'] += allocated_time
         for employee in to_recheck_leaves_per_leave_type:
             for leave_type in to_recheck_leaves_per_leave_type[employee]:

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -49,7 +49,21 @@ class HrLeaveType(models.Model):
     icon_id = fields.Many2one('ir.attachment', string='Cover Image', domain="[('res_model', '=', 'hr.leave.type'), ('res_field', '=', 'icon_id')]")
     active = fields.Boolean('Active', default=True,
                             help="If the active field is set to false, it will allow you to hide the time off type without removing it.")
-    hide_on_dashboard = fields.Boolean(default=False, string="Hide On Dashboard", help="Non-visible allocations can still be selected when taking a leave, but will simply not be displayed on the leave dashboard.")
+
+    hide_on_dashboard = fields.Boolean(
+        compute="_compute_hide_on_dashboard",
+        readonly=False,
+        default=False,
+        store=True,
+        string="Hide On Dashboard",
+        help="Non-visible allocations can still be selected when taking a leave, but will simply not be displayed on the leave dashboard.",
+    )
+
+    @api.depends("requires_allocation")
+    def _compute_hide_on_dashboard(self) -> None:
+        record: HrLeaveType
+        for record in self:
+            record.hide_on_dashboard = not record.requires_allocation
 
     # employee specific computed data
     max_leaves = fields.Float(compute='_compute_leaves', string='Maximum Allowed', search='_search_max_leaves',
@@ -85,7 +99,7 @@ class HrLeaveType(models.Model):
         ('hr', 'By Time Off Officer'),
         ('manager', "By Employee's Approver"),
         ('both', "By Employee's Approver and Time Off Officer")], default='hr', string='Time Off Validation')
-    requires_allocation = fields.Boolean(default=True, required=True, string='Requires allocation')
+    requires_allocation = fields.Boolean(default=True, required=True, string='Requires Allocation')
     employee_requests = fields.Boolean(default=False, required=True, string="Allow Employee Requests",
         help="""Extra Days Requests Allowed: User can request an allocation for himself.\n
         Not Allowed: User cannot request an allocation.""")
@@ -454,18 +468,28 @@ class HrLeaveType(models.Model):
 
     @api.model
     def get_allocation_data_request(self, target_date=None, hidden_allocations=True):
+        employee = self.env["hr.employee"]._get_contextual_employee()
+        if not employee:
+            return defaultdict(list)
         domain = [
-            '|',
-            ('company_id', 'in', self.env.context.get('allowed_company_ids')),
-            ('company_id', '=', False),
+            "|",
+            ("company_id", "in", self.env.context.get("allowed_company_ids")),
+            ("company_id", "=", False),
         ]
         if not hidden_allocations:
-            domain.append(('hide_on_dashboard', '=', False))
-        leave_types = self.search(domain, order='id')
-        employee = self.env['hr.employee']._get_contextual_employee()
-        if employee:
-            return leave_types.get_allocation_data(employee, target_date)[employee]
-        return []
+            domain.append(("hide_on_dashboard", "=", False))
+        leave_types = self.search(domain, order="id")
+        employee_leave_type_infos = leave_types.get_allocation_data(employee, target_date)[
+            employee
+        ]
+        # We only need to filter allocation_data for the dashboard
+        if not self.env.context.get("from_dashboard", False):
+            return employee_leave_type_infos
+        filtered_leave_type_infos = []
+        for leave_type_info in employee_leave_type_infos:
+            if leave_type_info[1]["max_leaves"]:
+                filtered_leave_type_infos.append(leave_type_info)
+        return filtered_leave_type_infos
 
     def get_allocation_data(self, employees, target_date=None):
         allocation_data = defaultdict(list)
@@ -479,10 +503,9 @@ class HrLeaveType(models.Model):
         allocations_leaves_consumed, extra_data = employees.with_context(
             ignored_leave_ids=self.env.context.get('ignored_leave_ids')
         )._get_consumed_leaves(self, target_date)
-        leave_type_requires_allocation = self.filtered(lambda lt: lt.requires_allocation)
 
         for employee in employees:
-            for leave_type in leave_type_requires_allocation:
+            for leave_type in self:
                 if len(allocations_leaves_consumed[employee][leave_type]) == 0:
                     continue
                 lt_info = (
@@ -592,13 +615,11 @@ class HrLeaveType(models.Model):
                     'closest_allocation_duration': closest_allocation_duration,
                     'holds_changes': holds_changes,
                 })
-                if not self.env.context.get('from_dashboard', False) or lt_info[1]['max_leaves']:
-                    allocation_data[employee].append(lt_info)
-        for employee in allocation_data:
-            for leave_type_data in allocation_data[employee]:
-                for key, value in leave_type_data[1].items():
+                # format all float fields
+                for key, value in lt_info[1].items():
                     if isinstance(value, float):
-                        leave_type_data[1][key] = round(value, 2)
+                        lt_info[1][key] = round(value, 2)
+                allocation_data[employee].append(lt_info)
         return allocation_data
 
     def _get_closest_expiring_leaves_date_and_count(self, allocations, remaining_leaves, target_date):

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -108,6 +108,24 @@ export class TimeOffCard extends Component {
         onWillRender(this.updateWarning);
     }
 
+
+    // e.g.: Input: 9.5 Output: 9:30
+    formatHour(hoursFloat) {
+        const hours = Math.floor(hoursFloat);
+        const minutes = Math.round((hoursFloat - hours) * 60);
+        // Pad minutes with leading zero if needed
+        const formattedMinutes = minutes < 10 ? `0${minutes}` : minutes;
+        return `${hours}:${formattedMinutes}`;
+    }
+
+    formatDuration(duration) {
+        if (this.props.data.request_unit === 'hour') {
+            return this.formatHour(duration);
+        }
+        return formatNumber(this.lang, duration);
+    }
+
+
     updateWarning() {
         const { data } = this.props;
         const errorLeavesSignificant = data.allows_negative

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -3,7 +3,7 @@
     <div t-name="hr_holidays.TimeOffCard" class="o_timeoff_card py-3 text-primary">
         <t t-set="data" t-value="props.data"/>
         <t t-set="duration" t-value="props.requires_allocation ? data.virtual_remaining_leaves : data.virtual_leaves_taken"/>
-        <t t-set="parsed_duration" t-value="formatNumber(this.lang, duration)"/>
+        <t t-set="parsed_duration" t-value="formatDuration(duration)"/>
         <t t-set="show_popover" t-value="true"/>
 
         <strong class="o_timeoff_name cursor-pointer btn-link" t-on-click="navigateTimeOffType"><t t-esc="props.name"/></strong>

--- a/addons/hr_holidays/static/tests/dashboard_card_hour_format.test.js
+++ b/addons/hr_holidays/static/tests/dashboard_card_hour_format.test.js
@@ -1,0 +1,68 @@
+import { expect, test, describe } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers"
+import { TimeOffCard } from "@hr_holidays/dashboard/time_off_card"
+import { defineHrHolidaysModels } from "./hr_holidays_test_helpers";
+
+function getHourProps(floatHour) {
+	return {
+		name: "Extra Hours",
+		data: {
+			accrual_bonus: 0,
+			allows_negative: false,
+			closest_allocation_duration: false,
+			closest_allocation_expire: false,
+			closest_allocation_remaining: 0,
+			employee_company: 1,
+			exceeding_duration: 0,
+			holds_changes: false,
+			icon: "/hr_holidays/static/src/img/icons/Compensatory_Time_Off.svg",
+			leaves_approved: 0,
+			leaves_requested: 0,
+			leaves_taken: 0,
+			max_allowed_negative: 0,
+			overtime_deductible: true,
+			request_unit: "hour",
+			total_virtual_excess: 0,
+			virtual_excess_data: {},
+			virtual_leaves_taken: 0,
+			max_leaves: floatHour,
+			remaining_leaves: floatHour,
+			virtual_remaining_leaves: floatHour,
+			virtual_leaves_taken: floatHour,
+		},
+		requires_allocation: false,
+		holidayStatusId: 6,
+		employeeId: null,
+	}
+}
+
+defineHrHolidaysModels();
+
+describe('Test if card of "hour" unit is well formatted in TimeOffCard', () => {
+	test("Basic hour format", async () => {
+		// floatHour can be between 0 and +infinity
+		const floatHour = 13 + 56 / 60;
+		const props = getHourProps(floatHour)
+		await mountWithCleanup(TimeOffCard, { props });
+		await animationFrame();
+		expect("span.o_timeoff_duration span").toHaveText("13:56");
+	});
+
+	test("Hour with need of zero padding", async () => {
+		const floatHour = 1 + 5 / 60;
+		const props = getHourProps(floatHour)
+		await mountWithCleanup(TimeOffCard, { props });
+		await animationFrame();
+		// no need for zeroes for hour since the hour can be any positive number
+		expect("span.o_timeoff_duration span").toHaveText("1:05");
+	});
+
+	test("Hour of value 0", async () => {
+		const floatHour = 0 + 0 / 60;
+		const props = getHourProps(floatHour)
+		await mountWithCleanup(TimeOffCard, { props });
+		await animationFrame();
+		expect("span.o_timeoff_duration span").toHaveText("0:00");
+	});
+});

--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -12,6 +12,15 @@ class HrLeaveType(models.Model):
         "Deduct Extra Hours", default=False,
         help="Once a time off of this type is approved, extra hours in attendances will be deducted.")
 
+    @api.depends("overtime_deductible", "requires_allocation")
+    def _compute_hide_on_dashboard(self) -> None:
+        record: HrLeaveType
+        for record in self:
+            if record.overtime_deductible:
+                record.hide_on_dashboard = False
+            else:
+                super()._compute_hide_on_dashboard()
+
     @api.depends('overtime_deductible', 'requires_allocation')
     @api.depends_context('request_type', 'leave', 'holiday_status_display_name', 'employee_id')
     def _compute_display_name(self):
@@ -34,15 +43,18 @@ class HrLeaveType(models.Model):
 
     def get_allocation_data(self, employees, target_date=None):
         res = super().get_allocation_data(employees, target_date)
-        deductible_time_off_types = self.env['hr.leave.type'].search([
-            ('overtime_deductible', '=', True),
-            ('requires_allocation', '=', False)])
-        leave_type_names = deductible_time_off_types.mapped('name')
+        deductible_time_off_types = self.env["hr.leave.type"].search(
+            [("overtime_deductible", "=", True), ("requires_allocation", "=", False)]
+        )
+        leave_type_names = deductible_time_off_types.mapped("name")
         for employee in res:
+            total_overtime = employee.sudo().total_overtime
             for leave_data in res[employee]:
                 if leave_data[0] in leave_type_names:
-                    leave_data[1]['virtual_remaining_leaves'] = employee.sudo().total_overtime
-                    leave_data[1]['overtime_deductible'] = True
+                    leave_data[1]["virtual_remaining_leaves"] = total_overtime
+                    leave_data[1]["max_leaves"] += total_overtime
+                    leave_data[1]["remaining_leaves"] += total_overtime
+                    leave_data[1]["overtime_deductible"] = True
                 else:
-                    leave_data[1]['overtime_deductible'] = False
+                    leave_data[1]["overtime_deductible"] = False
         return res


### PR DESCRIPTION
…oard when needed

To add the possibility to show the Extra Hours section on the dashboard, we had to change the filtering logic of leave_types in the API to make it only depend on:
- Hide in dashboard
- max_leaves

Since those are related, it would be more intuitive to have "Hide in Dashboard" automatically change according to overtime_deductible and requires_allocation. But we still let the user change it if they need to override this behavior. Thus the computed field is stored. Since overtime (Extra Hours) card was not well formatted (shown as a float instead of the hour format), we also had to change that to avoid some confusion (e.g.: 9:30 instead of 9.50)

task-5026228




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
