### PR TITLE
[FIX] hr_holidays: Add back a well-formatted "Extra Hours" section in…

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -502,6 +502,23 @@ class HrEmployee(models.Model):
 
         for employee in employees:
             for leave_type in leave_types:
+                if not leave_type.requires_allocation:
+                    # Ensure that leave types that do not require allocation are
+                    # still stored in the consumed allocation leaves.
+                    # False is the special key used for this type of leave
+                    allocations_leaves_consumed[employee][
+                        leave_type
+                    ][False].update(
+                        {
+                            "max_leaves": 0,
+                            "accrual_bonus": 0,
+                            "virtual_remaining_leaves": 0,
+                            "remaining_leaves": 0,
+                            "leaves_taken": 0,
+                            "virtual_leaves_taken": 0,
+                        }
+                    )
+
                 allocations_with_date_to = self.env['hr.leave.allocation']
                 allocations_without_date_to = self.env['hr.leave.allocation']
                 for leave_allocation in allocations_per_employee_type[employee][leave_type]:
@@ -578,9 +595,9 @@ class HrEmployee(models.Model):
                         else:
                             allocated_time = leave.number_of_days
                         leave_type_data[False]['virtual_leaves_taken'] += allocated_time
-                        leave_type_data[False]['virtual_remaining_leaves'] = 0
-                        leave_type_data[False]['remaining_leaves'] = 0
+                        leave_type_data[False]['virtual_remaining_leaves'] -= allocated_time
                         if leave.state == 'validate':
+                            leave_type_data[False]['remaining_leaves'] -= allocated_time
                             leave_type_data[False]['leaves_taken'] += allocated_time
         for employee in to_recheck_leaves_per_leave_type:
             for leave_type in to_recheck_leaves_per_leave_type[employee]:

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -108,6 +108,24 @@ export class TimeOffCard extends Component {
         onWillRender(this.updateWarning);
     }
 
