### PR TITLE
[FIX] website: fix duplicate sitemap entries when overriding controllers

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import logging
 import re
+import types
 from itertools import zip_longest
 
 import requests
@@ -1342,25 +1343,42 @@ class Website(models.Model):
 
         sitemap_endpoint_done = set()
 
-        for rule in router.iter_rules():
-            if 'sitemap' in rule.endpoint.routing and rule.endpoint.routing['sitemap'] is not True:
-                endpoint_func = rule.endpoint.func
-                if isinstance(endpoint_func, functools.partial): # follow partial in case of redirect
-                    endpoint_func = endpoint_func.func
-                if endpoint_func.__func__ in sitemap_endpoint_done:
-                    continue
-                sitemap_endpoint_done.add(endpoint_func.__func__)
+        # Helper to normalize URLs while keeping '/' intact
+        def _norm(url):
+            return '/' if url == '/' else url.rstrip('/')
 
-                func = rule.endpoint.routing['sitemap']
-                if func is False:
+        # Avoid recomputing identical sitemap callables more than once
+        def _unwrap_callable(f):
+            # Unwrap functools.partial and bound methods to a stable function key
+            if isinstance(f, functools.partial):
+                f = f.func
+            # Unwrap bound methods (obj.method) to their underlying function
+            if isinstance(f, types.MethodType):
+                return f.__func__
+            return f
+
+        for rule in router.iter_rules():
+            sitemap_func = rule.endpoint.routing.get('sitemap')
+            if sitemap_func is False:
+                continue
+
+            if callable(sitemap_func):
+                func_key = _unwrap_callable(sitemap_func)
+                if func_key in sitemap_endpoint_done:
                     continue
-                for loc in func(self.with_context(lang=self.default_lang_id.code).env, rule, query_string):
-                    yield loc
+                sitemap_endpoint_done.add(func_key)
+                for loc in sitemap_func(self.with_context(lang=self.default_lang_id.code).env, rule, query_string):
+                    loc_norm = {**loc, 'loc': _norm(loc['loc'])}
+                    url = loc_norm['loc']
+                    if url not in url_set:
+                        yield loc_norm
+                        url_set.add(url)
                 continue
 
             if not self.rule_is_enumerable(rule):
                 continue
 
+            # Warn only if the 'sitemap' key is absent from routing (legacy behavior)
             if 'sitemap' not in rule.endpoint.routing:
                 logger.warning('No Sitemap value provided for controller %s (%s)' %
                                (rule.endpoint.original_endpoint, ','.join(rule.endpoint.routing['routes'])))
@@ -1395,6 +1413,8 @@ class Website(models.Model):
 
             for value in values:
                 domain_part, url = rule.build(value, append_unknown=False)
+                # Normalize trailing slash but keep '/'
+                url = _norm(url)
                 pattern = query_string and '*%s*' % "*".join(query_string.split('/'))
                 if not query_string or fnmatch.fnmatch(url.lower(), pattern):
                     page = {'loc': url}

--- a/addons/website/tests/test_sitemap.py
+++ b/addons/website/tests/test_sitemap.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import TransactionCase, tagged
+import functools
+from unittest.mock import patch
 
 
 @tagged('-at_install', 'post_install')
@@ -46,3 +48,77 @@ class TestWebsiteSitemap(TransactionCase):
         new_date2 = "2015-10-01 12:00:00"
         set_write_dates(old_date, new_date2)
         self.assertEqual(str(get_sitemap_lastmod()), new_date2[:10])
+
+    def test_sitemap_dedup_overridden_controllers(self):
+        website = self.env['website'].search([], limit=1)
+
+        # Fake router and rule to simulate two sitemap entries with and without trailing slash
+        def fake_sitemap_callable(env, rule, qs):
+            yield {'loc': '/dupe'}
+            yield {'loc': '/dupe/'}
+
+        class FakeEndpoint:
+            routing = {'sitemap': fake_sitemap_callable}
+
+        class FakeRule:
+            endpoint = FakeEndpoint()
+
+        class FakeRouter:
+            def iter_rules(self):
+                return [FakeRule()]
+
+        # Patch routing_map to return our fake router so only our fake rules are considered
+        with patch('odoo.addons.website.models.ir_http.Http.routing_map', autospec=True, return_value=FakeRouter()):
+            locs = list(website.with_user(website.user_id)._enumerate_pages())
+
+        dupes = [l['loc'] for l in locs if l['loc'].startswith('/dupe')]
+        # Only one entry should remain, normalized to '/dupe'
+        self.assertEqual(dupes, ['/dupe'])
+
+    def test_sitemap_callable_dedup_with_partial_and_bound(self):
+        # Some routes are duplicated at runtime (e.g., when a redirect
+        # is configured). The framework may clone an existing endpoint for the
+        # extra rule, and 3rd-party modules sometimes wrap callables using
+        # `functools.partial` to adapt them.
+        # As a result, the very same sitemap generator can be referenced in two
+        # different ways: once as a classic bound method (self.sitemap) and once
+        # as a `functools.partial(self.sitemap)` wrapper.
+        # If we were deduplicating based on the callable object identity only,
+        # those two references would look different and the sitemap code could
+        # run twice.
+        website = self.env['website'].search([], limit=1)
+
+        call_count = {'n': 0}  # mutable object to be used in CallableHolder.
+
+        class CallableHolder:
+            def sitemap(self, env, rule, qs):
+                call_count['n'] += 1
+                yield {'loc': '/once'}
+
+        holder = CallableHolder()
+
+        # First rule uses the bound method directly
+        class EndpointBound:
+            routing = {'sitemap': holder.sitemap}
+
+        class RuleBound:
+            endpoint = EndpointBound()
+
+        # Second rule uses a partial wrapping the same bound method
+        class EndpointPartial:
+            routing = {'sitemap': functools.partial(holder.sitemap)}
+
+        class RulePartial:
+            endpoint = EndpointPartial()
+
+        class FakeRouter:
+            def iter_rules(self):
+                return [RuleBound(), RulePartial()]
+
+        with patch('odoo.addons.website.models.ir_http.Http.routing_map', autospec=True, return_value=FakeRouter()):
+            locs = list(website.with_user(website.user_id)._enumerate_pages())
+
+        # The sitemap callable should have been executed only once
+        self.assertEqual(call_count['n'], 1)
+        # And the returned loc should be present (normalized already)
+        self.assertIn({'loc': '/once'}, locs)


### PR DESCRIPTION
When extending controllers (e.g. `WebsiteSale.shop`), sitemap entries were duplicated because deduplication relied on the endpoint function object. Overridden methods result in different function objects but identical sitemap URLs, leading to duplicates.

This commit fixes the issue by deduplicating on the generated sitemap location (`loc['loc']`) instead of the function object, ensuring unique URLs in the sitemap even when controllers are extended.

Fixes #224193 
