### PR TITLE
[IMP] shell: add debugger tools for shell

### DIFF
--- a/odoo/cli/__init__.py
+++ b/odoo/cli/__init__.py
@@ -18,3 +18,5 @@ from . import neutralize
 from . import obfuscate
 from . import genproxytoken
 from . import db
+
+COMMAND = None

--- a/odoo/cli/command.py
+++ b/odoo/cli/command.py
@@ -63,6 +63,7 @@ def main():
 
     if command in commands:
         o = commands[command]()
+        odoo.cli.COMMAND = command
         o.run(args)
     else:
         sys.exit('Unknown command %r' % (command,))

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -115,6 +115,10 @@ class Shell(Command):
                 env = odoo.api.Environment(cr, uid, ctx)
                 local_vars['env'] = env
                 local_vars['self'] = env.user
+                # context_get() has started the transaction already. Rollback to
+                # avoid logging warning "rolling back the transaction before testing"
+                # from odoo.tests.shell.run_tests if the user hasn't done anything.
+                cr.rollback()
                 self.console(local_vars)
                 cr.rollback()
         else:

--- a/odoo/tests/result.py
+++ b/odoo/tests/result.py
@@ -193,7 +193,7 @@ class OdooTestResult(object):
 
     def __repr__(self):
         return ("<%s.%s run=%i errors=%i failures=%i>" %
-                (self.__class__.__module__, self.__class__.__qualname__, self.testsRun, len(self.errors_count), len(self.failures_count)))
+                (self.__class__.__module__, self.__class__.__qualname__, self.testsRun, self.errors_count, self.failures_count))
 
     def __str__(self):
         return f'{self.failures_count} failed, {self.errors_count} error(s) of {self.testsRun} tests'

--- a/odoo/tests/result.py
+++ b/odoo/tests/result.py
@@ -192,8 +192,7 @@ class OdooTestResult(object):
         return length
 
     def __repr__(self):
-        return ("<%s.%s run=%i errors=%i failures=%i>" %
-                (self.__class__.__module__, self.__class__.__qualname__, self.testsRun, self.errors_count, self.failures_count))
+        return f"<{self.__class__.__module__}.{self.__class__.__qualname__} run={self.testsRun} errors={self.errors_count} failures={self.failures_count}>"
 
     def __str__(self):
         return f'{self.failures_count} failed, {self.errors_count} error(s) of {self.testsRun} tests'

--- a/odoo/tests/shell.py
+++ b/odoo/tests/shell.py
@@ -1,0 +1,98 @@
+__all__ = ['run_tests']
+
+import logging
+import re
+import sys
+from psycopg2.extensions import STATUS_READY
+
+import odoo
+from odoo.modules.registry import Registry
+
+from .loader import make_suite, run_suite
+from .result import OdooTestResult
+
+_logger = logging.getLogger(__name__)
+
+TEST_MODULE_NAME_PATTERN = re.compile(r'^odoo\.addons\.\w+\.tests')
+
+
+def run_tests(env, test_tags, modules=None, reload_tests=False):
+    """Run tests for the given modules and test tags."""
+
+    if odoo.cli.COMMAND != 'shell':
+        _logger.error('run_tests should be used only in odoo shell')
+        return
+
+    if odoo.tools.config['workers'] != 0:
+        _logger.error('run_tests should be used only in threaded mode')
+        return
+
+    from odoo.service.server import server  # noqa: PLC0415
+    if not server.httpd:
+        # some tests need the http daemon to be available...
+        server.http_spawn()
+
+    if env.cr._cnx.status != STATUS_READY:
+        # rollback the cr in case it holds a database lock which may cause deadlock while running tests
+        _logger.warning("Rolling backin the transaction before testing")
+        env.cr.rollback()
+
+    if not modules:
+        modules = sorted(env.registry._init_modules)
+
+    if reload_tests:
+        _clear_loaded_test_modules()
+
+    odoo.tools.config['test_tags'] = test_tags
+    odoo.tools.config['test_enable'] = True
+    report = _run_tests(env.cr.dbname, modules)
+    odoo.tools.config['test_enable'] = None
+    odoo.tools.config['test_tags'] = None
+
+    _log_test_report(report)
+
+    return report
+
+
+def _run_tests(db_name, modules):
+    report = OdooTestResult()
+
+    # Run at_install tests
+    with Registry._lock:
+        registry = Registry(db_name)
+        try:
+            # best effort to restore the test environment
+            registry.loaded = False
+            registry.ready = False
+            at_install_suite = make_suite(modules, 'at_install')
+            if at_install_suite.countTestCases():
+                _logger.info("Starting at_install tests")
+                report.update(run_suite(at_install_suite, report))
+        finally:
+            registry.loaded = True
+            registry.ready = True
+
+    # Run post_install tests
+    post_install_suite = make_suite(modules, 'post_install')
+    if post_install_suite.countTestCases():
+        _logger.info("Starting post_install tests")
+        report.update(run_suite(post_install_suite, report))
+
+    return report
+
+
+def _clear_loaded_test_modules():
+    """Clear loaded test modules that may have been modified."""
+    for module_key in list(sys.modules):
+        if TEST_MODULE_NAME_PATTERN.match(module_key):
+            _logger.debug("Removing module from sys.modules for reload: %s", module_key)
+            del sys.modules[module_key]
+
+
+def _log_test_report(report):
+    if not report.wasSuccessful():
+        _logger.error('Tests failed: %s', report)
+    elif not report.testsRun:
+        _logger.warning('No tests executed: %s', report)
+    else:
+        _logger.info('Tests passed: %s', report)


### PR DESCRIPTION
This commit introduces a new function `run_tests` to the Odoo shell.
This function allows users to run specific tests directly from the
shell, even after the test code is modified. This significantly speeds
up the debugging process by avoiding the need for a full server restart.

In the odoo shell
```
>>> from odoo.tests.shell import *
>>> run_tests(env, 'test_tags', modules=[module_name], reload_tests=True)
```

Note: `run_tests` automatically reloads test modules but does not reload
Odoo model code. A shell restart is still required after any change to
business logic.



used by
https://github.com/HydrionBurst/odoo-test-vscode
for hot test
vscode extension: 
[odoo-test-0.0.1.vsix.zip](https://github.com/user-attachments/files/22089685/odoo-test-0.0.1.vsix.zip)


tutorial: https://github.com/HydrionBurst/odoo-test-vscode?tab=readme-ov-file#-hot-test



Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
