### PR TITLE
[IMP] account,l10n_in_edi: implement error but retry

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -464,22 +464,54 @@ class AccountMoveSend(models.AbstractModel):
     @api.model
     def _hook_if_errors(self, moves_data, allow_raising=True):
         """ Process errors found so far when generating the documents. """
+        group_by_partner = defaultdict(list)
         for move, move_data in moves_data.items():
             error = move_data['error']
             if allow_raising:
                 raise UserError(self._format_error_text(error))
-
+            group_by_partner[move_data['author_partner_id']].append(move.id)
             move.message_post(body=self._format_error_html(error))
+        self._send_notifications_to_partners(group_by_partner, is_success=False)
 
     @api.model
-    def _hook_if_success(self, moves_data):
+    def _hook_if_success(self, moves_data, from_cron=False):
         """ Process (typically send) successful documents."""
-        to_send_mail = {
-            move: move_data
-            for move, move_data in moves_data.items()
-            if 'email' in move_data['sending_methods'] and self._is_applicable_to_move('email', move, **move_data)
-        }
+        group_by_partner = defaultdict(list)
+        to_send_mail = {}
+        for move, move_data in moves_data.items():
+            if from_cron:
+                group_by_partner[move_data['author_partner_id']].append(move.id)
+            if 'email' in move_data['sending_methods'] and self._is_applicable_to_move('email', move, **move_data):
+                to_send_mail[move] = move_data
         self._send_mails(to_send_mail)
+        self._send_notifications_to_partners(group_by_partner)
+
+    @api.model
+    def _send_notifications_to_partners(self, moves_grouped_by_author_partner_id, is_success=True):
+        if not moves_grouped_by_author_partner_id:
+            return
+
+        def get_account_notification(move_ids, is_success: bool):
+            _ = self.env._
+            return [
+                'account_notification',
+                {
+                    'type': 'success' if is_success else 'warning',
+                    'title': _("Invoices sent") if is_success else _("Invoices in error"),
+                    'message': _("Invoices sent successfully.") if is_success else _(
+                        "One or more invoices couldn't be processed."),
+                    'action_button': {
+                        'name': _('Open'),
+                        'action_name': _("Sent invoices") if is_success else _("Invoices in error"),
+                        'model': 'account.move',
+                        'res_ids': move_ids,
+                    },
+                },
+            ]
+        ResPartner = self.env['res.partner']
+        for partner_id, move_ids in moves_grouped_by_author_partner_id.items():
+            partner = ResPartner.browse(partner_id)
+            partner._bus_send(*get_account_notification(move_ids, is_success))
 
     @api.model
     def _send_mail(self, move, mail_template, **kwargs):
@@ -772,15 +804,13 @@ class AccountMoveSend(models.AbstractModel):
         # Successfully generated a PDF - Process sending.
         success = {move: move_data for move, move_data in moves_data.items() if not move_data.get('error')}
         if success:
-            self._hook_if_success(success)
-
+            self._hook_if_success(success, from_cron=from_cron)
         # Update sending data of moves
         for move, move_data in moves_data.items():
-            if from_cron and move_data.get('error'):
-                move.sending_data = {'error': True}
-            else:
-                move.sending_data = False
-
+            # We keep the sending_data, so it will be retried
+            if from_cron and move_data.get('error', {}).get('retry'):
+                continue
+            move.sending_data = False
         # Return generated attachments.
         attachments = self.env['ir.attachment']
         for move, move_data in success.items():

--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -332,31 +332,25 @@ class AccountMoveSend(models.AbstractModel):
 
     @api.model
     def _format_error_text(self, error):
-        """ Format the error that can be either a dict (complex format needed) or a string (simple format) into a
-        regular string.
+        """ Format the error that can be a dict (complex format needed)
 
         :param error: the error to format.
         :return: a text formatted error.
         """
-        if isinstance(error, dict):
-            errors = '\n- '.join(error['errors'])
-            return f"{error['error_title']}\n- {errors}" if errors else error['error_title']
-        else:
-            return error
+        errors = '\n- '.join(error.get('errors', ''))
+        return f"{error['error_title']}\n- {errors}" if errors else error['error_title']
 
     @api.model
     def _format_error_html(self, error):
-        """ Format the error that can be either a dict (complex format needed) or a string (simple format) into a
-        valid html format.
+        """ Format the error that can be a dict (complex format needed)
 
         :param error: the error to format.
         :return: a html formatted error.
         """
-        if isinstance(error, dict):
-            errors = Markup().join(Markup("<li>%s</li>") % error for error in error['errors'])
-            return Markup("%s<ul>%s</ul>") % (error['error_title'], errors)
-        else:
-            return error
+        if 'errors' not in error:
+            return error['error_title']
+        errors = Markup().join(Markup("<li>%s</li>") % error for error in error['errors'])
+        return Markup("%s<ul>%s</ul>") % (error['error_title'], errors)
 
     # -------------------------------------------------------------------------
     # SENDING METHODS

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -881,7 +881,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
 
         def call_web_service_after_invoice_pdf_render(record, invoices_data):
             for invoice_data in invoices_data.values():
