### PR TITLE
[FIX] point_of_sale: load updated ptav

### DIFF
--- a/addons/point_of_sale/models/product_attribute.py
+++ b/addons/point_of_sale/models/product_attribute.py
@@ -46,6 +46,11 @@ class ProductTemplateAttributeValue(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
+        last_server_date = self.env.context.get('pos_last_server_date', False)
+        limited_loading = self.env.context.get('pos_limited_loading', True)
+        if last_server_date and limited_loading:
+            return []
+
         ptav_ids = {ptav_id for p in data['product.product'] for ptav_id in p['product_template_variant_value_ids']}
         ptav_ids.update({ptav_id for ptal in data['product.template.attribute.line'] for ptav_id in ptal['product_template_value_ids']})
         return AND([

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2638,6 +2638,54 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         with self.assertRaises(UserError):
             self.partner1.unlink()
 
+    def test_ptav_load_after_extra_price_change(self):
+        product = self.env['product.template'].create({
+            'name': 'Product Test',
+            'available_in_pos': True,
+            'list_price': 10,
+            'taxes_id': False,
+        })
+
+        attribute = self.env['product.attribute'].create({
+            'name': 'Attribute',
+            'create_variant': 'no_variant',
+            'value_ids': [(0, 0, {
+                'name': 'Value 1',
+            }), (0, 0, {
+                'name': 'Value 2',
+            })],
+        })
+
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product.id,
+            'attribute_id': attribute.id,
+            'value_ids': [(6, 0, attribute.value_ids.ids)],
+            'sequence': 3,
+        })
+
+        first_ptav = product.attribute_line_ids.product_template_value_ids[0]
+
+        self.pos_config.open_ui()
+        loaded_ptav = self.pos_config.current_session_id.load_data([])['product.template.attribute.value']
+
+        self.assertIn(first_ptav.id, [ptav['id'] for ptav in loaded_ptav])
+
+        loaded_ptav = self.pos_config.current_session_id.with_context(
+            pos_limited_loading=True,
+            pos_last_server_date=fields.Datetime.to_string(fields.Datetime.now()),
+        ).load_data([])['product.template.attribute.value']
+
+        self.assertNotIn(first_ptav.id, [ptav['id'] for ptav in loaded_ptav])
+
+        first_ptav.write({'price_extra': 5})
+
+        loaded_ptav = self.pos_config.current_session_id.with_context(
+            pos_limited_loading=True,
+            pos_last_server_date=fields.Datetime.to_string(first_ptav.write_date - timedelta(seconds=1)),
+        ).load_data([])['product.template.attribute.value']
+
+        self.assertIn(first_ptav.id, [ptav['id'] for ptav in loaded_ptav])
+
     def test_order_refund_lot_valuated(self):
         product2 = self.env['product.product'].create({
             'name': 'Product B',


### PR DESCRIPTION
Before this commit, when changing the extra price of a ptav with the no variant creation mode, the updated price was not loaded.

After this commit, the updated extra price is correctly loaded.

opw-5015868

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
