### PR TITLE
[FIX] sale_loyalty: handle multiple orders in `_recompute_prices`

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -545,8 +545,9 @@ class SaleOrder(models.Model):
     def _recompute_prices(self):
         """Recompute coupons/promotions after pricelist prices reset."""
         super()._recompute_prices()
-        if any(line.is_reward_line for line in self.order_line):
-            self._update_programs_and_rewards()
+        for order in self:
+            if any(line.is_reward_line for line in order.order_line):
+                order._update_programs_and_rewards()
 
     def _get_point_changes(self):
         """


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have 2 eCommerce sites;
2. have a user with an open cart in both sites;
3. have a reward applied in one or both of carts;
4. have a fiscal position applicable to the user's address;
5. change the user's country to one with a different fiscal position.

Issue
-----
> ValueError: Expected singleton: sale.order(1, 2)

Cause
-----
As of commit ede8846987a98, fiscal positions get recomputed on address changes. When a fiscal position changes, the `_recompute_prices` method gets called on all open carts.

This method does not include an `ensure_one` check, so it should be able to handle multiple sales orders.

However, the `sale_loyalty` override will call `_update_programs_and_rewards` on `self` if any reward line is encountered. This method does have an `ensure_one` check, leading to the error.

Solution
--------
Rewrite the override as a loop, so it can handle multiple records in `self`.

opw-5017669