### PR TITLE
[FIX] account: prevent error on opening form view for invoice lines

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -872,7 +872,7 @@ class AccountMoveLine(models.Model):
         AccountTax = self.env['account.tax']
         for line in self:
             # TODO remove the need of cogs lines to have a price_subtotal/price_total
-            if line.display_type not in ('product', 'cogs', 'non_deductible_product', 'non_deductible_product_total'):
+            if line.display_type not in ('product', 'cogs', 'non_deductible_product', 'non_deductible_product_total') or not line.move_id:
                 line.price_total = line.price_subtotal = False
                 continue
 


### PR DESCRIPTION
Currently an error occurs when user opens form view for invoice lines using studio.

**Steps to replicate:**
* Install `accountant` and `web_studio`
* Create new invoice but don't save > Open studio view
* Select Invoice Lines > Edit Form View > Error should occur in terminal

`ValueError: Expected singleton: account.move()`

**Root cause:**
* This error occurs because an empty `account.move()` record is passed as `self` to `_prepare_product_base_line_for_taxes_computation` at [1], which expects only a single record. Since the invoice has not yet been created, the recordset is empty.

  This issue happens only in version `18.4`, not in `18.3` or earlier. The reason is that in `18.4`, compute method [2] is called when opening the form view, whereas in `18.3` it is not.

  When [2] is called, it sets the `display_type` to `product`, allowing the code to bypass the condition at [3]. In contrast, in `18.3`,since [2] is not called, `display_type` remains `False` despite the code being the same.

**Solution:**
* To achieve similar behavior as in version `18.3` and skip that line, modify the condition to include a check for `move_id`.

[1]:
https://github.com/odoo/odoo/blob/0706aaef3894bbee6eea62679a2d89a3ee316f7b/addons/account/models/account_move_line.py#L880 
[2]:
https://github.com/odoo/odoo/blob/0706aaef3894bbee6eea62679a2d89a3ee316f7b/addons/account/models/account_move_line.py#L485 
[3]:
https://github.com/odoo/odoo/blob/0706aaef3894bbee6eea62679a2d89a3ee316f7b/addons/account/models/account_move_line.py#L875

**Sentry-6766906181**