### PR TITLE
[FIX] website_sale: prevent memory error by using `image_128`

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -212,7 +212,7 @@ class ProductProduct(models.Model):
         return [
             self.env['website'].image_url(extra_image, 'image_1920')
             for extra_image in self.product_variant_image_ids + self.product_template_image_ids
-            if extra_image.image_1920  # only images, no video urls
+            if extra_image.image_128  # only images, no video urls
         ]
 
     def _prepare_gmc_items(self):


### PR DESCRIPTION
This commit fixes an "out of memory" error caused by loading the `image_1920` field into memory for a large `product.product` recordset. To resolve this, the code has been changed to use `image_128` to limit the memory impact.

See also: 
- https://github.com/odoo/odoo/pull/222584

opw-4981983