### PR TITLE
[IMP] web: allow SelectMenu to have sections

### DIFF
--- a/addons/account/static/src/components/account_type_selection/account_type_selection.js
+++ b/addons/account/static/src/components/account_type_selection/account_type_selection.js
@@ -9,36 +9,46 @@ export class AccountTypeSelection extends SelectionField {
         const getChoicesForGroup = (group) => {
             return this.choices.filter(x => x.value.startsWith(group));
         }
-        this.groups = [
+        this.sections = [
             {
                 label: _t('Balance Sheet'),
+                name: "balance_sheet"
             },
+            {
+                label: _t('Profit & Loss'),
+                name: "profit_and_loss"
+            },
+        ]
+        this.groups = [
             {
                 label: _t('Assets'),
                 choices: getChoicesForGroup('asset'),
+                section: "balance_sheet",
             },
             {
                 label: _t('Liabilities'),
                 choices: getChoicesForGroup('liability'),
+                section: "balance_sheet",
             },
             {
                 label: _t('Equity'),
                 choices: getChoicesForGroup('equity'),
-            },
-            {
-                label: _t('Profit & Loss'),
+                section: "balance_sheet",
             },
             {
                 label: _t('Income'),
                 choices: getChoicesForGroup('income'),
+                section: "profit_and_loss",
             },
             {
                 label: _t('Expense'),
                 choices: getChoicesForGroup('expense'),
+                section: "profit_and_loss",
             },
             {
                 label: _t('Other'),
                 choices: getChoicesForGroup('off_balance'),
+                section: "profit_and_loss",
             },
         ];
     }

--- a/addons/account/static/src/components/account_type_selection/account_type_selection.xml
+++ b/addons/account/static/src/components/account_type_selection/account_type_selection.xml
@@ -6,6 +6,7 @@
         <xpath expr="//SelectMenu" position="attributes">
             <attribute name="choices"></attribute>
             <attribute name="groups">groups</attribute>
+            <attribute name="sections">sections</attribute>
         </xpath>
     </t>
 

--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -35,6 +35,7 @@ export class SelectMenu extends Component {
         searchPlaceholder: "",
         choices: [],
         groups: [],
+        sections: [],
         disabled: false,
     };
 
@@ -68,9 +69,20 @@ export class SelectMenu extends Component {
                                 "*": true,
                             },
                         },
+                    },
+                    section: {
+                        type: String,
                         optional: true,
                     },
                 },
+            },
+        },
+        sections: {
+            type: Array,
+            optional: true,
+            element: {
+                label: { type: String },
+                name: { type: String },
             },
         },
         id: { type: String, optional: true },
@@ -326,9 +338,16 @@ export class SelectMenu extends Component {
      * @param {String} searchString
      */
     filterOptions(searchString = "", groups) {
-        const groupsList = groups || [{ choices: this.props.choices }, ...this.props.groups];
+        const groupsList = groups || [
+            { choices: this.props.choices, section: "" },
+            ...this.props.groups,
+        ];
 
-        this.state.choices = [];
+        const _choices = [];
+        const _sections = new Set();
+        groupsList.sort((a, b) =>
+            a.section && b.section ? a.section.localeCompare(b.section) : 1
+        );
 
         for (const group of groupsList) {
             let filteredOptions = group.choices || [];
@@ -347,16 +366,23 @@ export class SelectMenu extends Component {
                 }
             }
 
-            if (group.choices && filteredOptions.length === 0) {
+            if (filteredOptions.length === 0) {
                 continue;
             }
-
-            if (group.label) {
-                this.state.choices.push({ ...group, isGroup: true });
+            if (group.section) {
+                const section = this.props.sections.find((e) => e.name === group.section);
+                if (!_sections.has(section)) {
+                    _sections.add(section);
+                    _choices.push({ ...section, isGroup: true });
+                }
             }
-            this.state.choices.push(...filteredOptions);
+            if (group.label) {
+                _choices.push({ ...group, isGroup: true });
+            }
+            _choices.push(...filteredOptions);
         }
 
+        this.state.choices = _choices;
         this.sliceDisplayedOptions();
     }
 

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -80,7 +80,7 @@
         <div
             t-if="choice.isGroup"
             class="o_select_menu_group position-sticky start-0 px-1 fw-bolder user-select-none"
-            t-att-class="{'o_select_menu_searchable_group': displayInputInDropdown }"
+            t-att-class="{'o_select_menu_searchable_group': displayInputInDropdown, 'ms-2': !!choice.section }"
         >
             <span t-esc="choice.label" />
         </div>

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -1102,32 +1102,67 @@ test("search value is cleared when reopening the menu", async () => {
     expect(".o_select_menu input").toHaveValue("");
 });
 
-test("Groups can be used without choices", async () => {
+test("Groups can be member of sections", async () => {
     class Parent extends Component {
         static props = ["*"];
         static components = { SelectMenu };
         static template = xml`
-            <SelectMenu choices="choices" groups="groups" />
+            <SelectMenu choices="choices" groups="groups" sections="sections" />
         `;
         setup() {
             this.choices = [{ label: "Hello", value: "hello" }];
+            this.sections = [
+                { label: "Group A", name: "sectionA" },
+                { label: "Group B", name: "sectionB" },
+            ];
             this.groups = [
-                { label: "Group A" },
                 {
                     label: "Subgroup 1",
                     choices: [
                         { label: "Option I", value: "optionI" },
                         { label: "Option II", value: "optionII" },
                     ],
+                    section: "sectionA",
                 },
-                { label: "Subgroup 2", choices: [] },
+                {
+                    label: "Subgroup 1B",
+                    choices: [{ label: "Option B.2", value: "optionB_2" }],
+                    section: "sectionB",
+                },
+                {
+                    label: "Subgroup 2",
+                    choices: [{ label: "Option 2.I", value: "option2_I" }],
+                    section: "sectionA",
+                },
             ];
         }
     }
     await mountSingleApp(Parent);
     await open();
-    expect(".o_select_menu_group").toHaveCount(2);
-    expect(".o_select_menu_item").toHaveCount(3);
+    expect(".o_select_menu_group").toHaveCount(5);
+    expect(".o_select_menu_item").toHaveCount(5);
+    expect(queryAllTexts(".o_select_menu_group")).toEqual([
+        "Group A",
+        "Subgroup 1",
+        "Subgroup 2",
+        "Group B",
+        "Subgroup 1B",
+    ]);
+    expect(queryAllTexts(".o_select_menu_item")).toEqual([
+        "Hello",
+        "Option I",
+        "Option II",
+        "Option 2.I",
+        "Option B.2",
+    ]);
+    await editInput("option 2");
+    expect(queryAllTexts(".o_select_menu_group")).toEqual([
+        "Group A",
+        "Subgroup 2",
+        "Group B",
+        "Subgroup 1B",
+    ]);
+    expect(queryAllTexts(".o_select_menu_item")).toEqual(["Option 2.I", "Option B.2"]);
 });
 
 test("Can add custom data to choices", async () => {


### PR DESCRIPTION
This commit brings the "sections" props to the component, allowing the SelectMenu to group 'groups' into 'sections'.

This is used by account_type_selection, and was not really well supported by the component, since the search would not filter visible sections, because the component had no knowledge of the link between different options.

task-5031491