### PR TITLE
[FIX] html_editor: make text_classes_regex match only color classes

### DIFF
--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -68,7 +68,8 @@ export function isColorCombinationName(name) {
     return !isNaN(number) && number % 100 !== 0;
 }
 
-export const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/;
+export const TEXT_CLASSES_REGEX =
+    /\btext-(primary|secondary|success|danger|warning|info|light|dark|body|muted|white|black|reset|gradient|opacity-\d{1,3}|o-[^\s]+|\d+)\b/;
 export const BG_CLASSES_REGEX = /\bbg-[^\s]*\b/;
 export const COLOR_COMBINATION_CLASSES_REGEX = /\bo_cc[0-9]+\b/g;
 

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -1043,3 +1043,47 @@ describe("list", () => {
         });
     });
 });
+
+describe("removeFormat must not remove non-style classes", () => {
+    test("does not remove non-color classes", async () => {
+        await testEditor({
+            contentBefore: '<p><font class="text-wrap">[test]</font></p>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: '<p><font class="text-wrap">[test]</font></p>',
+        });
+        await testEditor({
+            contentBefore: '<p><font class="text-center">[test]</font></p>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: '<p><font class="text-center">[test]</font></p>',
+        });
+        await testEditor({
+            contentBefore: '<p><font class="text-align">[test]</font></p>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: '<p><font class="text-align">[test]</font></p>',
+        });
+    });
+
+    test("removes all supported color classes", async () => {
+        const classes = [
+            "text-primary",
+            "text-secondary",
+            "text-success",
+            "text-danger",
+            "text-warning",
+            "text-info",
+            "text-light",
+            "text-muted",
+            "text-white",
+            "text-black",
+            "text-o-color-1",
+            "text-100",
+        ];
+        for (const cls of classes) {
+            await testEditor({
+                contentBefore: `<p><font class="${cls}">[test]</font></p>`,
+                stepFunction: (editor) => execCommand(editor, "removeFormat"),
+                contentAfter: "<p>[test]</p>",
+            });
+        }
+    });
+});

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -203,6 +203,19 @@ describe("popover should edit,copy,remove the link", () => {
             '<p>this is a <a href="http://test.com/">linknew[]</a></p>'
         );
     });
+    test("after edit the label, the text of the link should be updated (2)", async () => {
+        const { el } = await setupEditor(
+            '<p>this is a <a class="text-wrap" href="http://test.com/">li[]nk</a></p>'
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+
+        await contains(".o-we-linkpopover input.o_we_label_link").fill("new");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a class="text-wrap o_link_in_selection" href="http://test.com/">linknew[]</a></p>'
+        );
+    });
     test("when the label is empty, it should be set as the URL", async () => {
         const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");


### PR DESCRIPTION
Steps to Reproduce:

- Open the website.
- Create a mega menu.
- Enter edit mode.
- Change the mega menu template to “Cards”.
- Click on any option available in the mega menu.
- A link popover will open.
- Click the Edit link button in the popover.
- Click the Apply button to save the link.
- A traceback occurs.

Description of the issue:

The error occurs because the text-wrap class is applied to the link. When the `hasColor` method is triggered, it checks whether **a.nav-link** has a text color class. However, `TEXT_CLASSES_REGEX` incorrectly matches **text-wrap** as a color class. As a result, the removeColor method attempts to remove it and triggers `_applyColor` to remove the color, but in `_applyColor` method it does not find any color to remove on selected text. As a result, the `removeColor` process enters an infinite loop, which eventually leads to a traceback.

Solution:

Update `TEXT_CLASSES_REGEX` so that it only matches valid text color classes and excludes formatting classes such as text-wrap, text-center, etc.

