### PR TITLE
[REV] mrp*: remove redundant move line sorting while creating backorder

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1948,7 +1948,7 @@ class MrpProduction(models.Model):
             ml_by_move = []
             product_uom = initial_move.product_id.uom_id
             if not initial_move.picked:
-                for move_line in initial_move.move_line_ids.sorted(key=lambda ml: ml._sorting_move_lines()):
+                for move_line in initial_move.move_line_ids:
                     available_qty = move_line.product_uom_id._compute_quantity(move_line.quantity, product_uom, rounding_method="HALF-UP")
                     if product_uom.compare(available_qty, 0) <= 0:
                         continue

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -579,9 +579,6 @@ class StockMoveLine(models.Model):
             moves.with_prefetch()._recompute_state()
         return res
 
-    def _sorting_move_lines(self):
-        return (self.id,)
-
     def _action_done(self):
         """ This method is called during a move's `action_done`. It'll actually move a quant from
         the source location to the destination location, and unreserve if needed in the source


### PR DESCRIPTION
*stock

This commit reverts the change from:
[PR](https://github.com/odoo/odoo/pull/175355),
The `_sorting_move_lines()` method was introduced to ensure that failed move lines were processed first. It needed for quality points with operation type `Manufacturing` having control per `quantity`.

Revert is done since this [PR](https://github.com/odoo/enterprise/pull/67780) now prevents creating quality points with operation type `Manufacturing + control per quantity`, this sorting is no longer needed. As a result, the `_sorting_move_lines()` method is now redundant and has become dead code.

Task ID: [4915067](https://www.odoo.com/odoo/project/966/tasks/4915067)