### PR TITLE
[FIX] auth_totp: synchronisation of test_totp (hopefully)

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -1,7 +1,9 @@
-import { queryAll, waitFor } from "@odoo/hoot-dom";
+import { WORKER_STATE } from "@bus/workers/websocket_worker";
+import {animationFrame, queryAll, waitFor} from "@odoo/hoot-dom";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import {whenReady} from "@odoo/owl";
 
 function openRoot() {
     return [{
@@ -218,6 +220,20 @@ registry.category("web_tour.tours").add('totp_login_device', {
     trigger: "button:contains(Log in)",
     run: "click",
     expectUnloadPage: true,
+},
+{
+    trigger: ".o_web_client .o_navbar",
+    async run() {
+        await whenReady();
+        await animationFrame();
+        await new Promise((resolve) => {
+            const bus = odoo.__WOWL_DEBUG__.root.env.services.bus_service;
+            bus.addEventListener("BUS:CONNECT", resolve, { once: true });
+            if (bus.workerState === WORKER_STATE.CONNECTED) {
+                resolve();
+            }
+        });
+    },
 },
 {
     content: "check we're logged in",


### PR DESCRIPTION
Code and issue at hand are very similar to odoo/odoo#212102 so implement the same "fix" to synchronise the tour on the web client being ready, though technically the first two calls are just "wait a bit" then "wait a bit more" (wait until DOMContentLoaded, then until next frame, then until next event loop).

At which point we wait until the event bus has fully connected to the server before moving on to interact with the client for real. It does seem to reliably wait sufficiently long for the issue to go away so works for me...

Backport of #224066

https://runbot.odoo.com/odoo/error/181862
