### PR TITLE
[FIX] pos_loyalty: fix 0 discountable

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -1,6 +1,6 @@
 import { PosOrder } from "@point_of_sale/app/models/pos_order";
 import { patch } from "@web/core/utils/patch";
-import { roundDecimals, roundPrecision } from "@web/core/utils/numbers";
+import { roundDecimals, roundPrecision, floatIsZero } from "@web/core/utils/numbers";
 import { _t } from "@web/core/l10n/translation";
 import { loyaltyIdsGenerator } from "./pos_store";
 import { compute_price_force_price_include } from "@point_of_sale/app/models/utils/tax_utils";
@@ -1135,7 +1135,7 @@ patch(PosOrder.prototype, {
         }
         let { discountable, discountablePerTax } = getDiscountable(reward);
         discountable = Math.min(this.get_total_with_tax(), discountable);
-        if (!discountable) {
+        if (floatIsZero(discountable)) {
             return [];
         }
         let maxDiscount = reward.discount_max_amount || Infinity;


### PR DESCRIPTION
When selling some product and applying a giftcard, there could be 2 giftcard lines applied on the order one with a correct amount and the other one with 0 as amount.

Steps to reproduce:
-------------------
* Create a gift card with 50€
* Open PoS and add a Desk Pad and a Black Drawer
> Observation: There are 2 giftcard lines applied on the order

Why the fix:
------------
Sometimes the discountable amount could get weird values that are really close to 0 but that was not interpreted as False. To fix this we use `floatIsZero()` instead.

Note:
----------
I will introduce a hoot test in 18.3 to cover this weird use case.

opw-4866358