### PR TITLE
[FIX] point_of_sale: offline automatic receipt printing

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -326,7 +326,7 @@ export class PaymentScreen extends Component {
             }
         } catch (error) {
             if (error instanceof ConnectionLostError) {
-                this.pos.showScreen(this.nextScreen);
+                this.afterOrderValidation();
                 Promise.reject(error);
             } else if (error instanceof RPCError) {
                 this.currentOrder.state = "draft";


### PR DESCRIPTION
Steps to reproduce:
1. Configure a POS to use a receipt printer with automatic receipt printing.
2. Confirm that the receipt is printed automatically after a order is made as expected.
3. Disconnect from the internet so that POS continues in Offline mode (but ensure you still have access to the receipt printer on the local network).
4. Make an order in offline mode.

EXPECTED: The receipt is printed automatically as before
ACTUAL: The receipt is not printed.

The fix is to still run the `afterOrderValidation` method in offline mode, as previously it was being bypassed and the receipt screen being shown directly.

task-4946305

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
