### PR TITLE
[MOV] html_editor, web: move button classes to html_editor

### DIFF
--- a/addons/html_editor/static/src/scss/html_editor.common.scss
+++ b/addons/html_editor/static/src/scss/html_editor.common.scss
@@ -854,3 +854,18 @@ code.o_inline_code {
     font-size: 85%;
     color: $gray-900;
 }
+
+.o_button_area {
+    @include o-position-absolute(0, 0, 0, 0);
+}
+
+// Remove default user-agent styles on buttons
+.o_btn_reset {
+    appearance: none;
+    margin: unset;
+    padding: unset;
+    background: unset;
+    border: unset;
+    font-family: inherit;
+    font-size: 100%;
+}

--- a/addons/web/static/src/scss/ui.scss
+++ b/addons/web/static/src/scss/ui.scss
@@ -187,21 +187,6 @@ span.o_force_ltr {
     }
  }
 
-.o_button_area {
-    @include o-position-absolute(0, 0, 0, 0);
-}
-
-// Remove default user-agent styles on buttons
-.o_btn_reset {
-    appearance: none;
-    margin: unset;
-    padding: unset;
-    background: unset;
-    border: unset;
-    font-family: inherit;
-    font-size: 100%;
-}
-
 // Chess-like background
 .o_preview_alpha_background {
     @extend %o-preview-alpha-background;


### PR DESCRIPTION
Commit [960579e] added the `.o_button_area` util class and commit
[5edd681] added `.o_btn_reset`.
While in theory they can be useful in a number of places across the UI,
for now those are only used in html_editor-related modules, so we
restrict the classes to that module.

[960579e]: https://github.com/odoo/odoo/commit/960579ec35a9f9e190c23bd8daa20bd33378cbab
[5edd681]: https://github.com/odoo/odoo/commit/5edd6811bc05a923ef9faa8e5cc1de2031da70f1
