### PR TITLE
[FIX] l10n_it_stock_ddt,stock_delivery: kit component value

### DIFF
--- a/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
+++ b/addons/l10n_it_stock_ddt/report/l10n_it_ddt_report.xml
@@ -127,12 +127,17 @@
                                         <span t-field="move.sale_line_id.discount"/>
                                     </td>
                                     <td>
+                                        <!-- TODO: original block kept for XPath backward compatibility in stable.
+                                             lst_price will be overwritten if 'stock_delivery' is installed.
+                                             Remove this in master
+                                        -->
                                         <t t-if="move.sale_line_id">
                                             <t t-set="lst_price" t-value="move.sale_line_id.price_reduce_taxexcl * move.quantity + move.sale_line_id.price_tax"/>
                                         </t>
                                         <t t-else="">
                                             <t t-set="lst_price" t-value="move.product_id.lst_price * move.product_uom._compute_quantity(move.quantity, move.product_id.uom_id)"/>
                                         </t>
+                                        <t t-set="lst_price" t-value="move.move_line_ids[0].sale_price"/>
                                         <span t-esc="lst_price"  t-options='{"widget": "monetary", "display_currency": o.company_id.currency_id}'/>
                                         <t t-set="total_value" t-value="total_value + lst_price"/>
                                     </td>

--- a/addons/stock_delivery/models/stock_move.py
+++ b/addons/stock_delivery/models/stock_move.py
@@ -59,13 +59,19 @@ class StockMoveLine(models.Model):
         for move_line in self:
             sale_line_id = move_line.move_id.sale_line_id
             if sale_line_id and sale_line_id.product_id == move_line.product_id:
-                unit_price = sale_line_id.price_reduce_taxinc
+                # Compute the total price (tax included) for the actually delivered quantity
+                # using the same tax logic as the sale order line and purchase order line.
+                base_line = sale_line_id._convert_to_tax_base_line_dict()
                 qty = move_line.product_uom_id._compute_quantity(move_line.quantity, sale_line_id.product_uom)
+                base_line.update({'quantity': qty})
+                tax_results = self.env['account.tax'].with_company(sale_line_id.company_id)._compute_taxes([base_line])
+                totals = next(iter(tax_results['totals'].values()))
+                move_line.sale_price = totals['amount_untaxed'] + totals['amount_tax']
             else:
                 # For kits, use the regular unit price
                 unit_price = move_line.product_id.list_price
                 qty = move_line.product_uom_id._compute_quantity(move_line.quantity, move_line.product_id.uom_id)
-            move_line.sale_price = unit_price * qty
+                move_line.sale_price = unit_price * qty
         super(StockMoveLine, self)._compute_sale_price()
 
     def _get_aggregated_product_quantities(self, **kwargs):

--- a/addons/stock_delivery/tests/test_delivery_stock_move.py
+++ b/addons/stock_delivery/tests/test_delivery_stock_move.py
@@ -304,3 +304,33 @@ class StockMoveInvoice(AccountTestInvoicingCommon):
             {'date': yesterday},
             {'date': today},
         ])
+
+    def test_delivery_slip_product_value(self):
+        """Test that product value reported on the delivery slip is correct.
+        """
+        product = self.product_cable_management_box
+        tax = self.company_data['default_tax_sale']
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'partner_invoice_id': self.partner_a.id,
+            'partner_shipping_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_uom_qty': 180,
+                    'product_uom': product.uom_id.id,
+                    'price_unit': 1.49,
+                    'tax_id': [Command.set(tax.ids)],
+                })],
+        })
+
+        sale_order.action_confirm()
+
+        # Testing full quantity, should be equal to the price total on the sale order line
+        sale_order.picking_ids.move_ids.quantity = 180
+        self.assertEqual(sale_order.picking_ids.move_line_ids.sale_price, sale_order.order_line.price_total, "Price on delivery slip is not correct")
+
+        # Testing a partial quantity
+        sale_order.picking_ids.move_ids.quantity = 150
+        self.assertEqual(sale_order.picking_ids.move_line_ids.sale_price, 257.03, "Price on delivery slip is not correct")


### PR DESCRIPTION
Steps to reproduce:
- Have an IT company setup
- Create a product with a Sales Price and define a kit BOM with 2 components
- Create SO with product
- Confirm, go to delivery, validate
- Print

Issue:
In the delivery DDT, there is a summary of the delivery where each item has its own entry (product, quantity, value).
However, in case of kit BOM, each component is reported with the full value of the sale operation.

Analysis:
This occurs because in the report code we don't consider the possibility of kit products, where multiple components are associated to the same sale line.

Ticket [link](https://www.odoo.com/odoo/project.task/5013606)
opw-5013606