### PR TITLE
[IMP] point_of_sale: adapt change to add urban piper order filter

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -7,11 +7,11 @@
             <div class="screen-full-width d-flex w-100 h-100">
                 <t t-set="usePreset" t-value="pos.config.use_presets and pos.models['pos.preset'].length > 1" />
                 <div t-if="!ui.isSmall || pos.ticket_screen_mobile_pane === 'left'" class="rightpane pane-border d-flex flex-column flex-grow-1 w-100 h-100 h-lg-100 pe-lg-0 bg-view border-end overflow-y-auto">
-                    <div class="controls d-grid d-sm-flex align-items-center justify-content-between gap-2 gap-sm-3 p-2 border-bottom bg-view">
-                        <div class="buttons d-flex gap-1" t-if="usePreset">
+                    <div class="controls d-sm-flex align-items-center justify-content-between gap-2 gap-sm-3 p-2 border-bottom bg-view">
+                        <div class="filter-buttons buttons d-flex gap-1 overflow-auto" t-if="usePreset" t-att-class="{'mb-2 mb-sm-0': ui.isSmall}">
                             <button t-foreach="pos.models['pos.preset'].getAll()" t-as="preset" t-key="preset.id"
                                 class="btn btn-lg btn-secondary text-nowrap" t-on-click="() => this.onPresetSelected(preset)"
-                                t-attf-class="{{this.state.selectedPreset === preset ? 'active' : ''}}">
+                                t-att-class="{'active': this.state.selectedPreset === preset}">
                                 <t t-esc="preset.name"/>
                             </button>
                         </div>

--- a/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
@@ -234,3 +234,12 @@ export function back() {
         run: "click",
     };
 }
+
+export function clickFilterButton(buttonText) {
+    return [
+        {
+            trigger: `.filter-buttons button:contains("${buttonText}")`,
+            run: "click",
+        },
+    ];
+}


### PR DESCRIPTION
In this commit:
============
Adapted XML changes to introduce a new "Food Platform" filter button on the
ticket screen for UrbanPiper orders.
This allows easier management and separation of orders coming from UrbanPiper.

Task-5033759

Related PR: https://github.com/odoo/enterprise/pull/93192