### PR TITLE
[FIX] pos_sale: Fix amount with multiple down payment on same SO from POS

### DIFF
--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -507,8 +507,7 @@ export const accountTaxHelpers = {
         // compare_amounts does not exist in numbers.js
         const are_amounts_equal = (a, b) =>
             floatIsZero(
-                roundPrecision(base_line.price_unit, currency_dp) -
-                    roundPrecision(extra_tax_data.price_unit, currency_dp),
+                roundPrecision(a, currency_dp) - roundPrecision(b, currency_dp),
                 currency_dp
             );
 

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -237,8 +237,11 @@ patch(PosStore.prototype, {
         accountTaxHelpers.add_tax_details_in_base_lines(baseLines, this.company);
         accountTaxHelpers.round_base_lines_tax_details(baseLines, this.company);
 
-        const amount = parseFloat(payload);
-        const amountType = isPercentage ? "percent" : "fixed";
+        let amount = parseFloat(payload);
+        if (isPercentage) {
+            const percentage = amount / 100.0;
+            amount = baseLines.length ? saleOrder.amount_unpaid * percentage : 0.0;
+        }
         const downPaymentProduct = this.config.down_payment_product_id;
         const groupingFunction = (base_line) => ({
             grouping_key: { product_id: downPaymentProduct },
@@ -247,7 +250,7 @@ patch(PosStore.prototype, {
         const downPaymentBaseLines = accountTaxHelpers.prepare_down_payment_lines(
             baseLines,
             this.company,
-            amountType,
+            "fixed",
             amount,
             {
                 computation_key: "down_payment", // TODO: won't work with multiple down payment on the same order... is it a problem?


### PR DESCRIPTION
- Create a SO of 450 with 15% tax for a total of 517.50
- Create a first down payment from the POS of 10% => you pay 51.75
- Create a second down payment from the POS of 10% => we ask you to pay 51.75 again
=> We should ask him to pay 10% of 517.50 - 51.75 instead

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
