### PR TITLE
[IMP] loyalty: coupon wizard returns generatred coupons

### DIFF
--- a/addons/loyalty/wizard/loyalty_generate_wizard.py
+++ b/addons/loyalty/wizard/loyalty_generate_wizard.py
@@ -92,4 +92,4 @@ class LoyaltyGenerateWizard(models.TransientModel):
                 'issued': self.points_granted,
             } for coupon in coupons
         ])
-        return True
+        return coupons


### PR DESCRIPTION
Make the `loyalty.generate.wizard` return the generated coupons in the `generate_coupons()` method

old behaviour:
The `generate_coupons()` method returns `True` after creating the coupons

new behaviour:
The `generate_coupons()` method will return the generated coupons, allowing direct access to the created coupons without the need for searching.

This behaviour will be used in this enterprise PR to reuse the `loyalty.generate.wizard` module instead of doing unnecessary processing.
See https://github.com/odoo/enterprise/pull/87761

---

Task-4778562
