### PR TITLE
[FIX] mass_mailing: add required attribute for email_from field

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -335,7 +335,7 @@
                                             options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'mailing_model_real'}"
                                             readonly="state in ('sending', 'done')"
                                             widget="char_emojis" placeholder="e.g. Check it out before it's too late!"/>
-                                        <field name="email_from" readonly="state in ('sending', 'done')"/>
+                                        <field name="email_from" readonly="state in ('sending', 'done')" required="1"/>
                                         <label for="reply_to"/>
                                         <div name="reply_to_details">
                                             <field name="reply_to_mode" widget="radio"


### PR DESCRIPTION
**Steps to reproduce:**
- Install `mail_mailing`.
- Create a new record and leave the `email_from` field empty.

**Observed behavior:**
- A validation error is raised due to a bad query.

**Expected behavior:**
- Since the field is required, the UI should display a simple “Invalid fields” pop-up instead of a server-side validation error.

**Cause:**
The commit odoo@92c5b0699dffab98f55ed1a54a0236dbc4b5626a removed the `required` attribute from the `email_from` field and replaced it with a constraint. As a result, UI-level validation was lost and only the backend validation error is shown.

**Fix:**
Re-add the `required` attribute for the `email_from` field in the view so that the standard UI validation is triggered.

**Before Fix:**
<img width="1366" height="578" alt="email_from_empty" src="https://github.com/user-attachments/assets/23680aad-e9c8-4554-b990-de0784cb4442" />

**After Fix:**
<img width="1366" height="620" alt="after_fix_email_from" src="https://github.com/user-attachments/assets/ef34c680-8b17-4773-995d-d953a874e6a0" />


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
