### PR TITLE
[FIX] html_editor: prevent multiple save calls in media dialog

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -69,15 +69,19 @@ export class MediaDialog extends Component {
 
         this.state = useState({
             activeTab: this.initialActiveTab,
+            isSaving: false,
         });
 
         useEffect(
             (nbSelectedAttachments) => {
                 // Disable/enable the add button depending on whether some media
                 // are selected or not.
-                this.addButtonRef.el.toggleAttribute("disabled", !nbSelectedAttachments);
+                this.addButtonRef.el.toggleAttribute(
+                    "disabled",
+                    !nbSelectedAttachments || this.state.isSaving
+                );
             },
-            () => [this.selectedMedia[this.state.activeTab].length]
+            () => [this.selectedMedia[this.state.activeTab].length, this.state.isSaving]
         );
     }
 
@@ -307,6 +311,7 @@ export class MediaDialog extends Component {
             (this.state.activeTab !== this.tabs.ICONS.id ||
                 selectedMedia[0].initialIconChanged ||
                 !this.props.media);
+        this.state.isSaving = true;
         if (saveSelectedMedia) {
             const elements = await this.renderMedia(selectedMedia);
             if (this.props.multiImages) {
@@ -316,6 +321,7 @@ export class MediaDialog extends Component {
             }
         }
         this.props.close();
+        this.state.isSaving = false;
     }
 
     onTabChange(tab) {


### PR DESCRIPTION
Problem:
`this.props.save` is awaited, which might take a while to process. During that time, the user can click "Add" multiple times.

Cause:
Multiple clicks trigger multiple calls to the same RPC, leading to duplicate saves.

Solution:
Disable the "Add" button while saving to prevent multiple calls.

Steps to reproduce:
- Open website/shop.
- Open a product page.
- Add extra media to the product to open the media dialog.
- Select multiple images and click "Add" multiple times.
- The save is called multiple times, triggering the same RPC several times.

opw-4937004

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
