### PR TITLE
[REF] core,*: use hooks to skip field computation on init

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -4,7 +4,6 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError, ValidationError, RedirectWarning
 from odoo.tools.misc import formatLang, format_date
-from odoo.tools.sql import column_exists, create_column
 
 INV_LINES_PER_STUB = 9
 
@@ -44,15 +43,12 @@ class AccountPayment(models.Model):
             if not payment_check.check_number.isdecimal():
                 raise ValidationError(_('Check numbers can only consist of digits'))
 
-    def _auto_init(self):
-        """
-        Create compute stored field check_number
-        here to avoid MemoryError on large databases.
-        """
-        if not column_exists(self.env.cr, 'account_payment', 'check_number'):
-            create_column(self.env.cr, 'account_payment', 'check_number', 'varchar')
-
-        return super()._auto_init()
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'check_number',
+        ])
+        return fields_to_skip_compute
 
     @api.constrains('check_number', 'journal_id')
     def _constrains_check_number_unique(self):

--- a/addons/l10n_eg_edi_eta/models/account_move.py
+++ b/addons/l10n_eg_edi_eta/models/account_move.py
@@ -6,7 +6,6 @@ import json
 from odoo import api, models, fields, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import float_is_zero
-from odoo.tools.sql import column_exists, create_column
 from datetime import datetime
 
 _logger = logging.getLogger(__name__)
@@ -23,12 +22,13 @@ class AccountMove(models.Model):
     l10n_eg_signing_time = fields.Datetime('Signing Time', copy=False)
     l10n_eg_is_signed = fields.Boolean(copy=False)
 
-    def _auto_init(self):
-        if not column_exists(self.env.cr, "account_move", "l10n_eg_uuid"):
-            create_column(self.env.cr, "account_move", "l10n_eg_uuid", "VARCHAR")
-            # Since l10n_eg_uuid columns does not exist we can assume l10n_eg_submission_number doesn't exist either
-            create_column(self.env.cr, "account_move", "l10n_eg_submission_number", "VARCHAR")
-        return super()._auto_init()
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'l10n_eg_uuid',
+            'l10n_eg_submission_number',
+        ])
+        return fields_to_skip_compute
 
     @api.depends('l10n_eg_eta_json_doc_id.raw')
     def _compute_eta_long_id(self):

--- a/addons/l10n_gr_edi/models/account_move.py
+++ b/addons/l10n_gr_edi/models/account_move.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import cleanup_xml_node
-from odoo.tools.sql import column_exists, create_column
 
 from odoo.addons.l10n_gr_edi.models.l10n_gr_edi_document import _make_mydata_request
 from odoo.addons.l10n_gr_edi.models.preferred_classification import (
@@ -87,22 +86,17 @@ class AccountMove(models.Model):
         store=True,
     )
 
-    def _auto_init(self):
-        """
-        Create all compute-stored fields here to avoid MemoryError when initializing on large databases.
-        """
-        for column_name, column_type in (
-            ('l10n_gr_edi_mark', 'varchar'),
-            ('l10n_gr_edi_cls_mark', 'varchar'),
-            ('l10n_gr_edi_state', 'varchar'),
-            ('l10n_gr_edi_inv_type', 'varchar'),
-            ('l10n_gr_edi_payment_method', 'varchar'),
-            ('l10n_gr_edi_attachment_id', 'int4'),
-        ):
-            if not column_exists(self.env.cr, 'account_move', column_name):
-                create_column(self.env.cr, 'account_move', column_name, column_type)
-
-        return super()._auto_init()
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'l10n_gr_edi_mark',
+            'l10n_gr_edi_cls_mark',
+            'l10n_gr_edi_state',
+            'l10n_gr_edi_inv_type',
+            'l10n_gr_edi_payment_method',
+            'l10n_gr_edi_attachment_id',
+        ])
+        return fields_to_skip_compute
 
     ################################################################################
     # Standard Field Computes

--- a/addons/l10n_gr_edi/models/account_move_line.py
+++ b/addons/l10n_gr_edi/models/account_move_line.py
@@ -8,7 +8,6 @@ from odoo.addons.l10n_gr_edi.models.preferred_classification import (
     TAX_EXEMPTION_CATEGORY_SELECTION,
     TYPES_WITH_SEND_EXPENSE,
 )
