### PR TITLE
[IMP] mail: add SHIFT+M hotkey to toggle open/close of messaging menu

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -6,6 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { MessagingMenuQuickSearch } from "@mail/core/web/messaging_menu_quick_search";
+import { useCommand } from "@web/core/commands/command_hook";
 
 Object.assign(MessagingMenu.components, { MessagingMenuQuickSearch });
 
@@ -19,6 +20,11 @@ patch(MessagingMenu.prototype, {
             searchOpen: false,
         });
 
+        useCommand(
+            _t("Toggle Messaging Menu"),
+            () => (this.dropdown.isOpen ? this.dropdown.close() : this.dropdown.open()),
+            { hotkey: "Alt+Shift+M" }
+        );
         onExternalClick("selector", () => Object.assign(this.state, { adding: false }));
         useEffect(
             () => {

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//*[@t-name='mail.MessagingMenu']" position="inside">
             <div t-if="!env.inDiscussApp" t-att-class="discussSystray.class">
                 <Dropdown state="dropdown" beforeOpen.bind="beforeOpen" position="'bottom-end'" menuClass="discussSystray.menuClass" bottomSheet="false">
-                    <button class="bg-transparent">
+                    <button class="bg-transparent" data-hotkey="Shift+M">
                         <i class="fa fa-lg fa-comments" role="img" aria-label="Messages" t-on-click="() => store.discuss.activeTab = ui.isSmall and store.discuss.activeTab === 'notification' ? 'notification' : store.discuss.activeTab"></i>
                         <span t-if="counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>
                     </button>


### PR DESCRIPTION
In a formidable fight against VOIP team, Discuss team also adds a hotkey to quickly toggle the opening of messaging menu by means of ALT+SHIFT+M.