### PR TITLE
[FIX] website: restart interaction on bundle reload

### DIFF
--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -18,7 +18,7 @@ export const NO_IMAGE_SELECTION = Symbol.for("NoImageSelection");
 
 export class CustomizeWebsitePlugin extends Plugin {
     static id = "customizeWebsite";
-    static dependencies = ["builderActions", "history", "savePlugin"];
+    static dependencies = ["builderActions", "history", "savePlugin", "edit_interaction"];
     static shared = [
         "customizeWebsiteColors",
         "customizeWebsiteVariables",
@@ -234,6 +234,7 @@ export class CustomizeWebsitePlugin extends Plugin {
                 el.remove();
             }
         });
+        this.dependencies.edit_interaction.restartInteractions();
     }
 
     // -------------------------------------------------------------------------

--- a/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/chart_option_plugin.js
@@ -283,6 +283,7 @@ export class ColorChangeAction extends BaseChartAction {
         }
     }
     apply({ editingElement, value, params: { type, datasetIndex, dataIndex } }) {
+        value = value.replace("var(--", "").replace(")", "");
         const data = this.getData(editingElement);
         if (this.isPieChart(editingElement)) {
             data.datasets[datasetIndex][type][dataIndex] = value;


### PR DESCRIPTION

Before this commit, if theme colors were applied on charts or on
countdowns, they would not be updated right after changing the
theme colors. This was due to the fact the interactions were not
restarted and the old colors were kept.

To fix this issue and solve future ones, the interactions are now
restarted after any bundle reload.

task-4367641