### PR TITLE
[FIX] web_editor: fix rendering of bluesky icon

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -86,6 +86,8 @@ class Web_Editor(http.Controller):
             elif int(icon) == 61569:  # F081
                 icon = "59395"  # E803
                 font = "/web/static/fonts/twitter_x_only.woff"
+            elif int(icon) == 59651:
+                font = "/web/static/fonts/bluesky_only.woff"
 
         size = max(width, height, 1) if width else size
         width = width or size


### PR DESCRIPTION
The bluesky icon was not rendering correctly because it is not on the version of fontawesome that we are using. Added a change similar to other social media icons that are not on the version that we are using with the already existing bluesky icon that was in the fonts folder.

opw-5024970
