### PR TITLE
[FIX] stock_account: prevent lot valuated move line from having no lot

### DIFF
--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -1,4 +1,5 @@
-from odoo import api, models
+from odoo import api, models, _
+from odoo.exceptions import UserError
 
 
 class StockMoveLine(models.Model):
@@ -6,12 +7,30 @@ class StockMoveLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        for vals, lot_valuated in zip(vals_list, self.env['product.product'].browse([value['product_id'] for value in vals_list]).mapped('lot_valuated')):
+            if not lot_valuated:
+                continue
+            if not vals.get('lot_id', True) and not vals.get('lot_name', True):
+                products_list = self.env['product.product'].browse([value['product_id'] for value in vals_list]).filtered(lambda product: product.lot_valuated)
+                string_products_list = "\n".join(f"- {product_name}" for product_name in products_list.mapped("display_name"))
+                raise UserError(
+                    _("You need to supply a Lot/Serial Number for lot valuated product:\n%(products)s",
+                        products=string_products_list,
+                    ))
         mls = super().create(vals_list)
         if any(move.is_valued for move in mls.move_id):
             mls.move_id._set_value()
         return mls
 
     def write(self, vals):
+        if ('lot_id' in vals or 'lot_name' in vals) and any(self.product_id.mapped('lot_valuated')):
+            if not vals.get('lot_id', False) and not vals.get('lot_name', False):
+                products_list = self.product_id.filtered(lambda product: product.lot_valuated)
+                string_products_list = "\n".join(f"- {product_name}" for product_name in products_list.mapped("display_name"))
+                raise UserError(
+                    _("You need to supply a Lot/Serial Number for lot valuated product:\n%(products)s",
+                        products=string_products_list,
+                    ))
         move_to_update = set()
         valuation_fields = ['qty_done', 'location_id', 'location_dest_id', 'owner_id', 'quant_id', 'lot_id']
         valuation_trigger = any(field in vals for field in valuation_fields)

--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -7,30 +7,12 @@ class StockMoveLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        for vals, lot_valuated in zip(vals_list, self.env['product.product'].browse([value['product_id'] for value in vals_list]).mapped('lot_valuated')):
-            if not lot_valuated:
-                continue
-            if not vals.get('lot_id', True) and not vals.get('lot_name', True):
-                products_list = self.env['product.product'].browse([value['product_id'] for value in vals_list]).filtered(lambda product: product.lot_valuated)
-                string_products_list = "\n".join(f"- {product_name}" for product_name in products_list.mapped("display_name"))
-                raise UserError(
-                    _("You need to supply a Lot/Serial Number for lot valuated product:\n%(products)s",
-                        products=string_products_list,
-                    ))
         mls = super().create(vals_list)
         if any(move.is_valued for move in mls.move_id):
             mls.move_id._set_value()
         return mls
 
     def write(self, vals):
-        if ('lot_id' in vals or 'lot_name' in vals) and any(self.product_id.mapped('lot_valuated')):
-            if not vals.get('lot_id', False) and not vals.get('lot_name', False):
-                products_list = self.product_id.filtered(lambda product: product.lot_valuated)
-                string_products_list = "\n".join(f"- {product_name}" for product_name in products_list.mapped("display_name"))
-                raise UserError(
-                    _("You need to supply a Lot/Serial Number for lot valuated product:\n%(products)s",
-                        products=string_products_list,
-                    ))
         move_to_update = set()
         valuation_fields = ['qty_done', 'location_id', 'location_dest_id', 'owner_id', 'quant_id', 'lot_id']
         valuation_trigger = any(field in vals for field in valuation_fields)


### PR DESCRIPTION
#### Issue:
Updating move lines on a receipt for a lot valuated product doesn't require a lot.

#### Step to reproduce:
- Create a product tracked by lot and with valuation by lot,
- Create a receipt for 2 units of this product and Mark as To-do,
- In "Details" add a lot number and save,
- Validate the receipt,
- Unlock the receipt,
- In "Details" add a move line with no lot, then save

#### Current behavior:
 - new `move_line` was saved with no lot number

#### Expected behavior:
- Prevent saving move line without lot on lot valuated product

#### Solution:
On stock_move_line related to a lot_valuated product:
    - prevent creating new lines with no SN/lot
    - prevent removing SN/lot on existing lines

When marking a picking as To-do, it creates stock move lines with no lots. This call to create provide neither lot_id nor lot_name and should be valid as lots for these lines are required to validate the picking.

opw-4841162

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
