### PR TITLE
[IMP] sale: improve report & portal layout for sections and subsections

### DIFF
--- a/addons/l10n_br_sales/report/sale_order_templates.xml
+++ b/addons/l10n_br_sales/report/sale_order_templates.xml
@@ -11,14 +11,9 @@
     </template>
 
     <template id="report_saleorder_document_brazil" inherit_id="sale.report_saleorder_document" primary="True">
-        <th name="th_taxes" position="replace"/>
-        <td name="td_taxes" position="replace"/>
-        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
-            <attribute name="t-value">current_subtotal + line.price_total</attribute>
+        <t t-set="hide_taxes_details" position="attributes">
+            <attribute name="t-value">True</attribute>
         </t>
-        <span t-field="line.price_subtotal" position="attributes">
-            <attribute name="t-field">line.price_total</attribute>
-        </span>
         <xpath expr="//t[@t-call='sale.document_tax_totals']" position="replace">
             <t t-call="l10n_br_sales.document_tax_totals_brazil">
                 <t t-set="tax_totals" t-value="doc.tax_totals"/>

--- a/addons/l10n_br_sales/views/sale_portal_templates.xml
+++ b/addons/l10n_br_sales/views/sale_portal_templates.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="sale_order_portal_content_brazil" inherit_id="sale.sale_order_portal_content" primary="True">
-        <!-- hide the taxes th -->
-        <th id="taxes_header" position="replace"/>
-        <!-- hide the taxes td -->
-        <td id="taxes" position="replace"/>
-        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
-            <attribute name="t-value">current_subtotal + line.price_total</attribute>
+        <!-- hide the taxes -->
+        <t t-set="hide_taxes_details" position="attributes">
+            <attribute name="t-value">True</attribute>
         </t>
-        <span t-field="line.price_subtotal" position="attributes">
-            <attribute name="t-field">line.price_total</attribute>
-        </span>
         <xpath expr="//t[@t-call='sale.sale_order_portal_content_totals_table']" position="replace">
             <table class="table table-sm">
                 <t t-call="l10n_br_sales.document_tax_totals_brazil">

--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -111,9 +111,5 @@
                 <t t-set="line_number" t-value="line_number+1"/>
             </t>
         </xpath>
-        <!--adding currency to unit price-->
-        <xpath expr="//td[@name='td_priceunit']/span" position="attributes">
-            <attribute name="t-options"  >{"widget": "monetary", "display_currency": line.currency_id}</attribute>
-        </xpath>
     </template>
 </odoo>

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -79,7 +79,9 @@
             <!-- Is there a discount on at least one line? -->
             <t t-set="lines_to_report" t-value="doc._get_order_lines_to_report()"/>
             <t t-set="display_discount" t-value="any(l.discount for l in lines_to_report)"/>
-            <t t-set="display_taxes" t-value="any(l.tax_ids for l in lines_to_report)"/>
+            <!-- Hide taxes AND show taxed amounts on lines -->
+            <t t-set="hide_taxes_details" t-value="False"/>
+            <t t-set="display_taxes" t-value="not hide_taxes_details and any(l._has_taxes() for l in lines_to_report)"/>
 
             <div class="oe_structure"></div>
             <table class="o_has_total_table table o_main_table table-borderless">
@@ -102,30 +104,89 @@
                 </thead>
                 <tbody class="sale_tbody">
 
-                    <t t-set="current_subtotal" t-value="0"/>
+                    <t t-set="current_section" t-value="None"/>
+                    <t t-set="current_subsection" t-value="None"/>
+                    <t t-set="price_field" t-value="'price_total' if hide_taxes_details else 'price_subtotal'"/>
 
                     <t t-foreach="lines_to_report" t-as="line">
 
-                        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
+                        <t t-set="is_note" t-value="line.display_type == 'line_note'"/>
+                        <t t-set="is_section" t-value="line.display_type == 'line_section'"/>
+                        <t t-set="is_subsection" t-value="line.display_type == 'line_subsection'"/>
+                        <t t-set="is_combo" t-value="line.product_type == 'combo'"/>
 
