### PR TITLE
[IMP] website: add breadcrumb feature to website page

### DIFF
--- a/addons/website/models/assets.py
+++ b/addons/website/models/assets.py
@@ -220,6 +220,7 @@ class WebsiteAssets(models.AbstractModel):
                 'menu-secondary-gradient': 'null',
                 'footer-gradient': 'null',
                 'copyright-gradient': 'null',
+                'breadcrumb-gradient': 'null',
                 **preset_gradients,
             })
 

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -148,6 +148,7 @@ class WebsitePageVisibilityOptionsMixin(models.AbstractModel):
 
     header_visible = fields.Boolean(default=True)
     footer_visible = fields.Boolean(default=True)
+    breadcrumb_visible = fields.Boolean(default=True)
 
 
 class WebsitePageOptionsMixin(models.AbstractModel):
@@ -158,6 +159,9 @@ class WebsitePageOptionsMixin(models.AbstractModel):
     header_overlay = fields.Boolean()
     header_color = fields.Char()
     header_text_color = fields.Char()
+    breadcrumb_overlay = fields.Boolean()
+    breadcrumb_color = fields.Char()
+    breadcrumb_text_color = fields.Char()
 
 
 class WebsiteMultiMixin(models.AbstractModel):

--- a/addons/website/static/src/builder/plugins/options/base_visibility_option.js
+++ b/addons/website/static/src/builder/plugins/options/base_visibility_option.js
@@ -1,0 +1,24 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+
+export class BaseVisibilityOption extends BaseOptionComponent {
+    static template = "website.BaseVisibilityOption";
+    static dependencies = ["websitePageConfigOptionPlugin"];
+    static props = {
+        visibilityAction: { type: String, optional: true },
+        bgColor: { type: String, optional: true },
+        label: { type: String },
+        overlay: { type: String, optional: true },
+        textColor: { type: String, optional: true },
+        tooltip: { type: String, optional: true },
+        visibilityOpt: { type: String, optional: true },
+        level: { type: Number, optional: true },
+    };
+    static defaultProps = {
+        level: 0,
+    };
+
+    setup() {
+        super.setup();
+        this.hasPageOption = this.dependencies.websitePageConfigOptionPlugin.doesPageOptionExist;
+    }
+}

--- a/addons/website/static/src/builder/plugins/options/base_visibility_option.xml
+++ b/addons/website/static/src/builder/plugins/options/base_visibility_option.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.BaseVisibilityOption">
+    <BuilderRow label="props.label" tooltip="props.tooltip" t-if="!props.visibilityOpt or !this.isActiveItem(props.visibilityOpt)">
+        <BuilderSelect action="props.visibilityAction">
+            <BuilderSelectItem actionValue="'overTheContent'" id="'overTheContent'" t-if="hasPageOption(props.overlay)">Over The Content</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'regular'">Regular</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'hidden'">Hidden</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
+
+    <t t-if="isActiveItem('overTheContent')">
+        <BuilderRow label.translate="Background" level="props.level" t-if="props.bgColor and hasPageOption(props.bgColor)">
+            <BuilderColorPicker action="'setPageWebsiteDirty'" styleAction="'background-color'" enabledTabs="['custom']"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Text Color" level="props.level" t-if="props.textColor and hasPageOption(props.textColor)">
+            <BuilderColorPicker action="'setPageWebsiteDirty'" styleAction="'color'" enabledTabs="['solid', 'custom']"/>
+        </BuilderRow>
+    </t>
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/options/breadcrumb_option.js
+++ b/addons/website/static/src/builder/plugins/options/breadcrumb_option.js
@@ -1,0 +1,10 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BaseVisibilityOption } from "./base_visibility_option";
+
+export class BreadcrumbOption extends BaseOptionComponent {
+    static template = "website.BreadcrumbOption";
+    static components = { BaseVisibilityOption };
+    static selector = ".o_page_breadcrumb";
+    static groups = ["website.group_website_designer"];
+    static editableOnly = false;
+}

