### PR TITLE
[FIX] sale_stock: avoid recomputing delivery date on confirm

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -112,7 +112,7 @@ class AccountMove(models.Model):
 
         return res
 
-    @api.depends('line_ids.sale_line_ids.order_id')
+    @api.depends('line_ids.sale_line_ids.order_id.effective_date')
     def _compute_delivery_date(self):
         # EXTENDS 'account'
         super()._compute_delivery_date()
@@ -139,6 +139,16 @@ class AccountMove(models.Model):
             lambda line: any(line.sale_line_ids.mapped("is_downpayment"))
         )
         return dict(ctx, move_is_downpayment=move_is_downpayment)
+
+    def _get_protected_vals(self, vals, records):
+        res = super()._get_protected_vals(vals, records)
+        # `delivery_date` should be protected on any account.move/account.move.line write
+        perma_protected = {self._fields['delivery_date']}
+        if records._name == self._name:
+            res.append((perma_protected, records))
+        elif records._name == self.line_ids._name:
+            res.append((perma_protected, records.move_id))
+        return res
 
 
 class AccountMoveLine(models.Model):


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have a sale order with deliverable products & no payment terms;
2. confirm order & validate delivery;
3. create an invoice;
4. modify the delivery date;
5. save changes;
6. change product quantity of a line & confirm invoice.

Issue
-----
The delivery date got reset.

Cause
-----
The `_compute_show_delivery_date` method gets called, which triggers the recomputation of the `_compute_delivery_date` due it the latter having `line_ids.sale_line_ids.order_id` as its `depends`.

Due to the way how `depends` works, if any of the fields in the record chain gets modified, the compute gets triggered. In this case, because we modified a `line_ids` record by changing the quantity, it will therefore recompute the delivery date, overwriting the custom value.

Solution
--------
As we only want the delivery date to be recomputed when the `effective_date` on the order changes, we should add it to the `depends` to trigger the compute in that scenario.

In other scenarios, e.g. modifying the move or one of its lines, we don't want to trigger a recompute, which we can achieve by always including `delivery_date` via `_get_protected_vals` on create/write.

opw-4996654