### PR TITLE
[FIX] hr_homeworking: fix hr_presence_status js test

### DIFF
--- a/addons/hr_homeworking/static/tests/hr_presence_status.test.js
+++ b/addons/hr_homeworking/static/tests/hr_presence_status.test.js
@@ -38,7 +38,7 @@ test("Office Location (online)", async () => {
     expect("small.fa-building").toHaveCount(1);
     expect("small.fa-home").toHaveCount(0);
     expect("small.fa-map-marker").toHaveCount(0);
-    expect("small.fa-building").toHaveStyle({ color: "rgb(0, 136, 24)" }); // color == text-success
+    expect("small").toHaveClass(["text-success", "fa-building"]);; // color == text-success
     expect("small.fa-building[title='Office 1']").toHaveCount(1);
 });
 
@@ -67,6 +67,6 @@ test("Home Location (away)", async () => {
     expect("small.fa-home").toHaveCount(1);
     expect("small.fa-building").toHaveCount(0);
     expect("small.fa-map-marker").toHaveCount(0);
-    expect("small.fa-home").toHaveStyle({ color: "rgb(233, 157, 0)" }); // color == text-warning
+    expect("small").toHaveClass(["o_icon_employee_absent", "fa-home"]); // color == text-warning
     expect("small.fa-home[title='Home']").toHaveCount(1);
 });


### PR DESCRIPTION
The test `Home Location (away)` was failing because the text-danger value is not the same when enterprise is installed. To avoid this kinf of erros, we will check the classes instead of the style

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
