### PR TITLE
[IMP] base, *: remove _get_view from VAT label mixin

### DIFF
--- a/addons/base_vat/views/res_partner_views.xml
+++ b/addons/base_vat/views/res_partner_views.xml
@@ -9,7 +9,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='vat']" position="after">
                     <field name="perform_vies_validation" invisible="1"/>
-                    <label for="vat" string="Tax ID"/>
+                    <label for="vat"/>
                     <div name="vat_vies_container"/>
                 </xpath>
                 <xpath expr="//div[@name='vat_vies_container']" position="inside">

--- a/addons/contacts/tests/test_ui.py
+++ b/addons/contacts/tests/test_ui.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from ast import literal_eval
-from lxml import etree
 
 import odoo.tests
 
@@ -35,18 +34,11 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_vat_label_string(self):
         """ Test changing the vat_label field of the user company_id.
-            It be immediately reflected on partners views.
+            It should be immediately reflected on partners views.
         """
         partner = self.env['res.partner'].create({'name': 'Jean'})
-        # call get view to warm the cache
-        partner.get_view()
-
         self.env.user.company_id.country_id = self.env.ref('base.us')
         self.env.user.company_id.country_id.vat_label = "TVA"
-        view = partner.get_view()
+        res = partner.get_views([(False, "form")])
 
-        arch = etree.fromstring(view['arch'])
-        for node in arch.iterfind(".//field[@name='vat']"):
-            self.assertEqual(node.get("string"), 'TVA')
-        for node in arch.iterfind(".//label[@for='vat']"):
-            self.assertEqual(node.get("string"), 'TVA')
+        self.assertEqual(res['models']['res.partner']['fields']['vat']['string'], 'TVA')

--- a/addons/l10n_latam_base/views/res_partner_view.xml
+++ b/addons/l10n_latam_base/views/res_partner_view.xml
@@ -9,7 +9,7 @@
         <field type="xml" name="arch">
             <xpath expr="//label[@for='vat']" position="replace">
                 <label for="l10n_latam_identification_type_id" string="Identification Number" invisible="is_vat and 'LATAMID' not in fiscal_country_group_codes"/>
-                <label for="vat" string="Tax ID" invisible="not is_vat or 'LATAMID' in fiscal_country_group_codes"/>
+                <label for="vat" invisible="not is_vat or 'LATAMID' in fiscal_country_group_codes"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="replace">
                 <field name="l10n_latam_identification_type_id" options="{'no_open': True, 'no_create': True}"

--- a/addons/l10n_sg/models/res_company.py
+++ b/addons/l10n_sg/models/res_company.py
@@ -8,11 +8,3 @@ class ResCompany(models.Model):
     _inherit = ['res.company']
 
     l10n_sg_unique_entity_number = fields.Char(string='UEN', related="partner_id.l10n_sg_unique_entity_number", readonly=False)
-
-    def _get_view(self, view_id=None, view_type='form', **options):
-        arch, view = super()._get_view(view_id, view_type, **options)
-        company_vat_label = self.env.company.country_id.vat_label
-        if company_vat_label:
-            for node in arch.iterfind(".//field[@name='vat']"):
-                node.set("string", company_vat_label)
-        return arch, view

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -122,11 +122,9 @@ class ResCountry(models.Model):
         if ('code' in vals or 'phone_code' in vals):
             # Intentionally simplified by not clearing the cache in create and unlink.
             self.env.registry.clear_cache('stable')
-        if 'address_view_id' in vals or 'vat_label' in vals:
+        if 'address_view_id' in vals:
             # Changing the address view of the company must invalidate the view cached for res.partner
             # because of _view_get_address
-            # Same goes for vat_label
-            # because of _get_view override from FormatVATLabelMixin
             self.env.registry.clear_cache('templates')
         return res
 

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -47,15 +47,11 @@ class FormatVatLabelMixin(models.AbstractModel):
     _description = "Country Specific VAT Label"
 
     @api.model
-    def _get_view(self, view_id=None, view_type='form', **options):
-        arch, view = super()._get_view(view_id, view_type, **options)
-        if vat_label := self.env.company.country_id.vat_label:
-            for node in arch.iterfind(".//field[@name='vat']"):
-                node.set("string", vat_label)
-            # In some module vat field is replaced and so above string change is not working
-            for node in arch.iterfind(".//label[@for='vat']"):
-                node.set("string", vat_label)
-        return arch, view
+    def fields_get(self, allfields=None, attributes=None):
+        res = super().fields_get(allfields, attributes)
+        if attributes and 'string' in attributes and 'vat' in res:
+            res['vat']['string'] = self.env.company.country_id.vat_label or _("Tax ID")
+        return res
 
 
 class FormatAddressMixin(models.AbstractModel):


### PR DESCRIPTION
The FormatVatLabelMixin override of _get_view has been replaced with a fields_get override.

The previous approach was prone to Python cache issues, while the new implementation avoids such problems entirely while keeping the feature intact.

task-4900036