### PR TITLE
[FIX] mrp_subcontracting_dropshipping: fix failing test_dropship_stan…

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
@@ -347,9 +347,11 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
             'route_ids': [(6, 0, [self.dropship_route.id])],
             'seller_ids': [(0, 0, {'partner_id': self.supplier.id})],
         })
+        product.product_tmpl_id.categ_id = self.env.ref('product.product_category_all')
         product.product_tmpl_id.categ_id.property_cost_method = 'standard'
         product.product_tmpl_id.categ_id.property_valuation = 'real_time'
         product.product_tmpl_id.invoice_policy = 'order'
+        self._setup_category_stock_journals()
         sale_order = self.env['sale.order'].create({
             'partner_id': self.customer.id,
             'picking_policy': 'direct',


### PR DESCRIPTION
…dard_perpetual_anglosaxon_ordered_return_internal_aml test

this PR fixes the runbot error 230451
introduced by the test of PR
https://github.com/odoo/odoo/pull/221009

fix :
populate the accounts of the category before using them