### PR TITLE
[FIX] website: adapt highlight svg when span is moved to another parent

### DIFF
--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -46,7 +46,6 @@ export class HighlightPlugin extends Plugin {
         normalize_handlers: (root) => {
             for (const node of root.querySelectorAll(".o_text_highlight")) {
                 // Signal to the interaction that there is (maybe) a new element
-                // (the interaction will ignore duplicates)
                 node.dispatchEvent(new Event("text_highlight_added", { bubbles: true }));
             }
         },

--- a/addons/website/static/src/interactions/text_highlights.js
+++ b/addons/website/static/src/interactions/text_highlights.js
@@ -86,9 +86,6 @@ export class TextHighlight extends Interaction {
      * @param {HTMLElement} el
      */
     handleEl(el) {
-        if (this.observed.has(el)) {
-            return;
-        }
         this.observed.add(el);
         // The `ResizeObserver` cannot detect the width change on highlight
         // units (`.o_text_highlight_item`) as long as the width of the entire


### PR DESCRIPTION
With the [website builder refactor], the highlight did not resize when user changes the font block type in a parent of a highlighted span. This happens because the parent node is removed to do the replacement of tag, which does not triggers the observers of the interaction.

This commit fixes it by removing the optimization that if an element is observed, then it can be ignored during a normalize. Indeed, when a highlight is added on a node, the observers of the interaction do not only track the node itself, but also some other nodes. When the highlighted span is moved between different parents, the set of nodes that should be observed changes (and some observations may have been lost)

Steps to reproduce:
- Open website builder
- Drop a block with a title (for example, "Cover")
- Add a highlight inside the title
- Change the font (for example from "Header 1" to "Header 5")
- Bug: the highlight svg does not resize to follow the highlight span

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
