### PR TITLE
[FIX] hr_org: fixed the zoom button on public employee

### DIFF
--- a/addons/hr_org_chart/views/hr_views.xml
+++ b/addons/hr_org_chart/views/hr_views.xml
@@ -114,7 +114,7 @@
                     <div class="d-flex flex-column align-items-start mt-0 pt-4 w-100" style="cursor: default;">
                         <div class="d-flex justify-content-between w-100 mb-0">
                             <span class="text-uppercase fw-bolder" style="font-size: 13px">Organization Chart</span>
-                            <a name="%(hr_org_chart.action_hr_employee_org_chart)d"
+                            <a name="%(hr_org_chart.action_hr_employee_public_org_chart)d"
                                 type="action"
                                 role="button"
                                 context="{'hierarchy_res_id': id}">


### PR DESCRIPTION
Steps to Reproduce:
1. Install the HR module and log in with a user account that has no access rights.
2. Open the employee form view and click on the zoom button in the organizational chart.
3. A traceback error will occur.

Cause:
The action associated with this button is intended for the `hr.employee` model, which the user does not have access to.

Fix:
Use the action created for public employees to open the organizational view correctly.

Task-5039925