### PR TITLE
[FIX] l10n_eu_oss: add option for country specific field

### DIFF
--- a/addons/l10n_eu_oss/models/__init__.py
+++ b/addons/l10n_eu_oss/models/__init__.py
@@ -1,3 +1,4 @@
+from . import eu_field_map
 from . import eu_tax_map
 from . import eu_tag_map
 from . import res_company

--- a/addons/l10n_eu_oss/models/eu_field_map.py
+++ b/addons/l10n_eu_oss/models/eu_field_map.py
@@ -1,0 +1,17 @@
+"""
+The EU_FIELD_MAP contains localization specific fields for account.tax
+"""
+EU_FIELD_MAP = {
+    'es_assec': {
+        'l10n_es_type': 'no_sujeto_loc',
+    },
+    'es_common': {
+        'l10n_es_type': 'no_sujeto_loc',
+    },
+    'es_full': {
+        'l10n_es_type': 'no_sujeto_loc',
+    },
+    'es_pymes': {
+        'l10n_es_type': 'no_sujeto_loc',
+    },
+}

--- a/addons/l10n_eu_oss/models/res_company.py
+++ b/addons/l10n_eu_oss/models/res_company.py
@@ -4,6 +4,7 @@ import re
 from itertools import product
 
 from odoo import Command, _, api, models
+from .eu_field_map import EU_FIELD_MAP
 from .eu_tag_map import EU_TAG_MAP
 from .eu_tax_map import EU_TAX_MAP
 
@@ -90,6 +91,8 @@ class Company(models.Model):
                                 ('country_id', '=', company.account_fiscal_country_id.id),
                             ], order='sequence,id desc', limit=1)
                             foreign_tax_copy_name = existing_foreign_tax and _('%(tax_name)s (Copy)', tax_name=existing_foreign_tax.name)
+
+                            extra_fields = self._get_country_specific_account_tax_fields()
                             foreign_taxes[tax_amount] = self.env['account.tax'].create({
                                 'name': foreign_tax_copy_name or foreign_tax_name,
                                 'amount': tax_amount,
@@ -101,6 +104,7 @@ class Company(models.Model):
                                 'country_id': company.account_fiscal_country_id.id,
                                 'sequence': 1000,
                                 'company_id': company.id,
+                                **extra_fields,
                             })
                         mapping.append((0, 0, {'tax_src_id': domestic_tax.id, 'tax_dest_id': foreign_taxes[tax_amount].id}))
                 if mapping:
@@ -147,15 +151,7 @@ class Company(models.Model):
 
     def _get_oss_tags(self):
         oss_tag = self.env.ref('l10n_eu_oss.tag_oss')
-        country = None
-        # Try to use the VAT country if vat is set and easily guessable
-        if self.vat:
-            country_prefix = re.match('^[a-zA-Z]{2}|^', self.vat).group()
-            if country_prefix:
-                country = self.env['res.country'].search([('code', '=', country_prefix)], limit=1)
-        # otherwise fallback on the fiscal country
-        if not country:
-            country = self.account_fiscal_country_id
+        country = self._get_country_from_vat()
         chart_template = self.env['account.chart.template']._guess_chart_template(country)
 
         # If that l10n module isn't installed, it means the company doesn't use any tax report for that country
@@ -179,3 +175,25 @@ class Company(models.Model):
             mapping[repartition_line_key] = tag + oss_tag
 
         return mapping
+
+    def _get_country_from_vat(self):
+        self.ensure_one()
+        country = None
+        # Try to use the VAT country if vat is set and easily guessable
+        if self.vat:
+            country_prefix = re.match(r'^[a-zA-Z]{2}|^', self.vat).group()
+            if country_prefix:
+                country = self.env['res.country'].search([('code', '=', country_prefix)], limit=1)
+        # otherwise fallback on the fiscal country
+        if not country:
+            country = self.account_fiscal_country_id
+        return country
+
+    def _get_country_specific_account_tax_fields(self):
+        country = self._get_country_from_vat()
+        chart_template = self.env['account.chart.template']._guess_chart_template(country)
+        is_coa_module_installed = self.env['account.chart.template']._get_chart_template_mapping()[chart_template]['installed']
+
+        if is_coa_module_installed:
+            return EU_FIELD_MAP.get(chart_template, {})
+        return {}

--- a/addons/l10n_eu_oss/tests/test_oss.py
+++ b/addons/l10n_eu_oss/tests/test_oss.py
@@ -128,6 +128,18 @@ class TestOSSSpain(OssTemplateTestCase):
 
                 self.assertIn(expected_tag_id, oss_tag_id, f"{doc_type} tag from Spanish CoA not correctly linked")
 
+    def test_l10n_es_type_oss_tax(self):
+        """
+        Test that the foreign oss taxes generate with l10n_es_type as no_sujeto_loc
+        """
+        if self.env['ir.module.module']._get('l10n_es').state != 'installed':
+            self.skipTest(reason="L10n_es is required for this test.")
+
+        another_eu_country_code = (self.env.ref('base.europe').country_ids - self.company_data['company'].country_id)[0].code
+        tax_oss = self.env['account.tax'].search([('name', 'ilike', f'%{another_eu_country_code}%')], limit=1)
+
+        self.assertEqual(tax_oss.l10n_es_type, 'no_sujeto_loc')
+
 
 @tagged('post_install', 'post_install_l10n', '-at_install')
 class TestOSSUSA(OssTemplateTestCase):


### PR DESCRIPTION
The EU OSS taxes were generated with the wrong l10n_es_type.

- Install l10n_es and l10n_eu_oss. Then go to Settings and refresh the tax mapping in “EU Intra-community Distance Selling.”

- In Taxes, filter by tax group containing “OSS.” All OSS taxes appear with l10n_es_type = sujeto.

This is incorrect. The correct type should be “No Sujeto por reglas de localización” (see section 2): https://a3responde.wolterskluwer.com/es/s/article/version-3-05-del-moduloticketbai-batuz-de-a3erp-mejoras#OSS

This commit adds the possibility of adding country specific field during the account_tax creation using chart_template -> fields mapping.

opw-5009180


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
