### PR TITLE
[FIX] pos_online_payment: set order date's tz to UTC

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -9,7 +9,9 @@ import { ask } from "@point_of_sale/app/utils/make_awaitable_dialog";
 patch(PaymentScreen.prototype, {
     async addNewPaymentLine(paymentMethod) {
         if (paymentMethod.is_online_payment && typeof this.currentOrder.id === "string") {
-            this.currentOrder.date_order = luxon.DateTime.now().toFormat("yyyy-MM-dd HH:mm:ss");
+            this.currentOrder.date_order = luxon.DateTime.now()
+                .setZone("utc")
+                .toFormat("yyyy-MM-dd HH:mm:ss");
             this.pos.addPendingOrder([this.currentOrder.id]);
             await this.pos.syncAllOrders();
         }


### PR DESCRIPTION
In 2a5f1abf2e98ee09fa7a912b87d71879b5ff260b, we formatted the `order_date` with `toFormat(...)`, however, that transforms the date into local, while the backend expects it to be in UTC.

In this commit, we set the date tz back to UTC before formatting it.

opw-4942697