### PR TITLE
[FIX] pos_self_order: remove category-list class

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -4,7 +4,7 @@
         <div class="d-flex flex-column vh-100 overflow-hidden">
             <!-- Categories selector + Search -->
             <div class="navbar-container position-relative d-flex flex-nowrap w-100 bg-view border-bottom z-index-1">
-                <nav id="listgroup-categories" class="category-list d-flex flex-grow-1 py-2 px-3 gap-2 gap-md-3 overflow-x-auto" t-ref="categoryList">
+                <nav id="listgroup-categories" class="d-flex flex-grow-1 py-2 px-3 gap-2 gap-md-3 overflow-x-auto" t-ref="categoryList">
                     <a
                         t-foreach="Array.from(selfOrder.categoryList)"
                         t-as="category"


### PR DESCRIPTION
Issue:
The class category-list was used but not defined.

Solution:
Removed the class as it does not make any sense.

<img width="1346" height="524" alt="before adding component" src="https://github.com/user-attachments/assets/d965e4e0-2ccf-4798-8640-a93fc50928c5" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
