### PR TITLE
[IMP] point_of_sale:  mobile ui details

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.PaymentScreenPaymentLines">
-            <div class="paymentlines d-flex flex-column overflow-y-auto gap-2 mb-3">
+            <div t-if="props.paymentLines.length" class="paymentlines flex-grow-1 d-flex flex-column overflow-y-auto gap-2" t-att-class="{'mb-3': !this.ui.isSmall}">
                 <t t-foreach="props.paymentLines" t-as="line" t-key="line.uuid">
                     <t t-if="line.isSelected()">
                         <div t-attf-class="paymentline selected d-flex align-items-center rounded-3"

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -5,7 +5,7 @@
         <t t-if="ui.isSmall">
             <div class="payment-screen screen d-flex flex-column h-100 p-2 overflow-hidden gap-2">
                 <t t-call="point_of_sale.PaymentScreenDue" />
-                <div class="d-flex flex-grow-1 flex-column overflow-y-auto gap-1">
+                <div class="d-flex flex-column overflow-y-auto gap-1">
                     <t t-call="point_of_sale.PaymentScreenMethods" />
                 </div>
                 <PaymentScreenPaymentLines
@@ -106,7 +106,8 @@
 
     <t t-name="point_of_sale.PaymentScreenButtons">
         <div class="payment-buttons d-flex flex-column gap-1">
-            <div class="d-flex flex-column flex-sm-row gap-1 w-100">
+        <!-- To make Customer and Invoice button align on a single row -->
+            <div class="d-flex gap-1 w-100">
                 <t t-set="hasOptionalButtons" t-value="pos.config.iface_tipproduct and pos.config.tip_product_id or pos.config.iface_cashdrawer or pos.config.ship_later" />
                 <button class="button partner-button btn btn-secondary btn-lg w-100 w-md-50 lh-lg text-truncate"
                     t-att-class="{ 'highlight text-action': currentOrder.getPartner() }"
@@ -152,8 +153,9 @@
     </t>
 
     <t t-name="point_of_sale.PaymentScreenMethods">
-        <div class="paymentmethods-container mb-3" t-att-class="ui.isSmall ? 'my-2 rounded-3' : 'flex-grow-1'">
-            <div class="paymentmethods gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-200': ui.isSmall, 'd-flex flex-column gap-lg-2': !ui.isSmall }">
+        <div class="paymentmethods-container" t-att-class="ui.isSmall ? 'rounded-3' : 'flex-grow-1'">
+        <!-- Add scrollbar if more than 4 payment methods are configured -->
+            <div class="paymentmethods gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-200': ui.isSmall, 'd-flex flex-column gap-lg-2': !ui.isSmall }" t-att-style="ui.isSmall ? 'max-height: 120px;' : ''">
                 <t t-foreach="payment_methods_from_config" t-as="paymentMethod" t-key="paymentMethod.id">
                     <div t-if="!(this.pos.cashier._role === 'minimal' and paymentMethod.type === 'pay_later')" class="button paymentmethod btn btn-secondary btn-lg lh-lg flex-fill"
                         t-att-class="{'opacity-50': this.pos.paymentTerminalInProgress and paymentMethod.use_payment_terminal, 'd-flex justify-content-between align-items-center': true}"

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.xml
@@ -2,8 +2,8 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.PaymentScreenStatus">
-        <div t-if="props.order.payment_ids.length == 0" class="text-bg-light border text-center py-4 fs-4">
-    Please select a payment method 
+        <div t-if="props.order.payment_ids.length == 0" class="d-flex justify-content-center align-items-center text-center fs-4 flex-grow-1">
+    Please select a payment method
         </div>
         <section t-else="" t-attf-class="paymentlines-container border-top pt-3 {{ props.order.getDue() > 0 ? 'text-danger' : 'text-success'}}">
             <div class="payment-status-container d-flex flex-column-reverse flex-lg-row justify-content-between fs-2">

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -47,11 +47,11 @@
                     <span t-esc="this.fireCourseBtnText"></span>
                 </button>
                 <button
-                    class="button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center"
+                    class="button w-50 btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center"
                     t-on-click="() => doSubmitOrder.call()"
-                    t-elif="this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrints.length"
+                    t-elif="!ui.isSmall and this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrints.length"
                     t-att-disabled="doSubmitOrder.status === 'loading'">
-                    <i class="fa fa-cutlery" aria-hidden="true"></i>
+                    Reprint
                 </button>
                 <button
                     class="button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center w-50"


### PR DESCRIPTION
Following this commit:
- In mobile view, if more than 4 payment methods are configured, then a scrollbar is introduced.
- Extra space is removed in payment lines in mobile view
- In mobile view on the payment screen, the customer and invoice button have been aligned in a row, the same as the desktop view.
- Aligned instructions "Please select a payment method".
-  In desktop view, the Reprint button is shown instead of fa-cutlery icon.
- Extra Ok button is been removed from popup.

task-4919745
