### PR TITLE
[IMP] website_sale_wishlist: allow to change the number of columns

### DIFF
--- a/addons/website_sale_wishlist/controllers/website_sale.py
+++ b/addons/website_sale_wishlist/controllers/website_sale.py
@@ -19,7 +19,7 @@ class WebsiteSaleWishlist(main.WebsiteSale):
 
         current_website = request.env['website'].get_current_website()
 
-        wishlist_writable_fields = {'wishlist_opt_products_design_classes'}
+        wishlist_writable_fields = {'wishlist_opt_products_design_classes', 'wishlist_grid_columns', 'wishlist_mobile_columns', 'wishlist_gap'}
 
         wishlist_write_vals = {k: v for k, v in options.items() if k in wishlist_writable_fields}
         if wishlist_write_vals:

--- a/addons/website_sale_wishlist/models/website.py
+++ b/addons/website_sale_wishlist/models/website.py
@@ -19,3 +19,21 @@ class Website(models.Model):
         ),
         help="CSS class for wishlist page design"
     )
+
+    wishlist_grid_columns = fields.Integer(
+        string="Wishlist Grid Columns",
+        default=5,
+        help="Number of columns to display on the wishlist page"
+    )
+
+    wishlist_mobile_columns = fields.Integer(
+        string="Wishlist Mobile Columns",
+        default=2,
+        help="Number of columns to display on mobile for the wishlist page (1 or 2)"
+    )
+
+    wishlist_gap = fields.Char(
+        string="Wishlist Grid Gap",
+        default="16px",
+        help="Gap between products on the wishlist page"
+    )

--- a/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
+++ b/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
@@ -29,17 +29,47 @@
 }
 
 #o_comparelist_table {
