### PR TITLE
[FIX] hr_timesheet: allow approvers to access timesheets on followed tasks

### DIFF
--- a/addons/hr_timesheet/__manifest__.py
+++ b/addons/hr_timesheet/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Task Logs',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Services/Timesheets',
     'sequence': 23,
     'summary': 'Track employee time on tasks',

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -68,9 +68,10 @@
             <field name="model_id" ref="analytic.model_account_analytic_line" />
             <field name="domain_force">[
                 ('project_id', '!=', False),
-                '|',
+                '|', '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('task_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]" />
         </record>
@@ -109,9 +110,10 @@
             <field name="name">Timesheets Analysis Report approver</field>
             <field name="model_id" ref="model_timesheets_analysis_report"/>
             <field name="domain_force">[
-                '|',
+                '|', '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('task_id.message_partner_ids', 'in', [user.partner_id.id])
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_approver'))]"/>
         </record>

--- a/addons/hr_timesheet/upgrades/1.1/pre-migrate.py
+++ b/addons/hr_timesheet/upgrades/1.1/pre-migrate.py
@@ -1,0 +1,34 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+def migrate(cr, version):
+    cr.execute("""
+        UPDATE ir_rule r
+           SET domain_force = '[
+                ("project_id", "!=", False),
+                "|", "|",
+                    ("project_id.privacy_visibility", "!=", "followers"),
+                    ("project_id.message_partner_ids", "in", [user.partner_id.id]),
+                    ("task_id.message_partner_ids", "in", [user.partner_id.id])
+            ]'
+          FROM ir_model_data d
+         WHERE d.res_id = r.id
+           AND d.model = 'ir.rule'
+           AND d.module = 'hr_timesheet'
+           AND d.name = 'timesheet_line_rule_approver'
+    """)
+
+    cr.execute("""
+        UPDATE ir_rule r
+           SET domain_force = '[
+                "|", "|",
+                    ("project_id.privacy_visibility", "!=", "followers"),
+                    ("project_id.message_partner_ids", "in", [user.partner_id.id]),
+                    ("task_id.message_partner_ids", "in", [user.partner_id.id])
+            ]'
+          FROM ir_model_data d
+         WHERE d.res_id = r.id
+           AND d.model = 'ir.rule'
+           AND d.module = 'hr_timesheet'
+           AND d.name = 'timesheet_analysis_report_approver'
+    """)


### PR DESCRIPTION

**Issue:**

Users with "All Timesheets" rights can't see other users’ timesheets on tasks they followed within private projects, even though they had access to the task itself.

**Cause:**

The security rules for approvers (`timesheet_line_rule_approver` and `timesheet_analysis_report_approver`) only check project-level follower access and ignore task-level access.
https://github.com/odoo/odoo/blob/48cfd650053c794a838c130605c4280351b4f5d9/addons/hr_timesheet/security/hr_timesheet_security.xml#L66-L76

https://github.com/odoo/odoo/blob/48cfd650053c794a838c130605c4280351b4f5d9/addons/hr_timesheet/security/hr_timesheet_security.xml#L108-L117

**Steps to reproduce:**

1. Create a private project (`privacy_visibility == 'followers'`)
2. Give another user (e.g., Marc Demo) "All Timesheets" rights and only "User" project access
3. Add Marc Demo as a follower of a task in that private project
4. Have another user log time on that task
5. Log in as Marc Demo

Marc cannot see the other user's timesheets, neither on the task form nor in reporting.

opw-5022877