### PR TITLE
[FIX] mrp: ignore workorder product changes

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -481,6 +481,8 @@ class MrpWorkorder(models.Model):
                         workorder.production_id.with_context(force_date=True).write({
                             'date_finished': fields.Datetime.to_datetime(values['date_finished'])
                         })
+        if 'product_id' in values and values['product_id'] != self.production_id.product_id.id:
+            del values['product_id']
         return super(MrpWorkorder, self).write(values)
 
     @api.model_create_multi


### PR DESCRIPTION
Issue
-----
In the Planning view, grouped by Work Center > Product, dragging & dropping can change the product of the WO if the user is not careful and drops the WO on top of another product's WO.

Steps to reproduce
-----
- Have 2 products
- Create a MO for product 1 with a WO at work center 1, plan it
- Create a MO for product 2 with a WO at work center 2, plan it
- Got to Manufacturing, Planning, Planning by Work Center
- Add a custom group (by product)
- Drag the WO of WC2 and drop it on top of the other WO

> Both the WC and the product of the second WO change

Cause
-----
The problem is only for versions 17.0 & 18.0 where the `product_id` field of `mrp.workorder` is defined as such

https://github.com/odoo/odoo/blob/31e46a841b38de0f99beb1844f985bc670621486/addons/mrp/models/mrp_workorder.py#L34

While the user cannot change the field value manually, automatic actions such as a gantt view drag & drop can change its' value by using `write` since it is stored.

Starting in 18.2, the field is no longer stored so trying to write a value for it doesn't work anymore.

https://github.com/odoo/odoo/blob/f337573ffc2642524b50608e2990270c69e8e547/addons/mrp/models/mrp_workorder.py#L39

-----
Ticket:
opw-4875366