-                        <t
-                            t-if="line.display_type not in ('line_section', 'line_subsection')
-                                or line.product_type == 'combo'
-                                or not line.collapse_composition"
-                        >
-                        <tr
-                            t-if="not line.collapse_composition"
-                            t-att-class="'fw-bold o_line_section' if (
-                                line.display_type == 'line_section'
-                                or line.product_type == 'combo'
-                            )
-                            else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection'
-                            else 'fst-italic o_line_note' if line.display_type == 'line_note'
-                            else ''"
-                        >
-                            <t t-if="not line.display_type and line.product_type != 'combo'">
-                                <td name="td_name"><span t-field="line.name">Bacon Burger</span></td>
-                                <td name="td_quantity" class="o_td_quantity text-end">
+                        <t t-if="is_section">
+                            <t t-set="current_section" t-value="line"/>
+                            <t t-set="current_subsection" t-value="None"/>
+                            <t t-set="line_padding" t-value="0"/>
+                        </t>
+                        <t t-elif="is_subsection">
+                            <t t-set="current_subsection" t-value="line"/>
+                            <t t-set="line_padding" t-value="2"/>
+                        </t>
+                        <t t-else="">
+                            <t
+                                t-set="line_padding"
+                                t-value="3 if current_subsection else (2 if current_section else 0)"
+                            />
+                        </t>
+
+                        <t t-if="line.combo_item_id">
+                            <t t-set="line_padding" t-value="line_padding + 1"/>
+                        </t>
+
+                        <t t-set="padding_class" t-value="line_padding and ('px-' + str(line_padding)) or ''"/>
+
+                        <t t-if="not line.collapse_composition">
+                            <tr
+                                t-if="is_section or is_subsection"
+                                name="tr_section"
+                                t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
+                            >
+                                <td
+                                    name="td_section_name"
+                                    t-att-colspan="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                    t-att-class="padding_class"
+                                >
+                                    <span t-field="line.name">A section title</span>
+                                </td>
+                                <td name="td_section_price" class="text-end o_price_total">
+                                    <span
+                                        name="price_subtotal_section"
+                                        t-out="line._get_section_totals(price_field)"
+                                        class="text-nowrap"
+                                        t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"
+                                    >
+                                        27.00
+                                    </span>
+                                </td>
+                            </tr>
+                            <tr t-elif="is_note" name="tr_note" class="fst-italic o_line_note">
+                                <td
+                                    name="td_note_name"
+                                    colspan="99"
+                                    t-att-class="padding_class"
+                                >
+                                    <span t-field="line.name">A note, whose content usually applies to the section or product above.</span>
+                                </td>
+                            </tr>
+                            <tr t-elif="is_combo" name="tr_combo" class="fw-bold o_line_subsection">
+                                <td
+                                    name="td_combo_name"
+                                    colspan="99"
+                                    t-att-class="padding_class"
+                                >
+                                    <span t-field="line.name">Combo Product</span>
+                                </td>
+                            </tr>
+                            <tr t-else="" name="tr_product">
+                                <td
+                                    name="td_product_name"
+                                    t-att-class="padding_class"
+                                >
+                                    <span t-field="line.name">Bacon Burger</span>
+                                </td>
+                                <td name="td_product_quantity" class="o_td_quantity text-end">
                                     <span t-field="line.product_uom_qty" class="text-nowrap">3</span>
                                     <span t-field="line.product_uom_id">units</span>
                                     <span t-if="line.product_uom_id != line.product_id.uom_id" class="text-muted small">
@@ -133,114 +194,86 @@
                                         <br/><span t-esc="quantity_in_product_uom" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}"/> <span t-field="line.product_id.uom_id"/>
                                     </span>
                                 </td>
-                                <td name="td_priceunit" class="text-end text-nowrap">
+                                <td name="td_product_priceunit" class="text-end text-nowrap">
                                     <span
                                         t-if="not line.collapse_prices"
                                         t-field="line.price_unit"
+                                        t-options="{'widget': 'monetary', 'display_currency': line.currency_id}"
                                     >
-                                        3
+                                        25.00
                                     </span>
                                 </td>
-                                <td name="td_discount" t-if="display_discount" class="text-end">
-                                    <span t-field="line.discount">-</span>
+                                <td t-if="display_discount" name="td_product_discount" class="text-end">
+                                    <t t-if="not line.collapse_prices">
+                                        <!-- ! Always check collapse_prices separately; keep discount condition below for XPath -->
+                                        <span t-field="line.discount">-</span>
+                                    </t>
                                 </td>
                                 <t t-set="taxes" t-value="', '.join(tax.tax_label for tax in line.tax_ids if tax.tax_label)"/>
