### PR TITLE
[FIX] point_of_sale: prevent syncing draft orders

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2115,9 +2115,7 @@ export class PosStore extends WithLazyGetterTrap {
     }
     // There for override to do something before adding partner to current order from partner list
     setPartnerToCurrentOrder(partner) {
-        const order = this.getOrder();
-        order.setPartner(partner);
-        this.addPendingOrder([order.id]);
+        this.getOrder().setPartner(partner);
     }
     async selectPartner(currentOrder = this.getOrder()) {
         // FIXME, find order to refund when we are in the ticketscreen.

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -738,6 +738,8 @@ registry.category("web_tour.tours").add("test_draft_orders_not_syncing", {
             Dialog.confirm("Open Register"),
             ProductScreen.orderIsEmpty(),
             ProductScreen.clickDisplayedProduct("Desk Pad"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Deco Addict"),
             Chrome.createFloatingOrder(),
             ProductScreen.clickDisplayedProduct("Desk Pad"),
             ProductScreen.clickPayButton(),

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -964,4 +964,10 @@ patch(PosStore.prototype, {
             }
         }
     },
+    setPartnerToCurrentOrder(partner) {
+        super.setPartnerToCurrentOrder(partner);
+        if (this.config.module_pos_restaurant) {
+            this.addPendingOrder([this.getOrder().id]);
+        }
+    },
 });


### PR DESCRIPTION
Before this commit, in a non-restaurant PoS, when selecting a partner in a draft order, validating an order would also sync the draft order.

opw-5037759

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
