### PR TITLE
[FIX] point_of_sale: restore removed lines after page reload

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -284,13 +284,19 @@ export class PosData extends Reactive {
 
         const order = data["pos.order"] || [];
         const orderlines = data["pos.order.line"] || [];
+        const payments = data["pos.payment"] || [];
 
         delete data["pos.order"];
         delete data["pos.order.line"];
+        delete data["pos.payment"];
 
         this.models.loadData(data, this.modelToLoad);
-        this.models.loadData({ "pos.order": order, "pos.order.line": orderlines });
         const dbData = await this.loadIndexedDBData();
+        this.models.loadData({
+            "pos.order": order,
+            "pos.order.line": orderlines,
+            "pos.payment": payments,
+        });
         this.loadedIndexedDBProducts = dbData ? dbData["product.product"] : [];
         this.sanitizeData();
         this.network.loading = false;

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -13,7 +13,12 @@ import * as ProductScreenPos from "@point_of_sale/../tests/tours/utils/product_s
 import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/product_screen_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
-import { inLeftSide, negateStep, waitForLoading } from "@point_of_sale/../tests/tours/utils/common";
+import {
+    inLeftSide,
+    negateStep,
+    waitForLoading,
+    refresh,
+} from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 import { delay } from "@odoo/hoot-dom";
@@ -780,5 +785,26 @@ registry.category("web_tour.tours").add("test_combo_synchronisation", {
                 content: "Check if there still has combo lines",
                 trigger: ".orderline-combo",
             },
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_reload_order_line_removed", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("5"),
+            inLeftSide([
+                ...ProductScreen.clickLine("Coca-Cola"),
+                Numpad.click("⌫"),
+                Numpad.click("⌫"),
+                ...Order.doesNotHaveLine(),
+            ]),
+            refresh(),
+            FloorScreen.clickTable("5"),
+            inLeftSide(Order.hasLine({ productName: "Coca-Cola", quantity: 1 })),
         ].flat(),
 });

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -545,3 +545,9 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.is_order_printer = False
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_combo_synchronisation')
+
+    def test_reload_order_line_removed(self):
+        """ This test checks that when a saved order line is removed but not yet synced to the backend,
+            if PoS gets reloaded, the order line gets back
+        """
+        self.start_pos_tour('test_reload_order_line_removed')


### PR DESCRIPTION
Before this commit, it was possible for a removed line to still appear in the validated order on the backend. This happened when a line was removed in the UI but not yet synced with the server, and the page was refreshed.

With this commit, the POS ensures that server data is reloaded when the page is refreshed, so that lines not removed on the server are restored in the UI after reloading.

opw-4998948

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
