### PR TITLE
[FIX] website: fail popup test with more information about invisible el

### DIFF
--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -111,6 +111,9 @@ describe("Popup options: popup in page before edit", () => {
             contains(".o_we_invisible_entry .fa-eye-slash").click()
         );
         // Sometimes bootstrap.js takes a bit of time to display the popup
+        expect(":iframe .s_popup").not.toHaveClass("d-none");
+        expect(":iframe .s_popup .modal").toHaveClass("show");
+        expect(":iframe .s_popup .modal").toHaveStyle({ display: "block" });
         await waitFor(":iframe .s_popup .modal", { timeout: 1000, visible: true });
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         expect(":iframe .s_popup .modal").toBeVisible();
@@ -130,6 +133,9 @@ describe("Popup options: popup in page before edit", () => {
             contains(".o_we_invisible_entry .fa-eye-slash").click()
         );
         // Sometimes bootstrap.js takes a bit of time to display the popup
+        expect(":iframe .s_popup").not.toHaveClass("d-none");
+        expect(":iframe .s_popup .modal").toHaveClass("show");
+        expect(":iframe .s_popup .modal").toHaveStyle({ display: "block" });
         await waitFor(":iframe .s_popup .modal", { timeout: 1000, visible: true });
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         expect(":iframe .s_popup .modal").toBeVisible();


### PR DESCRIPTION
In order to fix the non-determinsitic test about popup that fails rarely, this commit gives more information in case of failure.

Attempts to fix the tests in 0706aaef3894bbee6eea62679a2d89a3ee316f7b by adding timeout did not succeed.
