### PR TITLE
[IMP] payment_xendit: error handling

### DIFF
--- a/addons/payment_xendit/static/src/js/payment_form.js
+++ b/addons/payment_xendit/static/src/js/payment_form.js
@@ -125,6 +125,10 @@ paymentForm.include({
             },
             (err, token) =>  
                 {
+                    // if any errors are reported, immediately report it
+                    if (err) {
+                        this._xenditHandleResponse(err, token, processingValues, '');
+                    }
                     // For multiple use tokens, we have to create an authentication first before
                     // charging.
                     if (processingValues['should_tokenize']) {


### PR DESCRIPTION
Previously, if error was found during token creation (i.e. invalid input) , it's not immediately reported but instead invalid data will be used for further process. Now, any errors caught early will be reported immediately back.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
