### PR TITLE
[IMP] website: improve Technical Pages listing and URL

### DIFF
--- a/addons/website/tests/test_website_technical_page.py
+++ b/addons/website/tests/test_website_technical_page.py
@@ -5,12 +5,11 @@ from odoo.tests import TransactionCase, tagged
 class TestWebsiteTechnicalPage(TransactionCase):
 
     def _validate_routes(self, expected_routes):
-        TechnicalPage = self.env["website.technical.page"]
-        TechnicalPage.get_static_routes()
-        routes = TechnicalPage.search([('website_url', 'in', expected_routes)]).mapped("website_url")
+        TechnicalPage = self.env['website.technical.page']
+        routes = TechnicalPage.search([]).mapped('website_url')
 
         for route in expected_routes:
-            self.assertIn(route, routes, f"Route '{route}' is missing from technical page records.")
+            self.assertIn(route, routes, f"Route {route} is missing from technical page records.")
 
     def test_load_website_technical_pages(self):
         self._validate_routes([

--- a/addons/website/views/website_technical_views.xml
+++ b/addons/website/views/website_technical_views.xml
@@ -13,8 +13,9 @@
 </record>
 
 <record id="action_website_technical_pages" model="ir.actions.act_window">
-    <field name="name">Technical Pages</field>
+    <field name="name">System Pages</field>
     <field name="res_model">website.technical.page</field>
+    <field name="path">system-pages</field>
     <field name="view_mode">list</field>
 </record>
 

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -416,7 +416,7 @@
 
         <menuitem id="menu_website_technical_pages"
             parent="menu_content"
-            name="Technical Pages"
+            name="System Pages"
             sequence="90"
             action="action_website_technical_pages"/>
 

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1493,8 +1493,13 @@ class WebsiteSale(payment_portal.PaymentPortal):
         order_sudo._update_address(partner_id, partner_fnames)
 
     # === CHECKOUT FLOW - EXTRA STEP METHODS === #
+    def system_page_extra_info(env):
+        website = env['website'].get_current_website()
+        if website.is_view_active('website_sale.extra_info'):
+            return _lt("Shop Checkout - Extra Information")
+        return False
 
-    @route(['/shop/extra_info'], type='http', auth="public", website=True, sitemap=False, list_as_website_content=_lt("Shop Checkout - Extra Information"))
+    @route(['/shop/extra_info'], type='http', auth="public", website=True, sitemap=False, list_as_website_content=system_page_extra_info)
     def extra_info(self, **post):
         # Check that this option is activated
         extra_step = request.website.viewref('website_sale.extra_info')

--- a/addons/website_sale/tests/test_technical_page.py
+++ b/addons/website_sale/tests/test_technical_page.py
@@ -6,11 +6,26 @@ from odoo.addons.website.tests.test_website_technical_page import TestWebsiteTec
 @tagged("post_install", "-at_install")
 class TestWebsiteSaleTechnicalPage(TestWebsiteTechnicalPage):
 
-    def test_load_website_sale_technical_pages(self):
-        self._validate_routes([
-            "/shop",
-            "/shop/confirmation",
-            "/shop/extra_info",
-            "/shop/payment",
-            "/shop/checkout"
-        ])
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.expected_routes = [
+            '/shop',
+            '/shop/confirmation',
+            '/shop/payment',
+            '/shop/checkout',
+        ]
+
+    def _set_extra_info_active(self, active):
+        """Helper to activate or deactivate the 'extra_info' view."""
+        website = self.env['website'].get_current_website()
+        view = website.viewref('website_sale.extra_info')
+        view.active = active
+
+    def test_routes_with_extra_info_toggle(self):
+        for active in [True, False]:
+            with self.subTest(active=active):
+                self._set_extra_info_active(active)
+                if active:
+                    self.expected_routes.append('/shop/extra_info')
+                self._validate_routes(self.expected_routes)


### PR DESCRIPTION
*: website_sale

Before this commit:
The pages listed in the Technical Pages menu were not ordered
alphabetically. The Technical Page URL ended with an action ID.

After this commit:
We improved the "Technical Pages" menu renamed to "System Pages".
pages in the System pages menu are now displayed in alphabetically.
System Page URL now end with /system-pages instead of an acton ID,
and The /shop/extra_info page is add in list conditionally only if the
corresponding option is enabled.

task-5028879