### PR TITLE
[IMP] html_builder, website: allow to drop inner snippets in grids 

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
@@ -62,6 +62,9 @@ export class BuilderOverlay {
     }
 
     hasSizingHandles() {
+        if (!this.hasOverlayOptions) {
+            return false;
+        }
         return this.isResizableY() || this.isResizableX() || this.isResizableGrid();
     }
 
@@ -175,6 +178,9 @@ export class BuilderOverlay {
     }
 
     initHandles() {
+        if (!this.hasSizingHandles) {
+            return;
+        }
         if (this.isResizableY()) {
             this.yHandles.forEach((handleEl) => handleEl.classList.remove("readonly"));
         }

--- a/addons/html_builder/static/src/core/drag_and_drop_plugin.js
+++ b/addons/html_builder/static/src/core/drag_and_drop_plugin.js
@@ -216,10 +216,12 @@ export class DragAndDropPlugin extends Plugin {
                 }
 
                 // Get the dropzone selectors.
+                const isColumn = parentEl.classList.contains("row");
+                const withGrids = isColumn || "filterOnly";
                 const selectors = this.dependencies.dropzone.getSelectors(
                     this.overlayTarget,
                     true,
-                    true
+                    withGrids
                 );
 
                 // Remove the dragged element and deactivate the options.

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -63,8 +63,10 @@ export class DropZonePlugin extends Plugin {
      * @param {HTMLElement} snippetEl the element
      * @param {Boolean} [checkLockedWithin=false] true if the selectors should
      *   be filtered based on the `dropLockWithin` selectors
-     * @param {Boolean} [withGrids=false] true if the elements in grid mode are
-     *   considered
+     * @param {Boolean|String} [withGrids=false]
+     *   - `true` if the elements in grid mode are considered,
+     *   - `"filterOnly"` if the grids should only be filtered out,
+     *   - `false`
      * @returns {Object} [selectorChildren, selectorSiblings]
      */
     getSelectors(snippetEl, checkLockedWithin = false, withGrids = false) {
@@ -169,7 +171,7 @@ export class DropZonePlugin extends Plugin {
 
         // Remove the siblings/children that would add a dropzone as a direct
         // child of a grid and make a dedicated set out of the identified grids.
-        const selectorGrids = new Set();
+        let selectorGrids = new Set();
         if (withGrids) {
             const filterGrids = (potentialGridEl) => {
                 if (potentialGridEl.matches(".o_grid_mode")) {
@@ -180,6 +182,11 @@ export class DropZonePlugin extends Plugin {
             };
             selectorSiblings = selectorSiblings.filter((el) => filterGrids(el.parentElement));
             selectorChildren = selectorChildren.filter((el) => filterGrids(el));
+
+            // If specified, only filter out the grids.
+            if (withGrids === "filterOnly") {
+                selectorGrids = new Set();
+            }
         }
 
         return {

--- a/addons/html_builder/static/src/core/dropzone_selector_plugin.js
+++ b/addons/html_builder/static/src/core/dropzone_selector_plugin.js
@@ -33,7 +33,7 @@ export class DropZoneSelectorPlugin extends Plugin {
                     ].join(", ");
                 },
                 exclude: `${special_cards_selector}`,
-                dropIn: "nav",
+                dropIn: "nav, .row.o_grid_mode",
                 get dropNear() {
                     return `p, h1, h2, h3, ul, ol, div:not(.o_grid_item_image) > img, div:not(.o_grid_item_image) > a, .btn, ${this.plugin
                         .getResource("so_content_addition_selector")

--- a/addons/html_builder/static/src/core/grid_layout/grid_layout_plugin.js
+++ b/addons/html_builder/static/src/core/grid_layout/grid_layout_plugin.js
@@ -226,8 +226,14 @@ export class GridLayoutPlugin extends Plugin {
     wrapInGridItem(el, dropzoneEl, dragState) {
         // Create the grid item.
         const columnEl = document.createElement("div");
-        columnEl.classList.add("o_grid_item", "col-lg-6", "g-col-lg-6", "g-height-1");
-        columnEl.style.gridArea = "1 / 1 / 2 / 7";
+        const columnSpan = dragState.snippet.gridColumnSpan || 6;
+        columnEl.classList.add(
+            "o_grid_item",
+            `col-lg-${columnSpan}`,
+            `g-col-lg-${columnSpan}`,
+            "g-height-1"
+        );
+        columnEl.style.gridArea = `1 / 1 / 2 / ${columnSpan + 1}`;
         dropzoneEl.after(columnEl);
         columnEl.append(el);
         dragState.draggedEl = columnEl;
@@ -239,8 +245,8 @@ export class GridLayoutPlugin extends Plugin {
 
         // Adjust the grid item dimensions to its content and store them.
         this.adjustGridItem(el, false);
-        const { rowStart, rowEnd, columnStart, columnEnd } = getGridItemProperties(columnEl);
-        dragState.columnSpan = columnEnd - columnStart;
+        const { rowStart, rowEnd } = getGridItemProperties(columnEl);
+        dragState.columnSpan = columnSpan;
         dragState.rowSpan = rowEnd - rowStart;
         return columnEl;
     }

--- a/addons/html_builder/static/src/plugins/image/image_snippet_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_snippet_option_plugin.js
@@ -9,7 +9,7 @@ class ImageSnippetOptionPlugin extends Plugin {
         so_content_addition_selector: [".s_image"],
     };
 
-    async onSnippetDropped({ snippetEl }) {
+    async onSnippetDropped({ snippetEl, dragState }) {
         if (!snippetEl.matches(".s_image")) {
             return;
         }
@@ -23,6 +23,11 @@ class ImageSnippetOptionPlugin extends Plugin {
                 save: async (selectedImageEl) => {
                     isImageSelected = true;
                     snippetEl.replaceWith(selectedImageEl);
+                    // If the "Image" snippet was dropped as a grid item, make
+                    // it a grid image.
+                    if (dragState.draggedEl.classList.contains("o_grid_item")) {
+                        dragState.draggedEl.classList.add("o_grid_item_image");
+                    }
                 },
             });
             onClose.then(() => {

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -315,7 +315,7 @@ export class BlockTab extends Component {
                 });
 
                 // The dragged element may change while dragging.
-                Object.assign(this.dragState, { draggedEl: snippetEl, snippetEl });
+                Object.assign(this.dragState, { draggedEl: snippetEl, snippetEl, snippet });
 
                 // Add the dropzones.
                 const withGrids =

--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -69,6 +69,22 @@ export class SnippetModel extends Reactive {
         );
     }
 
+    /**
+     * Checks if the given element is an inner content snippet.
+     *
+     * @param {HTMLElement} el the element
+     * @returns {Boolean}
+     */
+    isInnerContent(el) {
+        const snippetName = el.dataset.snippet;
+        if (!snippetName) {
+            return false;
+        }
+        return !!this.snippetsByCategory.snippet_content.find(
+            (snippet) => snippet.name === snippetName
+        );
+    }
+
     getSnippet(category, id) {
         return this.snippetsByCategory[category].find((snippet) => snippet.id === id);
     }

--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -198,6 +198,7 @@ export class SnippetModel extends Reactive {
                     label: snippetEl.dataset.oLabel,
                     isDisabled: false,
                     forbidSanitize: false,
+                    gridColumnSpan: 0,
                 };
                 const moduleId = snippetEl.dataset.moduleId;
                 if (moduleId) {
@@ -209,6 +210,9 @@ export class SnippetModel extends Reactive {
                 }
                 if (snippetEl.dataset.oeForbidSanitize) {
                     Object.assign(snippet, { forbidSanitize: snippetEl.dataset.oeForbidSanitize });
+                }
+                if (snippetEl.dataset.oGridColumnSpan) {
+                    snippet.gridColumnSpan = parseInt(snippetEl.dataset.oGridColumnSpan);
                 }
                 switch (snippetCategory.id) {
                     case "snippet_groups":

--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -96,10 +96,11 @@ class IrQweb(models.AbstractModel):
         # - "true": always forbid
         # - "form": forbid if forms are sanitized
         forbid_sanitize = el.attrib.pop('t-forbid-sanitize', None)
+        grid_column_span = el.attrib.pop('t-grid-column-span', None)
         snippet_group = el.attrib.pop('snippet-group', None)
         group = el.attrib.pop('group', None)
         label = el.attrib.pop('label', None)
-        div = Markup('<div name="%s" data-oe-type="snippet" data-o-image-preview="%s" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-snippet-key="%s" data-oe-keywords="%s" %s %s %s %s>') % (
+        div = Markup('<div name="%s" data-oe-type="snippet" data-o-image-preview="%s" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-snippet-key="%s" data-oe-keywords="%s" %s %s %s %s %s>') % (
             name,
             escape_silent(image_preview),
             thumbnail,
@@ -107,6 +108,7 @@ class IrQweb(models.AbstractModel):
             key.split('.')[-1],
             escape_silent(el.findtext('keywords')),
             Markup('data-oe-forbid-sanitize="%s"') % forbid_sanitize if forbid_sanitize else '',
+            Markup('data-o-grid-column-span="%s"') % grid_column_span if grid_column_span else '',
             Markup('data-o-snippet-group="%s"') % snippet_group if snippet_group else '',
             Markup('data-o-group="%s"') % group if group else '',
             Markup('data-o-label="%s"') % label if label else '',

--- a/addons/website/static/src/builder/plugins/options/button_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/button_option_plugin.js
@@ -101,12 +101,12 @@ class ButtonOptionPlugin extends Plugin {
                 if (siblingButtonEl.classList.contains("rounded-circle")) {
                     editingElement.classList.add("rounded-circle");
                 }
-            } else {
+            } else if (!siblingButtonEl) {
                 // To align with the editor's behavior, we need to enclose the
-                // button in a <p> tag if it's not dropped within a <p> tag. We only
-                // put the dropped button in a <p> if it's not next to another
-                // button, because some snippets have buttons that aren't inside a
-                // <p> (e.g. s_text_cover).
+                // button in a <p> tag if it's not dropped within a <p> tag. We
+                // only put the dropped button in a <p> if it's not next to
+                // another button, because some snippets have buttons that are
+                // not inside a <p> (e.g. s_text_cover).
                 // TODO: this definitely needs to be fixed at web_editor level.
                 // Nothing should prevent adding buttons outside of a paragraph.
                 const btnContainerEl = editingElement.closest("p");

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option_plugin.js
@@ -55,6 +55,8 @@ export class GoogleMapsOptionPlugin extends Plugin {
             ResetMapColorAction,
             ShowDescriptionAction,
         },
+        // TODO remove when the snippet will have a "Height" option.
+        keep_overlay_options: (el) => el.matches(".s_google_map"),
     };
 
     setup() {

--- a/addons/website/static/src/builder/plugins/options/map_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/map_option_plugin.js
@@ -18,6 +18,8 @@ class MapOptionPlugin extends Plugin {
             MapUpdateSrcAction,
             MapDescriptionAction,
         },
+        // TODO remove when the snippet will have a "Height" option.
+        keep_overlay_options: (el) => el.matches(".s_map"),
     };
 }
 

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -11,6 +11,7 @@ import {
     addPlugin,
     defineWebsiteModels,
     setupWebsiteBuilder,
+    setupWebsiteBuilderWithSnippet,
 } from "./website_helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
@@ -335,4 +336,19 @@ test("The overlay buttons should only appear for elements in editable areas, unl
     await contains(":iframe .test-editable").click();
     expect(".overlay .button-a").toHaveCount(1);
     expect(".overlay .button-b").toHaveCount(1);
+});
+
+test("An inner snippet alone in a column should not have overlay options", async () => {
+    await setupWebsiteBuilderWithSnippet("s_banner");
+    // Clicking on the "Blockquote" should activate the column overlay.
+    await contains(":iframe blockquote").click();
+    expect(".oe_overlay").toHaveCount(3);
+    expect(".oe_overlay.oe_active").toHaveCount(2);
+    // Clone the block so it is not alone anymore.
+    await contains(
+        ".options-container[data-container-title='Blockquote'] .oe_snippet_clone"
+    ).click();
+    // Only the "Blockquote" should have an overlay.
+    expect(".oe_overlay").toHaveCount(3);
+    expect(".oe_overlay.oe_active").toHaveCount(1);
 });

--- a/addons/website/static/tests/builder/website_builder/drag_and_drop.test.js
+++ b/addons/website/static/tests/builder/website_builder/drag_and_drop.test.js
@@ -3,7 +3,9 @@ import { contains } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
     dummyBase64Img,
+    getDragHelper,
     getDragMoveHelper,
+    setupWebsiteBuilder,
     setupWebsiteBuilderWithSnippet,
     waitForEndOfOperation,
 } from "../website_helpers";
@@ -118,4 +120,115 @@ test("A column in mobile view should not be draggable", async () => {
 
     await contains(":iframe section.s_text_image .row > div:nth-child(1)").click();
     expect(".overlay .o_overlay_options .o_move_handle").toHaveCount(0);
+});
+
+test("Drag and drop an inner content as a grid item", async () => {
+    await setupWebsiteBuilder(
+        `<section class="s_dummy" style="width: 600px;">
+            <div class="container">
+                <div class="row o_grid_mode" data-row-count="3">
+                    <div class="o_grid_item g-height-3 g-col-lg-6 col-lg-6" style="grid-area: 1 / 1 / 4 / 7; z-index: 1;">
+                        <p>Text</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+        `,
+        { loadIframeBundles: true }
+    );
+    // Drag over the grid and drop it as an inner content.
+    let dragUtils = await contains("#snippet_content [name='Alert'] .o_snippet_thumbnail").drag();
+    expect(":iframe .oe_drop_zone").toHaveCount(3);
+    expect(":iframe .oe_grid_zone").toHaveCount(1);
+    await dragUtils.moveTo(":iframe .oe_grid_zone", { position: { x: 555, y: 55 } });
+    expect(":iframe .o_we_background_grid").toHaveCount(1);
+    expect(":iframe .o_grid_item").toHaveCount(2);
+    await dragUtils.moveTo(":iframe .oe_drop_zone:not(.oe_grid_zone)");
+    expect(":iframe .o_we_background_grid").toHaveCount(0);
+    expect(":iframe .o_grid_item").toHaveCount(1);
+    expect(":iframe .oe_grid_zone").toHaveClass("invisible");
+    await dragUtils.drop(getDragHelper());
+    await waitForEndOfOperation();
+    expect(":iframe .o_grid_item:only-child div.s_alert").toHaveCount(1);
+    await contains(".o-website-builder_sidebar .fa-undo").click();
+    expect(":iframe div.s_alert").toHaveCount(0);
+
+    // Drag over the grid and drop it as a grid item.
+    dragUtils = await contains("#snippet_content [name='Alert'] .o_snippet_thumbnail").drag();
+    expect(":iframe .oe_drop_zone").toHaveCount(3);
+    expect(":iframe .oe_grid_zone").toHaveCount(1);
+    await dragUtils.moveTo(":iframe .oe_grid_zone", { position: { x: 555, y: 55 } });
+    expect(":iframe .o_we_background_grid").toHaveCount(1);
+    expect(":iframe .o_grid_item").toHaveCount(2);
+    expect(":iframe .o_we_drag_helper").toHaveStyle({
+        gridRowStart: 2,
+        gridColumnStart: 7,
+        gridColumnEnd: 13,
+    });
+    await dragUtils.moveTo(":iframe .oe_grid_zone", { position: { x: 5, y: 205 } });
+    await dragUtils.drop(getDragHelper());
+    await waitForEndOfOperation();
+    expect(":iframe .o_grid_item:nth-child(2)").toHaveStyle({
+        zIndex: 2,
+        gridRowStart: 5,
+        gridColumnStart: 1,
+        gridColumnEnd: 7,
+    });
+    await contains(".o-website-builder_sidebar .fa-undo").click();
+    expect(":iframe div.s_alert").toHaveCount(0);
+
+    // Drop near the grid (should become a grid item in the top left corner).
+    dragUtils = await contains("#snippet_content [name='Alert'] .o_snippet_thumbnail").drag();
+    expect(":iframe .oe_drop_zone").toHaveCount(3);
+    expect(":iframe .oe_grid_zone").toHaveCount(1);
+    await dragUtils.moveTo({ position: { x: 700, y: 55 } });
+    await dragUtils.drop(getDragHelper());
+    await waitForEndOfOperation();
+    expect(":iframe .o_grid_item").toHaveCount(2);
+    expect(":iframe .o_grid_item:nth-child(2)").toHaveStyle({
+        zIndex: 2,
+        gridRowStart: 1,
+        gridColumnStart: 1,
+        gridColumnEnd: 7,
+    });
+});
+
+test("Dragging an inner content from the sidebar in mobile view should not make grid dropzones appear", async () => {
+    await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
+    let dragUtils = await contains("#snippet_content [name='Alert'] .o_snippet_thumbnail").drag();
+    expect(":iframe .oe_grid_zone").toHaveCount(1);
+    await dragUtils.drop(getDragHelper());
+    await waitForEndOfOperation();
+    expect(":iframe .s_alert").toHaveCount(0);
+
+    // Toggle the mobile preview.
+    await contains(".o-snippets-top-actions [data-action='mobile']").click();
+    expect(".o_website_preview").toHaveClass("o_is_mobile");
+    dragUtils = await contains("#snippet_content [name='Alert'] .o_snippet_thumbnail").drag();
+    expect(":iframe .oe_grid_zone").toHaveCount(0);
+});
+
+test("Dragging an inner content from the page should not make grid dropzones appear", async () => {
+    await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
+    // Add an inner snippet in the first column.
+    let dragUtils = await contains("#snippet_content [name='Alert'] .o_snippet_thumbnail").drag();
+    expect(":iframe .oe_grid_zone").toHaveCount(1);
+    await dragUtils.moveTo(":iframe .oe_drop_zone");
+    await dragUtils.drop(getDragHelper());
+    await waitForEndOfOperation();
+    expect(":iframe .o_grid_item:nth-child(1) > .s_alert").toHaveCount(1);
+
+    // Redrag the snippet.
+    await contains(":iframe .s_alert").click();
+    dragUtils = await contains(".o_overlay_options .o_move_handle").drag();
+    expect(":iframe .oe_grid_zone").toHaveCount(0);
+    await dragUtils.moveTo(":iframe .oe_drop_zone");
+    await dragUtils.drop(getDragMoveHelper());
+    await waitForEndOfOperation();
+
+    // Check in mobile view.
+    await contains(".o-snippets-top-actions [data-action='mobile']").click();
+    expect(".o_website_preview").toHaveClass("o_is_mobile");
+    await contains(".o_overlay_options .o_move_handle").drag();
+    expect(":iframe .oe_grid_zone").toHaveCount(0);
 });

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -470,27 +470,27 @@
 
             <!-- Inner snippets -->
             <snippets id="snippet_content" string="Inner content">
-                <t t-snippet="website.s_inline_text" string="Text" t-thumbnail="/website/static/src/img/snippets_thumbs/s_inline_text.svg"/>
-                <t t-snippet="website.s_button" string="Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_button.svg"/>
+                <t t-snippet="website.s_inline_text" string="Text" t-thumbnail="/website/static/src/img/snippets_thumbs/s_inline_text.svg" t-grid-column-span="4"/>
+                <t t-snippet="website.s_button" string="Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_button.svg" t-grid-column-span="3"/>
                 <t t-snippet="website.s_image" string="Image" t-thumbnail="/website/static/src/img/snippets_thumbs/s_image.svg"/>
                 <t t-snippet="website.s_video" string="Video" t-thumbnail="/website/static/src/img/snippets_thumbs/s_video.svg"/>
                 <t t-snippet="website.s_hr" string="Separator" t-thumbnail="/website/static/src/img/snippets_thumbs/s_hr.svg"/>
                 <t t-snippet="website.s_accordion" string="Accordion" t-thumbnail="/website/static/src/img/snippets_thumbs/s_accordion.svg"/>
                 <t t-snippet="website.s_alert" string="Alert" t-thumbnail="/website/static/src/img/snippets_thumbs/s_alert.svg"/>
-                <t t-snippet="website.s_rating" string="Rating" t-thumbnail="/website/static/src/img/snippets_thumbs/s_rating.svg"/>
+                <t t-snippet="website.s_rating" string="Rating" t-thumbnail="/website/static/src/img/snippets_thumbs/s_rating.svg" t-grid-column-span="3"/>
                 <t t-snippet="website.s_card" string="Card" t-thumbnail="/website/static/src/img/snippets_thumbs/s_card.svg"/>
                 <t t-snippet="website.s_share" string="Share" t-thumbnail="/website/static/src/img/snippets_thumbs/s_share.svg"/>
                 <t t-snippet="website.s_social_media" string="Social Media" t-thumbnail="/website/static/src/img/snippets_thumbs/s_social_media.svg"/>
                 <t t-snippet="website.s_facebook_page" string="Facebook" t-thumbnail="/website/static/src/img/snippets_thumbs/s_facebook_page.svg"/>
-                <t t-snippet="website.s_searchbar_input" string="Search" t-thumbnail="/website/static/src/img/snippets_thumbs/s_searchbar_inline.svg" t-forbid-sanitize="form"/>
+                <t t-snippet="website.s_searchbar_input" string="Search" t-thumbnail="/website/static/src/img/snippets_thumbs/s_searchbar_inline.svg" t-forbid-sanitize="form" t-grid-column-span="5"/>
                 <t id="mass_mailing_newsletter_hook"/>
                 <t id="mail_group_hook"/>
                 <t t-snippet="website.s_text_highlight" string="Text Highlight" t-thumbnail="/website/static/src/img/snippets_thumbs/s_text_highlight.svg"/>
                 <t t-snippet="website.s_chart" string="Chart" t-thumbnail="/website/static/src/img/snippets_thumbs/s_chart.svg"/>
-                <t t-snippet="website.s_progress_bar" string="Progress Bar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_progress_bar.svg"/>
-                <t t-snippet="website.s_badge" string="Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_badge.svg"/>
-                <t t-snippet="website.s_cta_badge" string="CTA Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_cta_badge.svg"/>
-                <t t-snippet="website.s_blockquote" string="Blockquote" t-thumbnail="/website/static/src/img/snippets_thumbs/s_blockquote.svg"/>
+                <t t-snippet="website.s_progress_bar" string="Progress Bar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_progress_bar.svg" t-grid-column-span="4"/>
+                <t t-snippet="website.s_badge" string="Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_badge.svg" t-grid-column-span="2"/>
+                <t t-snippet="website.s_cta_badge" string="CTA Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_cta_badge.svg" t-grid-column-span="5"/>
+                <t t-snippet="website.s_blockquote" string="Blockquote" t-thumbnail="/website/static/src/img/snippets_thumbs/s_blockquote.svg" t-grid-column-span="5"/>
                 <!--
                 Note: this inner snippet is still allowed to be dropped as a
                 main snippet. Indeed, this handles the fact that the snippet

--- a/addons/website_mail_group/static/src/website_builder/mail_group_option_plugin.js
+++ b/addons/website_mail_group/static/src/website_builder/mail_group_option_plugin.js
@@ -18,6 +18,7 @@ class MailGroupOptionPlugin extends Plugin {
         dropzone_selector: {
             selector: ".s_group",
             dropNear: "p, h1, h2, h3, blockquote, .card",
+            dropIn: ".row.o_grid_mode",
         },
         builder_actions: {
             MailGroupAction,

--- a/addons/website_mail_group/views/snippets/snippets.xml
+++ b/addons/website_mail_group/views/snippets/snippets.xml
@@ -6,7 +6,7 @@
 
     <template id="snippets" inherit_id="website.snippets" name="Snippet Subscribe">
         <xpath expr="//t[@id='mail_group_hook']" position="replace">
-            <t t-snippet="website_mail_group.s_group" string="Discussion Group" t-thumbnail="/website/static/src/img/snippets_thumbs/s_group.svg"/>
+            <t t-snippet="website_mail_group.s_group" string="Discussion Group" t-thumbnail="/website/static/src/img/snippets_thumbs/s_group.svg" t-grid-column-span="5"/>
         </xpath>
     </template>
 </odoo>

--- a/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option_plugin.js
@@ -39,6 +39,7 @@ class NewsletterSubscribeCommonOptionPlugin extends Plugin {
             {
                 selector: ".js_subscribe",
                 dropNear: "p, h1, h2, h3, blockquote, .card",
+                dropIn: ".row.o_grid_mode",
             },
         ],
     };

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -32,7 +32,7 @@
         <t t-snippet="website_mass_mailing.s_newsletter_benefits_popup" string="Newsletter Benefits" t-forbid-sanitize="form" group="contact_and_forms"/>
     </xpath>
     <xpath expr="//t[@id='mass_mailing_newsletter_hook']" position="replace">
-        <t t-snippet="website_mass_mailing.s_newsletter_subscribe_form" string="Newsletter" t-thumbnail="/website/static/src/img/snippets_thumbs/s_newsletter_subscribe_form.svg" t-forbid-sanitize="form"/>
+        <t t-snippet="website_mass_mailing.s_newsletter_subscribe_form" string="Newsletter" t-thumbnail="/website/static/src/img/snippets_thumbs/s_newsletter_subscribe_form.svg" t-forbid-sanitize="form" t-grid-column-span="5"/>
     </xpath>
 </template>
 

--- a/addons/website_payment/views/snippets/snippets.xml
+++ b/addons/website_payment/views/snippets/snippets.xml
@@ -10,7 +10,7 @@
         <t t-snippet="website_payment.s_donation" string="Donation" t-forbid-sanitize="form" group="contact_and_forms"/>
     </xpath>
     <xpath expr="//t[@id='snippet_donation_button_hook']" position="replace">
-        <t t-snippet="website_payment.s_donation_button" string="Donation Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_donation_button.svg" t-forbid-sanitize="form"/>
+        <t t-snippet="website_payment.s_donation_button" string="Donation Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_donation_button.svg" t-forbid-sanitize="form" t-grid-column-span="3"/>
     </xpath>
     <xpath expr="//t[@id='snippet_supported_payment_methods_hook']" position="replace">
         <t

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -7,7 +7,7 @@
         <t t-snippet="website_sale.s_dynamic_snippet_category_list" string="Category List" group="catalog"/>
     </xpath>
     <xpath expr="//t[@id='snippet_add_to_cart_hook']" position="replace">
-        <t t-snippet="website_sale.s_add_to_cart" string="Add to Cart Button"  t-thumbnail="/website/static/src/img/snippets_thumbs/s_add_to_cart.svg"/>
+        <t t-snippet="website_sale.s_add_to_cart" string="Add to Cart Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_add_to_cart.svg" t-grid-column-span="3"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
[FIX] website: prevent always wrapping a custom button inside a <p>

When dropping a button snippet, the following rules currently apply:
- if it is dropped next to a button and if not a custom snippet, copy
  the style of that sibling button,
- otherwise, wrap it inside a `<p>` if it is not inside one yet.

This means that if a custom button is dropped (= a button saved as a
custom snippet),
- it will not copy the sibling style
=> This is normal, since it is custom.
- it will always be wrapped inside a `<p>` (if not inside one yet), even
  if it has a sibling.
=> This is wrong, it should behave like the other buttons.

This commit therefore fixes these conditions to not wrap a custom button
if not necessary.

Steps to reproduce:
- Drag a "Button" snippet inside the "Contact Us" navbar button or next
  to the "Text Cover" snippet button.
=> The structure is well `<a/> <a/>` (because it has a sibling).
- Customize a button and save it as a custom snippet.
- Drop this custom snippet at the same place as the first step.
=> The structure is `<a/> <p><a/></p>`, it should be `<a/> <a/>`
   instead, since the button has a sibling.

task-5032130
task-3369611

---
[IMP] website, *: disable overlay options for snippets alone in column

*: html_builder

When dropping the "Banner" snippet and clicking on its "Blockquote", the
displayed overlay is the inner snippet one and not the column one. While
it is the expected behavior, it confuses a lot of users who think it is
the column one: they expect it to move in the grid, but it can only be
dropped as an inner snippet. They could easily select the column by
clicking on the corresponding options container, but this is not really
instinctive for most users.

This commit fixes this confusion by disabling the overlay options of
elements that are alone in a column (like the "Banner" blockquote). This
means that clicking on it will now activate the column overlay options.
As soon as another sibling is added in the column, all these inner
elements will have their overlay options re-enabled.

Note that this fix will be especially needed when the inner snippets
will be allowed to be dropped as grid items, as they will all be in the
same situation (see next commit of this PR).

Also note that the `s_map` and `s_google_map` snippets overlay options
were temporarily kept. Indeed, their size is set by using the padding
handles so disabling them would prevent the user from changing it. Once
an option allowing to properly set their height is added, their overlay
options could safely be disabled too.

task-3369611

---
[IMP] html_builder, website, *: allow to drop inner snippets in grids

*: website_mail_group, website_mass_mailing

This commit adds the possibility to drop inner snippets directly as grid
items.

More precisely, if a snippet is dragged over a grid, it is wrapped in a
grid item, which then becomes the dragged element. When dragged out of
the dropzone, the snippet is unwrapped and becomes the dragged element
again. When dropped near (so not over) a grid dropzone, the snippet is
also wrapped in a grid item and placed on the top/left of the grid. This
wrapping was made in a way such that we can reach the same situation as
when dragging a grid item from the page, in order to reuse the original
grid mode code (which is therefore common).

Additionally:
- Since the previous commit of this PR, the snippets that are alone in a
  column do not have their overlay options anymore (it is the column
  ones that are activated instead). Given that we can therefore not
  resize them anymore (in order to change their vertical padding), and
  in order to align them properly, the original padding (pt/pb classes)
  and the vertical margins (but not the bottom if still necessary) of
  the snippets are now removed if they are dropped as grid items. The
  space around them can still be adjusted thanks to the grid item
  "Padding (Y, X)" option.

- When dropping the "Image" snippet as a grid item, it must become a
  grid image, in order to fill the grid area and to use the "Position"
  grid image option.

- In order to not pollute the UI, when dragging the snippet over an
  inner dropzone that would overlap with a grid dropzone, the grid one
  is hidden temporarily. This allows to properly see the snippet when it
  is considered as a content.

- The `on_snippet_preview_handlers` resource (used to properly preview
  the snippet when over a dropzone) was removed. Indeed, now that the
  `onDrag` hook is present, we cannot rely on the savepoint mechanism
  to revert the preview, as changes could happen in it and would
  therefore be reverted too. In order to still preview the snippets, we
  can still use the `on_snippet_over/out_dropzone_handlers` resources,
  by adapting the snippet when over a dropzone and providing a restore
  function to call when out of it. As a consequence of this change, the
  "Button" snippet preview was adapted by this commit.

Note: only the drag and drop from the sidebar allows to drop an inner
snippet in a grid. This means that a snippet already dropped on the page
will only be dropped in normal dropzones and will not display any grid
dropzone. Indeed, since the overlapping grid and inner dropzones really
pollute the UI, it was decided that if the user dropped it as a simple
content, it will stay a content. He can simply drop another snippet as a
grid item if he wants to.

task-3369611

---
[IMP] html_builder, *: force dimensions of inner snippets when in grids

*: web_editor, website, website_mail_group, website_mass_mailing,
   website_payment, website_sale

Currently, when dropping inner snippets as grid items, they all have a
column span of 6 grid columns. As some of them are quite small (e.g. the
buttons), 6 columns is a bit too big for them.

This commit allows to set the grid column span of the snippets, to make
them have a more appropriate width, thanks to the `t-grid-column-span`
attribute. This commit therefore also adapts the snippets that need it
(or that simply look better with a size other than 6).

task-3369611