### PR TITLE
[FIX] calendar: allow multi-record duplication of appointments

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -542,7 +542,7 @@ class Meeting(models.Model):
     def create(self, vals_list):
         # Prevent sending update notification when _inverse_dates is called
         self = self.with_context(is_calendar_event_new=True)
-        defaults = self.default_get([
+        defaults = self.browse().default_get([
             'activity_ids', 'allday', 'description', 'name', 'partner_ids',
             'res_model_id', 'res_id', 'start', 'user_id',
         ])


### PR DESCRIPTION
This error occurs when users attempt to duplicate multiple bookings within an appointment.

Steps to reproduce:
---
- Install `appointment` module
- Select an appointment (ie. Dental Care)
- Click on New and make 2 new bookings
- Go to list view > Select both records > Duplicate

Traceback:
---
`ValueError: Expected singleton: calendar.event(5, 8)`

This occurred because we called `default_get` with a non-empty recordset at the beginning of the `create` method.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
