### PR TITLE
[FIX] hr_org_chart: fix error when loading organization chart

### DIFF
--- a/addons/hr_org_chart/controllers/hr_org_chart.py
+++ b/addons/hr_org_chart/controllers/hr_org_chart.py
@@ -53,7 +53,7 @@ class HrOrgChartController(http.Controller):
         # compute employee data for org chart
         ancestors, current = request.env['hr.employee.public'].sudo(), employee.sudo()
         current_parent = new_parent if new_parent_id is not None else current.parent_id
-        max_level = (kw.get('context')['max_level'] or self._managers_level) + 1
+        max_level = (kw.get('context', {}).get('max_level', None) or self._managers_level) + 1
         while current_parent and current != current_parent and employee.sudo() != current_parent and len(ancestors) < max_level:
             current = current_parent
             current_parent = current.parent_id if current != employee or not new_parent else new_parent


### PR DESCRIPTION
When User tries to Open Work Information of an employee,
A traceback will appear.

In [Commit](https://github.com/odoo/odoo/commit/fefe07041c2559a6d1bb39f367477264aa5c3fb2), ``max_level`` key is added in the context,
However, organization charts that were already loaded before this change will
not have the ``max_level`` key in their context, leading to the error.
https://github.com/odoo/odoo/blob/fe252296d1534a01f7fd777275a643af3726f4c9/addons/hr_org_chart/controllers/hr_org_chart.py#L56

Traceback:
``KeyError: 'max_level'``

sentry-6834408745

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