-                                <td name="td_taxes" t-if="display_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
+                                <td t-if="display_taxes" name="td_product_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
                                     <span t-out="taxes">Tax 15%</span>
                                 </td>
-                                <td t-if="not line.is_downpayment" name="td_subtotal" class="text-end o_price_total">
-                                    <span
-                                        t-if="not line.collapse_prices"
-                                        t-field="line.price_subtotal"
-                                    >
-                                        27.00
-                                    </span>
+                                <td t-if="not line.is_downpayment" name="td_product_subtotal" class="text-end o_price_total">
+                                    <t t-if="not line.collapse_prices">
+                                        <span
+                                            t-if="price_field == 'price_subtotal'"
+                                            t-field="line.price_subtotal"
+                                        >
+                                            27.00
+                                        </span>
+                                        <span t-else="" t-field="line.price_total">
+                                            27.00
+                                        </span>
+                                    </t>
                                 </td>
-                            </t>
-                            <t
-                                t-elif="line.display_type in ('line_section', 'line_subsection')
-                                    or line.product_type == 'combo'"
-                            >
-                                <td name="td_section_line" colspan="99">
-                                    <span t-field="line.name">A section title</span>
-                                </td>
-                                <t t-if="line.display_type == 'line_section'">
-                                    <t t-set="current_section" t-value="line"/>
-                                    <t t-set="current_subtotal" t-value="0"/>
-                                </t>
-                            </t>
-                            <t t-elif="line.display_type == 'line_note'">
-                                <td name="td_note_line" colspan="99">
-                                    <span t-field="line.name">A note, whose content usually applies to the section or product above.</span>
-                                </td>
-                            </t>
-                        </tr>
+                            </tr>
                         </t>
-
-                        <t
-                            t-elif="(
-                                    line.display_type == 'line_subsection'
-                                    and not line.parent_id.collapse_composition
-                                )
-                                or line.display_type == 'line_section'"
-                        >
+                        <t t-else="">
+                            <!-- Displaying the section inner content, grouped by taxes -->
                             <tr
-                                t-foreach="line._get_grouped_section_summary()"
+                                t-foreach="line._get_grouped_section_summary(display_taxes)"
                                 t-as="section_line"
+                                name="tr_section_group"
                                 class="o_line_section"
                             >
-                                <td name="td_name">
-                                    <span t-out="section_line['name']">Section Summary</span>
+                                <td name="td_section_group_name" t-att-class="padding_class">
+                                    <span t-field="line.name">
+                                        Section Summary
+                                    </span>
                                 </td>
-                                <td name="td_quantity" class="text-end text-nowrap">
+                                <td name="td_section_group_quantity" class="text-end text-nowrap">
                                     <span>1.00 Units</span>
                                 </td>
-                                <td name="td_priceunit" class="text-end text-nowrap">
-                                    <span t-out="section_line['price_subtotal']"/>
+                                <td name="td_section_group_priceunit" class="text-end text-nowrap">
+                                    <span
+                                        name="price_subtotal_section_grouped"
+                                        t-out="section_line['price_subtotal']"
+                                        t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"
+                                    >
+                                        25.00
+                                    </span>
                                 </td>
-                                <td name="td_discount" t-if="display_discount"/>
+                                <td t-if="display_discount" name="td_section_group_discount">
+                                    <!-- NOTE: not computed atm, but at least provides the API for it if needed in the future -->
+                                    <t t-set="aggregated_discount" t-value="section_line.get('discount', 0)"/>
+                                    <span t-if="aggregated_discount" t-out="aggregated_discount">-</span>
+                                </td>
                                 <td
-                                    name="td_taxes"
                                     t-if="display_taxes"
-                                    t-attf-class="text-end {{ 'text-nowrap' if len(section_line['taxes']) &lt; 10 else '' }}"
+                                    name="td_section_group_taxes"
+                                    t-attf-class="text-end {{ 'text-nowrap' if len(section_line['tax_labels']) &lt; 10 else '' }}"
                                 >
-                                    <span t-out="', '.join(section_line['taxes'])">
+                                    <span t-out="', '.join(section_line['tax_labels'])">
                                         Tax 15%
                                     </span>
                                 </td>
