### PR TITLE
select menu does not focus when the list is empty on first open, or o…

### DIFF
--- a/addons/html_builder/static/tests/many2one_field.test.js
+++ b/addons/html_builder/static/tests/many2one_field.test.js
@@ -1,5 +1,37 @@
 import { expect, test } from "@odoo/hoot";
-import { setupHTMLBuilder } from "./helpers";
+import { addBuilderOption, setupHTMLBuilder } from "./helpers";
+import { Component, useState, xml } from "@odoo/owl";
+import { SelectMenu } from "@web/core/select_menu/select_menu";
+import { click } from "@odoo/hoot-dom";
+
+class Test extends Component {
+    static template = xml`
+        <SelectMenu
+            choices="getChoices()"
+        >
+        </SelectMenu>
+    `;
+    static components = { SelectMenu };
+    setup() {
+        this.state = useState({ choices: [] });
+    }
+    getChoices() {
+        // setTimeout(() => {
+        //     this.state.choices = [
+        //         { value: "a", label: "A" },
+        //         { value: "x", label: "X" },
+        //     ];
+        // }, 3000);
+        return this.state.choices;
+    }
+}
+
+test("autofocus in select menu", async () => {
+    addBuilderOption({ selector: ".test", OptionComponent: Test });
+    await setupHTMLBuilder(`<div class="test">TEST in html builder</div>`);
+    await click(":iframe .test");
+    expect(1).toBe(1);
+});
 
 test("should prevent edition in many2one field", async () => {
     await setupHTMLBuilder(

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -312,6 +312,8 @@ export class Dropdown extends Component {
             return;
         }
 
+        console.log("open popover");
+
         this.popoverRefresher = reactive({ token: 0 });
         const props = {
             beforeOpen: () => this.props.beforeOpen?.(),

--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -1,4 +1,4 @@
-import { Component, onWillUpdateProps, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, onPatched, onWillUpdateProps, useEffect, useRef, useState } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
@@ -137,6 +137,13 @@ export class SelectMenu extends Component {
                 },
             },
         };
+
+        onMounted(() => {
+            console.log("mounted", this.inputRef.el);
+        });
+        onPatched(() => {
+            console.log("patched", this.inputRef.el);
+        });
     }
 
     get displayValue() {
@@ -171,10 +178,12 @@ export class SelectMenu extends Component {
     }
 
     async onBeforeOpen() {
+        console.log("on before open", this.inputRef.el);
         await this.onInput("");
     }
 
     onStateChanged(open) {
+        console.log("on state changed", { open }, this.inputRef.el);
         this.isOpen = open;
         if (open) {
             this.menuRef.el?.addEventListener("scroll", (ev) => this.onScroll(ev));

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -53,6 +53,7 @@
                     <t t-if="state.choices.length === 0">
                         <span class="text-muted fst-italic mx-3">No result found</span>
                     </t>
+                    <t t-out="console.log('x')"/>
                     <t t-foreach="state.displayedOptions" t-as="choice" t-key="choice_index">
                         <t t-call="{{ this.constructor.choiceItemTemplate }}">
                             <t t-set="choice" t-value="choice" />

--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -60,7 +60,9 @@ export function useAutofocus({ refName, selectAll, mobile } = {}) {
     // LEGACY
     useEffect(
         (el) => {
+            console.log("effect of useFocus", el);
             if (isFocusable(el)) {
+                console.log("effect of useFocus: isFocusable");
                 el.focus();
                 if (["INPUT", "TEXTAREA"].includes(el.tagName) && el.type !== "number") {
                     el.selectionEnd = el.value.length;

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -89,21 +89,19 @@ test("Selecting a choice calls onSelect and the displayed value is updated", asy
         static components = { SelectMenu };
         static template = xml`
             <SelectMenu
-                groups="groups"
-                choices="choices"
-                value="state.value"
+                choices="[]"
                 onSelect.bind="onSelect"
             />
         `;
         setup() {
-            this.state = useState({ value: "world" });
-            this.choices = [{ label: "Hello", value: "hello" }];
-            this.groups = [
-                {
-                    label: "Group A",
-                    choices: [{ label: "World", value: "world" }],
-                },
-            ];
+            // this.state = useState({ value: "world" });
+            // this.choices = [{ label: "Hello", value: "hello" }];
+            // this.groups = [
+            //     {
+            //         label: "Group A",
+            //         choices: [{ label: "World", value: "world" }],
+            //     },
+            // ];
         }
 
         onSelect(value) {
@@ -113,21 +111,21 @@ test("Selecting a choice calls onSelect and the displayed value is updated", asy
     }
     await mountSingleApp(MyParent);
 
-    expect(".o_select_menu_toggler_slot").toHaveText("World");
+    // expect(".o_select_menu_toggler_slot").toHaveText("World");
 
-    await open();
-    await click(".o_select_menu_item_label:eq(0)");
-    await animationFrame();
+    // await open();
+    // await click(".o_select_menu_item_label:eq(0)");
+    // await animationFrame();
 
-    expect(".o_select_menu_toggler_slot").toHaveText("Hello");
-    expect.verifySteps(["hello"]);
+    // expect(".o_select_menu_toggler_slot").toHaveText("Hello");
+    // expect.verifySteps(["hello"]);
 
-    await open();
-    await click(".o_select_menu_item_label:eq(1)");
-    await animationFrame();
+    // await open();
+    // await click(".o_select_menu_item_label:eq(1)");
+    // await animationFrame();
 
-    expect(".o_select_menu_toggler_slot").toHaveText("World");
-    expect.verifySteps(["world"]);
+    // expect(".o_select_menu_toggler_slot").toHaveText("World");
+    // expect.verifySteps(["world"]);
 });
 
 test("Close dropdown on click outside", async () => {

--- a/addons/website/static/tests/builder/date_field.test.js
+++ b/addons/website/static/tests/builder/date_field.test.js
@@ -1,7 +1,39 @@
 import { expect, test } from "@odoo/hoot";
-import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { addOption, defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { Component, useState, xml } from "@odoo/owl";
+import { SelectMenu } from "@web/core/select_menu/select_menu";
+import { click } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
+
+class Test extends Component {
+    static template = xml`
+        <SelectMenu
+            choices="getChoices()"
+        >
+        </SelectMenu>
+    `;
+    static components = { SelectMenu };
+    setup() {
+        this.state = useState({ choices: [] });
+    }
+    getChoices() {
+        // setTimeout(() => {
+        //     this.state.choices = [
+        //         { value: "a", label: "A" },
+        //         { value: "x", label: "X" },
+        //     ];
+        // }, 3000);
+        return this.state.choices;
+    }
+}
+
+test("autofocus in select menu", async () => {
+    addOption({ selector: ".test", Component: Test });
+    await setupWebsiteBuilder(`<div class="test">TEST in website</div>`);
+    await click(":iframe .test");
+    expect(1).toBe(1);
+});
 
 test("should not allow edition of date and datetime fields", async () => {
     await setupWebsiteBuilder(

--- a/addons/website_forum/static/src/xml/website_forum_tags_wrapper.xml
+++ b/addons/website_forum/static/src/xml/website_forum_tags_wrapper.xml
@@ -4,7 +4,7 @@
 <t t-name="website_forum.WebsiteForumTagsWrapper">
     <input name="post_tags" type="hidden" class="form-control" t-att-value="state.value"/>
     <SelectMenu
-        choices="state.choices"
+        choices="[{label: 'something'}]"
         value="state.value"
         onInput.bind="loadChoices"
         onSelect.bind="onSelect"


### PR DESCRIPTION
…n later opens in some case

tests of interests:
- `autofocus in select menu` (there are 2 of them, one in website, one in html_builder)
- `Selecting a choice calls onSelect and the displayed value is updated` (in web)
- `http://localhost:8069/forum/help-1/ask` (there is the select menu for the tags at the bottom)

There is the select menu for tags in the 'new question' page in forum, it never focus

the selectmenu in tests with setupHTMLBuilder never focus

the selectmenu in tests with setupWebsiteBuilder and the one in web/core only does not focus on first open

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
