### PR TITLE
[FIX] html_editor,website: make popovers static in iframe

### DIFF
--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -70,6 +70,7 @@ export class ColorSelector extends Component {
                 themeColorPrefix: this.props.themeColorPrefix,
             },
             {
+                env: this.__owl__.childEnv,
                 onClose: () => {
                     this.props.applyColorResetPreview();
                     this.props.onClose();

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -182,6 +182,7 @@ export class LinkPopover extends Component {
                         },
                     },
                     {
+                        env: this.__owl__.childEnv,
                         onClose: this.onChange.bind(this),
                     }
                 );

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -291,6 +291,7 @@ class HighlightToolbarButton extends Component {
             ...this.props.highlightConfiguratorProps,
         });
         this.configuratorPopover = usePopover(StackingComponent, {
+            env: this.__owl__.childEnv,
             onClose: () => {
                 while (this.componentStack.stack.length > 1) {
                     this.componentStack.pop();

--- a/addons/website/static/src/builder/plugins/options/animate_text.js
+++ b/addons/website/static/src/builder/plugins/options/animate_text.js
@@ -1,4 +1,4 @@
-import { Component, onMounted, onWillDestroy, useRef, useState } from "@odoo/owl";
+import { Component, onMounted, onWillDestroy, useChildSubEnv, useRef, useState } from "@odoo/owl";
 import { toolbarButtonProps } from "@html_editor/main/toolbar/toolbar";
 import { AnimateOption } from "./animate_option";
 import { usePopover } from "@web/core/popover/popover_hook";
@@ -48,17 +48,17 @@ export class AnimateText extends Component {
         this.updateState();
 
         this.root = useRef("root");
+        useChildSubEnv({
+            dependencyManager: new DependencyManager(),
+            getEditingElement: () => this.activeElement,
+            getEditingElements: () => (this.activeElement ? [this.activeElement] : []),
+            weContext: {},
+            editor: this.props.config.editor,
+            editorBus: this.props.config.editorBus,
+            services: this.props.config.editor.services,
+        });
         this.popover = usePopover(AnimateTextPopover, {
-            env: {
-                ...this.env,
-                dependencyManager: new DependencyManager(),
-                getEditingElement: () => this.activeElement,
-                getEditingElements: () => (this.activeElement ? [this.activeElement] : []),
-                weContext: {},
-                editor: this.props.config.editor,
-                editorBus: this.props.config.editorBus,
-                services: this.props.config.editor.services,
-            },
+            env: this.__owl__.childEnv,
             onClose: () => {
                 if (!this.props.config.editor.isDestroyed) {
                     this.updateState();

--- a/addons/website/static/tests/builder/popover.test.js
+++ b/addons/website/static/tests/builder/popover.test.js
@@ -1,0 +1,77 @@
+import { setSelection } from "@html_editor/../tests/_helpers/selection";
+import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
+import { expect, test } from "@odoo/hoot";
+import { observe, queryFirst, queryOne, scroll, waitFor } from "@odoo/hoot-dom";
+import { contains } from "@web/../tests/web_test_helpers";
+import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { animationFrame } from "@odoo/hoot-mock";
+
+defineWebsiteModels();
+
+async function waitForReposition(target) {
+    await Promise.race([
+        new Promise((resolve) => {
+            const disconnect = observe(target, (mutations) => {
+                for (const mutation of mutations) {
+                    if (mutation.type === "attributes" && mutation.attributeName === "style") {
+                        disconnect();
+                        resolve();
+                    }
+                }
+            });
+        }),
+        new Promise((_, reject) => setTimeout(() => reject("Timeout waiting for reposition"), 300)),
+    ]);
+}
+
+test("Popovers scroll with iframe", async () => {
+    await setupWebsiteBuilder(`<p>plop</p>`);
+    const body = queryFirst(":iframe body");
+    const p = queryOne(":iframe p");
+    // Make sure we can scroll
+    p.style.height = "1000px";
+    setSelection({
+        anchorNode: p.firstChild,
+        anchorOffset: 0,
+        focusOffset: 4,
+    });
+
+    await waitFor(".o-we-toolbar");
+    await expandToolbar();
+
+    const expectScroll = async (popoverSelector) => {
+        const popover = await waitFor(popoverSelector);
+        const previousTop = parseFloat(getComputedStyle(popover).top);
+        // Wait for the initial positioning
+        await waitForReposition(popover);
+
+        const delta = 100;
+        await scroll(body, { y: delta }, { scrollable: false, force: true });
+        await animationFrame();
+        expect(popover).toHaveStyle({
+            top: `${previousTop - delta}px`,
+        });
+        await scroll(body, { y: 0 }, { scrollable: false });
+        await animationFrame();
+        expect(popover).toHaveStyle({
+            top: `${previousTop}px`,
+        });
+    };
+
+    await contains(".o-we-toolbar button.o-select-color-background").click();
+    await expectScroll(".o_popover:has(> .o_font_color_selector)");
+
+    await contains(".o-we-toolbar div[name=websiteDecoration] > button").click();
+    await expectScroll(".o_popover");
+
+    await contains(".o-we-toolbar button.o-select-highlight").click();
+    await expectScroll(".o_popover");
+
+    await contains(".o-we-toolbar button[title='Animate Text']").click();
+    await expectScroll(".o_popover:has(> .o_animate_text_popover)");
+
+    await contains(".o-we-toolbar button[name=link]").click();
+    await contains(".o-we-linkpopover select[name=link_type]").select("custom");
+    await contains(".o-we-linkpopover button.custom-text-picker").click();
+    await expectScroll(".o_popover:has(> .o_font_color_selector)");
+});


### PR DESCRIPTION
__Current behavior before commit:__
Some popovers that are toggled from the toolbar are not repositioned
when the user scrolls in the website iframe.

__Description of the fix:__
`this.__owl__.childEnv` is passed as `env` to `usePopover` such that the
`POSITION_BUS` entry is included.
Child env is used to avoid polluting the env of the parent component.

__Steps to reproduce the issue on runbot:__
1. Open the Website builder
2. Select some text
3. Click on the *Background Color* item
(or *Highlight* or *Link* > *Custom* > *Text Color*)
4. Scroll the page
The color picker popover doesn't follow the page scrolling.