### PR TITLE
[FIX] mail: immediately show call speaker autofocus disabled on UI

### DIFF
--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -57,6 +57,20 @@ export class Settings extends Record {
             }
         },
     });
+    useCallAutoFocus = fields.Attr(true, {
+        /** @this {import("models").Settings} */
+        compute() {
+            return !browser.localStorage.getItem("mail_user_setting_disable_call_auto_focus");
+        },
+        /** @this {import("models").Settings} */
+        onUpdate() {
+            if (this.useCallAutoFocus) {
+                browser.localStorage.removeItem("mail_user_setting_disable_call_auto_focus");
+                return;
+            }
+            browser.localStorage.setItem("mail_user_setting_disable_call_auto_focus", "true");
+        },
+    });
 
     // Voice settings
     // DeviceId of the audio input selected by the user
@@ -227,16 +241,6 @@ export class Settings extends Record {
             "mail_user_setting_camera_input_device_id",
             cameraInputDeviceId
         );
-    }
-    /**
-     * @param {Boolean} active
-     */
-    setCameraAutoFocus(active) {
-        if (active) {
-            browser.localStorage.removeItem("mail_user_setting_disable_call_auto_focus");
-            return;
-        }
-        browser.localStorage.setItem("mail_user_setting_disable_call_auto_focus", "true");
     }
     /**
      * @param {string} value

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -94,7 +94,7 @@ callActionsRegistry
         inactiveIcon: "fa-eye",
         icon: "fa-eye-slash",
         select: (component) => {
-            component.store.settings.setCameraAutoFocus(!component.store.settings.useCallAutoFocus);
+            component.store.settings.useCallAutoFocus = !component.store.settings.useCallAutoFocus;
         },
         sequence: 50,
     })

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -783,4 +783,9 @@ test("dynamic focus switches to talking participant", async () => {
     await contains(".o-discuss-CallParticipantCard[title='Alice']");
     rtc.updateSessionInfo({ [aliceSessionId]: { isTalking: false } });
     await contains(".o-discuss-CallParticipantCard[title='Bob']");
+    await click("[title='More']");
+    await click(".o-discuss-CallActionList-dropdownItem:contains('Disable speaker autofocus')");
+    await contains(".o-discuss-CallActionList-dropdownItem", { count: 0 });
+    await click("[title='More']");
+    await contains(".o-discuss-CallActionList-dropdownItem:contains('Autofocus speaker')");
 });


### PR DESCRIPTION
Before this commit, when disabling the speaker autofocus feature on discuss calls, the UI was still showing "Disable speaker autooffocus" even though the feature is already disabled.

This happens because the local storage entry was changed, but the UI was not reflected due to `useCallAutofocus` field not being in sync with the local storage.

This commit fixes the issue by fully syncing the field with the local storage, using a similar pattern as all other local storage fields.