### PR TITLE
[FIX] purchase:  respect product UoM when selecting from catalog

### DIFF
--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -74,6 +74,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             quantity: this.productCatalogData.quantity,
             res_model: this.env.orderResModel,
             child_field: this.env.childField,
+            uom_id: this.productCatalogData.uom?.id || false,
         }
     }
 

--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -53,6 +53,9 @@
             'purchase/static/src/interactions/**/*',
             'purchase/static/src/scss/purchase_portal.scss',
         ],
+        'web.assets_tests': [
+            'purchase/static/tests/tours/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/purchase/static/src/product_catalog/kanban_record.js
+++ b/addons/purchase/static/src/product_catalog/kanban_record.js
@@ -24,4 +24,11 @@ patch(ProductCatalogKanbanRecord.prototype, {
         }
     },
 
+    _getUpdateQuantityAndGetPriceParams() {
+        const params = super._getUpdateQuantityAndGetPriceParams();
+        if (this.productCatalogData.purchase_uom) {
+            params.uom_id = this.productCatalogData.purchase_uom.id;
+        }
+        return params;
+    },
 });

--- a/addons/purchase/static/tests/tours/purchase_product_catalog.js
+++ b/addons/purchase/static/tests/tours/purchase_product_catalog.js
@@ -1,0 +1,61 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "./tour_step_utils";
+
+registry.category("web_tour.tours").add("test_catalog_vendor_uom", {
+    steps: () => [
+        // Open the PO for the vendor selling product as "Units".
+        { trigger: "td[data-tooltip='PO/TEST/00002']", run: "click" },
+        ...stepUtils.displayFormOptionalField("discount"),
+        ...stepUtils.openCatalog(),
+        ...stepUtils.checkProductPrice("Crab Juice", "$ 2.50 / Units"),
+        // Add 6 units and check the price is correctly updated.
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.waitForQuantity("Crab Juice", 5),
+        ...stepUtils.checkProductPrice("Crab Juice", "$ 2.50 / Units"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.checkProductPrice("Crab Juice", "$ 2.45 / Units"),
+        // Add 6 units more and check the price is updated again.
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.waitForQuantity("Crab Juice", 11),
+        ...stepUtils.checkProductPrice("Crab Juice", "$ 2.45 / Units"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.checkProductPrice("Crab Juice", "$ 2.20 / Units"),
+        // Go back in the PO form view and check PO line price and qty is correct.
+        { trigger: ".o-kanban-button-back", run: "click" },
+        ...stepUtils.checkPurchaseOrderLineValues(0, {
+            product: "Crab Juice",
+            discount: "10.20",
+            quantity: "12.00",
+            unit: "Units",
+            unitPrice: "2.45",
+            totalPrice: "$ 26.40",
+        }),
+
+        // Open the PO for the vendor selling product as liter.
+        { trigger: "a[href='/odoo/purchase']", run: "click" },
+        { trigger: "td[data-tooltip='PO/TEST/00001']", run: "click" },
+        ...stepUtils.openCatalog(),
+        ...stepUtils.checkProductPrice("Crab Juice", "$ 1.55 / L"),
+        ...stepUtils.addProduct("Crab Juice"),
+        ...stepUtils.waitForQuantity("Crab Juice", 1),
+        ...stepUtils.checkProductPrice("Crab Juice", "$ 1.55 / L"),
+        // Go back in the PO form view and check PO line price and qty is correct.
+        { trigger: ".o-kanban-button-back", run: "click" },
+        ...stepUtils.checkPurchaseOrderLineValues(0, {
+            product: "Crab Juice",
+            quantity: "1.00",
+            discount: "22.50",
+            unit: "L",
+            unitPrice: "2.00",
+            totalPrice: "$ 1.55",
+        }),
+    ],
+});

--- a/addons/purchase/static/tests/tours/tour_step_utils.js
+++ b/addons/purchase/static/tests/tours/tour_step_utils.js
@@ -1,0 +1,74 @@
+export const stepUtils = {
+    // Form view utils.
+    checkPurchaseOrderLineValues(index, values) {
+        const fieldAndLabelDict = {
+            product: { fieldName: "product_id", label: "product" },
+            quantity: { fieldName: "product_qty", label: "quantity" },
+            unit: { fieldName: "product_uom_id", label: "unit of measure" },
+            unitPrice: { fieldName: "price_unit", label: "unit price" },
+            discount: { fieldName: "discount", label: "discount" },
+            totalPrice: { fieldName: "price_subtotal", label: "subtotal price" },
+        };
+        const trigger = `.o_form_renderer .o_list_view.o_field_x2many tbody tr.o_data_row:eq(${index})`;
+        const run = function ({ anchor }) {
+            const getFieldValue = (fieldName) => {
+                let selector = `td[name="${fieldName}"]`;
+                if (fieldName === "product_id") {
+                    // Special case for the product field because it can be replace by another field
+                    selector += ",td[name='product_template_id']";
+                }
+                const fieldEl = anchor.querySelector(selector);
+                return fieldEl ? fieldEl.innerText.replace(/\s/g, " ") : false;
+            };
+            for (const key in values) {
+                if (!Object.keys(fieldAndLabelDict).includes(key)) {
+                    throw new Error(
+                        `'checkPurchaseOrderLineValues' is called with unsupported key: ${key}`
+                    );
+                }
+                const value = values[key];
+                const { fieldName, label } = fieldAndLabelDict[key];
+                const lineValue = getFieldValue(fieldName);
+                if (!lineValue) {
+                    throw new Error(
+                        `Purchase order line at index ${index} expected ${value} as ${label} but got nothing`
+                    );
+                } else if (lineValue !== value) {
+                    throw new Error(
+                        `Purchase order line at index ${index} expected ${value} as ${label} but got ${lineValue} instead`
+                    );
+                }
+            }
+        };
+        return [{ trigger, run }];
+    },
+    displayFormOptionalField(fieldName) {
+        return [
+            {
+                trigger:
+                    ".o_form_renderer .o_list_view.o_field_x2many .o_optional_columns_dropdown button",
+                run: "click",
+            },
+            { trigger: `input[name="${fieldName}"]:not(:checked)`, run: "click" },
+            { trigger: `th[data-name="${fieldName}"]` },
+        ];
+    },
+    openCatalog() {
+        const trigger = ".o_field_x2many_list_row_add > button[name='action_add_from_catalog']";
+        return [{ trigger, run: "click" }];
+    },
+    // Product catalog utils.
+    addProduct(productName) {
+        const trigger = `.o_kanban_record:contains("${productName}") button:has(.fa-plus,.fa-shopping-cart)`;
+        return [{ trigger, run: "click" }];
+    },
+    checkProductPrice(productName, priceAndUoM) {
+        const trigger = `.o_kanban_record:contains("${productName}") .o_product_catalog_price:contains("Price: ${priceAndUoM}")`;
+        const content = `Check that the kanban record card for product "${productName}" has a price of ${priceAndUoM}`;
+        return [{ content, trigger }];
+    },
+    waitForQuantity(productName, quantity) {
+        const trigger = `.o_kanban_record:contains("${productName}") input[type=number]:value("${quantity}")`;
+        return [{ trigger }];
+    },
+};

--- a/addons/purchase/tests/test_purchase_product_catalog.py
+++ b/addons/purchase/tests/test_purchase_product_catalog.py
@@ -101,3 +101,51 @@ class TestPurchaseProductCatalog(AccountTestInvoicingCommon, HttpCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['result'], company_product_price)
+
+    # === TOUR TESTS ===#
+    def test_catalog_vendor_uom(self):
+        """Check the product's UoM matches the one set on the vendor line."""
+        group_uom = self.env.ref('uom.group_uom')
+        self.env.user.write({'group_ids': [Command.link(group_uom.id)]})
+        uom_liter = self.env.ref('uom.product_uom_litre')
+        vendor_by_liter, vendor_by_unit = self.env['res.partner'].create([
+            {'name': 'Vendor A (l)'},
+            {'name': 'Vendor B (unit)'},
+        ])
+        # Create a product and configure some vendor's prices.
+        self.env['product.template'].create({
+            'name': "Crab Juice",
+            'seller_ids': [
+                Command.create({
+                    'partner_id': vendor_by_liter.id,
+                    'product_uom_id': uom_liter.id,
+                    'price': 2,
+                    'discount': 22.5
+                }),
+                Command.create({
+                    'partner_id': vendor_by_unit.id,
+                    'product_uom_id': self.uom_unit.id,
+                    'price': 2.5,
+                }),
+                Command.create({
+                    'partner_id': vendor_by_unit.id,
+                    'product_uom_id': self.uom_unit.id,
+                    'min_qty': 6,
+                    'price': 2.45,
+                }),
+                Command.create({
+                    'partner_id': vendor_by_unit.id,
+                    'product_uom_id': self.uom_unit.id,
+                    'min_qty': 12,
+                    'price': 2.45,
+                    'discount': 10.2,
+                }),
+            ],
+        })
+        # Create two PO and rename them to find them easily in the tour.
+        purchase_orders = self.env['purchase.order'].create([{
+            'partner_id': vendor.id
+        } for vendor in (vendor_by_liter, vendor_by_unit)])
+        purchase_orders[0].name = "PO/TEST/00001"
+        purchase_orders[1].name = "PO/TEST/00002"
+        self.start_tour('/odoo/purchase', 'test_catalog_vendor_uom', login='accountman')


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - UoM: unit
    - Purchase tab:
        - Vendor: Azure interior
        - UoM: Pack of 6

- Create a purchase order:
    - Vendor: Azure interior
    - Click the Catalog button:
        - Select 1 unit of P1 (note: UoM cannot be changed in the catalog)

Problem:
The purchase order line is created, but with 1 pack of 6 instead of 1 unit

Fix:
Ensure the selected product quantity and UoM from the catalog are correctly applied to the PO line.

Opw-4794362