-                                <td class="text-end o_price_total">
-                                    <span t-out="section_line['price_subtotal']">
-                                        31.05
-                                    </span>
-                                </td>
-                            </tr>
-                            <t t-if="line.display_type == 'line_section'">
-                                <t t-set="current_section" t-value="line"/>
-                                <t t-set="current_subtotal" t-value="0"/>
-                            </t>
-                        </t>
-
-                        <t
-                            t-if="current_section and (
-                                line_last
-                                or lines_to_report[line_index+1].display_type == 'line_section'
-                                or lines_to_report[line_index+1].product_type == 'combo'
-                                or (
-                                    line.combo_item_id
-                                    and not lines_to_report[line_index+1].combo_item_id
-                                )
-                            )
-                            and not line.is_downpayment
-                            and not current_section.collapse_composition"
-                        >
-                            <t t-set="current_section" t-value="None"/>
-                            <tr class="is-subtotal text-end">
-                                <td name="td_section_subtotal" colspan="99">
-                                    <strong class="mr16">Subtotal</strong>
+                                <td name="td_section_group_total" class="text-end o_price_total">
                                     <span
-                                        t-out="current_subtotal"
-                                        t-options='{"widget": "monetary", "display_currency": doc.currency_id}'
-                                    >31.05</span>
+                                        t-out="section_line[price_field]"
+                                        t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"
+                                    >
+                                        30.00
+                                    </span>
                                 </td>
                             </tr>
                         </t>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -614,7 +614,7 @@
                                 <field name="selected_combo_items" column_invisible="1"/>
                                 <field name="virtual_id" column_invisible="1"/>
                                 <field name="linked_virtual_id" column_invisible="1"/>
-                                <field name="parent_id" column_invisible="True"/>
+                                <field name="parent_id" column_invisible="1"/>
                                 <field name="collapse_prices" column_invisible="1"/>
                                 <field name="collapse_composition" column_invisible="1"/>
 

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -706,10 +706,12 @@
                     </div>
                 </t>
 
-                <t t-set="display_discount" t-value="True in [line.discount > 0 for line in sale_order.order_line]"/>
-                <t t-set="display_taxes" t-value="any(line.tax_ids for line in sale_order.order_line)"/>
+                <t t-set="lines_to_report" t-value="sale_order._get_order_lines_to_report()"/>
+                <t t-set="display_discount" t-value="any(line.discount > 0 for line in lines_to_report)"/>
+                <t t-set="hide_taxes_details" t-value="False"/>
+                <t t-set="display_taxes" t-value="not hide_taxes_details and any(line._has_taxes() for line in lines_to_report)"/>
 
-                <div class="table-responsive">
+                <div name="sol_table" class="table-responsive">
                     <table t-att-data-order-id="sale_order.id" t-att-data-token="sale_order.access_token" class="table table-sm" id="sales_order_table">
                         <thead>
                             <tr>
@@ -731,153 +733,179 @@
                         </thead>
                         <tbody class="sale_tbody">
 
-                            <t t-set="current_subtotal" t-value="0"/>
-                            <t t-set="lines_to_report" t-value="sale_order._get_order_lines_to_report()"/>
+                            <t t-set="current_section" t-value="None"/>
+                            <t t-set="current_subsection" t-value="None"/>
+                            <t t-set="price_field" t-value="'price_total' if hide_taxes_details else 'price_subtotal'"/>
 
                             <t t-foreach="lines_to_report" t-as="line">
 
-                                <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                                 <t t-set="is_note" t-value="line.display_type == 'line_note'"/>
+                                <t t-set="is_section" t-value="line.display_type == 'line_section'"/>
+                                <t t-set="is_subsection" t-value="line.display_type == 'line_subsection'"/>
+                                <t t-set="is_combo" t-value="line.product_type == 'combo'"/>
 
-                                <!-- TODO VFE NIPL merge t-if -->
-                                <t t-if="line.display_type not in ('line_section', 'line_subsection')
-                                         or line.product_type == 'combo'
-                                         or not line.collapse_composition"
-                                >
-                                <tr
-                                    t-if="not line.collapse_composition"
-                                    t-att-class="'fw-bold o_line_section' if (
-                                        line.display_type == 'line_section'
-                                        or line.product_type == 'combo'
-                                    )
-                                    else 'fw-bold o_line_subsection' if line.display_type == 'line_subsection'
-                                    else 'fst-italic o_line_note' if is_note
-                                    else ''"
-                                >
+                                <t t-if="is_section">
+                                    <t t-set="current_section" t-value="line"/>
+                                    <t t-set="current_subsection" t-value="None"/>
+                                    <t t-set="line_padding" t-value="0"/>
+                                </t>
+                                <t t-elif="is_subsection">
+                                    <t t-set="current_subsection" t-value="line"/>
+                                    <t t-set="line_padding" t-value="2"/>
+                                </t>
+                                <t t-else="">
                                     <t
