### PR TITLE
[FIX] hr_skills: certification activity tests failing

### DIFF
--- a/addons/hr_skills/tests/test_certification_activities.py
+++ b/addons/hr_skills/tests/test_certification_activities.py
@@ -11,6 +11,7 @@ class TestCertificationActivities(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.today = date.today()
+        cls.demo_data_activities = cls.env["hr.employee"]._add_certification_activity_to_employees()
 
         cls.t_job = cls.env["hr.job"].create({"name": "Test Job"})
         cls.t_user_1, cls.t_user_2 = cls.env["res.users"].create(


### PR DESCRIPTION
Issue:
The certification activity tests are all failing from too many activities being created. The issue stems from the tests assuming no demo data while the tests are sometimes(?) run with demo data installed.

Fix:
Start the setup of the test with creating activities for all the demo data to prevent the demo data from interfering with the tests.

runbot error: 231207
task-5042851

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
