### PR TITLE
[PERF] stock,mrp: optimize _compute_quantities

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -343,7 +343,7 @@ class MrpBom(models.Model):
         :rtype: defaultdict(`lambda: self.env['mrp.bom']`)
         """
         bom_by_product = defaultdict(lambda: self.env['mrp.bom'])
-        products = products.filtered(lambda p: p.type != 'service')
+        products = products.filtered(lambda p: p.product_tmpl_id.type != 'service')
         if not products:
             return bom_by_product
         domain = self._bom_find_domain(products, picking_type=picking_type, company_id=company_id, bom_type=bom_type)

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -123,7 +123,7 @@ class Product(models.Model):
         'location', 'warehouse', 'allowed_company_ids'
     )
     def _compute_quantities(self):
-        products = self.with_context(prefetch_fields=False).filtered(lambda p: p.type != 'service').with_context(prefetch_fields=True)
+        products = self.with_context(prefetch_fields=False).filtered(lambda p: p.product_tmpl_id.type != 'service').with_context(prefetch_fields=True)
         res = products._compute_quantities_dict(self._context.get('lot_id'), self._context.get('owner_id'), self._context.get('package_id'), self._context.get('from_date'), self._context.get('to_date'))
         for product in products:
             product.update(res[product.id])
@@ -197,7 +197,7 @@ class Product(models.Model):
                     0.0,
                 )
                 continue
-            rounding = product.uom_id.rounding
+            rounding = product.product_tmpl_id.uom_id.rounding
             res[product_id] = {}
             if dates_in_the_past:
                 qty_available = quants_res.get(origin_product_id, [0.0])[0] - moves_in_res_past.get(origin_product_id, 0.0) + moves_out_res_past.get(origin_product_id, 0.0)


### PR DESCRIPTION
The performance when searching by `qty_available`, `virtual_available`, `free_qty`, `incoming_qty`, or `outgoing_qty` on databases with a large number of `product.product`s is currently poor. This is part of a two-part fix with #224031

Both `product.product.type` and `product.product.uom_id` are computed from `product_tmpl_id`. With large databases, `_compute_related()` is a large bottleneck when running `_compute_quantities()`

We fix this performance issue by directly fetching the fields instead.

Benchmark (with #224031 applied)
| `product.product` count | Before this PR | After this PR |
| ----------------------- | ----------- | ---------- |
| 5,000                   | 1.01s          | 0.67s         |
| 50,000                  | 9.97s          | 5.87s         |
| 500,000                 | 144s        | 78s        |

opw-4930856