### PR TITLE
[IMP] mail: have inbox/history only for 'Handle in Odoo' users 

### DIFF
--- a/addons/im_livechat/static/tests/join_livechat_needing_help.test.js
+++ b/addons/im_livechat/static/tests/join_livechat_needing_help.test.js
@@ -6,7 +6,7 @@ import { describe, expect, test } from "@odoo/hoot";
 import { tick } from "@odoo/hoot-dom";
 
 import { Deferred } from "@web/core/utils/concurrency";
-import { Command, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { Command, onRpc, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
 
 defineLivechatModels();
 describe.current.tags("desktop");
@@ -60,6 +60,7 @@ test("Show notification when joining a channel that already received help", asyn
 
 test("Hide 'help already received' notification when channel is not visible", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const bobPartnerId = pyEnv["res.partner"].create({
         name: "bob",
         user_ids: [Command.create({ name: "bob" })],

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -405,6 +405,7 @@ test("Message unread counter", async () => {
 test("unknown livechat can be displayed and interacted with", async () => {
     mockDate("2023-01-03 12:00:00");
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const partnerId = pyEnv["res.partner"].create({ name: "Jane" });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -169,6 +169,8 @@ export class Store extends BaseStore {
                 threads = threads.filter(({ channel_type }) =>
                     this.tabToThreadType("mailbox").includes(channel_type)
                 );
+            } else if (tab === "starred") {
+                threads = [this.starred];
             } else if (tab !== "notification") {
                 threads = threads.filter(({ channel_type }) =>
                     this.tabToThreadType(tab).includes(channel_type)

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -483,14 +483,6 @@ export class Thread extends Component {
         return this.state.showJumpPresent ? threshold - 200 : threshold;
     }
 
-    get preferenceButtonText() {
-        const [, before, inside, after] =
-            _t(
-                "<button>Change your preferences</button> to receive new notifications in your inbox."
-            ).match(/(.*)<button>(.*)<\/button>(.*)/) ?? [];
-        return { before, inside, after };
-    }
-
     updateShowJumpPresent() {
         this.state.showJumpPresent =
             this.visibleState.isVisible &&

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -165,7 +165,10 @@ export class MessagingMenu extends Component {
         ) {
             this.store.inbox.setAsDiscussThread();
         }
-        if (this.store.discuss.activeTab !== "inbox") {
+        if (this.store.discuss.activeTab === "starred") {
+            this.store.starred.setAsDiscussThread();
+        }
+        if (!["inbox", "starred"].includes(this.store.discuss.activeTab)) {
             this.store.discuss.thread = undefined;
         }
     }

--- a/addons/mail/static/src/core/public_web/messaging_menu.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.scss
@@ -14,6 +14,10 @@
     transform: translate(80%, 50%) !important;
 }
 
+.o-mail-MessagingMenu-tabCounter.o-starred {
+    background-color: $gray-400 !important;
+}
+
 .o-discuss-badge.o-mail-MessagingMenu-tabUnread {
     --o-discuss-badge-bg: #{transparent};
     opacity: 50%;

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -8,7 +8,7 @@
 <t t-name="mail.MessagingMenu.content">
     <div t-att-class="`${discussSystray.contentClass} o-mail-MessagingMenu ${ui.isSmall ? 'o-small' : ''}`">
         <t name="before-content"/>
-        <DiscussContent t-if="store.discuss.activeTab === 'inbox' and ui.isSmall"/>
+        <DiscussContent t-if="['inbox', 'starred'].includes(store.discuss.activeTab) and ui.isSmall"/>
         <div t-else="" class="o-mail-MessagingMenu-list d-flex flex-column overflow-auto o-scrollbar-thin flex-grow-1 list-group list-group-flush o-scrollbar-thin" t-ref="notification-list">
             <t t-foreach="threads" name="threads" t-as="thread" t-key="thread.localId">
                 <t t-set="message" t-value="thread.isChatChannel or (thread.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentOfAllMessage : thread.needactionMessages.at(-1)"/>
@@ -66,7 +66,7 @@
         }" t-on-click="() => this.onClickNavTab(tab.id)">
             <i t-attf-class="p-1 fs-2 {{ tab.icon }}" t-att-class="{ 'o-opacity-35': store.discuss.activeTab !== tab.id }"/>
             <span class="smaller text-truncate" t-esc="tab.label" t-att-class="{ 'o-opacity-35': store.discuss.activeTab !== tab.id }"/>
-            <span t-if="tab.counter" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabCounter overflow-visible d-inline-block" t-esc="tab.counter"/>
+            <span t-if="tab.counter" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabCounter overflow-visible d-inline-block" t-att-class="{ 'o-starred': tab.id === 'starred' }" t-esc="tab.counter"/>
             <span t-elif="tab.channelHasUnread" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabUnread overflow-visible d-inline-block ms-2"><i class="fa fa-circle"/></span>
         </button>
     </div>

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -63,7 +63,9 @@ patch(Thread.prototype, {
         this.store.discuss.activeTab = !this.store.env.services.ui.isSmall
             ? "notification"
             : this.model === "mail.box"
-            ? "inbox"
+            ? this.store.self.main_user_id?.notification_type === "inbox"
+                ? "inbox"
+                : "starred"
             : ["chat", "group"].includes(this.channel_type)
             ? "chat"
             : "channel";

--- a/addons/mail/static/src/core/web/discuss_content_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_content_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussContent" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='root']" position="before">
-            <div t-if="ui.isSmall and store.discuss.activeTab === 'inbox'" class="w-100 border-bottom" t-call="mail.DiscussContent.mobileTopbar" t-ref="mobileTopbar"/>
+            <div t-if="ui.isSmall and store.discuss.activeTab === 'inbox' and store.self.main_user_id?.notification_type === 'inbox'" class="w-100 border-bottom" t-call="mail.DiscussContent.mobileTopbar" t-ref="mobileTopbar"/>
         </xpath>
         <xpath expr="//*[@t-ref='main']" position="inside">
             <t t-if="!ui.isSmall" t-call="mail.Discuss.loading"/>

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -3,9 +3,9 @@
 
     <t t-name="mail.DiscussSidebarMailboxes">
         <div class="d-flex flex-column flex-grow-0 o-gap-0_5 bg-inherit">
-            <Mailbox mailbox="store.inbox"/>
+            <Mailbox t-if="store.self.main_user_id?.notification_type === 'inbox'" mailbox="store.inbox"/>
             <Mailbox mailbox="store.starred"/>
-            <Mailbox mailbox="store.history"/>
+            <Mailbox t-if="store.self.main_user_id?.notification_type === 'inbox'" mailbox="store.history"/>
         </div>
     </t>
 

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -100,10 +100,22 @@ patch(MessagingMenu.prototype, {
                 sequence: 10,
             },
             {
-                counter: this.store.inbox.counter,
-                icon: "fa fa-inbox",
-                id: "inbox",
-                label: _t("Inbox"),
+                counter:
+                    this.store.self.main_user_id?.notification_type === "inbox"
+                        ? this.store.inbox.counter
+                        : this.store.starred.counter,
+                icon:
+                    this.store.self.main_user_id?.notification_type === "inbox"
+                        ? "fa fa-inbox"
+                        : "fa fa-star-o",
+                id:
+                    this.store.self.main_user_id?.notification_type === "inbox"
+                        ? "inbox"
+                        : "starred",
+                label:
+                    this.store.self.main_user_id?.notification_type === "inbox"
+                        ? _t("Inbox")
+                        : _t("Starred"),
                 sequence: 100,
             },
             ...super._tabs,

--- a/addons/mail/static/src/core/web/thread_patch.xml
+++ b/addons/mail/static/src/core/web/thread_patch.xml
@@ -4,13 +4,7 @@
         <xpath expr="//*[@name='empty-message']" position="replace">
             <t t-if="props.thread.isEmpty and props.thread.model === 'mail.box'">
                 <t t-if="props.thread.id === 'inbox' and state.mountedAndLoaded">
-                    <div t-if="store.self.main_user_id?.notification_type !== 'inbox'" class="align-items-center text-center">
-                        <h4 class="mb-3 fw-bolder">Your inbox is empty</h4>
-                        <t t-esc="preferenceButtonText.before"/>
-                        <button class="btn btn-link m-0 p-0 align-baseline o-hover-text-underline" t-on-click="onClickPreferences" t-esc="preferenceButtonText.inside"/>
-                        <t t-esc="preferenceButtonText.after"/>
-                    </div>
-                    <div t-else="" class="align-items-center text-center">
+                    <div class="align-items-center text-center">
                         <h4 class="mb-3 fw-bolder">Congratulations, your inbox is empty</h4>
                         New messages appear here.
                     </div>

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
@@ -3,7 +3,7 @@
     <t t-inherit="mail.MessagingMenu.content" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-MessagingMenu-header')]" position="inside">
             <t t-if="ui.isSmall">
-                <DiscussSearch t-if="store.discuss.activeTab !== 'inbox'" class="'w-100 px-2 pb-1'"/>
+                <DiscussSearch t-if="!['inbox', 'starred'].includes(store.discuss.activeTab)" class="'w-100 px-2 pb-1'"/>
             </t>
             <t t-else="">
                 <div class="flex-grow-1"/>

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1155,6 +1155,7 @@ test('can quickly add emoji with ":" keyword', async () => {
 
 test("composer reply-to message is restored on thread change", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const partnerId = pyEnv["res.partner"].create({ name: "Marc Demo" });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -117,6 +117,7 @@ test("new message separator is shown after first mark as read, on receiving new 
 
 test("keep new message separator until user goes back to the thread", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const partnerId = pyEnv["res.partner"].create({ name: "Foreigner partner" });
     const channelId = pyEnv["discuss.channel"].create({
         name: "test",
@@ -340,6 +341,7 @@ test("only show new message separator in its thread", async () => {
     // when a message acts as the reference for displaying new message separator,
     // this should applies only when vieweing the message in its thread.
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const demoPartnerId = pyEnv["res.partner"].create({ name: "Demo" });
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const messageIds = pyEnv["mail.message"].create([

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -166,6 +166,7 @@ test("Message (hard) delete notification", async () => {
     // Note: This isn't a notification from when user click on "Delete message" action:
     // this happens when mail_message server record is effectively deleted (unlink)
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const messageId = pyEnv["mail.message"].create({
         body: "Needaction message",
         model: "res.partner",

--- a/addons/mail/static/tests/discuss/core/web/sidebar.test.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar.test.js
@@ -10,13 +10,14 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
-import { asyncStep, Command, waitForSteps } from "@web/../tests/web_test_helpers";
+import { asyncStep, Command, serverState, waitForSteps } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
 
 test("unknown channel can be displayed and interacted with", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const partnerId = pyEnv["res.partner"].create({ name: "Jane" });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [Command.create({ partner_id: partnerId })],

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -62,7 +62,7 @@ test("sanity check", async () => {
         stepsAfter: ['/mail/inbox/messages - {"fetch_params":{"limit":30}}'],
     });
     await contains(".o-mail-DiscussSidebar");
-    await contains("h4:contains(Your inbox is empty)");
+    await contains("h4:contains('Congratulations, your inbox is empty')");
 });
 
 test.tags("focus required");
@@ -471,6 +471,7 @@ test("Can reply to history message", async () => {
 
 test("receive new needaction messages", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const partnerId = pyEnv["res.partner"].create({ name: "Frodo Baggins" });
     await start();
     await openDiscuss("mail.box_inbox");
@@ -532,6 +533,7 @@ test("receive new needaction messages", async () => {
 
 test("receive a message that is not linked to thread", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const partnerId = pyEnv["res.partner"].create({ name: "Frodo Baggins" });
     await start();
     await openDiscuss("mail.box_inbox");
@@ -572,6 +574,8 @@ test("basic rendering", async () => {
 });
 
 test("basic rendering: sidebar", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebar button", { text: "Inbox" });
@@ -583,6 +587,8 @@ test("basic rendering: sidebar", async () => {
 });
 
 test("sidebar: Inbox should have icon", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     await start();
     await openDiscuss("mail.box_inbox");
     await contains("button", { text: "Inbox", contains: [".fa-inbox"] });
@@ -614,6 +620,8 @@ test("channel deletion fallbacks to no conversation selected", async () => {
 });
 
 test("sidebar: change active", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     await start();
     await openDiscuss("mail.box_inbox");
     await contains("button.o-active", { text: "Inbox" });
@@ -823,6 +831,7 @@ test("Unfollow message", async function () {
 
 test('messages marked as read move to "History" mailbox', async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const channelId = pyEnv["discuss.channel"].create({ name: "other-disco" });
     const [messageId_1, messageId_2] = pyEnv["mail.message"].create([
         {
@@ -856,11 +865,11 @@ test('messages marked as read move to "History" mailbox', async () => {
     await contains(".o-mail-Thread h4", { text: "No history messages" });
     await click("button", { text: "Inbox" });
     await contains("button.o-active", { text: "Inbox" });
-    await contains(".o-mail-Thread h4", { count: 0, text: "Your inbox is empty" });
+    await contains(".o-mail-Thread h4", { count: 0, text: "Congratulations, your inbox is empty" });
     await contains(".o-mail-Thread .o-mail-Message", { count: 2 });
     await click("button", { text: "Mark all read" });
     await contains("button.o-active", { text: "Inbox" });
-    await contains(".o-mail-Thread h4", { text: "Your inbox is empty" });
+    await contains(".o-mail-Thread h4", { text: "Congratulations, your inbox is empty" });
     await click("button", { text: "History" });
     await contains("button.o-active", { text: "History" });
     await contains(".o-mail-Thread h4", { count: 0, text: "No history messages" });
@@ -869,6 +878,7 @@ test('messages marked as read move to "History" mailbox', async () => {
 
 test('mark a single message as read should only move this message to "History" mailbox', async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const [messageId_1, messageId_2] = pyEnv["mail.message"].create([
         {
             body: "not empty 1",
@@ -911,6 +921,7 @@ test('mark a single message as read should only move this message to "History" m
 
 test('all messages in "Inbox" in "History" after marked all as read', async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     for (let i = 0; i < 40; i++) {
         const messageId = pyEnv["mail.message"].create({
             body: "not empty",
@@ -1051,6 +1062,7 @@ test("starred: unstar all", async () => {
 test.tags("focus required");
 test("auto-focus composer on opening thread", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const partnerId = pyEnv["res.partner"].create({ name: "Demo User" });
     pyEnv["discuss.channel"].create([
         { name: "General" },
@@ -1780,6 +1792,8 @@ test("Channel is added to discuss after invitation", async () => {
 });
 
 test("select another mailbox", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss();
@@ -1792,6 +1806,8 @@ test("select another mailbox", async () => {
 });
 
 test('auto-select "Inbox nav bar" when discuss had inbox as active thread', async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     patchUiSize({ size: SIZES.SM });
     await start();
     await openDiscuss();
@@ -1799,7 +1815,7 @@ test('auto-select "Inbox nav bar" when discuss had inbox as active thread', asyn
     await contains(".o-mail-DiscussContent-threadName", { value: "Inbox" });
     await contains(".o-mail-MessagingMenu-navbar button.o-active", { text: "Inbox" });
     await contains("button.active.o-active", { text: "Inbox" });
-    await contains("h4", { text: "Your inbox is empty" });
+    await contains("h4", { text: "Congratulations, your inbox is empty" });
 });
 
 test("composer should be focused automatically after clicking on the send button", async () => {

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -373,6 +373,7 @@ test('subject should not be shown when subject differs from thread name only by 
 
 test("inbox: mark all messages as read", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const [messageId_1, messageId_2] = pyEnv["mail.message"].create([
         {
@@ -617,6 +618,7 @@ test("emptying inbox displays rainbow man in inbox", async () => {
 
 test("emptying inbox doesn't display rainbow man in another thread", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const partnerId = pyEnv["res.partner"].create({});
     const messageId = pyEnv["mail.message"].create({
@@ -647,7 +649,7 @@ test("emptying inbox doesn't display rainbow man in another thread", async () =>
 
 test("Counter should be incremented by 1 when receiving a message with a mention in a channel", async () => {
     const pyEnv = await startServer();
-    pyEnv["res.users"].write([serverState.userId], { notification_type: "inbox" });
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const partnerId = pyEnv["res.partner"].create({ name: "Thread" });
     const partnerUserId = pyEnv["res.partner"].create({ name: "partner1" });

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -36,6 +36,7 @@ defineMailModels();
 
 test("toggling category button hide category items", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     pyEnv["discuss.channel"].create({
         name: "general",
         channel_type: "channel",
@@ -177,6 +178,7 @@ test("channel - states: open manually by clicking the title", async () => {
 
 test("sidebar: inbox with counter", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     pyEnv["mail.notification"].create({
         notification_type: "inbox",
         res_partner_id: serverState.partnerId,
@@ -188,6 +190,7 @@ test("sidebar: inbox with counter", async () => {
 
 test("default thread rendering", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
     pyEnv["discuss.channel"].create([
         { name: "General", channel_type: "channel" },
@@ -208,7 +211,7 @@ test("default thread rendering", async () => {
     await contains(".o-mail-DiscussSidebar-item", { text: "General" });
     await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-Thread", {
-        text: "Your inbox is emptyChange your preferences to receive new notifications in your inbox.",
+        text: "Congratulations, your inbox is empty New messages appear here.",
     });
     await click("button", { text: "Starred messages" });
     await contains("button.o-active", { text: "Starred messages" });
@@ -829,6 +832,7 @@ test("channel - states: open from the bus", async () => {
 
 test("channel - states: the active category item should be visible even if the category is closed", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     pyEnv["discuss.channel"].create({ name: "channel1" });
     await start();
     await openDiscuss();
@@ -971,6 +975,7 @@ test("chat - states: open from the bus", async () => {
 
 test("chat - states: the active category item should be visible even if the category is closed", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     pyEnv["discuss.channel"].create({ channel_type: "chat" });
     await start();
     await openDiscuss();

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -15,13 +15,14 @@ import { describe, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
 
-import { asyncStep, waitForSteps } from "@web/../tests/web_test_helpers";
+import { asyncStep, serverState, waitForSteps } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("mobile");
 defineMailModels();
 
 test("auto-select 'Inbox' when discuss had channel as active thread", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     patchUiSize({ size: SIZES.SM });
     await start();

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -48,6 +48,7 @@ export class ResUsers extends webModels.ResUsers {
                             "avatar_128",
                             "im_status",
                             "is_admin",
+                            mailDataHelpers.Store.one("main_user_id", ["notification_type"]),
                             "name",
                             "notification_type",
                             "user",

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -726,6 +726,7 @@ test("Thread messages are only loaded once", async () => {
 test.tags("focus required");
 test("Opening thread with needaction messages should mark all messages of thread as read", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
     onRpc("mail.message", "mark_all_as_read", ({ args }) => {
@@ -740,7 +741,7 @@ test("Opening thread with needaction messages should mark all messages of thread
     await contains(".o-mail-Composer-input");
     await triggerEvents(".o-mail-Composer-input", ["blur", "focusout"]);
     await click("button", { text: "Inbox" });
-    await contains("h4", { text: "Your inbox is empty" });
+    await contains("h4", { text: "Congratulations, your inbox is empty" });
     const messageId = pyEnv["mail.message"].create({
         author_id: partnerId,
         body: "@Mitchel Admin",
@@ -773,6 +774,7 @@ test("Opening thread with needaction messages should mark all messages of thread
 
 test("[technical] Opening thread without needaction messages should not mark all messages of thread as read", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     onRpc("mail.message", "mark_all_as_read", () => asyncStep("mark-all-messages-as-read"));
     await start();

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -125,6 +125,7 @@ test("remove banner when scrolling to bottom", async () => {
 
 test("remove banner when opening thread at the bottom", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
     const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob" });
     const messageId = pyEnv["mail.message"].create({


### PR DESCRIPTION
This commit removes inbox and history in list of mailboxes shown to
"Handle by Email" users. This means the discuss sidebar for these
users only show "Starred Messages". In mobile, the navbar menu
"Inbox" is simply "Starred" for these users, which shows the starred
messages. The counter is the starred messages too instead of inbox.

Part of Task-4967071

Before / After (desktop - "Handle by Email" user)
<img width="303" height="368" alt="desktop-0" src="https://github.com/user-attachments/assets/58d1bf68-9cc0-4bab-8975-4ed4bf006643" /> <img width="303" height="313" alt="desktop-1" src="https://github.com/user-attachments/assets/9d6a8bda-05e4-437f-9bcc-cae7f2cb17d6" />

Before / After (mobile - "Handle by Email" user)
<img width="405" height="984" alt="mobile-0" src="https://github.com/user-attachments/assets/0291f955-e400-492e-8462-2c53b49a9217" /> <img width="404" height="985" alt="mobile-1" src="https://github.com/user-attachments/assets/f468a781-3a75-402f-b48b-692cb62ae132" />
