### PR TITLE
[REF] *: avoid using hoot helpers in tour files

### DIFF
--- a/addons/auth_totp/static/tests/apikeys_flow.js
+++ b/addons/auth_totp/static/tests/apikeys_flow.js
@@ -1,4 +1,3 @@
-import { queryAll, queryText } from "@odoo/hoot-dom";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 
@@ -49,7 +48,7 @@ registry.category("web_tour.tours").add('apikeys_tour_setup', {
     content: "Check that we're on the last step & grab key",
     trigger: '.modal p:contains("Here is your new API key")',
     run: async () => {
-        const key = queryText("code [name=key] span");
+        const key = document.querySelector("code [name=key] span").textContent;
         await rpc('/web/dataset/call_kw', {
             model: 'ir.logging', method: 'send_key',
             args: [key],
@@ -110,10 +109,5 @@ registry.category("web_tour.tours").add('apikeys_tour_teardown', {
     run: 'click',
 }, {
     content: "Check that there's no more keys",
-    trigger: '.o_notebook',
-    run: function() {
-        if (queryAll("[name=api_key_ids]:visible", { root: this.anchor }).length) {
-            console.error("Expected API keys to be hidden (because empty), but it's not");
-        }
-    }
+    trigger: "body:not(:has(.o_notebook [name=api_key_ids]))",
 }]});

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -1,9 +1,8 @@
 import { WORKER_STATE } from "@bus/workers/websocket_worker";
-import {animationFrame, queryAll, waitFor} from "@odoo/hoot-dom";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
-import {whenReady} from "@odoo/owl";
+import { whenReady } from "@odoo/owl";
 
 function openRoot() {
     return [{
@@ -53,16 +52,18 @@ function closeProfileDialog({content, totp_state}) {
 
     return [{
         content,
-        //TODO: remove when PIPU macro PR is merged: https://github.com/odoo/odoo/pull/194508
         trigger: 'a[role=tab]:contains("Account Security").active',
+    }, 
+    {
+        trigger,
         async run(helpers) {
-            await waitFor(trigger, { timeout: 5000 });
             const modal = document.querySelector(".o_dialog");
             if (modal) {
                 modal.querySelector("button[name=preference_cancel]").click();
             }
         }
-    }, {
+    },
+    {
         trigger: 'body',
         async run() {
             while (document.querySelector('.o_dialog')) {
@@ -79,12 +80,11 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
     url: '/odoo',
     steps: () => [...openUserProfileAtSecurityTab(), {
     content: "Open totp wizard",
-    //TODO: remove when PIPU macro PR is merged: https://github.com/odoo/odoo/pull/194508
     trigger: 'a[role=tab]:contains("Account Security").active',
-    async run(actions) {
-        const el = await waitFor('button[name=action_totp_enable_wizard]', { timeout: 5000 });
-        await actions.click(el);
-    }
+},
+{
+    trigger: "button[name=action_totp_enable_wizard]",
+    run: "click",
 },
 {
     trigger: ".modal div:contains(entering your password)",
@@ -256,7 +256,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
     trigger: ".o_web_client .o_navbar",
     async run() {
         await whenReady();
-        await animationFrame();
+        await new Promise((resolve) => requestAnimationFrame(resolve));
         await new Promise((resolve) => {
             const bus = odoo.__WOWL_DEBUG__.root.env.services.bus_service;
             bus.addEventListener("BUS:CONNECT", resolve, { once: true });
@@ -384,6 +384,7 @@ registry.category("web_tour.tours").add('totp_admin_disables', {
     content: "Find test_user User",
     trigger: 'td.o_data_cell:contains("test_user")',
     run(helpers) {
+        const { queryAll } = odoo.loader.modules.get("@odoo/hoot-dom");
         const titles = queryAll("tr:first th", { root: this.anchor.closest("table") });
         titles.forEach((el, i) => {
             columns[el.getAttribute('data-name')] = i;

--- a/addons/auth_totp_mail/static/tests/totp_flow.js
+++ b/addons/auth_totp_mail/static/tests/totp_flow.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
-import { queryFirst } from "@odoo/hoot-dom";
 
 function openAccountSettingsTab() {
     return [{
@@ -48,16 +47,7 @@ registry.category("web_tour.tours").add('totp_admin_self_invite', {
     run: "click",
 }, {
     content: "check that user cannot invite themselves to use 2FA.",
-    trigger: "body",
-    run: function () {
-        const inviteBtn = queryFirst('button:contains(Invite to use 2FA)');
-        if (!inviteBtn) {
-            document.body.classList.add('CannotInviteYourself');
-        }
-    }
-}, {
-    content: "check that user cannot invite themself.",
-    trigger: "body.CannotInviteYourself",
+    trigger: "body:not(:has(button:contains(Invite to use 2FA)))",
 }]});
 
 registry.category("web_tour.tours").add('totp_admin_invite', {

--- a/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
@@ -1,7 +1,4 @@
-import { waitFor } from "@odoo/hoot-dom";
-
 import { registry } from "@web/core/registry";
-
 import { stepUtils } from "@web_tour/tour_utils";
 
 function createChatbotSteps(...stepMessages) {
@@ -17,8 +14,7 @@ function createChatbotSteps(...stepMessages) {
                     run: `edit ${message}`,
                 },
                 {
-                    trigger: `.modal textarea#message_0`,
-                    run: () => waitFor(`.modal textarea#message_0:value(${message})`),
+                    trigger: `.modal textarea#message_0:value(${message})`,
                 },
                 {
                     trigger: ".modal button:contains(Save & New)",
@@ -28,8 +24,7 @@ function createChatbotSteps(...stepMessages) {
                     trigger: `tr:contains(${message})`,
                 },
                 {
-                    trigger: ".modal textarea#message_0",
-                    run: () => waitFor(".modal textarea#message_0:empty"),
+                    trigger: ".modal textarea#message_0:empty",
                 },
             ])
             .flat(),

--- a/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
@@ -1,4 +1,4 @@
-import { delay } from "@odoo/hoot-dom";
+import { delay } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour", {

--- a/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
@@ -1,6 +1,6 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
-import { delay } from "@odoo/hoot-dom";
+import { delay } from "@web/core/utils/concurrency";
 
 registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour", {
     url: "/odoo",
@@ -57,7 +57,7 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
                 // Ensure the system has registered a correct model value before
                 // we try to open the DPH.
                 // It seems that the autocomplete validation can be very slow.
-                await new Promise((r) => setTimeout(r, 200));
+                await delay(200);
             },
         },
         {

--- a/addons/mass_mailing_sms/static/tests/tours/mailing_activities_split.js
+++ b/addons/mass_mailing_sms/static/tests/tours/mailing_activities_split.js
@@ -1,4 +1,3 @@
-import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('mailing_activities_split', {
@@ -15,12 +14,12 @@ registry.category("web_tour.tours").add('mailing_activities_split', {
         }, {
             content: 'Open Email Marketing record in the kanban view',
             trigger: '.o_list_renderer .o_data_cell:contains("New Email!")',
-            run: () => {
-                if (queryAll('.o_list_renderer .o_data_cell:contains("New SMS!")').length !== 0) {
-                    console.error('SMS Marketing record should not appear in this view');
-                }
-            },
-        }, {
+        },
+        {
+            content: "SMS Marketing record should not appear in this view",
+            trigger: "body:not(:has(.o_list_renderer .o_data_cell:contains(New SMS!)))",
+        },
+        {
             content: 'Open Activity Systray',
             trigger: '.o-mail-ActivityMenu-counter',
             run: "click",
@@ -31,11 +30,10 @@ registry.category("web_tour.tours").add('mailing_activities_split', {
         }, {
             content: 'Open SMS Marketing record in the kanban view',
             trigger: '.o_list_renderer .o_data_cell:contains("New SMS!")',
-            run: () => {
-                if (queryAll('.o_list_renderer .o_data_cell:contains("New Email!")').length !== 0) {
-                    console.error('Email Marketing record should not appear in this view');
-                }
-            },
-        }
+        },
+        {
+            content: "Email Marketing record should not appear in this view",
+            trigger: "body:not(:has(.o_list_renderer .o_data_cell:contains(New Email!)))",
+        },
     ],
 });

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -10,7 +10,7 @@ import * as ChromePos from "@point_of_sale/../tests/pos/tours/utils/chrome_util"
 import * as ChromeRestaurant from "@pos_restaurant/../tests/tours/utils/chrome";
 const Chrome = { ...ChromePos, ...ChromeRestaurant };
 import { registry } from "@web/core/registry";
-import { delay } from "@odoo/hoot-dom";
+import { delay } from "@web/core/utils/concurrency";
 
 registry.category("web_tour.tours").add("ControlButtonsTour", {
     steps: () =>

--- a/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
@@ -1,4 +1,4 @@
-import { delay } from "@odoo/hoot-dom";
+import { delay } from "@web/core/utils/concurrency";
 
 export function selectLocation(locationName) {
     return {

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -1,4 +1,4 @@
-import { delay } from "@odoo/hoot-dom";
+import { delay } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
@@ -244,7 +244,10 @@ registry.category("web_tour.tours").add("portal_project_sharing_chatter_mention_
         {
             trigger: "body:not(:has(.o-mail-Composer-suggestion))",
             run: async () => {
-                await delay(odoo.loader.modules.get("@mail/core/common/suggestion_hook").DELAY_FETCH);
+                const delay_fetch = odoo.loader.modules.get(
+                    "@mail/core/common/suggestion_hook"
+                ).DELAY_FETCH;
+                await delay(delay_fetch);
             },
         },
         { trigger: ".o-mail-Composer-input", run: "edit @Georges" },

--- a/addons/survey/static/tests/tours/certification_failure.js
+++ b/addons/survey/static/tests/tours/certification_failure.js
@@ -1,4 +1,3 @@
-import { queryAll, queryOne } from "@odoo/hoot-dom";
 import { patch } from "@web/core/utils/patch";
 
 /**
@@ -183,19 +182,11 @@ const retrySteps = [
     },
 ];
 
-const lastSteps = [
-    {
-        trigger: 'h1:contains("You scored")',
-        run: function () {
-            if (queryAll('a:contains("Retry")').length === 0) {
-                queryOne('h1:contains("You scored")').classList.add("tour_success");
-            }
-        },
-    },
-    {
-        trigger: "h1.tour_success",
-    },
-];
+var lastSteps = [{
+    trigger: 'h1:contains("You scored")',
+}, {
+    trigger: 'body:not(:has(a:contains("Retry")))',
+}];
 
 registry.category("web_tour.tours").add("test_certification_failure", {
     url: "/survey/start/4ead4bc8-b8f2-4760-a682-1fde8daaaaac",

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -1,4 +1,3 @@
-import { delay } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("configurator_flow", {
@@ -126,10 +125,6 @@ registry.category("web_tour.tours").add("configurator_flow", {
         })),
         {
             trigger: ":iframe h1:contains(your journey starts here)",
-            async run() {
-                //Wait assets are loaded
-                await delay(1000);
-            },
         },
     ],
 });

--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -1,4 +1,3 @@
-import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_favorite_management", {
@@ -111,14 +110,14 @@ registry.category("web_tour.tours").add("test_favorite_management", {
         },
         {
             trigger: ".o_favorite_menu .o-dropdown-item:contains(Apps2)",
-            run() {
-                if (queryAll(".o_searchview_facet").length) {
-                    throw new Error("There should not be any facet inside the search bar");
-                }
-                if (queryAll(".o_favorite_menu .o-dropdown-item:contains(Apps1)").length) {
-                    throw new Error("The Apps1 filter should be deleted");
-                }
-            },
+        },
+        {
+            content: "There should not be any facet inside the search bar",
+            trigger: "body:not(:has(.o_searchview_facet))",
+        },
+        {
+            content: "The Apps1 filter should be deleted",
+            trigger: "body:not(:has(.o_favorite_menu .o-dropdown-item:contains(Apps1)))",
         },
     ],
 });

--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 import { WORKER_STATE } from "@bus/workers/websocket_worker";
 import { whenReady } from "@odoo/owl";
-import { animationFrame } from "@odoo/hoot-dom";
 
 function logout() {
     return [
@@ -9,7 +8,7 @@ function logout() {
             trigger: ".o_web_client .o_navbar",
             async run() {
                 await whenReady();
-                await animationFrame();
+                await new Promise((resolve) => requestAnimationFrame(resolve));
                 await new Promise((resolve) => {
                     const bus = odoo.__WOWL_DEBUG__.root.env.services.bus_service;
                     bus.addEventListener("BUS:CONNECT", resolve, { once: true });

--- a/addons/website/static/tests/tours/carousel.js
+++ b/addons/website/static/tests/tours/carousel.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-import { delay } from "@odoo/hoot-dom";
+import { delay } from "@web/core/utils/concurrency";
 import {
     insertSnippet,
     clickOnSnippet,

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -1,6 +1,5 @@
 /* global ace */
 
-import { delay } from "@odoo/hoot-dom";
 import {clickOnSave, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 const adminCssModif = '#wrap {display: none;}';
@@ -218,10 +217,6 @@ registerWebsitePreviewTour('test_html_editor_scss', {
         },
         {
             trigger: "nav img[src]:not([src=''])",
-            async run() {
-                //Avoid Error received after termination
-                await delay(5000);
-            },
         },
     ]
 );

--- a/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
+++ b/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
@@ -1,4 +1,4 @@
-import { delay } from "@odoo/hoot-dom";
+import { delay } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 import { WORKER_STATE } from "@bus/services/worker_service";
 

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -1,4 +1,4 @@
-import { delay } from "@odoo/hoot-dom";
+import { delay } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 
 /**


### PR DESCRIPTION
In this commit, we prefer to use :
- trigger instead of assertions in run function. Tour engine wait for trigger in DOM while run fires directly when trigger is found. Then if trigger is too much obvious (like 'body') run is fired ... and assertions can occur too fast.
- delay from currency, not hoot.
- animation frame from native, not hoot.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
