### PR TITLE
[FIX] web_editor: apply border-radius correctly on grid images

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -52,6 +52,15 @@
                 }
             }
         }
+
+        &.o_grid_item_image img {
+            // See BORDER_VARIABLES_RULES_EXTENSION
+            border-radius:
+                calc(var(--box-border-top-left-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-left-width, 0px)))
+                calc(var(--box-border-top-right-radius, 0px) - max(var(--box-border-top-width, 0px), var(--box-border-right-width, 0px)))
+                calc(var(--box-border-bottom-right-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-right-width, 0px)))
+                calc(var(--box-border-bottom-left-radius, 0px) - max(var(--box-border-bottom-width, 0px), var(--box-border-left-width, 0px)));
+        }
     }
 }
 


### PR DESCRIPTION
When a border radius and/or width is applied to an image grid item (e.g. in "Masonry"), the image overflows its parent box. This happens because the style was only applied to the column, not the image itself. This commit adds necessary style to the image to take into account the border radius and width of the parent box.

Steps to reproduce:
1. In Website Builder, add the "Masonry" snippet.
2. Select a block with an image (i.e. the block with the largest image)
and apply a border radius.
3. Notice that the image does not respect the border radius.

Related to task-3358501