### PR TITLE
[FIX] hr_holidays : Freeze time for the accrual allocation test

### DIFF
--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -3919,6 +3919,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation_data = leave_type_day.get_allocation_data(self.employee_emp)
             self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 1)
 
+    @freeze_time('2025-01-01')
     def test_accrual_allocation_date_in_the_future(self):
         vals = {
             'accrual_validity': True,


### PR DESCRIPTION
The test is failing when run one year in the future as it depends on the date but we don't freeze the time.

runbot-error-230721