--- a/addons/website/static/src/builder/plugins/options/breadcrumb_option.xml
+++ b/addons/website/static/src/builder/plugins/options/breadcrumb_option.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.BreadcrumbOption">
+    <BuilderRow label.translate="Background Color">
+        <BuilderColorPicker
+            enabledTabs="['theme', 'custom', 'gradient']"
+            preview="false"
+            defaultColor="''"
+            action="'customizeWebsiteColor'"
+            actionParam="{
+                mainParam: 'breadcrumb-custom',
+                gradientColor: 'breadcrumb-gradient',
+                combinationColor: 'breadcrumb',
+                nullValue: 'NULL',
+            }"
+         />
+    </BuilderRow>
+    <BaseVisibilityOption
+        label.translate="Breadcrumb Position"
+        tooltip.translate="Change the Breadcrumb Position on this page"
+        visibilityAction="'setWebsiteBreadcrumbVisibility'"
+        textColor="'breadcrumb_text_color'"
+        bgColor="'breadcrumb_color'"
+        level="1"
+        overlay="'breadcrumb_overlay'"
+    />
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/options/website_page_config_option.js
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option.js
@@ -1,16 +1,13 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BaseVisibilityOption } from "./base_visibility_option";
 
 export class TopMenuVisibilityOption extends BaseOptionComponent {
     static template = "website.TopMenuVisibilityOption";
-    static dependencies = ["websitePageConfigOptionPlugin"];
+    static components = {
+        BaseVisibilityOption,
+    };
     static selector =
         "[data-main-object]:has(input.o_page_option_data[name='header_visible']) #wrapwrap > header";
     static groups = ["website.group_website_designer"];
     static editableOnly = false;
-
-    setup() {
-        super.setup();
-        this.doesPageOptionExist =
-            this.dependencies.websitePageConfigOptionPlugin.doesPageOptionExist;
-    }
 }

--- a/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
@@ -2,21 +2,16 @@
 <templates xml:space="preserve">
 
 <t t-name="website.TopMenuVisibilityOption">
-    <BuilderRow label.translate="Header Position" tooltip.translate="Change the Header Position on this page" t-if="!this.isActiveItem('header_sidebar_opt')">
-        <BuilderSelect action="'setWebsiteHeaderVisibility'">
-            <BuilderSelectItem actionValue="'overTheContent'" id="'overTheContent'" t-if="doesPageOptionExist('header_overlay')">Over The Content</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'regular'">Regular</BuilderSelectItem>
-            <BuilderSelectItem actionValue="'hidden'">Hidden</BuilderSelectItem>
-        </BuilderSelect>
-    </BuilderRow>
-    <t t-if="isActiveItem('overTheContent')">
-        <BuilderRow label.translate="Background" level="1" t-if="doesPageOptionExist('header_color')">
-            <BuilderColorPicker action="'setPageWebsiteDirty'" styleAction="'background-color'" enabledTabs="['custom']"/>
-        </BuilderRow>
-        <BuilderRow label.translate="Text Color" level="1" t-if="doesPageOptionExist('header_text_color')">
-            <BuilderColorPicker action="'setPageWebsiteDirty'" styleAction="'color'" enabledTabs="['solid', 'custom']"/>
-        </BuilderRow>
-    </t>
+    <BaseVisibilityOption
+        label.translate="Header Position"
+        tooltip.translate="Change the Header Position on this page"
+        visibilityAction="'setWebsiteHeaderVisibility'"
+        bgColor="'header_color'"
+        textColor="'header_text_color'"
+        level="1"
+        overlay="'header_overlay'"
+        visibilityOpt="'header_sidebar_opt'"
+    />
 </t>
 
 <t t-name="website.HideFooterOption">

--- a/addons/website/static/src/interactions/page_breadcrumb.js
+++ b/addons/website/static/src/interactions/page_breadcrumb.js
@@ -1,0 +1,36 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+export class PageBreadcrumb extends Interaction {
+    static selector = ".o_page_breadcrumb";
+
+    start() {
+        this.headerEl = document.querySelector("#top");
+        // Watch the header element so we can reposition the breadcrumb whenever
+        // the header's height changes (e.g. on resize or style updates).
+        const updatePageBreadcrumbOnResize = this.protectSyncAfterAsync(
+            this.updatePageBreadcrumbOnResize.bind(this)
+        );
+        this.headerObserver = new ResizeObserver(updatePageBreadcrumbOnResize);
+        this.headerObserver.observe(this.headerEl);
+    }
+
+    destroy() {
+        this.headerObserver.disconnect();
+    }
+
+    /**
+     * Calculates the breadcrumb position so it stays aligned directly below the
+     * header.
+     */
+    updatePageBreadcrumbOnResize() {
+        const headerHeight = this.headerEl.getBoundingClientRect().height;
+        this.el.style.top = `${headerHeight}px`;
+    }
+}
+
+registry.category("public.interactions").add("website.page_breadcrumb", PageBreadcrumb);
+
+registry.category("public.interactions.edit").add("website.page_breadcrumb", {
+    Interaction: PageBreadcrumb,
+});

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -21,6 +21,8 @@ $o-base-color-palette: map-merge($o-base-color-palette, (
     'footer-custom': null,
     'copyright': null,
     'copyright-custom': null,
+    'breadcrumb': 1, // o_cc1
+    'breadcrumb-custom': null,
 ));
 
 // By default, all user color palette values are null. Each null value is
