### PR TITLE
[IMP] account: reduce likelihood of accidental demo data creation

### DIFF
--- a/addons/account/static/src/components/bill_guide/bill_guide.js
+++ b/addons/account/static/src/components/bill_guide/bill_guide.js
@@ -1,5 +1,6 @@
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { DocumentFileUploader } from "../document_file_uploader/document_file_uploader";
 
 import { Component, onWillStart } from "@odoo/owl";
@@ -14,6 +15,7 @@ export class BillGuide extends Component {
     setup() {
         this.orm = useService("orm");
         this.action = useService("action");
+        this.dialog = useService("dialog");
         this.context = null;
         this.alias = null;
         onWillStart(this.onWillStart);
@@ -38,13 +40,23 @@ export class BillGuide extends Component {
         }
     }
 
-    handleButtonClick(action, model="account.journal") {
-        this.action.doActionButton({
-            resModel: model,
-            name: action,
-            context: this.context || this.env.searchModel.context,
-            type: 'object',
+    handleButtonClick(action, model = "account.journal") {
+        // Prevent accidental data pollution with confirmation window
+        this.dialog.add(ConfirmationDialog, {
+            body: "Creating a sample bill will add demo data to your database. Are you sure you wish to proceed?",
+
+            confirm: () => {
+                this.action.doActionButton({
+                    resModel: model,
+                    name: action,
+                    context: this.context || this.env.searchModel.context,
+                    type: 'object',
+                });
+            },
+
+            cancel: () => { },
         });
+
     }
 }
 

--- a/addons/account/static/src/components/bill_guide/bill_guide.xml
+++ b/addons/account/static/src/components/bill_guide/bill_guide.xml
@@ -8,7 +8,7 @@
                 </div>
                 <div class="text-center mt-2">
                     <span class="btn account_drag_drop_btn pe-none">Drag &amp; drop</span>
-                    <div>
+                    <div t-if="!this.env.model">
                         <span class="btn pe-none px-1 fw-normal">or</span>
                         <a class="btn btn-link px-0 fw-normal"
                             href="#"


### PR DESCRIPTION
When accessing the accounting module's dashboard on a new database, the bills widget displays the option to "try our sample" bill, which will create a contact record (Deco Addict), several products and categories, and a vendor bill with this newly created demo data prepopulated. This option to "try our sample" not only exists on the bills widget in the Accounting dashboard on a fresh database, but exists in the bills list view if either there are no bills in the database, or if a search filter
 is applied such that the result set is empty.

The implementation is problematic for two reasons:
1. It is not made clear to the user that several database models will be populated with demo data.
2. The "try our sample" button is presented to users outside of its intended context.

The current implementation does not clearly communicate to the user that they will be creating real demo records in several models on their database, which would obviously pollute a production database. Being that we provide an explicit warning when demo data is enabled for the whole database, a similar confirmation seems appropriate in this case, which has been added. Additionally, it does not seem appropriate that the "try our sample" option should be present in the list view. This is because its intent is to allow the user to try the bill functionality in the case that their database does not have any data. When a user is in the list view, more often than not will users who have applied an invalid search filter on existing data be shown the option, rather than new users on a new database. This can cause accidental addition of demo data. By only presenting the option only in the dashboard widget, it is far more likely that this prompt is shown only in the intended context.

Enterprise PR:
https://github.com/odoo/enterprise/pull/93352
opw-4959767