### PR TITLE
[FIX] l10n_tr_nilvera_{*}: Add Dispatch Reference in e-Invoice XML

### DIFF
--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -464,6 +464,11 @@
                     <cbc:DocumentTypeCode t-out="billing_reference_vals.get('document_type_code')"/>
                 </cac:InvoiceDocumentReference>
             </cac:BillingReference>
+            <cac:DespatchDocumentReference t-foreach="vals.get('dispatch_document_reference_vals', [])" t-as="foreach_vals">
+                <cbc:ID t-out="foreach_vals.get('id')"/>
+                <cbc:IssueDate t-out="foreach_vals.get('issue_date')"/>
+                <cbc:DocumentTypeCode t-out="foreach_vals.get('document_type_code')"/>
+            </cac:DespatchDocumentReference>
             <t t-foreach="vals.get('additional_document_reference_list', [])" t-as="foreach_vals">
                 <cac:AdditionalDocumentReference>
                     <cbc:ID t-out="foreach_vals.get('id')"/>

--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
@@ -217,6 +217,7 @@ class StockPicking(models.Model):
             self.date_done,
         )
         values = {
+            'id': self._get_nilvera_document_serial_number(),
             'ubl_version_id': 2.1,
             'customization_id': 'TR1.2.1',
             'uuid': dispatch_uuid,
@@ -270,3 +271,12 @@ class StockPicking(models.Model):
         self.filtered(
             lambda p: p.country_code == 'TR' and p.picking_type_code == 'outgoing'
         ).l10n_tr_nilvera_dispatch_state = 'sent'
+
+    def _get_nilvera_document_serial_number(self):
+        """
+        Returns the serial number for the e-Dispatch document in a format accepted by Nilvera.
+        The format is: '[Picking Type Code][Year (YYYY)][Sequence Number of 9 digits padded with 0]'
+        Example: 'OUT2025123456789'
+        """
+        sequence_number = self.name.removeprefix(self.picking_type_id.sequence_id.prefix or '').removesuffix(self.picking_type_id.sequence_id.suffix or '')
+        return f"{self.picking_type_id.sequence_code.upper()}{self.scheduled_date.year}{sequence_number.zfill(9)}"

--- a/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
+++ b/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
@@ -93,7 +93,7 @@
             <cbc:UBLVersionID t-out="ubl_version_id"/>
             <cbc:CustomizationID t-out="customization_id"/>
             <cbc:ProfileID t-out="dispatch_scenario"/>
-            <cbc:ID t-out="picking.picking_type_id.sequence_code"/>
+            <cbc:ID t-out="id"/>
             <cbc:CopyIndicator t-out="copy_indicator"/>
             <cbc:UUID t-out="uuid"/>
             <cbc:IssueDate t-out="issue_date"/>


### PR DESCRIPTION
Invoices can be linked with a sale order, which has some Delivery Orders, so invoices and delivery orders (dispatches) are linked together in a manner via the SO. In Nilvera we can add the reference of the Dispatches (delivery documents) to the e-Invoice.
This PR adds that dispatch information to the e-Invoice XML through a new XML tag `<cac:DespatchDocumentReference>`.
It also updates the <cbc:ID> element of the e-Dispatch XML, by giving a properly formatted document id which is more compliant with Nilvera.

task-5024394

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
