### PR TITLE
[IMP] crm: automatically assign email opportunities by default

### DIFF
--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -51,7 +51,7 @@ class CrmTeam(models.Model):
             team.assignment_max = sum(member.assignment_max for member in team.crm_team_member_ids)
 
     def _compute_assignment_enabled(self):
-        assign_enabled = self.env['ir.config_parameter'].sudo().get_param('crm.lead.auto.assignment', False)
+        assign_enabled = self.env['ir.config_parameter'].sudo().get_param('crm.lead.auto.assignment.action', 'incoming_emails') in ['manual', 'auto']
         auto_assign_enabled = False
         if assign_enabled:
             assign_cron = self.sudo().env.ref('crm.ir_cron_crm_lead_assign', raise_if_not_found=False)

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -634,7 +634,7 @@ class TestLeadConvertCommon(TestCrmCommon):
 
     @classmethod
     def _switch_to_auto_assign(cls):
-        cls.env['ir.config_parameter'].set_param('crm.lead.auto.assignment', True)
+        cls.env['ir.config_parameter'].set_param('crm.lead.auto.assignment.action', 'auto')
         cls.assign_cron = cls.env.ref('crm.ir_cron_crm_lead_assign')
         cls.assign_cron.update({
             'active': True,

--- a/addons/crm/tests/test_crm_lead_assignment.py
+++ b/addons/crm/tests/test_crm_lead_assignment.py
@@ -68,7 +68,6 @@ class TestLeadAssign(TestLeadAssignCommon):
 
         with patch.object(fields.Datetime, 'now', return_value=now_patch):
             config = self.env['res.config.settings'].create({
-                'crm_use_auto_assignment': True,
                 'crm_auto_assignment_action': 'auto',
                 'crm_auto_assignment_interval_number': 19,
                 'crm_auto_assignment_interval_type': 'hours'
@@ -102,8 +101,7 @@ class TestLeadAssign(TestLeadAssignCommon):
             self.assertEqual(self.assign_cron.nextcall, datetime(2020, 11, 1, 10, 0, 0))
 
             config.write({
-                'crm_use_auto_assignment': False,
-                'crm_auto_assignment_action': 'auto',
+                'crm_auto_assignment_action': 'incoming_emails',
             })
             config.execute()
             self.assertFalse(self.assign_cron.active)

--- a/addons/crm/tests/test_crm_lead_multicompany.py
+++ b/addons/crm/tests/test_crm_lead_multicompany.py
@@ -302,6 +302,7 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
         self.assertEqual(crm_lead_form.company_id, self.company_2, 'Crm: company comes from partner')
 
     def test_gateway_incompatible_company_error_on_incoming_email(self):
+        self.env['ir.config_parameter'].set_param('crm.lead.auto.assignment.action', 'never')
         self.assertTrue(self.sales_team_1.alias_name)
         self.assertFalse(self.sales_team_1.company_id)
         customer_company = self.env['res.partner'].create({

--- a/addons/crm/views/res_config_settings_views.xml
+++ b/addons/crm/views/res_config_settings_views.xml
@@ -52,33 +52,36 @@
                                     class="btn-primary"/>
                             </div>
                         </setting>
-                        <setting title="This can be used to automatically assign leads to sales persons based on rules" documentation="/applications/sales/crm/track_leads/lead_scoring.html#assign-leads">
-                            <field name="crm_use_auto_assignment"/>
-                            <div class="text-muted">
-                                <span>Periodically assign leads based on priorities and filters.</span><br />
-                                <span invisible="not crm_use_auto_assignment">
+                        <setting title="This can be used to automatically assign leads to sales persons based on rules" documentation="/applications/sales/crm/track_leads/lead_scoring.html#assign-leads"
+                            string="Automatic Lead Assignment" help="Automatically assign leads to available sales members.">
+                            <div class="text-muted" invisible="crm_auto_assignment_action == 'never'">
+                                <span invisible="crm_auto_assignment_action != 'incoming_emails'">
+                                    Leads received through email will be automatically assigned.
+                                </span>
+                                <span invisible="crm_auto_assignment_action not in ['manual', 'auto']">
+                                    Unassigned leads will be assigned based on priorities and filters.
                                     All sales teams will use this setting by default unless
                                     specified otherwise.
                                 </span>
                             </div>
-                            <div class="row flex-row flex-nowrap mt16" invisible="not crm_use_auto_assignment">
+                            <div class="row flex-row flex-nowrap mt16">
                                 <label string="Running" for="crm_auto_assignment_action" class="col-lg-3 o_light_label"/>
-                                <field name="crm_auto_assignment_action"
-                                    required="crm_use_auto_assignment"/>
-                                <button name="action_crm_assign_leads" type="object" class="btn-link w-auto">
+                                <field name="crm_auto_assignment_action" required="1"/>
+                                <button name="action_crm_assign_leads" type="object" class="btn-link w-auto"
+                                    invisible="crm_auto_assignment_action in ['incoming_emails', 'never']">
                                     <i title="Update now" role="img" aria-label="Update now" class="fa fa-fw fa-refresh"></i>
                                 </button>
                             </div>
-                            <div class="row mt16" invisible="not crm_use_auto_assignment or crm_auto_assignment_action == 'manual'">
-                                <label string="Repeat every" for="crm_auto_assignment_interval_type" class="col-lg-3 o_light_label"/>
+                            <div class="row mt16" invisible="crm_auto_assignment_action != 'auto'">
+                                <label string="Repeat every" for="crm_auto_assignment_interval_type" class="col-lg-3 pe-0 o_light_label"/>
                                 <field name="crm_auto_assignment_interval_number"
-                                    class="oe_inline me-2"
-                                    required="crm_use_auto_assignment and crm_auto_assignment_action == 'auto'"/>
+                                    class="oe_inline me-2" style="width: 25% !important"
+                                    required="crm_auto_assignment_action == 'auto'"/>
                                 <field name="crm_auto_assignment_interval_type"
-                                    class="oe_inline"
-                                    required="crm_use_auto_assignment and crm_auto_assignment_action == 'auto'"/>
+                                    class="oe_inline" style="width: 25% !important"
+                                    required="crm_auto_assignment_action == 'auto'"/>
                             </div>
-                            <div class="row" invisible="not crm_use_auto_assignment or crm_auto_assignment_action == 'manual'">
+                            <div class="row" invisible="crm_auto_assignment_action != 'auto'">
                                 <label string="Next Run" for="crm_auto_assignment_run_datetime" class="col-lg-3 o_light_label"/>
                                 <field name="crm_auto_assignment_run_datetime"/>
                             </div>


### PR DESCRIPTION
Previously, when setting custom aliases for a team, it was not uncommon for the opportunities generated through sent emails to lay dormant and unopened for quite some time.

This commit adds a new mode for automatic assigns, 'For Incoming Emails', which is active by default and can be disabled by switching automatic assign actions to 'Manual' or 'Auto'. When this mode is active, a newly received email generating an opportunity will be automatically attributed to the "least busy user" by lead month count.

A 'Never' assignment mode is also added, disabling automatic assignment completely (through it is functionally equivalent to setting assignment mode to Manual and then never running it).

task-4684660