### PR TITLE
[FIX] hr_work_entry_holidays: prevent singleton traceback on time-off validation

### DIFF
--- a/addons/hr_work_entry_holidays/models/hr_contract.py
+++ b/addons/hr_work_entry_holidays/models/hr_contract.py
@@ -45,8 +45,10 @@ class HrContract(models.Model):
         # Overriden in hr_work_entry_contract_holiday to select the
         # global time off first (eg: Public Holiday > Home Working)
         self.ensure_one()
-        if 'work_entry_type_id' in interval[2] and interval[2].work_entry_type_id.code in bypassing_codes:
-            return interval[2].work_entry_type_id
+        if 'work_entry_type_id' in interval[2]:
+            bypassed_we_types = interval[2].work_entry_type_id.filtered(lambda we_type: we_type.code in bypassing_codes)
+            if bypassed_we_types:
+                return bypassed_we_types[:1]
 
         interval_start = interval[0].astimezone(pytz.utc).replace(tzinfo=None)
         interval_stop = interval[1].astimezone(pytz.utc).replace(tzinfo=None)


### PR DESCRIPTION
**Steps to reproduce:**

1- Install Work Entries - Contract and Attendances modules.
2- Search for a contract from the homepage.
    i- Go the Running contract.
3- Set its working schedule to Standard 40 hours/week.
4- Open the schedule, and for each day:
     i- Add a row for lunch with work entry type = Generic Time Off.
     ii- For other rows, choose work entry type = Attendance.
5- Create and approve a time off (for any employee with a running contract
   except Mitchell Admin). Validate the time off → a traceback occurs.

**Issue:**

https://github.com/odoo/odoo/blob/528234d740de64778a4bac412a0d0bb3b1bf481a/addons/hr_work_entry_holidays/models/hr_contract.py#L47-L49

A traceback is raised:
```
  Expected singleton: hr.work.entry.type(1, 2)
```

**Cause:**

https://github.com/odoo/odoo/blob/853a9f547ec48d7cce873ad0a51785e946237ca6/addons/resource/models/resource.py#L67-L87

The `work_entry_type_id` is returning multiple values because the contract is
configured with more than one work entry type. When applying for time off after
adding a lunch break in the contract, the function encounters an unsorted order
of intervals.

**Expected order:**
start → stop, start → stop, start → stop

**Actual order:**
start → start, start → stop, stop → start

- This results in multiple consecutive `start` entries without a matching `stop`
  which produces multiple `work_entry_type_id` values for single record and
  triggers the singleton error.

- In newer Odoo versions, this issue does not occur since the `workIntervals`
 class is used, which ensures the intervals are generated in the correct
 sorted order.

**Solution:**

- Safely check the codes using mapped('code') and return only the first record
  from  work_entry_type_id to avoid singleton issues.
- This approach aligns with newer versions of odoo, where work_entry_type_id[:1]
  is already used.
  
**Related Enterprise PR -**  https://github.com/odoo/enterprise/pull/93688

opw- 4952770