### PR TITLE
[FIX] hr_recruitment_skills: missing field in parent view

### DIFF
--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -85,7 +85,7 @@
     <record id="crm_case_tree_view_inherit_hr_recruitment_skills" model="ir.ui.view">
         <field name="name">hr.applicant.view.tree.inherit.skills</field>
         <field name="model">hr.applicant</field>
-        <field name="inherit_id" ref="hr_recruitment.crm_case_tree_view_job"/>
+        <field name="inherit_id" ref="hr_recruitment_skills.crm_case_tree_view_job"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//list" position="attributes">


### PR DESCRIPTION
Issue:
In the recruitment skills there are two views inheriting the same base view and modifying it. However, the second view tries to also adjust changes made by the first view/inheritance which causes field not found type errors.

Fix:
Make the second view inherit from the first inherited view, rather than the base view.

runbot error: 231203
task-5042835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
