### PR TITLE
[IMP] website: fix ui issues in edit mode

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -73,9 +73,9 @@
                 <t t-set-slot="collapse">
                     <t t-foreach="state.presets" t-as="preset" t-key="preset.id">
                         <BuilderRow t-slot-scope="row">
-                            <div class="o_cc_preview_wrapper" t-on-click="row.toggleCollapseContent">
+                            <div class="o_cc_preview_wrapper w-100" t-on-click="row.toggleCollapseContent">
                                 <div inert="" t-att-class="`o_cc${preset.id}`"
-                                     class="w-100 p-2 d-flex justify-content-between align-items-center ms-3">
+                                     class="p-2 d-flex justify-content-between align-items-center ms-3">
                                     <h3 class="m-0">
                                         Title
                                     </h3>

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -3,7 +3,7 @@
 
 <t t-name="website.WebsiteBuilderClientAction">
     <div class="d-flex h-100 w-100" t-ref="container">
-        <div class="o_website_preview border-top flex-grow-1" t-ref="website_preview">
+        <div class="o_website_preview flex-grow-1" t-att-class="state.isEditing ? '' : 'border-top'" t-ref="website_preview">
             <div class="o_iframe_container">
                 <iframe t-if="!testMode" t-att-src="iframeFallbackUrl"
                     class="o_ignore_in_tour"


### PR DESCRIPTION
Some improvements on the UI while in edit mode:
- Remove border top from the preview iFrame
- Make the theme preset full width

task-4367641