### PR TITLE
[FIX] website: timelineImagesOption dot/dotLines color

### DIFF
--- a/addons/website/static/src/builder/plugins/options/dot_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dot_option.xml
@@ -3,13 +3,13 @@
 
 <t t-name="website.DotColorOption">
     <BuilderRow label.translate="Dot Color">
-        <BuilderColorPicker styleAction="'color'" applyTo="'.o_dot'"/>
+        <BuilderColorPicker styleAction="'color'" applyTo="'.o_dot'" enabledTabs="['solid', 'custom']"/>
     </BuilderRow>
 </t>
 
 <t t-name="website.DotLinesColorOption">
     <BuilderRow label.translate="Dot Lines Color">
-        <BuilderColorPicker styleAction="'border-color'" applyTo="'.o_dot_line'" />
+        <BuilderColorPicker styleAction="'border-color'" applyTo="'.o_dot_line'" enabledTabs="['solid', 'custom']"/>
     </BuilderRow>
 </t>
 


### PR DESCRIPTION
The goal of this commit is to display only the ‘solid’ and ‘custom’ tabs for the color pickers used to choose the color of the dots and dot lines for the timelineImages snippet.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
