### PR TITLE
[FIX] mail: composition mode doesn't send message on ENTER

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -522,7 +522,7 @@ export class Composer extends Component {
                     ev.preventDefault();
                     return;
                 }
-                if (this.isMobileOS) {
+                if (this.isMobileOS || ev.isComposing) {
                     return;
                 }
                 const shouldPost = this.env.inChatter ? ev.ctrlKey : !ev.shiftKey;

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -33,7 +33,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { Composer } from "@mail/core/common/composer";
-import { press, queryFirst } from "@odoo/hoot-dom";
+import { edit, press, queryFirst } from "@odoo/hoot-dom";
 import { browser } from "@web/core/browser/browser";
 
 describe.current.tags("desktop");
@@ -467,9 +467,15 @@ test('post message on channel with "Enter" keyboard shortcut', async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "Test");
+    await focus(".o-mail-Composer-input");
+    await edit("Test");
     await contains(".o-mail-Message", { count: 0 });
-    triggerHotkey("Enter");
+    await press("Enter");
+    await contains(".o-mail-Message");
+    // check composition mode doesn't send message
+    await edit("test", { composition: true });
+    await press("Enter", { isComposing: true });
+    await animationFrame();
     await contains(".o-mail-Message");
 });
 


### PR DESCRIPTION
Before this commit, pressing ENTER to pick a composition suggestion from IME in a discuss channel composer would send a message with the current content of composer.

This is definitely not the intended behavior: it should change the composing text by the IME software but the send on ENTER press should not happen while the text is in composing.

This commit fixes the issue by adding condition for composing text.

Task-5043396