### PR TITLE
[IMP] mail: discuss app remembers last discuss conversation open

### DIFF
--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -426,7 +426,7 @@ test("unknown livechat can be displayed and interacted with", async () => {
     env.services.bus_service.subscribe("discuss.channel/new_message", () =>
         asyncStep("discuss.channel/new_message")
     );
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -3,6 +3,7 @@ import { browser } from "@web/core/browser/browser";
 
 const NO_MEMBERS_DEFAULT_OPEN_LS = "mail.user_setting.no_members_default_open";
 export const DISCUSS_SIDEBAR_COMPACT_LS = "mail.user_setting.discuss_sidebar_compact";
+export const LAST_DISCUSS_ACTIVE_ID_LS = "mail.user_setting.discuss_last_active_id";
 
 export class DiscussApp extends Record {
     INSPECTOR_WIDTH = 300;
@@ -40,7 +41,26 @@ export class DiscussApp extends Record {
             }
         },
     });
-    thread = fields.One("Thread");
+    lastActiveId = fields.Attr(undefined, {
+        /** @this {import("models").DiscussApp} */
+        compute() {
+            return browser.localStorage.getItem(LAST_DISCUSS_ACTIVE_ID_LS) ?? undefined;
+        },
+        /** @this {import("models").DiscussApp} */
+        onUpdate() {
+            if (this.lastActiveId) {
+                browser.localStorage.setItem(LAST_DISCUSS_ACTIVE_ID_LS, this.lastActiveId);
+            } else {
+                browser.localStorage.removeItem(LAST_DISCUSS_ACTIVE_ID_LS);
+            }
+        },
+    });
+    thread = fields.One("Thread", {
+        /** @this {import("models").DiscussApp} */
+        onUpdate() {
+            this.lastActiveId = this.store.Thread.localIdToActiveId(this.thread?.localId);
+        },
+    });
     hasRestoredThread = false;
 
     static new() {

--- a/addons/mail/static/src/core/public_web/discuss_client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_client_action.js
@@ -39,7 +39,7 @@ export class DiscussClientAction extends Component {
             props.action.context.active_id ??
             props.action.params?.active_id ??
             this.store.Thread.localIdToActiveId(this.store.discuss.thread?.localId) ??
-            (this.env.services.ui.isSmall ? undefined : "mail.box_inbox")
+            (this.env.services.ui.isSmall ? undefined : this.store.discuss.lastActiveId)
         );
     }
 