+
+    // e.g.: Input: 9.5 Output: 9:30
+    formatHour(hoursFloat) {
+        const hours = Math.floor(hoursFloat);
+        const minutes = Math.round((hoursFloat - hours) * 60);
+        // Pad minutes with leading zero if needed
+        const formattedMinutes = minutes < 10 ? `0${minutes}` : minutes;
+        return `${hours}:${formattedMinutes}`;
+    }
+
+    formatDuration(duration) {
+        if (this.props.data.request_unit === 'hour') {
+            return this.formatHour(duration);
+        }
+        return formatNumber(this.lang, duration);
+    }
+
+
     updateWarning() {
         const { data } = this.props;
         const errorLeavesSignificant = data.allows_negative

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -3,7 +3,7 @@
     <div t-name="hr_holidays.TimeOffCard" class="o_timeoff_card py-3 text-primary">
         <t t-set="data" t-value="props.data"/>
         <t t-set="duration" t-value="props.requires_allocation ? data.virtual_remaining_leaves : data.virtual_leaves_taken"/>
-        <t t-set="parsed_duration" t-value="formatNumber(this.lang, duration)"/>
+        <t t-set="parsed_duration" t-value="formatDuration(duration)"/>
         <t t-set="show_popover" t-value="true"/>
 
         <strong class="o_timeoff_name cursor-pointer btn-link" t-on-click="navigateTimeOffType"><t t-esc="props.name"/></strong>

--- a/addons/hr_holidays/static/tests/dashboard_card_hour_format.test.js
+++ b/addons/hr_holidays/static/tests/dashboard_card_hour_format.test.js
@@ -1,0 +1,67 @@
+import { expect, test, describe } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers"
+import { TimeOffCard } from "@hr_holidays/dashboard/time_off_card"
+import { defineHrHolidaysModels } from "./hr_holidays_test_helpers";
+
+function getHourProps(floatHour) {
+	return {
+		name: "Extra Hours",
+		data: {
+			accrual_bonus: 0,
+			allows_negative: false,
+			closest_allocation_duration: false,
+			closest_allocation_expire: false,
+			closest_allocation_remaining: 0,
+			employee_company: 1,
+			exceeding_duration: 0,
+			holds_changes: false,
+			icon: "/hr_holidays/static/src/img/icons/Compensatory_Time_Off.svg",
+			leaves_approved: 0,
+			leaves_requested: 0,
+			leaves_taken: 0,
+			max_allowed_negative: 0,
+			overtime_deductible: true,
+			request_unit: "hour",
+			total_virtual_excess: 0,
+			virtual_excess_data: {},
+			max_leaves: floatHour,
+			remaining_leaves: floatHour,
+			virtual_remaining_leaves: floatHour,
+			virtual_leaves_taken: floatHour,
+		},
+		requires_allocation: false,
+		holidayStatusId: 6,
+		employeeId: null,
+	}
+}
+
+defineHrHolidaysModels();
+
+describe('Test if card of "hour" unit is well formatted in TimeOffCard', () => {
+	test("Basic hour format", async () => {
+		// floatHour can be between 0 and +infinity
+		const floatHour = 13 + 56 / 60;
+		const props = getHourProps(floatHour)
+		await mountWithCleanup(TimeOffCard, { props });
+		await animationFrame();
+		expect("span.o_timeoff_duration span").toHaveText("13:56");
+	});
+
+	test("Hour with need of zero padding", async () => {
+		const floatHour = 1 + 5 / 60;
+		const props = getHourProps(floatHour)
+		await mountWithCleanup(TimeOffCard, { props });
+		await animationFrame();
+		// no need for zeroes for hour since the hour can be any positive number
+		expect("span.o_timeoff_duration span").toHaveText("1:05");
+	});
+
+	test("Hour of value 0", async () => {
+		const floatHour = 0 + 0 / 60;
+		const props = getHourProps(floatHour)
+		await mountWithCleanup(TimeOffCard, { props });
+		await animationFrame();
+		expect("span.o_timeoff_duration span").toHaveText("0:00");
+	});
+});

--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -39,9 +39,12 @@ class HrLeaveType(models.Model):
             ('requires_allocation', '=', False)])
         leave_type_names = deductible_time_off_types.mapped('name')
         for employee in res:
+            total_overtime = employee.sudo().total_overtime
             for leave_data in res[employee]:
                 if leave_data[0] in leave_type_names:
-                    leave_data[1]['virtual_remaining_leaves'] = employee.sudo().total_overtime
+                    leave_data[1]['virtual_remaining_leaves'] = total_overtime
+                    leave_data[1]['max_leaves'] += total_overtime
+                    leave_data[1]['remaining_leaves'] += total_overtime
                     leave_data[1]['overtime_deductible'] = True
                 else:
                     leave_data[1]['overtime_deductible'] = False


### PR DESCRIPTION
… the Time Off dashboard

Any card on the Time Off dashboard that had on hourly value did not have the correct format (e.g.: 9.5 instead of 9:30).
This commit fixes that so that there is no more confusion about the hour (e.g.: thinking 9.17 is 9 hours and 17 minutes).

To add the possibility to show the Extra Hours section on the dashboard, I had to change the filtering logic of leave_types in the API to make it only depend on:
- Hide in dashboard
- max_leaves Since those are related, it would be more intuitive to have *"Hide in Dashboard"* automatically change according to overtime_deductible and `requires_allocation`. But we still let the user change it if they need to override this behavior. Thus the computed field is stored.

Some leave types, that are deductible and do not require allocation were not displayed on the dashboard when we wanted it to. Since the filter of leave types for the dashboard was done inside `get_allocation_data()`, it was difficult to get what we wanted (here, the *extra hours*) on the dashboard.

I thus had to move that filtering logic out of that function, in `get_allocation_data_request()`, so that overriding and adding the overtime in `get_allocation_data()` is possible.

task-5026228




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
