### PR TITLE
[PERF] account: Fix OOM when opening Secure Entries wizard

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3933,7 +3933,25 @@ class AccountMove(models.Model):
         """
         if not self:
             return False
-        last_move_in_chain = max(self, key=lambda m: m.sequence_number)
+
+        # Delegate to the database, instead of max(self, key=lambda m: m.sequence_number)
+        last_move_in_chain = (
+            self.env['account.move']
+            .sudo()
+            .search_fetch(
+                domain=[('id', 'in', self.ids)],
+                field_names=[
+                    'sequence_prefix',
+                    'sequence_number',
+                    'journal_id',
+                    # Pre-emptive fetching for `_is_move_restricted`
+                    'state',
+                    'restrict_mode_hash_table',
+                ],
+                order='sequence_number desc',
+                limit=1,
+            )
+        )
         journal = last_move_in_chain.journal_id
         if not self._is_move_restricted(last_move_in_chain, force_hash=force_hash):
             return False
@@ -3942,10 +3960,10 @@ class AccountMove(models.Model):
             ('journal_id', '=', journal.id),
             ('sequence_prefix', '=', last_move_in_chain.sequence_prefix),
         ]
-        last_move_hashed = self.env['account.move'].search([
+        last_move_hashed = self.env['account.move'].search_fetch([
             *common_domain,
             ('inalterable_hash', '!=', False),
-        ], order='sequence_number desc', limit=1)
+        ], ['sequence_number', 'inalterable_hash'], order='sequence_number desc', limit=1)
 
         domain = self.env['account.move']._get_move_hash_domain([
             *common_domain,
@@ -3960,34 +3978,43 @@ class AccountMove(models.Model):
         # so we can stop the computation early if we find at least one document to hash
         if early_stop:
             return self.env['account.move'].sudo().search_count(domain, limit=1)
-        moves_to_hash = self.env['account.move'].sudo().search(domain, order='sequence_number')
-        warnings = set()
-        if moves_to_hash:
-            # gap warning
-            if last_move_hashed:
-                first = last_move_hashed.sequence_number
-                difference = len(moves_to_hash)
-            else:
-                first = moves_to_hash[0].sequence_number
-                difference = len(moves_to_hash) - 1
-            last = moves_to_hash[-1].sequence_number
-            if first + difference != last:
-                warnings.add('gap')
-
-            # unreconciled warning
-            unreconciled = False in moves_to_hash.statement_line_ids.mapped('is_reconciled')
-            if unreconciled:
-                warnings.add('unreconciled')
-        else:
-            warnings.add('no_document')
-        moves = moves_to_hash.sudo(False)
-        return {
+        moves_to_hash = self.env['account.move'].sudo().search_fetch(domain, ['sequence_number'], order='sequence_number')
+        info = {
             'previous_hash': last_move_hashed.inalterable_hash,
             'last_move_hashed': last_move_hashed,
+        }
+        if self.env.context.get('chain_info_warnings', True):
+            warnings = set()
+            if moves_to_hash:
+                # gap warning
+                if last_move_hashed:
+                    first = last_move_hashed.sequence_number
+                    difference = len(moves_to_hash)
+                else:
+                    first = moves_to_hash[0].sequence_number
+                    difference = len(moves_to_hash) - 1
+                last = moves_to_hash[-1].sequence_number
+                if first + difference != last:
+                    warnings.add('gap')
+
+                # unreconciled warning
+                has_unreconciled = bool(self.env['account.bank.statement.line'].search_count([
+                    ('move_id', 'in', moves_to_hash.ids),
+                    ('is_reconciled', '=', False),
+                ], limit=1))
+                if has_unreconciled:
+                    warnings.add('unreconciled')
+            else:
+                warnings.add('no_document')
+
+            info['warnings'] = warnings
+
+        moves = moves_to_hash.sudo(False)
+        info.update({
             'moves': moves,
             'remaining_moves': self - moves,
-            'warnings': warnings,
-        }
+        })
+        return info
 
     def _get_chains_to_hash(self, force_hash=False, raise_if_gap=True, raise_if_no_document=True, include_pre_last_hash=False, early_stop=False):
         """

--- a/addons/account/wizard/account_secure_entries_wizard.py
+++ b/addons/account/wizard/account_secure_entries_wizard.py
@@ -67,13 +67,18 @@ class AccountSecureEntries(models.TransientModel):
     def _compute_max_hash_date(self):
         today = fields.Date.context_today(self)
         for wizard in self:
-            chains_to_hash = wizard._get_chains_to_hash(wizard.company_id, today)
+            chains_to_hash = wizard.with_context(chain_info_warnings=False)._get_chains_to_hash(wizard.company_id, today)
             moves = self.env['account.move'].concat(
                 *[chain['moves'] for chain in chains_to_hash],
                 *[chain['not_hashable_unlocked_moves'] for chain in chains_to_hash],
             )
             if moves:
