### PR TITLE
[IMP] purchase: open related PO from purchase analysis list view

### DIFF
--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -159,3 +159,12 @@ class PurchaseReport(models.Model):
             f_qty=self._field_to_sql(self._table, 'qty_ordered', query),
             f_price=self._field_to_sql(self._table, 'price_average', query),
         )
+
+    def action_open_purchase_order(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'purchase.order',
+            'res_id': self.order_id.id,
+            'views': [(False, 'form')],
+        }

--- a/addons/purchase/report/purchase_report_views.xml
+++ b/addons/purchase/report/purchase_report_views.xml
@@ -27,7 +27,7 @@
             <field name="name">purchase.report.view.list</field>
             <field name="model">purchase.report</field>
             <field name="arch" type="xml">
-                <list string="Purchase Analysis">
+                <list string="Purchase Analysis" action="action_open_purchase_order" type="object">
                     <field name="date_order"/>
                     <field name="order_id" optional="show"/>
                     <field name="partner_id" optional="show"/>


### PR DESCRIPTION
Purpose:
==============================
Currently, when users click on a record in the Purchase Analysis list view, it opens the default form view of `purchase.report`, which only shows aggregated data. However, the UI is not optimal, and all relevant details are already available in the Purchase Order form. Instead, opening the Purchase Order form provides a more intuitive and complete view.


With this Commit:
==============================
- This commit changes the behavior of the Purchase Analysis list view so that clicking a record opens the actual corresponding Purchase Order form.
- This improvement ensures users can easily access the corresponding Purchase Order details directly from the Purchase Analysis list view, providing the intuitive PO view instead of the default aggregated data form view of `purchase.report`.

TaskID–4885729
