### PR TITLE
[IMP] account: add bank statement line label to outstanding debits/credits hover

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -25,7 +25,7 @@
                                t-on-click.prevent="() => this.assignOutstandingCredit(info.moveId, line.id)">Add</a>
                         </td>
                         <td style="max-width: 11em;">
-                            <a t-att-title="line.formattedDate"
+                            <a t-att-title="(line.bank_label ? line.bank_label + ' - ' : '') + line.formattedDate"
                                role="button"
                                class="oe_form_field btn btn-link open_account_move"
                                t-on-click="() => this.openMove(line.move_id)"


### PR DESCRIPTION
Before this PR:
- Hovering over outstanding debits/credits from bank journals only displays the date

After this PR:
- Hovering over outstanding debits/credits from bank journals now shows both the bank statement line label and date
- Format: "Bank statement line label - 01/01/2025"

Related PR : https://github.com/odoo/enterprise/pull/93159

Task : 5039914

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
