### PR TITLE
Master mail imp pinning messages in chatter akus

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -983,7 +983,7 @@ class DiscussChannel(models.Model):
     #   - when a message is posted on a channel (to the channel, using _notify() method)
     # ------------------------------------------------------------
 
-    def set_message_pin(self, message_id, pinned):
+    def set_message_pin(self, message_id, pinned, model):
         """ (Un)pin a message on the channel and send a notification to the
         members.
         :param message_id: id of the message to be pinned.
@@ -992,7 +992,7 @@ class DiscussChannel(models.Model):
         self.ensure_one()
         message_to_update = self.env['mail.message'].search([
             ['id', '=', message_id],
-            ['model', '=', 'discuss.channel'],
+            ['model', '=', model],
             ['res_id', '=', self.id],
             ['pinned_at', '=' if pinned else '!=', False]
         ])

--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -32,6 +32,14 @@
                         <i class="oi oi-search" role="img"/>
                     </button>
                 </t>
+                <button t-if="hasPinnedMessages"
+                        class="btn btn-link text-action"
+                        aria-label="Pinned Messages"
+                        title="Pinned Messages"
+                        t-attf-class="o_Chatter_button {{ state.pinnedMessagesActive ? 'o-active' : '' }}"
+                        t-on-click="onClickPinnedMessages">
+                    <i class="fa fa-thumb-tack" role="img"/>
+                </button>
                 <button t-if="props.hasAttachmentPreview and state.thread.attachmentsInWebClientView.length" class="btn btn-link text-action" t-on-click="popoutAttachment">
                     <i class="fa fa-window-restore" aria-hidden="Pop out Attachments" title="Pop out Attachments"/>
                 </button>
@@ -63,6 +71,9 @@
                 </t>
                 <Composer composer="state.thread.composer" autofocus="true" className="state.composerType === 'message' ? '' : 'pt-4'" mode="'extended'" onPostCallback.bind="onPostCallback" onCloseFullComposerCallback.bind="onCloseFullComposerCallback" dropzoneRef="rootRef" type="state.composerType" t-key="props.threadId"/>
             </t>
+        </div>
+        <div t-if="state.pinnedMessagesActive and hasPinnedMessages" class="o-discuss-PinnedMessagesPanel bg-inherit">
+            <PinnedMessagesPanel thread="state.thread"/>
         </div>
         <div class="o-mail-Chatter-content d-flex flex-column flex-grow-1 bg-inherit">
             <t>

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -13,6 +13,7 @@ import { SearchMessageInput } from "@mail/core/common/search_message_input";
 import { SearchMessageResult } from "@mail/core/common/search_message_result";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { status, useEffect } from "@odoo/owl";
+import { PinnedMessagesPanel } from "@mail/discuss/message_pin/common/pinned_messages_panel";
 
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
@@ -34,6 +35,7 @@ Object.assign(Chatter.components, {
     Dropdown,
     FileUploader,
     FollowerList,
+    PinnedMessagesPanel,
     RecipientsInput,
     ScheduledMessage,
     SearchMessageInput,
@@ -79,6 +81,7 @@ patch(Chatter.prototype, {
     setup() {
         this.messageHighlight = useMessageScrolling();
         super.setup(...arguments);
+        this.state.pinnedMessagesActive = false;
         this.orm = useService("orm");
         this.keepLastSuggestedRecipientsUpdate = new KeepLast();
         /** @deprecated equivalent to partner_fields and primary_email_field on thread */
@@ -167,7 +170,15 @@ patch(Chatter.prototype, {
             () => [this.props.isChatterAside]
         );
     },
-
+    onClickPinnedMessages() {
+        this.state.pinnedMessagesActive = !this.state.pinnedMessagesActive;
+    },
+    get hasPinnedMessages() {
+        if (!this.state.thread?.pinnedMessages?.length) {
+            this.state.pinnedMessagesActive = false
+        }
+        return this.state.thread?.pinnedMessages?.length > 0;
+    },
     async updateRecipients(record, mode = this.state.composerType) {
         if (!record) {
             return;

--- a/addons/mail/static/src/discuss/message_pin/common/message_actions.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_actions.js
@@ -3,7 +3,7 @@ import { registerMessageAction } from "@mail/core/common/message_actions";
 
 registerMessageAction("pin", {
     condition: (component) =>
-        component.store.self_partner && component.props.thread?.model === "discuss.channel",
+        component.store.self_partner && component.props.thread,
     icon: "fa fa-thumb-tack",
     iconLarge: "fa fa-lg fa-thumb-tack",
     name: (component) => (component.props.message.pinned_at ? _t("Unpin") : _t("Pin")),

--- a/addons/mail/static/src/discuss/message_pin/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_model_patch.js
@@ -35,7 +35,7 @@ patch(Message.prototype, {
                         "discuss.channel",
                         "set_message_pin",
                         [this.thread.id],
-                        { message_id: this.id, pinned: true }
+                        { message_id: this.id, pinned: true, model: this.model}
                     );
                 },
             },
@@ -63,7 +63,7 @@ patch(Message.prototype, {
                         "discuss.channel",
                         "set_message_pin",
                         [this.thread.id],
-                        { message_id: this.id, pinned: false }
+                        { message_id: this.id, pinned: false, model: this.model }
                     );
                 },
             },

--- a/addons/mail/static/src/discuss/message_pin/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/message_pin/common/thread_actions.js
@@ -9,7 +9,6 @@ registerThreadAction("pinned-messages", {
     actionPanelComponent: PinnedMessagesPanel,
     condition(component) {
         return (
-            component.thread?.model === "discuss.channel" &&
             (!component.props.chatWindow || component.props.chatWindow.isOpen)
         );
     },


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
Important messages in the Chatter are often hard to locate since users need 
to scroll through a long history. While Discuss already supports pinning 
messages for quick access, the Chatter did not provide this functionality.

**Current behavior before PR:**
----------------------------------------------
- Users cannot pin/unpin messages in the Chatter.
- No quick way to view important messages.
- Pin icon not visible in Chatter.

**Desired behavior after PR is merged:**
----------------------------------------------
- Users can pin/unpin messages in the Chatter, similar to Discuss.
- A pinned messages panel is available for quick access.
- The pin icon in Chatter only appears when pinned messages exist.

Task-4686372

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at https://www.odoo.com/submit-pr
