### PR TITLE
[FIX] mail, tools: hide mention URLs in web notifications

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4623,7 +4623,7 @@ class MailThread(models.AbstractModel):
                 }
             }
         }
-        payload['options']['body'] = tools.html2plaintext(body)
+        payload['options']['body'] = html2plaintext(body, include_references=False)
         payload['options']['body'] += self._generate_tracking_message(message)
 
         return payload


### PR DESCRIPTION
BACKPORT

Before this commit:

When a user mentioned a channel or another user in a message, the web notification displayed the mention URL on the recipient’s side, causing a UI issue.

After this commit:

This commit resolves the issue by hiding the mention URL in web notification when a user mentions a channel or another user in a message.

original-commit: 116b9d78ae74b6cd4884e62ba1eefe6af328d148

Related: https://github.com/odoo/enterprise/pull/90449

Fw bot up to saas-17.4