-                                        name="product_line_row"
-                                        t-if="not line.display_type and line.product_type != 'combo'"
+                                        t-set="line_padding"
+                                        t-value="3 if current_subsection else (2 if current_section else 0)"
+                                    />
+                                </t>
+
+                                <t t-if="line.combo_item_id">
+                                    <t t-set="line_padding" t-value="line_padding + 1"/>
+                                </t>
+
+                                <t t-set="padding_class" t-value="line_padding and ('px-' + str(line_padding)) or ''"/>
+
+                                <t t-if="not line.collapse_composition">
+                                    <tr
+                                        t-if="is_section or is_subsection"
+                                        name="tr_section"
+                                        t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
                                     >
-                                        <td id="product_name">
+                                        <td
+                                            name="td_section_name"
+                                            t-att-colspan="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                            t-att-class="padding_class"
+                                        >
                                             <span t-field="line.name"/>
                                         </td>
-                                        <td class="text-end" id="quote_qty_td">
+                                        <td name="td_section_price" class="text-end o_price_total">
+                                            <span
+                                                name="price_subtotal_section"
+                                                t-out="line._get_section_totals(price_field)"
+                                                class="text-nowrap"
+                                                t-options="{'widget': 'monetary', 'display_currency': sale_order.currency_id}"
+                                            />
+                                        </td>
+                                    </tr>
+                                    <tr t-elif="is_note" name="tr_note" class="fst-italic o_line_note">
+                                        <td
+                                            name="td_note_name"
+                                            colspan="99"
+                                            t-att-class="padding_class"
+                                        >
+                                            <span t-field="line.name"/>
+                                        </td>
+                                    </tr>
+                                    <tr t-elif="is_combo" name="tr_combo" class="fw-bold o_line_subsection">
+                                        <td
+                                            name="td_combo_name"
+                                            colspan="99"
+                                            t-att-class="padding_class"
+                                        >
+                                            <span t-field="line.name">Combo Product</span>
+                                        </td>
+                                    </tr>
+                                    <tr t-else="" name="tr_product">
+                                        <td
+                                            name="td_product_name"
+                                            t-att-class="padding_class"
+                                        >
+                                            <span name="span_product_name" t-field="line.name"/>
+                                        </td>
+                                        <td name="td_product_quantity" class="text-end">
                                             <div id="quote_qty">
                                                 <span t-field="line.product_uom_qty"/>
                                                 <span t-field="line.product_uom_id"/>
                                             </div>
                                         </td>
-                                        <td t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
-                                            <div
-                                                t-if="line.discount &gt;= 0 and not line.collapse_prices"
-                                                t-field="line.price_unit"
-                                                t-att-style="line.discount and 'text-decoration: line-through' or None"
-                                                t-att-class="(line.discount and 'text-danger' or '') + ' text-end'"
-                                            />
-                                            <div t-if="line.discount">
-                                                <t t-out="(1-line.discount / 100.0) * line.price_unit" t-options='{"widget": "float", "decimal_precision": "Product Price"}'/>
-                                            </div>
+                                        <td
+                                            name="td_product_priceunit"
+                                            t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}"
+                                        >
+                                            <t t-if="not line.collapse_prices">
+                                                <div
+                                                    t-if="line.discount &gt;= 0"
+                                                    t-field="line.price_unit"
+                                                    t-att-style="line.discount and 'text-decoration: line-through' or None"
+                                                    t-att-class="(line.discount and 'text-danger' or '') + ' text-end'"
+                                                    t-options="{'widget': 'monetary', 'display_currency': line.currency_id}"
+                                                />
+                                                <div t-if="line.discount">
+                                                    <t
+                                                        t-out="(1-line.discount / 100.0) * line.price_unit"
+                                                        t-options='{"widget": "float", "decimal_precision": "Product Price"}'
+                                                    />
+                                                </div>
+                                            </t>
                                         </td>