-from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMoveLine(models.Model):
@@ -55,21 +54,16 @@ class AccountMoveLine(models.Model):
         readonly=False,
     )
 
-    def _auto_init(self):
-        """
-        Create all compute-stored fields here to avoid MemoryError when initializing on large databases.
-        """
-        for column_name, column_type in (
-            ('l10n_gr_edi_detail_type', 'varchar'),
-            ('l10n_gr_edi_cls_category', 'varchar'),
-            ('l10n_gr_edi_cls_type', 'varchar'),
-            ('l10n_gr_edi_cls_vat', 'varchar'),
-            ('l10n_gr_edi_tax_exemption_category', 'varchar'),
-        ):
-            if not column_exists(self.env.cr, 'account_move_line', column_name):
-                create_column(self.env.cr, 'account_move_line', column_name, column_type)
-
-        return super()._auto_init()
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'l10n_gr_edi_detail_type',
+            'l10n_gr_edi_cls_category',
+            'l10n_gr_edi_cls_type',
+            'l10n_gr_edi_cls_vat',
+            'l10n_gr_edi_tax_exemption_category',
+        ])
+        return fields_to_skip_compute
 
     @api.depends('move_id.l10n_gr_edi_inv_type')
     def _compute_l10n_gr_edi_detail_type(self):

--- a/addons/l10n_gr_edi/models/res_partner.py
+++ b/addons/l10n_gr_edi/models/res_partner.py
@@ -1,5 +1,4 @@
 from odoo import api, fields, models
-from odoo.tools.sql import column_exists, create_column
 
 
 class ResPartner(models.Model):
@@ -13,10 +12,12 @@ class ResPartner(models.Model):
         readonly=False,
     )
 
-    def _auto_init(self):
-        if not column_exists(self.env.cr, 'res_partner', 'l10n_gr_edi_branch_number'):
-            create_column(self.env.cr, 'res_partner', 'l10n_gr_edi_branch_number', 'int4')
-        return super()._auto_init()
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'l10n_gr_edi_branch_number',
+        ])
+        return fields_to_skip_compute
 
     @api.depends('country_code')
     def _compute_l10n_gr_edi_branch_number(self):

--- a/addons/l10n_it_edi_ndd/models/account_move.py
+++ b/addons/l10n_it_edi_ndd/models/account_move.py
@@ -1,5 +1,4 @@
 from odoo import api, fields, models
-from odoo.tools.sql import column_exists, create_column
 from odoo.addons.l10n_it_edi_ndd.models.account_payment_methode_line import L10N_IT_PAYMENT_METHOD_SELECTION
 from odoo.addons.l10n_it_edi.models.account_move import get_text
 
@@ -22,14 +21,13 @@ class AccountMove(models.Model):
         copy=False,
     )
 
-    def _auto_init(self):
-        # Create compute stored field l10n_it_document_type and l10n_it_payment_method
-        # here to avoid timeout error on large databases.
-        if not column_exists(self.env.cr, 'account_move', 'l10n_it_payment_method'):
-            create_column(self.env.cr, 'account_move', 'l10n_it_payment_method', 'varchar')
-        if not column_exists(self.env.cr, 'account_move', 'l10n_it_document_type'):
-            create_column(self.env.cr, 'account_move', 'l10n_it_document_type', 'integer')
-        return super()._auto_init()
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'l10n_it_payment_method',
+            'l10n_it_document_type',
+        ])
+        return fields_to_skip_compute
 
     @api.depends('line_ids.matching_number', 'payment_state', 'matched_payment_ids')
     def _compute_l10n_it_payment_method(self):

--- a/addons/l10n_latam_invoice_document/models/account_move_line.py
+++ b/addons/l10n_latam_invoice_document/models/account_move_line.py
@@ -1,19 +1,18 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
-from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMoveLine(models.Model):
 
     _inherit = 'account.move.line'
 
