### PR TITLE
[FIX] account: error while changing currency rate date in invoice

### DIFF
--- a/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
+++ b/addons/account/static/src/components/account_pick_currency_rate/account_pick_currency_rate.js
@@ -22,7 +22,7 @@ export class AccountPickCurrencyDate extends Component {
                 const rate = await this.orm.call(
                     'account.move',
                     'get_currency_rate',
-                    [record.resId, record.data.company_id.id, record.data.currency_id.id, date],
+                    [record.resId, record.data.company_id.id, record.data.currency_id.id, date.toISODate()],
                 );
                 this.props.record.update({ invoice_currency_rate: rate });
                 await this.props.record.save();


### PR DESCRIPTION
A traceback occurs while we try to change the date for the currency rate in invoice.

Reason:
This is because, from the JS side, while we make the orm call to fetch the latest currency rate, the complete datetime string is directly passed to the function parameters.

Solution:
the date string is formatted to send only date.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
