### PR TITLE
[IMP] hr_timesheet,project,sale_*: formatted_display_name in M2X fields

### DIFF
--- a/addons/project/models/project_milestone.py
+++ b/addons/project/models/project_milestone.py
@@ -134,10 +134,13 @@ class ProjectMilestone(models.Model):
                 milestone_mapping[old_milestone.id] = new_milestone.id
         return new_milestones
 
+    @api.depends_context('formatted_display_name')
     def _compute_display_name(self):
         super()._compute_display_name()
         if not self.env.context.get('display_milestone_deadline'):
             return
         for milestone in self:
-            if milestone.deadline:
+            if milestone.deadline and self.env.context.get('formatted_display_name'):
+                milestone.display_name = f'{milestone.display_name} \t --{format_date(self.env, milestone.deadline)}--'
+            elif milestone.deadline:
                 milestone.display_name = f'{milestone.display_name} - {format_date(self.env, milestone.deadline)}'

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -330,15 +330,18 @@ class SaleOrder(models.Model):
     #=== COMPUTE METHODS ===#
 
     @api.depends('partner_id')
-    @api.depends_context('sale_show_partner_name')
+    @api.depends_context('sale_show_partner_name', 'formatted_display_name')
     def _compute_display_name(self):
         if not self.env.context.get('sale_show_partner_name'):
             return super()._compute_display_name()
         for order in self:
-            name = order.name
             if order.partner_id.name:
-                name = f'{name} - {order.partner_id.name}'
-            order.display_name = name
+                if self.env.context.get('formatted_display_name'):
+                    order.display_name = f"{order.name} \t --{order.partner_id.name}--"
+                else:
+                    order.display_name = f'{order.name} - {order.partner_id.name}'
+            else:
+                order.display_name = order.name
 
     @api.depends('order_line.product_id')
     def _compute_has_archived_products(self):

--- a/addons/sale_timesheet/models/sale_order_line.py
+++ b/addons/sale_timesheet/models/sale_order_line.py
@@ -16,7 +16,7 @@ class SaleOrderLine(models.Model):
     timesheet_ids = fields.One2many('account.analytic.line', 'so_line', domain=[('project_id', '!=', False)], string='Timesheets', export_string_translation=False)
 
     @api.depends('remaining_hours_available', 'remaining_hours')
-    @api.depends_context('with_remaining_hours', 'company')
+    @api.depends_context('with_remaining_hours', 'company', 'formatted_display_name')
     def _compute_display_name(self):
         super()._compute_display_name()
         with_remaining_hours = self.env.context.get('with_remaining_hours')
@@ -39,7 +39,10 @@ class SaleOrderLine(models.Model):
                     elif is_day:
                         remaining_days = company.project_time_mode_id._compute_quantity(line.remaining_hours, encoding_uom, round=False)
                         remaining_time = f' ({remaining_days:.02f} {unit_label})'
-                    name = f'{line.display_name}{remaining_time}'
+                    if self.env.context.get('formatted_display_name'):
+                        name = f'{line.display_name} --{remaining_time}--'
+                    else:
+                        name = f'{line.display_name}{remaining_time}'
                     line.display_name = name
 
     @api.depends('product_id.service_policy')


### PR DESCRIPTION
_*=sale_service, sale_timesheet

New formatting for M2X selection of:
 - sale order
 - sale order line
 - timesheet task
 - project milestone (with deadline)

 Improved display_name of Sale Orders, Sale Order Lines, Tasks in Timesheets,
 and Project Milestones (including deadline formatting) in M2X dropdowns by
 applying formatted_display_name.

task-4972325
Examples :
<img width="451" height="276" alt="so" src="https://github.com/user-attachments/assets/ed893147-a598-46b1-a10a-e47d61c429da" />

<img width="819" height="324" alt="image" src="https://github.com/user-attachments/assets/b97fe00f-9261-4843-a4a4-70fde27b0d41" />

<img width="653" height="506" alt="timesheet" src="https://github.com/user-attachments/assets/ac05bfb6-1e64-487a-a4bd-5a9013c5ab97" />

<img width="625" height="336" alt="image" src="https://github.com/user-attachments/assets/9f419515-fef4-4520-a845-761650ac8a56" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
