### PR TITLE
[IMP] core: make test cases readonly during tests

### DIFF
--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -101,51 +101,47 @@ class TestSaleMrpKitBom(BaseCommon):
                 # * 1 x Component B (Cost: $ 10, QTY: 2, UOM: Unit)
             # cost of Kit A = (6 * 1 * 12) + (10 * 2) = $ 92
         """
-        self.customer = self.env['res.partner'].create({
-            'name': 'customer'
-        })
-
-        self.kit_product = self._create_product('Kit Product', True, 1.00)
+        kit_product = self._create_product('Kit Product', True, 1.00)
         # Creating components
-        self.component_a = self._create_product('Component A', True, 1.00)
-        self.component_a.product_tmpl_id.standard_price = 6
-        self.component_b = self._create_product('Component B', True, 1.00)
-        self.component_b.product_tmpl_id.standard_price = 10
+        component_a = self._create_product('Component A', True, 1.00)
+        component_a.product_tmpl_id.standard_price = 6
+        component_b = self._create_product('Component B', True, 1.00)
+        component_b.product_tmpl_id.standard_price = 10
 
         cat = self.env['product.category'].create({
             'name': 'fifo',
             'property_cost_method': 'fifo'
         })
-        self.kit_product.product_tmpl_id.categ_id = cat
-        self.component_a.product_tmpl_id.categ_id = cat
-        self.component_b.product_tmpl_id.categ_id = cat
+        kit_product.product_tmpl_id.categ_id = cat
+        component_a.product_tmpl_id.categ_id = cat
+        component_b.product_tmpl_id.categ_id = cat
 
-        self.bom = self.env['mrp.bom'].create({
-            'product_tmpl_id': self.kit_product.product_tmpl_id.id,
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': kit_product.product_tmpl_id.id,
             'product_qty': 1.0,
             'type': 'phantom'
         })
 
         self.env['mrp.bom.line'].create({
-                'product_id': self.component_a.id,
+                'product_id': component_a.id,
                 'product_qty': 1.0,
-                'bom_id': self.bom.id,
+                'bom_id': bom.id,
                 'product_uom_id': self.env.ref('uom.product_uom_dozen').id,
         })
         self.env['mrp.bom.line'].create({
-                'product_id': self.component_b.id,
+                'product_id': component_b.id,
                 'product_qty': 2.0,
-                'bom_id': self.bom.id,
+                'bom_id': bom.id,
                 'product_uom_id': self.env.ref('uom.product_uom_unit').id,
         })
 
         # Create a SO with one unit of the kit product
         so = self.env['sale.order'].create({
-            'partner_id': self.customer.id,
+            'partner_id': self.env['res.partner'].create({'name': 'customer'}).id,
             'order_line': [
                 (0, 0, {
-                    'name': self.kit_product.name,
-                    'product_id': self.kit_product.id,
+                    'name': kit_product.name,
+                    'product_id': kit_product.id,
                     'product_uom_qty': 1.0,
                 })],
         })

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -799,15 +799,15 @@ class TestSaleProject(TestSaleProjectCommon):
             is confirmed.
         """
         # Create archived Project template with one task
