### PR TITLE
[FIX] l10n_es_edi_verifactu: prevent error when nif is missing

### DIFF
--- a/addons/l10n_es_edi_verifactu/models/verifactu_document.py
+++ b/addons/l10n_es_edi_verifactu/models/verifactu_document.py
@@ -314,7 +314,7 @@ class L10nEsEdiVerifactuDocument(models.Model):
     def _check_record_values(self, vals):
         errors = []
 
-        company_NIF = vals['company'].partner_id._l10n_es_edi_verifactu_get_values()['NIF']
+        company_NIF = vals['company'].partner_id._l10n_es_edi_verifactu_get_values().get('NIF')
         if not company_NIF or len(company_NIF) != 9:  # NIFType
             errors.append(_("The NIF '%(company_NIF)s' of the company is not exactly 9 characters long.",
                             company_NIF=company_NIF))


### PR DESCRIPTION
The system will crash when user tries to send the invoice.

**Steps to produce:-**
- Install the **Accounting** module and switch to the **ES company** (with demo data).
- Remove the **VAT** from the ES company and save the changes.
- Go to **Accounting** and create any invoice.
- Click on **Send**.
- In the send wizard, ensure that **Veri\*Factu** is checked at the top, then click the **Send** button.

**Error:-**
`KeyError: 'NIF'`

**Cause:-**
- When the company VAT is not set,` _l10n_es_edi_verifactu_get_values()` does not provide an 'NIF' key.
- Accessing 'NIF' directly in such cases raises a `KeyError` when sending an invoice.

**Solution:-**
- In this PR, `.get('NIF')` instead of direct key access to safely handle missing values.

**sentry-6829500308**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
