### PR TITLE
[FIX] website: default highlight as primary and styled highlight picker

### DIFF
--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
@@ -3,6 +3,7 @@ import { ColorPicker } from "@web/core/color_picker/color_picker";
 import { HighlightPicker } from "./highlight_picker";
 import { normalizeColor } from "@html_builder/utils/utils_css";
 import { getHtmlStyle } from "@html_editor/utils/formatting";
+import { _t } from "@web/core/l10n/translation";
 
 export const highlightIdToName = {
     underline: "Underline",
@@ -42,6 +43,7 @@ export class HighlightConfigurator extends Component {
         revertHighlightStyle: Function,
         componentStack: Object,
         getUsedCustomColors: Function,
+        getMaxFontSize: Function,
     };
 
     setup() {
@@ -55,14 +57,25 @@ export class HighlightConfigurator extends Component {
     }
 
     openHighlightPicker(withPrevious = true) {
+        // Picker's samples use the fs-3 class
+        const fs3 = document.createElement("div");
+        fs3.classList.add("fs-3");
+        document.body.append(fs3);
+        const fs3Size = parseFloat(getComputedStyle(fs3).fontSize);
+        fs3.remove();
+        const fontRatio = this.props.getMaxFontSize() / fs3Size;
         this.props.componentStack.push(
             HighlightPicker,
             {
                 selectHighlight: this.selectHighlight.bind(this),
                 previewHighlight: this.props.previewHighlight,
                 revertHighlight: this.props.revertHighlight,
+                style: `
+                    --text-highlight-width: ${(this.state.thickness || 2) / fontRatio}px;
+                    --text-highlight-color: ${this.state.color || "var(--o-color-1)"};
+                `,
             },
-            "Select a highlight",
+            _t("Select a highlight"),
             withPrevious
         );
     }

--- a/addons/website/static/src/builder/plugins/highlight/highlight_picker.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_picker.js
@@ -11,6 +11,7 @@ export class HighlightPicker extends Component {
         selectHighlight: Function,
         previewHighlight: Function,
         revertHighlight: Function,
+        style: { type: String, optional: true },
     };
 
     setup() {

--- a/addons/website/static/src/builder/plugins/highlight/highlight_picker.xml
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_picker.xml
@@ -10,7 +10,8 @@
                     t-on-mouseenter="() => this.props.previewHighlight(highlight)"
                     t-on-mouseleave="() => this.props.revertHighlight()">
                 <div class="overflow-visible position-relative fw-bolder fs-3 text-center">
-                    <span t-attf-class="o_text_highlight o_text_highlight_{{highlight}}">Text</span>
+                    <span t-att-style="props.style"
+                          t-attf-class="o_text_highlight o_text_highlight_{{highlight}}">Text</span>
                 </div>
             </div>
         </t>

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -37,6 +37,7 @@ export class HighlightPlugin extends Plugin {
                         getHighlightState: () => this.highlightState,
                         getUsedCustomColors: this.getUsedCustomColors.bind(this),
                         deleteHighlight: this.deleteSelectedHighlight.bind(this),
+                        getMaxFontSize: this.getMaxFontSize.bind(this),
                     },
                     onClick: this.completeHighlightSelection.bind(this),
                 },
@@ -80,6 +81,25 @@ export class HighlightPlugin extends Plugin {
         });
     }
 
