### PR TITLE
[IMP] l10n_ro_edi_stock: include move ID in EDI stock data

### DIFF
--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -837,6 +837,7 @@ class Picking(models.Model):
                         'greutateNeta': move.weight,
                         'greutateBruta': self._l10n_ro_edi_stock_get_gross_weight(move),
                         'valoareLeiFaraTva': product.list_price,
+                        'move_id': move.id,
                     }
                     for move in data['stock_move_ids'] for product in move.product_id
                 ],

--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -669,13 +669,7 @@ class Picking(models.Model):
     # Send Logic
     ################################################################################
 
-    def _l10n_ro_edi_stock_send_etransport_document(self, send_type: str):
-        """
-        Send the eTransport document to anaf
-        :param send_type: 'send' (initial sending of document) | 'amend' (correct the already sent document)
-        """
-        self.ensure_one()
-
+    def _l10n_ro_edi_stock_prepare_data_etransport_document(self, send_type: str):
         data = {
             'partner_id': self.partner_id,
             'transport_partner_id': self.carrier_id.l10n_ro_edi_stock_partner_id,
@@ -699,6 +693,16 @@ class Picking(models.Model):
             'l10n_ro_edi_stock_end_customs_office': self.l10n_ro_edi_stock_end_customs_office,
             'l10n_ro_edi_stock_document_uit': self.l10n_ro_edi_stock_document_uit,
         }
+        return data
+
+    def _l10n_ro_edi_stock_send_etransport_document(self, send_type: str):
+        """
+        Send the eTransport document to anaf
+        :param send_type: 'send' (initial sending of document) | 'amend' (correct the already sent document)
+        """
+        self.ensure_one()
+
+        data = self._l10n_ro_edi_stock_prepare_data_etransport_document(send_type=send_type)
 
         if errors := self._l10n_ro_edi_stock_validate_data(data=data):
             document_values = {'message': '\n'.join(errors)}


### PR DESCRIPTION


Description of the issue/feature this PR addresses:

Add `move_id` to the stock data for EDI export to ensure each move is uniquely identifiable. 

Current behavior before PR:

Desired behavior after PR is merged:
This enhancement facilitates better traceability and debugging of stock movements in the EDI context.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
