### PR TITLE
[FIX] website_sale_loyalty: claim chosen multiproduct reward on checkout

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -29,7 +29,7 @@ class WebsiteSale(main.WebsiteSale):
                     reward = rewards
                 else:
                     reward = reward_id in rewards.ids and rewards.browse(reward_id)
-                if reward and (not reward.multi_product or request.env.get('product_id')):
+                if reward and (not reward.multi_product or request.env.context.get('product_id')):
                     reward_successfully_applied = self._apply_reward(order, reward, coupon)
 
             if reward_successfully_applied:


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a coupon program with a free product reward using a product tag;
2. generate coupons & copy a coupon code;
3. have 2 or more products with the tag;
4. go to /shop & add any product to your cart;
5. go to checkout;
6. apply coupon code;
7. select a free product;
8. click "Use".

Issue
-----
Product isn't added to the cart.

Cause
-----
On forward porting a fix for a similar issue in bb92ba5fbba94, it accidentally checks for the `product_id` in `request.env` instead of `request.env.context`. As no `product_id` is found, no product is added.

Solution
--------
Check `request.env.context` instead of `request.env`.

opw-4979939