### PR TITLE
[IMP] website_sale(_wishlist): review products' presets default image ratios

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -119,7 +119,7 @@ class Website(models.Model):
         string="Shop Design Class",
         default=(
             'o_wsale_products_opt_layout_catalog o_wsale_products_opt_design_thumbs '
-            'o_wsale_products_opt_name_color_regular o_wsale_products_opt_thumb_6_5 '
+            'o_wsale_products_opt_name_color_regular o_wsale_products_opt_rounded_2 '
             'o_wsale_products_opt_thumb_cover o_wsale_products_opt_img_secondary_show '
             'o_wsale_products_opt_img_hover_zoom_out_light o_wsale_products_opt_has_cta '
             'o_wsale_products_opt_actions_onhover o_wsale_products_opt_has_wishlist '

--- a/addons/website_sale/static/src/website_builder/products_design_panel.xml
+++ b/addons/website_sale/static/src/website_builder/products_design_panel.xml
@@ -10,7 +10,7 @@
         <t t-set="showcaseLabel">Showcase</t>
 
         <t t-set="suggestedClassesCatalogDefault">
-            o_wsale_products_opt_name_color_regular o_wsale_products_opt_thumb_6_5
+            o_wsale_products_opt_name_color_regular
             o_wsale_products_opt_thumb_cover o_wsale_products_opt_img_secondary_show
             o_wsale_products_opt_img_hover_zoom_out_light o_wsale_products_opt_has_cta
             o_wsale_products_opt_has_wishlist o_wsale_products_opt_has_comparison
@@ -49,7 +49,7 @@
                 label: chipsLabel,
                 className: 'o_wsale_products_opt_layout_catalog o_wsale_products_opt_design_chips',
                 img: '/website_sale/static/src/img/products_entries_design/style_catalog_chips.svg',
-                suggestedClasses: suggestedClassesCatalogDefault + suggestedClassesCatalogDefaultPromote + ' o_wsale_products_opt_rounded_4',
+                suggestedClasses: suggestedClassesCatalogDefault + suggestedClassesCatalogDefaultPromote + ' o_wsale_products_opt_rounded_4 o_wsale_products_opt_thumb_6_5',
                 gap: 16,
             },
             {
@@ -67,7 +67,7 @@
                 label: gridLabel,
                 className: 'o_wsale_products_opt_layout_catalog o_wsale_products_opt_design_grid',
                 img: '/website_sale/static/src/img/products_entries_design/style_catalog_grid.svg',
-                suggestedClasses: suggestedClassesCatalogDefault + suggestedClassesCatalogSubtle,
+                suggestedClasses: suggestedClassesCatalogDefault + suggestedClassesCatalogSubtle + ' o_wsale_products_opt_thumb_4_3',
                 gap: 0,
             },
             {
@@ -76,7 +76,7 @@
                 label: thumbnailsLabel,
                 className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_thumbs',
                 img: '/website_sale/static/src/img/products_entries_design/style_list_thumbs.svg',
-                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_rounded_2 o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote',
+                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_rounded_2 o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote o_wsale_products_opt_thumb_4_5',
                 gap: 16,
             },
             {
@@ -94,7 +94,7 @@
                 label: gridLabel,
                 className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_grid',
                 img: '/website_sale/static/src/img/products_entries_design/style_list_grid.svg',
-                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_name_size_body o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote',
+                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc1 o_wsale_products_opt_name_size_body o_wsale_products_opt_img_secondary_show o_wsale_products_opt_actions_promote o_wsale_products_opt_thumb_4_3',
                 gap: 0,
             },
             {
@@ -103,7 +103,7 @@
                 type: 'list',
                 className: 'o_wsale_products_opt_layout_list o_wsale_products_opt_design_showcase',
                 img: '/website_sale/static/src/img/products_entries_design/style_list_showcase.svg',
-                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_thumb_6_5 o_wsale_products_opt_cc o_wsale_products_opt_cc5 o_wsale_products_opt_name_color_regular o_wsale_products_opt_actions_theme',
+                suggestedClasses: suggestedClassesListDefault + ' o_wsale_products_opt_cc o_wsale_products_opt_cc5 o_wsale_products_opt_name_color_regular o_wsale_products_opt_actions_theme o_wsale_products_opt_thumb_4_3',
                 gap: 0,
             },
         ]"/>

--- a/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
@@ -12,7 +12,7 @@
             <t
                 t-if="'o_wsale_products_opt_layout_catalog' not in default_design_classes"
                 t-set="default_design_classes"
-                t-value="'o_wsale_products_opt_name_color_regular o_wsale_products_opt_thumb_6_5
+                t-value="'o_wsale_products_opt_name_color_regular 
                     o_wsale_products_opt_thumb_cover o_wsale_products_opt_img_secondary_show
                     o_wsale_products_opt_img_hover_zoom_out_light o_wsale_products_opt_cc1
                     o_wsale_products_opt_rounded_2 o_wsale_products_opt_layout_catalog

--- a/addons/website_sale_wishlist/models/website.py
+++ b/addons/website_sale_wishlist/models/website.py
@@ -11,7 +11,7 @@ class Website(models.Model):
         string="Wishlist Page Design Class",
         default=(
             'o_wsale_products_opt_layout_catalog o_wsale_products_opt_design_thumbs '
-            'o_wsale_products_opt_name_color_regular o_wsale_products_opt_thumb_6_5 '
+            'o_wsale_products_opt_name_color_regular '
             'o_wsale_products_opt_thumb_cover o_wsale_products_opt_img_secondary_show '
             'o_wsale_products_opt_img_hover_zoom_out_light o_wsale_products_opt_has_cta '
             'o_wsale_products_opt_actions_inline o_wsale_products_opt_has_description '


### PR DESCRIPTION
This PR replaces the default 6:5 aspect ratio (`.o_wsale_products_opt_thumb_6_5`) with a 1:1 ratio for product images on the shop, wishlist and compare pages, and in the dynamic product snippet.

In addition, new default aspect ratios have been added to the various available designs, based on the values below.

Desired defaults for catalog presets:
- o_wsale_products_opt_design_thumbs: 1/1
- o_wsale_products_opt_design_chips: 6/5
- o_wsale_products_opt_design_cards: 1/1
- o_wsale_products_opt_design_grid: 4/3

Desired defaults for list presets:
- o_wsale_products_opt_design_thumbs: 4/5
- o_wsale_products_opt_design_cards: 1/1
- o_wsale_products_opt_design_grid: 4/3
- o_wsale_products_opt_design_showcase: 4/3

task-5013513

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