--- a/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
+++ b/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
@@ -27,7 +27,7 @@ patch(DiscussCoreCommon.prototype, {
             (msg) => !msg.thread?.eq(thread)
         );
         if (thread.eq(this.store.discuss.thread)) {
-            this.store.inbox.setAsDiscussThread();
+            this.store.discuss.thread = undefined;
         }
         super._handleNotificationChannelDelete(thread, metadata);
     },

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -179,7 +179,7 @@ test("Message (hard) delete notification", async () => {
         res_partner_id: serverState.partnerId,
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await click("[title='Mark as Todo']");
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     await contains("button", { text: "Starred messages", contains: [".badge", { text: "1" }] });

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -507,7 +507,7 @@ test("start call when accepting from push notification", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-DiscussContent-threadName[title=Inbox]");
     serviceWorker.dispatchEvent(
         new MessageEvent("message", {

--- a/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
@@ -91,7 +91,7 @@ test("open channel in discuss from push notification", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-DiscussContent-threadName[title='Inbox']");
     browser.navigator.serviceWorker.dispatchEvent(
         new MessageEvent("message", {

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -41,10 +41,12 @@ test("can create a new channel", async () => {
     listenStoreFetch(undefined, { logParams: ["/discuss/create_channel"] });
     await start();
     await openDiscuss();
-    await waitStoreFetch(
-        ["failures", "systray_get_activities", "init_messaging", "channels_as_member"],
-        { stepsAfter: ['/mail/inbox/messages - {"fetch_params":{"limit":30}}'] }
-    );
+    await waitStoreFetch([
+        "failures",
+        "systray_get_activities",
+        "init_messaging",
+        "channels_as_member",
+    ]);
     await contains(".o-mail-Discuss");
     await contains(".o-mail-DiscussSidebar-item", { text: "abc", count: 0 });
     await click("input[placeholder='Search conversations']");
@@ -99,9 +101,7 @@ test("can make a DM chat", async () => {
     await start();
     await waitStoreFetch(["failures", "systray_get_activities", "init_messaging"]);
     await openDiscuss();
-    await waitStoreFetch(["channels_as_member"], {
-        stepsAfter: ['/mail/inbox/messages - {"fetch_params":{"limit":30}}'],
-    });
+    await waitStoreFetch(["channels_as_member"]);
     await contains(".o-mail-Discuss");
     await contains(".o-mail-DiscussSidebar-item", { text: "Mario", count: 0 });
     await click("input[placeholder='Search conversations']");

--- a/addons/mail/static/tests/discuss/core/web/sidebar.test.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar.test.js
@@ -27,7 +27,7 @@ test("unknown channel can be displayed and interacted with", async () => {
     env.services.bus_service.subscribe("discuss.channel/new_message", () =>
         asyncStep("discuss.channel/new_message")
     );
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await openDiscuss(channelId);

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -41,7 +41,7 @@ test("reply: discard on reply button toggle", async () => {
         res_partner_id: serverState.partnerId,
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
     await click("[title='Reply']");
     await contains(".o-mail-Composer");
@@ -69,7 +69,7 @@ test("reply: discard on pressing escape", async () => {
         res_partner_id: serverState.partnerId,
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
     await click("[title='Reply']");
     await contains(".o-mail-Composer");
@@ -114,7 +114,7 @@ test('"reply to" composer should log note if message replied to is a note', asyn
         expect(args.post_data.subtype_xmlid).toBe("mail.mt_note");
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
     await click("[title='Reply']");
     await contains(".o-mail-Composer [placeholder='Log an internal note…']");
@@ -148,7 +148,7 @@ test('"reply to" composer should send message if message replied to is not a not
         expect(args.post_data.subtype_xmlid).toBe("mail.mt_comment");
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
     await click("[title='Reply']");
     await contains(".o-mail-Composer [placeholder='Send a message to followers…']");
@@ -173,7 +173,7 @@ test("show subject of message in Inbox", async () => {
         res_partner_id: serverState.partnerId,
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message", { text: "Subject: Salutations, voyageurnot empty" });
 });
 
@@ -401,7 +401,7 @@ test("inbox: mark all messages as read", async () => {
         },
     ]);
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains("button", { text: "Inbox", contains: [".badge", { text: "2" }] });
     await contains(".o-mail-DiscussSidebarChannel", {
         contains: [
@@ -445,7 +445,7 @@ test("inbox: mark as read should not display jump to present", async () => {
             }))
     );
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     // scroll up so that there's the "Jump to Present".
     // So that assertion of negative matches the positive assertion
     await contains(".o-mail-Message", { count: 30 });
@@ -488,7 +488,7 @@ test("click on (non-channel/non-partner) origin thread link should redirect to f
         },
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
     await click(".o-mail-Message-header a", { text: "Some record" });
     await def;
@@ -534,7 +534,7 @@ test("inbox messages are never squashed", async () => {
         },
     ]);
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message", { count: 2 });
     await contains(".o-mail-Message:not(.o-squashed)", { text: "body1" });
     await contains(".o-mail-Message:not(.o-squashed)", { text: "body2" });
@@ -558,7 +558,7 @@ test("reply: stop replying button click", async () => {
         res_partner_id: serverState.partnerId,
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
     await click("[title='Reply']");
     await contains(".o-mail-Composer");
@@ -583,7 +583,7 @@ test("error notifications should not be shown in Inbox", async () => {
         res_partner_id: serverState.partnerId,
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
     await contains(".o-mail-Message-header small", { text: "on Demo User" });
     await contains(`.o-mail-Message-header a[href*='/odoo/res.partner/${partnerId}']`, {
@@ -609,7 +609,7 @@ test("emptying inbox displays rainbow man in inbox", async () => {
         },
     ]);
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
     await click("button:enabled", { text: "Mark all read" });
     await contains(".o_reward_rainbow");
@@ -666,7 +666,7 @@ test("Counter should be incremented by 1 when receiving a message with a mention
         },
     ]);
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     const mention = [serverState.partnerId];
     const mentionName = serverState.partnerName;
@@ -715,7 +715,7 @@ test("Clear need action counter when opening a channel", async () => {
         },
     ]);
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-DiscussSidebar-item", {
         text: "General",
         contains: [".badge", { text: "2" }],
@@ -745,7 +745,7 @@ test("can reply to email message", async () => {
         res_partner_id: serverState.partnerId,
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
     await click("[title='Reply']");
     await contains(".o-mail-Composer", { text: "Replying to md@oilcompany.fr" });

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -41,7 +41,7 @@ test("toggling category button hide category items", async () => {
         channel_type: "channel",
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel");
     await click(
@@ -201,7 +201,7 @@ test("default thread rendering", async () => {
         },
     ]);
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await contains("button", { text: "Inbox" });
     await contains("button", { text: "Starred messages" });
     await contains("button", { text: "History" });
@@ -1288,7 +1288,7 @@ test("Redirect to the thread containing the starred message and highlight the me
         body: "<p>Hello there!!!</p>",
     });
     await start();
-    await openDiscuss();
+    await openDiscuss("mail.box_inbox");
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await click(".o-mail-Message [title='Mark as Todo']");
     await click("button", { text: "Starred messages", contains: [".badge", { count: 1 }] });

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -198,6 +198,17 @@ export class DiscussChannel extends models.ServerModel {
         this.write([channel.id], { description });
     }
 
+    unlink(ids) {
+        /** @type {import("mock_models").BusBus} */
+        const BusBus = this.env["bus.bus"];
+
+        const channels = this.browse(ids);
+        for (const channel of channels) {
+            BusBus._sendone(channel, "discuss.channel/delete", { id: channel.id });
+        }
+        return super.unlink(...arguments);
+    }
+
     /**
      * @param {string} name
      * @param {string} [group_id]

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -811,7 +811,7 @@ test("can be marked as read while loading", async () => {
     const loadDeferred = new Deferred();
     onRpc("/discuss/channel/messages", () => loadDeferred);
     await start();
-    await openDiscuss(undefined);
+    await openDiscuss();
     await contains(".o-discuss-badge", { text: "1" });
     await click(".o-mail-DiscussSidebarChannel", { text: "Demo" });
     loadDeferred.resolve();


### PR DESCRIPTION
Before this commit, active thread of discuss when none is provided (i.e. no active id in URL, no "open in discuss" from chat window) would default to inbox all the time.

This is great for "Handle in Odoo" notification preference users, but for "Handle by Email" (which is the default), this is depressing to see the same empty screen.

This commit improves the UX by remembering the last open thread in discuss app even after a page reload. Before this commit this was saved in RAM but a page reload would keep showing inbox. With this commit, thanks to saving this info in local storage, a non-inbox user would never have inbox pre-selected automatically.

This makes also using discuss app more natural to use, since the likelihood to be interested by last opened conversation is high.

When the last conversation cannot be recovered, this commit now fallbacks to the "no conversation selected" state. This is again a better showing than inbox, which is planned for reduced visibility for "Handle by Email" users.

Part of Task-4967071
