### PR TITLE
[FIX] website_event: search on description

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -28,7 +28,7 @@ class WebsiteEventController(http.Controller):
 
     def _get_events_search_options(self, **post):
         return {
-            'displayDescription': False,
+            'displayDescription': True,
             'displayDetail': False,
             'displayExtraDetail': False,
             'displayExtraLink': False,


### PR DESCRIPTION
Purpose
=======
Making sure that, when typing a search term, all the results displayed in the search bar dropdown are visible on the page when clicking Enter.

Specification
=============
Previously, the search bar dropdown was displaying all the events where the name or description matched the search term.
However, when clicking Enter, only the events where the name matched were displayed on the page (the ones where only the description matched were ignored).

Fixing the issue by considering the description in the event search options.

Task-5039221

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
