### PR TITLE
[FIX] purchase: correct 'Not Acknowledged' and 'Late Receipt' count

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -408,8 +408,8 @@
                     <filter name="draft_rfqs" string="New" domain="[('state', '=', 'draft')]"/>
                     <filter name="waiting_rfqs" string="Sent" domain="[('state', '=', 'sent')]"/>
                     <filter name="late" string="Late" domain="[('state', 'in', ['draft', 'sent', 'to approve']),('date_order', '&lt;', datetime.datetime.now())]"/>
-                    <filter name="not_acknowledged" string="Not Acknowledged" domain="[('state', '=', 'purchase'), ('acknowledged', '=', False)]"/>
-                    <filter name="late_receipt" string="Late Receipts" domain="[('is_late', '=', True)]"/>
+                    <filter name="not_acknowledged" string="Not Acknowledged" domain="[('state', 'in', ['purchase', 'done']), ('acknowledged', '=', False)]"/>
+                    <filter name="late_receipt" string="Late Receipts" domain="[('state', 'in', ['purchase', 'done']), ('is_late', '=', True)]"/>
                     <separator/>
                     <filter invisible="1" string="Late Activities" name="activities_overdue"
                         domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
 
 from odoo import api, Command, fields, models, SUPERUSER_ID, _
+from odoo.fields import Domain
 from odoo.tools.float_utils import float_compare, float_repr
 from odoo.exceptions import UserError
 from odoo.tools import format_list
@@ -207,6 +208,12 @@ class PurchaseOrder(models.Model):
         result['my']['otd'] = _("%(otd)s %%", otd=float_repr(my_otd_purchase_count / my_purchase_count * 100 if my_purchase_count else 100, precision_digits=0))
         result['days_to_purchase'] = self.env.company.days_to_purchase
         return result
+
+    def _get_domain_is_late(self, operator, value):
+        domain = super()._get_domain_is_late(operator, value)
+        if operator == "=" and value or operator == "!=" and not value:
+            domain &= Domain.OR([Domain('picking_ids', '=', False), Domain('picking_ids.state', '!=', 'done')])
+        return domain
 
     def _get_action_view_picking(self, pickings):
         """ This function returns an action that display existing picking orders of given purchase order ids. When only one found, show the picking immediately.

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -38,6 +38,10 @@ class StockPicking(models.Model):
         date_value = fields.Datetime.from_string(value)
         return [('purchase_id.date_order', operator, date_value)]
 
+    def _action_done(self):
+        self.purchase_id.sudo().action_acknowledge()
+        return super()._action_done()
+
 
 class StockWarehouse(models.Model):
     _inherit = 'stock.warehouse'


### PR DESCRIPTION
Before this commit:
-------------------------
- On the Purchase Dashboard, the 'Not Acknowledged' and 'Late Receipt' counters
  also included purchase orders whose receipts had already been done.
- For Not Acknowledged:
  - Such POs should be implicitly considered acknowledged once their receipts
    are done, but they were still shown at the counter.
  - Additionally, unacknowledged POs that were locked were incorrectly excluded
    from the counter.
- For Late Receipt:
  - POs with received products were incorrectly counted as late, even
    though their receipts were already done.
  - Locked POs with late receipts were also excluded from the counter, which was
    an incorrect behavior.

Steps to reproduce:
-------------------------
1. Install the 'purchase_stock' module.
2. Open Purchase module.
3. On the Purchase Dashboard, click on the 'Not Acknowledged' or 'Late
   Receipt' card.
4. Notice that POs whose receipts are already completed still appear in the
   counters and some locked POs that are unacknowledged or have late receipts
   are missing from the counters

Cause of the issue
-------------------------
- The domains for both Not Acknowledged and Late Receipt counters only relied on
  the purchase order state without checking whether the receipts were done.
- As a result, POs with done receipts were still included in the counters, while
  some locked POs were incorrectly excluded.

After this commit:
-----------------------
- Updated the search domains for both counters to properly exclude POs whose
  receipts are done.
- The action_done method now triggers action_acknowledged, ensuring that any
  unacknowledged POs with completed receipts are automatically marked as
  acknowledged and excluded from the Not Acknowledged counter. Locked POs that
  remain unacknowledged will still correctly appear in the counter.
- Now the POs with received products are no longer shown as late once their
  receipts are completed and Locked POs with late receipts will now correctly
  continue to appear in the counter.
- This ensures that the dashboard accurately reflects only pending
  acknowledgments and genuinely late receipts, helping users track POs in
  the correct state.

Task ID: 4874116