### PR TITLE
[FIX] payment_mercado_pago: add condition during fetching token

### DIFF
--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -260,7 +260,10 @@ class PaymentProvider(models.Model):
 
         if (
             self.mercado_pago_access_token
-            and fields.Datetime.now() <= self.mercado_pago_access_token_expiry
+            and (
+                not self.mercado_pago_access_token_expiry  # Legacy access token
+                or self.mercado_pago_access_token_expiry >= fields.Datetime.now()
+            )
         ):
             return self.mercado_pago_access_token
         else:


### PR DESCRIPTION
If user is connected with old credentials, it will return access token instead of throwing an error due to lack of
'mercado_pago_access_token_expiry'.
