### PR TITLE
[FIX] mail: Parent parsing prefers non-internal messages

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1638,14 +1638,12 @@ class MailThread(models.AbstractModel):
         if msg_dict['in_reply_to']:
             parent_ids = self.env['mail.message'].search(
                 [('message_id', '=', msg_dict['in_reply_to'])],
-                order='create_date DESC, id DESC',
-                limit=1)
+                order='create_date DESC, id DESC')
         if msg_dict['references'] and not parent_ids:
             references_msg_id_list = tools.unfold_references(msg_dict['references'])
             parent_ids = self.env['mail.message'].search(
                 [('message_id', 'in', [x.strip() for x in references_msg_id_list])],
-                order='create_date DESC, id DESC',
-                limit=1)
+                order='create_date DESC, id DESC')
         if parent_ids:
             msg_dict.update(self._message_parse_extract_from_parent(parent_ids))
 
@@ -1653,9 +1651,11 @@ class MailThread(models.AbstractModel):
         msg_dict.update(self._message_parse_extract_bounce(message, msg_dict))
         return msg_dict
 
-    def _message_parse_extract_from_parent(self, parent_message):
-        """Derive message values from the parent."""
-        if parent_message:
+    def _message_parse_extract_from_parent(self, parent_messages):
+        """Derive message values from the parents."""
+        if parent_messages:
+            # If there's multiple parents, assume the non-internal one is the real parent
+            parent_message = parent_messaged.sorted(lambda m: bool(m.subtype_id and m.subtype_id.internal))[0]
             parent_is_internal = bool(parent_message.subtype_id and parent_message.subtype_id.internal)
             parent_is_auto_comment = parent_message.message_type == 'auto_comment'
             return {

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1655,7 +1655,7 @@ class MailThread(models.AbstractModel):
         """Derive message values from the parents."""
         if parent_messages:
             # If there's multiple parents, assume the non-internal one is the real parent
-            parent_message = parent_messaged.sorted(lambda m: bool(m.subtype_id and m.subtype_id.internal))[0]
+            parent_message = parent_messages.sorted(lambda m: bool(m.subtype_id and m.subtype_id.internal))[0]
             parent_is_internal = bool(parent_message.subtype_id and parent_message.subtype_id.internal)
             parent_is_auto_comment = parent_message.message_type == 'auto_comment'
             return {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Due to the changes in the mail header introduced by https://github.com/odoo/odoo/commit/bf40ac65fd2978491756cdecee48b4b9e00da268 the outgoing mail can contain internal messages in its references. This means that when the answer mail is matched and the In-Reply-To field is not usable for matching, the customer answer might be flagged as "internal" by accident.

Current behavior before PR:
When attempting to determine the parent message for an answering mail via the "References" header entry, it always takes the most recent match, even if that is an internal message. This is especially a problem for account.move entries, where the [_message_post_after_hook](https://github.com/odoo/odoo/blob/16.0/addons/account/models/account_move.py#L4352-L4383) function is almost guaranteed to have generated a more recent internal message than the outgoing message the mail is an answer to (due to the execution order with the mail being sent post-commit, that internal message is put into the "References" header of the mail sent out from the initial message_post).

Desired behavior after PR is merged:
When matching the parent messages for an incoming mail, it passes all possible parents from either the "In-Reply-To" or the "References" mail header to _message_parse_extract_from_parent, which then does a second sorting step to prefer non-internal messages as the parent. Thus it fails more safely, by assuming a mail is not an internal message if it's in reference to at least one non-internal message.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
