### PR TITLE
[FIX] l10n_in_*: log message on retry

### DIFF
--- a/addons/l10n_in_edi/i18n/l10n_in_edi.pot
+++ b/addons/l10n_in_edi/i18n/l10n_in_edi.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~18.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-26 12:51+0000\n"
-"PO-Revision-Date: 2025-05-26 12:51+0000\n"
+"POT-Creation-Date: 2025-08-26 07:18+0000\n"
+"PO-Revision-Date: 2025-08-26 07:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -208,6 +208,14 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_in_edi.selection__account_move__l10n_in_edi_cancel_reason__1
 #: model:ir.model.fields.selection,name:l10n_in_edi.selection__l10n_in_edi_cancel__cancel_reason__1
 msgid "Duplicate"
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/account_move.py:0
+msgid ""
+"Duplicate IRN found for this invoice, but the buyer details or invoice "
+"values do not match."
 msgstr ""
 
 #. module: l10n_in_edi
@@ -451,6 +459,19 @@ msgstr ""
 #. module: l10n_in_edi
 #: model_terms:ir.ui.view,arch_db:l10n_in_edi.res_config_settings_view_form_inherit_l10n_in_edi
 msgid "Password"
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/account_move.py:0
+msgid ""
+"Retrying to send cancellation request for E-Invoice to government portal."
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/account_move.py:0
+msgid "Retrying to send your E-Invoice to government portal."
 msgstr ""
 
 #. module: l10n_in_edi

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -201,6 +201,9 @@ class AccountMove(models.Model):
         if self.l10n_in_edi_error:
             # make sure to clear the error before sending again
             self.l10n_in_edi_error = False
+            self.message_post(body=_(
+                "Retrying to send your E-Invoice to government portal."
+            ))
         partners = set(self._get_l10n_in_seller_buyer_party().values())
         for partner in partners:
             if partner_validation := partner._l10n_in_edi_strict_error_validation():
@@ -315,6 +318,9 @@ class AccountMove(models.Model):
         if self.l10n_in_edi_error:
             # make sure to clear the error before cancelling again
             self.l10n_in_edi_error = False
