### PR TITLE
[FIX] hr_holidays: prevent error when date not present

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -357,7 +357,7 @@ class HrLeave(models.Model):
             # used to get the contracts for which these leaves apply and
             # contract start- and end-dates are just dates (and not datetimes)
             # these dates are comparable.
-            if not leave.employee_id:
+            if not leave.employee_id or not leave.request_date_from or not leave.request_date_to:
                 continue
             contracts = self.env['hr.version'].search([('employee_id', '=', leave.employee_id.id)]).filtered(
                 lambda c: c.date_start <= leave.request_date_to and

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1563,3 +1563,13 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 'request_date_from': '2024-07-01',
                 'request_date_to': '2024-07-02',
             })
+
+    def test_duration_display_without_request_date_to(self):
+        req_form = Form(self.env['hr.leave'])
+        req_form.employee_id = self.employee_emp
+        req_form.holiday_status_id = self.holidays_type_1
+
+        req_form.request_date_from = fields.Date.to_date('2025-08-26')
+        req_form.request_date_to = False
+
+        self.assertEqual(req_form.duration_display, "0 days")


### PR DESCRIPTION
Currently, an error occurs when user removes value from `request_date_to` field.

**Steps to replicate:**
- Install Time Off app and open it.
- Click new and remove values from the `request_date_to` field (the second date field in the row) and click somewhere else.

**Error:**
`TypeError: '<=' not supported between instances of 'datetime.date' and 'bool'`

**Cause:**
- The field `leave.request_date_to` is received as `False` in the line [1] as the user deleted it.

**Solution:**
- Added a check for date values, if the date values are false, the further code execution is skipped because the validation is already present.

[1]: https://github.com/odoo/odoo/blob/b6c4c190331a7dc826df1b2ef399c0f6be32f657/addons/hr_holidays/models/hr_leave.py#L363

sentry-6830356042
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
