### PR TITLE
[FIX] mail, *: update the rating summary when a message is deleted

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -764,7 +764,9 @@ export class Composer extends Component {
                 MessageConfirmDialog,
                 {
                     message: composer.message,
-                    onConfirm: () => this.message.remove(),
+                    onConfirm: this.message.remove({
+                        removeFromThread: this.shouldHideFromMessageListOnDelete,
+                    }),
                     prompt: _t("Are you sure you want to delete this message?"),
                 },
                 { context: this }
@@ -835,5 +837,9 @@ export class Composer extends Component {
         } catch {
             browser.localStorage.removeItem(composer.localId);
         }
+    }
+
+    get shouldHideFromMessageListOnDelete() {
+        return false;
     }
 }

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -491,6 +491,10 @@ export class Message extends Component {
     async onClickToggleTranslation() {
         toRaw(this.props.message).onClickToggleTranslation();
     }
+
+    get shouldHideFromMessageListOnDelete() {
+        return false;
+    }
 }
 
 discussComponentRegistry.add("Message", Message);

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -163,7 +163,9 @@ messageActionsRegistry
                     prompt: _t("Are you sure you want to delete this message?"),
                     onConfirm: () => {
                         def.resolve(true);
-                        message.remove();
+                        message.remove({
+                            removeFromThread: component.shouldHideFromMessageListOnDelete,
+                        });
                     },
                 },
                 { context: component, onClose: () => def.resolve(false) }

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -529,9 +529,12 @@ export class Message extends Record {
         );
     }
 
-    async remove() {
+    async remove({ removeFromThread = false } = {}) {
         const data = await rpc("/mail/message/update_content", this.removeParams);
         this.store.insert(data, { html: true });
+        if (this.thread && removeFromThread) {
+            this.thread.messages = this.thread.messages.filter((message) => message.notEq(this));
+        }
         return data;
     }
 

--- a/addons/portal/static/src/chatter/frontend/composer_patch.js
+++ b/addons/portal/static/src/chatter/frontend/composer_patch.js
@@ -13,4 +13,8 @@ patch(Composer.prototype, {
     get showComposerAvatar() {
         return super.showComposerAvatar || (this.compact && this.props.composer.portalComment);
     },
+
+    get shouldHideFromMessageListOnDelete() {
+        return this.env.inFrontendPortalChatter || super.shouldHideFromMessageListOnDelete;
+    },
 });

--- a/addons/portal/static/src/chatter/frontend/message_patch.js
+++ b/addons/portal/static/src/chatter/frontend/message_patch.js
@@ -12,4 +12,8 @@ patch(Message.prototype, {
         }
         return super.authorAvatarUrl;
     },
+
+    get shouldHideFromMessageListOnDelete() {
+        return this.env.inFrontendPortalChatter || super.shouldHideFromMessageListOnDelete;
+    },
 });

--- a/addons/portal_rating/static/src/chatter/frontend/message_model_patch.js
+++ b/addons/portal_rating/static/src/chatter/frontend/message_model_patch.js
@@ -3,16 +3,12 @@ import { patch } from "@web/core/utils/patch";
 
 /** @type {import("models").Message} */
 const messagePatch = {
-    async remove() {
+    async remove({ removeFromThread = false } = {}) {
         const data = await super.remove(...arguments);
-        this.store.env.bus.trigger("reload_rating_popup_composer", data);
-        return data;
-    },
-
-    async edit() {
-        const data = await super.edit(...arguments);
-        if (data) {
-            this.store.env.bus.trigger("reload_rating_popup_composer", data);
+        if (this.thread && removeFromThread) {
+            this.thread.messages.forEach((message) => {
+                message.rating_stats = this.thread.rating_stats;
+            });
         }
         return data;
     },

--- a/addons/portal_rating/static/src/chatter/frontend/portal_chatter_patch.xml
+++ b/addons/portal_rating/static/src/chatter/frontend/portal_chatter_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="portal.Chatter" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-Chatter-top')]/*[1]" position="before">
-            <div t-if="ratingStats" class="my-2" t-att-class="{ 'mb-4':props.twoColumns }">
+            <div t-if="ratingStats and ratingStats.total" class="my-2" t-att-class="{ 'mb-4':props.twoColumns }">
                 <t t-call="portal_rating.rating_card">
                     <t t-set="two_columns" t-value="props.twoColumns"/>
                     <t t-set="rating_stats" t-value="ratingStats"/>

--- a/addons/rating/static/src/core/common/message_model_patch.js
+++ b/addons/rating/static/src/core/common/message_model_patch.js
@@ -14,7 +14,7 @@ patch(Message.prototype, {
     },
 
      async remove() {
-        const data = await super.remove();
+        const data = await super.remove(...arguments);
         this.rating_value = false;
         return data;
     },

--- a/addons/website_slides/static/tests/tours/slides_course_review_modification.js
+++ b/addons/website_slides/static/tests/tours/slides_course_review_modification.js
@@ -36,6 +36,10 @@ registry.category("web_tour.tours").add("course_review_modification", {
             run: "click",
         },
         {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Chatter .o_website_rating_card_container .o_website_rating_table_row[data-star='4']:contains(100%)",
+        },
+        {
             trigger: "#chatterRoot:shadow .o-mail-Message:contains(First review)",
             run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Expand']",
         },
@@ -46,6 +50,10 @@ registry.category("web_tour.tours").add("course_review_modification", {
         {
             trigger: "#chatterRoot:shadow button:contains(Confirm)",
             run: "click",
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Chatter:not(:has(.o_website_rating_card_container))",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Thread:contains(The conversation is empty.)",
@@ -83,6 +91,10 @@ registry.category("web_tour.tours").add("course_review_modification", {
         },
         {
             trigger:
+                "#chatterRoot:shadow .o-mail-Chatter .o_website_rating_card_container .o_website_rating_table_row[data-star='3']:contains(100%)",
+        },
+        {
+            trigger:
                 "#chatterRoot:shadow .o-mail-Message:contains(Second review) .o_website_rating_static[title='3 stars on 5']",
         },
         {
@@ -108,6 +120,10 @@ registry.category("web_tour.tours").add("course_review_modification", {
         {
             trigger: "a[id=review-tab]:contains(Reviews (1))",
             run: "click",
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Chatter .o_website_rating_card_container .o_website_rating_table_row[data-star='2']:contains(100%)",
         },
         {
             trigger:
@@ -169,6 +185,10 @@ registry.category("web_tour.tours").add("course_review_modification", {
         {
             trigger: "#chatterRoot:shadow button:contains(Confirm)",
             run: "click",
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Chatter:not(:has(.o_website_rating_card_container))",
         },
         {
             trigger: "span:contains(Add Review)",


### PR DESCRIPTION
*: portal, portal_rating, website_slides

PR #221050, makes it possible to properly remove a message in the portal and PR #216044 retrieves the rating cards feature. There is an overlap between what these two PRs do. When a user removes a rating message and there is a rating cards feature on the page, it should be updated. 
Most of the remove method changes are indeed what we did in forward port of #221050 (#222517).

task-5106543