-                                        <td t-if="display_discount" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
-                                            <strong t-if="line.discount &gt; 0" class="text-info">
-                                                <t t-out="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
-                                            </strong>
+                                        <td t-if="display_discount" name="td_product_discount" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
+                                            <t t-if="not line.collapse_prices">
+                                                <!-- ! Always check collapse_prices separately; keep discount condition below for XPath -->
+                                                <strong t-if="line.discount &gt; 0" class="text-info">
+                                                    <t t-out="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
+                                                </strong>
+                                            </t>
                                         </td>
-                                        <td t-if="display_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes">
+                                        <td t-if="display_taxes" name="td_product_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                             <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
                                         </td>
-                                        <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
-                                            <span
-                                                t-if="not line.collapse_prices"
-                                                class="oe_order_line_price_subtotal"
-                                                t-field="line.price_subtotal"
-                                            />
+                                        <td t-if="not line.is_downpayment" name="td_product_subtotal" class="text-end">
+                                            <t t-if="not line.collapse_prices">
+                                                <span
+                                                    t-if="price_field == 'price_subtotal'"
+                                                    t-field="line.price_subtotal"
+                                                />
+                                                <span
+                                                    t-else="" t-field="line.price_total"
+                                                />
+                                            </t>
                                         </td>
-                                    </t>
-                                    <t
-                                        t-if="line.display_type in ('line_section','line_subsection')
-                                            or line.product_type == 'combo'"
-                                    >
-                                        <td colspan="99">
-                                            <span t-field="line.name"/>
-                                        </td>
-                                        <t t-if="line.display_type == 'line_section'">
-                                            <t t-set="current_section" t-value="line"/>
-                                            <t t-set="current_subtotal" t-value="0"/>
-                                        </t>
-                                    </t>
-                                    <t t-if="is_note">
-                                        <td colspan="99">
-                                            <span t-field="line.name"/>
-                                        </td>
-                                    </t>
-                                </tr>
+                                    </tr>
                                 </t>
-
-                                <t
-                                    t-elif="(
-                                            line.display_type == 'line_subsection'
-                                            and not line.parent_id.collapse_composition
-                                        )
-                                        or line.display_type == 'line_section'"
-                                >
+                                <t t-else="">
+                                    <!-- Displaying the section inner content, grouped by taxes -->
                                     <tr
-                                        t-foreach="line._get_grouped_section_summary()"
+                                        t-foreach="line._get_grouped_section_summary(display_taxes)"
                                         t-as="section_line"
+                                        name="tr_section_group"
                                         class="o_line_section"
                                     >
-                                        <td name="td_name">
-                                            <span t-out="section_line['name']">Section Summary</span>
+                                        <td name="td_section_group_name" t-att-class="padding_class">
+                                            <span t-field="line.name">
+                                                Section Summary
+                                            </span>
                                         </td>
-                                        <td name="td_quantity" class="text-end text-nowrap">
+                                        <td name="td_section_group_quantity" class="text-end text-nowrap">
                                             <span>1.00 Units</span>
                                         </td>
-                                        <td name="td_priceunit" class="text-end text-nowrap">
-                                            <span t-out="section_line['price_subtotal']"/>
+                                        <td name="td_section_group_priceunit" class="text-end text-nowrap">
+                                            <span
+                                                t-out="section_line['price_subtotal']"
+                                                t-options="{'widget': 'monetary', 'display_currency': sale_order.currency_id}"
+                                            />
                                         </td>
-                                        <td name="td_discount" t-if="display_discount"/>
+                                        <td t-if="display_discount" name="td_section_group_discount"/>
                                         <td
-                                            name="td_taxes"
                                             t-if="display_taxes"
-                                            t-attf-class="text-end {{ 'text-nowrap' if len(section_line['taxes']) &lt; 10 else '' }}"
+                                            name="td_section_group_taxes"
+                                            t-attf-class="text-end {{ 'text-nowrap' if len(section_line['tax_labels']) &lt; 10 else '' }}"
                                         >
-                                            <span t-out="', '.join(section_line['taxes'])">
+                                            <span t-out="', '.join(section_line['tax_labels'])">
                                                 Tax 15%
                                             </span>
                                         </td>
-                                        <td class="text-end o_price_total">
-                                            <span t-out="section_line['price_subtotal']">
+                                        <td name="td_section_group_total" class="text-end o_price_total">
+                                            <span
+                                                name="price_subtotal_section_grouped"
+                                                t-out="section_line[price_field]"
+                                                t-options="{'widget': 'monetary', 'display_currency': sale_order.currency_id}"
+                                            >
                                                 31.05
                                             </span>
                                         </td>
                                     </tr>
