### PR TITLE
[IMP] html_editor, *: add srcset attribute for website images

### DIFF
--- a/addons/html_editor/models/ir_attachment.py
+++ b/addons/html_editor/models/ir_attachment.py
@@ -24,7 +24,12 @@ class IrAttachment(models.Model):
     image_src = fields.Char(compute='_compute_image_src')
     image_width = fields.Integer(compute='_compute_image_size')
     image_height = fields.Integer(compute='_compute_image_size')
-    original_id = fields.Many2one('ir.attachment', string="Original (unoptimized, unresized) attachment", index='btree_not_null')
+    original_id = fields.Many2one(
+        'ir.attachment',
+        string="Original (unoptimized, unresized) attachment",
+        index='btree_not_null',
+        ondelete='cascade',
+    )
 
     def _compute_local_url(self):
         for attachment in self:

--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -276,6 +276,7 @@ export class ImagePostProcessPlugin extends Plugin {
         el.classList.add("o_modified_image_to_save");
         if (el.tagName === "IMG") {
             el.setAttribute("src", url);
+            el.removeAttribute("srcset");
         } else {
             this.dependencies.style.setBackgroundImageUrl(el, url);
         }

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -2251,7 +2251,8 @@ describe("save image", () => {
                 expect(params.res_id).toBe(1);
                 await modifyImagePromise;
                 modifyImageCount++;
-                return newImageSrc;
+                const res = { original: newImageSrc };
+                return res;
             } else {
                 // Fail the test if too many modify_image are called.
                 throw new Error("The image should only have been modified once during this test");

--- a/addons/html_editor/tests/test_controller.py
+++ b/addons/html_editor/tests/test_controller.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
 import json
 
 import odoo.tests
@@ -280,3 +281,23 @@ class TestController(HttpCase):
         )
         self.assertEqual(200, response_abstract_model.status_code)
         self.assertTrue('error_msg' in response_abstract_model.text)
+
+    def test_attachment_variant_delete_cascade(self):
+        self.authenticate('admin', 'admin')
+        payload = base64.b64decode(self.pixel)
+        original = self.env['ir.attachment'].create({
+            'name': 'original.gif',
+            'raw': payload,
+            'res_model': 'ir.ui.view',
+            'res_id': 0,
+        })
+        variant = self.env['ir.attachment'].create({
+            'name': 'variant.gif',
+            'raw': payload,
+            'res_model': 'ir.ui.view',
+            'res_id': 0,
+            'original_id': original.id,
+        })
+        self.assertTrue(variant.exists())
+        original.unlink()
+        self.assertFalse(self.env['ir.attachment'].browse(variant.id).exists())

--- a/addons/test_website_modules/tests/test_controllers.py
+++ b/addons/test_website_modules/tests/test_controllers.py
@@ -45,8 +45,8 @@ class TestWebEditorController(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             if expect_fail:
                 return json_safe.loads(response.content)
             url = json_safe.loads(response.content).get('result')
-            self.assertTrue(url.endswith(name), "Expect name in URL")
-            response = self.url_open(url)
+            self.assertTrue(url['original'].endswith(name), "Expect name in URL")
+            response = self.url_open(url['original'])
             self.assertEqual(200, response.status_code, "Expect response")
             self.assertTrue('image/svg+xml' in response.headers.get('Content-Type'), "Expect SVG mimetype")
             self.assertEqual(svg, response.content, "Expect unchanged SVG")

--- a/addons/website/static/tests/tours/snippet_image_srcset.js
+++ b/addons/website/static/tests/tours/snippet_image_srcset.js
@@ -1,0 +1,57 @@
+import {
+    clickOnSave,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "website_image_srcset",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({
+            id: "s_picture",
+            name: "Title - Image",
+            groupName: "Images",
+        }),
+        {
+            content: "Select image",
+            trigger: ":iframe .s_picture img",
+            run: "click",
+        },
+        {
+            content: "Set low quality",
+            trigger:
+                ".o_customize_tab div[data-container-title='Image'] div[data-action-id='setImageQuality'] input",
+            run: "range 5",
+        },
+        {
+            content: "Wait for image update: NOT original image",
+            trigger: ':iframe .s_picture img:not([src$="s_picture_default_image"])',
+        },
+        ...clickOnSave(),
+        {
+            content: "Wait for the saved page to reload with the modified image",
+            trigger: ':iframe .s_picture img:not([src$="s_picture_default_image"])',
+        },
+        {
+            content: "Verify responsive candidates persist after save",
+            trigger: ':iframe .s_picture img:not([src$="s_picture_default_image"])',
+            run() {
+                const img = this.anchor;
+                if (!img?.srcset) {
+                    throw new Error("Modified image should have a srcset");
+                }
+                const candidates = img.srcset
+                    .split(",")
+                    .map((entry) => entry.trim())
+                    .filter(Boolean);
+                if (candidates.length < 2) {
+                    throw new Error("Expected multiple srcset candidates, got: " + img.srcset);
+                }
+            },
+        },
+    ]
+);

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -48,3 +48,6 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
             'raw': text,
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_link_to_document', login="admin")
+
+    def test_04_image_srcset(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_image_srcset', login="admin")

--- a/addons/website_sale/static/tests/tours/product_page_zoom.js
+++ b/addons/website_sale/static/tests/tours/product_page_zoom.js
@@ -15,6 +15,19 @@ registry.category("web_tour.tours").add('website_sale.product_page_zoom', {
             expectUnloadPage: true,
         },
         {
+            content: "check that the product image has a srcset",
+            trigger: imageSelector,
+            run() {
+                const img = document.querySelector(imageSelector);
+                if (!img?.srcset) {
+                    throw new Error('Image srcset attribute missing');
+                }
+                if (!img?.srcset.includes('image_512')) {
+                    throw new Error('Srcset should list at least image_512');
+                }
+            },
+        },
+        {
             content: "click on the image",
             trigger: imageSelector,
             run: "click",


### PR DESCRIPTION
*: test_website_modules, web, website_sale, website

Currently the `/web/image` and t-field images 
only have one selectable size whatever the device, which can lead to
lower performance and waste of ressources.

This PR adds srcset support for the images in the website, so the browser can
choose the best size for the screen.

Now, if the screen width is reduced, the page can load a smaller sized
image to reduce the loading time. This can help increase the
performances and lower the data consumption on mid-range and lowcost
smartphones.

For `/web/image` images, we are generating new images at these sizes:
600, 750, 900, 1080 and 1280
These sizes are optimized so it can fit most phones on the market,
while reducing the number of images we have to generate and store.
The maximum size being the one selected by the user.
To further reduce the number of images, for a size to be generated,
it needs to be at least 15% smaller than the original image.

For t-field images, we are using the already generated images
image_128, image_256 ... image_1920, the maximum size being the size 
of the `preview_image`.

task-4563867