### PR TITLE
[FIX] html_editor: ensure color inheritance and gradient visibility in lists

### DIFF
--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -2,6 +2,10 @@ li p {
     margin-bottom: 0px;
 }
 
+li * {
+    color: inherit;
+}
+
 // Checklist
 ul.o_checklist {
     > li {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -32,7 +32,7 @@ import { compareListTypes, createList, insertListAfter, isListItem } from "./uti
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { withSequence } from "@html_editor/utils/resource";
 import { FONT_SIZE_CLASSES, getFontSizeOrClass } from "@html_editor/utils/formatting";
-import { getTextColorOrClass } from "@html_editor/utils/color";
+import { getTextColorOrClass, isColorGradient } from "@html_editor/utils/color";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 
 export class ListPlugin extends Plugin {
@@ -996,7 +996,7 @@ export class ListPlugin extends Plugin {
                 .map((n) => closestElement(n, "li"))
                 .filter(Boolean)
         );
-        if (!selectedNodes.size || mode !== "color") {
+        if (!selectedNodes.size || mode !== "color" || isColorGradient(color)) {
             return;
         }
         for (const list of selectedNodes) {

--- a/addons/html_editor/static/tests/list/color_list.test.js
+++ b/addons/html_editor/static/tests/list/color_list.test.js
@@ -206,3 +206,15 @@ test("should change color of subpart of a list item (2)", async () => {
             '<ol><li style="color: rgb(255, 0, 0);">a<font style="color: rgb(0, 0, 255);">[bc</font></li><li style="color: rgb(255, 0, 0);"><font style="color: rgb(0, 0, 255);">gh]</font>i</li></ol>',
     });
 });
+
+test("should apply gradient color style only on font inside list item", async () => {
+    await testEditor({
+        contentBefore: "<ol><li>[abc]</li><li>def</li></ol>",
+        stepFunction: setColor(
+            "linear-gradient(135deg, rgb(255, 0, 0) 0%, rgb(0, 0, 255) 100%)",
+            "color"
+        ),
+        contentAfter:
+            '<ol><li><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 0, 0) 0%, rgb(0, 0, 255) 100%);">[abc]</font></li><li>def</li></ol>',
+    });
+});


### PR DESCRIPTION
Steps to Reproduce:

- Create a list in the editor.
- Apply a text color to an item.
- Change the font type of the text inside the list (e.g., to H1–H6).
- Apply a gradient color to text inside a list item.
- Move the cursor outside the list by pressing Enter twice and start typing in the new container.

Current behavior before PR:

- When changing the font type (H1–H6) after applying a color, the text color turns to default color. also when applying a gradient color and then changing the font type, the text becomes transparent.
- This happens because the gradient style was incorrectly applied both on the `<li>` and its child `<font>` element. As a result, Checklist items lose their line-through when checked. Also new base container outside the list ends up with a `<font>` wrapping another `<font>`.

Desired behavior after PR is merged:

- All child elements inside the list item inherit the color and Gradient styles are applied only to the `<font>` element.
- Checklist items correctly show the line-through when checked and No invalid nested `<font class="text-gradient">` tags are created when writing outside the list after pressing Enter twice.

task-5039499

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
