### PR TITLE
[FIX] mail: Fix json searlization issue

### DIFF
--- a/addons/mail/models/res_users_settings.py
+++ b/addons/mail/models/res_users_settings.py
@@ -37,6 +37,8 @@ class ResUsersSettings(models.Model):
             volume_settings = self.volume_settings_ids._discuss_users_settings_volume_format()
             res.pop('volume_settings_ids', None)
             res['volumes'] = [('ADD', volume_settings)]
+        if "mute_until_dt" in fields_to_format:
+            res["mute_until_dt"] = fields.Datetime.to_string(self.mute_until_dt)
         return res
 
     def set_custom_notifications(self, custom_notifications):


### PR DESCRIPTION
[this](
https://github.com/odoo/odoo/commit/a9532d64c3f9c541f602979225a319ec89af5194#diff-f0beb94587c1e74a64245761f99c97af110a898c0da1b3b9f195b971ee284588L42-L43) commit remove the ``mute_until_dt`` formatting from from_settings which cause json serialzation issue and not letting login in database while dumping ``session_info`` as value can still exist database are coming from older version. For handling that adding back condtion to solve the issue and handle the ``mute_until_dt`` field formatting

**Note**: This issue won't reproduce on ``18.4`` instance but if database is coming from older version ``mute_until_dt`` will have  the value that will break
```py 
Traceback (most recent call last):
  File "<193>", line 199, in template_web_webclient_bootstrap_193
  File "<193>", line 181, in template_web_webclient_bootstrap_193_content
  File "<193>", line 149, in template_web_webclient_bootstrap_193_t_call_0
  File "<193>", line 24, in template_web_webclient_bootstrap_193_t_set_2
  File "/home/odoo/py_env/src/odoo/18.0/odoo/tools/json.py", line 57, in dumps
    return _ScriptSafe(json_.dumps(*args, **kwargs))
  File "/usr/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/py_env/src/odoo/18.0/odoo/http.py", line 2666, in __call__
    response = request._serve_db()
  File "/home/odoo/py_env/src/odoo/18.0/odoo/http.py", line 2169, in _serve_db
    return self._transactioning(
  File "/home/odoo/py_env/src/odoo/18.0/odoo/http.py", line 2233, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/home/odoo/py_env/src/odoo/18.0/odoo/service/model.py", line 176, in retrying
    result = func()
  File "/home/odoo/py_env/src/odoo/18.0/odoo/http.py", line 2200, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/py_env/src/odoo/18.0/odoo/http.py", line 2369, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/py_env/src/odoo/18.0/odoo/addons/base/models/ir_http.py", line 356, in _dispatch
    result.flatten()
  File "/home/odoo/py_env/src/odoo/18.0/odoo/tools/facade.py", line 83, in wrap_func
    func(self._wrapped__, *args, **kwargs)
  File "/home/odoo/py_env/src/odoo/18.0/odoo/http.py", line 1472, in flatten
    self.response.append(self.render())
  File "/home/odoo/py_env/src/odoo/18.0/odoo/http.py", line 1464, in render
    return request.env["ir.ui.view"]._render_template(self.template, self.qcontext)
  File "/home/odoo/py_env/src/odoo/18.0/odoo/addons/base/models/ir_ui_view.py", line 2463, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "/home/odoo/py_env/src/odoo/18.0/odoo/addons/base/models/ir_qweb.py", line 623, in _render
    result = ''.join(rendering)
  File "<193>", line 207, in template_web_webclient_bootstrap_193
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
TypeError: Object of type datetime is not JSON serializable
Template: web.webclient_bootstrap
Path: /t/t/t[1]/script/t
Node: <t t-out="json.dumps(session_info)"/>
```
opw - 5016301
upg - 3095362

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
