### PR TITLE
Master reopen options when returning to style tab bvr

### DIFF
--- a/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
+++ b/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
@@ -55,7 +55,7 @@
                         </sup>
                     </label>
                     <label class="o_switch col-form-label col-md-8" t-att-class="{'o_switch_disabled': !state.googleFontFamily}" for="google_font_serve">
-                        <input type="checkbox" checked="checked" t-att-disabled="!state.googleFontFamily" id="google_font_serve" t-model="state.googleServe"/>
+                        <input type="checkbox" checked="checked" class="visually-hidden" t-att-disabled="!state.googleFontFamily" id="google_font_serve" t-model="state.googleServe"/>
                         <span/>
                     </label>
                 </div>

--- a/addons/website/static/tests/builder/snippets_menu.test.js
+++ b/addons/website/static/tests/builder/snippets_menu.test.js
@@ -109,7 +109,7 @@ test("Clicking on the 'Blocks' or 'Theme' tab should deactivate the options", as
     expect(".oe_overlay").toHaveCount(0);
     await contains(".o-snippets-tabs button:contains('Style')").click();
     expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
-    expect(".o_customize_tab .options-container").toHaveCount(0);
+    expect(".o_customize_tab .options-container").toHaveCount(1);
 
     await contains(":iframe .s_banner").click();
     await waitFor(".o_customize_tab .options-container");
@@ -121,7 +121,7 @@ test("Clicking on the 'Blocks' or 'Theme' tab should deactivate the options", as
     expect(".oe_overlay").toHaveCount(0);
     await contains(".o-snippets-tabs button:contains('Style')").click();
     expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
-    expect(".o_customize_tab .options-container").toHaveCount(0);
+    expect(".o_customize_tab .options-container").toHaveCount(1);
 });
 
 test("Hotkeys on Theme and Blocks tab", async () => {


### PR DESCRIPTION
After this PR, when a snippet is selected and its options are
visible in the "Style" tab, if the user clicks on the "Blocks" or
"Theme" tab afterward, the next time they return to the "Style" tab, the
previously selected snippet will be reactivated and its options will be
visible again in the sidebar.

task-3103768