### PR TITLE
[FIX] website: add theme tab step in homepage tour

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -521,14 +521,16 @@ export function registerThemeHomepageTour(name, steps) {
         throw new Error(`tour.steps has to be a function that returns TourStep[]`);
     }
     return registerWebsitePreviewTour(
-        name,
+        "homepage", // it overrides the community tour with the associated theme tour
         {
             url: "/",
         },
         () => [
             ...clickOnEditAndWaitEditMode(),
-            ...prepend_trigger(
-                steps().concat(clickOnSave())),
+            // FIXME(?) this should probably reuse the prepend_trigger function
+            // so that we do check that we are really on the homepage.
+            ...steps(),
+            ...clickOnSave(),
         ]
     );
 }

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -117,11 +117,11 @@ export function changeImage(snippet, position = "bottom") {
     By default, prevents the step from being active if a palette is opened.
     Set allowPalette to true to select options within a palette.
 */
-export function changeOption(optionName, weName = '', optionTooltipLabel = '', position = "bottom", allowPalette = false) {
+export function changeOption(blockName, actionId = '', optionTooltipLabel = '', position = "bottom", allowPalette = false) {
     const noPalette = allowPalette ? "" : !document.querySelector(".o_popover .o_font_color_selector") && ".o_customize_tab";
-    const option_block = `${noPalette} [data-container-title='${optionName}']`;
+    const option_block = `${noPalette} [data-container-title='${blockName}']`;
     return {
-        trigger: `${option_block} ${weName}, ${option_block} [data-action-id="${weName}"]`,
+        trigger: `${option_block} ${actionId}, ${option_block} [data-action-id="${actionId}"]`,
         content: markup(_t("<b>Click</b> on this option to change the %s of the block.", optionTooltipLabel)),
         tooltipPosition: position,
         run: "click",

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -419,6 +419,10 @@ export function goToTheme(position = "bottom") {
             tooltipPosition: position,
             run: "click",
         },
+        {
+            content: "Check that the theme tab is active",
+            trigger: ".o-tab-content .options-container [data-action-id='switchTheme']",
+        },
     ];
 }
 
@@ -530,6 +534,7 @@ export function registerThemeHomepageTour(name, steps) {
             // FIXME(?) this should probably reuse the prepend_trigger function
             // so that we do check that we are really on the homepage.
             ...steps(),
+            ...goToTheme(),
             ...clickOnSave(),
         ]
     );


### PR DESCRIPTION
This commit adds the `goToTheme` step to the homepage tour. This step is used to showcase the theme features and to ensure no theme specific error on that tab in `test_02_homepage_tour_every_theme` test.