### PR TITLE
[REV] pos_restaurant: revert updating payment line when tipping after

### DIFF
--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -60,17 +60,3 @@ class PosOrder(models.Model):
         if self.table_id:
             self.send_table_count_notification(self.table_id)
         return result
-
-    def set_tip(self, tip_amount, payment_line_id):
-        """Update tip state on `self` and the tip amount on the payment line."""
-
-        self.ensure_one()
-
-        payment_line = self.payment_ids.filtered(lambda line: line.id == payment_line_id)
-        payment_line.write({
-            'amount': payment_line.amount + tip_amount,
-        })
-        self.write({
-            "is_tipped": True,
-            "tip_amount": tip_amount,
-        })

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -76,9 +76,7 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
             TipScreen.percentAmountIs("25%", "0.50"),
             TipScreen.clickPercentTip("20%"),
             TipScreen.inputAmountIs("0.40"),
-            TipScreen.clickSettle(),
-            ReceiptScreen.isShown(),
-            ReceiptScreen.clickNextOrder(),
+            Chrome.clickPlanButton(),
             FloorScreen.isShown(),
             Chrome.clickMenuOption("Orders"),
 

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -265,9 +265,6 @@ class TestFrontend(TestFrontendCommon):
         order_tips.sort()
         self.assertEqual(order_tips, [0.0, 0.4, 1.0, 1.0, 1.5])
 
-        order1 = self.env['pos.order'].search([('pos_reference', 'ilike', '%-0001')], limit=1, order='id desc')
-        self.assertEqual(order1.payment_ids.amount, 2.4)
-
         order4 = self.env['pos.order'].search([('pos_reference', 'ilike', '%-0004')], limit=1, order='id desc')
         self.assertEqual(order4.customer_count, 2)
 


### PR DESCRIPTION
Revert e3c95b9e34388bd059bbe41665ba3d62de0acab5 since it's breaking the flow of tipping after when "Invoice" is checked.

Why it's breaking the flow? Because we are trying to update the payment line of an invoiced order, which is prevented by https://github.com/odoo/odoo/blob/3e05005e56bd5c69251ddf13ec6085ce922d8bd4/addons/point_of_sale/models/pos_payment.py#L62