### PR TITLE
[FIX] base_import: prevent traceback when canceling

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -98,6 +98,10 @@ export class ImportAction extends Component {
     }
 
     exit(resIds) {
+        if (!resIds) {
+            this.env.config.historyBack();
+            return;
+        }
         this.actionService.doAction({
             type: "ir.actions.act_window",
             name: _t("Imported records"),

--- a/addons/base_import/static/tests/import_action.test.js
+++ b/addons/base_import/static/tests/import_action.test.js
@@ -513,6 +513,8 @@ describe("Import view", () => {
         });
         await mountWebClient();
         await getService("action").doAction(1);
+        // Should not get a traceback when clicking Cancel
+        await contains("button:contains('Cancel')").click();
         expect.verifySteps(["action"]);
         queryOne(".o_nocontent_help").draggable = true;
         const file = new File(["fake_file"], "fake_file.csv", {


### PR DESCRIPTION
To reproduce:
==============
1. Go to any import screen in Odoo (e.g., Contacts, Products).
2. Click on *Cancel*.
→ Traceback occurs.

Problem:
========
In the old behavior clicking on cancel will call historyBack function which will call restore.
https://github.com/odoo/odoo/blob/93451453deff4b316cb1865055d1817f8290f8ef/addons/web/static/src/webclient/actions/action_service.js#L1668 and now in this version. this PR changed the way the exit works. https://github.com/odoo/odoo/pull/211187
So when you click on `Cancel` it will call doAction with resIds undefined instead of calling restore.

Solution:
==========
In case the resIds is undefined we can proceed with the old behavior which is calling the historyBack function.

opw-5015226
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
