### PR TITLE
[FIX] core: fix inherited properties field

### DIFF
--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -1695,6 +1695,7 @@ class PropertiesCase(TestPropertiesMixin):
                 'value': 'red',
             }],
         })
+        email.invalidate_recordset()
 
         values = email.read(['attributes'])
         self.assertEqual(values[0]['attributes'][0]['value'], 'red')

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3363,9 +3363,10 @@ class Properties(Field):
             assert self.definition.count(".") == 1
             self.definition_record, self.definition_record_field = self.definition.rsplit('.', 1)
 
-            # make the field computed, and set its dependencies
-            self._depends = (self.definition_record, )
-            self.compute = self._compute
+            if not self.inherited_field:
+                # make the field computed, and set its dependencies
+                self._depends = (self.definition_record, )
+                self.compute = self._compute
 
     def setup_related(self, model):
         super().setup_related(model)


### PR DESCRIPTION
inherited properties should be computed from its related field after cache miss

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
