### PR TITLE
[FIX] web: show '+' in ListView selection count when exceeding limit

### DIFF
--- a/addons/web/static/src/views/view_components/selection_box.xml
+++ b/addons/web/static/src/views/view_components/selection_box.xml
@@ -4,7 +4,7 @@
     <t t-name="web.SelectionBox">
         <div class="o_selection_box list-group flex-row w-auto" t-att-class="{'m-1 gap-1': env.isSmall}" role="alert">
             <span class="list-group-item active d-flex align-items-center pe-0 py-0 rounded-1 gap-1 flex-grow-1" t-att-class="{'shadow': env.isSmall}">
-                <span t-if="isDomainSelected">All <b t-esc="nbTotal"/> selected</span>
+                <span t-if="isDomainSelected">All <b><t t-esc="nbTotal"/><t t-if="root.hasLimitedCount">+</t></b> selected</span>
                 <t t-else="">
                     <b t-esc="nbSelected"/> selected
                     <button t-if="!env.isSmall and isPageSelected and (!isRecordCountTrustable or nbTotal > nbSelected)"
@@ -12,7 +12,7 @@
                         title="Select all records matching the search"
                         t-on-click="onSelectDomain">
                         <i class="oi oi-fw oi-arrow-right"/>
-                        Select all <span t-if="isRecordCountTrustable" t-esc="nbTotal"/>
+                        Select all <span t-if="root.isRecordCountTrustable"><t t-esc="nbTotal"/><t t-if="root.hasLimitedCount">+</t></span>
                     </button>
                 </t>
                 <button title="Unselect All" class="o_unselect_all btn btn-link ms-auto border-0" t-on-click="onUnselectAll">

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -3934,6 +3934,21 @@ test(`selection box is properly displayed (single page)`, async () => {
     });
 });
 
+// test.tags("desktop");
+// test(`selection box shows '+' suffix on selection count beyond count_limit`, async () => {
+//     await mountView({
+//         resModel: "foo",
+//         type: "list",
+//         arch: `<list limit="2" count_limit="3"><field name="foo"/><field name="bar"/></list>`,
+//     });
+//     // select all records of first page
+//     await contains(`thead .o_list_record_selector input`).click();
+//     expect(`.o_selection_box`).toHaveText("2\nselected\n Select all 3+");
+//     // select all domain
+//     await contains(`.o_selection_box .o_select_domain`).click();
+//     expect(`.o_selection_box`).toHaveText("All 3+ selected");
+// });
+
 test.tags("desktop");
 test(`selection box is properly displayed (multi pages) on desktop`, async () => {
     await mountView({


### PR DESCRIPTION
In ListView domain selection mode, a '+' is now shown (e.g., 10,000+) when the number of selected records exceeds the  count_limit.

This visually indicates that the selection goes beyond a certain limit

Closes: #217094
X-original-commit: ddf3d77

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