-                wizard.max_hash_date = min(move.date for move in moves) - timedelta(days=1)
+                min_date = self.env.execute_query(
+                    self.env['account.move']
+                    ._search([('id', 'in', moves.ids)])
+                    .select('MIN(date)')
+                )[0][0]
+                wizard.max_hash_date = min_date - timedelta(days=1)
             else:
                 wizard.max_hash_date = False
 
@@ -81,30 +86,30 @@ class AccountSecureEntries(models.TransientModel):
     def _get_chains_to_hash(self, company_id, hash_date):
         self.ensure_one()
         res = []
-        moves = self.env['account.move'].sudo().search(
-            self._get_unhashed_moves_in_hashed_period_domain(company_id, hash_date, [('state', '=', 'posted')])
-        )
-        for journal, journal_moves in moves.grouped('journal_id').items():
-            for chain_moves in journal_moves.grouped('sequence_prefix').values():
-                chain_info = chain_moves._get_chain_info(force_hash=True)
-                if not chain_info:
-                    continue
+        for *__, chain_moves in self.env['account.move'].sudo()._read_group(
+            domain=self._get_unhashed_moves_in_hashed_period_domain(company_id, hash_date, [('state', '=', 'posted')]),
+            groupby=['journal_id', 'sequence_prefix'],
+            aggregates=['id:recordset']
+        ):
+            chain_info = chain_moves._get_chain_info(force_hash=True)
+            if not chain_info:
+                continue
 
-                last_move_hashed = chain_info['last_move_hashed']
-                # It is possible that some moves cannot be hashed (i.e. after upgrade).
-                # We show a warning ('account_not_hashable_unlocked_moves') if that is the case.
-                # These moves are ignored for the warning and max_hash_date in case they are protected by the Hard Lock Date
-                if last_move_hashed:
-                    # remaining_moves either have a hash already or have a higher sequence_number than the last_move_hashed
-                    not_hashable_unlocked_moves = chain_info['remaining_moves'].filtered(
-                        lambda move: (not move.inalterable_hash
-                                      and move.sequence_number < last_move_hashed.sequence_number
-                                      and move.date > self.company_id.user_hard_lock_date)
-                    )
-                else:
-                    not_hashable_unlocked_moves = self.env['account.move']
-                chain_info['not_hashable_unlocked_moves'] = not_hashable_unlocked_moves
-                res.append(chain_info)
+            last_move_hashed = chain_info['last_move_hashed']
+            # It is possible that some moves cannot be hashed (i.e. after upgrade).
+            # We show a warning ('account_not_hashable_unlocked_moves') if that is the case.
+            # These moves are ignored for the warning and max_hash_date in case they are protected by the Hard Lock Date
+            if last_move_hashed:
+                # remaining_moves either have a hash already or have a higher sequence_number than the last_move_hashed
+                not_hashable_unlocked_moves = chain_info['remaining_moves'].filtered(
+                    lambda move: (not move.inalterable_hash
+                                  and move.sequence_number < last_move_hashed.sequence_number
+                                  and move.date > self.company_id.user_hard_lock_date)
+                )
+            else:
+                not_hashable_unlocked_moves = self.env['account.move']
+            chain_info['not_hashable_unlocked_moves'] = not_hashable_unlocked_moves
+            res.append(chain_info)
         return res
 
     @api.depends('company_id', 'company_id.user_hard_lock_date', 'hash_date')


### PR DESCRIPTION
Description
-----------
On a database where the user doesn't Secure their accounting entries regularly, it's possible over a long period to accumulate a lot of pending invoices that needs to be hashed.

This can lead to the processing of a large number of moves when opening the Secure Entries wizard, more specifically: 
```
-> `_compute_warnings`
    -> `_compute_hash_date`
        -> `_compute_max_hash_date`
            -> `_get_chains_to_hash`
```
While manipulating this large recordset, the ORM prefetcher will read *all* fields on the model upon the first cache miss, which usually are a lot, and some of them are quite large (label type fields).

This commit refactors the code to avoid any cache miss by fetching only what is necessary. This is achieved by:
- Use of a `_read_group` instead of 2 subsequent `groupby`
- Delegate `max` and `min` lookup to the database
- Explicitly fetch the fields that are going to be read
- Avoid the linear search into the associated statement lines for unreconciled moves
- Introduce a context key `chain_info_warnings` to skip the warnings computation of `_get_chain_info`, as it's unused for the context of `_compute_max_hash_date`.

Benchmark
---------
On a database with over 1.3M `account.move` that are pending hashing, opening the wizard for the Secure Entries took:

|              | Before* | After   | Improvement |
|--------------|---------|---------|-------------|
| Memory       | 6.8 GiB | 700 MiB | 9.9x        |
| Query Count  | 26.7k   | 18.5k   | 1.4x        |
| Timing SQL   | 41.2s   | 18s     | 2.3x        |
| Timing PY    | 7.29min | 14s     | 31.2x       |
| Timing Total | 7.98min | 32s     | 15x         |

\* - benchmark was taken with unlimited memory, the request takes more than 2 GiB -> OOM killed and never completes

Reference
---------
opw-5014345

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
