### PR TITLE
[FIX] website_sale: prevent autocomplete in list view variants

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1384,7 +1384,7 @@
                 <t t-set="attribute_exclusions" t-value="product._get_attribute_exclusions()"/>
                 <t t-set="filtered_sorted_variants" t-value="product._get_possible_variants_sorted()"/>
                 <ul class="d-none js_add_cart_variants mb-0" t-att-data-attribute_exclusions="json.dumps(attribute_exclusions)"/>
-                <input type="hidden" class="product_template_id" t-att-value="product.id"/>
+                <input type="hidden" class="product_template_id" t-att-value="product.id" autocomplete="off"/>
                 <input type="hidden" t-if="len(filtered_sorted_variants) == 1" class="product_id" name="product_id" t-att-value="filtered_sorted_variants[0].id"/>
                 <t t-if="len(filtered_sorted_variants) &gt; 1">
                     <div class="mb-4">


### PR DESCRIPTION
### Problem:
Switching the variants view from "Options" to "Product List" using the web editor, in Firefox, causes an error stating that the `product_template_id` doesn't exist. Add to cart and switching variants won't work until refreshing the page.

This issue occurs only in Firefox because it incorrectly preserves hidden input values during DOM replacement. It assigns the value of the first hidden input (`product_id`) to the new `product_template_id` input, based on its position in the DOM.

### How to reproduce:
* Create a product with variants.
* Go to the product page in website shop using Firefox.
* Open website editor on Customize.
* Switch the variants view from Options to Product List.

### Solution:
Disable autocomplete on the `product_template_id` input to prevent Firefox from preserving and reusing the previous value during DOM updates.

opw-4901316