-    def _auto_init(self):
-        # Skip the computation of the field `l10n_latam_document_type_id` at the module installation
-        # See `_auto_init` in `l10n_latam_invoice_document/models/account_move.py` for more information
-        if not column_exists(self.env.cr, "account_move_line", "l10n_latam_document_type_id"):
-            create_column(self.env.cr, "account_move_line", "l10n_latam_document_type_id", "int4")
-        return super()._auto_init()
-
     l10n_latam_document_type_id = fields.Many2one(
         related='move_id.l10n_latam_document_type_id', auto_join=True, store=True, index='btree_not_null')
+
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'l10n_latam_document_type_id',
+        ])
+        return fields_to_skip_compute

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -4,7 +4,6 @@
 from collections import defaultdict
 
 from odoo import api, fields, models, _
-from odoo.tools.sql import column_exists, create_column
 
 
 class StockRoute(models.Model):
@@ -104,17 +103,12 @@ class StockPicking(models.Model):
             pg = self.env['procurement.group'].create(vals)
             self.group_id = pg
 
-    def _auto_init(self):
-        """
-        Create related field here, too slow
-        when computing it afterwards through _compute_related.
-
-        Since group_id.sale_id is created in this module,
-        no need for an UPDATE statement.
-        """
-        if not column_exists(self.env.cr, 'stock_picking', 'sale_id'):
-            create_column(self.env.cr, 'stock_picking', 'sale_id', 'int4')
-        return super()._auto_init()
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'sale_id',
+        ])
+        return fields_to_skip_compute
 
     def _action_done(self):
         res = super()._action_done()

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -5,7 +5,6 @@ from odoo.addons.mail.tools.discuss import Store
 from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.tools import get_lang
-from odoo.tools.sql import column_exists, create_column
 
 
 class WebsiteVisitor(models.Model):
@@ -17,12 +16,12 @@ class WebsiteVisitor(models.Model):
                                        string="Visitor's livechat channels", readonly=True)
     session_count = fields.Integer('# Sessions', compute="_compute_session_count")
 
-    def _auto_init(self):
-        # Skip the computation of the field `livechat_operator_id` at the module installation
-        # We can assume no livechat operator attributed to visitor if it was not installed
-        if not column_exists(self.env.cr, "website_visitor", "livechat_operator_id"):
-            create_column(self.env.cr, "website_visitor", "livechat_operator_id", "int4")
-        return super()._auto_init()
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'livechat_operator_id',
+        ])
+        return fields_to_skip_compute
 
     @api.depends('discuss_channel_ids.livechat_active', 'discuss_channel_ids.livechat_operator_id')
     def _compute_livechat_operator_id(self):

--- a/addons/website_sale/models/account_move.py
+++ b/addons/website_sale/models/account_move.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-from odoo.tools.sql import column_exists, create_column
 
 
 class AccountMove(models.Model):
@@ -12,13 +11,12 @@ class AccountMove(models.Model):
         help='Website through which this invoice was created for eCommerce orders.',
         store=True, readonly=True, tracking=True)
 
-    def _auto_init(self):
-        if not column_exists(self.env.cr, "account_move", "website_id"):
-            # Creating the column via `_auto_init` prevents a MemoryError in databases where many
-            # invoices exist when `website_sale` is installed, as it skips the computation of the
-            # `website_id` field.
-            create_column(self.env.cr, "account_move", "website_id", "int4")
-        super()._auto_init()
+    def _get_fields_to_skip_compute_on_init(self):
+        fields_to_skip_compute = super()._get_fields_to_skip_compute_on_init()
+        fields_to_skip_compute.update([
+            'website_id',
+        ])
+        return fields_to_skip_compute
 
     def preview_invoice(self):
         action = super().preview_invoice()


### PR DESCRIPTION
This commit adds a hook called on the `_auto_init` method to be called whenever a new computed stored field should not be computed when installing the module containing it.

It is common for a new model to add an `_auto_init` extension method to create the column of a new computed stored field to prevent it from being computed. This is usually done to prevent MemoryError on large databases.

The way it has been written is however not intuitive, as one would have to know non-existent columns are going to be computed when the column is created, and the way we have been preventing them would not be understood normally without reading the comments.

This refactor makes it clear from the hook method name that we are adding fields that we intend to skip computation on, and is less complex and much more easier to understand at first glance.

related-enterprise-PR: https://github.com/odoo/enterprise/pull/93193
task-5031330