### PR TITLE
[FIX] pos_online_payment: synchronize the order partner in the backend

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/models/pos_order.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/models/pos_order.js
@@ -9,13 +9,15 @@ patch(PosOrder.prototype, {
             onlinePaymentData: { ...this.onlinePaymentData },
         };
     },
-    set_partner(partner) {
+    async set_partner(partner) {
         super.set_partner(...arguments);
-        return rpc("/web/dataset/call_kw/pos.order/write", {
-            model: "pos.order",
-            method: "write",
-            args: [this.id, { partner_id: partner ? partner.id : false }],
-            kwargs: {},
-        });
+        if (typeof this.id === "number") {
+            await rpc("/web/dataset/call_kw/pos.order/write", {
+                model: "pos.order",
+                method: "write",
+                args: [this.id, { partner_id: partner ? partner.id : false }],
+                kwargs: {},
+            });
+        }
     },
 });

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/models/pos_order.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/models/pos_order.js
@@ -1,5 +1,6 @@
 import { patch } from "@web/core/utils/patch";
 import { PosOrder } from "@point_of_sale/app/models/pos_order";
+import { rpc } from "@web/core/network/rpc";
 
 patch(PosOrder.prototype, {
     getCustomerDisplayData() {
@@ -7,5 +8,14 @@ patch(PosOrder.prototype, {
             ...super.getCustomerDisplayData(),
             onlinePaymentData: { ...this.onlinePaymentData },
         };
+    },
+    set_partner(partner) {
+        super.set_partner(...arguments);
+        return rpc("/web/dataset/call_kw/pos.order/write", {
+            model: "pos.order",
+            method: "write",
+            args: [this.id, { partner_id: partner ? partner.id : false }],
+            kwargs: {},
+        });
     },
 });


### PR DESCRIPTION
# Steps to Reproduce
1. Configure a payment method as **Online Payment**.  
2. Select a customer and proceed to pay the order.  
3. The QR code for online payment is generated.  
4. Note: the partner is correctly loaded in the backend.  
5. Close the QR popup and change the partner.  
6. Scan the QR again and proceed to pay.  

# Expected Behavior
- The transaction should reflect the updated partner, not the previous one.  

# Actual Behavior
- The transaction is recorded under the previous partner.  
- The partner is not updated in the order.  

# Issue
- Updating the partner does not immediately update the order in the backend from the POS UI.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
