### PR TITLE
[IMP] api_doc: Hide api_key and link to generate key

### DIFF
--- a/addons/api_doc/__manifest__.py
+++ b/addons/api_doc/__manifest__.py
@@ -16,6 +16,7 @@ the methods over HTTP, with examples in various programming languages.
     'data': [
         'security/res_groups.xml',
         'views/docclient.xml',
+        'data/doc_api_actions.xml',
     ],
     'assets': {
         'api_doc.assets': [

--- a/addons/api_doc/data/doc_api_actions.xml
+++ b/addons/api_doc/data/doc_api_actions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="action_api_key_wizard" model="ir.actions.act_window">
+            <field name="name">API Key Wizard</field>
+            <field name="res_model">res.users.apikeys.description</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/api_doc/static/src/components/doc_modal_api_key.js
+++ b/addons/api_doc/static/src/components/doc_modal_api_key.js
@@ -30,4 +30,8 @@ export class ApiKeyModal extends Component {
     cancel() {
         this.env.modelStore.showApiKeyModal = false;
     }
+
+    openAPIKeyForm() {
+        window.open(`${window.location.origin}/web#action=api_doc.action_api_key_wizard`, "_blank").focus();
+    }
 }

--- a/addons/api_doc/static/src/components/doc_modal_api_key.xml
+++ b/addons/api_doc/static/src/components/doc_modal_api_key.xml
@@ -3,14 +3,17 @@
 
 <t t-name="web.DocApiKeyModal">
     <div class="modal-bg d-flex flex-nowrap justify-content-center align-items-center">
-        <div class="modal p-3 d-flex flex-nowrap flex-column mb-2" style="height: 14rem; width: 25rem" t-ref="modalRef">
+        <div class="modal h-auto p-3 d-flex flex-nowrap flex-column mb-2" style="width: 25rem" t-ref="modalRef">
             <h2 class="mb-2">API key</h2>
 
-            <p>To try the API, please insert your API key here</p>
+            <p class="mb-1">To try the API, please insert your API key here</p>
+            <a href="#" t-on-click="openAPIKeyForm">Generate a new API key here</a>
             <input
-                class="mt-1"
-                type="text"
+                class="mt-2 w-100"
+                type="password"
+                name="api-key"
                 autocorrect="off"
+                autocomplete="one-time-code"
             />
 
             <div class="d-flex flex-nowrap flex-content-between mt-2">

--- a/addons/api_doc/static/src/doc_client.js
+++ b/addons/api_doc/static/src/doc_client.js
@@ -14,7 +14,7 @@ export class DocClient extends Component {
         DocModel,
         ApiKeyModal,
         SearchModal,
-    };t
+    };
     static props = {};
 
     setup() {


### PR DESCRIPTION
This commit sets the field type of the api key setting as password to hide
it from the user.

It also adds a link in the api key dialog to open the api key page in the
backend and let the user create an api key more easily.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
