### PR TITLE
[FIX] website: show animate text tool as active when text is highlighted

### DIFF
--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -304,8 +304,7 @@ export class AnimateOptionPlugin extends Plugin {
         const ancestor = closestElement(selection.commonAncestorContainer, ".o_animated_text");
         if (
             ancestor &&
-            (selection.isCollapsed ||
-                this.dependencies.selection.areNodeContentsFullySelected(ancestor))
+            (selection.isCollapsed || selection.textContent() === ancestor.textContent)
         ) {
             return ancestor;
         }

--- a/addons/website/static/tests/builder/website_builder/animate_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/animate_option.test.js
@@ -1,6 +1,6 @@
 import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
 import { describe, expect, test } from "@odoo/hoot";
-import { queryFirst, waitFor } from "@odoo/hoot-dom";
+import { queryFirst, queryOne, waitFor } from "@odoo/hoot-dom";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
@@ -540,5 +540,15 @@ describe("animate text in toolbar", () => {
         expect(":iframe span:eq(0)").toHaveText("b");
         expect(":iframe span:eq(1)").toHaveText("i");
         expect(":iframe .test").toHaveText("abcdefghij");
+    });
+
+    test("tool is active when text in span is selected even if there are unselected empty node at the end", async () => {
+        await setupWebsiteBuilder(
+            `<p class="test">a<span class="o_animated_text">bc<svg/></span>d</p>`
+        );
+        const span = queryOne(":iframe span");
+        setSelection({ anchorNode: span, anchorOffset: 0, focusNode: span, focusOffset: 1 });
+        await expandToolbar();
+        expect("button[title='Animate Text']").toHaveClass("active");
     });
 });


### PR DESCRIPTION
The commit e80a2a20d4ba49b51f31f8ed06a5a0d3d1fa2e6d added the text animation in the toolbar as part of the website builder refactor

The tool in the toolbar was shown as active when the animated node was fully selected (or selection collapsed). But if the text inside is highlighted, extra nodes with no text are added with the highlight's svg, and these are not selected.

With this commit, the comparison checks if the text content of the selection is the same as the text content of the animated span, thus empty dom nodes are ignored.

Steps to reproduce:
- Open website builder
- Select some text (for example in the footer)
- Add an animation
- Add an highlight
- Select the same text again
- Bug: the animate text tool is not shown as active

task-4367641
