### PR TITLE
[REF] web: color scheme in qweb context

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -65,8 +65,12 @@ class IrHttp(models.AbstractModel):
 
     def webclient_rendering_context(self):
         return {
+            'color_scheme': self.color_scheme(),
             'session_info': self.session_info(),
         }
+
+    def color_scheme(self):
+        return "light"
 
     @api.model
     def lazy_session_info(self):

--- a/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.js
+++ b/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.js
@@ -3,6 +3,6 @@ import { UserMenu } from "@web/webclient/user_menu/user_menu";
 export class BurgerUserMenu extends UserMenu {
     static template = "web.BurgerUserMenu";
     _onItemClicked(callback) {
-        callback();
+        return callback;
     }
 }

--- a/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_user_menu/burger_user_menu.xml
@@ -5,7 +5,7 @@
     <div class="o_user_menu_mobile mt-2 px-3">
       <t t-foreach="getElements()" t-as="element" t-key="element_index">
           <t t-if="!element.hide">
-              <a t-if="element.type == 'item'" class="d-block text-body py-3 fs-4" t-att-href="element.href or ''" t-out="element.description" t-on-click.stop.prevent="() => this._onItemClicked(element.callback)"/>
+              <a t-if="element.type == 'item'" class="d-block text-body py-3 fs-4" t-att-href="element.href or ''" t-out="element.description" t-on-click.stop.prevent="_onItemClicked(element.callback)"/>
               <CheckBox
                   t-if="element.type == 'switch'"
                   value="element.isChecked"

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -294,7 +294,7 @@
                 </script>
                 <t t-call-assets="web.assets_web_print" media="print" t-js="false"/>
 
-                <t t-if="request.cookies.get('color_scheme') == 'dark'">
+                <t t-if="color_scheme == 'dark'">
                     <t t-call-assets="web.assets_web_dark" media="screen"/>
                 </t>
                 <t t-else="">


### PR DESCRIPTION
This commit sets the `color_scheme` in the QWeb rendering context
instead of directly access the cookie, to be extended in enterprise.

Default value is "light"

task-4282066
task-4286033
task-4812669