-    --gap: var(--o-wsale-products-grid-gap);
-
-    &.o_wsale_products_opt_layout_list article {
-        grid-column: auto/span 12;
+    &.o_wsale_products_opt_layout_catalog,
+    &.o_wsale_products_opt_layout_list {
+        --o-wsale-products-grid-gap: var(--o-wsale-wishlist-grid-gap, 16px);
+        --o-wsale-products-grid-gap-y: calc(var(--o-wsale-wishlist-grid-gap, 16px) * var(--o-wsale-products-grid-gap-y-multiplier, 1.25));
+        --gap: var(--o-wsale-products-grid-gap-y) var(--o-wsale-wishlist-grid-gap, 16px);
     }
 
+    &.o_wsale_products_opt_layout_catalog.o_wsale_products_opt_design_grid,
+    &.o_wsale_products_opt_layout_list.o_wsale_products_opt_design_grid {
+        --gap: 0px;
+        --o-wsale-card-padding: calc(var(--o-wsale-products-grid-gap-y, 0px) * 0.5) calc(var(--o-wsale-wishlist-grid-gap, 0px) * 0.5);
+    }
+
+    // List layouts
+    &.o_wsale_products_opt_layout_list {
+        .o_wishlist_item {
+            grid-column: auto/span 12;
+        }
+
+        &.o_wsale_products_opt_design_grid {
+            .o_wishlist_item {
+                --o-wsale-card-border-width: #{$border-width} #{$border-width} 0px #{$border-width};
+
+                &:last-of-type {
+                    --o-wsale-card-border-width: #{$border-width};
+                }
+            }
+        }
+
+        &.o_wsale_products_opt_design_thumbs {
+            --o-wsale-card-padding: 0 0 var(--o-wsale-wishlist-grid-gap, 16px);
+        }
+    }
+
+    // Card layouts
     &.o_wsale_products_opt_layout_catalog {
         --o-wsale-card-info-position: none;
         --o-wsale-card-btns-flex-direction: row;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
 
-        article {
+        .o_wishlist_item {
             position: relative;
             grid-column: auto/span 6;
 
@@ -50,12 +80,67 @@
             @include media-breakpoint-up(lg) {
                 grid-column: auto/span 3;
             }
+
             @include media-breakpoint-up(xxl) {
                 grid-column: auto/span 2;
             }
-
             .o_wish_rm {
                 @include o-wsale-card-btn-design-subtle($body-bg, $body-color);
+            }
+        }
+
+        &[data-wishlist-mobile-columns="1"] {
+            grid-template-columns: 1fr;
+        }
+
+        &[data-wishlist-mobile-columns="2"] {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        @include media-breakpoint-up(lg) {
+            @for $i from 2 through 6 {
+                &[data-wishlist-grid-columns="#{$i}"] {
+                    grid-template-columns: repeat(#{$i}, minmax(0, 1fr));
+                }
+            }
+        }
+
+        &[data-wishlist-grid-columns] .o_wishlist_item {
+            grid-column: auto/span 1 !important;
+        }
+
+        &.o_wsale_products_opt_design_grid {
+            .o_wishlist_item {
+                --o-wsale-card-border-width: #{$border-width} #{$border-width} #{$border-width} 0px;
+
+                &:first-of-type {
+                    --o-wsale-card-border-width: #{$border-width};
+                }
+            }
+
+            @mixin o-wishlist-grid-borders($cols) {
+                .o_wishlist_item:nth-of-type(n + #{$cols + 1}) {
+                    --o-wsale-card-border-width: 0 #{$border-width} #{$border-width} 0;
+                }
+                .o_wishlist_item:nth-of-type(#{$cols}n + 1):not(:nth-of-type(-n + #{$cols})) {
+                    --o-wsale-card-border-width: 0 #{$border-width} #{$border-width} #{$border-width};
+                }
+            }
+
+            @for $i from 2 through 6 {
+                &[data-wishlist-grid-columns="#{$i}"] {
+                    @include o-wishlist-grid-borders($i);
+                }
+            }
+
+            @include media-breakpoint-down(lg) {
+                &[data-wishlist-mobile-columns="1"] {
+                    @include o-wishlist-grid-borders(1);
+                }
+
+                &[data-wishlist-mobile-columns="2"] {
+                    @include o-wishlist-grid-borders(2);
+                }
             }
         }
     }

--- a/addons/website_sale_wishlist/static/src/website_builder/products_design_panel.xml
+++ b/addons/website_sale_wishlist/static/src/website_builder/products_design_panel.xml
@@ -59,6 +59,52 @@
             On Hover
         </BuilderSelectItem>
     </BuilderSelectItem>
+
+    <BuilderRow label.translate="Gap" position="replace">
+        <!--
+            Override the Gap row to use wishlist-specific action and make it always visible
+        -->
+        <BuilderRow label.translate="Gap">
+            <BuilderRange
+                t-if="props.recordName === 'wishlist_opt_products_design_classes'"
+                action="'wishlistSetGap'"
+                min="0"
+                max="28"
+                unit="'px'"
+                displayRangeValue="true"
+            />
+            <BuilderRange
+                t-else=""
+                action="'setGap'"
+                min="0"
+                max="28"
+                unit="'px'"
+                displayRangeValue="true"
+            />
+        </BuilderRow>
+    </BuilderRow>
+</t>
+
+<t
+    t-name="website_sale_wishlist.ProductsDesignPanelPresetsOverride"
+    t-inherit="website_sale.ProductsDesignPanelPresets"
+    t-inherit-mode="extension"
+>
+    <BuilderSelectItem id="style.id" position="attributes">
+        <attribute name="actionParam">[
+            {
+                action: 'classActionWithSave',
+                actionParam: {
+                    className: style.className,
+                    suggestedClasses: style.suggestedClasses,
+                }
+            },
+            {
+                action: (props.recordName === 'wishlist_opt_products_design_classes' ? 'wishlistSetGap' : 'setGap'),
+                actionValue: style.gap + 'px'
+            }
+        ]</attribute>
+    </BuilderSelectItem>
 </t>
 
 </templates>

--- a/addons/website_sale_wishlist/static/src/website_builder/wishlist_page_option.xml
+++ b/addons/website_sale_wishlist/static/src/website_builder/wishlist_page_option.xml
@@ -5,8 +5,33 @@
     <ProductsDesignPanel
         recordName="'wishlist_opt_products_design_classes'"
         label.translate="Products Design"
-        openByDefault="true"
     />
+
+    <BuilderRow t-if="this.isActiveItem('grid_view_opt')" label.translate="Desktop" level="1">
+        <BuilderSelect action="'wishlistGridColumns'" id="'o_wsale_wishlist_grid_columns'">
+            <BuilderSelectItem actionValue="2">2 Columns</BuilderSelectItem>
+            <BuilderSelectItem actionValue="3">3 Columns</BuilderSelectItem>
+            <BuilderSelectItem actionValue="4">4 Columns</BuilderSelectItem>
+            <BuilderSelectItem actionValue="5">5 Columns</BuilderSelectItem>
+            <BuilderSelectItem actionValue="6">6 Columns</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+
+    <BuilderRow t-if="this.isActiveItem('grid_view_opt')" label.translate="Mobile" level="1">
+        <BuilderSelect action="'wishlistMobileColumns'" id="'o_wsale_wishlist_mobile_columns'">
+            <BuilderSelectItem actionValue="1">1 Column</BuilderSelectItem>
+            <BuilderSelectItem actionValue="2">2 Columns</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+
+    <div class="d-none">
+        <BuilderRow label.translate="Layout">
+            <BuilderButtonGroup>
+                <BuilderButton id="'grid_view_opt'" classAction="'o_wsale_products_opt_layout_catalog'"/>
+                <BuilderButton classAction="'o_wsale_products_opt_layout_list'"/>
+            </BuilderButtonGroup>
+        </BuilderRow>
+    </div>
 </t>
 
 </templates>

--- a/addons/website_sale_wishlist/static/src/website_builder/wishlist_page_option_plugin.js
+++ b/addons/website_sale_wishlist/static/src/website_builder/wishlist_page_option_plugin.js
@@ -1,21 +1,86 @@
 
 import { Plugin } from "@html_editor/plugin";
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 class WishlistPageOptionPlugin extends Plugin {
     static id = "wishlistPageOption";
     resources = {
-        builder_options: [
-            {
-                template: "website_sale_wishlist.WishlistPageOption",
-                selector: ".o_wishlist_table",
-                editableOnly: false,
-                title: _t("Wishlist Page"),
-                groups: ["website.group_website_designer"],
-            },
-        ],
+        builder_options: {
+            template: "website_sale_wishlist.WishlistPageOption",
+            selector: ".o_wishlist_table",
+            editableOnly: false,
+            title: _t("Wishlist Page"),
+            groups: ["website.group_website_designer"],
+        },
+        builder_actions: {
+            WishlistGridColumnsAction,
+            WishlistMobileColumnsAction,
+            WishlistSetGapAction
+        },
+        save_handlers: this.onSave.bind(this),
     };
+
+    async onSave() {
+        const wishlistEl = this.editable.querySelector(".o_wishlist_table");
+        if (!wishlistEl) return;
+
+        const gridColumns = parseInt(wishlistEl.dataset.wishlistGridColumns) || 5;
+        const mobileColumns = parseInt(wishlistEl.dataset.wishlistMobileColumns) || 2;
+        const gap = wishlistEl.style.getPropertyValue("--o-wsale-wishlist-grid-gap") || "16px";
+
+        return rpc("/shop/config/website", {
+            wishlist_grid_columns: gridColumns,
+            wishlist_mobile_columns: mobileColumns,
+            wishlist_gap: gap,
+        });
+    }
+}
+
+export class WishlistGridColumnsAction extends BuilderAction {
+    static id = "wishlistGridColumns";
+
+    isApplied({ editingElement, value }) {
+        return parseInt(editingElement.dataset.wishlistGridColumns) === value;
+    }
+    getValue({ editingElement }) {
+        return parseInt(editingElement.dataset.wishlistGridColumns);
+    }
+    apply({ editingElement, value }) {
+        editingElement.dataset.wishlistGridColumns = value;
+    }
+}
+
+export class WishlistMobileColumnsAction extends BuilderAction {
+    static id = "wishlistMobileColumns";
+
+    isApplied({ editingElement, value }) {
+        return parseInt(editingElement.dataset.wishlistMobileColumns) === value;
+    }
+    getValue({ editingElement }) {
+        return parseInt(editingElement.dataset.wishlistMobileColumns);
+    }
+    apply({ editingElement, value }) {
+        editingElement.dataset.wishlistMobileColumns = value;
+    }
+}
+
+export class WishlistSetGapAction extends BuilderAction {
+    static id = "wishlistSetGap";
+
+    isApplied() {
+        return true;
+    }
+
+    getValue({ editingElement }) {
+        return editingElement.style.getPropertyValue("--o-wsale-wishlist-grid-gap");
+    }
+
+    apply({ editingElement, value }) {
+        editingElement.style.setProperty("--o-wsale-wishlist-grid-gap", value);
+    }
 }
 
 registry

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -309,12 +309,15 @@
 
                         <div
                             id="o_comparelist_table"
-                            style="--o-wsale-products-grid-gap: 16px;"
+                            t-att-data-wishlist-grid-columns="website.wishlist_grid_columns"
+                            t-att-data-wishlist-mobile-columns="website.wishlist_mobile_columns"
+                            t-attf-style="--o-wsale-wishlist-grid-gap: {{website.wishlist_gap}};"
                             t-attf-class="o_wishlist_table grid table-comparator mb-5 {{website.wishlist_opt_products_design_classes}}"
                         >
                             <t t-foreach="wishes" t-as="wish">
                                 <t t-set="combination_info" t-value="wish.product_id._get_combination_info_variant()"/>
                                 <article
+                                    class="o_wishlist_item"
                                     t-att-data-wish-id="wish.id"
                                     t-att-data-product-id="wish.product_id.id"
                                 >


### PR DESCRIPTION
Before this commit, the wishlist page always used a fixed 5-column grid and the “Products Design” panel auto-opened.

This commit adds editor controls to select the number of desktop (2–6) and mobile (1–2) columns and disables the auto‑open of the Products Design panel.

Additionally, grid spacing and border behavior for the `grid card preset` have been refined. Gaps are now adapted, and borders are adjusted for the first and subsequent rows based on the selected number of columns.

task-5003268

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
