### PR TITLE
[FIX] l10n_{latam_base,ar} : add missing translations

### DIFF
--- a/addons/l10n_ar/i18n/es_419.po
+++ b/addons/l10n_ar/i18n/es_419.po
@@ -58,6 +58,26 @@ msgid "- CUIT:"
 msgstr "- CUIT:"
 
 #. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.address_form_fields
+msgid "<option value=\"\">AFIP Responsibility...</option>"
+msgstr "<option value=\"\">Responsabilidad AFIP...</option>"
+
+#. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.address_form_fields
+msgid "AFIP Responsibility"
+msgstr "Responsabilidad AFIP"
+
+#. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.address_form_fields
+msgid ""
+"Changing AFIP Responsibility type is not allowed once document(s) have "
+"been issued for your account. Please contact us "
+"directly for this operation."
+msgstr ""
+"No puede cambiar el tipo de responsabilidad AFIP después de que haya emitido"
+" documentos para su cuenta. Contáctenos para realizar esta operación."
+
+#. module: l10n_ar
 #: model:ir.model.fields.selection,name:l10n_ar.selection__account_tax_group__l10n_ar_tribute_afip_code__01
 msgid "01 - National Taxes"
 msgstr "01 - Impuestos nacionales"

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -147,6 +147,11 @@ msgid "<br/><strong>Source:</strong>"
 msgstr ""
 
 #. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.address_form_fields
+msgid "<option value=\"\">AFIP Responsibility...</option>"
+msgstr ""
+
+#. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
 msgid "<span>Amount</span>"
 msgstr ""
@@ -234,6 +239,11 @@ msgstr ""
 #. module: l10n_ar
 #: model:ir.model.fields,field_description:l10n_ar.field_account_journal__l10n_ar_afip_pos_system
 msgid "AFIP POS System"
+msgstr ""
+
+#. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.address_form_fields
+msgid "AFIP Responsibility"
 msgstr ""
 
 #. module: l10n_ar
@@ -379,6 +389,14 @@ msgstr ""
 msgid ""
 "Can not create chart of account until you configure your company AFIP "
 "Responsibility and VAT."
+msgstr ""
+
+#. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.address_form_fields
+msgid ""
+"Changing AFIP Responsibility type is not allowed once document(s) have "
+"been issued for your account. Please contact us "
+"directly for this operation."
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_latam_base/i18n/es_419.po
+++ b/addons/l10n_latam_base/i18n/es_419.po
@@ -91,6 +91,7 @@ msgstr "Número de identificación para el tipo seleccionado"
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_partner__l10n_latam_identification_type_id
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_users__l10n_latam_identification_type_id
 #: model:ir.ui.menu,name:l10n_latam_base.menu_l10n_latam_identification_type
+#: model_terms:ir.ui.view,arch_db:l10n_latam_base.address_form_fields
 msgid "Identification Type"
 msgstr "Tipo de Identificación"
 
@@ -98,6 +99,21 @@ msgstr "Tipo de Identificación"
 #: model:ir.model,name:l10n_latam_base.model_l10n_latam_identification_type
 msgid "Identification Types"
 msgstr "Tipos de identificación"
+
+#. module: l10n_latam_base
+#: model_terms:ir.ui.view,arch_db:l10n_latam_base.address_form_fields
+msgid "<option value=\"\">Identification Type...</option>"
+msgstr "<option value=\"\">Tipo de identificación...</option>"
+
+#. module: l10n_latam_base
+#: model_terms:ir.ui.view,arch_db:l10n_latam_base.address_form_fields
+msgid ""
+"Changing Identification type is not allowed once document(s) have been "
+"issued for your account. Please contact us directly "
+"for this operation."
+msgstr ""
+"No puede cambiar el tipo de identificación después de que haya emitido "
+"documentos para su cuenta. Contáctenos para realizar esta operación."
 
 #. module: l10n_latam_base
 #: model:ir.model.fields,field_description:l10n_latam_base.field_l10n_latam_identification_type__is_vat

