### PR TITLE
[FIX] l10n_id_efaktur_coretax: prevent error when multiple taxes in invoice

### DIFF
--- a/addons/l10n_id_efaktur_coretax/models/account_move_line.py
+++ b/addons/l10n_id_efaktur_coretax/models/account_move_line.py
@@ -38,7 +38,7 @@ class AccountMoveLine(models.Model):
             "TotalDiscount": idr.round(self.discount * tax_res['total_excluded'] * self.quantity / 100),
             "TaxBase": idr.round(self.price_subtotal),  # DPP
             "VATRate": 12,
-            "STLGRate": luxury_tax.amount if luxury_tax else 0.0,
+            "STLGRate": sum(luxury_tax.mapped('amount')) if luxury_tax else 0.0,
         }
 
         # Code 04 represents "Using other value as tax base". This code is now the norm
@@ -49,7 +49,7 @@ class AccountMoveLine(models.Model):
             line_val['OtherTaxBase'] = idr.round(self.price_subtotal * 11 / 12)
         # For all other code, OtherTaxBase will follow TaxBase and calculation of VAT should follow the amount of tax itself
         else:
-            line_val['VATRate'] = regular_tax.amount
+            line_val['VATRate'] = sum(regular_tax.mapped('amount'))
             line_val['OtherTaxBase'] = line_val['TaxBase']
 
         line_val['VAT'] = idr.round(line_val['OtherTaxBase'] * line_val['VATRate'] / 100)


### PR DESCRIPTION
The system crashes with an error when a user tries to `download the e-Faktur` document.

**Steps to produce:-**
- Install `Accounting` and switch to `ID Company`(with demo data).
- Create a `new invoice` and select customer as `ID Company`.
- Add the product and in `taxes add 11% and 0% (2 non-luxury taxes)` and confirm the invoice.
- Click on gear icon and click on `Download e-Faktur` button.

**Error:-**
`ValueError: ValueError('Expected singleton: account.tax(5, 15)') while
 evaluating 'action = records.download_efaktur()'`

**Root cause:-**
- When more than one non-luxury tax is applied and the e-Faktur document is downloading, the code at [1] expects a single tax record, but multiple non-luxury taxes are found.

**Solution:-**
- Since luxury tax is already excluded from the regular tax computation at [2], I think we can directly sum all non-luxury taxes.

[1]: https://github.com/odoo/odoo/blob/52aa6231130ea165fdb44e6370ec3e396b7603cc/addons/l10n_id_efaktur_coretax/models/account_move_line.py#L52
[2]: https://github.com/odoo/odoo/blob/52aa6231130ea165fdb44e6370ec3e396b7603cc/addons/l10n_id_efaktur_coretax/models/account_move_line.py#L24-L25

**sentry-6837559933**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
