### PR TITLE
[FIX] point_of_sale: fix double orderline deletion with bbox

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -97,8 +97,7 @@ export class OrderSummary extends Component {
         ) {
             await this._showDecreaseQuantityPopup();
             if (selectedLine.getQuantity() === 0) {
-                const val = buffer === null ? "remove" : buffer;
-                this._setValue(val);
+                this._setValue("remove");
             }
             return;
         } else if (
@@ -203,9 +202,6 @@ export class OrderSummary extends Component {
         const selectedLine = this.currentOrder.getSelectedOrderline();
         const decreaseQuantity = selectedLine.getQuantity() - newQuantity;
         selectedLine.setQuantity(newQuantity);
-        if (newQuantity == 0) {
-            this.currentOrder.removeOrderline(selectedLine);
-        }
         return decreaseQuantity;
     }
     async handleDecreaseLine(newQuantity) {

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -894,6 +894,7 @@ registry.category("web_tour.tours").add("test_delete_line", {
                 },
             },
             inLeftSide([
+                ...ProductScreen.orderLineHas("Desk Organizer", "1"),
                 ...ProductScreen.selectedOrderlineHasDirect("Desk Organizer", "1"),
                 Numpad.click("⌫"),
                 {


### PR DESCRIPTION
- Fix issue in `handleDecreaseUnsavedLine` which was leading to removing two orderlines instead of one in the current order. This issue appeared since this commit (8e964000474125ca2db4ee4e5883be8424d9fca1). Since we already set the line qty to 0 (or remove it) inside `updateSelectedOrderline` after calling `_showDecreaseQuantityPopup`, we don't need to call `removeOrderLine` inside `handleDecreaseUnsavedLine`.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
