### PR TITLE
[FIX] mail: composition mode doesn't send message on ENTER

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -433,7 +433,7 @@ export class Composer extends Component {
                     ev.preventDefault();
                     return;
                 }
-                if (this.isMobileOS()) {
+                if (this.isMobileOS() || ev.isComposing) {
                     return;
                 }
                 const shouldPost = this.props.mode === "extended" ? ev.ctrlKey : !ev.shiftKey;


### PR DESCRIPTION
Before this commit, pressing ENTER to pick a composition suggestion from IME in a discuss channel composer would send a message with the current content of composer.

This is definitely not the intended behavior: it should change the composing text by the IME software but the send on ENTER press should not happen while the text is in composing.

This commit fixes the issue by adding condition for composing text.

Task-5043396