+    getMaxFontSize() {
+        const nodes = this.dependencies.selection
+            .getTargetedNodes()
+            .map((n) => closestElement(n, "*"))
+            .filter(Boolean);
+        const uniqueNodes = new Set(nodes);
+        if (uniqueNodes.size === 0) {
+            uniqueNodes.add(this.document.body);
+        }
+        let max = 0;
+        for (const node of uniqueNodes) {
+            const size = parseFloat(getComputedStyle(node).fontSize);
+            if (size > max) {
+                max = size;
+            }
+        }
+        return max;
+    }
+
     updateSelectedHighlight() {
         const nodes = this.getSelectedHighlightNodes();
         const uniqueNodes = new Set(nodes);
@@ -98,20 +118,22 @@ export class HighlightPlugin extends Plugin {
             const style = nodes.map((node) =>
                 getComputedStyle(node).getPropertyValue("--text-highlight-color")
             );
-            this.highlightState.color = style.every((v) => v === style[0]) ? style[0] : undefined;
+            this.highlightState.color = style.every((v) => v === style[0])
+                ? style[0]
+                : getComputedStyle(this.document.body).getPropertyValue("--o-color-1");
             const thickness = nodes.map((node) =>
                 getComputedStyle(node).getPropertyValue("--text-highlight-width")
             );
             this.highlightState.thickness = thickness.every((v) => v === thickness[0])
                 ? parseInt(thickness[0])
-                : "";
+                : 2;
         }
     }
 
     _applyHighlight(highlightId) {
         const highlightedNodes = this.getSelectedHighlightNodes();
-        let thicknessToRestore;
-        let colorToRestore;
+        let thicknessToRestore = "2px";
+        let colorToRestore = "var(--o-color-1)";
         if (highlightedNodes.length > 0) {
             const style = getComputedStyle(highlightedNodes[0]);
             colorToRestore = style.getPropertyValue("--text-highlight-color");

--- a/addons/website/static/src/builder/plugins/highlight/stacking_component.js
+++ b/addons/website/static/src/builder/plugins/highlight/stacking_component.js
@@ -18,7 +18,7 @@ export class StackingComponent extends Component {
             <div data-prevent-closing-overlay="true" t-if="componentSpec_last" t-attf-class="{{this.props.class}} {{componentSpec_last ? '': 'd-none' }}" t-att-style="this.props.style">
                 <div t-if="this.stack.length > 1 || componentSpec.title" class="d-flex align-items-center">
                     <button t-if="this.stack.length > 1 and componentSpec.withPrevious" class="fa fa-angle-left btn btn-secondary bg-transparent border-0" t-on-click="this.props.stackState.pop"></button>
-                    <span t-out="componentSpec.title" class="lead mb-0"/>
+                    <span t-out="componentSpec.title" class="lead mb-0" t-att-class="{ 'cursor-pointer': componentSpec.withPrevious }" t-on-click="this.props.stackState.pop"/>
                 </div>
                 <t t-component="componentSpec.component" t-props="componentSpec.props" />
             </div>

--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -31,8 +31,15 @@ test("Can highlight a selected text", async () => {
     await waitFor(".o_popover .o_text_highlight_underline");
 
     expect("p>.o_text_highlight_underline").toHaveCount(0);
+    const color = getComputedStyle(document.documentElement).getPropertyValue("--o-color-1");
+    expect(".o_popover .o_text_highlight_underline").toHaveStyle({
+        "--text-highlight-color": color,
+    });
     await click(".o_popover .o_text_highlight_underline");
     expect("p>.o_text_highlight_underline").toHaveCount(1);
+    expect("span.o_text_highlight_freehand_2").toHaveStyle({
+        "--text-highlight-color": color,
+    });
 });
 
 test("Can set a color to a highlight", async () => {
@@ -49,9 +56,9 @@ test("Can set a color to a highlight", async () => {
     await animationFrame();
     await click("#colorButton");
     await animationFrame();
-    await click("button[style='background-color: var(--o-color-1)']");
+    await click("button[style='background-color: var(--o-color-2)']");
     await animationFrame();
-    const color = getComputedStyle(document.documentElement).getPropertyValue("--o-color-1");
+    const color = getComputedStyle(document.documentElement).getPropertyValue("--o-color-2");
     expect("span.o_text_highlight_freehand_2").toHaveStyle({
         "--text-highlight-color": color,
     });


### PR DESCRIPTION
The hightlight picker is always shown with default black color and default thickness.

This commit adapts the preview to use the currently set color and thickness.
It also defaults the color to primary.

task-4367641
