### PR TITLE
[REF] web: add multiple entry points for calendar view functions.

### DIFF
--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_renderer.xml
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/calendar_common/work_entry_calendar_common_renderer.xml
@@ -2,8 +2,8 @@
 
 <templates>
     <t t-name="hr_work_entry.WorkEntryCalendarCommonRenderer.event" t-inherit="web.CalendarCommonRenderer.event" t-inherit-mode="primary">
-        <div t-out="title" position="after">
+        <t t-out="title" position="after">
             <i t-if="rawRecord.state === 'validated'" class="fa fa-lock position-absolute top-0 end-0" style="font-size: x-small"/>
-        </div>
+        </t>
     </t>
 </templates>

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.js
@@ -80,34 +80,47 @@ export class CalendarCommonPopover extends Component {
         const isSameDay = start.hasSame(end, "day");
 
         if (!record.isTimeHidden && !record.isAllDay && isSameDay) {
-            const timeFormat = is24HourFormat() ? "HH:mm" : "hh:mm a";
-            this.time = `${start.toFormat(timeFormat)} - ${end.toFormat(timeFormat)}`;
-
-            const duration = end.diff(start, ["hours", "minutes"]);
-            const formatParts = [];
-            if (duration.hours > 0) {
-                const hourString = duration.hours === 1 ? _t("hour") : _t("hours");
-                formatParts.push(`h '${hourString}'`);
-            }
-            if (duration.minutes > 0) {
-                const minuteStr = duration.minutes === 1 ? _t("minute") : _t("minutes");
-                formatParts.push(`m '${minuteStr}'`);
-            }
-            this.timeDuration = duration.toFormat(formatParts.join(", "));
+            this.time = this.formatTimeRange(start, end, is24HourFormat() ? "HH:mm" : "hh:mm a");
+            this.timeDuration = this.formatTimeDuration(end.diff(start, ["hours", "minutes"]));
         }
-
         if (!this.props.model.isDateHidden) {
-            this.date = getFormattedDateSpan(start, end);
-
-            if (record.isAllDay) {
-                if (isSameDay) {
-                    this.dateDuration = _t("All day");
-                } else {
-                    const duration = end.plus({ day: 1 }).diff(start, "days");
-                    this.dateDuration = duration.toFormat(`d '${_t("days")}'`);
-                }
-            }
+            this.date = this.formatDateRange(start, end);
+            this.dateDuration = this.formatDateDuration(start, end);
         }
+    }
+
+    formatTimeRange(start, end, timeFormat) {
+        return `${start.toFormat(timeFormat)} - ${end.toFormat(timeFormat)}`;
+    }
+
+    formatTimeDuration(duration) {
+        const formatParts = [];
+        if (duration.hours > 0) {
+            const hourString = duration.hours === 1 ? _t("hour") : _t("hours");
+            formatParts.push(`h '${hourString}'`);
+        }
+        if (duration.minutes > 0) {
+            const minuteStr = duration.minutes === 1 ? _t("minute") : _t("minutes");
+            formatParts.push(`m '${minuteStr}'`);
+        }
+        return duration.toFormat(formatParts.join(", "));
+    }
+
+    formatDateRange(start, end) {
+        return getFormattedDateSpan(start, end);
+    }
+
+    formatDateDuration(start, end) {
+        if (!this.props.record.isAllDay) {
+            return null;
+        }
+        if (start.hasSame(end, "day")) {
+            return _t("All day");
+        }
+        return end
+            .plus({ day: 1 })
+            .diff(start, "days")
+            .toFormat(`d '${_t("days")}'`);
     }
 
     onEditEvent() {

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
@@ -10,7 +10,10 @@
                 <span class="d-none d-lg-inline fc-time" t-esc="startTime" />
                 <t> </t>
             </t>
-            <div class="o_event_title text-truncate" t-out="title"/>
+            <div class="o_event_title text-truncate">
+                <i area-hidden="true" t-if="titleIcon" t-attf-class="me-2 {{titleIcon}}"/>
+                <t t-out="title"/>
+            </div>
     </t>
 
     <t t-name="web.CalendarCommonRendererHeader">

--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_popover.xml
@@ -62,7 +62,10 @@
             t-att-data-title="record.title"
         >
             <span t-if="record.startHour"><t t-out="record.startHour" /></span>
-            <span t-esc="record.title"/>
+            <span>
+                <i area-hidden="true" t-if="record.titleIcon" t-attf-class="me-2 {{record.titleIcon}}"/>
+                <t t-esc="record.title"/>
+            </span>
         </a>
     </t>
 

--- a/addons/web/static/src/views/calendar/utils.js
+++ b/addons/web/static/src/views/calendar/utils.js
@@ -37,7 +37,15 @@ export function getColor(key) {
     return colorMap.get(key);
 }
 
-export function getFormattedDateSpan(start, end) {
+/**
+ * Formats a date span between two dates with various formatting options.
+ * @param {DateTime} start
+ * @param {DateTime} end
+ * @param {Object} options
+ * @param {string} [options.sameDayFormat] - Format string for when start and end are the same day. If not provided, the default is "DDD".
+ * @returns {string}
+ */
+export function getFormattedDateSpan(start, end, options = {}) {
     const isSameDay = start.hasSame(end, "days");
 
     if (!isSameDay && start.hasSame(end, "month")) {
@@ -45,7 +53,7 @@ export function getFormattedDateSpan(start, end) {
         return start.toFormat("LLLL d") + "-" + end.toFormat("d, y");
     } else {
         return isSameDay
-            ? start.toFormat("DDD")
+            ? start.toFormat(options.sameDayFormat ?? "DDD")
             : start.toFormat("DDD") + " - " + end.toFormat("DDD");
     }
 }


### PR DESCRIPTION
This commit adds multiple entry points and options for the calendar view helper functions to make it easier for overriding them. This helps not to copy paste all the function/s. This commis adds an options paramater to `getFormattedDateSpan` to make it possible to alter the date format. It also adds multiple entry points to `computeDateTimeAndDuration` to make it easier and cleaner to be overriden.

Task-5025572

Enterprise: https://github.com/odoo/enterprise/pull/92940