--- a/addons/l10n_latam_base/i18n/l10n_latam_base.pot
+++ b/addons/l10n_latam_base/i18n/l10n_latam_base.pot
@@ -16,6 +16,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_latam_base
+#: model_terms:ir.ui.view,arch_db:l10n_latam_base.address_form_fields
+msgid "<option value=\"\">Identification Type...</option>"
+msgstr ""
+
+#. module: l10n_latam_base
 #: model_terms:ir.ui.view,arch_db:l10n_latam_base.view_partner_latam_form
 msgid "<span class=\"oe_read_only\"> - </span>"
 msgstr ""
@@ -29,6 +34,14 @@ msgstr ""
 #. module: l10n_latam_base
 #: model_terms:ir.ui.view,arch_db:l10n_latam_base.view_l10n_latam_identification_type_search
 msgid "Archived"
+msgstr ""
+
+#. module: l10n_latam_base
+#: model_terms:ir.ui.view,arch_db:l10n_latam_base.address_form_fields
+msgid ""
+"Changing Identification type is not allowed once document(s) have been "
+"issued for your account. Please contact us directly "
+"for this operation."
 msgstr ""
 
 #. module: l10n_latam_base
@@ -91,6 +104,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_partner__l10n_latam_identification_type_id
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_users__l10n_latam_identification_type_id
 #: model:ir.ui.menu,name:l10n_latam_base.menu_l10n_latam_identification_type
+#: model_terms:ir.ui.view,arch_db:l10n_latam_base.address_form_fields
 msgid "Identification Type"
 msgstr ""
 

--- a/addons/l10n_latam_base/i18n/pt_BR.po
+++ b/addons/l10n_latam_base/i18n/pt_BR.po
@@ -89,6 +89,7 @@ msgstr "Número de identificação do tipo selecionado"
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_partner__l10n_latam_identification_type_id
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_users__l10n_latam_identification_type_id
 #: model:ir.ui.menu,name:l10n_latam_base.menu_l10n_latam_identification_type
+#: model_terms:ir.ui.view,arch_db:l10n_latam_base.address_form_fields
 msgid "Identification Type"
 msgstr "Tipo de identificação"
 
@@ -96,6 +97,22 @@ msgstr "Tipo de identificação"
 #: model:ir.model,name:l10n_latam_base.model_l10n_latam_identification_type
 msgid "Identification Types"
 msgstr "Tipos de identificação"
+
+#. module: l10n_latam_base
+#: model_terms:ir.ui.view,arch_db:l10n_latam_base.address_form_fields
+msgid "<option value=\"\">Identification Type...</option>"
+msgstr "<option value=\"\">Tipo de identificação...</option>"
+
+#. module: l10n_latam_base
+#: model_terms:ir.ui.view,arch_db:l10n_latam_base.address_form_fields
+msgid ""
+"Changing Identification type is not allowed once document(s) have been "
+"issued for your account. Please contact us directly "
+"for this operation."
+msgstr ""
+"Não é permitido alterar o tipo de identificação depois que o(s) documento(s) "
+"tiver(em) sido emitido(s) para sua conta. Entre em contato conosco "
+"diretamente para essa operação."
 
 #. module: l10n_latam_base
 #: model:ir.model.fields,field_description:l10n_latam_base.field_l10n_latam_identification_type__is_vat


### PR DESCRIPTION
Step to reproduce:
- install `l10n_ar` , `website_sale` and `payment_demo`
- Add a language e.g. : spanish (AR)
- switch to `(AR) Responsable Inscripto` and create a website for this company
- change default company for "marc demo" user to `(AR) Responsable Inscripto`
- login with "marc demo" , go to shop page, and change site language to sapnish
- add a product e.g, three set sofa to cart and goto checkout page
- proceed and you will be directed to "Address management page"

Observation:
"Identification Type " and "AFIP Responsibility" are not translated

Cause:
After this commit [1], module l10n_ar_website_sale was dropped and address logic
was mooved to l10n_ar and l10n_latam_base
but the following pot files were not updated, this caused missing of tranlation
in following modules

[1] https://github.com/odoo/odoo/commit/5a93da8e9220ecbf664b26445b04717a9245ef5e

Fix:
Add missing translations in respective po and pot files

Before:
<img width="903" height="517" alt="image" src="https://github.com/user-attachments/assets/f1e265bd-e976-4698-b83b-9de821073b8c" />

After:
<img width="806" height="374" alt="image" src="https://github.com/user-attachments/assets/a04dfde9-8e5d-4699-a1a4-1a8c36339f63" />


opw-5000512

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
