### PR TITLE
[FIX] project_sale_expense: wrong analityc distrib computation

### DIFF
--- a/addons/project_sale_expense/models/hr_expense.py
+++ b/addons/project_sale_expense/models/hr_expense.py
@@ -1,16 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import models
 
 
 class Expense(models.Model):
     _inherit = "hr.expense"
 
-    @api.depends('sale_order_id')
     def _compute_analytic_distribution(self):
         super()._compute_analytic_distribution()
         if not self.env.context.get('project_id'):
-            for expense in self:
-                if not self.sale_order_id:
-                    continue
+            for expense in self.filtered('sale_order_id'):
                 expense.analytic_distribution = expense.sale_order_id.project_id._get_analytic_distribution()

--- a/addons/project_sale_expense/tests/test_project_sale_expense.py
+++ b/addons/project_sale_expense/tests/test_project_sale_expense.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
+
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 from odoo.addons.sale.tests.common import TestSaleCommon
 from odoo.tests import Form, tagged
@@ -34,11 +36,20 @@ class TestSaleExpense(TestExpenseCommon, TestSaleCommon):
         self.assertFalse(so.project_account_id)
 
     def test_compute_analytic_distribution_expense(self):
+        """ Test that the analytic distibution is well computed when we link a sale order to an expense """
+
+        # Make sure the user has access to analytic accounting, otherwise the 'analytic_distribution' field will not appear
+        # in the view and will not be computed
+        self.env.user.write({'groups_id': [Command.link(self.env.ref('analytic.group_analytic_accounting').id)]})
+        # Set the expense policy to 'sales_price' to make the 'sale_order_id' field visible on the form view
+        self.product_c.expense_policy = 'sales_price'
+
         project = self.env['project.project'].create({'name': 'SO Project'})
         project.account_id = self.analytic_account_1
+
         so_values = {
             'partner_id': self.partner_a.id,
-            'order_line': [(0, 0, {
+            'order_line': [Command.create({
                 'name': self.product_a.name,
                 'product_id': self.product_a.id,
                 'product_uom_qty': 2,
@@ -47,13 +58,15 @@ class TestSaleExpense(TestExpenseCommon, TestSaleCommon):
             })],
             'project_id': project.id,
         }
-
         so1 = self.env['sale.order'].create(so_values)
+
         expense = self.env['hr.expense'].create({
             'name': 'Expense Test',
             'employee_id': self.expense_employee.id,
             'sale_order_id': so1.id,
+            'product_id': self.product_c.id,
         })
+
         self.assertEqual(
             expense.analytic_distribution,
             {str(self.analytic_account_1.id): 100},
@@ -62,8 +75,59 @@ class TestSaleExpense(TestExpenseCommon, TestSaleCommon):
 
         project.account_id = False
         so2 = self.env['sale.order'].create(so_values)
-        expense.sale_order_id = so2
+
+        # We use the form to trigger the onchange on sale_order_id, which adds the 'analytic_distribution' field to the fields to recompute
+        with Form(expense) as exp_form:
+            exp_form.sale_order_id = so2
+
         self.assertFalse(
             expense.analytic_distribution,
             "The analytic distribution of the expense should be unset as the project has no account.",
         )
+
+    def test_change_product_expense_policy_analytic_distribution(self):
+        """ Test that analytic distribution is not recomputed when changing the expense policy of the expense product """
+        analytic_account_2 = self.analytic_account_1.copy()
+        self.product_a.expense_policy = 'sales_price'
+        distribution_model = self.env['account.analytic.distribution.model'].create({
+            'account_prefix': self.company_data['default_account_expense'].code,
+            'analytic_distribution': {self.analytic_account_1.id: 100.0},
+        })
+        expenses = self.env['hr.expense'].create([
+            {
+                'name': f'Expense {i}',
+                'employee_id': self.expense_employee.id,
+                'product_id': self.product_a.id,
+            } for i in range(1, 3)
+        ])
+        self.assertRecordValues(expenses, [
+            {
+                'account_id': self.company_data['default_account_expense'].id,
+                'analytic_distribution': {str(self.analytic_account_1.id): 100.0},
+            },
+            {
+                'account_id': self.company_data['default_account_expense'].id,
+                'analytic_distribution': {str(self.analytic_account_1.id): 100.0},
+            },
+        ])
+
+        distribution_model.analytic_distribution = {analytic_account_2.id: 100.0}
+        expenses |= self.env['hr.expense'].create({
+            'name': 'Expense 3',
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_a.id,
+        })
+
+        self.product_a.expense_policy = 'cost'
+
+        self.assertRecordValues(expenses, [
+            {
+                'analytic_distribution': {str(self.analytic_account_1.id): 100.0},
+            },
+            {
+                'analytic_distribution': {str(self.analytic_account_1.id): 100.0},
+            },
+            {
+                'analytic_distribution': {str(analytic_account_2.id): 100.0},
+            },
+        ])


### PR DESCRIPTION
When changing the expense policy of an expense product, the
compute of analytic distribution of all expenses linked to the product
is triggered.

Steps:

- Have an expense product X with expense policy 'at_sales'
- Create several expenses with an expense product X and  any analytic account
- Create an analytic distribution model that link the expense account of
  X with a specific analytic account AA
- Create a new expense for product X, the analytic account AA should be set
  from the distribution model
- Go to the form view of product x and change the expense policy to
  'cost'
- Go back to the expense list view
-> All expenses having the product X have the AA account

Cause:

`sale_order_id` has been added to the `depends` of `hr_expense._compute_analytic_distribution`
by 2b3bf5e0fe31d4b4ef6b487da493657f695b14e1 but this wrong since we have
the `sale_expense._onchange_sale_order_id` that add the
`analytic_dostribution` field to the fields to be computed.
The compute is triggered since we change `product_id.expense_policy`,
which triggers the `_compute_can_be_reinvoiced` which triggers
the `_compute_sale_order_id`

Fix:

With this commit, we emove the depends on the compute and we also adapt
`test_compute_analytic_distribution_expense` in a way that it triggers the onchange
as we do in the original flow.

opw-4998899
