### PR TITLE
[FIX] payment_razorpay: check and refresh expired access token

### DIFF
--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -194,6 +194,8 @@ class PaymentProvider(models.Model):
         url = f'https://api.razorpay.com/{api_version}/{endpoint}'
         headers = None
         if self.razorpay_access_token:
+            if self.razorpay_access_token_expiry < fields.Datetime.now():
+                self._razorpay_refresh_access_token()
             headers = {'Authorization': f'Bearer {self.razorpay_access_token}'}
         auth = (self.razorpay_key_id, self.razorpay_key_secret) if self.razorpay_key_id else None
         try:


### PR DESCRIPTION
Version:
- saas-18.2

Issue:
- The refresh token method was removed in PR https://github.com/odoo/odoo/pull/188774. Because of this, the Razorpay access token expiry was no longer being checked.

Fix:
- When a user makes a payment, the system now checks if the Razorpay access token has expired. If it has, a new token will be generated automatically.

opw-4953953