@@ -2175,6 +2177,7 @@ $o-base-website-values-palette: (
     'menu-secondary-gradient': null,
     'footer-gradient': null,
     'copyright-gradient': null,
+    'breadcrumb-gradient': null,
 
     'header-template': 'default', // 'default' / 'hamburger' / 'vertical' / 'sidebar'
     'header-font-size': null, // Default to BS (normal font-size)

--- a/addons/website/static/src/scss/secondary_variables.scss
+++ b/addons/website/static/src/scss/secondary_variables.scss
@@ -150,6 +150,7 @@ $-actual-user-color-palette: map-merge($-palette-default, $o-user-color-palette)
     'header-sales_three': 'header-sales_three-custom',
     'header-sales_four': 'header-sales_four-custom',
     'footer': 'footer-custom',
+    'breadcrumb': 'breadcrumb-custom',
     'copyright': 'copyright-custom'
 ) {
     $-base-value: map-get($-actual-user-color-palette, $name);

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -46,7 +46,7 @@ $-seen-urls: ();
     // 3) The values in the $colors map are also printed by Bootstrap. However,
     // we have color variables which can contain a reference to a color
     // combination and that is the info we want in that case.
-    @each $key in ('menu', 'header-sales_one', 'header-sales_two', 'header-sales_three', 'header-sales_four', 'footer', 'copyright') {
+    @each $key in ('menu', 'header-sales_one', 'header-sales_two', 'header-sales_three', 'header-sales_four', 'footer', 'breadcrumb', 'copyright') {
         $-value: map-get($o-color-palette, $key);
         @if type-of($-value) == 'number' {
             @include print-variable($key, $-value);
@@ -219,6 +219,43 @@ body {
 #wrapwrap {
     @if o-website-value('body-image') {
         @include body-image-bg-style();
+    }
+
+    > main:not(.o_breadcrumb_overlay) {
+        div.o_page_breadcrumb {
+            nav {
+                @include o-apply-colors('breadcrumb');
+                @include o-apply-colors('breadcrumb-custom');
+                @include o-add-gradient('breadcrumb-gradient');
+            }
+            a, .breadcrumb-item, li::before {
+                color: inherit !important;
+            }
+        }
+    }
+
+    &.o_header_overlay div.o_page_breadcrumb {
+        @include o-position-absolute(auto, auto, auto, auto);
+        z-index: 1 !important;
+        width: 100%;
+    }
+
+    > main.o_breadcrumb_overlay {
+        div.o_page_breadcrumb {
+            @include o-position-absolute(auto, auto, auto, auto);
+            z-index: 1 !important;
+            width: 100%;
+            a, .breadcrumb-item, li::before {
+                color: inherit !important;
+            }
+            nav {
+                @include o-apply-colors(1);
+                background-color: transparent !important;
+                background-image: none !important;
+                border-color: transparent;
+                color: inherit;
+            }
+        }
     }
 
     @if o-website-value('layout') != 'full' {

--- a/addons/website/static/tests/builder/options/breadcrumb_visibility_option.test.js
+++ b/addons/website/static/tests/builder/options/breadcrumb_visibility_option.test.js
@@ -1,0 +1,109 @@
+import { redo, undo } from "@html_editor/../tests/_helpers/user_actions";
+import { expect, test } from "@odoo/hoot";
+import { queryOne, waitFor } from "@odoo/hoot-dom";
+import { contains } from "@web/../tests/web_test_helpers";
+import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+
+defineWebsiteModels();
+
+function insertBreadcrumb(iframe, { content = "Breadcrumb Content" } = {}) {
+    const wrapwrap = iframe.contentDocument.querySelector("#wrapwrap");
+    const wrap = wrapwrap.querySelector("#wrap");
+    const main = iframe.contentDocument.createElement("main");
+    const breadcrumb = iframe.contentDocument.createElement("div");
+    breadcrumb.className = "o_page_breadcrumb";
+    breadcrumb.setAttribute("data-name", "Breadcrumb");
+    breadcrumb.textContent = content;
+    wrap.parentNode.insertBefore(main, wrap);
+    main.appendChild(breadcrumb);
+    return breadcrumb;
+}
+
+test("BreadcrumbVisibility option should appear without overTheContent", async () => {
+    await setupWebsiteBuilder("", {
+        beforeWrapwrapContent: `<input type="hidden" class="o_page_option_data" name="breadcrumb_visible">`,
+        onIframeLoaded: (iframe) => insertBreadcrumb(iframe),
+    });
+    await contains(":iframe .o_page_breadcrumb").click();
+    await waitFor("[data-label='Breadcrumb Position']");
+    expect("[data-label='Breadcrumb Position']").toBeVisible();
+    await contains("[data-label='Breadcrumb Position'] .dropdown").click();
+    expect(".o-overlay-container [data-action-value='overTheContent']").not.toHaveCount();
+});
+
+test("BreadcrumbVisibility option should appear with overTheContent", async () => {
+    await setupWebsiteBuilder("", {
+        beforeWrapwrapContent: `
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="breadcrumb_visible">
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="breadcrumb_overlay">`,
+        onIframeLoaded: (iframe) => insertBreadcrumb(iframe),
+    });
+    await contains(":iframe .o_page_breadcrumb").click();
+    await waitFor("[data-label='Breadcrumb Position']");
+    expect("[data-label='Breadcrumb Position']").toBeVisible();
+    await contains("[data-label='Breadcrumb Position'] .dropdown").click();
+    expect(".o-overlay-container [data-action-value='overTheContent']").toBeVisible();
+});
+
+test("undo/redo Breadcrumb visibility options", async () => {
+    const { getEditor } = await setupWebsiteBuilder("", {
+        beforeWrapwrapContent: `
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="breadcrumb_visible">
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="breadcrumb_overlay">`,
+        onIframeLoaded: (iframe) => insertBreadcrumb(iframe),
+    });
+    const editor = getEditor();
+    await contains(":iframe .o_page_breadcrumb").click();
+    const precedentBreadcrumb = queryOne(":iframe .o_page_breadcrumb").outerHTML;
+    await contains("[data-label='Breadcrumb Position'] .dropdown").click();
+    await contains(".o-overlay-container [data-action-value='overTheContent']").click();
+    undo(editor);
+    redo(editor);
+    undo(editor);
+    const modifiedBreadcrumb = queryOne(":iframe .o_page_breadcrumb");
+    expect(modifiedBreadcrumb).toHaveOuterHTML(precedentBreadcrumb);
+    await contains("[data-label='Breadcrumb Position'] .dropdown").click();
+    await contains(".o-overlay-container [data-action-value='hidden']").click();
+    undo(editor);
+    redo(editor);
+    undo(editor);
+    const newModifiedBreadcrumb = queryOne(":iframe .o_page_breadcrumb");
+    expect(newModifiedBreadcrumb).toHaveOuterHTML(precedentBreadcrumb);
+    // test the invisible elements panel
+    await contains(":iframe .o_page_breadcrumb").click();
+    await contains("[data-label='Breadcrumb Position'] .dropdown").click();
+    await contains(".o-overlay-container [data-action-value='hidden']").click();
+    expect(modifiedBreadcrumb).toHaveClass("d-none");
+    await contains(".o_we_invisible_el_panel div:contains('Breadcrumb')").click();
+    expect(modifiedBreadcrumb).not.toHaveClass("d-none");
+});
+
+test("Breadcrumb over the content displays background and text color options", async () => {
+    const { getEditor } = await setupWebsiteBuilder("", {
+        beforeWrapwrapContent: `
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="breadcrumb_visible">
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="breadcrumb_overlay">
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="breadcrumb_color">
+            <input type="hidden" class="o_page_option_data" autocomplete="off" name="breadcrumb_text_color">`,
+        onIframeLoaded: (iframe) => insertBreadcrumb(iframe),
+    });
+    const editor = getEditor();
+    await contains(":iframe .o_page_breadcrumb").click();
+    await waitFor("[data-label='Breadcrumb Position']");
+    await contains("[data-label='Breadcrumb Position'] .dropdown").click();
+    await contains(".o-overlay-container [data-action-value='overTheContent']").click();
+    await waitFor("[data-label='Background']");
+    await waitFor("[data-label='Text Color']");
+    expect("[data-label='Background']").toBeVisible();
+    expect("[data-label='Text Color']").toBeVisible();
+    await contains("[data-label='Background'].hb-row-sublevel-1 .o_we_color_preview").click();
+    await contains("[data-color='600']").click();
+    const precedentBreadcrumb = queryOne(":iframe .o_page_breadcrumb").outerHTML;
+    await contains("[data-label='Breadcrumb Position'] .dropdown").click();
+    await contains(".o-overlay-container [data-action-value='regular']").click();
+    undo(editor);
+    redo(editor);
+    undo(editor);
+    const modifiedBreadcrumb = queryOne(":iframe .o_page_breadcrumb");
+    expect(modifiedBreadcrumb).toHaveOuterHTML(precedentBreadcrumb);
+});

--- a/addons/website/static/tests/interactions/header/breadcrumb_position.test.js
+++ b/addons/website/static/tests/interactions/header/breadcrumb_position.test.js
@@ -1,0 +1,35 @@
+import { animationFrame, expect, test } from "@odoo/hoot";
+import { queryOne, waitFor } from "@odoo/hoot-dom";
+import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
+import { switchToEditMode } from "../../helpers";
+
+setupInteractionWhiteList("website.page_breadcrumb");
+
+test("Breadcrumb adjusts its position on header resize", async () => {
+    const { core } = await startInteractions(
+        `<div id="wrapwrap" contenteditable="false" class="odoo-editor-editable">
+            <header id="top" data-anchor="true" data-name="Header" class="o_header_standard o_top_fixed_element">
+                    Header Content
+            </header>
+            <main class="o_breadcrumb_overlay">
+                <div class="o_page_breadcrumb" data-name="Breadcrumb">
+                    Breadcrumb Content
+                </div>
+            </main>
+        </div>`
+    );
+    await switchToEditMode(core);
+    await animationFrame();
+    await waitFor("div#wrapwrap > header");
+    await waitFor("div.o_page_breadcrumb");
+    const header = queryOne("header#top");
+    const breadcrumb = queryOne(".o_page_breadcrumb");
+    await animationFrame();
+    expect(breadcrumb.getBoundingClientRect().top).toBe(header.getBoundingClientRect().height);
+    header.style.height = "50px";
+    await animationFrame();
+    expect(breadcrumb.style.top).toBe("50px");
+    header.classList.add("d-none");
+    await animationFrame();
+    expect(breadcrumb.style.top).toBe("0px");
+});

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -110,3 +110,176 @@ registerWebsitePreviewTour(
         },
     ]
 );
+
+const breadcrumb = { id: "o_page_breadcrumb", name: "Breadcrumb" };
+let selectedGradient = null;
+
+function openColorPicker(type) {
+    return [
+        {
+            content: "Open the color picker for breadcrumb",
+            trigger: `div[data-label='${type}'] .o_we_color_preview`,
+            run: "click",
+        },
+    ];
+}
+
+function openBackgroundColorPicker(type, selector) {
+    return [
+        ...openColorPicker(type),
+        {
+            content: `Open ${selector} tab`,
+            trigger: `.o_font_color_selector button:contains(${selector})`,
+            run: "click",
+        },
+    ];
+}
+
+registerWebsitePreviewTour(
+    "website_page_breadcrumb",
+    {
+        url: "/contactus",
+        edition: false,
+    },
+    () => [
+        {
+            content: "Open the Site Menu",
+            trigger: "button[data-menu-xmlid='website.menu_site']",
+            run: "click",
+        },
+        {
+            content: "Select the Properties option from the menu",
+            trigger: "a[data-menu-xmlid='website.menu_page_properties']",
+            run: "click",
+        },
+        {
+            content: "Enable the Parent Page Option",
+            trigger: "div[name='has_parent_page'] input",
+            run: "click",
+        },
+        {
+            content: "Save the changes",
+            trigger: "button.o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Verify that the Breadcrumb is visible",
+            trigger: ":iframe div[data-name='Breadcrumb']",
+        },
+        {
+            content: "Verify that Home is displayed in the breadcrumb",
+            trigger:
+                ":iframe nav[aria-label='breadcrumb'] ol.breadcrumb li:first-child a:contains(Home)",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        ...openBackgroundColorPicker("Background Color", "Theme"),
+        {
+            content: "Apply Preset-4 background color to the breadcrumb",
+            trigger: ".o_cc_preview_wrapper button[data-color='o_cc4']",
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Verify that the breadcrumb background color matches Preset 4",
+            trigger: ":iframe nav[aria-label='breadcrumb']",
+            run() {
+                const occBg = getComputedStyle(document.documentElement)
+                    .getPropertyValue("--o-cc4-bg")
+                    .trim();
+                const breadcrumbBgPreset = getComputedStyle(this.anchor)
+                    .getPropertyValue("--o-cc-bg")
+                    .trim();
+                if (occBg != breadcrumbBgPreset) {
+                    console.error(
+                        `Expected Preset 4 background but received "${breadcrumbBgPreset}"`
+                    );
+                }
+            },
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        ...openBackgroundColorPicker("Background Color", "Custom"),
+        {
+            content: "Set the breadcrumb background color to black-600",
+            trigger: ".popover button[data-color='600']",
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Verify that the breadcrumb background color is black-600",
+            trigger: ":iframe .o_page_breadcrumb nav",
+            run() {
+                const bgColor = getComputedStyle(this.anchor).backgroundColor;
+                if (bgColor !== "rgb(108, 117, 125)") {
+                    console.error(
+                        `Expected breadcrumb background rgb(108,117,125) but received ${bgColor}`
+                    );
+                }
+            },
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        ...openBackgroundColorPicker("Background Color", "Gradient"),
+        {
+            content: "Apply the first gradient option to the breadcrumb background",
+            trigger: ".o_colorpicker_sections button.o_gradient_color_button",
+            run() {
+                selectedGradient = this.anchor.dataset.color;
+                this.anchor.click();
+            },
+        },
+        {
+            content: "Verify that the breadcrumb background gradient is applied correctly",
+            trigger: ":iframe nav[aria-label='breadcrumb']",
+            run() {
+                const breadcrumbBgGradient = getComputedStyle(this.anchor).backgroundImage.trim();
+                if (breadcrumbBgGradient !== selectedGradient) {
+                    console.error(
+                        `Expected breadcrumb background gradient "${selectedGradient}" but received "${breadcrumbBgGradient}"`
+                    );
+                }
+            },
+        },
+        ...changeOptionInPopover("Breadcrumb", "Breadcrumb Position", "Over the content"),
+        ...clickOnSave(),
+        {
+            content: "Verify that the breadcrumb is positioned over the content",
+            trigger: ":iframe main.o_breadcrumb_overlay",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        ...openColorPicker("Background"),
+        {
+            content: "Set the breadcrumb background color to black-600",
+            trigger: ".popover button[data-color='600']",
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Verify that the breadcrumb background color is black-600",
+            trigger: ":iframe .o_page_breadcrumb.bg-600",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        ...openColorPicker("Text Color"),
+        {
+            content: "Set the breadcrumb text color to red",
+            trigger: ".popover button[data-color='#FF0000']",
+            run: "click",
+        },
+        ...clickOnSave(),
+        {
+            content: "Verify that the breadcrumb text color is red",
+            trigger: ':iframe .o_page_breadcrumb[style*="color: rgb(255, 0, 0)"]',
+        },
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnSnippet(breadcrumb),
+        ...changeOptionInPopover("Breadcrumb", "Breadcrumb Position", "Hidden"),
+        ...clickOnSave(),
+        {
+            content: "Verify that the breadcrumb is hidden",
+            trigger: ":iframe main:has(div.o_page_breadcrumb.d-none.o_snippet_invisible)",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -512,6 +512,9 @@ class TestUi(HttpCaseWithWebsiteUser):
         })
         self.start_tour("/odoo/action-website.action_website_menu", "parent_child_menu", login="admin")
 
+    def test_34_website_page_breadcrumb(self):
+        self.start_tour('/contactus', 'website_page_breadcrumb', login='admin')
+
     def test_website_media_dialog_image_shape(self):
         self.start_tour("/", 'website_media_dialog_image_shape', login='admin')
 

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -47,8 +47,8 @@
                     <field name="is_in_menu" widget="boolean_toggle" options="{'autosave': False}"/>
                     <button type="action" name="%(website.open_custom_menu)d" context="{'xmlid': 'website.menu_edit_menu'}" string="Edit Menu" class="btn-link" icon="oi-arrow-right"/>
                 </div>
-
-                <field name="is_homepage" string="Is Homepage" widget="boolean_toggle" options="{'autosave': False}"/>
+                <!-- is_homepage toggle auto-save is enabled to update the current homepage for assigning parent_id -->
+                <field name="is_homepage" string="Is Homepage" widget="boolean_toggle"/>
                 <field invisible="not can_publish" string="Published" name="is_published" widget="boolean_toggle" readonly="publish_on" options="{'autosave': False}"/>
                 <label invisible="not can_publish or is_published" for="publish_on" string="Publish on"/>
                 <div invisible="not can_publish or is_published" class="o_row">
@@ -85,6 +85,14 @@
                 </div>
             </div>
         </xpath>
+        <field name="is_homepage" position="after">
+            <label for="has_parent_page" invisible="is_homepage"/>
+            <div class="d-flex" invisible="is_homepage">
+                <field name="has_parent_page" class="w-25" widget="boolean_toggle" options="{'autosave': False}"/>
+                <label for="parent_id" string="/" invisible="not has_parent_page"/>
+                <field name="parent_id" widget="many2one" invisible="not has_parent_page" required="has_parent_page and not is_homepage"/>
+            </div>
+        </field>
         <xpath expr="//group/*[last()]" position="after"> <!-- Bottom -->
             <label for="website_indexed" string="Indexed"/>
             <div class="o_row">
@@ -114,6 +122,7 @@
             <field name="is_in_menu" string="Is In Main Menu"/>
             <field name="is_seo_optimized"/>
             <field name="website_published" invisible="publish_on and website_published"/>
+            <field name="parent_id" widget="many2one" optional="show"/>
             <field name="publish_on" string="Scheduled" invisible="not publish_on"/>
 
             <field name="create_uid" widget="many2one_avatar" optional="hide"/>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -274,11 +274,54 @@
         </t>
     </xpath>
 
+    <!-- Breadcrumb -->
+    <xpath expr="//main/*[1]" position="before">
+        <t t-if="main_object.sudo()._name == 'website.page' and main_object.sudo()['parent_id']">
+            <div data-name="Breadcrumb"
+                t-attf-class="o_page_breadcrumb #{breadcrumb_bg_color_class} #{breadcrumb_text_color_class} #{'d-none o_snippet_invisible' if 'breadcrumb_visible' in main_object and not main_object.sudo().breadcrumb_visible else ''}"
+                t-attf-style="#{breadcrumb_bg_color_style and ('background-color: %s;' % breadcrumb_bg_color_style)} #{breadcrumb_text_color_style and ('color: %s;' % breadcrumb_text_color_style)}"
+                t-att-data-invisible="'1' if 'breadcrumb_visible' in main_object and not main_object.sudo().breadcrumb_visible else None"
+            >
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb container p-2 mb-0">
+                        <t t-set="ancestors" t-value="main_object.sudo().parent_ids"/>
+                        <!-- Grand Parent -->
+                        <li class="breadcrumb-item">
+                            <a t-att-href="ancestors[0].url" t-out="ancestors[0].name"/>
+                        </li>
+                        <t t-if="len(ancestors) &lt;= 2">
+                            <li t-foreach="ancestors[1:]" t-as="ancestor" class="breadcrumb-item">
+                                <a t-att-href="ancestor.url" t-out="ancestor.name"/>
+                            </li>
+                        </t>
+                        <t t-else="">
+                            <!-- Dropdown -->
+                            <li class="breadcrumb-item dropdown">
+                                <a role="button" data-bs-toggle="dropdown">...</a>
+                                <div role="menu" class="dropdown-menu">
+                                    <a t-foreach="ancestors[1:len(ancestors)-1]" t-as="ancestor" class="dropdown-item" t-att-href="ancestor.url" t-out="ancestor.name"/>
+                                </div>
+                            </li>
+                            <!-- Direct Parent -->
+                            <li class="breadcrumb-item">
+                                <a t-att-href="ancestors[len(ancestors)-1].url" t-out="ancestors[len(ancestors)-1].name"/>
+                            </li>
+                        </t>
+                        <!-- Current Page -->
+                        <li class="breadcrumb-item active" aria-current="page">
+                            <t t-out="main_object.sudo().name"/>
+                        </li>
+                    </ol>
+                </nav>
+            </div>
+        </t>
+    </xpath>
+
     <!-- Page options -->
     <xpath expr="//div[@id='wrapwrap']" position="before">
         <!-- Todo: Refactor this part. These inputs were initially used for multiple use cases but are now only used to determine if a given option is activated on the page. We should probably implement the feature using an RPC. -->
         <t groups="website.group_website_restricted_editor">
-            <t t-foreach="['header_overlay', 'header_color', 'header_text_color', 'header_visible', 'footer_visible']" t-as="optionName">
+            <t t-foreach="['header_overlay', 'header_color', 'header_text_color', 'header_visible', 'footer_visible', 'breadcrumb_overlay', 'breadcrumb_color', 'breadcrumb_text_color', 'breadcrumb_visible']" t-as="optionName">
                 <!-- Firefox autocomplete is too aggressive and works on hidden inputs,
                 so we need to disable it (https://bugzilla.mozilla.org/show_bug.cgi?id=520561) -->
                 <input t-if="optionName in main_object" type="hidden" class="o_page_option_data" autocomplete="off" t-att-name="optionName" t-att-value="main_object.sudo()[optionName]"/>
@@ -294,6 +337,16 @@
         <t t-set="header_text_color_is_class" t-value="'text-' in header_text_color"/>
         <t t-set="header_text_color_class" t-value="header_text_color_is_class and header_text_color or ''"/>
         <t t-set="header_text_color_style" t-value="(not header_text_color_is_class) and header_text_color or ''"/>
+
+        <t t-set="breadcrumb_bg_color" t-value="'breadcrumb_color' in main_object and main_object.sudo().breadcrumb_color or ''"/>
+        <t t-set="breadcrumb_bg_color_is_class" t-value="'bg-' in breadcrumb_bg_color"/>
+        <t t-set="breadcrumb_bg_color_class" t-value="breadcrumb_bg_color_is_class and breadcrumb_bg_color or ''"/>
+        <t t-set="breadcrumb_bg_color_style" t-value="(not breadcrumb_bg_color_is_class) and breadcrumb_bg_color or ''"/>
+
+        <t t-set="breadcrumb_text_color" t-value="'breadcrumb_text_color' in main_object and main_object.sudo().breadcrumb_text_color or ''"/>
+        <t t-set="breadcrumb_text_color_is_class" t-value="'text-' in breadcrumb_text_color"/>
+        <t t-set="breadcrumb_text_color_class" t-value="breadcrumb_text_color_is_class and breadcrumb_text_color or ''"/>
+        <t t-set="breadcrumb_text_color_style" t-value="(not breadcrumb_text_color_is_class) and breadcrumb_text_color or ''"/>
 
         <div groups="base.group_user" class="o_frontend_to_backend_nav position-fixed d-none">
             <svg class="o_frontend_to_backend_icon position-absolute" width="24px" height="24px"
@@ -329,6 +382,9 @@
     <xpath expr="//footer[@id='bottom']" position="attributes">
         <attribute name="t-attf-class" add="#{'d-none o_snippet_invisible' if 'footer_visible' in main_object and not main_object.sudo().footer_visible else ''}" separator=" "/>
         <attribute name="t-att-data-invisible">'1' if 'footer_visible' in main_object and not main_object.sudo().footer_visible else None</attribute>
+    </xpath>
+    <xpath expr="//main" position="attributes">
+        <attribute name="t-attf-class" add="#{'o_breadcrumb_overlay' if 'breadcrumb_overlay' in main_object and main_object.sudo().breadcrumb_overlay else ''}" />
     </xpath>
 </template>
 


### PR DESCRIPTION
This PR introduces breadcrumb support on website pages and generalizes existing page options (previously only used for the header) so they can also be applied to breadcrumbs.

Key Changes:
- Allow adding breadcrumbs by setting a parent page under `Site -> Properties`.
- Prevent circular breadcrumb references by restricting the parent selection domain (a page cannot be set its own parent, nor can it select its descendant as parent).
- Prevent assigning parent pages to the Homepage (Homepage cannot have breadcrumbs).
- Supports multi-level hierarchies but only show the last two parents plus the current page for simplicity (Grandparent / Parent / Child).
- Breadcrumb options behave like header options:
  - Changes are applied globally across pages.
  - Like the header, a background color can be set for breadcrumbs,
    and they share the same visibility options (Regular,
    Over the content, or Hidden) for consistency.

task-[3791063](https://www.odoo.com/odoo/project/974/tasks/3791063)