### PR TITLE
[IMP] core: log database name when loading the registry

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -898,9 +898,7 @@ class WebsocketRequest:
         self.session = self._get_session()
 
         try:
-            self.registry = Registry(self.db)
-            threading.current_thread().dbname = self.registry.db_name
-            self.registry.check_signaling()
+            self.registry = Registry(self.db).check_signaling()
         except (
             AttributeError, psycopg2.OperationalError, psycopg2.ProgrammingError
         ) as exc:

--- a/odoo/cli/shell.py
+++ b/odoo/cli/shell.py
@@ -133,7 +133,6 @@ class Shell(Command):
             'odoo': odoo,
         }
         if dbname:
-            threading.current_thread().dbname = dbname
             registry = Registry(dbname)
             with registry.cursor() as cr:
                 uid = api.SUPERUSER_ID

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2289,7 +2289,6 @@ class Request:
                 self.registry = registry.check_signaling(cr)
             except (AttributeError, psycopg2.OperationalError, psycopg2.ProgrammingError) as e:
                 raise RegistryError(f"Cannot get registry {self.db}") from e
-            threading.current_thread().dbname = self.registry.db_name
 
             # find the controller endpoint to use
             self.env = odoo.api.Environment(cr, self.session.uid, self.session.context)

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -113,6 +113,9 @@ class Registry(Mapping[str, type["BaseModel"]]):
     def __new__(cls, db_name: str):
         """ Return the registry for the given database name."""
         assert db_name, "Missing database name"
+        # set the database name for logging
+        current_thread = threading.current_thread()
+        current_thread.dbname = db_name
         with cls._lock:
             try:
                 return cls.registries[db_name]

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -109,7 +109,6 @@ def dispatch(method, params):
         raise AccessDenied
     # access checked once we open a cursor
 
-    threading.current_thread().dbname = db
     threading.current_thread().uid = uid
     registry = Registry(db).check_signaling()
     try:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When loading the registry, the database name was not set on the current thread and did not appear in the logs. In http, check signaling was done without the database set.

The following would not log the database name when loading the registry or during check signaling.
`odoo-bin --log-handler odoo.registry:DEBUG --database ''`

Current behavior before PR:
We don't know which registry is loaded.

Desired behavior after PR is merged:
Show the loaded registry.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
