### PR TITLE
[FIX] website_event: regex matches incorrect event

### DIFF
--- a/addons/website_event/static/src/snippets/options.js
+++ b/addons/website_event/static/src/snippets/options.js
@@ -56,7 +56,7 @@ options.registry.WebsiteEvent = options.Class.extend({
      * @private
      */
     _getEventObjectId() {
-        const objectIds = this.currentWebsiteUrl.match(/\d+(?![-\w])/);
+        const objectIds = this.currentWebsiteUrl.match(/\d+(?=\/|$)/);
         return parseInt(objectIds[0]) | 0;
     },
 });


### PR DESCRIPTION
Issue:
The Website Event page uses a matching regex to get the event id from the url. URLs are formatted like: '/event/[event-title]-[event-id]/register' The event-id is recovered from the url by matching on the first number that is not followed by a word character. However, for non-latin event titles (e.g. Chinese), the characters are converted using '%' characters and numbers (e.g. '%E6%88%91%E'). The regex consistently fails to get the event id in this case, and returns incorrect IDs.

Steps to reproduce:

1. Install `website_event` and go to the website view of any event.
2. Edit the event, to add a Chinese title
3. Save, and try to edit again the same title.

Solution: The regex is modified to look for the first number that is followed by either a "/" or the end of a String.

opw-5038334

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
