### PR TITLE
[FIX] point_of_sale: make receipt numbers consistent without connection

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1231,7 +1231,7 @@ export class PosStore extends WithLazyGetterTrap {
                 error instanceof ConnectionAbortedError ||
                 error instanceof RPCError
             ) {
-                return this.getNextOrderRefsLocal(_t("Order"), order);
+                return this.getNextOrderRefsLocal("", order);
             } else {
                 throw error;
             }
@@ -1251,7 +1251,7 @@ export class PosStore extends WithLazyGetterTrap {
         const SSS = this.session.id.toString().padStart(3, "0");
         const F = "1";
         const OOOO = sequenceNumber.toString().padStart(4, "0");
-        const posReference = `${refPrefix} ${YY}${LL}-${SSS}-${F}${OOOO}`;
+        const posReference = `${YY}${LL}-${SSS}-${F}${OOOO}`;
         order.pos_reference = posReference;
         order.sequence_number = sequenceNumber;
         order.tracking_number = trackingNumber;

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -989,3 +989,24 @@ registry.category("web_tour.tours").add("test_pos_ui_round_globally", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_consistent_order_receipt_number_offline", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            OfflineUtil.setOfflineMode(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            Dialog.confirm("Continue with limited functionality"),
+            ReceiptScreen.clickNextOrder(),
+            OfflineUtil.setOnlineMode(),
+            ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -14,6 +14,7 @@ from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_c
 from datetime import date, timedelta
 from odoo.addons.point_of_sale.tests.common import archive_products
 from odoo.exceptions import UserError
+from freezegun import freeze_time
 
 _logger = logging.getLogger(__name__)
 
@@ -2831,6 +2832,23 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_cross_exclusion_attribute_values')
+
+    @freeze_time("2025-08-28 04:15:00")
+    def test_consistent_order_receipt_number_offline(self):
+        """
+        Tests that an order will have the same receipt number if it was done
+        online or offline, with only the last part of the receipt number being
+        an exception as the first number is 0 if it was done online and 1 if
+        it was done offline.
+        """
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_consistent_order_receipt_number_offline', login="pos_user")
+
+        orders = self.env['pos.order'].search([], order="id desc", limit=2)
+        # Online, with a 0
+        self.assertEqual(orders[1].pos_reference, f"2501-{orders[1].session_id.id:03d}-00001")
+        # Offline, with a 1 and no Order
+        self.assertEqual(orders[0].pos_reference, f"2501-{orders[0].session_id.id:03d}-10001")
 
 
 # This class just runs the same tests as above but with mobile emulation


### PR DESCRIPTION
**Steps to reproduce:**
- Go to PoS, make an order and pay for it
- Before clicking next order close your connection with the server
- Make a purchase like this
- Go back online and check the orders in the backend

The order made online only has the receipt number, but the order made offline has *Order* in front of it.

**Why the fix:**
The receipt number on a PoS order should be consistand and should not be changed depending on if the purchase was made online or offline.
With this commit, every order will have only it's receipt number without the *Order* in front of it even if it was made offline.

It is still possible to see if an order was made online or offline with the **F** variable, which is the first number of the last part of the receipt number. If it is 1, the order was made offline, if it is 0, it was made online.

The *refPrefix* parameter from the *getNextOrderRefsLocal* function is not used anymore, so it has been replaced by an empty string in the function call in stable and could be deleted when in master.

opw-4965095