### PR TITLE
[FIX] web: Allow users to view record data with field properties

### DIFF
--- a/addons/web/static/tests/core/debug/debug_manager.test.js
+++ b/addons/web/static/tests/core/debug/debug_manager.test.js
@@ -497,12 +497,28 @@ describe("DebugMenu", () => {
 
             name = fields.Char();
             raw = fields.Binary();
+            properties = fields.Properties({
+                string: "Properties",
+                definition_record: "product_id",
+                definition_record_field: "definitions",
+            });
+            definitions = fields.PropertiesDefinition({
+                string: "Definitions",
+            });
 
             _records = [
                 {
                     id: 1,
                     name: "custom1",
                     raw: "<raw>",
+                    properties: [
+                        {
+                            name: "bd6404492c244cff",
+                            string: "test",
+                            type: "char",
+                        },
+                    ],
+                    definitions: [{ name: "xphone_prop_1", string: "P1", type: "boolean" }],
                 },
             ];
         }
@@ -521,16 +537,24 @@ describe("DebugMenu", () => {
         await contains(".dropdown-menu .dropdown-item:contains(/^Data/)").click();
         expect(".modal").toHaveCount(1);
         const data = queryText(".modal-body pre");
-        expect(data).not.toMatch(/"raw"/, { message: "binary fields should not be displayed" });
-        const lines = data.split("\n");
-        expect(lines.shift()).toMatch(/\{$/);
-        expect(lines.shift()).toMatch(/"create_date": "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"/);
-        expect(lines.shift()).toMatch(/"display_name": "custom1"/);
-        expect(lines.shift()).toMatch(/"id": 1/);
-        expect(lines.shift()).toMatch(/"name": "custom1"/);
-        expect(lines.shift()).toMatch(/"write_date": "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"/);
-        expect(lines.shift()).toMatch(/\}$/);
-        expect(lines).toBeEmpty();
+        const modalObj = JSON.parse(data);
+        expect(modalObj).toInclude("create_date");
+        expect(modalObj).toInclude("write_date");
+        expect(modalObj).not.toInclude("raw");
+        const expectedObj = {
+            display_name: "custom1",
+            id: 1,
+            name: "custom1",
+            properties: false,
+            definitions: [
+                {
+                    name: "xphone_prop_1",
+                    string: "P1",
+                    type: "boolean",
+                },
+            ],
+        };
+        expect(modalObj).toMatchObject(expectedObj);
     });
 
     test("view metadata: basic rendering", async () => {


### PR DESCRIPTION
Example Steps:
- Install `crm`
- Add a random field properties in a random form view
- Enable debug mode
- Open debug menu
- Select Data
- Traceback

```py
raise ValueError(f"Invalid field {field_name!r} on model {self._name!r}")
ValueError: Invalid field 'properties.xyz' on model 'x.y'
```

There are two causes for this problem.
First, we use orm.read to retrieve data from records, which does not directly handle sub-field properties. We only need to use `definition_property` (which contains the overall schema of the JSON field).

Second, when displaying the data, we use JSON.stringify with `replacer`:

```js
    get content() {
        const record = this.props.record;
        return JSON.stringify(record, Object.keys(record).sort(), 2);
    }
```
In this case, replace contains all the keys present in record, sorted. The problem is that the properties fields are themselves objects that contain the keys: `name`, `string`, `type`, `default`, `value`.

And giving an array to replace in `JSON.stringify` will filter the keys and keep only those that are whitelisted in it.
```js
// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
const foo = {
  foundation: “Mozilla”,
  model: “box”,
  week: 45,
  transport: “car”,
  month: 7,
};

JSON.stringify(foo, [“week”, “month”]);
// ‘{“week”:45,“month”:7}’, only keep ‘week’ and “month” properties
```

This will ignore the keys of the properties fields.

The fix is therefore to sort the object before stringifying it, without using replace.

Thanks to these two fixes, the data is displayed as expected, regardless of whether there are field properties or not.

opw-5017425