### PR TITLE
[FIX] website: replace deleted vimeo video

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1958,7 +1958,7 @@ const MediapickerUserValueWidget = UserValueWidget.extend({
             noDocuments: true,
             isForBgVideo: true,
             vimeoPreviewIds: ['528686125', '430330731', '509869821', '397142251', '763851966', '486931161',
-                '499761556', '392935303', '728584384', '865314310', '511727912', '466830211'],
+                '499761556', '1092009120', '728584384', '865314310', '511727912', '466830211'],
             'res_model': $editable.data('oe-model'),
             'res_id': $editable.data('oe-id'),
             save,


### PR DESCRIPTION
This commit replaces an unavailable vimeo video with a new one to maintain the dialog structure.

This commit is a backport of [1], which was merged only into master, but is also necessary in the stable versions.

[1]: https://github.com/odoo/odoo/commit/ad6f8716ea7e886b6dd3b657309d7cc51e5eb50f