### PR TITLE
[FIX] product_expiry: fix future failed test

### DIFF
--- a/addons/product_expiry/static/tests/tours/stock_picking_tour.js
+++ b/addons/product_expiry/static/tests/tours/stock_picking_tour.js
@@ -24,7 +24,7 @@ registry.category("web_tour.tours").add('test_generate_serial_with_expiration', 
             run: () => {
                 const exp_dates = document.querySelectorAll("td.o_field_cell[name=expiration_date]");
                 for (const exp_date of exp_dates) {
-                    if (exp_date.innerText.trim() !== "Jun 3, 12:00 AM") {
+                    if (exp_date.innerText.trim() !== "Jun 3, 2020, 12:00 AM") {
                         throw new Error("Expiration date should be Jun 3, 12:00 AM.");
                     }
                 }

--- a/addons/product_expiry/tests/test_generate_serial_numbers.py
+++ b/addons/product_expiry/tests/test_generate_serial_numbers.py
@@ -243,7 +243,7 @@ class TestStockLot(StockGenerateCommon):
 
 class TestProductExpiryTour(TestStockPickingTour):
 
-    @freeze_time("2025-06-01")
+    @freeze_time("2020-06-01")
     def test_generate_serial_with_expiration(self):
         """
         Ensure that serial/lot numbers generated using the 'Generate Serials/Lots' button in Detailed


### PR DESCRIPTION
The test 'test_generate_serial_with_expiration' was freeze in
2025, so the format of the date will be different starting from next
year. So, in prevention, the date has already been put in the past.

runbot build error: 230718

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
