### PR TITLE
[FIX] account:  Show popup only when entries need hashing

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -1072,6 +1072,11 @@ class AccountJournal(models.Model):
             action['views'] = [[False, 'form']]
         return action
 
+    def action_post_all_entries(self):
+        ctx = dict(self.env.context, active_model='account.journal', active_id=self.id)
+        moves_to_validate = self.env['account.move'].search([('journal_id', '=', self.id)])
+        return moves_to_validate.with_context(ctx).action_validate_moves_with_confirmation()
+
     def open_action_with_context(self):
         action_name = self.env.context.get('action_name', False)
         if not action_name:

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5779,6 +5779,37 @@ class AccountMove(models.Model):
             return autopost_bills_wizard
         return False
 
+    def action_validate_moves_with_confirmation(self):
+        """
+        If 'restrict_mode_hash_table' is enabled or future-dated moves, open a confirmation wizard;
+        otherwise, validate moves directly.
+        """
+        draft_moves = self.filtered(lambda m: m.state == 'draft' and m.line_ids)
+        if not draft_moves:
+            raise UserError(_('There are no journal items in the draft state to post.'))
+
+        need_confirmation_moves = draft_moves.filtered(lambda move:
+            (move.date or move.invoice_date) > fields.Date.context_today(self)
+            or move.restrict_mode_hash_table
+        )
+        direct_validate_moves = draft_moves - need_confirmation_moves
+        if direct_validate_moves:
+            direct_validate_moves._post(soft=False)
+        if need_confirmation_moves:
+            wizard = self.env['validate.account.move'].create({
+                'move_ids': [Command.set(need_confirmation_moves.ids)],
+            })
+            return {
+                'name': _("Confirm Entries"),
+                'type': 'ir.actions.act_window',
+                'res_model': 'validate.account.move',
+                'res_id': wizard.id,
+                'view_mode': 'form',
+                'view_id': self.env.ref('account.validate_account_move_view').id,
+                'target': 'new',
+            }
+        return False
+
     def js_assign_outstanding_line(self, line_id):
         ''' Called by the 'payment' widget to reconcile a suggested journal item to the present
         invoice.

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -183,7 +183,7 @@
                                         <span>Operations</span>
                                     </h5>
                                     <div>
-                                        <a type="object" name="open_action_with_context" context="{'action_name': 'action_validate_account_move', 'search_default_journal': True}">Post All Entries</a>
+                                        <a type="object" name="action_post_all_entries">Post All Entries</a>
                                     </div>
                                 </div>
                             </div>

--- a/addons/account/wizard/account_validate_account_move.py
+++ b/addons/account/wizard/account_validate_account_move.py
@@ -9,6 +9,8 @@ class ValidateAccountMove(models.TransientModel):
     move_ids = fields.Many2many('account.move')
     force_post = fields.Boolean(string="Force", help="Entries in the future are set to be auto-posted by default. Check this checkbox to post them now.")
     display_force_post = fields.Boolean(compute='_compute_display_force_post')
+    force_hash = fields.Boolean(string="Force Hash")
+    display_force_hash = fields.Boolean(compute='_compute_display_force_hash')
     is_entries = fields.Boolean(compute='_compute_is_entries')
     abnormal_date_partner_ids = fields.One2many('res.partner', compute='_compute_abnormal_date_partner_ids')
     ignore_abnormal_date = fields.Boolean()
@@ -22,9 +24,14 @@ class ValidateAccountMove(models.TransientModel):
             wizard.display_force_post = wizard.move_ids.filtered(lambda m: (m.date or m.invoice_date or today) > today)
 
     @api.depends('move_ids')
+    def _compute_display_force_hash(self):
+        for wizard in self:
+            wizard.display_force_hash = wizard.move_ids.filtered('restrict_mode_hash_table')
+
+    @api.depends('move_ids')
     def _compute_is_entries(self):
         for wizard in self:
-            wizard.is_entries = all(move_type == 'entry' for move_type in wizard.move_ids.mapped('move_type'))
+            wizard.is_entries = any(move_type == 'entry' for move_type in wizard.move_ids.mapped('move_type'))
 
     @api.depends('move_ids')
     def _compute_abnormal_date_partner_ids(self):
@@ -61,8 +68,12 @@ class ValidateAccountMove(models.TransientModel):
             self.abnormal_date_partner_ids.ignore_abnormal_invoice_date = True
         if self.force_post:
             self.move_ids.auto_post = 'no'
-        self.move_ids._post(not self.force_post)
+        if self.force_hash:
+            moves_to_post = self.move_ids
+        else:
+            moves_to_post = self.move_ids.filtered(lambda m: not m.restrict_mode_hash_table)
+        moves_to_post._post(not self.force_post)
 
-        if autopost_bills_wizard := self.move_ids._show_autopost_bills_wizard():
+        if autopost_bills_wizard := moves_to_post._show_autopost_bills_wizard():
             return autopost_bills_wizard
         return {'type': 'ir.actions.act_window_close'}

--- a/addons/account/wizard/account_validate_move_view.xml
+++ b/addons/account/wizard/account_validate_move_view.xml
@@ -9,11 +9,12 @@
             <field name="arch" type="xml">
                 <form string="Confirm Entries">
                     <field name="move_ids" invisible="1"/>
-                    <h2 class="mb-4">
-                        Validating
+                    <h4 class="mb-4">
+                        The selected
                         <t invisible="not is_entries"> entries </t>
                         <t invisible="is_entries"> invoices </t>
-                        is a key action. Have you reviewed everything?</h2>
+                        will be posted. Some of them may be future-dated or require hashing,</h4>
+                    <h4>and will not be posted automatically.</h4>
                     <group invisible="not display_force_post">
                         <field name="display_force_post" invisible="1"/>
                         <div colspan="2">
@@ -22,6 +23,14 @@
                             <t invisible="is_entries"> invoices </t>
                             will auto-confirm on their respective dates.
                             <field name="force_post" class="oe_inline"/><label for="force_post" string="Confirm them now"/>
+                        </div>
+                    </group>
+                    <group invisible="not display_force_hash">
+                        <div colspan="2"> Some
+                            <t invisible="not is_entries"> entries </t>
+                            <t invisible="is_entries"> invoices </t>
+                            will be secured with hash.
+                            <field name="force_hash" class="oe_inline"/><label for="force_hash" string="Yes, confirm and secure them now."/>
                         </div>
                     </group>
                     <group invisible="not abnormal_date_partner_ids">
@@ -58,17 +67,14 @@
             </field>
         </record>
 
-        <record id="action_validate_account_move" model="ir.actions.act_window">
+        <record id="action_validate_account_moves" model="ir.actions.server">
             <field name="name">Confirm Entries</field>
-            <field name="res_model">validate.account.move</field>
-            <field name="view_mode">form</field>
-            <field name="view_id" ref="validate_account_move_view"/>
-            <field name="context">{}</field>
-            <field name="target">new</field>
-            <field name="help">This wizard will validate all journal entries selected. Once journal entries are validated, you can not update them anymore.</field>
-            <field name="group_ids" eval="[(4, ref('account.group_account_invoice'))]"/>
+            <field name="model_id" ref="account.model_account_move" />
+            <field name="group_ids" eval="[(4, ref('account.group_account_invoice'))]" />
             <field name="binding_model_id" ref="account.model_account_move" />
             <field name="binding_view_types">list,kanban</field>
+            <field name="state">code</field>
+            <field name="code">action = records.action_validate_moves_with_confirmation()</field>
         </record>
 
     </data>


### PR DESCRIPTION
Issue:
- The confirmation popup was always shown when posting journal entries.

Fix:
- Changed the flow so the popup opens only when entries need to be hashed.
- If hashing is not needed, the entries are posted directly.

Impact:
- Saves time by avoiding unnecessary popups.
- Users see the popup only when their confirmation is truly required.

task-5006124