### PR TITLE
[FIX] hr_holidays: dashboard allocations not updating when calendar year changes

### DIFF
--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
@@ -2,12 +2,12 @@ import { TimeOffCard } from "./time_off_card";
 import { useNewAllocationRequest } from "@hr_holidays/views/hooks";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { DateTimeInput } from "@web/core/datetime/datetime_input";
-import { Component, useState, onWillStart } from "@odoo/owl";
+import { Component, useState, useEffect } from "@odoo/owl";
 
 export class TimeOffDashboard extends Component {
     static components = { TimeOffCard, DateTimeInput };
     static template = "hr_holidays.TimeOffDashboard";
-    static props = ["employeeId"];
+    static props = ["employeeId", "model"];
 
     setup() {
         this.orm = useService("orm");
@@ -19,12 +19,23 @@ export class TimeOffDashboard extends Component {
             holidays: [],
             allocationRequests: 0,
         });
+
+        useEffect(
+            () => {
+                const calDate = this.props.model.date;
+                const today = this.state.today;
+                if (calDate.year > today.year) {
+                    this.state.date = this.props.model.data.range.start;
+                } else {
+                    this.state.date = calDate;
+                }
+                this.loadDashboardData();
+            },
+            () => [this.props.model.date.year]
+        );
+
         useBus(this.env.timeOffBus, "update_dashboard", async () => {
             await this.loadDashboardData();
-        });
-
-        onWillStart(async () => {
-            this.loadDashboardData();
         });
     }
 

--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -72,6 +72,9 @@ export class TimeOffCalendarModel extends CalendarModel {
             context["default_date_from"] = serializeDateTime(
                 deserialize(context["default_date_from"]).set({ hours: 7 })
             );
+            if (!("leave_date_from" in context)) {
+                context["leave_date_from"] = context["default_date_from"];
+            }
         }
         if ("default_date_to" in context) {
             context["default_date_to"] = serializeDateTime(

--- a/addons/hr_holidays/static/src/views/calendar/calendar_renderer.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_renderer.xml
@@ -3,7 +3,7 @@
 
     <t t-name="hr_holidays.CalendarRenderer">
         <div class="o_timeoff_calendar d-flex flex-column">
-            <TimeOffDashboard t-if="showDashboard" employeeId="employeeId"/>
+            <TimeOffDashboard t-if="showDashboard" employeeId="employeeId" model="props.model"/>
             <t t-call="web.CalendarRenderer"/>
         </div>
     </t>


### PR DESCRIPTION
Before:
When changing the calendar year in Time Off, dashboard allocations remained
static and did not reflect the selected year.

After:
Dashboard allocations now refresh dynamically when the calendar year changes.
For a future year, allocations valid on January 1st of that year are displayed,
ensuring cross-year allocations are visible in the correct year and add
'leave_date_from' in context so 'default_date_from' doesn’t become null
on subsequent 'compute_leave' calls.

task-5023819