### PR TITLE
[FIX] web: wait calendar load instead of just waiting the multi-create

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -272,7 +272,7 @@ export class CalendarModel extends Model {
             const createdRecords = await this.orm.create(this.meta.resModel, records, {
                 context: this.meta.context,
             });
-            this.load();
+            await this.load();
             return createdRecords;
         }
     }


### PR DESCRIPTION
Before this commit, when the user creates multi records in the calendar view, the creation method no longer waits the reload of the calendar view due to the recent changes made in 9ba85c2

This commit makes sure, the method to multi create records in calendar view waits the reload of the calendar view.

related to task-4916256
