### PR TITLE
[IMP] website: move header position option and add tooltip

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.TopMenuVisibilityOption">
-    <BuilderRow label.translate="Header Position" level="1" t-if="!this.isActiveItem('header_sidebar_opt')">
+    <BuilderRow label.translate="Header Position" tooltip.translate="Change the Header Position on this page" t-if="!this.isActiveItem('header_sidebar_opt')">
         <BuilderSelect preview="false" action="'setWebsiteHeaderVisibility'">
             <BuilderSelectItem actionValue="'overTheContent'" id="'overTheContent'" t-if="props.doesPageOptionExist('header_overlay')">Over The Content</BuilderSelectItem>
             <BuilderSelectItem actionValue="'regular'">Regular</BuilderSelectItem>


### PR DESCRIPTION
Since the "Header Position" is only applied on the current page and is
current not available on all pages, it is not considered a sub-option
of "Template" anymore.

To emphasize this difference, a tooltip was added to indicate that it
is only applied on the current page.

task-4556047