### PR TITLE
[FIX] hr_holidays: prevent multi-day display of single-day leaves

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1144,13 +1144,18 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             else:
                 meeting_name = _("%s on Time Off : %.2f day(s)") % (holiday.employee_id.name or holiday.category_id.name, holiday.number_of_days)
                 allday_value = not holiday.request_unit_half
+
+            leave_tz = timezone(holiday.tz) if holiday.tz else UTC
+            start_value = UTC.localize(holiday.date_from).astimezone(leave_tz).replace(tzinfo=None)
+            stop_value = UTC.localize(holiday.date_to).astimezone(leave_tz).replace(tzinfo=None)
+
             meeting_values = {
                 'name': meeting_name,
                 'duration': holiday.number_of_days * (holiday.resource_calendar_id.hours_per_day or HOURS_PER_DAY),
                 'description': holiday.notes,
                 'user_id': user.id,
-                'start': holiday.date_from,
-                'stop': holiday.date_to,
+                'start': start_value,
+                'stop': stop_value,
                 'allday': allday_value,
                 'privacy': 'confidential',
                 'event_tz': user.tz,

--- a/addons/hr_holidays/tests/test_holidays_calendar.py
+++ b/addons/hr_holidays/tests/test_holidays_calendar.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import date, timedelta
+from datetime import date, datetime, time, timedelta
 
 from odoo.addons.base.tests.common import HttpCase
 from odoo.tests.common import tagged
@@ -40,3 +40,62 @@ class TestHolidaysCalendar(HttpCase, TestHrHolidaysCommon):
         self.assertEqual(last_leave.date_from.weekday(), 3, "It should be Thursday")
         self.assertEqual(last_leave.date_from.hour, expected_leave_start, "Wrong start of the day")
         self.assertEqual(last_leave.date_to.hour, expected_leave_end, "Wrong end of the day")
+
+    def test_timezone_calendar_event_single_day(self):
+        """
+        Test that single-day time off requests have a single day display in calendar
+        """
+
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Test Leave Type',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'no_validation',
+            'create_calendar_meeting': True,
+        })
+
+        # case 1: full day in Los/Angeles tz
+
+        test_date = date(2025, 4, 22)
+        self.employee_emp.user_id.tz = 'America/Los_Angeles'
+        self.employee_emp.resource_calendar_id.tz = 'America/Los_Angeles'
+        leave = self.env['hr.leave'].create({
+            'name': 'Single Day Leave',
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': test_date,
+            'request_date_to': test_date,
+            'request_unit_half': False,
+        })
+
+        leave.action_validate()
+
+        expected_fd_start = datetime.combine(test_date, time(8, 0))
+        expected_fd_stop = datetime.combine(test_date, time(17, 0))
+        self.assertEqual(leave.meeting_id.start, expected_fd_start,
+                        f"Meeting start date should be {expected_fd_start}")
+        self.assertEqual(leave.meeting_id.stop, expected_fd_stop,
+                        f"Meeting end date should be {expected_fd_stop}")
+
+        # case 2: half day in Los/Angeles tz
+
+        test_date_half = date(2025, 4, 23)
+
+        leave_half = self.env['hr.leave'].create({
+            'name': 'Half Day Leave LA',
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': test_date_half,
+            'request_date_to': test_date_half,
+            'request_unit_half': True,
+            'request_date_from_period': 'pm',
+        })
+
+        leave_half.action_validate()
+
+        expected_hd_start = datetime.combine(test_date_half, time(13, 0))
+        expected_hd_stop = datetime.combine(test_date_half, time(17, 0))
+
+        self.assertEqual(leave_half.meeting_id.start, expected_hd_start,
+                        f"Half-day meeting start date should be {expected_hd_start}")
+        self.assertEqual(leave_half.meeting_id.stop, expected_hd_stop,
+                        f"Half-day meeting end date should be {expected_hd_stop}")


### PR DESCRIPTION
**Issue:**

Single-day time off requests appear as multi-day events in the Calendar app when using certain tim>

**Cause:**

The `_compute_date_from_to()` method converts user-specified dates to UTC. https://github.com/odoo/odoo/blob/028e7228cb830e47a9726bef4c82793ba4590cd5/addons/hr_holidays/models/hr_leave.py#L316-L317
 The `_prepare_holidays_meeting_values()` method then uses these UTC datetime values (`holiday.date_from`, `holiday.date_to`)

In Los Angeles timezone, and for a one day leave on september 17 2025 this leads to:

- holiday.date_from: September 17, 2025 at 03:00 UTC
- holiday.date_to: September 18, 2025 at 12:00 UTC

causing a single-day leave to be displayed as a two-day event.

**After fix:**

- start_value: September 17, 2025 at 12:00
- stop_value: September 17, 2025 at 11:59

**Steps to Reproduce:**

1. Set the user timezone to "America/Los_Angeles"
2. Set the browser timezone to the same timezone
3. Create a one-day time off request (e.g., September 17, 2025)
4. Open the Calendar app: the event spans across two days

opw-4744817
