### PR TITLE
[IMP] mail: placeholder for html composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -278,6 +278,7 @@ export class Composer extends Component {
     get wysiwygConfig() {
         return {
             content: this.props.composer.composerHtml,
+            placeholder: this.placeholder,
             Plugins: this.ui.isSmall ? MAIL_SMALL_UI_PLUGINS : MAIL_PLUGINS,
             classList: ["o-mail-Composer-html"],
             onChange: () => this.onChangeWysiwygContent(),

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -1,5 +1,6 @@
 import { fields, OR, Record } from "@mail/core/common/record";
 import { convertBrToLineBreak, prettifyMessageContent } from "@mail/utils/common/format";
+import { markup } from "@odoo/owl";
 
 export class Composer extends Record {
     static id = OR("thread", "message");
@@ -47,7 +48,7 @@ export class Composer extends Record {
             });
         },
     });
-    composerHtml = fields.Html("", {
+    composerHtml = fields.Html(markup("<p><br></p>"), {
         onUpdate() {
             if (this.updateFromText) {
                 return;

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -1,0 +1,31 @@
+import { Plugin } from "@html_editor/plugin";
+import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
+import { isEmptyBlock } from "@html_editor/utils/dom_info";
+import { childNodes } from "@html_editor/utils/dom_traversal";
+import { withSequence } from "@html_editor/utils/resource";
+
+export class MailComposerPlugin extends Plugin {
+    static id = "mail.composer";
+    static dependencies = ["hint"];
+    resources = {
+        hints: [
+            withSequence(1, {
+                selector: `.odoo-editor-editable > ${baseContainerGlobalSelector}:only-child`,
+                text: this.config.placeholder,
+            }),
+        ],
+        hint_targets_providers: (selectionData, editable) => {
+            const el = editable.firstChild;
+            if (
+                !selectionData.documentSelectionIsInEditable &&
+                childNodes(editable).length === 1 &&
+                isEmptyBlock(el) &&
+                el.matches(baseContainerGlobalSelector)
+            ) {
+                return [el];
+            } else {
+                return [];
+            }
+        },
+    };
+}

--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -4,11 +4,13 @@ import { ShortCutPlugin } from "@html_editor/core/shortcut_plugin";
 import { InlineCodePlugin } from "@html_editor/main/inline_code";
 import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
 import { HintPlugin } from "@html_editor/main/hint_plugin";
+import { MailComposerPlugin } from "@mail/core/common/plugin/mail_composer_plugin";
 
 export const MAIL_PLUGINS = [
     ...CORE_PLUGINS,
-    InlineCodePlugin,
     HintPlugin,
+    InlineCodePlugin,
+    MailComposerPlugin,
     ShortCutPlugin,
     TabulationPlugin,
     ToolbarPlugin,
@@ -16,8 +18,9 @@ export const MAIL_PLUGINS = [
 
 export const MAIL_SMALL_UI_PLUGINS = [
     ...CORE_PLUGINS,
-    InlineCodePlugin,
     HintPlugin,
+    InlineCodePlugin,
+    MailComposerPlugin,
     ShortCutPlugin,
     TabulationPlugin,
 ];

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -73,7 +73,7 @@ test("composer text input: basic rendering when linked thread is a discuss.chann
     await contains("textarea.o-mail-Composer-input");
 });
 
-test("composer text input placeholder should contain channel name when thread does not have specific correspondent", async () => {
+test("[text composer] composer text input placeholder should contain channel name when thread does not have specific correspondent", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         channel_type: "channel",
@@ -84,7 +84,23 @@ test("composer text input placeholder should contain channel name when thread do
     await contains("textarea.o-mail-Composer-input[placeholder='Message #General…']");
 });
 
-test("composer input placeholder in channel thread", async () => {
+test.tags("html composer");
+test("composer text input placeholder should contain channel name when thread does not have specific correspondent", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "General",
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(channelId);
+    await contains(
+        ".o-mail-Composer-html.odoo-editor-editable .o-we-hint[o-we-hint-text='Message #General…']"
+    );
+});
+
+test("[text composer] composer input placeholder in channel thread", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "General",
@@ -96,6 +112,25 @@ test("composer input placeholder in channel thread", async () => {
     await start();
     await openDiscuss(subchannelID);
     await contains(`.o-mail-Composer-input[placeholder='Message "ThreadFromGeneral"']`);
+});
+
+test.tags("html composer");
+test("composer input placeholder in channel thread", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "General",
+    });
+    const subchannelID = pyEnv["discuss.channel"].create({
+        name: "ThreadFromGeneral",
+        parent_channel_id: channelId,
+    });
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openDiscuss(subchannelID);
+    await contains(
+        ".o-mail-Composer-html.odoo-editor-editable .o-we-hint[o-we-hint-text='Message \"ThreadFromGeneral\"']"
+    );
 });
 
 test("add an emoji", async () => {
@@ -543,7 +578,7 @@ test("Can post suggestions", async () => {
     await contains(".o-mail-Message .o_channel_redirect");
 });
 
-test("composer text input placeholder should contain correspondent name when thread has exactly one correspondent", async () => {
+test("[text composer] composer text input placeholder should contain correspondent name when thread has exactly one correspondent", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Marc Demo" });
     const channelId = pyEnv["discuss.channel"].create({
@@ -556,6 +591,26 @@ test("composer text input placeholder should contain correspondent name when thr
     await start();
     await openDiscuss(channelId);
     await contains("textarea.o-mail-Composer-input[placeholder='Message Marc Demo…']");
+});
+
+test.tags("html composer");
+test("composer text input placeholder should contain correspondent name when thread has exactly one correspondent", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Marc Demo" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "chat",
+    });
+    await start();
+    await openDiscuss(channelId);
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await contains(
+        ".o-mail-Composer-html.odoo-editor-editable .o-we-hint[o-we-hint-text='Message Marc Demo…']"
+    );
 });
 
 test.tags("focus required");


### PR DESCRIPTION
This commit introduce placeholder for the html composer and re-uses the existing placeholder logic from the text composer with a mail composer plugin. This allows us to have the same placeholder behavior in both text and html composers based on the current context.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
