### PR TITLE
[IMP] l10n_pe:  Autofill correct doc type for credit/debit notes of boletas

### DIFF
--- a/addons/l10n_pe/models/account_move.py
+++ b/addons/l10n_pe/models/account_move.py
@@ -1,6 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, models
 
+PE_DOC_SUBTYPES = [
+    ("l10n_pe.document_type01", "l10n_pe.document_type07", "l10n_pe.document_type08"),  # e-invoice
+    ("l10n_pe.document_type02", "l10n_pe.document_type07b", "l10n_pe.document_type08b"),  # e-boleta
+]
+
 
 class AccountMove(models.Model):
     _inherit = "account.move"
@@ -10,6 +15,15 @@ class AccountMove(models.Model):
         result = super()._get_l10n_latam_documents_domain()
         if self.company_id.country_id.code != "PE" or not self.l10n_latam_use_documents or self.journal_id.type != "sale":
             return result
+        if self.debit_origin_id:
+            result.append(("internal_type", "=", "debit_note"))
+        if (original_move := self.reversed_entry_id or self.debit_origin_id) and (doc_type := original_move.l10n_latam_document_type_id):
+            doc_type_xml_id = doc_type.get_external_id().get(doc_type.id)
+            for doc_subtype_group in PE_DOC_SUBTYPES:
+                if doc_type_xml_id in doc_subtype_group:
+                    doc_subtype_group_ids = tuple(self.env.ref(type).id for type in doc_subtype_group)
+                    result.append(("id", "in", doc_subtype_group_ids))
+                    break
         result.append(("code", "in", ("01", "03", "07", "08", "20", "40")))
         if self.partner_id.l10n_latam_identification_type_id.l10n_pe_vat_code != '6' and self.move_type == 'out_invoice':
             result.append(('id', 'in', (

--- a/addons/l10n_pe/tests/__init__.py
+++ b/addons/l10n_pe/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_latam_doc_types

--- a/addons/l10n_pe/tests/test_l10n_latam_doc_types.py
+++ b/addons/l10n_pe/tests/test_l10n_latam_doc_types.py
@@ -1,0 +1,126 @@
+from odoo import Command
+from odoo.tests.common import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('-at_install', 'post_install', 'post_install_l10n')
+class TestL10nPeLatamDocTypes(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('pe')
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company_data['company'].partner_id.write({
+            'vat': '20557912879',
+            'l10n_latam_identification_type_id': cls.env.ref('l10n_pe.it_RUC').id,
+        })
+        cls.company_data['default_journal_sale'].l10n_latam_use_documents = True
+        cls.company_data['default_journal_purchase'].l10n_latam_use_documents = True
+
+        cls.partner_pe_dni, cls.partner_pe_ruc = cls.env['res.partner'].create([
+            {
+                'name': 'test partner PE DNI',
+                'l10n_latam_identification_type_id': cls.env.ref('l10n_pe.it_DNI').id,
+                'vat': '20121888549',
+            },
+            {
+                'name': 'test partner PE RUC',
+                'l10n_latam_identification_type_id': cls.env.ref('l10n_pe.it_RUC').id,
+                'vat': '20462509236',
+            },
+        ])
+
+        cls.product_pe = cls.env['product.product'].create([{
+            'name': 'test product PE',
+            'lst_price': 1000.0,
+            'default_code': 'VAT 22',
+        }])
+
+        cls.document_type01 = cls.env.ref('l10n_pe.document_type01').id
+        cls.document_type02 = cls.env.ref('l10n_pe.document_type02').id
+        cls.document_type07 = cls.env.ref('l10n_pe.document_type07').id
+        cls.document_type07b = cls.env.ref('l10n_pe.document_type07b').id
+        cls.document_type08 = cls.env.ref('l10n_pe.document_type08').id
+        cls.document_type08b = cls.env.ref('l10n_pe.document_type08b').id
+
+    def test_l10n_pe_document_type(self):
+        """Test that the l10n latam document type is correctly set"""
+
+        boleta = self.env['account.move'].create([{
+            'partner_id': self.partner_pe_dni.id,
+            'move_type': 'out_invoice',
+            'journal_id': self.company_data['default_journal_sale'].id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_pe.id,
+                'quantity': 1.0,
+                'price_unit': 100.0,
+            })]
+        }])
+        boleta.action_post()
+
+        invoice = self.env['account.move'].create([{
+            'partner_id': self.partner_pe_ruc.id,
+            'move_type': 'out_invoice',
+            'journal_id': self.company_data['default_journal_sale'].id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_pe.id,
+                'quantity': 1.0,
+                'price_unit': 100.0,
+            })]
+        }])
+        invoice.action_post()
+
+        self.assertEqual(boleta.l10n_latam_document_type_id.id, self.document_type02, 'Not Boleta')
+        self.assertEqual(invoice.l10n_latam_document_type_id.id, self.document_type01, 'Not Invoice')
+
+        # Test that the credit note wizard apply the correct document type
+        refund_wizard_boleta = self.env['account.move.reversal']\
+            .with_context(active_ids=boleta.ids, active_model='account.move')\
+            .create([{
+                'reason': 'Mercadería defectuosa',
+                'journal_id': boleta.journal_id.id,
+            }])
+        refund_boleta = self.env['account.move'].browse(refund_wizard_boleta.reverse_moves()['res_id'])
+        self.assertRecordValues(refund_boleta, [{
+            'l10n_latam_document_type_id': self.document_type07b,
+            'l10n_latam_available_document_type_ids': [self.document_type07b],
+        }])
+
+        refund_wizard_invoice = self.env['account.move.reversal']\
+            .with_context({'active_ids': invoice.ids, 'active_model': 'account.move'})\
+            .create([{
+                'reason': 'Mercadería defectuosa',
+                'journal_id': invoice.journal_id.id,
+            }])
+        refund_invoice = self.env['account.move'].browse(refund_wizard_invoice.reverse_moves()['res_id'])
+        self.assertRecordValues(refund_invoice, [{
+            'l10n_latam_document_type_id': self.document_type07,
+            'l10n_latam_available_document_type_ids': [self.document_type07],
+        }])
+
+        # Test that the debit note wizard apply the correct document type
+        debit_note_wizard_boleta = self.env['account.debit.note']\
+            .with_context({'active_ids': boleta.ids, 'active_model': 'account.move'})\
+            .create([{
+                'reason': 'Mercadería defectuosa',
+                'journal_id': boleta.journal_id.id,
+            }])
+        debit_note_boleta = self.env['account.move'].browse(debit_note_wizard_boleta.create_debit()['res_id'])
+        self.assertRecordValues(debit_note_boleta, [{
+            'l10n_latam_document_type_id': self.document_type08b,
+            'l10n_latam_available_document_type_ids': [self.document_type08b],
+        }])
+
+        debit_note_wizard_invoice = self.env['account.debit.note']\
+            .with_context({'active_ids': invoice.ids, 'active_model': 'account.move'})\
+            .create([{
+                'reason': 'Mercadería defectuosa',
+                'journal_id': invoice.journal_id.id,
+            }])
+        debit_note_invoice = self.env['account.move'].browse(debit_note_wizard_invoice.create_debit()['res_id'])
+        self.assertRecordValues(debit_note_invoice, [{
+            'l10n_latam_document_type_id': self.document_type08,
+            'l10n_latam_available_document_type_ids': [self.document_type08],
+        }])


### PR DESCRIPTION
Before this pr:
- In Peru localization, users have to manually set the correct l10n_latam_document_type when creating credit/debit notes.

After this pr:
- The correct l10n_latam_document_type based on the originating document will be set automatically while creating credit/debit notes.

Task: 4284986