### PR TITLE
[FIX] website: fix countdown boxes background color removal issue

### DIFF
--- a/addons/website/static/src/snippets/s_countdown/000.js
+++ b/addons/website/static/src/snippets/s_countdown/000.js
@@ -38,6 +38,7 @@ const CountdownWidget = publicWidget.Widget.extend({
             this.el.dataset.display = this.display;
         }
 
+        this.defaultColor = "rgba(0, 0, 0, 0)";
         this.layout = this.el.dataset.layout;
         this.layoutBackground = this.el.dataset.layoutBackground;
         this.progressBarStyle = this.el.dataset.progressBarStyle;

--- a/addons/website/static/src/snippets/s_countdown/options.js
+++ b/addons/website/static/src/snippets/s_countdown/options.js
@@ -116,7 +116,7 @@ options.registry.countdown = options.Class.extend({
 
             case 'selectDataAttribute': {
                 if (params.colorNames) {
-                    params.attributeDefaultValue = 'rgba(0, 0, 0, 255)';
+                    params.attributeDefaultValue = "rgba(0, 0, 0, 0)";
                 }
                 break;
             }


### PR DESCRIPTION
Steps to Reproduce:
1. Add a Countdown snippet.
2. Change the layout to Boxes.
3. Apply a background color to the layout.
4. Hover over the delete button in the color picker.
5. A traceback error occurs.

Issue:
A traceback error occurs because the does not have a default value
assigned. This is necessary for the snippet to preview correctly when
no additional color is applied.

Fix:
Assign a default value to ensure that the hover behavior works
properly, even when no color is set.

The issue was produced here: https://github.com/odoo/odoo/commit/03c552690b15#diff-a0262b81bb090b8c62afbd342b2a30f054cf353a35f9fc0ceeb0f86b7b9cd645

task-4752497

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
