### PR TITLE
[REM] hr: remove versions' computed dates

### DIFF
--- a/addons/hr/models/resource_calendar_leaves.py
+++ b/addons/hr/models/resource_calendar_leaves.py
@@ -22,8 +22,8 @@ class ResourceCalendarLeaves(models.Model):
         )
         for contract, leaves in leaves_by_contract.items():
             tz = ZoneInfo(contract.resource_calendar_id.tz or 'UTC')
-            start_dt = date2datetime(contract.date_start, tz)
-            end_dt = date2datetime(contract.date_end, tz) if contract.date_end else datetime.max
+            start_dt = date2datetime(contract.contract_date_start or contract.date_version, tz)
+            end_dt = date2datetime(contract._get_version_validity_end_date(), tz)
             # only modify leaves that fall under the active contract
             leaves.filtered(
                 lambda leave: start_dt <= leave.date_from < end_dt

--- a/addons/hr/tests/test_calendar_sync.py
+++ b/addons/hr/tests/test_calendar_sync.py
@@ -19,7 +19,7 @@ class TestContractCalendars(TestHrCommon):
 
         cls.contract_cdd_values = {
             'date_version': Date.to_date('2016-01-01'),
-            'date_start': Date.to_date('2016-01-01'),
+            'contract_date_start': Date.to_date('2016-01-01'),
             'name': 'First CDD Contract for Richard',
             'resource_calendar_id': cls.calendar_35h.id,
             'wage': 5000.0,
@@ -27,7 +27,7 @@ class TestContractCalendars(TestHrCommon):
 
         cls.contract_fully_flexible_values = {
             'date_version': Date.to_date('2017-01-01'),
-            'date_start': Date.to_date('2017-01-01'),
+            'contract_date_start': Date.to_date('2017-01-01'),
             'name': 'Fully Flexible Contract for Richard',
             'resource_calendar_id': False,
             'wage': 5000.0,

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -652,8 +652,6 @@ class TestHrVersion(TestHrCommon):
             "create_date",
             "create_uid",
             "currency_id",
-            "date_end",
-            "date_start",
             "departure_description",
             "display_name",
             "id",
@@ -782,3 +780,46 @@ class TestHrVersion(TestHrCommon):
         self.assertEqual(HrEmployee_with_manager_user.search([('hr_responsible_id', '=', self.res_users_hr_manager.id), ('id', 'in', employees.ids)]), employee1)
         self.assertEqual(HrEmployee_with_manager_user.search([('version_id.hr_responsible_id', '=', self.res_users_hr_manager.id), ('id', 'in', employees.ids)]), employee1)
         self.assertEqual(HrEmployee_with_manager_user.search([('member_of_department', '=', True), ('id', 'in', employees.ids)]), employee1)
+
+    def test_hr_version_next_version(self):
+        """
+        Test the added next_version field on hr.version useful for computations on versions.
+        """
+        employee = self.env['hr.employee'].create([
+            {
+                'name': 'Employee',
+                'date_version': '2025-01-01',
+            }
+        ])
+        version1 = employee.version_id
+
+        # Only one version
+        self.assertEqual(version1.next_version, self.env["hr.version"], "no next version exists")
+
+        # 2 versions :
+        # 1 -> 2
+        version2 = employee.create_version({'date_version': '2025-03-01'})
+        self.assertEqual(version1.next_version, version2,
+                         "the next version should be the version 2")
+        self.assertEqual(version2.next_version, self.env["hr.version"],
+                         "the last version should not have a next version")
+
+        # 1 new version in the middle of the 2 previous ones
+        # 1 -> 3 -> 2
+        version3 = employee.create_version({'date_version': '2025-02-01'})
+        self.assertEqual(version1.next_version, version3,
+                         "the next version should be the version 3")
+        self.assertEqual(version3.next_version, version2,
+                         "the next version should be the version 2")
+        self.assertEqual(version2.next_version, self.env["hr.version"],
+                         "the last version should not have a next version")
+
+        # the last version edited to be between the 2 others:
+        # 1 -> 2 -> 3
+        version2.update({'date_version': '2025-01-15'})
+        self.assertEqual(version1.next_version, version2,
+                         "the next version should be the version 2")
+        self.assertEqual(version2.next_version, version3,
+                         "the next version should be the version 3")
+        self.assertEqual(version3.next_version, self.env["hr.version"],
+                         "the last version should not have a next_version")

--- a/addons/hr/wizard/mail_activity_schedule.py
+++ b/addons/hr/wizard/mail_activity_schedule.py
@@ -43,7 +43,7 @@ class MailActivitySchedule(models.TransientModel):
         todo = self.filtered(lambda s: s.res_model == 'hr.employee')
         for scheduler in todo:
             selected_employees = scheduler._get_applied_on_records()
-            start_dates = selected_employees.filtered('date_start').mapped('date_start')
+            start_dates = selected_employees.filtered('contract_date_start').mapped('contract_date_start')
             if start_dates:
                 today = fields.Date.today()
                 planned_due_date = min(start_dates)

--- a/addons/hr_calendar/tests/test_working_hours.py
+++ b/addons/hr_calendar/tests/test_working_hours.py
@@ -351,7 +351,6 @@ class TestWorkingHoursWithVersion(TestHrContractCalendarCommon):
         self.env.user.company_id = self.company_A
         self.env.user.company_ids = [self.company_A.id]
 
-        self.contractB.date_end = datetime(2023, 12, 28)
         self.contractB.contract_date_end = datetime(2023, 12, 28)
         work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
             [self.partnerA.id, self.partnerB.id],

--- a/addons/hr_holidays/tests/test_multi_contract.py
+++ b/addons/hr_holidays/tests/test_multi_contract.py
@@ -57,7 +57,7 @@ class TestHolidaysMultiContract(TestHolidayContract):
         self.create_leave(start, end, name="Doctor Appointment", employee_id=self.jules_emp.id)
 
         # begins during contract, ends after contract => should not raise
-        self.contract_cdi.date_end = datetime.strptime('2015-11-30', '%Y-%m-%d').date()
+        self.contract_cdi.contract_date_end = datetime.strptime('2015-11-30', '%Y-%m-%d').date()
         start = datetime.strptime('2015-11-25 07:00:00', '%Y-%m-%d %H:%M:%S')
         end = datetime.strptime('2015-12-05 18:00:00', '%Y-%m-%d %H:%M:%S')
         self.create_leave(start, end, name="Doctor Appointment", employee_id=self.jules_emp.id)

--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -168,7 +168,7 @@ class HrEmployee(models.Model):
             current_version = employee_versions[i]
             next_version = employee_versions[i + 1]
             current_date_start = max(current_version.date_version, current_version.contract_date_start or date.min)
-            current_date_end = min(next_version.date_version + relativedelta(days=-1), current_version.contract_date_end or date.max)
+            current_date_end = current_version._get_version_validity_end_date()
             if not current_version.job_title:
                 if interval_date_start:
                     previous_version = employee_versions[i - 1]


### PR DESCRIPTION
There are currently 5 dates used in a version :
date_version: date at which the version starts to be effective contract_date_start: start date of the contract
date_start (computed): maximum between the start of contract and the start of version
contract_date_end: end date of the contract
date_end (computed): minimum between the end of contract and the start of next version - 1 day

This can create a lot of confusion between which fields should be really used, thus the decision was taken to remove the computed dates and do the computation explicitly when needed.


