### PR TITLE
[FIX] l10n_ae: fix column alignment when tax field is empty in invoice report

### DIFF
--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -87,19 +87,21 @@
         </t>
 
         <xpath expr="//thead//th[@name='th_taxes']" position="replace">
-            <th name="th_taxes"
-                t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                <span t-if="o.company_id.country_id.code == 'AE'">VAT</span>
-                <span t-else="">Taxes</span>
-            </th>
-            <th t-if="o.company_id.country_id.code == 'AE'" name="tax_amount"
-                t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                <span>VAT Amount</span>
-            </th>
+            <t t-if="display_taxes">
+                <th name="th_taxes"
+                    t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                    <span t-if="o.company_id.country_id.code == 'AE'">VAT</span>
+                    <span t-else="">Taxes</span>
+                </th>
+                <th t-if="o.company_id.country_id.code == 'AE'" name="tax_amount"
+                    t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                    <span>VAT Amount</span>
+                </th>
+            </t>
         </xpath>
 
         <xpath expr="//span[@id='line_tax_ids']/.." position="after">
-            <td t-if="o.company_id.country_id.code == 'AE'">
+            <td t-if="o.company_id.country_id.code == 'AE' and display_taxes">
                 <span t-field="line.l10n_ae_vat_amount" id="line_tax_amount"/>
             </td>
         </xpath>


### PR DESCRIPTION
**Steps to reproduce:**

1- Install UAE localization (l10n_ae).
2- Create an invoice without adding any taxes in the invoice lines. 
3- Print the invoice → column alignment is broken.

**Issue:**
In UAE localization, the invoice report shows misaligned columns when the tax field is empty.

**Cause:**
Since Odoo 18.4, the core report logic hides the tax column when no taxes are applied. However, l10n_ae does not handle this scenario properly while replacing columns, which results in broken alignment.

**Solution:**
Added a condition in l10n_ae to correctly handle the case when the tax field is empty, ensuring column alignment is maintained in the invoice report.

**Before Fix:**
<img width="777" height="326" alt="image" src="https://github.com/user-attachments/assets/1416c03a-9da5-45fe-8ade-2a9037f70812" />



**After Fix:**
<img width="767" height="341" alt="image" src="https://github.com/user-attachments/assets/9d418945-45e2-409e-b00e-b4f8272ea013" />


opw-4965240

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
