### PR TITLE
[IMP] website: remove href=#

### DIFF
--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -124,7 +124,7 @@ const cannotAddNewContent = () => [
 const canEditInBackEnd = () => [
     {
         content: "Edit in backend",
-        trigger: ".o_menu_systray .o_website_edit_in_backend a",
+        trigger: ".o_menu_systray .o_website_edit_in_backend button",
         run: "click",
     },
     {
@@ -141,7 +141,7 @@ const canEditInBackEnd = () => [
 const canViewInBackEnd = () => [
     {
         content: "Go to backend",
-        trigger: ".o_menu_systray .o_website_edit_in_backend a",
+        trigger: ".o_menu_systray .o_website_edit_in_backend button",
         run: "click",
     },
     {

--- a/addons/website/static/src/client_actions/website_preview/edit_in_backend.xml
+++ b/addons/website/static/src/client_actions/website_preview/edit_in_backend.xml
@@ -3,10 +3,10 @@
 <t t-name="website.EditInBackendSystrayItem">
     <div class="o_website_edit_in_backend d-flex">
         <span class="o_website_systray_separator d-none d-md-block w-0 border-start"/>
-        <a href="#" class="o_nav_entry btn d-flex align-items-center mx-1 border-0 rounded-0 px-2 px-md-3" accesskey="e" t-on-click="editInBackend">
+        <button class="o_nav_entry btn d-flex align-items-center mx-1 border-0 rounded-0 px-2 px-md-3" accesskey="e" t-on-click="editInBackend">
             <span class="fa fa-cog d-block d-md-none"/>
             <span class= "d-none d-md-block" t-esc="state.mainObjectName"/>
-        </a>
+        </button>
     </div>
 </t>
 </templates>

--- a/addons/website/static/src/client_actions/website_preview/mobile_preview_systray.xml
+++ b/addons/website/static/src/client_actions/website_preview/mobile_preview_systray.xml
@@ -3,10 +3,10 @@
 <t t-name="website.MobilePreviewSystrayItem">
     <div class="o_mobile_preview o_menu_systray_item d-none d-md-flex"
          t-att-class="{ 'o_mobile_preview_active': this.state.isMobile }">
-        <a href="#" accesskey="v" class="o_nav_entry mx-1 px-3"
+        <button accesskey="v" class="o_nav_entry mx-1 px-3"
            t-on-click="onClick">
             <span title="Mobile preview" role="img" aria-label="Mobile preview" class="fa fa-2x fa-mobile"/>
-        </a>
+        </button>
     </div>
 </t>
 </templates>

--- a/addons/website/static/src/client_actions/website_preview/publish_website_systray_item.xml
+++ b/addons/website/static/src/client_actions/website_preview/publish_website_systray_item.xml
@@ -3,16 +3,16 @@
 
 <t t-name="website.PublishSystrayItem">
     <div class="o_menu_systray_item o_website_publish_container d-flex ms-auto" t-on-click.prevent="onContainerClick" t-att-data-processing="state.processing and 1">
-        <a t-if="state.scheduled" href="#" class="o_nav_entry d-flex align-items-center mx-1" t-on-click.prevent="editInBackend" t-att-data-tooltip="state.formattedPublishAt">
+        <button t-if="state.scheduled" class="o_nav_entry d-flex align-items-center mx-1" t-on-click.prevent="editInBackend" t-att-data-tooltip="state.formattedPublishAt">
             <span class="d-none d-md-block mx-0 pe-1">
                 <RelativePublishTime datetime="state.publishOn" negativeDeltaCallback.bind="triggerPublish"/>
             </span>
             <CheckBox disabled="true" value="state.published" className="'form-switch d-flex justify-content-center m-0 pe-none'"/>
-        </a>
-        <a t-else="" href="#" class="o_nav_entry d-flex align-items-center mx-1" data-hotkey="p">
+        </button>
+        <button t-else="" class="o_nav_entry d-flex align-items-center mx-1" data-hotkey="p">
             <span class="d-none d-md-block mx-0 pe-1" t-esc="this.label"/>
             <CheckBox value="state.published" className="'form-switch d-flex justify-content-center m-0 pe-none'"/>
-        </a>
+        </button>
     </div>
 </t>
 

--- a/addons/website/static/src/components/dialog/edit_menu.xml
+++ b/addons/website/static/src/components/dialog/edit_menu.xml
@@ -71,12 +71,12 @@
         </ul>
         <div class="d-flex mt-4 justify-content-between align-items-end">
             <div class="d-flex flex-column">
-                <a href="#" t-on-click="() => this.addMenu(false)">
+                <button class="btn btn-link p-0 fw-normal text-start" t-on-click="() => this.addMenu(false)">
                     <i class="fa fa-plus-circle me-1"/> Add Menu Item
-                </a>
-                <a href="#" t-on-click="() => this.addMenu(true)">
+                </button>
+                <button class="btn btn-link p-0 fw-normal" t-on-click="() => this.addMenu(true)">
                     <i class="fa fa-plus-circle me-1"/> Add Mega Menu Item
-                </a>
+                </button>
             </div>
             <small class="text-muted">
                 <i class="fa fa-info-circle me-1"/> Drag to the right to get a submenu

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -21,7 +21,7 @@
                 <t t-call="{{ constructor.popoverTemplate }}"/>
             </t>
             <div t-att-data-bs-template="depTemplate" data-bs-html="true" title="Dependencies" t-ref="action">
-                Could be used in many places, see here: <a href="#" t-on-click="showDependencies">Dependencies</a>
+                Could be used in many places, see here: <button class="btn btn-link p-0 fw-normal" t-on-click="showDependencies">Dependencies</button>
             </div>
         </t>
         <t t-else="">

--- a/addons/website/static/src/components/website_loader/website_loader.xml
+++ b/addons/website/static/src/components/website_loader/website_loader.xml
@@ -5,11 +5,11 @@
          class="o_website_loader_container position-fixed fixed-top fixed-left h-100 w-100 d-flex"
          t-att-class="currentWaitingMessage.flag ? ('o_website_loader_container_' + currentWaitingMessage.flag) : ''">
         <div class="o_website_loader_container_content position-relative d-flex flex-column p-3 p-lg-5">
-            <a t-if="state.showCloseButton"
-               href="#" class="btn" style="position: absolute; right: 0; top: 0; margin: 15px;"
+            <button t-if="state.showCloseButton"
+               class="btn" style="position: absolute; right: 0; top: 0; margin: 15px;"
                t-on-click="close">
                 <i class="oi oi-close oi-large" role="presentation"/>
-            </a>
+            </button>
 
             <div class="o_website_loader_odoo_logo mb-5" style="height: 31px; width: 78px;"/>
 

--- a/addons/website/static/src/js/backend/view_hierarchy/view_hierarchy.xml
+++ b/addons/website/static/src/js/backend/view_hierarchy/view_hierarchy.xml
@@ -12,14 +12,14 @@
             <div class="o_tree_container ms-2 container mt-2" style="margin-bottom: 50px;">
                 <div t-if="siblingViews.length > 0" class="alert alert-info m-1 p-1">
                     Multiple tree exists for this view
-                    <a t-foreach="siblingViews" t-as="siblingView" t-key="siblingView.id" href="#" class="o_load_hierarchy" t-on-click.stop.prevent="() => this.onShowHierarchy(siblingView.id)">
+                    <button t-foreach="siblingViews" t-as="siblingView" t-key="siblingView.id" class="o_load_hierarchy btn btn-link p-0" t-on-click.stop.prevent="() => this.onShowHierarchy(siblingView.id)">
                         <i class="oi oi-arrow-right me-1"/>
                         <t t-esc="siblingView.display_name"/>
                         &lt;<t t-esc="siblingView.key"/>&gt;
                         <t t-if="siblingView.website_id">
                             [<t t-esc="siblingView.website_id[1]"/>]
                         </t>
-                    </a>
+                    </button>
                 </div>
                 <t t-set="viewTree" t-value="state.viewTree"/>
                 <t t-call="website.report_viewhierarchy_children"/>
@@ -37,12 +37,12 @@
             <t t-esc="viewTree.name"/> (<span class="fw-bold" t-esc="viewTree.key"/>)
             <span class="o_text_orange" t-if="viewTree.website_name" t-esc="`[${viewTree.website_name}]`"/>
         </span>
-        <a href="#" t-on-click.stop.prevent="() => this.openFormView(viewTree.id)">
+        <button class="border-0 bg-transparent p-0" t-on-click.stop.prevent="() => this.openFormView(viewTree.id)">
             <i class="fa fa-eye ms-2 text-muted" title="Go to View"/>
-        </a>
-        <a class="o_show_diff" href="#" t-on-click.stop.prevent="() => this.onShowDiffClick(viewTree.id)">
+        </button>
+        <button class="o_show_diff border-0 bg-transparent p-0" t-on-click.stop.prevent="() => this.onShowDiffClick(viewTree.id)">
             <i class="fa fa-files-o ms-2 text-muted" title="Show Arch Diff"/>
-        </a>
+        </button>
         <t t-if="state.searchedView.id === viewTree.id">
             <span class="o_tab_hint text-info ms-auto small fst-italic pe-2">Press &lt;Tab&gt; for next [<t t-esc="state.searchedView.index+1"/>/<t t-esc="state.searchedView.total"/>]</span>
         </t>

--- a/addons/website/static/src/scss/view_hierarchy.scss
+++ b/addons/website/static/src/scss/view_hierarchy.scss
@@ -24,12 +24,12 @@
     }
 
     .o_tree_entry {
-        a {
+        button {
             display: none;
         }
 
         &:hover {
-            a {
+            button {
                 display: block;
             }
         }

--- a/addons/website/static/src/xml/website.cookies_bar.xml
+++ b/addons/website/static/src/xml/website.cookies_bar.xml
@@ -16,12 +16,12 @@
         </p>
     </t>
     <t t-name="website.cookies_bar.text_button_all">
-        <a href="#" id="cookies-consent-all" role="button"
-           class="js_close_popup o_cookies_bar_accept_all o_cookies_bar_text_button btn btn-outline-primary rounded-circle mb-1 px-2 py-1">Allow all cookies</a>
+        <button id="cookies-consent-all"
+           class="js_close_popup o_cookies_bar_accept_all o_cookies_bar_text_button btn btn-outline-primary rounded-circle mb-1 px-2 py-1">Allow all cookies</button>
     </t>
     <t t-name="website.cookies_bar.text_button_essential">
-        <a href="#" id="cookies-consent-essential" role="button"
-           class="js_close_popup o_cookies_bar_accept_essential o_cookies_bar_text_button_essential btn btn-outline-primary rounded-circle mt-1 mb-2 px-2 py-1">Only allow essential cookies</a>
+        <button id="cookies-consent-essential"
+           class="js_close_popup o_cookies_bar_accept_essential o_cookies_bar_text_button_essential btn btn-outline-primary rounded-circle mt-1 mb-2 px-2 py-1">Only allow essential cookies</button>
     </t>
     <t t-name="website.cookies_bar.discrete">
         <!-- When updating this template, do not forget to also update the
@@ -36,10 +36,10 @@
                         </p>
                     </div>
                     <div class="col-lg-4 text-end pt16 pb16">
-                        <a href="#" id="cookies-consent-essential" role="button"
-                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm px-2">Only essentials</a>
-                        <a href="#" id="cookies-consent-all" role="button"
-                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm">I agree</a>
+                        <button id="cookies-consent-essential"
+                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm px-2">Only essentials</button>
+                        <button id="cookies-consent-all"
+                           class="js_close_popup btn btn-outline-primary rounded-circle btn-sm">I agree</button>
                     </div>
                 </div>
             </div>

--- a/addons/website/static/tests/tours/create_missing_page.js
+++ b/addons/website/static/tests/tours/create_missing_page.js
@@ -16,7 +16,7 @@ registerWebsitePreviewTour(
         changeOption("Header", "[aria-label='Open menu editor']"),
         {
             content: "Open the link dialog (click 'Add Menu Item')",
-            trigger: ".modal-body a:eq(0)",
+            trigger: ".modal-body button:contains(Add Menu Item)",
             run: "click",
         },
         {
@@ -130,7 +130,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Open the link dialog (click 'Add Menu Item')",
-            trigger: ".modal-body a:eq(0)",
+            trigger: ".modal-body button:contains(Add Menu Item)",
             run: "click",
         },
         {

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -49,7 +49,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Trigger the link dialog (click 'Add Mega Menu Item')",
-            trigger: ".modal-body a:eq(1)",
+            trigger: ".modal-body button:contains(Add Mega Menu Item)",
             run: "click",
         },
         {
@@ -152,7 +152,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Trigger the link dialog (click 'Add Mega Menu Item')",
-            trigger: ".modal-body a:eq(1)",
+            trigger: ".modal-body button:contains(Add Mega Menu Item)",
             run: "click",
         },
         {
@@ -226,7 +226,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Trigger the link dialog (click 'Add Mega Menu Item')",
-            trigger: ".modal-body a:eq(1)",
+            trigger: ".modal-body button:contains(Add Mega Menu Item)",
             run: "click",
         },
         {
@@ -285,7 +285,7 @@ const createMegaMenu = function (name) {
     return [
         {
             content: "Create a new mega menu item",
-            trigger: ".modal-body a:eq(1)",
+            trigger: ".modal-body button:contains(Add Mega Menu Item)",
             run: "click",
         },
         {
@@ -304,7 +304,7 @@ const createDropdown = function (name) {
     return [
         {
             content: "Create a new menu item for the dropdown",
-            trigger: ".modal-body a:eq(0)",
+            trigger: ".modal-body button:contains(Add Menu Item)",
             run: "click",
         },
         {
@@ -322,7 +322,7 @@ const createDropdown = function (name) {
         },
         {
             content: "Create a new menu item for the dropdown item",
-            trigger: ".modal-body a:eq(0)",
+            trigger: ".modal-body button:contains(Add Menu Item)",
             run: "click",
         },
         {
@@ -470,7 +470,7 @@ registerWebsitePreviewTour(
         }),
         {
             content: "Switch to mobile view",
-            trigger: ".o_mobile_preview > a",
+            trigger: ".o_mobile_preview > button",
             run: "click",
         },
         openMenu(),

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -96,7 +96,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Trigger the link dialog (click 'Add Mega Menu Item')",
-            trigger: ".modal:not(.o_inactive_modal) .modal-body a:eq(1)",
+            trigger: ".modal:not(.o_inactive_modal) .modal-body button:contains(Add Mega Menu Item)",
             run: "click",
         },
         {
@@ -142,7 +142,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Trigger the link dialog (click 'Add Menu Item')",
-            trigger: ".modal-body a:eq(0)",
+            trigger: ".modal-body button:contains(Add Menu Item)",
             run: "click",
         },
         {
@@ -454,7 +454,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Trigger link dialog (click 'Add Menu Item')",
-            trigger: ".modal-body a:eq(0)",
+            trigger: ".modal-body button:contains(Add Menu Item)",
             run: "click",
         },
         {
@@ -478,7 +478,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Trigger link dialog (click 'Add Menu Item')",
-            trigger: ".modal-body a:eq(0)",
+            trigger: ".modal-body button:contains(Add Menu Item)",
             run: "click",
         },
         {

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -98,7 +98,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Toggle the mobile view",
-            trigger: ".o_mobile_preview > a",
+            trigger: ".o_mobile_preview > button",
             run: "click",
         },
         {

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -61,7 +61,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Enable the mobile view",
-            trigger: ".o_mobile_preview > a",
+            trigger: ".o_mobile_preview > button",
             run: "click",
         },
         {
@@ -75,7 +75,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Disable the mobile view",
-            trigger: ".o_mobile_preview > a",
+            trigger: ".o_mobile_preview > button",
             run: "click",
         },
         ...clickOnEditAndWaitEditMode(),

--- a/addons/website/static/tests/tours/website_seo_notification.js
+++ b/addons/website/static/tests/tours/website_seo_notification.js
@@ -51,7 +51,7 @@ registerWebsitePreviewTour(
         ...clickOnSave(),
         {
             content: "Publish your website",
-            trigger: ".o_menu_systray_item.o_website_publish_container a",
+            trigger: ".o_menu_systray_item.o_website_publish_container button",
             run: "click",
         },
         {

--- a/addons/website_blog/static/src/tours/website_blog.js
+++ b/addons/website_blog/static/src/tours/website_blog.js
@@ -85,7 +85,7 @@ registerWebsitePreviewTour(
         },
         ...clickOnSave(),
         {
-            trigger: ".o_menu_systray_item.o_mobile_preview > a",
+            trigger: ".o_menu_systray_item.o_mobile_preview > button",
             content: markup(
                 _t("Use this icon to preview your blog post on <b>mobile devices</b>.")
             ),
@@ -96,7 +96,7 @@ registerWebsitePreviewTour(
             trigger: ".o_website_preview.o_is_mobile",
         },
         {
-            trigger: ".o_menu_systray_item.o_mobile_preview > a",
+            trigger: ".o_menu_systray_item.o_mobile_preview > button",
             content: _t(
                 "Once you have reviewed the content on mobile, you can switch back to the normal view by clicking here again"
             ),
@@ -107,7 +107,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe body:not(.editor_enable)",
         },
         {
-            trigger: '.o_menu_systray_item a:contains("Unpublished")',
+            trigger: '.o_menu_systray_item button:contains("Unpublished")',
             tooltipPosition: "bottom",
             content: markup(
                 _t("<b>Publish your blog post</b> to make it visible to your visitors.")
@@ -115,7 +115,7 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: '.o_menu_systray_item a:contains("Published")',
+            trigger: '.o_menu_systray_item button:contains("Published")',
         },
     ]
 );

--- a/addons/website_crm_partner_assign/static/tests/tours/publish.js
+++ b/addons/website_crm_partner_assign/static/tests/tours/publish.js
@@ -60,7 +60,7 @@ registerWebsitePreviewTour('test_cannot_publish_partner', {
     run: "click",
 }, {
     content: 'Wait for the "edit in backend" button to appear before checking the publish button',
-    trigger: '.o_menu_systray .o_website_edit_in_backend > a',
+    trigger: '.o_menu_systray .o_website_edit_in_backend > button',
     // Seems enough to just wait for that button presence before checking the
     // following step but a bit of delay seems a bit more robust to potential
     // code changes. At least if the rendering flow changes or the tour system
@@ -68,5 +68,5 @@ registerWebsitePreviewTour('test_cannot_publish_partner', {
     run: () => new Promise(resolve => setTimeout(resolve, 100)),
 }, {
     content: 'Check there is no Publish/Unpublish',
-    trigger: '.o_menu_systray:has(.o_website_edit_in_backend > a):not(:has(.o_menu_systray_item.o_website_publish_container))',
+    trigger: '.o_menu_systray:has(.o_website_edit_in_backend > button):not(:has(.o_menu_systray_item.o_website_publish_container))',
 }]);

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -69,13 +69,13 @@ function websiteCreateEventTourSteps() {
         }),
         ...clickOnSave(),
         {
-            trigger: ".o_menu_systray_item.o_website_publish_container a",
+            trigger: ".o_menu_systray_item.o_website_publish_container button",
             content: "Click to publish your event.",
             tooltipPosition: "top",
             run: "click",
         },
         {
-            trigger: ".o_website_edit_in_backend > a",
+            trigger: ".o_website_edit_in_backend > button",
             content: "Click here to customize your event further.",
             tooltipPosition: "bottom",
         },

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -90,7 +90,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe body:not(.editor_enable)",
         },
         {
-            trigger: ".o_menu_systray_item.o_website_publish_container a",
+            trigger: ".o_menu_systray_item.o_website_publish_container button",
             content: _t("Click on this button so your customers can see it."),
             tooltipPosition: "bottom",
             run: "click",

--- a/addons/website_sale/static/tests/tours/restricted_editor_ui.js
+++ b/addons/website_sale/static/tests/tours/restricted_editor_ui.js
@@ -36,7 +36,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click on publish/unpublish",
-            trigger: '.o_website_publish_container a:has(input:checked)',
+            trigger: '.o_website_publish_container button:has(input:checked)',
             run: "click",
         },
         {
@@ -45,7 +45,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click on edit-in-backend",
-            trigger: '.o_menu_systray .o_website_edit_in_backend a',
+            trigger: '.o_menu_systray .o_website_edit_in_backend button',
             run: "click",
         },
         {


### PR DESCRIPTION
We use `href=#` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href=#` and replaces it with the appropriate element or class to activate the <a> elements correctly.

task-4380519


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