-                                    <t t-if="line.display_type == 'line_section'">
-                                        <t t-set="current_section" t-value="line"/>
-                                        <t t-set="current_subtotal" t-value="0"/>
-                                    </t>
                                 </t>
-                                <tr
-                                    t-if="current_section and (
-                                        line_last
-                                        or lines_to_report[line_index+1].display_type == 'line_section'
-                                        or lines_to_report[line_index+1].product_type == 'combo'
-                                        or (
-                                            line.combo_item_id
-                                            and not lines_to_report[line_index+1].combo_item_id
-                                        )
-                                    )
-                                    and not line.is_downpayment
-                                    and current_section.collapse_composition"
-                                    class="is-subtotal text-end"
-                                >
-                                    <t t-set="current_section" t-value="None"/>
-                                    <td colspan="99">
-                                        <strong class="mr16">Subtotal</strong>
-                                        <span t-out="current_subtotal"
-                                            t-options='{"widget": "monetary", "display_currency": sale_order.currency_id}'
-                                        />
-                                    </td>
-                                </tr>
                             </t>
                         </tbody>
                     </table>

--- a/addons/sale_loyalty/views/sale_portal_templates.xml
+++ b/addons/sale_loyalty/views/sale_portal_templates.xml
@@ -75,7 +75,7 @@
     <template id="sale_order_portal_content_inherit"
               name="Gift Card Products Portal"
               inherit_id="sale.sale_order_portal_content">
-        <xpath expr="//section[@id='details']//td[@id='product_name']/*[last()]" position="after">
+        <xpath expr="//section[@id='details']//td[@name='td_product_name']/*[last()]" position="after">
             <t t-if="line.coupon_id and line.coupon_id.program_id.program_type == 'gift_card'"
                t-call="sale_loyalty.used_gift_card"/>
         </xpath>

--- a/addons/sale_management/views/sale_portal_templates.xml
+++ b/addons/sale_management/views/sale_portal_templates.xml
@@ -13,8 +13,8 @@
             </th>
         </xpath>
 
-        <xpath expr="//section[@id='details']//t[@name='product_line_row']" position="inside">
-            <td class="text-center" t-if="display_remove">
+        <xpath expr="//section[@id='details']//tr[@name='tr_product']" position="inside">
+            <td t-if="display_remove" class="text-center">
                 <a t-if="line._can_be_edited_on_portal()"
                    t-att-data-line-id="line.id"
                    t-att-data-unlink="True"

--- a/addons/website_sale/views/sale_portal_templates.xml
+++ b/addons/website_sale/views/sale_portal_templates.xml
@@ -2,17 +2,17 @@
 <odoo>
 
     <template id="sale_order_portal_content_inherit_website_sale" name="Orders Followup Products Links" inherit_id="sale.sale_order_portal_content">
-        <xpath expr="//section[@id='details']//div[hasclass('table-responsive')]" position="attributes">
+        <div name="sol_table" position="attributes">
             <attribute name="class" remove="table-responsive" separator=" "/>
-        </xpath>
-        <xpath expr="//section[@id='details']//td[@id='product_name']/*" position="replace">
+        </div>
+        <span name="span_product_name" position="replace">
             <a t-if="line.product_id.website_published" t-att-href="line.product_id.website_url" class="d-block text-wrap" style="max-width: 35vw">
                 <span t-field="line.name" />
             </a>
             <t t-if="not line.product_id.website_published">
                 <span t-field="line.name" class="d-block text-wrap" style="max-width: 35vw"/>
             </t>
-        </xpath>
+        </span>
     </template>
 
     <template id="sale_order_re_order_btn" inherit_id="sale.sale_order_portal_template" name="Sale Order Order Again">


### PR DESCRIPTION
Before this commit:
- Sections, subsections, and notes were visually indistinguishable in reports
  and the portal.
- Section subtotals were displayed inconsistently.
- Hiding a (sub)section caused totals and unit prices to lose proper currency
  formatting.

After this commit:
- Sections and subsections are bolded, with sections slightly bolder.
- Visual spacing applied:
  - Sections (and subsections) shifted by one level (px-based).
  - Subsections shifted by two levels.
  - Combo items shifted by one level.
- Subtotals are now displayed directly on their section line.
- Fixed currency display for totals and unit prices when (sub)sections are
  hidden.

task-5009037

See Also:
https://github.com/odoo/enterprise/pull/93315

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