-        self.archived_project_template = self.env['project.project'].create({
+        archived_project_template = self.env['project.project'].create({
             'name': 'Archived project template',
             'allow_billable': True,
         })
-        self.archived_project_template_task = self.env['project.task'].create({
+        self.env['project.task'].create({
             'name': 'Task 1',
             'project_id': self.archived_project_template.id,
         })
-        self.archived_project_template.active = False
+        archived_project_template.active = False
 
         # Create service product using the project template
         service_with_project_template = self.env['product.product'].create({
@@ -815,7 +815,7 @@ class TestSaleProject(TestSaleProjectCommon):
             'type': 'service',
             'invoice_policy': 'order',
             'service_tracking': 'task_in_project',
-            'project_template_id': self.archived_project_template.id,
+            'project_template_id': archived_project_template.id,
         })
 
         # Create SO with the service product

--- a/addons/sale_project/tests/test_so_line_milestones.py
+++ b/addons/sale_project/tests/test_so_line_milestones.py
@@ -82,20 +82,19 @@ class TestSoLineMilestones(TestSaleCommon):
         })
 
     def test_reached_milestones_delivered_quantity(self):
-        self.milestone2 = self.env['project.milestone'].create({
+        milestone2, milestone3 = self.env['project.milestone'].create([{
             'name': 'Milestone 2',
             'project_id': self.project.id,
             'is_reached': False,
             'sale_line_id': self.sol2.id,
             'quantity_percentage': 0.2,
-        })
-        self.milestone3 = self.env['project.milestone'].create({
+        }, {
             'name': 'Milestone 3',
             'project_id': self.project.id,
             'is_reached': False,
             'sale_line_id': self.sol2.id,
             'quantity_percentage': 0.4,
-        })
+        }])
 
         self.assertEqual(self.sol1.qty_delivered, 0.0, "Delivered quantity should start at 0")
         self.assertEqual(self.sol2.qty_delivered, 0.0, "Delivered quantity should start at 0")
@@ -103,10 +102,10 @@ class TestSoLineMilestones(TestSaleCommon):
         self.milestone1.is_reached = True
         self.assertEqual(self.sol1.qty_delivered, 10.0, "Delivered quantity should update after a milestone is reached")
 
-        self.milestone2.is_reached = True
+        milestone2.is_reached = True
         self.assertEqual(self.sol2.qty_delivered, 6.0, "Delivered quantity should update after a milestone is reached")
 
-        self.milestone3.is_reached = True
+        milestone3.is_reached = True
         self.assertEqual(self.sol2.qty_delivered, 18.0, "Delivered quantity should update after a milestone is reached")
 
     def test_update_reached_milestone_quantity(self):

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -483,7 +483,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         self.assertEqual(sale_order.invoice_status, 'to invoice')
 
         # Context for sale.advance.payment.inv wizard
-        self.context = {
+        context = {
             'active_model': 'sale.order',
             'active_ids': [sale_order.id],
             'active_id': sale_order.id,
@@ -491,7 +491,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         }
 
         # invoice SO
-        wizard = self.env['sale.advance.payment.inv'].with_context(self.context).create({
+        wizard = self.env['sale.advance.payment.inv'].with_context(context).create({
             'advance_payment_method': 'delivered',
             'date_start_invoice_timesheet': today - timedelta(days=16),
             'date_end_invoice_timesheet': today - timedelta(days=10)

--- a/addons/sale_timesheet/tests/test_so_line_determined_in_timesheet.py
+++ b/addons/sale_timesheet/tests/test_so_line_determined_in_timesheet.py
@@ -66,7 +66,7 @@ class TestSoLineDeterminedInTimesheet(TestCommonSaleTimesheet):
             4) Change the SOL in the task and check if the SOL in the timesheet has also changed.
         """
         # 1) Define a SO and SOL in the project
-        self.project_project_rate = self.project_task_rate.copy({
+        project_project_rate = self.project_task_rate.copy({
             'name': 'Project with pricing_type="project_rate"',
             'sale_line_id': self.so.order_line[0].id,
         })
@@ -74,7 +74,7 @@ class TestSoLineDeterminedInTimesheet(TestCommonSaleTimesheet):
         # 2) Create task and check if the SOL is the one defined in the project
         task = self.env['project.task'].create({
             'name': 'Task',
-            'project_id': self.project_project_rate.id,
+            'project_id': project_project_rate.id,
         })
         self.assertEqual(task.sale_line_id, self.so.order_line[0], "The SOL in the task should be the one containing the prepaid service product.")
         self.assertTrue(all(sol.qty_delivered == 0 for sol in self.so.order_line), "The quantity delivered should be equal to 0 because we have no timesheet for each SOL containing in the SO.")
@@ -84,7 +84,7 @@ class TestSoLineDeterminedInTimesheet(TestCommonSaleTimesheet):
             'name': 'Test Line',
             'unit_amount': 1,
             'employee_id': self.employee_manager.id,
-            'project_id': self.project_project_rate.id,
+            'project_id': project_project_rate.id,
             'task_id': task.id,
         })
         self.assertTrue(timesheet.so_line == task.sale_line_id == self.so.order_line[0], "The SOL in the timesheet should be the same than the one in the task.")
@@ -107,7 +107,7 @@ class TestSoLineDeterminedInTimesheet(TestCommonSaleTimesheet):
             6) Change the SOL in the mapping and check if the timesheet conserne by the mapping has its SOL has been changed too.
         """
         # 1) Define a SO, SOL and mapping for an employee in the project,
-        self.project_employee_rate = self.project_task_rate.copy({
+        project_employee_rate = self.project_task_rate.copy({
             'name': 'Project with pricing_type="employee_rate"',
             'sale_line_id': self.so.order_line[0].id,
             'sale_line_employee_ids': [(0, 0, {
@@ -115,12 +115,12 @@ class TestSoLineDeterminedInTimesheet(TestCommonSaleTimesheet):
                 'sale_line_id': self.so.order_line[1].id,
             })]
         })
-        mapping = self.project_employee_rate.sale_line_employee_ids
+        mapping = project_employee_rate.sale_line_employee_ids
 
         # 2) Create task and check if the SOL is the one defined in the project,
         task = self.env['project.task'].create({
             'name': 'Task',
-            'project_id': self.project_employee_rate.id,
+            'project_id': project_employee_rate.id,
         })
         self.assertEqual(task.sale_line_id, self.so.order_line[0], "The SOL in the task should be the one containing the prepaid service product.")
         self.assertTrue(all(sol.qty_delivered == 0 for sol in self.so.order_line), "The quantity delivered should be equal to 0 because we have no timesheet for each SOL containing in the SO.")
@@ -131,7 +131,7 @@ class TestSoLineDeterminedInTimesheet(TestCommonSaleTimesheet):
             'unit_amount': 1,
             'auto_account_id': self.analytic_account_sale.id,
             'employee_id': self.employee_manager.id,
-            'project_id': self.project_employee_rate.id,
+            'project_id': project_employee_rate.id,
             'task_id': task.id,
         })
         self.assertTrue(timesheet.so_line == task.sale_line_id == self.so.order_line[0], "The SOL in the timesheet should be the same than the one in the task.")
@@ -144,7 +144,7 @@ class TestSoLineDeterminedInTimesheet(TestCommonSaleTimesheet):
             'unit_amount': 2,
         })
         employee_user_timesheet._compute_so_line()
-        self.assertTrue(employee_user_timesheet.so_line == self.project_employee_rate.sale_line_employee_ids[0].sale_line_id == self.so.order_line[1], "The SOL in the timesheet should be the one defined in the mapping for the employee user.")
+        self.assertTrue(employee_user_timesheet.so_line == project_employee_rate.sale_line_employee_ids[0].sale_line_id == self.so.order_line[1], "The SOL in the timesheet should be the one defined in the mapping for the employee user.")
         self.assertEqual(self.so.order_line[1].qty_delivered, 2, "The quantity delivered for this SOL should be equal to 2 hours.")
 
         # 5) Change the SOL in the task and check if only the SOL in the timesheet which does not concerne about the mapping changes,

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2743,7 +2743,7 @@ class TestRoutes(TestStockCommon):
         """ Creates 2 warehouses and make a replenish using one warehouse
         to ressuply the other one, Then check if the quantity and the product are matching
         """
-        self.product_uom_qty = 42
+        product_uom_qty = 42
 
         warehouse_1 = self.warehouse_1
         warehouse_2 = self.env['stock.warehouse'].create({
@@ -2759,7 +2759,7 @@ class TestRoutes(TestStockCommon):
             'product_id': self.product1.id,
             'product_tmpl_id': self.product1.product_tmpl_id.id,
             'product_uom_id': self.uom_unit.id,
-            'quantity': self.product_uom_qty,
+            'quantity': product_uom_qty,
             'warehouse_id': self.warehouse_1.id,
         })
 
@@ -2774,8 +2774,8 @@ class TestRoutes(TestStockCommon):
         self.assertTrue(last_picking_id, 'Picking not found')
         move_line = last_picking_id.move_ids.search([('product_id', '=', self.product1.id)])
         self.assertTrue(move_line,'The product is not in the picking')
-        self.assertEqual(move_line[0].product_uom_qty, self.product_uom_qty, 'Quantities does not match')
-        self.assertEqual(move_line[1].product_uom_qty, self.product_uom_qty, 'Quantities does not match')
+        self.assertEqual(move_line[0].product_uom_qty, product_uom_qty, 'Quantities does not match')
+        self.assertEqual(move_line[1].product_uom_qty, product_uom_qty, 'Quantities does not match')
 
     def test_pick_ship_from_subloc(self):
         """ Checks that if a picking is sent to a sublocation of its original destination during the pick->ship route,
@@ -3236,7 +3236,7 @@ class TestAutoAssign(TestStockCommon):
         self.assertEqual(customer_picking5.move_ids.quantity, 10, "Reservation Method: 'at_confirm' should auto-assign at confirmation")
 
     def test_serial_lot_ids(self):
-        self.product_serial = self.env['product.product'].create({
+        product_serial = self.env['product.product'].create({
             'name': 'PSerial',
             'is_storable': True,
             'tracking': 'serial',
@@ -3245,22 +3245,22 @@ class TestAutoAssign(TestStockCommon):
         move = self.env['stock.move'].create({
             'location_id': self.supplier_location.id,
             'location_dest_id': self.stock_location.id,
-            'product_id': self.product_serial.id,
+            'product_id': product_serial.id,
             'product_uom': self.uom_unit.id,
             'picking_type_id': self.picking_type_in.id,
         })
         self.assertEqual(move.state, 'draft')
         lot1 = self.env['stock.lot'].create({
             'name': 'serial1',
-            'product_id': self.product_serial.id,
+            'product_id': product_serial.id,
         })
         lot2 = self.env['stock.lot'].create({
             'name': 'serial2',
-            'product_id': self.product_serial.id,
+            'product_id': product_serial.id,
         })
         lot3 = self.env['stock.lot'].create({
             'name': 'serial3',
-            'product_id': self.product_serial.id,
+            'product_id': product_serial.id,
         })
         move.lot_ids = [Command.link(lot1.id)]
         move.lot_ids = [Command.link(lot2.id)]
@@ -3272,7 +3272,7 @@ class TestAutoAssign(TestStockCommon):
         move = self.env['stock.move'].create({
             'location_id': self.supplier_location.id,
             'location_dest_id': self.stock_location.id,
-            'product_id': self.product_serial.id,
+            'product_id': product_serial.id,
             'product_uom': self.uom_dozen.id,
             'picking_type_id': self.picking_type_in.id,
         })

--- a/addons/stock/tests/test_old_rules.py
+++ b/addons/stock/tests/test_old_rules.py
@@ -353,15 +353,15 @@ class TestOldRules(TestStockCommon):
         """
 
         warehouse = self.warehouse_3_steps
-        self.product = self.env['product.product'].create({
+        product = self.env['product.product'].create({
             'name': 'Test product',
             'is_storable': True,
         })
 
         ship_move = self.env['stock.move'].create({
-            'product_id': self.product.id,
+            'product_id': product.id,
             'product_uom_qty': 5.0,
-            'product_uom': self.product.uom_id.id,
+            'product_uom': product.uom_id.id,
             'location_id': warehouse.wh_output_stock_loc_id.id,
             'location_dest_id': self.customer_location.id,
             'warehouse_id': warehouse.id,

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -1718,17 +1718,17 @@ class TestPackagePropagation(TestPackingCommon):
             'name': 'disposable Package',
             'package_type_id': disposable_type.id,
         })
-        self.productA = self.env['product.product'].create({
+        productA = self.env['product.product'].create({
             'name': 'productA',
             'is_storable': True,
             'tracking': 'none',
         })
-        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 2)
+        self.env['stock.quant']._update_available_quantity(productA, self.stock_location, 2)
         self.env['stock.rule'].run([
             self.env['stock.rule'].Procurement(
-                self.productA,
+                productA,
                 2.0,
-                self.productA.uom_id,
+                productA.uom_id,
                 self.customer_location,
                 'propagation_test',
                 'propagation_test',

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -263,26 +263,26 @@ class TestProcRule(TransactionCase):
         # Required for `location_id` to be visible in the view
         self.env.user.group_ids += self.env.ref('stock.group_stock_multi_locations')
 
-        self.productA = self.env['product.product'].create({
+        productA = self.env['product.product'].create({
             'name': 'Desk Combination',
             'is_storable': True,
         })
 
-        self.productB = self.env['product.product'].create({
+        productB = self.env['product.product'].create({
             'name': 'Desk Decoration',
             'is_storable': True,
         })
 
         warehouse = self.env['stock.warehouse'].search([], limit=1)
         orderpoint_form = Form(self.env['stock.warehouse.orderpoint'])
-        orderpoint_form.product_id = self.productA
+        orderpoint_form.product_id = productA
         orderpoint_form.product_min_qty = 0.0
         orderpoint_form.product_max_qty = 5.0
-        orderpoint = orderpoint_form.save()
+        orderpoint_form.save()
 
         self.env['stock.warehouse.orderpoint'].create({
             'name': 'ProductB RR',
-            'product_id': self.productB.id,
+            'product_id': productB.id,
             'product_min_qty': 0,
             'product_max_qty': 5,
         })
@@ -324,7 +324,7 @@ class TestProcRule(TransactionCase):
         self.assertEqual(receipt_move.product_uom_qty, 17.0)
 
         delivery_picking.write({'move_ids': [(0, 0, {
-            'product_id': self.productB.id,
+            'product_id': productB.id,
             'product_uom': self.uom_unit.id,
             'product_uom_qty': 5.0,
             'location_id': warehouse.lot_stock_id.id,
@@ -334,7 +334,7 @@ class TestProcRule(TransactionCase):
         })]})
 
         receipt_move2 = self.env['stock.move'].search([
-            ('product_id', '=', self.productB.id),
+            ('product_id', '=', productB.id),
             ('location_id', '=', self.env.ref('stock.stock_location_suppliers').id)
         ])
 
@@ -345,7 +345,7 @@ class TestProcRule(TransactionCase):
     def test_reordering_rule_3(self):
         """Test how replenishment_uom_id affects qty_to_order"""
         stock_location = self.stock_location = self.env.ref('stock.stock_location_stock')
-        self.productA = self.env['product.product'].create({
+        productA = self.env['product.product'].create({
             'name': 'Desk Combination',
             'is_storable': True,
         })
@@ -355,14 +355,14 @@ class TestProcRule(TransactionCase):
             'relative_uom_id': self.env.ref('uom.product_uom_unit').id,
         })
         self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.productA.id,
+            'product_id': productA.id,
             'location_id': stock_location.id,
             'inventory_quantity': 14.5,
         }).action_apply_inventory()
 
         orderpoint = self.env['stock.warehouse.orderpoint'].create({
             'name': 'ProductA RR',
-            'product_id': self.productA.id,
+            'product_id': productA.id,
             'product_min_qty': 15.0,
             'product_max_qty': 30.0,
             'replenishment_uom_id': pack_of_10.id,
@@ -371,7 +371,7 @@ class TestProcRule(TransactionCase):
         # Test search on computed field
         rr = self.env['stock.warehouse.orderpoint'].search([
             ('qty_to_order', '>', 0),
-            ('product_id', '=', self.productA.id),
+            ('product_id', '=', productA.id),
         ])
         self.assertTrue(rr)
         orderpoint.write({

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -168,8 +168,8 @@ class TestStockQuant(TestStockCommon):
             'location_id': self.stock_location.id,
             'quantity': 1.0,
         })
-        self.env = self.env(user=self.demo_user)
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 1.0)
+        env = self.env(user=self.demo_user)
+        self.assertEqual(env['stock.quant']._get_available_quantity(self.productA, self.stock_location), 1.0)
 
     def test_increase_available_quantity_1(self):
         """ Increase the available quantity when no quants are already in a location.
@@ -219,8 +219,8 @@ class TestStockQuant(TestStockCommon):
     def test_increase_available_quantity_4(self):
         """ Increase the available quantity when no quants are already in a location with a user without access right.
         """
-        self.env = self.env(user=self.demo_user)
-        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 1.0)
+        env = self.env(user=self.demo_user)
+        env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 1.0)
 
     def test_increase_available_quantity_5(self):
         """ Increase the available quantity when no quants are already in stock.
@@ -317,8 +317,8 @@ class TestStockQuant(TestStockCommon):
             'location_id': self.stock_location.id,
             'quantity': 1.0,
         })
-        self.env = self.env(user=self.demo_user)
-        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, -1.0)
+        env = self.env(user=self.demo_user)
+        env['stock.quant']._update_available_quantity(self.productA, self.stock_location, -1.0)
         self.assertEqual(len(self.gather_relevant(self.productA, self.stock_location)), 0)
 
     def test_increase_reserved_quantity_1(self):
@@ -500,9 +500,9 @@ class TestStockQuant(TestStockCommon):
             'location_id': self.stock_location.id,
             'quantity': 1.0,
         })
-        self.env = self.env(user=self.demo_user)
+        env = self.env(user=self.demo_user)
         with self.assertRaises(AccessError):
-            self.env['stock.quant'].create({
+            env['stock.quant'].create({
                 'product_id': self.productA.id,
                 'location_id': self.stock_location.id,
                 'quantity': 1.0,
@@ -512,8 +512,8 @@ class TestStockQuant(TestStockCommon):
         with self.assertRaises(UserError):
             quant.with_user(self.demo_user).unlink()
 
-        self.env = self.env(user=self.user_stock_user)
-        self.env['stock.quant'].create({
+        env = env(user=self.user_stock_user)
+        env['stock.quant'].create({
             'product_id': self.productA.id,
             'location_id': self.stock_location.id,
             'quantity': 1.0,

--- a/addons/stock/tests/test_quant_inventory_mode.py
+++ b/addons/stock/tests/test_quant_inventory_mode.py
@@ -199,7 +199,7 @@ class TestEditableQuant(TransactionCase):
         """ Try to edit a record without the inventory mode.
         Must raise an error.
         """
-        self.demo_user = mail_new_test_user(
+        demo_user = mail_new_test_user(
             self.env,
             name='Pauline Poivraisselle',
             login='pauline',
@@ -215,7 +215,7 @@ class TestEditableQuant(TransactionCase):
         self.assertEqual(quant.quantity, 12)
         # Try to write on quant without permission
         with self.assertRaises(AccessError):
-            quant.with_user(self.demo_user).write({'inventory_quantity': 8})
+            quant.with_user(demo_user).write({'inventory_quantity': 8})
         self.assertEqual(quant.quantity, 12)
 
         # Try to write on quant with permission

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -197,7 +197,7 @@ class TestLotValuation(TestStockValuationCommon):
 
     def test_enable_lot_valuation_variant(self):
         """ test enabling the lot valuation for template with multiple variant"""
-        self.size_attribute = self.env['product.attribute'].create({
+        size_attribute = self.env['product.attribute'].create({
             'name': 'Size',
             'value_ids': [
                 Command.create({'name': 'S'}),
@@ -213,10 +213,10 @@ class TestLotValuation(TestStockValuationCommon):
             'categ_id': self.env.ref('product.product_category_goods').id,
             'attribute_line_ids': [
                 Command.create({
-                    'attribute_id': self.size_attribute.id,
+                    'attribute_id': size_attribute.id,
                     'value_ids': [
-                        Command.link(self.size_attribute.value_ids[0].id),
-                        Command.link(self.size_attribute.value_ids[1].id),
+                        Command.link(size_attribute.value_ids[0].id),
+                        Command.link(size_attribute.value_ids[1].id),
                 ]}),
             ],
         })

--- a/addons/stock_delivery/tests/test_delivery_cost.py
+++ b/addons/stock_delivery/tests/test_delivery_cost.py
@@ -8,8 +8,8 @@ class TestDeliveryCost(common.TransactionCase):
     def test_delivery_real_cost(self):
         """Ensure that the price is correctly set on the delivery line in the case of a Back Order
         """
-        self.partner_18 = self.env['res.partner'].create({'name': 'My Test Customer'})
-        self.product_4 = self.env['product.product'].create({'name': 'A product to deliver', 'weight': 1.0})
+        partner_18 = self.env['res.partner'].create({'name': 'My Test Customer'})
+        product_4 = self.env['product.product'].create({'name': 'A product to deliver', 'weight': 1.0})
 
         product_delivery = self.env['product.product'].create({
             'name': 'Delivery Charges',
@@ -27,12 +27,12 @@ class TestDeliveryCost(common.TransactionCase):
             'free_over': False,
         })
         so = self.env['sale.order'].create({
-            'partner_id': self.partner_18.id,
-            'partner_invoice_id': self.partner_18.id,
-            'partner_shipping_id': self.partner_18.id,
+            'partner_id': partner_18.id,
+            'partner_invoice_id': partner_18.id,
+            'partner_shipping_id': partner_18.id,
             'order_line': [(0, 0, {
                 'name': 'PC Assamble + 2GB RAM',
-                'product_id': self.product_4.id,
+                'product_id': product_4.id,
                 'product_uom_qty': 2,
                 'price_unit': 120.00,
             })],

--- a/addons/stock_delivery/tests/test_delivery_stock_move.py
+++ b/addons/stock_delivery/tests/test_delivery_stock_move.py
@@ -44,7 +44,7 @@ class TestStockMoveInvoice(TestSaleCommon):
 
     def test_01_delivery_stock_move(self):
         # Test if the stored fields of stock moves are computed with invoice before delivery flow
-        self.sale_prepaid = self.SaleOrder.create({
+        sale_prepaid = self.SaleOrder.create({
             'partner_id': self.partner_18.id,
             'partner_invoice_id': self.partner_18.id,
             'partner_shipping_id': self.partner_18.id,
@@ -58,45 +58,45 @@ class TestStockMoveInvoice(TestSaleCommon):
 
         # I add delivery cost in Sales order
         delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context({
-            'default_order_id': self.sale_prepaid.id,
+            'default_order_id': sale_prepaid.id,
             'default_carrier_id': self.normal_delivery.id,
         }))
         choose_delivery_carrier = delivery_wizard.save()
         choose_delivery_carrier.button_confirm()
 
         # I confirm the SO.
-        self.sale_prepaid.action_confirm()
-        self.sale_prepaid._create_invoices()
+        sale_prepaid.action_confirm()
+        sale_prepaid._create_invoices()
 
         # I check that the invoice was created
-        self.assertEqual(len(self.sale_prepaid.invoice_ids), 1, "Invoice not created.")
+        self.assertEqual(len(sale_prepaid.invoice_ids), 1, "Invoice not created.")
 
         # I confirm the invoice
 
-        self.invoice = self.sale_prepaid.invoice_ids
-        self.invoice.action_post()
+        invoice = sale_prepaid.invoice_ids
+        invoice.action_post()
 
         # I pay the invoice.
-        self.journal = self.AccountJournal.search([('type', '=', 'cash'), ('company_id', '=', self.sale_prepaid.company_id.id)], limit=1)
+        journal = self.AccountJournal.search([('type', '=', 'cash'), ('company_id', '=', sale_prepaid.company_id.id)], limit=1)
 
-        register_payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=self.invoice.ids).create({
-            'journal_id': self.journal.id,
+        register_payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+            'journal_id': journal.id,
         })
         register_payments._create_payments()
 
         # Check the SO after paying the invoice
-        self.assertNotEqual(self.sale_prepaid.invoice_count, 0, 'order not invoiced')
-        self.assertTrue(self.sale_prepaid.invoice_status == 'invoiced', 'order is not invoiced')
-        self.assertEqual(len(self.sale_prepaid.picking_ids), 1, 'pickings not generated')
+        self.assertNotEqual(sale_prepaid.invoice_count, 0, 'order not invoiced')
+        self.assertTrue(sale_prepaid.invoice_status == 'invoiced', 'order is not invoiced')
+        self.assertEqual(len(sale_prepaid.picking_ids), 1, 'pickings not generated')
 
         # Check the stock moves
-        moves = self.sale_prepaid.picking_ids.move_ids
+        moves = sale_prepaid.picking_ids.move_ids
         self.assertEqual(moves[0].product_qty, 2, 'wrong product_qty')
         self.assertEqual(moves[0].weight, 2.0, 'wrong move weight')
 
         # Ship
         moves.move_line_ids.write({'quantity': 2})
-        self.picking = self.sale_prepaid.picking_ids._action_done()
+        sale_prepaid.picking_ids._action_done()
         self.assertEqual(moves[0].move_line_ids.sale_price, 1725.0, 'wrong shipping value')
 
     def test_02_delivery_stock_move(self):
@@ -110,7 +110,7 @@ class TestStockMoveInvoice(TestSaleCommon):
             'product_id': self.product_cable_management_box.id,
         } for x in range(5)])
 
-        self.sale_prepaid = self.SaleOrder.create({
+        sale_prepaid = self.SaleOrder.create({
             'partner_id': self.partner_18.id,
             'partner_invoice_id': self.partner_18.id,
             'partner_shipping_id': self.partner_18.id,
@@ -124,19 +124,19 @@ class TestStockMoveInvoice(TestSaleCommon):
 
         # I add delivery cost in Sales order
         delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context({
-            'default_order_id': self.sale_prepaid.id,
+            'default_order_id': sale_prepaid.id,
             'default_carrier_id': self.normal_delivery.id,
         }))
         choose_delivery_carrier = delivery_wizard.save()
         choose_delivery_carrier.button_confirm()
 
         # I confirm the SO.
-        self.sale_prepaid.action_confirm()
-        moves = self.sale_prepaid.picking_ids.move_ids
+        sale_prepaid.action_confirm()
+        moves = sale_prepaid.picking_ids.move_ids
         # Ship
         for ml, lot in zip(moves.move_line_ids, serial_numbers):
             ml.write({'quantity': 1, 'lot_id': lot.id})
-        self.picking = self.sale_prepaid.picking_ids._action_done()
+        sale_prepaid.picking_ids._action_done()
         self.assertEqual(moves[0].move_line_ids[0].sale_price, 862.5, 'wrong shipping value')
 
     def test_03_invoiced_status(self):

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -258,9 +258,9 @@ class TestDropship(common.TransactionCase):
         self.assertEqual(purchase_order.order_line.qty_received, 0)
 
     def test_correct_vendor_dropship(self):
-        self.supplier_2 = self.env['res.partner'].create({'name': 'Vendor 2'})
+        supplier_2 = self.env['res.partner'].create({'name': 'Vendor 2'})
         # dropship route to be added in test
-        self.dropship_product = self.env['product.product'].create({
+        dropship_product = self.env['product.product'].create({
             'name': "Pen drive",
             'is_storable': "True",
             'lst_price': 100.0,
@@ -275,7 +275,7 @@ class TestDropship(common.TransactionCase):
                 }),
                 (0, 0, {
                     'delay': 5,
-                    'partner_id': self.supplier_2.id,
+                    'partner_id': supplier_2.id,
                     'min_qty': 1.0,
                     'price': 10
                 })
@@ -287,13 +287,13 @@ class TestDropship(common.TransactionCase):
         so_form.partner_id = self.customer
         with mute_logger('odoo.tests.common.onchange'):
             with so_form.order_line.new() as line:
-                line.product_id = self.dropship_product
+                line.product_id = dropship_product
                 line.product_uom_qty = 1
                 line.route_ids = self.dropshipping_route
         sale_order_drp_shpng = so_form.save()
         sale_order_drp_shpng.action_confirm()
 
-        purchase = self.env['purchase.order'].search([('partner_id', '=', self.supplier_2.id)])
+        purchase = self.env['purchase.order'].search([('partner_id', '=', supplier_2.id)])
         self.assertTrue(purchase, "an RFQ should have been created by the scheduler")
         self.assertTrue((purchase.date_planned - purchase.date_order).days == 5, "The second supplier has a delay of 5 days")
         self.assertTrue(purchase.amount_untaxed == 10, "the suppliers sells the item for 10$")
@@ -302,7 +302,7 @@ class TestDropship(common.TransactionCase):
         so_form.partner_id = self.customer
         with mute_logger('odoo.tests.common.onchange'):
             with so_form.order_line.new() as line:
-                line.product_id = self.dropship_product
+                line.product_id = dropship_product
                 line.product_uom_qty = 2
                 line.route_ids = self.dropshipping_route
         sale_order_drp_shpng = so_form.save()

--- a/addons/stock_dropshipping/tests/test_stockvaluation.py
+++ b/addons/stock_dropshipping/tests/test_stockvaluation.py
@@ -365,11 +365,11 @@ class TestStockValuation(ValuationReconciliationTestCommon):
 
         # --- Create Dropship 2 --- #
         self.sale_order1.order_line.product_uom_qty = 2  # Should create a new PO
-        self.purchase_order2 = self.env['purchase.order'].search(
+        purchase_order2 = self.env['purchase.order'].search(
             [('reference_ids', '=', self.sale_order1.reference_ids.id), ('state', '=', 'draft')]
         )
-        self.purchase_order2.order_line.price_unit = 16
-        self.purchase_order2.button_confirm()
+        purchase_order2.order_line.price_unit = 16
+        purchase_order2.button_confirm()
 
         # Validate dropship transfer
         dropship2 = self.sale_order1.picking_ids.filtered(lambda pck: pck.state != "done")
@@ -391,11 +391,11 @@ class TestStockValuation(ValuationReconciliationTestCommon):
 
         # --- Create Dropship 3 --- #
         self.sale_order1.order_line.product_uom_qty = 3  # Should create a new PO
-        self.purchase_order3 = self.env['purchase.order'].search(
+        purchase_order3 = self.env['purchase.order'].search(
             [('reference_ids', '=', self.sale_order1.reference_ids.id), ('state', '=', 'draft')]
         )
-        self.purchase_order3.order_line.price_unit = 24
-        self.purchase_order3.button_confirm()
+        purchase_order3.order_line.price_unit = 24
+        purchase_order3.button_confirm()
 
         # Validate dropship transfer
         dropship3 = self.sale_order1.picking_ids.filtered(lambda pck: pck.state != "done")

--- a/addons/survey/tests/test_survey_ui_feedback.py
+++ b/addons/survey/tests/test_survey_ui_feedback.py
@@ -172,14 +172,14 @@ class TestUiFeedback(HttpCaseWithUserDemo):
         # Setup survey translation
         self.assertEqual([lang[0] for lang in self.env['res.lang'].get_installed()], ['en_US'])
         self.env['res.lang']._activate_lang('fr_BE')
-        self.survey_feedback_fr = self.survey_feedback.with_context(lang='fr_BE')
-        self.survey_feedback_fr.title = "Enquête de satisfaction"
-        for survey_item in self.survey_feedback_fr.question_and_page_ids:
+        survey_feedback_fr = self.survey_feedback.with_context(lang='fr_BE')
+        survey_feedback_fr.title = "Enquête de satisfaction"
+        for survey_item in survey_feedback_fr.question_and_page_ids:
             survey_item.title = f"FR: {survey_item.with_context(lang='en_US').title}"
         self.survey_feedback.lang_ids = self.env['res.lang'].search([('code', 'in', ['fr_BE', 'en_US'])])
 
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey_multilang')
+        self.start_tour(f"/survey/start/{access_token}", 'test_survey_multilang')
 
     def test_04_public_survey_with_triggers(self):
         """ Check that chained conditional questions are correctly

--- a/addons/test_mail/tests/test_mail_alias.py
+++ b/addons/test_mail/tests/test_mail_alias.py
@@ -403,18 +403,18 @@ class TestAliasCompany(TestMailAliasCommon):
         archived company"""
 
         # add archived company to multi company setup
-        self.company_archived = self.env['res.company'].create({
+        company_archived = self.env['res.company'].create({
                 'country_id': self.env.ref('base.be').id,
                 'currency_id': self.env.ref('base.EUR').id,
                 'email': 'company_archived@test.example.com',
                 'name': 'Company Archived Test',
             })
-        self.company_archived.action_archive()
+        company_archived.action_archive()
 
         # create record inheriting from mail.thread to be used as owner/target thread
         test_record_archived_company = self.env['mail.test.simple.unfollow'].create({
                 'name': 'Test record (mail.thread) specific to archived company',
-                'company_id': self.company_archived.id,
+                'company_id': company_archived.id,
             })
 
         unfollow_model_id = self.env['ir.model']._get_id('mail.test.simple.unfollow')
@@ -454,7 +454,7 @@ class TestAliasCompany(TestMailAliasCommon):
                          'Parent thread has the wrong alias domain')
         self.assertEqual(mc_archived_target.alias_domain_id.id, mc_alias_domain.id,
                          'Target thread has the wrong alias domain')
-        self.assertEqual(self.company_archived.alias_domain_id.id, mc_alias_domain.id,
+        self.assertEqual(company_archived.alias_domain_id.id, mc_alias_domain.id,
                          'Archived company was attributed wrong alias domain')
 
     @mute_logger('odoo.models.unlink')

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -2221,14 +2221,14 @@ class TestMailGatewayLoops(MailGatewayCommon):
             f'"MAILER-DAEMON" <{self.alias_bounce}@{self.alias_domain}>',
             [customer_email],
             subject='Re: Should Bounce (initial)')
-        original_mail = self._mails
+        original_mail, self._mails[:] = self._mails[:], []
 
         # auto-reply: write to bounce = no more bounce
         self.gateway_mail_reply_last_email(MAIL_TEMPLATE, force_email_to=f'{self.alias_bounce}@{self.alias_domain}')
         self.assertNotSentEmail()
 
         # auto-reply but forwarded to catchall -> should not bounce again
-        self._mails = original_mail  # just to revert state prior to auto reply
+        self._mails[:] = original_mail  # just to revert state prior to auto reply
         self.gateway_mail_reply_last_email(MAIL_TEMPLATE, force_email_to=f'{self.alias_catchall}@{self.alias_domain}')
         # TDE FIXME: this should not bounce again
         # self.assertNotSentEmail()

--- a/addons/test_mail_sms/tests/test_sms_sms.py
+++ b/addons/test_mail_sms/tests/test_sms_sms.py
@@ -27,17 +27,18 @@ class TestSMSPost(SMSCommon, MockLinkTracker):
             })
 
     def test_sms_send_batch_size(self):
-        self.count = 0
+        count = 0
 
         def _send(sms_self, unlink_failed=False, unlink_sent=True, raise_exception=False):
-            self.count += 1
+            nonlocal count
+            count += 1
             return DEFAULT
 
         self.env['ir.config_parameter'].set_param('sms.session.batch.size', '3')
         with patch.object(SmsModel, '_send', autospec=True, side_effect=_send) as _send_mock:
             self.env['sms.sms'].browse(self.sms_all.ids).send()
 
-        self.assertEqual(self.count, 4)
+        self.assertEqual(count, 4)
 
     def test_sms_send_crash_employee(self):
         with self.assertRaises(exceptions.AccessError):

--- a/addons/test_resource/tests/test_calendar.py
+++ b/addons/test_resource/tests/test_calendar.py
@@ -213,7 +213,7 @@ class TestCalendar(TestResourceCommon):
         self.assertEqual(res, 5.0)
 
     def test_calendar_working_hours_24(self):
-        self.att_4 = self.env['resource.calendar.attendance'].create({
+        self.env['resource.calendar.attendance'].create({
             'name': 'Att4',
             'calendar_id': self.calendar_jean.id,
             'dayofweek': '2',

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime
+from itertools import cycle
 
 from pytz import utc
 
@@ -44,17 +45,16 @@ class TestResource(TestResourceCommon):
         self.assertFalse(interval - false_entry[false_calendar], "Calendar validity should cover all interval")
 
     def test_performance(self):
-        calendars = [self.calendar_jean, self.calendar_john, self.calendar_jules, self.calendar_patel]
-        calendars_len = len(calendars)
-        self.resources_test = self.env['resource.test'].create([{
-            'name': 'resource ' + str(i),
-            'resource_calendar_id': calendars[i % calendars_len].id,
-        } for i in range(0, 50)])
+        calendars = cycle([self.calendar_jean, self.calendar_john, self.calendar_jules, self.calendar_patel])
+        resources_test = self.env['resource.test'].create([{
+            'name': f'resource {i}',
+            'resource_calendar_id': next(calendars).id,
+        } for i in range(50)])
 
         start = utc.localize(datetime(2021, 7, 7, 12, 0, 0))
         end = utc.localize(datetime(2021, 7, 16, 23, 59, 59))
         with self.assertQueryCount(13):
-            work_intervals, _ = self.resources_test.resource_id._get_valid_work_intervals(start, end)
+            work_intervals, _ = resources_test.resource_id._get_valid_work_intervals(start, end)
 
         self.assertEqual(len(work_intervals), 50)
 

--- a/addons/test_website/tests/test_reset_views.py
+++ b/addons/test_website/tests/test_reset_views.py
@@ -38,10 +38,10 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
 
     @mute_logger('odoo.http')
     def test_01_reset_specific_page_view(self):
-        self.test_page_view = self.Website.viewref('test_website.test_page_view')
+        test_page_view = self.Website.viewref('test_website.test_page_view')
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
-        break_view(self.test_page_view.with_context(website_id=1))
+        break_view(test_page_view.with_context(website_id=1))
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view")
         self.fix_it('/test_page_view')
 
@@ -56,22 +56,22 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
 
     @mute_logger('odoo.http')
     def test_03_reset_specific_view_controller_t_called(self):
-        self.test_view_to_be_t_called = self.Website.viewref('test_website.test_view_to_be_t_called')
+        test_view_to_be_t_called = self.Website.viewref('test_website.test_view_to_be_t_called')
 
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
-        break_view(self.test_view_to_be_t_called.with_context(website_id=1))
+        break_view(test_view_to_be_t_called.with_context(website_id=1))
         break_view(self.test_view, to='<t t-call="test_website.test_view_to_be_t_called"/>')
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view")
         self.fix_it('/test_view')
 
     @mute_logger('odoo.http')
     def test_04_reset_specific_view_controller_inherit(self):
-        self.test_view_child_broken = self.Website.viewref('test_website.test_view_child_broken')
+        test_view_child_broken = self.Website.viewref('test_website.test_view_child_broken')
 
         # Activate and break the inherited view
-        self.test_view_child_broken.active = True
-        break_view(self.test_view_child_broken.with_context(website_id=1, load_all_views=True))
+        test_view_child_broken.active = True
+        break_view(test_view_child_broken.with_context(website_id=1, load_all_views=True))
 
         self.fix_it('/test_view')
 
@@ -102,12 +102,12 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
 
     @mute_logger('odoo.http')
     def test_08_reset_specific_page_view_hard_mode(self):
-        self.test_page_view = self.Website.viewref('test_website.test_page_view')
+        test_page_view = self.Website.viewref('test_website.test_page_view')
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
-        break_view(self.test_page_view.with_context(website_id=1))
+        break_view(test_page_view.with_context(website_id=1))
         # Break it again to have a previous arch different than file arch
-        break_view(self.test_page_view.with_context(website_id=1))
+        break_view(test_page_view.with_context(website_id=1))
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view")
 
         with self.assertRaises(AssertionError):
@@ -116,4 +116,4 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
             self.fix_it('/test_page_view')
         self.fix_it('/test_page_view', 'hard')
         # hard reset should set arch_updated to false
-        self.assertFalse(self.test_page_view.arch_updated)
+        self.assertFalse(test_page_view.arch_updated)

--- a/addons/test_website_slides_full/tests/test_ui_wslides.py
+++ b/addons/test_website_slides_full/tests/test_ui_wslides.py
@@ -139,7 +139,7 @@ class TestUi(TestUICommon):
     @users("portal")
     def test_course_certification_employee(self):
         # use proper environment to test user dependent computes
-        self.furniture_course = self.env['slide.channel'].browse(self.furniture_course.id)
+        furniture_course = self.env['slide.channel'].browse(self.furniture_course.id)
 
         user_portal = self.env.user
         sale_order_data = {
@@ -158,17 +158,17 @@ class TestUi(TestUICommon):
         # =================
         self.env['sale.order'].sudo().create(sale_order_data).action_confirm()
         # Member should have access to the course
-        self.assertTrue(self.furniture_course.is_member)
+        self.assertTrue(furniture_course.is_member)
         self.start_tour('/slides', 'certification_member_failure', login=user_portal.login)
         # Member should no longer have access to the course
-        self.assertFalse(self.furniture_course.is_member)
+        self.assertFalse(furniture_course.is_member)
 
         # ===================
         # SUCCESSFUL ATTEMPT
         # ===================
         self.env['sale.order'].sudo().create(sale_order_data).action_confirm()
         # Member regains access to the course
-        self.assertTrue(self.furniture_course.is_member)
+        self.assertTrue(furniture_course.is_member)
 
         self.start_tour('/slides', 'certification_member_success', login=user_portal.login)
 
@@ -176,7 +176,7 @@ class TestUi(TestUICommon):
         # EXTRA TESTS
         # ============
         member = self.env['slide.channel.partner'].sudo().search([
-            ('channel_id', '=', self.furniture_course.id),
+            ('channel_id', '=', furniture_course.id),
             ('partner_id', '=', user_portal.partner_id.id),
         ])
         self.assertTrue(member)

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -51,26 +51,26 @@ class TestPage(common.TransactionCase):
         Page = self.env['website.page']
         Menu = self.env['website.menu']
         # Specific page
-        self.specific_view = View.create({
+        specific_view = View.create({
             'name': 'Base',
             'type': 'qweb',
             'arch': '<div>Specific View</div>',
             'key': 'test.specific_view',
         })
-        self.page_specific = Page.create({
-            'view_id': self.specific_view.id,
+        page_specific = Page.create({
+            'view_id': specific_view.id,
             'url': '/page_specific',
             'website_id': 1,
         })
-        self.page_specific_menu = Menu.create({
+        Menu.create({
             'name': 'Page Specific menu',
-            'page_id': self.page_specific.id,
+            'page_id': page_specific.id,
             'website_id': 1,
         })
         total_pages = Page.search_count([])
         total_menus = Menu.search_count([])
         # Copying a specific page should create a new page with an unique URL (suffixed by -X)
-        Page.clone_page(self.page_specific.id, clone_menu=True)
+        Page.clone_page(page_specific.id, clone_menu=True)
         cloned_page = Page.search([('url', '=', '/page_specific-1')])
         cloned_menu = Menu.search([('url', '=', '/page_specific-1')])
         self.assertEqual(len(cloned_page), 1, "A page with an URL /page_specific-1 should've been created")
@@ -79,7 +79,7 @@ class TestPage(common.TransactionCase):
         self.assertEqual(len(cloned_menu), 1, "A specific page (with a menu) being cloned should have it's menu also cloned")
         self.assertEqual(cloned_menu.page_id, cloned_page, "The new cloned menu and the new cloned page should be linked (m2o)")
         self.assertEqual(Menu.search_count([]), total_menus + 1, "Should have cloned the page menu")
-        Page.clone_page(self.page_specific.id, page_name="about-us", clone_menu=True)
+        Page.clone_page(page_specific.id, page_name="about-us", clone_menu=True)
         cloned_page_about_us = Page.search([('url', '=', '/about-us')])
         cloned_menu_about_us = Menu.search([('url', '=', '/about-us')])
         self.assertEqual(len(cloned_page_about_us), 1, "A page with an URL /about-us should've been created")

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -116,7 +116,7 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
         View = self.env['ir.ui.view']
         Page = self.env['website.page']
 
-        self.generic_view = View.create({
+        generic_view = View.create({
             'name': 'Generic',
             'type': 'qweb',
             'arch': '''
@@ -125,8 +125,8 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
             'key': 'test.generic_view',
         })
 
-        self.generic_page = Page.create({
-            'view_id': self.generic_view.id,
+        Page.create({
+            'view_id': generic_view.id,
             'url': '/generic',
         })
 

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -56,7 +56,7 @@ class TestEventRegisterUTM(HttpCase, TestEventOnlineCommon):
 class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
 
     def test_website_event_tour_admin(self):
-        self.upcoming_event = self.env['event.event'].create({
+        self.env['event.event'].create({
             'name': 'Upcoming Event',
             'date_begin': fields.Datetime.now() + relativedelta(days=10),
             'date_end': fields.Datetime.now() + relativedelta(days=13),
@@ -83,7 +83,7 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         """ Will execute the tour that fills up two tickets with a few questions answers
         and then assert that the answers are correctly saved for each attendee. """
 
-        self.design_fair_event = self.env['event.event'].create({
+        self.env['event.event'].create({
             'name': 'Design Fair New York',
             'date_begin': fields.Datetime.now() - relativedelta(days=15),
             'date_end': fields.Datetime.now() + relativedelta(days=15),

--- a/addons/website_forum/tests/test_forum_karma_access.py
+++ b/addons/website_forum/tests/test_forum_karma_access.py
@@ -18,78 +18,78 @@ class TestForumCRUD(TestForumCommon):
         self.user_employee.karma = 500
 
         # create some posts
-        self.admin_post = self.post
-        self.portal_post = Post.with_user(self.user_portal).create({
+        admin_post = self.post
+        portal_post = Post.with_user(self.user_portal).create({
             'name': 'Post from Portal User',
             'content': 'I am not a bird.',
             'forum_id': self.forum.id,
         })
-        self.employee_post = Post.with_user(self.user_employee).create({
+        employee_post = Post.with_user(self.user_employee).create({
             'name': 'Post from Employee User',
             'content': 'I am not a bird.',
             'forum_id': self.forum.id,
         })
 
         # vote on some posts
-        self.employee_vote_on_admin_post = Vote.with_user(self.user_employee).create({
-            'post_id': self.admin_post.id,
+        employee_vote_on_admin_post = Vote.with_user(self.user_employee).create({
+            'post_id': admin_post.id,
             'vote': '1',
         })
-        self.portal_vote_on_admin_post = Vote.with_user(self.user_portal).create({
-            'post_id': self.admin_post.id,
+        portal_vote_on_admin_post = Vote.with_user(self.user_portal).create({
+            'post_id': admin_post.id,
             'vote': '1',
         })
-        self.admin_vote_on_portal_post = Vote.create({
-            'post_id': self.portal_post.id,
+        admin_vote_on_portal_post = Vote.create({
+            'post_id': portal_post.id,
             'vote': '1',
         })
-        self.admin_vote_on_employee_post = Vote.create({
-            'post_id': self.employee_post.id,
+        admin_vote_on_employee_post = Vote.create({
+            'post_id': employee_post.id,
             'vote': '1',
         })
 
         # One should not be able to modify someone else's vote
         with self.assertRaises(UserError):
-            self.admin_vote_on_portal_post.with_user(self.user_employee).write({
+            admin_vote_on_portal_post.with_user(self.user_employee).write({
                 'vote': '-1',
             })
         with self.assertRaises(UserError):
-            self.admin_vote_on_employee_post.with_user(self.user_portal).write({
+            admin_vote_on_employee_post.with_user(self.user_portal).write({
                 'vote': '-1',
             })
 
         # One should not be able to give his vote to someone else
-        self.employee_vote_on_admin_post.with_user(self.user_employee).write({
+        employee_vote_on_admin_post.with_user(self.user_employee).write({
             'user_id': 1,
         })
-        self.assertEqual(self.employee_vote_on_admin_post.user_id, self.user_employee, 'User employee should not be able to give its vote ownership to someone else')
+        self.assertEqual(employee_vote_on_admin_post.user_id, self.user_employee, 'User employee should not be able to give its vote ownership to someone else')
         # One should not be able to change his vote's post to a post of his own (would be self voting)
         with self.assertRaises(UserError):
-            self.employee_vote_on_admin_post.with_user(self.user_employee).write({
-                'post_id': self.employee_post.id,
+            employee_vote_on_admin_post.with_user(self.user_employee).write({
+                'post_id': employee_post.id,
             })
 
         # One should not be able to give his vote to someone else
-        self.portal_vote_on_admin_post.with_user(self.user_portal).write({
+        portal_vote_on_admin_post.with_user(self.user_portal).write({
             'user_id': 1,
         })
-        self.assertEqual(self.portal_vote_on_admin_post.user_id, self.user_portal, 'User portal should not be able to give its vote ownership to someone else')
+        self.assertEqual(portal_vote_on_admin_post.user_id, self.user_portal, 'User portal should not be able to give its vote ownership to someone else')
         # One should not be able to change his vote's post to a post of his own (would be self voting)
         with self.assertRaises(UserError):
-            self.portal_vote_on_admin_post.with_user(self.user_portal).write({
-                'post_id': self.portal_post.id,
+            portal_vote_on_admin_post.with_user(self.user_portal).write({
+                'post_id': portal_post.id,
             })
 
         # One should not be able to vote for its own post
         with self.assertRaises(UserError):
             Vote.with_user(self.user_employee).create({
-                'post_id': self.employee_post.id,
+                'post_id': employee_post.id,
                 'vote': '1',
             })
         # One should not be able to vote for its own post
         with self.assertRaises(UserError):
             Vote.with_user(self.user_portal).create({
-                'post_id': self.portal_post.id,
+                'post_id': portal_post.id,
                 'vote': '1',
             })
 
@@ -97,26 +97,26 @@ class TestForumCRUD(TestForumCommon):
             with self.assertRaises(IntegrityError):
                 # One should not be able to vote more than once on a same post
                 Vote.with_user(self.user_employee).create({
-                    'post_id': self.admin_post.id,
+                    'post_id': admin_post.id,
                     'vote': '1',
                 })
             with self.assertRaises(IntegrityError):
                 # One should not be able to vote more than once on a same post
                 Vote.with_user(self.user_employee).create({
-                    'post_id': self.admin_post.id,
+                    'post_id': admin_post.id,
                     'vote': '1',
                 })
 
         # One should not be able to create a vote for someone else
         new_employee_vote = Vote.with_user(self.user_employee).create({
-            'post_id': self.portal_post.id,
+            'post_id': portal_post.id,
             'user_id': 1,
             'vote': '1',
         })
         self.assertEqual(new_employee_vote.user_id, self.user_employee, 'Creating a vote for someone else should not be allowed. It should create it for yourself instead')
         # One should not be able to create a vote for someone else
         new_portal_vote = Vote.with_user(self.user_portal).create({
-            'post_id': self.employee_post.id,
+            'post_id': employee_post.id,
             'user_id': 1,
             'vote': '1',
         })

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -403,7 +403,8 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
     def test_livechat_visitor_to_store(self):
         """Test livechat_visitor_id is sent with livechat channels data even when there is no
         visitor."""
-        self.target_visitor = None
+
+        self.patch(self.registry['website.visitor'], '_get_visitor_from_request', lambda _self, **_: None)
         channel_data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {"channel_id": self.livechat_channel.id},

--- a/addons/website_livechat/tests/test_livechat_request.py
+++ b/addons/website_livechat/tests/test_livechat_request.py
@@ -28,7 +28,7 @@ class TestLivechatRequestHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
     def test_cancel_chat_request_on_visitor_demand(self):
         self._clean_livechat_sessions()
 
-        self.operator_b = self.env['res.users'].create({
+        operator_b = self.env['res.users'].create({
             'name': 'Operator Marc',
             'login': 'operator_b',
             'email': 'operatormarc@example.com',
@@ -37,11 +37,11 @@ class TestLivechatRequestHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         })
 
         # Open Chat Request
-        self.visitor.with_user(self.operator_b).sudo().action_send_chat_request()
+        self.visitor.with_user(operator_b).sudo().action_send_chat_request()
         chat_request = self.env["discuss.channel"].search(
             [("livechat_visitor_id", "=", self.visitor.id), ("livechat_end_dt", "=", False)]
         )
-        self.assertEqual(chat_request.livechat_operator_id, self.operator_b.partner_id, "Operator for active livechat session must be Operator Marc")
+        self.assertEqual(chat_request.livechat_operator_id, operator_b.partner_id, "Operator for active livechat session must be Operator Marc")
 
         # Click on livechatbutton at client side
         res = self.url_open(url=self.open_chat_url, json=self.open_chat_params)

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -599,17 +599,17 @@ class TestCheckoutAddress(WebsiteSaleCommon):
 
     def test_11_payment_term_when_address_change(self):
         """Make sure the expected payment terms are set on ecommerce orders"""
-        self.portal_user = self.user_portal
-        self.portal_partner = self.portal_user.partner_id
+        portal_user = self.user_portal
+        portal_partner = portal_user.partner_id
         self.assertFalse(self.portal_partner.property_payment_term_id)
-        so = self._create_so(partner_id=self.portal_partner.id)
+        so = self._create_so(partner_id=portal_partner.id)
         self.assertTrue(so.payment_term_id, "A payment term should be set by default on the sale order")
 
-        website = self.website.with_user(self.portal_user).with_context({})
+        website = self.website.with_user(portal_user).with_context({})
         with MockRequest(website.env, website=website) as req:
             req.httprequest.method = "POST"
 
-            self.default_address_values['partner_id'] = self.portal_partner.id
+            self.default_address_values['partner_id'] = portal_partner.id
             self.WebsiteSaleController.shop_address_submit(**self.default_billing_address_values)
             self.assertTrue(so.payment_term_id, "A payment term should still be set on the sale order")
 

--- a/addons/website_sale/tests/test_delivery_controller.py
+++ b/addons/website_sale/tests/test_delivery_controller.py
@@ -32,7 +32,7 @@ class TestWebsiteSaleDeliveryController(PaymentCommon, WebsiteSaleCommon):
 
     def test_available_methods(self):
         self.env['delivery.carrier'].search([]).action_archive()
-        self.product_delivery_poste = self.env['product.product'].create({
+        product_delivery_poste = self.env['product.product'].create({
             'name': 'The Poste',
             'type': 'service',
             'categ_id': self.env.ref('delivery.product_category_deliveries').id,
@@ -44,7 +44,7 @@ class TestWebsiteSaleDeliveryController(PaymentCommon, WebsiteSaleCommon):
             {
                 'name': 'Over 300',
                 'delivery_type': 'base_on_rule',
-                'product_id': self.product_delivery_poste.id,
+                'product_id': product_delivery_poste.id,
                 'website_published': True,
                 'price_rule_ids': [
                     Command.create({
@@ -56,7 +56,7 @@ class TestWebsiteSaleDeliveryController(PaymentCommon, WebsiteSaleCommon):
             }, {
                 'name': 'Under 300',
                 'delivery_type': 'base_on_rule',
-                'product_id': self.product_delivery_poste.id,
+                'product_id': product_delivery_poste.id,
                 'website_published': True,
                 'price_rule_ids': [
                     Command.create({
@@ -68,11 +68,11 @@ class TestWebsiteSaleDeliveryController(PaymentCommon, WebsiteSaleCommon):
             }, {
                 'name': 'No rules',
                 'delivery_type': 'base_on_rule',
-                'product_id': self.product_delivery_poste.id,
+                'product_id': product_delivery_poste.id,
                 'website_published': True,
             }, {
                 'name': 'Fixed',
-                'product_id': self.product_delivery_poste.id,
+                'product_id': product_delivery_poste.id,
                 'website_published': True,
             },
         ])

--- a/addons/website_sale/tests/test_delivery_ui.py
+++ b/addons/website_sale/tests/test_delivery_ui.py
@@ -38,7 +38,7 @@ class TestUi(odoo.tests.HttpCase):
             'free_over': True,
             'amount': 10,
         })
-        self.product_delivery_poste = self.env['product.product'].create({
+        product_delivery_poste = self.env['product.product'].create({
             'name': 'The Poste',
             'type': 'service',
             'categ_id': self.env.ref('delivery.product_category_deliveries').id,
@@ -46,12 +46,12 @@ class TestUi(odoo.tests.HttpCase):
             'purchase_ok': False,
             'list_price': 20.0,
         })
-        self.carrier = self.env['delivery.carrier'].create({
+        self.env['delivery.carrier'].create({
             'name': 'The Poste',
             'sequence': 9999, # ensure last to load price async
             'fixed_price': 20.0,
             'delivery_type': 'base_on_rule',
-            'product_id': self.product_delivery_poste.id,
+            'product_id': product_delivery_poste.id,
             'website_published': True,
             'price_rule_ids': [
                 Command.create({

--- a/addons/website_sale/tests/test_ecommerce_access.py
+++ b/addons/website_sale/tests/test_ecommerce_access.py
@@ -76,7 +76,7 @@ class TestEcommerceAccess(HttpCaseWithUserDemo, WebsiteSaleCommon):
         self.assertEqual(response.status_code, 200)  # Check that customers can access
 
     def test_ecommerce_menu_visibility_public_user(self):
-        self.menu = self.env['website.menu'].create({
+        menu = self.env['website.menu'].create({
             'name': 'Shop',
             'url': '/shop',
             'parent_id': self.website.menu_id.id,
@@ -85,11 +85,11 @@ class TestEcommerceAccess(HttpCaseWithUserDemo, WebsiteSaleCommon):
         })
 
         # Check if by default public user can see shop menu
-        self.menu.with_user(self.public_user).sudo()._compute_visible()  # Needs to be sudoed as
+        menu.with_user(self.public_user).sudo()._compute_visible()  # Needs to be sudoed as
         # public user can't access _compute_visible
-        self.assertTrue(self.menu.is_visible)
+        self.assertTrue(menu.is_visible)
 
         self.website.ecommerce_access = 'logged_in'
-        self.menu.with_user(self.public_user).sudo()._compute_visible()
+        menu.with_user(self.public_user).sudo()._compute_visible()
         # Check if menu is hidden for public user when ecommerce is restricted
-        self.assertFalse(self.menu.is_visible)
+        self.assertFalse(menu.is_visible)

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -110,14 +110,14 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
             'tax_group_id': tax_group.id
         })
         # storage box
-        self.product_product_7 = self.env['product.product'].create({
+        product_product_7 = self.env['product.product'].create({
             'name': 'Storage Box Test',
             'standard_price': 70.0,
             'list_price': 79.0,
             'website_published': True,
             'invoice_policy': 'delivery',
         })
-        self.product_product_7.taxes_id = [tax.id]
+        product_product_7.taxes_id = [tax.id]
         self.env['res.config.settings'].create({
             'auth_signup_uninvited': 'b2c',
             'show_line_subtotals_tax_selection': 'tax_excluded',

--- a/addons/website_sale/tests/test_website_sale_gmc.py
+++ b/addons/website_sale/tests/test_website_sale_gmc.py
@@ -232,16 +232,16 @@ class TestWebsiteSaleGMC(WebsiteSaleGMCCommon, HttpCase):
             {'name': 'Indoor Furnitures', 'parent_id': furnitures_categ.id},
             {'name': 'Indoor Sofas', 'sequence': 2},
         ])
-        self.public_categories = sofas_categ + indoor_sofas_categ
-        self.product_template_sofa.public_categ_ids = self.public_categories
+        public_categories = sofas_categ + indoor_sofas_categ
+        self.product_template_sofa.public_categ_ids = public_categories
 
         self.update_items()
 
         self.assertListEqual(
-            list(
-                name.replace('/', '>')
-                for name in self.public_categories.sorted('sequence').mapped('display_name')
-            ),
+            [
+                c.display_name.replace('/', '>')
+                for c in public_categories.sorted('sequence')
+            ],
             self.red_sofa_item['product_type']
         )
 

--- a/addons/website_sale/tests/test_website_sale_image.py
+++ b/addons/website_sale/tests/test_website_sale_image.py
@@ -384,13 +384,13 @@ class TestWebsiteSaleRemoveImage(HttpCase):
         })
 
     def test_website_sale_add_and_remove_main_product_image_no_variant(self):
-        self.product = self.env['product.product'].create({
+        product = self.env['product.product'].create({
             'product_tmpl_id': self.template.id,
         })
 
         self.start_tour(self.env['website'].get_client_action_url('/'), 'add_and_remove_main_product_image_no_variant', login='admin')
         self.assertFalse(self.template.image_1920)
-        self.assertFalse(self.product.image_1920)
+        self.assertFalse(product.image_1920)
 
     def test_website_sale_remove_main_product_image_with_variant(self):
         # Set the color attribute and values on the template.
@@ -399,9 +399,9 @@ class TestWebsiteSaleRemoveImage(HttpCase):
             'product_tmpl_id': self.template.id,
             'value_ids': [(6, 0, self.attr_values.ids)]
         }])
-        self.product = self.env['product.product'].create({
+        product = self.env['product.product'].create({
             'product_tmpl_id': self.template.id,
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'remove_main_product_image_with_variant', login='admin')
         self.assertFalse(self.template.image_1920)
-        self.assertFalse(self.product.image_1920)
+        self.assertFalse(product.image_1920)

--- a/addons/website_sale/tests/test_website_sale_invoice.py
+++ b/addons/website_sale/tests/test_website_sale_invoice.py
@@ -26,8 +26,7 @@ class TestWebsiteSaleInvoice(AccountPaymentCommon, SaleCommon):
         self.sale_order.website_id = self.website.id
 
         # Create the payment
-        self.amount = self.sale_order.amount_total
-        tx = self._create_transaction(flow='redirect', sale_order_ids=[self.sale_order.id], state='done')
+        tx = self._create_transaction(flow='redirect', sale_order_ids=[self.sale_order.id], state='done', amount=self.sale_order.amount_total)
         with mute_logger('odoo.addons.sale.models.payment_transaction'):
             tx._post_process()
 

--- a/addons/website_sale/tests/test_website_sale_product_page.py
+++ b/addons/website_sale/tests/test_website_sale_product_page.py
@@ -40,14 +40,14 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
             ("key", "=", "website_sale.product_comment")
         ]).write({"active": True})
 
-        self.product_product_7 = self.env["product.product"].create({
+        product_product_7 = self.env["product.product"].create({
             "name": "Storage Box Test",
             "standard_price": 70.0,
             "list_price": 79.0,
             "website_published": True,
             "invoice_policy": "delivery",
         })
-        message = self.product_product_7.product_tmpl_id.message_post(
+        message = product_product_7.product_tmpl_id.message_post(
             body="Bad box!",
             message_type="comment",
             rating_value="1",

--- a/addons/website_sale/tests/test_website_sale_product_ribbon.py
+++ b/addons/website_sale/tests/test_website_sale_product_ribbon.py
@@ -84,8 +84,8 @@ class TestProductRibbon(WebsiteSaleCommon):
 
         self.new_ribbon.sequence = 1
         self.sale_ribbon.sequence = 2
-        self.auto_assign_ribbon = self.env['product.ribbon'].search([('assign', '!=', 'manual')])
-        ribbon = self.product.product_tmpl_id._get_ribbon(products_prices, self.auto_assign_ribbon)
+        auto_assign_ribbon = self.env['product.ribbon'].search([('assign', '!=', 'manual')])
+        ribbon = self.product.product_tmpl_id._get_ribbon(products_prices, auto_assign_ribbon)
         self.assertEqual(
             ribbon,
             self.new_ribbon,

--- a/addons/website_sale/tests/test_website_sale_snippets.py
+++ b/addons/website_sale/tests/test_website_sale_snippets.py
@@ -48,7 +48,7 @@ class TestSnippets(HttpCase):
             with MockRequest(user.with_user(user).env, website=self.env['website'].get_current_website()):
                 website_visitor = Visitor.create({'partner_id': user.partner_id.id})
         self.assertEqual(website_visitor.name, user.name, "The visitor should be linked to the admin user, not OdooBot or anything.")
-        self.product = self.env['product.product'].create({
+        product = self.env['product.product'].create({
             'name': 'Storage Box',
             'website_published': True,
             'image_512': b'/product/static/img/product_product_9-image.jpg',
@@ -56,7 +56,7 @@ class TestSnippets(HttpCase):
             'description_sale': 'Pedal-based opening system',
         })
         before_tour_product_ids = website_visitor.product_ids.ids
-        website_visitor._add_viewed_product(self.product.id)
+        website_visitor._add_viewed_product(product.id)
 
         self.start_tour('/', 'website_sale.products_snippet_recently_viewed', login='admin')
         self.assertEqual(before_tour_product_ids, website_visitor.product_ids.ids, "There shouldn't be any new product in recently viewed after this tour")

--- a/addons/website_sale/tests/test_website_sale_visitor.py
+++ b/addons/website_sale/tests/test_website_sale_visitor.py
@@ -91,7 +91,8 @@ class WebsiteSaleVisitorTests(WebsiteSaleCommon):
             'sale_ok': True,
         })
 
-        self.website = self.website.with_user(public_user).with_context(website_id=self.website.id)
+
+        website = self.website.with_user(public_user).with_context(website_id=self.website.id)
 
         snippet_filter = self.env.ref('website_sale.dynamic_filter_latest_viewed_products')
 
@@ -100,9 +101,9 @@ class WebsiteSaleVisitorTests(WebsiteSaleCommon):
         self.assertFalse(res)
 
         # AFTER VISITING THE PRODUCT
-        with MockRequest(self.website.env, website=self.website):
+        with MockRequest(website.env, website=website):
             cookies = self.WebsiteSaleController.products_recently_viewed_update(product.id)
-        with MockRequest(self.website.env, website=self.website, cookies=cookies):
+        with MockRequest(website.env, website=website, cookies=cookies):
             res = snippet_filter._prepare_values(limit=16, search_domain=[])
         res_products = [res_product['_record'] for res_product in res]
         self.assertIn(product, res_products)
@@ -110,6 +111,6 @@ class WebsiteSaleVisitorTests(WebsiteSaleCommon):
         # AFTER CHANGING PRODUCT COMPANY
         product.product_tmpl_id.company_id = new_company
         product.product_tmpl_id.flush_recordset(['company_id'])
-        with MockRequest(self.website.env, website=self.website, cookies=cookies):
+        with MockRequest(website.env, website=website, cookies=cookies):
             res = snippet_filter._prepare_values(limit=16, search_domain=[])
         self.assertFalse(res)

--- a/addons/website_sale_collect/tests/test_delivery_carrier.py
+++ b/addons/website_sale_collect/tests/test_delivery_carrier.py
@@ -22,10 +22,10 @@ class TestDeliveryCarrier(ClickAndCollectCommon, WebsiteSaleStockCommon):
 
     def test_same_company_for_delivery_method_and_warehouse(self):
         self.in_store_dm.company_id = self.company_id
-        self.companyA = self.env['res.company'].create({'name': 'Company A'})
-        self.warehouse_2 = self._create_warehouse(company_id=self.companyA.id)
+        companyA = self.env['res.company'].create({'name': 'Company A'})
+        warehouse_2 = self._create_warehouse(company_id=companyA.id)
         with self.assertRaises(ValidationError):
-            self.in_store_dm.warehouse_ids = [Command.set([self.warehouse_2.id])]
+            self.in_store_dm.warehouse_ids = [Command.set([warehouse_2.id])]
 
     def test_creating_in_store_delivery_method_sets_integration_level_to_rate(self):
         new_in_store_carrier = self.env['delivery.carrier'].create({

--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -16,9 +16,9 @@ class TestSaleOrder(ClickAndCollectCommon):
         cls.product_2 = cls._create_product()
 
     def test_warehouse_is_updated_when_changing_delivery_line(self):
-        self.warehouse_2 = self._create_warehouse()
+        warehouse_2 = self._create_warehouse()
         self.website.warehouse_id = self.warehouse
-        so = self._create_in_store_delivery_order(warehouse_id=self.warehouse_2.id)
+        so = self._create_in_store_delivery_order(warehouse_id=warehouse_2.id)
         so._set_delivery_method(self.free_delivery)
         self.assertEqual(so.warehouse_id, self.warehouse)
 
@@ -79,8 +79,7 @@ class TestSaleOrder(ClickAndCollectCommon):
         self.assertNotEqual(so.fiscal_position_id, fp_us)
 
     def test_free_qty_calculated_from_order_wh_if_dm_is_in_store(self):
-        self.warehouse_2 = self._create_warehouse()
-        self.website.warehouse_id = self.warehouse_2
+        self.website.warehouse_id = self._create_warehouse()
         so = self._create_in_store_delivery_order()
         so.warehouse_id = self.warehouse
         free_qty = so._get_free_qty(self.storable_product)
@@ -132,7 +131,7 @@ class TestSaleOrder(ClickAndCollectCommon):
         self.assertIn(cart.order_line, insufficient_stock_data)
 
     def test_product_in_different_warehouse_is_unavailable(self):
-        self.warehouse_2 = self._create_warehouse()
+        warehouse_2 = self._create_warehouse()
         cart = self._create_in_store_delivery_order(
             order_line=[
                 Command.create({
@@ -141,5 +140,5 @@ class TestSaleOrder(ClickAndCollectCommon):
                 })
             ]
         )
-        insufficient_stock_data = cart._get_insufficient_stock_data(self.warehouse_2.id)
+        insufficient_stock_data = cart._get_insufficient_stock_data(warehouse_2.id)
         self.assertIn(cart.order_line, insufficient_stock_data)

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -333,7 +333,7 @@ class TestWebsiteSaleCoupon(HttpCase, WebsiteSaleCommon):
         chair = self.env['product.product'].create({
             'name': 'Super Chair', 'list_price': 1000, 'website_published': True
         })
-        self.discount_code_program_multi_rewards = self.env['loyalty.program'].create({
+        self.env['loyalty.program'].create({
             'name': 'Discount code program',
             'program_type': 'promo_code',
             'applies_on': 'current',

--- a/addons/website_sale_slides/tests/test_course_purchase_flow.py
+++ b/addons/website_sale_slides/tests/test_course_purchase_flow.py
@@ -32,7 +32,7 @@ class TestCoursePurchaseFlow(common.SlidesCase):
             'product_id': self.course_product.id
         })
 
-        self.channel_2 = self.env['slide.channel'].with_user(self.user_officer).create({
+        channel_2 = self.env['slide.channel'].with_user(self.user_officer).create({
             'name': 'Test Channel',
             'enroll': 'payment',
             'product_id': self.course_product.id,
@@ -56,7 +56,7 @@ class TestCoursePurchaseFlow(common.SlidesCase):
 
         # Step 3: check that the customer is now a member of both channel
         self.assertIn(self.customer, self.channel.partner_ids)
-        self.assertIn(self.customer, self.channel_2.partner_ids)
+        self.assertIn(self.customer, channel_2.partner_ids)
 
         # Step 4: Same test as salesman
         salesman_sale_order = self.env['sale.order'].with_user(self.user_salesman).create({
@@ -74,7 +74,7 @@ class TestCoursePurchaseFlow(common.SlidesCase):
         salesman_sale_order.action_confirm()
 
         self.assertIn(self.user_portal.partner_id, self.channel.partner_ids)
-        self.assertIn(self.user_portal.partner_id, self.channel_2.partner_ids)
+        self.assertIn(self.user_portal.partner_id, channel_2.partner_ids)
 
     @users('user_officer')
     def test_course_product_published_synch(self):

--- a/addons/website_slides/tests/test_attendee.py
+++ b/addons/website_slides/tests/test_attendee.py
@@ -77,12 +77,12 @@ class TestAttendee(common.SlidesCase):
         self.assertFalse(user_portal_partner.id in self.channel.partner_ids.ids)
 
         # Enroll partner to course
-        self.slide_channel_invite_wizard = self.env['slide.channel.invite'].create({
+        slide_channel_invite_wizard = self.env['slide.channel.invite'].create({
             'channel_id': self.channel.id,
             'partner_ids': [(6, 0, [self.user_portal.partner_id.id])],
             'enroll_mode': True,
         })
-        self.slide_channel_invite_wizard.action_invite()
+        slide_channel_invite_wizard.action_invite()
 
         # The partner should be in the attendees as 'joined'
         user_portal_channel_partner = self.channel.channel_partner_all_ids.filtered(lambda p: p.partner_id.id == user_portal_partner.id)
@@ -101,12 +101,12 @@ class TestAttendee(common.SlidesCase):
         self.assertFalse(user_portal_partner.id in self.channel.partner_ids.ids)
 
         # Invite partner to course
-        self.slide_channel_invite_wizard = self.env['slide.channel.invite'].create({
+        slide_channel_invite_wizard = self.env['slide.channel.invite'].create({
             'channel_id': self.channel.id,
             'partner_ids': [(6, 0, [self.user_portal.partner_id.id])],
             'send_email': True,
         })
-        self.slide_channel_invite_wizard.action_invite()
+        slide_channel_invite_wizard.action_invite()
 
         # The partner should be in the attendees as 'invited'
         user_portal_channel_partner = self.channel.channel_partner_all_ids.filtered(lambda p: p.partner_id.id == user_portal_partner.id)
@@ -132,12 +132,12 @@ class TestAttendee(common.SlidesCase):
         self.assertEqual(user_portal_channel_partner.member_status, 'ongoing')
 
         # Invite archived ongoing partner to course
-        self.slide_channel_invite_wizard = self.env['slide.channel.invite'].create({
+        slide_channel_invite_wizard = self.env['slide.channel.invite'].create({
             'channel_id': self.channel.id,
             'partner_ids': [(6, 0, [self.user_portal.partner_id.id])],
             'send_email': True,
         })
-        self.slide_channel_invite_wizard.action_invite()
+        slide_channel_invite_wizard.action_invite()
 
         # The partner should be reactivated in the attendees as 'invited'
         self.assertTrue(user_portal_channel_partner.active)
@@ -146,9 +146,9 @@ class TestAttendee(common.SlidesCase):
 
         # Archive then enroll the attendee
         user_portal_channel_partner.action_archive()
-        self.slide_channel_invite_wizard.enroll_mode = True
-        self.slide_channel_invite_wizard.flush_recordset()
-        self.slide_channel_invite_wizard.action_invite()
+        slide_channel_invite_wizard.enroll_mode = True
+        slide_channel_invite_wizard.flush_recordset()
+        slide_channel_invite_wizard.action_invite()
 
         # The partner should be reactivated in the attendees as 'ongoing'
         self.assertTrue(user_portal_channel_partner.active)

--- a/addons/website_slides/tests/test_slide_slide.py
+++ b/addons/website_slides/tests/test_slide_slide.py
@@ -13,14 +13,14 @@ class TestSlideInternals(slides_common.SlidesCase):
         """
             Check that we properly calculate the completion time of a course without error, after deleting a slide.
         """
-        self.category2 = self.env['slide.slide'].with_user(self.user_officer).create({
+        category2 = self.env['slide.slide'].with_user(self.user_officer).create({
             'name': 'Cooking Tips For Dieting',
             'channel_id': self.channel.id,
             'is_category': True,
             'is_published': True,
             'sequence': 5,
         })
-        self.slide_4 = self.env['slide.slide'].with_user(self.user_officer).create({
+        slide_4 = self.env['slide.slide'].with_user(self.user_officer).create({
             'name': 'Vegan Diet',
             'channel_id': self.channel.id,
             'slide_category': 'document',
@@ -28,7 +28,7 @@ class TestSlideInternals(slides_common.SlidesCase):
             'completion_time': 5.0,
             'sequence': 6,
         })
-        self.slide_5 = self.env['slide.slide'].with_user(self.user_officer).create({
+        slide_5 = self.env['slide.slide'].with_user(self.user_officer).create({
             'name': 'Normal Diet',
             'channel_id': self.channel.id,
             'slide_category': 'document',
@@ -37,14 +37,14 @@ class TestSlideInternals(slides_common.SlidesCase):
             'sequence': 7,
         })
 
-        before_unlink = self.category2.completion_time
-        self.assertEqual(before_unlink, self.slide_4.completion_time + self.slide_5.completion_time)
+        before_unlink = category2.completion_time
+        self.assertEqual(before_unlink, slide_4.completion_time + slide_5.completion_time)
 
         self.channel.slide_ids[6].sudo().unlink()
-        self.category2._compute_category_completion_time()
+        category2._compute_category_completion_time()
 
-        after_unlink = self.category2.completion_time
-        self.assertEqual(after_unlink, self.slide_4.completion_time)
+        after_unlink = category2.completion_time
+        self.assertEqual(after_unlink, slide_4.completion_time)
 
     @mute_logger('odoo.sql_db')
     @users('user_manager')

--- a/addons/website_slides/tests/test_statistics.py
+++ b/addons/website_slides/tests/test_statistics.py
@@ -114,27 +114,27 @@ class TestChannelStatistics(common.SlidesCase):
         self.assertEqual(channel_publisher.completion, 33)
 
         # Should update completion when a new published slide is created
-        self.slide_4 = self.slide_3.copy({'is_published': True})
+        slide_4 = self.slide_3.copy({'is_published': True})
         self.assertEqual(member_emp.completion, 100)
         self.assertEqual(channel_emp.completion, 100)
         self.assertEqual(member_publisher.completion, 25)
         self.assertEqual(channel_publisher.completion, 25)
 
         # Should update completion when slide is (un)published
-        self.slide_4.is_published = False
+        slide_4.is_published = False
         self.assertEqual(member_emp.completion, 100)
         self.assertEqual(channel_emp.completion, 100)
         self.assertEqual(member_publisher.completion, 33)
         self.assertEqual(channel_publisher.completion, 33)
 
-        self.slide_4.is_published = True
+        slide_4.is_published = True
         self.assertEqual(member_emp.completion, 100)
         self.assertEqual(channel_emp.completion, 100)
         self.assertEqual(member_publisher.completion, 25)
         self.assertEqual(channel_publisher.completion, 25)
 
         # Should update completion when a slide is unlinked
-        self.slide_4.with_user(self.user_manager).unlink()
+        slide_4.with_user(self.user_manager).unlink()
         self.assertEqual(member_emp.completion, 100)
         self.assertEqual(channel_emp.completion, 100)
         self.assertEqual(member_publisher.completion, 33)

--- a/addons/website_slides_survey/tests/test_course_certification_failure.py
+++ b/addons/website_slides_survey/tests/test_course_certification_failure.py
@@ -39,7 +39,7 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
                 ])
 
         # Step 1.1: create a simple channel
-        self.channel = self.env['slide.channel'].sudo().create({
+        channel = self.env['slide.channel'].sudo().create({
             'name': 'Test Channel',
             'channel_type': 'training',
             'enroll': 'public',
@@ -48,19 +48,19 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
         })
 
         # Step 2: link the certification to a slide of category 'certification'
-        self.slide_certification = self.env['slide.slide'].sudo().create({
+        slide_certification = self.env['slide.slide'].sudo().create({
             'name': 'Certification slide',
-            'channel_id': self.channel.id,
+            'channel_id': channel.id,
             'slide_category': 'certification',
             'survey_id': certification.id,
             'is_published': True,
         })
         # Step 3: add portal user as member of the channel
-        self.channel._action_add_members(self.user_portal.partner_id)
+        channel._action_add_members(self.user_portal.partner_id)
         # forces recompute of partner_ids as we create directly in relation
-        self.channel.invalidate_model()
-        slide_partner = self.slide_certification._action_set_viewed(self.user_portal.partner_id)
-        self.slide_certification.with_user(self.user_portal)._generate_certification_url()
+        channel.invalidate_model()
+        slide_partner = slide_certification._action_set_viewed(self.user_portal.partner_id)
+        slide_certification.with_user(self.user_portal)._generate_certification_url()
 
         self.assertEqual(1, len(slide_partner.user_input_ids), 'A user input should have been automatically created upon slide view')
 
@@ -70,17 +70,17 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
 
         self.assertFalse(slide_partner.survey_scoring_success, 'Quizz should not be marked as passed with wrong answers')
         # forces recompute of partner_ids as we delete directly in relation
-        self.channel.invalidate_model()
-        self.assertIn(self.user_portal.partner_id, self.channel.partner_ids, 'Portal user should still be a member of the course because they still have attempts left')
-        certification_urls = self.slide_certification.with_user(self.user_portal)._generate_certification_url()
-        self.assertEqual(certification_urls[self.slide_certification.id],
+        channel.invalidate_model()
+        self.assertIn(self.user_portal.partner_id, channel.partner_ids, 'Portal user should still be a member of the course because they still have attempts left')
+        certification_urls = slide_certification.with_user(self.user_portal)._generate_certification_url()
+        self.assertEqual(certification_urls[slide_certification.id],
                          slide_partner.user_input_ids[0].get_start_url(),
                          "Make sure that the url generated is the same even if we enter again the certification without doing retry.")
         # Step 5: simulate a 'retry'
-        retry_user_input = self.slide_certification.survey_id.sudo()._create_answer(
+        retry_user_input = slide_certification.survey_id.sudo()._create_answer(
             partner=self.user_portal.partner_id,
             **{
-                'slide_id': self.slide_certification.id,
+                'slide_id': slide_certification.id,
                 'slide_partner_id': slide_partner.id
             },
             invite_token=slide_partner.user_input_ids[0].invite_token
@@ -89,19 +89,19 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
         # Step 6: fill in the new user_input with wrong answers again
         self.fill_in_answer(retry_user_input, certification.question_ids)
         # forces recompute of partner_ids as we delete directly in relation
-        self.channel.invalidate_model()
+        channel.invalidate_model()
         channel_partner = self.env['slide.channel.partner'].with_context(active_test=False).search([
-            ('channel_id', 'in', self.channel.ids),
+            ('channel_id', 'in', channel.ids),
             ('partner_id', 'in', slide_partner.partner_id.ids),
         ])
         self.assertFalse(channel_partner.active, 'Portal user membership should have been archived from the course attendee because he failed his last attempt')
 
         # Step 7: add portal user as member of the channel once again
-        self.channel._action_add_members(self.user_portal.partner_id)
+        channel._action_add_members(self.user_portal.partner_id)
         # forces recompute of partner_ids as we create directly in relation
-        self.channel.invalidate_model()
+        channel.invalidate_model()
 
-        self.slide_certification.with_user(self.user_portal)._generate_certification_url()
+        slide_certification.with_user(self.user_portal)._generate_certification_url()
         self.assertTrue(channel_partner.active, 'Portal user membership should be a unarchived upon joining the course once again')
         self.assertEqual(1, len(slide_partner.user_input_ids), 'A new user input should have been automatically created upon slide view')
         first_attempt_in_second_pool = slide_partner.user_input_ids[0]
@@ -109,8 +109,8 @@ class TestCourseCertificationFailureFlow(TestSurveyCommon):
         self.fill_in_answer(slide_partner.user_input_ids, certification.question_ids, good_answers=True)
         self.assertTrue(slide_partner.survey_scoring_success, 'Quizz should be marked as passed with correct answers')
         # forces recompute of partner_ids as we delete directly in relation
-        self.channel.invalidate_model()
-        self.assertIn(self.user_portal.partner_id, self.channel.partner_ids, 'Portal user should still be a member of the course')
+        channel.invalidate_model()
+        self.assertIn(self.user_portal.partner_id, channel.partner_ids, 'Portal user should still be a member of the course')
         # Checking the attempts numbers
         self.assertEqual(1, first_attempt_in_first_pool.attempts_number,
                          'The first attempt of the first pool should be number 1')

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -479,7 +479,7 @@ ZeroDivisionError: division by zero""" % self.test_server_action.id
 
         group0 = self.env['res.groups'].create({'name': 'country group'})
 
-        self.context = {
+        context = {
             'active_model': 'res.country',
             'active_id': self.test_country.id,
         }
@@ -497,7 +497,7 @@ ZeroDivisionError: division by zero""" % self.test_server_action.id
         self.assertFalse(bindings)
 
         with self.assertRaises(AccessError):
-            self.action.with_context(self.context).run()
+            self.action.with_context(context).run()
         self.assertFalse(self.test_country.vat_label)
 
         # add group to the user, and test again
@@ -506,24 +506,22 @@ ZeroDivisionError: division by zero""" % self.test_server_action.id
         bindings = Actions.get_bindings('res.country')
         self.assertItemsEqual(bindings.get('action'), self.action.read(['name', 'sequence', 'binding_view_types']))
 
-        self.action.with_context(self.context).run()
+        self.action.with_context(context).run()
         self.assertEqual(self.test_country.vat_label, 'VatFromTest', 'vat label should be changed to VatFromTest')
 
     def test_60_sort(self):
         """ check the actions sorted by sequence """
-        Actions = self.env['ir.actions.actions']
-
         # Do: update model
         self.action.write({
             'model_id': self.res_country_model.id,
             'binding_model_id': self.res_country_model.id,
         })
-        self.action2 = self.action.copy({'name': 'TestAction2', 'sequence': 1})
+        self.action.copy({'name': 'TestAction2', 'sequence': 1})
 
         # Test: action returned by sequence
-        bindings = Actions.get_bindings('res.country')
-        self.assertEqual([vals.get('name') for vals in bindings['action']], ['TestAction2', 'TestAction'])
-        self.assertEqual([vals.get('sequence') for vals in bindings['action']], [1, 5])
+        bindings = self.env['ir.actions.actions'].get_bindings('res.country')
+        self.assertEqual([vals['name'] for vals in bindings['action']], ['TestAction2', 'TestAction'])
+        self.assertEqual([vals['sequence'] for vals in bindings['action']], [1, 5])
 
     def test_70_copy_action(self):
         # first check that the base case (reset state) works normally

--- a/odoo/addons/base/tests/test_ir_embedded_actions.py
+++ b/odoo/addons/base/tests/test_ir_embedded_actions.py
@@ -54,8 +54,8 @@ class TestEmbeddedActionsBase(TransactionCaseWithUserDemo):
             'action_id': cls.action_2.id,
         })
 
-    def get_embedded_actions_ids(self, parent_action):
-        return parent_action.with_context(self.context).read()[0]['embedded_action_ids']
+    def get_embedded_actions_ids(self, parent_action, **context):
+        return parent_action.with_context(context or self.context).read()[0]['embedded_action_ids']
 
     def test_parent_has_embedded_actions(self):
         res = self.get_embedded_actions_ids(self.parent_action)
@@ -85,10 +85,6 @@ class TestEmbeddedActionsBase(TransactionCaseWithUserDemo):
             'name': 'CustomPartner',
             'employee': False,
         })
-        self.context = {
-            'active_model': 'res.partner',
-            'active_id': test_partner_custo.id,
-        }
         embedded_action_custo = self.env['ir.embedded.actions'].create({
             'name': 'EmbeddedActionCusto',
             'parent_res_model': 'res.partner',
@@ -96,7 +92,7 @@ class TestEmbeddedActionsBase(TransactionCaseWithUserDemo):
             'action_id': self.action_2.id,
             'domain': [('employee', '=', True)]
         })
-        res = self.get_embedded_actions_ids(self.parent_action)
+        res = self.get_embedded_actions_ids(self.parent_action, active_model='res.partner', active_id=test_partner_custo.id)
         self.assertTrue(embedded_action_custo.id not in res, "The embedded action not respecting the domain should\
                          not be returned in the read method")
 

--- a/odoo/addons/base/tests/test_res_config.py
+++ b/odoo/addons/base/tests/test_res_config.py
@@ -78,11 +78,7 @@ class TestResConfig(TransactionCase):
     def test_30_get_config_warning_wo_menu(self):
         """ The get_config_warning() method should return a Warning exception """
         res = self.ResConfig.get_config_warning(self.error_msg_wo_menu)
-
-        # Check type
         self.assertIsInstance(res, exceptions.UserError)
-
-        # Check returned value
         self.assertEqual(res.args[0], self.expected_final_error_msg_wo_menu)
 
     # TODO: ASK DLE if this test can be removed
@@ -159,7 +155,7 @@ class TestResConfigExecute(TransactionCase):
         """
         all_config_settings = self.env['ir.model'].search([('name', 'like', 'config.settings')])
         for config_settings in all_config_settings:
-            _logger.info("Testing %s" % (config_settings.name))
+            _logger.info("Testing %s", config_settings.name)
             self.env[config_settings.name].create({}).execute()
 
     def test_settings_access(self):
@@ -171,7 +167,6 @@ class TestResConfigExecute(TransactionCase):
         """
         ResUsers = self.env['res.users']
         group_system = self.env.ref('base.group_system')
-        self.settings_view = self.env.ref('base.res_config_settings_view_form')
         settings_only_user = ResUsers.create({
             'name': 'Sleepy Joe',
             'login': 'sleepy',
@@ -201,15 +196,13 @@ class TestResConfigExecute(TransactionCase):
         # Check user has access to all models of relational fields in view
         # because the webclient makes a read of display_name request for all specified records
         # even if they are not shown to the user.
-        settings_view_arch = etree.fromstring(settings.get_view(view_id=self.settings_view.id)['arch'])
-        seen_fields = set()
-        for node in settings_view_arch.iterdescendants(tag='field'):
-            fname = node.get('name')
-            if fname not in settings._fields:
-                # fname isn't a settings fields, but the field of a model
-                # linked to settings through a relational field
-                continue
-            seen_fields.add(fname)
+        settings_view = self.env.ref('base.res_config_settings_view_form')
+        settings_view_arch = etree.fromstring(settings.get_view(view_id=settings_view.id)['arch'])
+        seen_fields = {
+            fname
+            for node in settings_view_arch.iterdescendants(tag='field')
+            if (fname := node.get('name')) in settings._fields
+        }
 
         models_to_check = defaultdict(set)
         for field_name in seen_fields:

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -204,7 +204,7 @@ class TestUsers(UsersCommonCase):
 
         # The deletion will fail for "portal_user_2",
         # because of the absence of "ondelete=cascade"
-        self.cron = self.env['ir.cron'].create({
+        self.env['ir.cron'].create({
             'name': 'Test Cron',
             'user_id': portal_user_2.id,
             'model_id': self.env.ref('base.model_res_partner').id,

--- a/odoo/addons/base/tests/test_test_suite.py
+++ b/odoo/addons/base/tests/test_test_suite.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import difflib
+import itertools
 import logging
 import re
 from contextlib import contextmanager
@@ -40,7 +41,7 @@ class TestRunnerLoggingCommon(TransactionCase):
     """
 
     def setUp(self):
-        self.expected_logs = None
+        self.expected_logs = []
         self.expected_first_frame_methods = None
         return super().setUp()
 
@@ -110,11 +111,13 @@ class TestRunnerLoggingCommon(TransactionCase):
             self._assert_log_equal(log_record, 'fn', __file__)
             self._assert_log_equal(log_record, 'func', self._testMethodName)
 
-        if self.expected_logs is not None:
-            for log_record in log_records:
-                level, msg = self.expected_logs.pop(0)
-                self._assert_log_equal(log_record, 'level', level)
-                self._assert_log_equal(log_record, 'msg', msg)
+        for log_record, expected in itertools.zip_longest(
+            log_records,
+            self.expected_logs,
+        ):
+            level, msg = expected or (None, None)
+            self._assert_log_equal(log_record, 'level', level)
+            self._assert_log_equal(log_record, 'msg', msg)
 
     def _assert_log_equal(self, log_record, key, expected):
         """ Check the content of a log record. """
@@ -171,7 +174,7 @@ Traceback (most recent call last):
     raise Exception('{message}')
 Exception: {message}
 ''')
-        self.expected_logs = [
+        self.expected_logs[:] = [
             (logging.INFO, '=' * 70),
             (logging.ERROR, make_message('This is an error')),
         ]
@@ -180,7 +183,7 @@ Exception: {message}
 
         self.assertFalse(self.expected_logs, "Error should have been logged immediatly")
 
-        self.expected_logs = [
+        self.expected_logs[:] = [
             (logging.INFO, '=' * 70),
             (logging.ERROR, make_message('This is an error2')),
         ]
@@ -204,7 +207,7 @@ Traceback (most recent call last):
     raise Exception('This is an error')
 Exception: This is an error
 ''')
-        self.expected_logs = [
+        self.expected_logs[:] = [
             (logging.INFO, '=' * 70),
             (logging.ERROR, message),
         ]
@@ -240,7 +243,7 @@ Traceback (most recent call last):
     raise Exception('This is an error')
 Exception: This is an error
 ''')
-        self.expected_logs = [
+        self.expected_logs[:] = [
             (logging.INFO, '=' * 70),
             (logging.ERROR, message),
         ]
@@ -270,7 +273,7 @@ Traceback (most recent call last):
     raise Exception('This is an error')
 Exception: This is an error
 ''')
-        self.expected_logs = [
+        self.expected_logs[:] = [
             (logging.INFO, '=' * 70),
             (logging.ERROR, message),
         ]
@@ -302,7 +305,7 @@ Traceback (most recent call last):
     raise Exception('This is an error')
 Exception: This is an error
 ''')
-        self.expected_logs = [
+        self.expected_logs[:] = [
             (logging.INFO, '=' * 70),
             (logging.ERROR, message),
         ]
@@ -331,7 +334,7 @@ Traceback (most recent call last):
     self.fail(msg % (login, count, expected, funcname, filename, linenum))
 AssertionError: Query count more than expected for user __system__: 1 > 0 in test_assertQueryCount at base/tests/test_test_suite.py:$line
 ''')
-        self.expected_logs = [
+        self.expected_logs[:] = [
             (logging.INFO, '=' * 70),
             (logging.ERROR, message),
         ]
@@ -356,7 +359,7 @@ Traceback (most recent call last):
     raise Exception('This is an error')
 Exception: This is an error
 ''')
-        self.expected_logs = [
+        self.expected_logs[:] = [
             (logging.INFO, '=' * 70),
             (logging.ERROR, message),
         ]
@@ -392,7 +395,7 @@ Traceback (most recent call last):
     raise Exception('This is an error2')
 Exception: This is an error2
 ''')
-        self.expected_logs = [
+        self.expected_logs[:] = [
             (logging.INFO, '=' * 70),
             (logging.ERROR, message),
         ]

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3457,7 +3457,7 @@ class TestViews(ViewCase):
         self.assertWarning('<form><input type="email" class="btn" role="button"/></form>')
 
     def test_partial_validation(self):
-        self.View = self.View.with_context(load_all_views=True)
+        View = self.View.with_context(load_all_views=True)
 
         # base view
         view0 = self.assertValid("""
@@ -3499,17 +3499,17 @@ class TestViews(ViewCase):
         )
 
         # replacing an element should validate the whole view
-        view_arch = self.View.get_views([(view0.id, 'form')])['views']['form']['arch']
+        view_arch = View.get_views([(view0.id, 'form')])['views']['form']['arch']
         self.assertFalse(etree.fromstring(view_arch).xpath('//field[@name="model"][@invisible][@readonly]'))
         view0bis = None
         view0bis = self.assertValid(
             """<field name="model" position="replace"/>""",
             inherit_id=view0.id,
         )
-        view_arch = self.View.get_views([(view0.id, 'form')])['views']['form']['arch']
+        view_arch = View.get_views([(view0.id, 'form')])['views']['form']['arch']
         self.assertTrue(etree.fromstring(view_arch).xpath('//field[@name="model"][@invisible][@readonly]'))
         view0bis.active = False
-        view_arch = self.View.get_views([(view0.id, 'form')])['views']['form']['arch']
+        view_arch = View.get_views([(view0.id, 'form')])['views']['form']['arch']
         self.assertFalse(etree.fromstring(view_arch).xpath('//field[@name="model"][@invisible][@readonly]'))
 
         # moving an element should have no impact; this test checks that the
@@ -3527,7 +3527,7 @@ class TestViews(ViewCase):
         view1.arch = """<form position="inside">
             <field name="type"/>
         </form>"""
-        view_arch = self.View.get_views([(view0.id, 'form')])['views']['form']['arch']
+        view_arch = View.get_views([(view0.id, 'form')])['views']['form']['arch']
         self.assertTrue(etree.fromstring(view_arch).xpath('//field[@name="name"][@invisible][@readonly]'))
 
     def test_graph_fields(self):

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -156,37 +156,37 @@ class TestJavascriptAssetsBundle(FileTouchable):
         """ Checks that a bundle creates an ir.attachment record when its `js` method is called
         for the first time and this ir.attachment is different depending on `is_minified` param.
         """
-        self.bundle = self._get_asset(self.jsbundle_name, debug_assets=False)
+        bundle = self._get_asset(self.jsbundle_name, debug_assets=False)
 
         # there shouldn't be any minified attachment associated to this bundle
         self.assertEqual(len(self._any_ira_for_bundle('min.js')), 0,
                          "there shouldn't be any minified attachment associated to this bundle")
-        self.assertEqual(len(self.bundle.get_attachments('min.js')), 0,
+        self.assertEqual(len(bundle.get_attachments('min.js')), 0,
                          "there shouldn't be any minified attachment associated to this bundle")
 
         # trigger the first generation and, thus, the first save in database
-        self.bundle.js()
+        bundle.js()
 
         # there should be one minified attachment associated to this bundle
         self.assertEqual(len(self._any_ira_for_bundle('min.js')), 1,
                          "there should be one minified attachment associated to this bundle")
-        self.assertEqual(len(self.bundle.get_attachments('min.js')), 1,
+        self.assertEqual(len(bundle.get_attachments('min.js')), 1,
                          "there should be one minified attachment associated to this bundle")
 
         # there shouldn't be any non-minified attachment associated to this bundle
         self.assertEqual(len(self._any_ira_for_bundle('js')), 0,
                          "there shouldn't be any non-minified attachment associated to this bundle")
-        self.assertEqual(len(self.bundle.get_attachments('js')), 0,
+        self.assertEqual(len(bundle.get_attachments('js')), 0,
                          "there shouldn't be any non-minified attachment associated to this bundle")
 
         # trigger the first generation and, thus, the first save in database for the non-minified version.
-        self.bundle_debug = self._get_asset(self.jsbundle_name, debug_assets=True)
-        self.bundle_debug.js()
+        bundle_debug = self._get_asset(self.jsbundle_name, debug_assets=True)
+        bundle_debug.js()
 
         # there should be one non-minified attachment associated to this bundle
         self.assertEqual(len(self._any_ira_for_bundle('js')), 1,
                          "there should be one non-minified attachment associated to this bundle")
-        self.assertEqual(len(self.bundle.get_attachments('js')), 1,
+        self.assertEqual(len(bundle.get_attachments('js')), 1,
                          "there should be one non-minified attachment associated to this bundle")
 
     def test_02_access(self):
@@ -341,10 +341,10 @@ class TestJavascriptAssetsBundle(FileTouchable):
 
     def test_08_css_generation3(self):
         # self.cssbundle_xlmid contains 3 rules (not checked below)
-        self.bundle = self._get_asset(self.cssbundle_name)
-        self.bundle.css()
+        bundle = self._get_asset(self.cssbundle_name)
+        bundle.css()
         self.assertEqual(len(self._any_ira_for_bundle('min.css')), 1)
-        self.assertEqual(len(self.bundle.get_attachments('min.css')), 1)
+        self.assertEqual(len(bundle.get_attachments('min.css')), 1)
 
     def test_09_css_access(self):
         """ Checks that the bundle's cache is working, i.e. that a bundle creates only enough
@@ -436,29 +436,29 @@ class TestJavascriptAssetsBundle(FileTouchable):
         """ Checks that a bundle creates an ir.attachment record when its `css` method is called
         for the first time for language with different direction and separate bundle is created for rtl direction.
         """
-        self.bundle = self._get_asset(self.cssbundle_name, rtl=True)
+        bundle = self._get_asset(self.cssbundle_name, rtl=True)
 
         # there shouldn't be any attachment associated to this bundle
         self.assertEqual(len(self._any_ira_for_bundle('min.css', rtl=True)), 0)
-        self.assertEqual(len(self.bundle.get_attachments('min.css')), 0)
+        self.assertEqual(len(bundle.get_attachments('min.css')), 0)
 
         # trigger the first generation and, thus, the first save in database
-        self.bundle.css()
+        bundle.css()
 
         # there should be no compilation errors
-        self.assertEqual(len(self.bundle.css_errors), 0)
+        self.assertEqual(len(bundle.css_errors), 0)
 
         # there should be one attachment associated to this bundle
         self.assertEqual(len(self._any_ira_for_bundle('min.css', rtl=True)), 1)
-        self.assertEqual(len(self.bundle.get_attachments('min.css')), 1)
+        self.assertEqual(len(bundle.get_attachments('min.css')), 1)
 
     def test_15_rtl_invalid_css_generation(self):
         """ Checks that erroneous css cannot be compiled by rtlcss and that errors are registered """
-        self.bundle = self._get_asset('test_assetsbundle.broken_css', rtl=True)
+        bundle = self._get_asset('test_assetsbundle.broken_css', rtl=True)
         with mute_logger('odoo.addons.base.models.assetsbundle'):
-            self.bundle.css()
-        self.assertEqual(len(self.bundle.css_errors), 1)
-        self.assertIn('rtlcss: error processing payload', self.bundle.css_errors[0])
+            bundle.css()
+        self.assertEqual(len(bundle.css_errors), 1)
+        self.assertIn('rtlcss: error processing payload', bundle.css_errors[0])
 
     def test_16_ltr_and_rtl_css_access(self):
         """ Checks that the bundle's cache is working, i.e. that the bundle creates only one
@@ -678,45 +678,45 @@ class TestXMLAssetsBundle(FileTouchable):
         error message.
         """
         with mute_logger('odoo.addons.base.models.assetsbundle'):
-            self.bundle = self._get_asset('test_assetsbundle.broken_xml')
+            bundle = self._get_asset('test_assetsbundle.broken_xml')
 
             # there shouldn't be any test_assetsbundle.invalid_xml template.
             # there should be an parsing_error template with the parsing error message.
             with self.assertRaisesRegex(XMLAssetError, "Invalid XML template: Opening and ending tag mismatch: SomeComponent line 4 and t, line 5, column 7\' in file \'/test_assetsbundle/static/invalid_src/xml/invalid_xml.xml"):
-                self.bundle.xml()
+                bundle.xml()
 
     def test_02_multiple_broken_xml(self):
         """ Checks that a bundle with multiple broken xml returns a comprehensive error message.
         """
         with mute_logger('odoo.addons.base.models.assetsbundle'):
-            self.bundle = self._get_asset('test_assetsbundle.multiple_broken_xml')
+            bundle = self._get_asset('test_assetsbundle.multiple_broken_xml')
 
             # there shouldn't be any test_assetsbundle.invalid_xml template or test_assetsbundle.second_invalid_xml template.
             # there should be one parsing_error templates with the parsing error message for the first file.
             with self.assertRaisesRegex(XMLAssetError, "Invalid XML template: Opening and ending tag mismatch: SomeComponent line 4 and t, line 5, column 7\' in file \'/test_assetsbundle/static/invalid_src/xml/invalid_xml.xml"):
-                self.bundle.xml()
+                bundle.xml()
 
     def test_04_template_wo_name(self):
         """ Checks that a bundle with template without name returns a comprehensive error message.
         """
         with mute_logger('odoo.addons.base.models.assetsbundle'):
-            self.bundle = self._get_asset('test_assetsbundle.wo_name')
+            bundle = self._get_asset('test_assetsbundle.wo_name')
 
             # there shouldn't be raise a ValueError, there should a parsing_error template with
             # the error message.
             with self.assertRaisesRegex(XMLAssetError, "'Template name is missing.' in file \'/test_assetsbundle/static/invalid_src/xml/template_wo_name.xml\'"):
-                self.bundle.xml()
+                bundle.xml()
 
     def test_05_file_not_found(self):
         """ Checks that a bundle with a file in error (file not found, encoding error, or other) returns a comprehensive error message.
         """
         with mute_logger('odoo.addons.base.models.assetsbundle'):
-            self.bundle = self._get_asset('test_assetsbundle.file_not_found')
+            bundle = self._get_asset('test_assetsbundle.file_not_found')
 
             # there shouldn't be raise a ValueError, there should a parsing_error template with
             # the error message.
             with self.assertRaisesRegex(XMLAssetError, "Could not get content for test_assetsbundle/static/invalid_src/xml/file_not_found.xml."):
-                self.bundle.xml()
+                bundle.xml()
 
 @tagged('-at_install', 'post_install')
 class TestAssetsBundleInBrowser(HttpCase):

--- a/odoo/addons/test_http/tests/test_common.py
+++ b/odoo/addons/test_http/tests/test_common.py
@@ -46,7 +46,6 @@ class TestHttpBase(HttpCaseWithUserDemo):
             return self.url_open(url, *args, allow_redirects=allow_redirects, **kwargs)
 
     def multidb_url_open(self, url, *args, allow_redirects=False, dblist=(), **kwargs):
-        dblist = dblist or self.db_list
         assert len(dblist) >= 2, "There should be at least 2 databases"
         with patch('odoo.http.db_list') as db_list, \
              patch('odoo.http.db_filter') as db_filter, \

--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -264,9 +264,10 @@ class TestHttpEnsureDb(TestHttpBase):
         self.assertEqual(res.text, 'db1')
 
     def test_ensure_db4_unicode(self):
-        self.db_list = ["basededonnée1", "basededonnée2"]  # é matters
-
-        res = self.multidb_url_open('/test_http/ensure_db?db=basededonnée1')
+        res = self.multidb_url_open(
+            '/test_http/ensure_db?db=basededonnée1',
+            dblist=("basededonnée1", "basededonnée2"),  # é matters
+        )
         res.raise_for_status()
         self.assertEqual(res.status_code, 302)
         self.assertURLEqual(

--- a/odoo/addons/test_http/tests/test_session.py
+++ b/odoo/addons/test_http/tests/test_session.py
@@ -74,8 +74,6 @@ class TestHttpSession(TestHttpBase):
         self.assertURLEqual(res.headers.get('Location'), '/web/database/selector')
 
     def test_session04_web_authenticate_multidb(self):
-        self.db_list = [get_db_name(), 'another_database']
-
         payload = json.dumps({
             'jsonrpc': '2.0',
             'id': None,
@@ -90,7 +88,8 @@ class TestHttpSession(TestHttpBase):
         res = self.multidb_url_open(
             '/web/session/authenticate', data=payload, headers={
                 'Content-Type': 'application/json',
-            }
+            },
+            dblist=(get_db_name(), 'another_database'),
         )
         res.raise_for_status()
         self.assertEqual(res.status_code, 200)

--- a/odoo/addons/test_lint/tests/test_override_signatures.py
+++ b/odoo/addons/test_lint/tests/test_override_signatures.py
@@ -156,8 +156,8 @@ def assert_attribute_override(parent_method, child_method, is_private):
 
 @tagged('-at_install', 'post_install')
 class TestLintOverrideSignatures(LintCase):
+    failureException = TypeError
     def test_lint_override_signature(self):
-        self.failureException = TypeError
         registry = Registry(get_db_name())
 
         for model_name, model_cls in registry.items():

--- a/odoo/addons/test_orm/tests/test_one2many.py
+++ b/odoo/addons/test_orm/tests/test_one2many.py
@@ -94,9 +94,6 @@ class One2manyCase(TransactionExpressionCase):
         self.operations()
 
     def test_rpcstyle_one_by_one_on_new(self):
-        self.multi = self.env["test_orm.multi"].new({
-            "name": "What is up?",
-        })
         for name in range(10):
             self.multi.lines = [Command.create({"name": str(name)})]
         self.operations()
@@ -107,9 +104,6 @@ class One2manyCase(TransactionExpressionCase):
         self.operations()
 
     def test_rpcstyle_single_on_new(self):
-        self.multi = self.env["test_orm.multi"].new({
-            "name": "What is up?",
-        })
         self.multi.lines = [Command.create({'name': str(name)}) for name in range(10)]
         self.operations()
 


### PR DESCRIPTION
Modifying a TestCase instance during a test can make autoretry blow up as `setUp` can modify attributes it assumes were set up by `setUpClass`, but if those were re-set by tests they are now rolled back and broken leading to confusing errors. This can be mitigated by fully reinstantiating testcase instances to implement repeat, but that's not currently the case.

It also makes it harder to know what the dependencies between setup and tests are, and which variables or attributes are dead, and makes it much easier to create implicit cross-dependencies between tests.
