### PR TITLE
[FIX] core: Browser.stop being called with a closed ws

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1220,6 +1220,13 @@ class ChromeBrowser:
                 self._logger.debug('\n<- %s', msg)
             except websocket.WebSocketTimeoutException:
                 continue
+            except websocket.WebSocketConnectionClosedException as e:
+                if not self._result.done():
+                    self.ws = None
+                    self._result.set_exception(e)
+                    for f in self._responses.values():
+                        f.cancel()
+                return
             except Exception as e:
                 if isinstance(e, ConnectionResetError) and self._result.done():
                     return


### PR DESCRIPTION
As far as I can tell this can occur if the ws connection gets closed while we're in a `recv`: in that case `recv` will mark the connection as closed (`connected=False` and `sock=None`) and raise `WebSocketConnectionClosedException`, then any attempt to `send` will fail with `WebSocketConnectionClosedException`.

Here this likely is an issue because in `_receive` `WebSocketConnectionClosedException` goes through the generic exception handler, which sees that:

- it's not a `ConnectionResetError`
- the result is not set
- and the ws is not connected

So `_receive` just cancels the result and `return`s, and when whatever's waiting on a future finally times out it tries to cleanly shut down and hits a connection that's already closed.

Handle a connection closed in that context more properly:

- unset `ws` so we don't try to clean it up, as we know it's closed
- set the result as being in error
- cancel every future in order to immediately go to the tour failure step rather than wait for timeouts

Note that this will not really *fix* any error per se, because every time this happens it means the browser abruptly closed the WS connection (possibly straight up died), so this should mostly properly attribute the error so we can investigate it.

https://runbot.odoo.com/odoo/error/229793
