### PR TITLE
[FIX] web_editor: display Threads icon in email marketing

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -86,6 +86,18 @@ class Web_Editor(http.Controller):
             elif int(icon) == 61569:  # F081
                 icon = "59395"  # E803
                 font = "/web/static/fonts/twitter_x_only.woff"
+            elif int(icon) == 59651:
+                font = "/web/static/fonts/bluesky_only.woff"
+            elif int(icon) == 59648:
+                font = "/web/static/fonts/discord_only.woff"
+            elif int(icon) == 59649:
+                font = "/web/static/fonts/google_play_only.woff"
+            elif int(icon) == 59652:
+                font = "/web/static/fonts/kickstarter_only.woff"
+            elif int(icon) == 59650:
+                font = "/web/static/fonts/strava_only.woff"
+            elif int(icon) == 59653:
+                font = "/web/static/fonts/threads_only.woff"
 
         size = max(width, height, 1) if width else size
         width = width or size


### PR DESCRIPTION
Problem:
When adding the Threads icon to an email marketing snippet and sending the email, the icon does not appear in the received email.

Solution:
Add support for the newly added icons from commit
21db1065aee9b403a316389f306c865cc47354ed (same fix as commit 7e9466e27d61fa8ece43d2238e1570dc3e65337a).

Steps to reproduce:
- Add the Threads icon to an email marketing snippet.
- Send a test email.
- Observe that the icon is not visible in the received email.

opw-5024970

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
