### PR TITLE
[FIX] project: fix project sharing control panel

### DIFF
--- a/addons/project/static/src/project_sharing/search/control_panel/control_panel.xml
+++ b/addons/project/static/src/project_sharing/search/control_panel/control_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-inherit="web.ControlPanel" t-inherit-mode="extension">
+    <t t-inherit="project.ProjectTaskControlPanel" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o_control_panel_main_buttons')]" position="before">
             <a class="btn btn-link" href="/my/projects" title="Go back to 'My Projects'"><i class="fa fa-arrow-left"/></a>
         </xpath>

--- a/addons/project/static/src/project_sharing/views/form/project_sharing_form_view.js
+++ b/addons/project/static/src/project_sharing/views/form/project_sharing_form_view.js
@@ -1,6 +1,8 @@
 import { formView } from '@web/views/form/form_view';
+import { ProjectTaskControlPanel } from "@project/views/project_task_control_panel/project_task_control_panel";
 import { ProjectSharingFormController } from './project_sharing_form_controller';
 import { ProjectSharingFormRenderer } from './project_sharing_form_renderer';
 
 formView.Controller = ProjectSharingFormController;
+formView.ControlPanel = ProjectTaskControlPanel;
 formView.Renderer = ProjectSharingFormRenderer;

--- a/addons/project/static/src/project_sharing/views/view.js
+++ b/addons/project/static/src/project_sharing/views/view.js
@@ -1,4 +1,5 @@
 import { patch } from "@web/core/utils/patch";
+import { router } from "@web/core/browser/router";
 import { session } from "@web/session";
 import { View } from "@web/views/view";
 
@@ -6,11 +7,10 @@ import { View } from "@web/views/view";
 patch(View.prototype, {
     setup() {
         super.setup();
-        const params = this.props.context?.params;
         if (
-            params?.action === "project_sharing" &&
-            !("resId" in params) &&
-            params.active_id === session.project_id
+            router.current.action === "project_sharing" &&
+            !router.current.resId &&
+            router.current.active_id === session.project_id
         ) {
             this.env.config.setDisplayName(session.project_name);
         }


### PR DESCRIPTION
**Steps to reproduce**
- Share a project with a portal user with "Edit" access rights.
- With portal user, navigate to the portal project view: back arrow is missing and "Project Sharing" appears instead of project name.

<img width="1450" height="894" alt="image" src="https://github.com/user-attachments/assets/05dc16fd-2255-4f90-be3e-b2e870958a6d" />

**1st issue (project name)**
Caused by 1b86bd7ecf4d8751015b5056e9d48e49d68d195c removing the `params` key from context.

**2nd issue (back arrow)**
939ad768b78d3b705df2589312608e9227604776 introduced a new ProjectTaskControlPanel component.

opw-5036315