### PR TITLE
[FIX] iot_drivers: keep temporary disconnected printers

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -28,6 +28,7 @@ class PrinterDriver(PrinterDriverBase):
         self.receipt_protocol = 'star' if 'STR_T' in device['device-id'] else 'escpos'
         self.connected_by_usb = self.device_connection == 'direct'
         self.device_name = device['device-make-and-model']
+        self.ip = device.get('ip')
 
         if any(cmd in device['device-id'] for cmd in ['CMD:STAR;', 'CMD:ESC/POS;']):
             self.device_subtype = "receipt_printer"

--- a/addons/iot_drivers/iot_handlers/interfaces/printer_interface_L.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/printer_interface_L.py
@@ -16,6 +16,7 @@ import pyudev
 import time
 
 from odoo.addons.iot_drivers.interface import Interface
+from odoo.addons.iot_drivers.main import iot_devices
 
 _logger = logging.getLogger(__name__)
 
@@ -127,6 +128,14 @@ class PrinterInterface(Interface):
         sorted_printers = sorted(discovered_printers.values(), key=lambda printer: str(printer.get('ip')))
 
         for ip, printers_with_same_ip in groupby(sorted_printers, lambda printer: printer.get('ip')):
+            already_registered_identifier = next((
+                identifier for identifier, device in iot_devices.items()
+                if device.device_type == 'printer' and ip and ip == device.ip
+            ), None)
+            if already_registered_identifier:
+                result.append({'identifier': already_registered_identifier})
+                continue
+
             printers_with_same_ip = sorted(printers_with_same_ip, key=lambda printer: printer['identifier'])
             if ip is None or len(printers_with_same_ip) == 1:
                 result += printers_with_same_ip


### PR DESCRIPTION
Some printers (`lpd...PASSTHRU`s for example) tend to disappear when checking available printers list. They are often switching between one time `lpd...PASSTHRU` and the second time `socket...` protocols. As we get ip addresses for printers, we now check if the new protocol still correspond to the same printer, and if so, we keep the old one.

As the printer will still be in the cups queue list, it will still be able to print through it.
