### PR TITLE
[FIX] web: fix crash when viewing empty helpdesk ticket list view

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -566,7 +566,7 @@ export class RelationalModel extends Model {
                     }
                 } else {
                     if (!groupConfig.isFolded) {
-                        group.records = groupData.__records;
+                        group.records = groupData.__records || [];
                         group.length = groupData.__count;
                     } else {
                         group.records = [];


### PR DESCRIPTION
Previously, accessing the Helpdesk ticket list view with zero tickets caused a crash due to improper handling of folded sample data.

This commit resolves the root issue by ensuring sample data folding does not trigger errors in empty views, improving stability.

Steps to reproduce the original issue:
- Navigate to Helpdesk > Teams > Tickets.
- Ensure zero tickets exist and switch to list view.

Task-4971510

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
