### PR TITLE
[FIX] project: fix URL redirect to open task’s correct project

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1999,7 +1999,7 @@ class Task(models.Model):
         menu_id = self.env.ref('project.menu_project_management_all_tasks').id
         return {
             'type': 'ir.actions.act_url',
-            'url': f"/odoo/1/action-project.act_project_project_2_project_task_all/{self.id}?menu_id={menu_id}",
+            'url': f"/odoo/{self.project_id.id}/action-project.act_project_project_2_project_task_all/{self.id}?menu_id={menu_id}",
             'target': 'new',
         }
 


### PR DESCRIPTION
Steps to Reproduce:
-------------
1. Install project and create two projects and tasks.
2. Share both projects with edit access.
3. Edit a task from the portal view (Back to edit mode) then click the (back to tasks) button.
4. Instead of the correct project the page redirects to the another project kanban view.

Issue:
--------------
- When redirecting to a task from project sharing (edit mode – task form view) it redirects to a different project’s kanban view instead of the actual project.

Cause:
-------------
- In the portal view the URL is hardcoded with `id=1` instead of dynamically using the correct project ID.

Fix:
---------------
- pass the correct `project_id` in the URL instead of using a hardcoded value.

The issue occurred from this  PR-https://github.com/odoo/odoo/pull/174648

task-5031632