-                invoice_data['error'] = "turlututu"
+                invoice_data['error'] = {'error_title': "turlututu"}
 
         with patch(
                 'odoo.addons.account.models.account_move_send.AccountMoveSend._call_web_service_after_invoice_pdf_render',
@@ -902,7 +902,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         wizard = self.create_send_and_print(invoice, sending_methods=['email'])
 
         def _hook_invoice_document_before_pdf_report_render(self, invoice, invoice_data):
-            invoice_data['error'] = 'test_proforma_pdf'
+            invoice_data['error'] = {'error_title': 'test_proforma_pdf'}
 
         # Process.
         with patch(
@@ -923,7 +923,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         wizard = self.create_send_and_print(invoice, sending_methods=['email'])
 
         def _hook_invoice_document_before_pdf_report_render(self, invoice, invoice_data):
-            invoice_data['error'] = 'prout'
+            invoice_data['error'] = {'error_title': 'prout'}
             invoice_data['error_but_continue'] = True
 
         # Process.
@@ -986,7 +986,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
 
         def _call_web_service_after_invoice_pdf_render(self, invoices_data):
             for move_data in invoices_data.values():
-                move_data['error'] = 'service_failed_after'
+                move_data['error'] = {'error_title': 'service_failed_after'}
 
         # Process.
         with patch(
@@ -1008,7 +1008,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
 
         def _call_web_service_before_invoice_pdf_render(self, invoices_data):
             for move_data in invoices_data.values():
-                move_data['error'] = 'service_failed_before'
+                move_data['error'] = {'error_title': 'service_failed_before'}
 
         # Process.
         with patch(
@@ -1065,7 +1065,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
 
         def _hook_invoice_document_before_pdf_report_render(self, invoice, invoice_data):
             if invoice.id in invoices_error.ids:
-                invoice_data['error'] = 'blblblbl'
+                invoice_data['error'] = {'error_title': 'blblblbl'}
 
         self.assertTrue(all(invoice.sending_data for invoice in invoices_success + invoices_error))
         self.assertTrue(all(invoice.sending_data.get('author_partner_id') == sp_partner_1.id for invoice in invoices_success))

--- a/addons/l10n_in_edi/models/account_move_send.py
+++ b/addons/l10n_in_edi/models/account_move_send.py
@@ -56,7 +56,8 @@ class AccountMoveSend(models.AbstractModel):
                         'error_title': self.env._(
                             "Error when sending the invoice to government:"
                         ),
-                        'errors': [error] if not isinstance(error, list) else error,
+                        'errors': error['messages'],
+                        'retry': error.get('is_warning'),
                     }
                 elif invoice.invoice_pdf_report_id:
                     invoice.write({'invoice_pdf_report_file': False})

--- a/addons/l10n_ke_edi_tremol/models/account_move_send.py
+++ b/addons/l10n_ke_edi_tremol/models/account_move_send.py
@@ -38,6 +38,8 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS account
         super()._hook_invoice_document_before_pdf_report_render(invoice, invoice_data)
         if invoice.country_code == 'KE' and not invoice._l10n_ke_fiscal_device_details_filled():
-            invoice_data['error'] = _(
-                "This document does not have details related to the fiscal device, a proforma invoice will be used."
-            )
+            invoice_data['error'] = {
+                'error_title': _(
+                    "This document does not have details related to the fiscal device, a proforma invoice will be used."
+                )
+            }

--- a/addons/l10n_ro_edi/models/account_move_send.py
+++ b/addons/l10n_ro_edi/models/account_move_send.py
@@ -55,7 +55,9 @@ class AccountMoveSend(models.AbstractModel):
 
                 if invoice.l10n_ro_edi_document_ids:
                     # If a document is on the invoice, we shouldn't send it again
-                    invoice_data['error'] = _("The CIUS-RO E-Factura has already been sent")
+                    invoice_data['error'] = {
+                        'error_title': _("The CIUS-RO E-Factura has already been sent"),
+                    }
                     continue
 
                 if invoice_data.get('ubl_cii_xml_attachment_values'):
@@ -63,7 +65,9 @@ class AccountMoveSend(models.AbstractModel):
                 elif invoice.ubl_cii_xml_id:
                     xml_data = invoice.ubl_cii_xml_id.raw
                 else:
-                    invoice_data['error'] = _("The CIUS-RO E-Factura could not be found")
+                    invoice_data['error'] = {
+                        'error_title': _("The CIUS-RO E-Factura could not be found"),
+                    }
                     continue
 
                 if errors := invoice._l10n_ro_edi_send_invoice(xml_data):

--- a/addons/snailmail_account/models/account_move_send.py
+++ b/addons/snailmail_account/models/account_move_send.py
@@ -48,10 +48,8 @@ class AccountMoveSend(models.AbstractModel):
         else:
             return super()._is_applicable_to_move(method, move, **move_data)
 
-    def _hook_if_success(self, moves_data):
+    def _hook_if_success(self, moves_data, from_cron=False):
         # EXTENDS 'account'
-        super()._hook_if_success(moves_data)
-
         to_send = {
             move: move_data
             for move, move_data in moves_data.items()
@@ -66,3 +64,4 @@ class AccountMoveSend(models.AbstractModel):
                 for move, move_data in to_send.items()
             ])\
             ._snailmail_print(immediate=False)
+        super()._hook_if_success(moves_data, from_cron)


### PR DESCRIPTION
In this commit, we implement the retrying in of moves
in case of a particular error by implementing, a key
in sending_data i.e. `error_but_retry`

As an additional improvement, we move the send notification
part to from `account.move` to `account.move.send` as it
should be `_generate_and_send_invoices` not outside of it

Enterprise- https://github.com/odoo/enterprise/pull/95366

task-5040124

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
