### PR TITLE
[FIX] mail: smaller livechat status in discuss sidebar

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_category_patch.xml
@@ -12,6 +12,7 @@
         <t t-set="btn" t-value="templateParams.btn"/>
         <t t-set="inThreadActions" t-value="templateParams.inThreadActions"/>
         <span class="o-livechat-LivechatStatusLabel fa fa-stack" t-att-title="btn.label" t-att-class="{
+            'o-xsmaller': !env.inLivechatInfoPanel,
             'ms-n1': inThreadActions,
             'o-warning': btn.status === 'waiting',
             'o-info': btn.status === 'need_help',
@@ -31,6 +32,7 @@
 
     <t t-name="im_livechat.LivechatStatusLabelOfThread">
         <span t-if="livechatThread.channel_type === 'livechat' and (['waiting', 'need_help'].includes(livechatThread.livechat_status) or livechatThread.livechat_end_dt)" class="o-livechat-LivechatStatusLabel fa fa-stack" t-att-title="livechatThread.livechatStatusLabel" t-att-class="{
+            'o-xsmaller': !env.inLivechatInfoPanel,
             'position-absolute top-0 start-0 z-1': env.inDiscussSidebar or env.inChatBubble,
             'm-n1': env.inDiscussSidebar,
             'm-n2': env.inChatBubble,

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -3,7 +3,7 @@ import { TranscriptSender } from "@im_livechat/core/common/transcript_sender";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { prettifyMessageContent } from "@mail/utils/common/format";
 
-import { Component, useEffect } from "@odoo/owl";
+import { Component, useEffect, useSubEnv } from "@odoo/owl";
 
 import { rpc } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
@@ -20,6 +20,7 @@ export class LivechatChannelInfoList extends Component {
         super.setup();
         this.store = useService("mail.store");
         this.ui = useService("ui");
+        useSubEnv({ inLivechatInfoPanel: true });
         useEffect(
             () => {
                 if (this.props.thread.hasFetchedLivechatSessionData) {

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -58,7 +58,7 @@ registerThreadAction("livechat-status", {
         };
     },
     name: (component) => component.thread.livechatStatusLabel,
-    nameClass: "fst-italic small mx-2",
+    nameClass: "fst-italic small",
     sequence: (component) => (component.isDiscussSidebarChannelActions ? 10 : 5),
     sequenceGroup: (component) => (component.isDiscussSidebarChannelActions ? 5 : 7),
     toggle: true,


### PR DESCRIPTION
Recent change reduced size of avatar and spacing in discuss sidebar. As a consequence, other UI elements had to be adapted, usually by shrinking their size.

The livechat status was not considered and looked to big, which this commit solves. The `LivechatStatusLabelOfThread` in all context a single icon is shown on the thread, whether in discuss sidebar, discuss sidebar actions, chat bubbles, chat window header. All of them appreciate a smaller icon for the livechat status.

Before
<img width="960" height="438" alt="before" src="https://github.com/user-attachments/assets/36c6f526-101d-4a0f-9b8e-79046f3d9ba4" />

After
<img width="958" height="439" alt="after" src="https://github.com/user-attachments/assets/d747493c-c58e-4eb0-898c-6375e986c866" />

