### PR TITLE
[FIX] whatsapp: disable composer actions on inactive whatsapp convo

### DIFF
--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -58,12 +58,12 @@
         'o-danger': action.danger,
         'o-success': action.success,
     }).filter(([_, val]) => val).map(([key, _]) => key).join(' ')"/>
-    <t t-set="attrs" t-value="{ 'disabled': action.disabledCondition, 'title': action.name, 'name': action.id }"/>
+    <t t-set="attrs" t-value="{ 'disabled': action.disabledCondition, 'name': action.id }"/>
     <t t-if="action.component and action.componentCondition" t-component="action.component" t-props="action.componentProps"/>
-    <DropdownItem t-elif="props.dropdown" class="btnClass + ' d-flex align-items-center gap-1'" tag="'button'" onSelected="(ev) => action.onSelected(ev)">        
+    <DropdownItem t-elif="props.dropdown" class="btnClass + ' d-flex align-items-center gap-1'" tag="'button'" onSelected="(ev) => action.onSelected(ev)" attrs="attrs">
         <t t-call="mail.ActionList.actionContent"/>
     </DropdownItem>
-    <button t-else="" t-att-class="btnClass" t-att="attrs" t-on-click="(ev) => action.onSelected(ev)">
+    <button t-else="" t-att-class="btnClass" t-att="Object.assign(attrs, { 'title': action.name })" t-on-click="(ev) => action.onSelected(ev)">
         <t t-call="mail.ActionList.actionContent"/>
     </button>
 </t>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -275,10 +275,6 @@ export class Composer extends Component {
         return "";
     }
 
-    get showQuickAction() {
-        return true;
-    }
-
     get wysiwygConfig() {
         return {
             content: this.props.composer.composerHtml,

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -156,6 +156,7 @@
         <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
             <t t-set="moreName">More Actions</t>
             <ActionList inline="true" actions="[{
+                'disabledCondition': areAllActionsDisabled,
                 'icon': 'fa fa-plus-circle',
                 'iconLarge': 'fa fa-lg fa-plus-circle',
                 'id': 'more-actions',

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -169,6 +169,16 @@ class ComposerAction extends Action {
         return composerActionsInternal.condition(this._component, this.id, this.explicitDefinition);
     }
 
+    get disabledCondition() {
+        return (
+            composerActionsInternal.disabledCondition(
+                this._component,
+                this.id,
+                this.explicitDefinition
+            ) ?? super.disabledCondition
+        );
+    }
+
     get isPicker() {
         return this.explicitDefinition.isPicker;
     }
@@ -200,6 +210,12 @@ export const composerActionsInternal = {
         return typeof action.condition === "function"
             ? action.condition(component)
             : action.condition;
+    },
+    disabledCondition(component, id, action) {
+        if (!action?.disabledCondition) {
+            return false;
+        }
+        return undefined;
     },
 };
 


### PR DESCRIPTION
Before this commit, whatsapp composer actions were enabled when the whatsapp conversation is inactive. This shouldn't be the case, and happened from the recent technical changes around discuss actions that affected composer actions.

`showQuickAction` no longer exists in template. Commit puts the semantically equivalent code in composer action definition.