### PR TITLE
[FIX] website: show highlight tool as active in toolbar

### DIFF
--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -256,7 +256,7 @@ class HighlightToolbarButton extends Component {
         getSelection: Function,
     };
     static template = xml`
-        <button t-ref="root" t-attf-class="btn btn-light o-select-highlight" t-on-click="openHighlightConfigurator" t-att-title="props.title">
+        <button t-ref="root" t-attf-class="btn btn-light o-select-highlight {{highlightState.highlightId ? 'active' : ''}}" t-on-click="openHighlightConfigurator" t-att-title="props.title">
             <i class="fa oi oi-text-effect oi-fw py-1"/>
         </button>
     `;

--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -107,6 +107,7 @@ test("Can remove an highlight with the trash button", async () => {
     );
     await expandToolbar();
     expect(".o-select-highlight").toHaveCount(1);
+    expect(".o-select-highlight").toHaveClass("active");
     expect(".o_text_highlight").toHaveCount(1);
     await click(".o-we-toolbar .o-select-highlight");
     await waitFor("button[title='Reset']");


### PR DESCRIPTION
With the initial [website builder refactor], the highlight tool did not show when it is active or not. This commit adds the `active` class on the button when it is.

Steps to reproduce:
- Open website builder
- Select some text
- Add a highlight
- Select the same text again (and expand the toolbar again)
- Bug: the highlight tool is not shown as active

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
