### PR TITLE
[IMP] mail: add partitioned actions in standard action

### DIFF
--- a/addons/crm_livechat/static/src/core/thread_action_patch.js
+++ b/addons/crm_livechat/static/src/core/thread_action_patch.js
@@ -7,7 +7,8 @@ patch(threadActionsInternal, {
         if (
             id === "create-lead" &&
             component.thread?.channel_type === "livechat" &&
-            component.store.has_access_create_lead
+            component.store.has_access_create_lead &&
+            !component.isDiscussSidebarChannelActions
         ) {
             return true;
         }

--- a/addons/crm_livechat/static/src/core/thread_actions.js
+++ b/addons/crm_livechat/static/src/core/thread_actions.js
@@ -16,7 +16,7 @@ registerThreadAction("create-lead", {
         icon: "fa fa-handshake-o",
     }),
     close: (component, action) => action.popover?.close(),
-    condition: (component) => false,
+    condition: (component) => false, // managed by threadActionsInternal patch
     panelOuterClass: "bg-100",
     icon: "fa fa-handshake-o",
     iconLarge: "fa-lg fa fa-handshake-o",

--- a/addons/hr/static/src/core/web/thread_actions.js
+++ b/addons/hr/static/src/core/web/thread_actions.js
@@ -7,7 +7,8 @@ registerThreadAction("open-hr-profile", {
         return (
             component.thread?.channel_type === "chat" &&
             component.props.chatWindow?.isOpen &&
-            component.thread.correspondent?.partner_id?.employeeId
+            component.thread.correspondent?.partner_id?.employeeId &&
+            !component.isDiscussSidebarChannelActions
         );
     },
     icon: "fa fa-fw fa-id-card",

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -6,7 +6,10 @@ import { LivechatChannelInfoList } from "@im_livechat/core/web/livechat_channel_
 registerThreadAction("livechat-info", {
     actionPanelComponent: LivechatChannelInfoList,
     condition(component) {
-        return component.thread?.channel_type === "livechat";
+        return (
+            component.thread?.channel_type === "livechat" &&
+            !component.isDiscussSidebarChannelActions
+        );
     },
     panelOuterClass: "o-livechat-ChannelInfoList bg-inherit",
     icon: "fa fa-fw fa-info",
@@ -19,7 +22,11 @@ registerThreadAction("livechat-info", {
 registerThreadAction("livechat-status", {
     actionPanelComponent: LivechatChannelInfoList,
     condition(component) {
-        return component.thread?.channel_type === "livechat" && !component.thread.livechat_end_dt;
+        return (
+            component.thread?.channel_type === "livechat" &&
+            !component.thread.livechat_end_dt &&
+            !component.isDiscussContent
+        );
     },
     dropdown: {
         template: "im_livechat.LivechatStatusAction",
@@ -52,16 +59,15 @@ registerThreadAction("livechat-status", {
     },
     name: (component) => component.thread.livechatStatusLabel,
     nameClass: "fst-italic small mx-2",
-    partition: (component) => !component.env.inDiscussApp,
-    sequence: 5,
-    sequenceGroup: 7,
-    sidebar: true,
-    sidebarSequence: 10,
-    sidebarSequenceGroup: 5,
+    sequence: (component) => (component.isDiscussSidebarChannelActions ? 10 : 5),
+    sequenceGroup: (component) => (component.isDiscussSidebarChannelActions ? 5 : 7),
     toggle: true,
 });
 registerThreadAction("join-livechat-needing-help", {
-    condition: (comp) => comp.thread?.livechat_status === "need_help" && !comp.thread?.selfMember,
+    condition: (comp) =>
+        comp.thread?.livechat_status === "need_help" &&
+        !comp.thread?.selfMember &&
+        !comp.isDiscussSidebarChannelActions,
     icon: "fa fa-fw fa-sign-in",
     iconLarge: "fa fa-fw fa-lg fa-sign-in",
     name: _t("Join Chat"),

--- a/addons/im_livechat/static/src/embed/common/thread_actions.js
+++ b/addons/im_livechat/static/src/embed/common/thread_actions.js
@@ -6,7 +6,7 @@ import { patch } from "@web/core/utils/patch";
 
 registerThreadAction("restart", {
     condition(component) {
-        return component.thread?.chatbot?.canRestart;
+        return component.thread?.chatbot?.canRestart && !component.isDiscussSidebarChannelActions;
     },
     icon: "fa fa-fw fa-refresh",
     iconLarge: "fa fa-lg fa-fw fa-refresh",

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -9,7 +9,7 @@ import { Deferred } from "@web/core/utils/concurrency";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
 import { isMobileOS } from "@web/core/browser/feature_detection";
-import { Action } from "./action";
+import { Action, UseActions } from "./action";
 
 const { DateTime } = luxon;
 
@@ -233,6 +233,10 @@ export const messageActionsInternal = {
     },
 };
 
+class UseMessageActions extends UseActions {
+    ActionClass = MessageAction;
+}
+
 export function useMessageActions() {
     const component = useComponent();
     const transformedActions = messageActionsRegistry
@@ -241,17 +245,6 @@ export function useMessageActions() {
     for (const action of transformedActions) {
         action.setup();
     }
-    const state = useState({
-        get actions() {
-            const actions = transformedActions
-                .filter((action) => action.condition)
-                .sort((a1, a2) => a1.sequence - a2.sequence);
-            if (actions.length > 0) {
-                actions.at(0).isFirst = true;
-                actions.at(-1).isLast = true;
-            }
-            return actions;
-        },
-    });
+    const state = useState(new UseMessageActions(component, transformedActions));
     return state;
 }

--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -34,6 +34,7 @@ export class DiscussContent extends Component {
         this.threadActions = useThreadActions();
         this.root = useRef("root");
         this.state = useState({ jumpThreadPresent: 0 });
+        this.isDiscussContent = true;
         useEffect(
             () => this.actionPanelAutoOpenFn(),
             () => [this.thread]

--- a/addons/mail/static/src/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/core/public_web/thread_actions.js
@@ -3,7 +3,8 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
 registerThreadAction("leave", {
-    condition: (component) => component.thread?.canLeave || component.thread?.canUnpin,
+    condition: (component) =>
+        (component.thread?.canLeave || component.thread?.canUnpin) && !component.isDiscussContent,
     danger: true,
     icon: "fa fa-fw fa-sign-out",
     iconLarge: "fa fa-fw fa-lg fa-sign-out",
@@ -17,6 +18,4 @@ registerThreadAction("leave", {
     setup(component) {
         component.ui = useService("ui");
     },
-    sidebarSequence: 10,
-    sidebarSequenceGroup: 40,
 });

--- a/addons/mail/static/src/core/web/thread_actions.js
+++ b/addons/mail/static/src/core/web/thread_actions.js
@@ -5,7 +5,7 @@ import { useService } from "@web/core/utils/hooks";
 
 registerThreadAction("mark-all-read", {
     condition(component) {
-        return component.thread?.id === "inbox";
+        return component.thread?.id === "inbox" && !component.isDiscussSidebarChannelActions;
     },
     disabledCondition(component) {
         return component.thread.isEmpty;
@@ -21,7 +21,7 @@ registerThreadAction("mark-all-read", {
 });
 registerThreadAction("unstar-all", {
     condition(component) {
-        return component.thread?.id === "starred";
+        return component.thread?.id === "starred" && !component.isDiscussSidebarChannelActions;
     },
     disabledCondition(component) {
         return component.thread.isEmpty;

--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -24,8 +24,6 @@ registerThreadAction("call", {
     setup(component) {
         component.rtc = useService("discuss.rtc");
     },
-    sidebarSequence: 10,
-    sidebarSequenceGroup: 10,
     success: true,
 });
 registerThreadAction("camera-call", {
@@ -48,8 +46,6 @@ registerThreadAction("camera-call", {
     setup(component) {
         component.rtc = useService("discuss.rtc");
     },
-    sidebarSequence: 20,
-    sidebarSequenceGroup: 10,
     success: true,
 });
 registerThreadAction("call-settings", {
@@ -60,7 +56,8 @@ registerThreadAction("call-settings", {
     condition(component) {
         return (
             component.thread?.allowCalls &&
-            (component.props.chatWindow?.isOpen || component.store.inPublicPage)
+            (component.props.chatWindow?.isOpen || component.store.inPublicPage) &&
+            !component.isDiscussSidebarChannelActions
         );
     },
     icon: "fa fa-fw fa-gear",
@@ -74,16 +71,17 @@ registerThreadAction("call-settings", {
     toggle: true,
 });
 registerThreadAction("disconnect", {
-    condition: (component) => component.rtc.selfSession?.in(component.thread?.rtc_session_ids),
+    condition: (component) =>
+        component.rtc.selfSession?.in(component.thread?.rtc_session_ids) &&
+        component.isDiscussSidebarChannelActions,
     danger: true,
     open: (component) => component.rtc.toggleCall(component.thread),
     icon: "fa fa-fw fa-phone text-danger",
     iconLarge: "fa fa-fw fa-lg fa-phone text-danger",
     name: _t("Disconnect"),
-    partition: false,
+    sequence: 30,
+    sequenceGroup: 10,
     setup(component) {
         component.rtc = useService("discuss.rtc");
     },
-    sidebarSequence: 30,
-    sidebarSequenceGroup: 10,
 });

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -43,7 +43,7 @@ registerThreadAction("notification-settings", {
         component.store = useService("mail.store");
     },
     open(component, action) {
-        if (action.sidebar) {
+        if (component.isDiscussSidebarChannelActions) {
             action.dialogService?.add(ChannelActionDialog, {
                 title: component.thread.name,
                 contentComponent: NotificationSettings,
@@ -75,15 +75,14 @@ registerThreadAction("notification-settings", {
     panelOuterClass: "bg-100 border border-secondary",
     sequence: 10,
     sequenceGroup: 30,
-    sidebarSequence: 10,
-    sidebarSequenceGroup: 30,
     toggle: true,
 });
 registerThreadAction("attachments", {
     actionPanelComponent: AttachmentPanel,
     condition: (component) =>
         component.thread?.hasAttachmentPanel &&
-        (!component.props.chatWindow || component.props.chatWindow.isOpen),
+        (!component.props.chatWindow || component.props.chatWindow.isOpen) &&
+        !component.isDiscussSidebarChannelActions,
     icon: "fa fa-fw fa-paperclip",
     iconLarge: "fa fa-fw fa-lg fa-paperclip",
     name: _t("Attachments"),
@@ -114,7 +113,7 @@ registerThreadAction("invite-people", {
     iconLarge: "fa fa-fw fa-lg fa-user-plus",
     name: _t("Invite People"),
     open(component, action) {
-        if (action.sidebar) {
+        if (component.isDiscussSidebarChannelActions) {
             action.dialogService?.add(ChannelActionDialog, {
                 title: component.thread.name,
                 contentComponent: ChannelInvitation,
@@ -133,7 +132,7 @@ registerThreadAction("invite-people", {
             });
         }
     },
-    sequence: 10,
+    sequence: (component) => (component.isDiscussSidebarChannelActions ? 20 : 10),
     sequenceGroup: 20,
     setup(component) {
         if (!component.props.chatWindow) {
@@ -144,8 +143,6 @@ registerThreadAction("invite-people", {
         }
         this.dialogService = useService("dialog");
     },
-    sidebarSequence: 20,
-    sidebarSequenceGroup: 20,
     toggle: true,
 });
 registerThreadAction("member-list", {
@@ -162,7 +159,8 @@ registerThreadAction("member-list", {
     condition(component) {
         return (
             component.thread?.hasMemberList &&
-            (!component.props.chatWindow || component.props.chatWindow.isOpen)
+            (!component.props.chatWindow || component.props.chatWindow.isOpen) &&
+            !component.isDiscussSidebarChannelActions
         );
     },
     panelOuterClass: "o-discuss-ChannelMemberList bg-inherit",
@@ -187,12 +185,12 @@ registerThreadAction("mark-read", {
     condition: (component) =>
         component.thread?.selfMember &&
         component.thread.selfMember.message_unread_counter > 0 &&
-        !component.thread.selfMember.mute_until_dt,
+        !component.thread.selfMember.mute_until_dt &&
+        component.isDiscussSidebarChannelActions,
     open: (component) => component.thread.markAsRead(),
     icon: "fa fa-fw fa-check",
     iconLarge: "fa fa-lg fa-fw fa-check",
     name: _t("Mark Read"),
-    partition: false,
-    sidebarSequence: 10,
-    sidebarSequenceGroup: 20,
+    sequence: 10,
+    sequenceGroup: 20,
 });

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.js
@@ -16,6 +16,7 @@ export class DiscussSidebarChannelActions extends Component {
 
     setup() {
         this.store = useService("mail.store");
+        this.isDiscussSidebarChannelActions = true;
         this.threadActions = useThreadActions();
     }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarChannelActions">
-        <ActionList actions="threadActions.sidebarActions" dropdown="true" thread="thread"/>
+        <t t-set="partitionedActions" t-value="threadActions.partition"/>
+        <ActionList actions="[partitionedActions.quick, partitionedActions.other, ...partitionedActions.group]" dropdown="true" thread="thread"/>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_actions.js
@@ -13,8 +13,9 @@ registerThreadAction("show-threads", {
         action.popover?.close();
     },
     condition: (component) =>
-        component.thread?.hasSubChannelFeature ||
-        component.thread?.parent_channel_id?.hasSubChannelFeature,
+        (component.thread?.hasSubChannelFeature ||
+            component.thread?.parent_channel_id?.hasSubChannelFeature) &&
+        !component.isDiscussSidebarChannelActions,
     icon: "fa fa-fw fa-comments-o",
     iconLarge: "fa fa-fw fa-lg fa-comments-o",
     name: _t("Threads"),

--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -9,7 +9,8 @@ registerThreadAction("expand-discuss", {
             component.thread &&
             component.props.chatWindow?.isOpen &&
             component.thread.model === "discuss.channel" &&
-            !component.ui.isSmall
+            !component.ui.isSmall &&
+            !component.isDiscussSidebarChannelActions
         );
     },
     setup(component) {
@@ -37,7 +38,7 @@ registerThreadAction("expand-discuss", {
     sequenceGroup: 5,
 });
 registerThreadAction("advanced-settings", {
-    condition: (component) => component.thread,
+    condition: (component) => component.thread && component.isDiscussSidebarChannelActions,
     open(component, action) {
         action.actionService.doAction({
             type: "ir.actions.act_window",
@@ -50,10 +51,9 @@ registerThreadAction("advanced-settings", {
     icon: "fa fa-fw fa-gear",
     iconLarge: "fa fa-lg fa-fw fa-gear",
     name: _t("Advanced Settings"),
-    partition: false,
     setup() {
         this.actionService = useService("action");
     },
-    sidebarSequence: 20,
-    sidebarSequenceGroup: 30,
+    sequence: 20,
+    sequenceGroup: 30,
 });

--- a/addons/mail/static/src/discuss/message_pin/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/message_pin/common/thread_actions.js
@@ -10,7 +10,8 @@ registerThreadAction("pinned-messages", {
     condition(component) {
         return (
             component.thread?.model === "discuss.channel" &&
-            (!component.props.chatWindow || component.props.chatWindow.isOpen)
+            (!component.props.chatWindow || component.props.chatWindow.isOpen) &&
+            !component.isDiscussSidebarChannelActions
         );
     },
     panelOuterClass: "o-discuss-PinnedMessagesPanel bg-inherit",


### PR DESCRIPTION
This commit harmonizes discuss actions further:

- "sidebar" actions of thread actions has been removed: this is now using conditions and dynamic sequence of partition
- partitioned actions is now supported on all actions and not just thread actions