### PR TITLE
[FIX] account: fix broken account tour

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -18,7 +18,7 @@ export const accountTourSteps = {
     newInvoice() {
         return [
             {
-                trigger: ".out_invoice_tree button.o_list_button_add",
+                trigger: "button.o_list_button_add",
                 content: _t("Now, we'll create your first invoice"),
                 run: "click",
             },

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -593,9 +593,6 @@
             <field name="inherit_id" ref="account.view_invoice_tree"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <list position="attributes">
-                    <attribute name="class">out_invoice_tree</attribute>
-                </list>
                 <button name="action_force_register_payment" position="before">
                     <button name="action_send_and_print" type="object" string="Send"/>
                 </button>


### PR DESCRIPTION
The nightly build were failing due to the wrong menu being opened, the solution is to use a more generic filter for the Add button, this is not a perfect solution as it will also select add button on other views that we dont want.

task-4822215