+            self.message_post(body=_(
+                "Retrying to send cancellation request for E-Invoice to government portal."
+            ))
         self._l10n_in_lock_invoice()
         l10n_in_edi_response_json = self._get_l10n_in_edi_response_json()
         cancel_json = {

--- a/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
+++ b/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~18.1+e\n"
+"Project-Id-Version: Odoo Server saas~18.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-26 05:36+0000\n"
-"PO-Revision-Date: 2025-06-26 05:36+0000\n"
+"POT-Creation-Date: 2025-08-29 09:25+0000\n"
+"PO-Revision-Date: 2025-08-29 09:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -90,7 +90,7 @@ msgstr ""
 msgid ""
 "<br/>\n"
 "                                            <br/>\n"
-"                                            ::Dispatch From:: <br/><br/>"
+"                                            Dispatch From <br/><br/>"
 msgstr ""
 
 #. module: l10n_in_ewaybill
@@ -98,7 +98,7 @@ msgstr ""
 msgid ""
 "<br/>\n"
 "                                            <br/>\n"
-"                                            ::Ship To:: <br/><br/>"
+"                                            Ship To <br/><br/>"
 msgstr ""
 
 #. module: l10n_in_ewaybill
@@ -324,12 +324,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in_ewaybill/models/error_codes.py:0
 msgid "Both Transaction and Vehicle Number Blank"
-msgstr ""
-
-#. module: l10n_in_ewaybill
-#. odoo-python
-#: code:addons/l10n_in_ewaybill/tools/ewaybill_api.py:0
-msgid "Buy Credits"
 msgstr ""
 
 #. module: l10n_in_ewaybill
@@ -767,12 +761,20 @@ msgstr ""
 #. module: l10n_in_ewaybill
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_account_bank_statement_line__l10n_in_ewaybill_ids
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_account_move__l10n_in_ewaybill_ids
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_res_company__l10n_in_ewaybill_feature
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_res_config_settings__l10n_in_ewaybill_feature
 msgid "E-Waybill"
 msgstr ""
 
 #. module: l10n_in_ewaybill
 #: model:ir.model,name:l10n_in_ewaybill.model_l10n_in_ewaybill_type
 msgid "E-Waybill Document Type"
+msgstr ""
+
+#. module: l10n_in_ewaybill
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_account_bank_statement_line__l10n_in_ewaybill_feature_enabled
+#: model:ir.model.fields,field_description:l10n_in_ewaybill.field_account_move__l10n_in_ewaybill_feature_enabled
+msgid "E-Waybill Feature Enabled"
 msgstr ""
 
 #. module: l10n_in_ewaybill
@@ -2164,12 +2166,6 @@ msgstr ""
 
 #. module: l10n_in_ewaybill
 #. odoo-python
-#: code:addons/l10n_in_ewaybill/tools/ewaybill_api.py:0
-msgid "Please buy more credits and retry: "
-msgstr ""
-
-#. module: l10n_in_ewaybill
-#. odoo-python
 #: code:addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py:0
 msgid "Please generate the E-Waybill to print it."
 msgstr ""
@@ -2247,6 +2243,18 @@ msgstr ""
 #. module: l10n_in_ewaybill
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill__activity_user_id
 msgid "Responsible User"
+msgstr ""
+
+#. module: l10n_in_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py:0
+msgid "Retrying E-Waybill generation on the government portal."
+msgstr ""
+
+#. module: l10n_in_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py:0
+msgid "Retrying to request cancellation of E-waybill on government portal."
 msgstr ""
 
 #. module: l10n_in_ewaybill
@@ -3125,12 +3133,6 @@ msgstr ""
 msgid ""
 "You cannot update transporter details, as the current tranporter is already "
 "entered Part B details of the eway bill"
-msgstr ""
-
-#. module: l10n_in_ewaybill
-#. odoo-python
-#: code:addons/l10n_in_ewaybill/tools/ewaybill_api.py:0
-msgid "You have insufficient credits to send this document!"
 msgstr ""
 
 #. module: l10n_in_ewaybill

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -489,6 +489,10 @@ class L10nInEwaybill(models.Model):
             'cancelRmrk': self.cancel_remarks,
         }
         ewb_api = EWayBillApi(self.company_id)
+        if self.error_message and self.blocking_level == 'error':
+            self.message_post(body=_(
+                "Retrying to request cancellation of E-waybill on government portal."
+            ))
         self._lock_ewaybill()
         try:
             response = ewb_api._ewaybill_cancel(cancel_json)
@@ -504,8 +508,15 @@ class L10nInEwaybill(models.Model):
         self._write_successfully_response({'state': 'cancel'})
         self._cr.commit()
 
+    def _log_retry_message_on_generate(self):
+        if self.error_message and self.blocking_level == 'error':
+            self.message_post(body=_(
+                "Retrying E-Waybill generation on the government portal."
+            ))
+
     def _generate_ewaybill(self):
         self.ensure_one()
+        self._log_retry_message_on_generate()
         ewb_api = EWayBillApi(self.company_id)
         self._lock_ewaybill()
         try:

--- a/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
@@ -82,6 +82,7 @@ class L10nInEwaybill(models.Model):
 
     def _generate_ewaybill_by_irn(self):
         self.ensure_one()
+        self._log_retry_message_on_generate()
         self._lock_ewaybill()
         try:
             response = self._ewaybill_generate_by_irn(self._ewaybill_generate_irn_json())


### PR DESCRIPTION
Manual fw-port of https://github.com/odoo/odoo/pull/223957, https://github.com/odoo/odoo/pull/223886, https://github.com/odoo/odoo/pull/207184

*=edi,ewaybill,ewaybill_irn

Following the implementation of [Black list request by GST](odoo/iap-apps#1039) the users are blocked for 24 hours on generating too many request. When processing through EDI there is no log when clicked on the retry button, Which is more essentially needed now to know by which user the EDI was retried and we logged the same on the move

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
