### PR TITLE
[FIX] html_builder, website: reduces the display delay of the theme tab

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_row.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.js
@@ -19,8 +19,9 @@ export class BuilderRow extends Component {
         level: { type: Number, optional: true },
         expand: { type: Boolean, optional: true },
         extraLabelClass: { type: String, optional: true },
+        observeCollapseContent: { type: Boolean, optional: true },
     };
-    static defaultProps = { expand: false };
+    static defaultProps = { expand: false, observeCollapseContent: false };
 
     setup() {
         useBuilderComponent();
@@ -52,5 +53,12 @@ export class BuilderRow extends Component {
 
     toggleCollapseContent() {
         this.state.expanded = !this.state.expanded;
+    }
+
+    get displayCollapseContent() {
+        return (
+            !!this.props.slots.collapse &&
+            (this.props.observeCollapseContent || this.state.expanded)
+        );
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.xml
@@ -52,7 +52,7 @@
                 <t t-slot="default" toggleCollapseContent="() => this.toggleCollapseContent()"/>
             </div>
         </div>
-        <div t-if="props.slots.collapse" t-att-class="{ 'd-none': !state.expanded }" t-ref="collapse-content" t-att-id="collapseContentId">
+        <div t-if="displayCollapseContent" t-att-class="{ 'd-none': !state.expanded }" t-ref="collapse-content" t-att-id="collapseContentId">
             <t t-slot="collapse"/>
         </div>
     </BuilderComponent>

--- a/addons/website/static/src/builder/plugins/options/visibility_option.xml
+++ b/addons/website/static/src/builder/plugins/options/visibility_option.xml
@@ -39,7 +39,7 @@
     <t t-set="language_ids" t-value="env.services.website.currentWebsite.language_ids || []"/>
 
     <t t-set="geoip_country_code" t-value="this.props.websiteSession.geoip_country_code"/>
-    <BuilderRow label.translate="Visibility" expand="true">
+    <BuilderRow label.translate="Visibility" expand="true" observeCollapseContent="true">
         <t t-call="website.DeviceVisibility"></t>
         <BuilderSelect dataAttributeAction="'visibility'" action="'forceVisible'" preview="false">
             <BuilderSelectItem dataAttributeActionValue="null">No condition</BuilderSelectItem>

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_row.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_row.test.js
@@ -65,8 +65,12 @@ describe("website tests", () => {
     });
 
     /* ================= Collapse template ================= */
-    const collapseOptionTemplate = (dependency = false, expand = false) => xml`
-        <BuilderRow label="'Test Collapse'" expand="${expand}">
+    const collapseOptionTemplate = ({
+        dependency = false,
+        expand = false,
+        observeCollapseContent = false,
+    } = {}) => xml`
+        <BuilderRow label="'Test Collapse'" expand="${expand}" observeCollapseContent="${observeCollapseContent}">
             <BuilderButton classAction="'a'" ${
                 dependency ? "id=\"'test_opt'\"" : ""
             }>A</BuilderButton>
@@ -94,7 +98,7 @@ describe("website tests", () => {
         test("expand=true is expanded by default", async () => {
             addOption({
                 selector: ".test-options-target",
-                template: collapseOptionTemplate(false, true),
+                template: collapseOptionTemplate({ dependency: false, expand: true }),
             });
             await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
             await contains(":iframe .test-options-target").click();
@@ -106,7 +110,10 @@ describe("website tests", () => {
         test("Toggler button is not visible if no dependency is active", async () => {
             addOption({
                 selector: ".test-options-target",
-                template: collapseOptionTemplate(true),
+                template: collapseOptionTemplate({
+                    dependency: true,
+                    observeCollapseContent: true,
+                }),
             });
             await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
             await contains(":iframe .test-options-target").click();
@@ -117,7 +124,7 @@ describe("website tests", () => {
         test("expand=true works when a dependency becomes active", async () => {
             addOption({
                 selector: ".test-options-target",
-                template: collapseOptionTemplate(true, true),
+                template: collapseOptionTemplate({ dependency: true, expand: true }),
             });
             await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
             await contains(":iframe .test-options-target").click();
@@ -175,6 +182,24 @@ describe("website tests", () => {
             await contains(":iframe .test-options-target").click();
             expect(".options-container").toBeVisible();
             expect(".o_hb_collapse_toggler:not(.d-none)").not.toHaveClass("active");
+            expect(".options-container button[data-class-action='b']").toHaveCount(0);
+            await contains(".o_hb_collapse_toggler:not(.d-none)").click();
+            expect(".o_hb_collapse_toggler:not(.d-none)").toHaveClass("active");
+            expect(".options-container button[data-class-action='b']").toBeVisible();
+            await contains(".o_hb_collapse_toggler:not(.d-none)").click();
+            expect(".o_hb_collapse_toggler:not(.d-none)").not.toHaveClass("active");
+            expect(".options-container button[data-class-action='b']").toHaveCount(0);
+        });
+
+        test("Click on toggler collapses / expands the BuilderRow (with observeCollapseContent)", async () => {
+            addOption({
+                selector: ".test-options-target",
+                template: collapseOptionTemplate({ observeCollapseContent: true }),
+            });
+            await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+            await contains(":iframe .test-options-target").click();
+            expect(".options-container").toBeVisible();
+            expect(".o_hb_collapse_toggler:not(.d-none)").not.toHaveClass("active");
             expect(".options-container button[data-class-action='b']").not.toBeVisible();
             await contains(".o_hb_collapse_toggler:not(.d-none)").click();
             expect(".o_hb_collapse_toggler:not(.d-none)").toHaveClass("active");
@@ -193,6 +218,24 @@ describe("website tests", () => {
             await contains(":iframe .test-options-target").click();
             expect(".options-container").toBeVisible();
             expect(".o_hb_collapse_toggler:not(.d-none)").not.toHaveClass("active");
+            expect(".options-container button[data-class-action='b']").toHaveCount(0);
+            await contains("[data-label='Test Collapse'] span:contains('Test Collapse')").click();
+            expect(".o_hb_collapse_toggler:not(.d-none)").toHaveClass("active");
+            expect(".options-container button[data-class-action='b']").toBeVisible();
+            await contains("[data-label='Test Collapse'] span:contains('Test Collapse')").click();
+            expect(".o_hb_collapse_toggler:not(.d-none)").not.toHaveClass("active");
+            expect(".options-container button[data-class-action='b']").toHaveCount(0);
+        });
+
+        test("Click header row's label collapses / expands the BuilderRow (with observeCollapseContent)", async () => {
+            addOption({
+                selector: ".test-options-target",
+                template: collapseOptionTemplate({ observeCollapseContent: true }),
+            });
+            await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+            await contains(":iframe .test-options-target").click();
+            expect(".options-container").toBeVisible();
+            expect(".o_hb_collapse_toggler:not(.d-none)").not.toHaveClass("active");
             expect(".options-container button[data-class-action='b']").not.toBeVisible();
             await contains("[data-label='Test Collapse'] span:contains('Test Collapse')").click();
             expect(".o_hb_collapse_toggler:not(.d-none)").toHaveClass("active");
@@ -205,7 +248,7 @@ describe("website tests", () => {
         test("Two BuilderRows with collapse content on the same option are toggled independently", async () => {
             addOption({
                 selector: ".test-options-target",
-                template: collapseOptionTemplate(true, true),
+                template: collapseOptionTemplate({ dependency: true, expand: true }),
             });
             addOption({
                 selector: ".test-options-target",

--- a/addons/website/static/tests/tours/website_text_font_size.js
+++ b/addons/website/static/tests/tours/website_text_font_size.js
@@ -7,18 +7,18 @@ import {
 import {FONT_SIZE_CLASSES} from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 
 const classNameInfo = new Map();
-classNameInfo.set("display-1-fs", {scssVariableName: "display-1-font-size", start: 80, end: 90});
-classNameInfo.set("display-2-fs", {scssVariableName: "display-2-font-size", start: 72, end: 80});
-classNameInfo.set("display-3-fs", {scssVariableName: "display-3-font-size", start: 64, end: 70});
-classNameInfo.set("display-4-fs", {scssVariableName: "display-4-font-size", start: 56, end: 60});
-classNameInfo.set("h1-fs", {scssVariableName: "h1-font-size", start: 48, end: 50});
-classNameInfo.set("h2-fs", {scssVariableName: "h2-font-size", start: 40, end: 42});
-classNameInfo.set("h3-fs", {scssVariableName: "h3-font-size", start: 32, end: 38});
-classNameInfo.set("h4-fs", {scssVariableName: "h4-font-size", start: 24, end: 34});
-classNameInfo.set("h5-fs", {scssVariableName: "h5-font-size", start: 20, end: 30});
-classNameInfo.set("h6-fs", {scssVariableName: "h6-font-size", start: 16, end: 26});
-classNameInfo.set("base-fs", {scssVariableName: "font-size-base", start: 16, end: 26});
-classNameInfo.set("o_small-fs", {scssVariableName: "small-font-size", start: 14, end: 24});
+classNameInfo.set("display-1-fs", {scssVariableName: "display-1-font-size", start: 80, end: 90, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("display-2-fs", {scssVariableName: "display-2-font-size", start: 72, end: 80, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("display-3-fs", {scssVariableName: "display-3-font-size", start: 64, end: 70, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("display-4-fs", {scssVariableName: "display-4-font-size", start: 56, end: 60, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("h1-fs", {scssVariableName: "h1-font-size", start: 48, end: 50, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("h2-fs", {scssVariableName: "h2-font-size", start: 40, end: 42, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("h3-fs", {scssVariableName: "h3-font-size", start: 32, end: 38, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("h4-fs", {scssVariableName: "h4-font-size", start: 24, end: 34, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("h5-fs", {scssVariableName: "h5-font-size", start: 20, end: 30, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("h6-fs", {scssVariableName: "h6-font-size", start: 16, end: 26, scssVariableMainName: "h1-font-size"});
+classNameInfo.set("base-fs", {scssVariableName: "font-size-base", start: 16, end: 26, scssVariableMainName: "font-size-base"});
+classNameInfo.set("o_small-fs", {scssVariableName: "small-font-size", start: 14, end: 24, scssVariableMainName: "font-size-base"});
 
 function checkComputedFontSize(fontSizeClass, stage) {
     return {
@@ -54,7 +54,7 @@ function getFontSizeTestSteps(fontSizeClass) {
         ...goToTheme(),
         {
             content: `Open the collapse to see the font size of ${fontSizeClass}`,
-            trigger: `.we-bg-options-container:has([data-action-param="${classNameInfo.get(fontSizeClass).scssVariableName}"]) [data-label="Font Size"] .o_hb_collapse_toggler`,
+            trigger: `.we-bg-options-container:has([data-action-param="${classNameInfo.get(fontSizeClass).scssVariableMainName}"]) [data-label="Font Size"] .o_hb_collapse_toggler`,
             run: "click",
         }, {
             content: `Check that the setting for ${fontSizeClass} is correct`,
@@ -76,7 +76,7 @@ function getFontSizeTestSteps(fontSizeClass) {
         ...goToTheme(),
         {
             content: `Open the collapse to see the font size of ${fontSizeClass}`,
-            trigger: `.we-bg-options-container:has([data-action-param="${classNameInfo.get(fontSizeClass).scssVariableName}"]) [data-label="Font Size"] .o_hb_collapse_toggler`,
+            trigger: `.we-bg-options-container:has([data-action-param="${classNameInfo.get(fontSizeClass).scssVariableMainName}"]) [data-label="Font Size"] .o_hb_collapse_toggler`,
             run: "click",
         },
         {
@@ -89,7 +89,7 @@ function getFontSizeTestSteps(fontSizeClass) {
         },
         {
             content: `Close the collapse to hide the font size of ${fontSizeClass}`,
-            trigger: `.we-bg-options-container:has([data-action-param="${classNameInfo.get(fontSizeClass).scssVariableName}"]) [data-label="Font Size"] .o_hb_collapse_toggler`,
+            trigger: `.we-bg-options-container:has([data-action-param="${classNameInfo.get(fontSizeClass).scssVariableMainName}"]) [data-label="Font Size"] .o_hb_collapse_toggler`,
             run: "click",
         },
         checkComputedFontSize(fontSizeClass, "end"),


### PR DESCRIPTION
The purpose of this commit is to reduce the rendering time of the theme tab. Currently, when we have a BuilderRow that contains a collapse slot, we always render it in order to know whether it contains content or not, so that we can display the collapse arrow. The collapse feature is widely used in the theme tab. This results in a lot of unnecessary calculations, because the only case that requires dynamic calculation of the collapse arrow is the BuilderOption for visibility.

So we will therefore add the “observeCollapseContent” props to enable or disable the rendering of the slot in order to dynamically display the collapse arrow.

This change saves approximately 20% of time.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
