### PR TITLE
[IMP] hr: auto-format employee phone numbers using phone_validation

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -252,6 +252,13 @@ class HrEmployee(models.Model):
         if not self.contract_date_start:
             self.contract_date_end = False
 
+    @api.onchange('work_phone', 'mobile_phone', 'company_country_id', 'company_id')
+    def _onchange_phone_validation_employee(self):
+        if self.work_phone:
+            self.work_phone = self._phone_format(number=self.work_phone, force_format='INTERNATIONAL') or self.work_phone
+        if self.mobile_phone:
+            self.mobile_phone = self._phone_format(number=self.mobile_phone, force_format='INTERNATIONAL') or self.mobile_phone
+
     @api.model
     def _get_new_hire_field(self):
         return 'create_date'


### PR DESCRIPTION
Current behavior before PR
------------------------
Employee phone numbers (`work_phone`, `mobile_phone`) are saved as entered, without automatic formatting.
In the Contacts app, phone numbers are automatically formatted according to the country.

Desired behavior after PR
------------------------
Employee phone numbers should also be formatted consistently, using the same logic as Contacts.

Solution
------------------------
Add an `onchange` method to `hr.employee` to format `work_phone` and `mobile_phone` automatically when edited in the UI.