### PR TITLE
[IMP] pos_restaurant: default course allocation on product select

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -394,8 +394,10 @@ export class ProductScreen extends Component {
                 options["presetVariant"] = searchedProduct[0];
             }
         }
-        await this.pos.addLineToCurrentOrder({ product_tmpl_id: product }, options);
+        const line = await this.pos.addLineToCurrentOrder({ product_tmpl_id: product }, options);
         this.showOptionalProductPopupIfNeeded(product);
+
+        return line;
     }
     showOptionalProductPopupIfNeeded(product) {
         if (product.pos_optional_product_ids?.length) {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
@@ -38,7 +38,7 @@ export async function generateFireCourseReceipts() {
         new: [],
         cancelled: [],
         noteUpdate: course.lines.map((line) => ({ product_id: line.getProduct().id })),
-        noteUpdateTitle: _t("Course %s fired", "" + course.index),
+        noteUpdateTitle: `${course.name} ${_t("fired")}`,
         printNoteUpdateData: false,
     };
     return await generateReceiptsToPrint(order, orderChange);

--- a/addons/point_of_sale/views/pos_category_view.xml
+++ b/addons/point_of_sale/views/pos_category_view.xml
@@ -19,7 +19,7 @@
                         <group name="sequence">
                             <field name="color" widget="color_picker" />
                         </group>
-                        <div name="available_between" class="row col-lg-12" invisible="1">
+                        <div name="available_between" class="row col-lg-6" invisible="1">
                             <span class="text-900 fw-bold">Available between
                                 <span class="col-lg-4 o_light_label">
                                     <a class="o-tooltip"><sup title="Only works for online and self order">?</sup></a>

--- a/addons/pos_restaurant/__manifest__.py
+++ b/addons/pos_restaurant/__manifest__.py
@@ -21,6 +21,8 @@ This module adds several features to the Point of Sale that are specific to rest
     'data': [
         'security/ir.model.access.csv',
         'data/scenarios/restaurant_preset.xml',
+        'views/pos_category_view.xml',
+        'views/pos_course_views.xml',
         'views/pos_order_views.xml',
         'views/pos_restaurant_views.xml',
         'views/pos_preset_views.xml',

--- a/addons/pos_restaurant/models/__init__.py
+++ b/addons/pos_restaurant/models/__init__.py
@@ -10,3 +10,5 @@ from . import pos_session
 from . import res_config_settings
 from . import pos_preset
 from . import restaurant_order_course
+from . import pos_category
+from . import pos_course

--- a/addons/pos_restaurant/models/pos_category.py
+++ b/addons/pos_restaurant/models/pos_category.py
@@ -1,0 +1,11 @@
+from odoo import fields, models, api
+
+
+class PosCategory(models.Model):
+    _inherit = 'pos.category'
+
+    course_id = fields.Many2one('pos.course', string="Course", index=True)
+
+    @api.model
+    def _load_pos_data_fields(self, config):
+        return super()._load_pos_data_fields(config) + ['course_id']

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -13,6 +13,7 @@ class PosConfig(models.Model):
     floor_ids = fields.Many2many('restaurant.floor', string='Restaurant Floors', help='The restaurant floors served by this point of sale.', copy=False)
     set_tip_after_payment = fields.Boolean('Set Tip After Payment', help="Adjust the amount authorized by payment terminals to add a tip after the customers left or at the end of the day.")
     default_screen = fields.Selection([('tables', 'Tables'), ('register', 'Register')], string='Default Screen', default='tables')
+    use_course_allocation = fields.Boolean(string="Enable Course Allocation")
 
     def _get_forbidden_change_fields(self):
         forbidden_keys = super(PosConfig, self)._get_forbidden_change_fields()

--- a/addons/pos_restaurant/models/pos_course.py
+++ b/addons/pos_restaurant/models/pos_course.py
@@ -1,0 +1,30 @@
+from odoo import api, fields, models
+
+
+class PosCourse(models.Model):
+    _name = 'pos.course'
+    _description = 'POS Course'
+    _inherit = ['pos.load.mixin']
+    _order = 'sequence'
+
+    def _default_sequence(self):
+        return (self.search([], order="sequence desc", limit=1).sequence or 0) + 1
+
+    name = fields.Char(string="Course Name", required=True)
+    sequence = fields.Integer(string="Sequence", default=_default_sequence)
+    category_ids = fields.One2many('pos.category', 'course_id', string="Pos Category")
+
+    _name_unique = models.Constraint(
+        'unique (name)',
+        'A course with this name already exists',
+    )
+
+    @api.model
+    def _load_pos_data_domain(self, data, config):
+        pos_categ = config.iface_available_categ_ids.ids
+        available_categ_ids = pos_categ if len(pos_categ) else self.env['pos.category'].search([]).ids
+        return [['category_ids', 'in', available_categ_ids]]
+
+    @api.model
+    def _load_pos_data_fields(self, config):
+        return ['name', 'sequence', 'category_ids']

--- a/addons/pos_restaurant/models/pos_session.py
+++ b/addons/pos_restaurant/models/pos_session.py
@@ -12,7 +12,7 @@ class PosSession(models.Model):
     def _load_pos_data_models(self, config):
         data = super()._load_pos_data_models(config)
         if self.config_id.module_pos_restaurant:
-            data += ['restaurant.floor', 'restaurant.table', 'restaurant.order.course']
+            data += ['restaurant.floor', 'restaurant.table', 'restaurant.order.course', 'pos.course']
         return data
 
     @api.model

--- a/addons/pos_restaurant/models/res_config_settings.py
+++ b/addons/pos_restaurant/models/res_config_settings.py
@@ -11,6 +11,7 @@ class ResConfigSettings(models.TransientModel):
     pos_iface_splitbill = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False)
     pos_set_tip_after_payment = fields.Boolean(compute='_compute_pos_set_tip_after_payment', store=True, readonly=False)
     pos_default_screen = fields.Selection(related="pos_config_id.default_screen", readonly=False)
+    pos_use_course_allocation = fields.Boolean(related='pos_config_id.use_course_allocation', readonly=False)
 
     @api.depends('pos_module_pos_restaurant', 'pos_config_id')
     def _compute_pos_module_pos_restaurant(self):

--- a/addons/pos_restaurant/models/restaurant_order_course.py
+++ b/addons/pos_restaurant/models/restaurant_order_course.py
@@ -9,6 +9,8 @@ class RestaurantOrderCourse(models.Model):
     _description = 'POS Restaurant Order Course'
     _inherit = ['pos.load.mixin']
 
+    name = fields.Char(string="Course Name", readonly=True)
+    course_id = fields.Many2one('pos.course', string="Course", readonly=True)
     fired = fields.Boolean(string="Fired", default=False)
     fired_date = fields.Datetime(string="Fired Date")
     uuid = fields.Char(string='Uuid', readonly=True, default=lambda self: str(uuid4()), copy=False)
@@ -27,4 +29,4 @@ class RestaurantOrderCourse(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['uuid', 'fired', 'order_id', 'line_ids', 'index', 'write_date']
+        return ['name', 'course_id', 'uuid', 'fired', 'order_id', 'line_ids', 'index', 'write_date']

--- a/addons/pos_restaurant/security/ir.model.access.csv
+++ b/addons/pos_restaurant/security/ir.model.access.csv
@@ -4,3 +4,5 @@ access_restaurant_floor_manager,restaurant.floor.manager,model_restaurant_floor,
 access_restaurant_table,restaurant.table.user,model_restaurant_table,point_of_sale.group_pos_user,1,0,0,0
 access_restaurant_table_manager,restaurant.table.manager,model_restaurant_table,point_of_sale.group_pos_manager,1,1,1,1
 access_restaurant_order_course,restaurant.order.course,model_restaurant_order_course,point_of_sale.group_pos_user,1,1,1,1
+access_pos_course,pos.course.user,model_pos_course,point_of_sale.group_pos_user,1,0,0,0
+access_pos_course_manager,pos.course.manager,model_pos_course,point_of_sale.group_pos_manager,1,1,1,1

--- a/addons/pos_restaurant/static/src/app/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order.js
@@ -111,7 +111,24 @@ patch(PosOrder.prototype, {
         }
     },
     get courses() {
-        return this.course_ids.toSorted((a, b) => a.index - b.index);
+        // Sort courses first by thier sequences, then by their index.
+        // Course that have sequence are backend created ones.
+        return this.course_ids.toSorted((a, b) => {
+            const aHasSeq = a.course_id?.sequence !== undefined;
+            const bHasSeq = b.course_id?.sequence !== undefined;
+
+            if (aHasSeq && bHasSeq) {
+                return a.course_id.sequence - b.course_id.sequence || a.index - b.index;
+            }
+
+            // If only one has sequence, keep original order (don't force top/bottom)
+            if (aHasSeq !== bHasSeq) {
+                return a.index - b.index;
+            }
+
+            // Neither has sequence sort by index
+            return a.index - b.index;
+        });
     },
     hasCourses() {
         return this.course_ids.length > 0;

--- a/addons/pos_restaurant/static/src/app/models/restaurant_order_course.js
+++ b/addons/pos_restaurant/static/src/app/models/restaurant_order_course.js
@@ -1,13 +1,9 @@
 import { registry } from "@web/core/registry";
 import { Base } from "@point_of_sale/app/models/related_models";
-import { _t } from "@web/core/l10n/translation";
 
 export class RestaurantOrderCourse extends Base {
     static pythonModel = "restaurant.order.course";
 
-    get name() {
-        return _t("Course") + " " + this.index;
-    }
     isSelected() {
         return this.order_id?.uiState.selected_course_uuid === this.uuid;
     }

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.js
@@ -6,6 +6,7 @@ import { Orderline } from "@point_of_sale/app/components/orderline/orderline";
 import { OrderDisplay } from "@point_of_sale/app/components/order_display/order_display";
 import { useRouterParamsChecker } from "@point_of_sale/app/hooks/pos_router_hook";
 import { PriceFormatter } from "@point_of_sale/app/components/price_formatter/price_formatter";
+import { _t } from "@web/core/l10n/translation";
 
 export class SplitBillScreen extends Component {
     static template = "pos_restaurant.SplitBillScreen";
@@ -129,6 +130,7 @@ export class SplitBillScreen extends Component {
                         newCourse = this.pos.models["restaurant.order.course"].create({
                             order_id: newOrder,
                             index: courseIndex,
+                            name: _t("Course ") + courseIndex,
                         });
                         newCourses.set(courseIndex, newCourse);
                     }

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -310,6 +310,7 @@ patch(PosStore.prototype, {
                         index: courseDetails.index,
                         fired: courseDetails.fired,
                         fired_date: courseDetails.fired_date,
+                        name: _t("Course ") + courseDetails.index,
                     });
                     courseDetails.lines?.forEach((lineUuid) => {
                         courseByLines[lineUuid] = course;
@@ -860,12 +861,14 @@ patch(PosStore.prototype, {
         order?.ensureCourseSelection();
         super.setOrder(order);
     },
-    addCourse() {
+    addCourse({ backendCourse } = {}) {
         const order = this.getOrder();
-
+        const nextIdx = order.getNextCourseIndex();
         const course = this.data.models["restaurant.order.course"].create({
             order_id: order,
-            index: order.getNextCourseIndex(),
+            index: nextIdx,
+            course_id: backendCourse ? backendCourse : false,
+            name: backendCourse ? backendCourse.name : _t("Course ") + nextIdx,
         });
         let selectedCourse = course;
         if (order.course_ids.length === 1 && order.lines.length > 0) {
@@ -875,6 +878,7 @@ patch(PosStore.prototype, {
             selectedCourse = this.data.models["restaurant.order.course"].create({
                 order_id: order,
                 index: order.getNextCourseIndex(),
+                name: _t("Course ") + order.getNextCourseIndex(),
             });
         }
         order.recomputeOrderData(); // To ensure that courses are stored locally
@@ -899,7 +903,7 @@ patch(PosStore.prototype, {
                 new: [],
                 cancelled: [],
                 noteUpdate: course.lines.map((line) => ({ product_id: line.getProduct().id })),
-                noteUpdateTitle: _t("Course %s fired", "" + course.index),
+                noteUpdateTitle: `${course.name} ${_t("fired")}`,
                 printNoteUpdateData: false,
             };
             this.getOrder().uiState.lastPrints.push(changes);

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -18,11 +18,7 @@ import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_in
 import * as PreparationReceipt from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
 import * as NumberPopup from "@point_of_sale/../tests/generic_helpers/number_popup_util";
 import { checkPreparationTicketData } from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
-import {
-    negate,
-    negateStep,
-    assertCurrentOrderDirty,
-} from "@point_of_sale/../tests/generic_helpers/utils";
+import { negateStep, assertCurrentOrderDirty } from "@point_of_sale/../tests/generic_helpers/utils";
 import * as FeedbackScreen from "@point_of_sale/../tests/pos/tours/utils/feedback_screen_util";
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
@@ -247,9 +243,7 @@ registry.category("web_tour.tours").add("test_pos_restaurant_course", {
             Chrome.closePrintingWarning(),
             FloorScreen.clickTable("5"),
             // Check only 2 courses are there and empty course gets removed on clicking Order button
-            {
-                trigger: negate('.order-course-name:eq(2) > span:contains("Course 3")'),
-            },
+            negateStep(ProductScreen.checkCourseAtIndex(2, "Course 3")),
             ProductScreen.fireCourseButtonHighlighted("Course 2"),
             ProductScreen.payButtonNotHighlighted(),
             ProductScreen.clickCourseButton(),
@@ -257,18 +251,44 @@ registry.category("web_tour.tours").add("test_pos_restaurant_course", {
             FloorScreen.isShown(),
             FloorScreen.clickTable("5"),
             // Check only 2 courses are there and empty course gets removed on clicking Plan button
-            {
-                trigger: negate('.order-course-name:eq(2) > span:contains("Course 3")'),
-            },
+            negateStep(ProductScreen.checkCourseAtIndex(2, "Course 3")),
             // Check empty course gets remove after fire course.
             ProductScreen.clickCourseButton(),
             ProductScreen.selectCourseLine("Course 2"),
             ProductScreen.fireCourseButton(),
             Chrome.closePrintingWarning(),
             FloorScreen.clickTable("5"),
-            {
-                trigger: negate('.order-course-name:eq(2) > span:contains("Course 3")'),
-            },
+            negateStep(ProductScreen.checkCourseAtIndex(2, "Course 3")),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_pos_restaurant_default_course", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickDisplayedProduct("Water"),
+            ProductScreen.checkCourseAtIndex(0, "Test - Starter"),
+            // if both categories are selected, the default course should be first one
+            ProductScreen.clickDisplayedProduct("Test Multi Category Product"),
+            negateStep(ProductScreen.checkCourseAtIndex(1, "Test - Main")),
+            ProductScreen.clickDisplayedProduct("Bruschetta"),
+            ProductScreen.checkCourseAtIndex(1, "Test - Main"),
+            ProductScreen.clickCourseButton(),
+            ProductScreen.clickDisplayedProduct("Wholemeal loaf"),
+            ProductScreen.checkCourseAtIndex(2, "Course 3"),
+            ProductScreen.clickOrderButton(),
+            Chrome.closePrintingWarning(),
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.checkCourseAtIndex(0, "Test - Starter"),
+            ProductScreen.clickCourseButton(),
+            ProductScreen.clickDisplayedProduct("Wholemeal loaf"),
+            ProductScreen.checkCourseAtIndex(1, "Course 2"),
+            ProductScreen.clickDisplayedProduct("Bruschetta"),
+            ProductScreen.checkCourseAtIndex(2, "Test - Main"),
         ].flat(),
 });
 

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -106,3 +106,10 @@ export function releaseTable() {
         },
     ];
 }
+
+export function checkCourseAtIndex(index, courseName) {
+    return {
+        content: `Verify that course "${courseName}" exists at index ${index}`,
+        trigger: `.order-course-name:eq(${index}) > span:contains("${courseName}")`,
+    };
+}

--- a/addons/pos_restaurant/static/tests/unit/components/product_screen.test.js
+++ b/addons/pos_restaurant/static/tests/unit/components/product_screen.test.js
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
+
+definePosModels();
+
+describe("product_screen.js", () => {
+    test("addProductToOrder", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const order = store.addNewOrder();
+
+        order.config.use_course_allocation = true;
+        order.config.iface_available_categ_ids = [1, 2, 4];
+
+        const product1 = models["product.template"].get(5);
+        const product2 = models["product.template"].get(6);
+        const product3 = models["product.template"].get(12);
+
+        const screen = await mountWithCleanup(ProductScreen, {
+            props: {
+                orderUuid: order.uuid,
+            },
+        });
+
+        await screen.addProductToOrder(product1);
+
+        expect(order.getOrderlines()).toHaveLength(1);
+        expect(order.courses).toHaveLength(1);
+        expect(order.courses[0].name).toBe("Default Course 1");
+
+        await screen.addProductToOrder(product2);
+
+        expect(order.getOrderlines()).toHaveLength(2);
+        expect(order.courses).toHaveLength(2);
+        expect(order.courses[1].name).toBe("Default Course 2");
+
+        await screen.addProductToOrder(product3);
+
+        expect(order.getOrderlines()).toHaveLength(3);
+        expect(order.courses).toHaveLength(2);
+    });
+});

--- a/addons/pos_restaurant/static/tests/unit/data/pos_category.data.js
+++ b/addons/pos_restaurant/static/tests/unit/data/pos_category.data.js
@@ -1,0 +1,8 @@
+import { patch } from "@web/core/utils/patch";
+import { PosCategory } from "@point_of_sale/../tests/unit/data/pos_category.data";
+
+patch(PosCategory.prototype, {
+    _load_pos_data_fields() {
+        return [...super._load_pos_data_fields(), "course_id"];
+    },
+});

--- a/addons/pos_restaurant/static/tests/unit/data/pos_course.data.js
+++ b/addons/pos_restaurant/static/tests/unit/data/pos_course.data.js
@@ -1,0 +1,18 @@
+import { patch } from "@web/core/utils/patch";
+import { hootPosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+import { models } from "@web/../tests/web_test_helpers";
+
+export class PosCourse extends models.ServerModel {
+    _name = "pos.course";
+
+    _load_pos_data_fields() {
+        return ["name", "sequence", "category_ids"];
+    }
+
+    _records = [
+        { id: 1, name: "Default Course 1", sequence: 1, category_ids: [1] },
+        { id: 2, name: "Default Course 2", sequence: 2, category_ids: [2] },
+    ];
+}
+
+patch(hootPosModels, [...hootPosModels, PosCourse]);

--- a/addons/pos_restaurant/static/tests/unit/data/pos_session.data.js
+++ b/addons/pos_restaurant/static/tests/unit/data/pos_session.data.js
@@ -8,6 +8,7 @@ patch(PosSession.prototype, {
             "restaurant.floor",
             "restaurant.table",
             "restaurant.order.course",
+            "pos.course",
         ];
     },
 });

--- a/addons/pos_restaurant/static/tests/unit/data/restaurant_order_course.data.js
+++ b/addons/pos_restaurant/static/tests/unit/data/restaurant_order_course.data.js
@@ -6,7 +6,16 @@ export class RestaurantOrderCourse extends models.ServerModel {
     _name = "restaurant.order.course";
 
     _load_pos_data_fields() {
-        return ["uuid", "fired", "order_id", "line_ids", "index", "write_date"];
+        return [
+            "name",
+            "course_id",
+            "uuid",
+            "fired",
+            "order_id",
+            "line_ids",
+            "index",
+            "write_date",
+        ];
     }
 }
 

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -18,6 +18,7 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
 
         food_category = cls.env['pos.category'].create({'name': 'Food', 'sequence': 1})
         drinks_category = cls.env['pos.category'].create({'name': 'Drinks', 'sequence': 2})
+        breads_category = cls.env['pos.category'].create({'name': 'Breads', 'sequence': 3})
 
         printer = cls.env['pos.printer'].create({
             'name': 'Preparation Printer',
@@ -145,6 +146,22 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
             'taxes_id': [(6, 0, [])],
         })
 
+        cls.bruschetta = cls.env['product.product'].create({
+            'available_in_pos': True,
+            'list_price': 8.50,
+            'name': 'Bruschetta',
+            'pos_categ_ids': [(4, food_category.id)],
+            'taxes_id': [(6, 0, [])],
+        })
+
+        cls.wholemeal_loaf = cls.env['product.product'].create({
+            'available_in_pos': True,
+            'list_price': 2.99,
+            'name': 'Wholemeal loaf',
+            'pos_categ_ids': [(4, breads_category.id)],
+            'taxes_id': [(6, 0, [])],
+        })
+
         # multiple categories product
         cls.env['product.product'].create({
             'available_in_pos': True,
@@ -206,6 +223,16 @@ class TestFrontendCommon(TestPointOfSaleHttpCommon):
 
         pricelist = cls.env['product.pricelist'].create({'name': 'Restaurant Pricelist'})
         cls.pos_config.write({'pricelist_id': pricelist.id})
+
+        cls.starter_course = cls.env['pos.course'].create({
+            'name': 'Test - Starter',
+            'category_ids': [(4, drinks_category.id)],
+        })
+
+        cls.main_course = cls.env['pos.course'].create({
+            'name': 'Test - Main',
+            'category_ids': [(4, food_category.id)],
+        })
 
 
 class TestFrontend(TestFrontendCommon):
@@ -338,6 +365,17 @@ class TestFrontend(TestFrontendCommon):
     def test_pos_restaurant_course(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_pos_restaurant_course')
+
+    def test_pos_restaurant_default_course(self):
+        drinks_category = self.env['pos.category'].search([('name', '=', 'Drinks')], limit=1)
+        food_category = self.env['pos.category'].search([('name', '=', 'Food')], limit=1)
+        breads_category = self.env['pos.category'].search([('name', '=', 'Breads')], limit=1)
+        self.pos_config.write({
+            'use_course_allocation': True,
+            "iface_available_categ_ids": [(6, 0, [drinks_category.id, food_category.id, breads_category.id])],
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_pos_restaurant_default_course')
 
     def test_preparation_printer_content(self):
         self.preset_eat_in = self.env['pos.preset'].create({

--- a/addons/pos_restaurant/views/pos_category_view.xml
+++ b/addons/pos_restaurant/views/pos_category_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pos_category_form_inherit_course" model="ir.ui.view">
+        <field name="name">pos.category.form.inherit.course</field>
+        <field name="model">pos.category</field>
+        <field name="inherit_id" ref="point_of_sale.product_pos_category_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='available_between']" position="after">
+                <group>
+                    <field name="course_id" class="o_text_overflow" options="{'no_create_edit': True}"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="pos_restaurant_product_pos_category_tree_view" model="ir.ui.view">
+        <field name="name">pos.restaurant.pos.category.list.view</field>
+        <field name="model">pos.category</field>
+        <field name="inherit_id" ref="point_of_sale.product_pos_category_tree_view"/>
+        <field name="arch" type="xml">
+            <field name="parent_id" position="after">
+                <field name="course_id"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/pos_restaurant/views/pos_course_views.xml
+++ b/addons/pos_restaurant/views/pos_course_views.xml
@@ -1,0 +1,41 @@
+<odoo>
+    <record id="view_pos_course_list" model="ir.ui.view">
+        <field name="name">pos.course.list</field>
+        <field name="model">pos.course</field>
+        <field name="arch" type="xml">
+            <list string="Courses" editable="bottom">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+                <field name="category_ids" widget="many2many_tags"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_pos_course_form" model="ir.ui.view">
+        <field name="name">pos.course.form</field>
+        <field name="model">pos.course</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="category_ids" widget="many2many_tags"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_pos_course" model="ir.actions.act_window">
+        <field name="name">Courses</field>
+        <field name="res_model">pos.course</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_pos_course"
+              name="Courses"
+              parent="point_of_sale.pos_menu_products_configuration"
+              action="action_pos_course"
+              groups="base.group_no_one"
+              sequence="13"/>
+</odoo>

--- a/addons/pos_restaurant/views/res_config_settings_views.xml
+++ b/addons/pos_restaurant/views/res_config_settings_views.xml
@@ -36,6 +36,11 @@
                     <field name="pos_default_screen" widget="radio"/>
                 </setting>
             </block>
+            <block id="pos_preparation_section" position="inside">
+                <setting string="Automatic course allocation" help="Assign categories to default course" id="use_course_allocation" invisible="not pos_module_pos_restaurant">
+                    <field name="pos_use_course_allocation"/>
+                </setting>
+            </block>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Before this commit:
=======================
- There was no way to set default courses or connect them with product categories. (e.g., Starter, Main).
- No model or configuration existed to manage default courses in POS.

After this commit:
=======================
- Added `pos.course` model to define courses and link them to product categories.
- Added a course selection field in `pos.category`.
- Added an option in POS settings to turn course allocation on or off.
- Updated `restaurant.order.course` to fetch and display course names.
- Products are now automatically assigned to a course based on their category.

Task - 4982871

Related PR:
- Enterprise: https://github.com/odoo/enterprise/pull/93399