### PR TITLE
[FIX] portal: prevent ISE when salesperson has no email

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -412,7 +412,7 @@
             <h4>Your contact</h4>
             <hr class="mt-1 mb0"/>
             <h6 class="mb-1"><b t-esc="sales_user.name"/></h6>
-            <div class="d-flex align-items-center mb-1">
+            <div t-if="sales_user.email_normalized" class="d-flex align-items-center mb-1">
                 <div class="fa fa-envelope fa-fw me-1"></div>
                 <a t-att-href="'mailto:'+sales_user.email" t-esc="sales_user.email"/>
             </div>

--- a/doc/cla/individual/GautamKantesariya.md
+++ b/doc/cla/individual/GautamKantesariya.md
@@ -1,0 +1,9 @@
+India, 2025-08-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Gautam gautamkantesariya@yahoo.com https://github.com/GautamKantesariya


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Portal crashes with Internal Server Error if the assigned salesperson does not have an email address.

Current behavior before PR:
When opening /my/home with a portal user linked to a salesperson without an email, the view portal.portal_contact tries to concatenate a False value with a string while building the mailto: link. This raises a TypeError: can only concatenate str (not "bool") to str.

Desired behavior after PR is merged:
Portal pages should render normally even if the salesperson has no email address. The link is only generated when the field is available, avoiding the crashink, preventing the crash and ensuring portal pages remain accessible even if a salesperson does not have an email.

Fixes #223677

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
