### PR TITLE
[IMP] test_assetsbundle: disable test with faketime

### DIFF
--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -11,6 +11,7 @@ import textwrap
 import pathlib
 import lxml
 import base64
+import unittest
 
 import odoo
 from odoo import api
@@ -2050,6 +2051,7 @@ class AssetsNodeOrmCacheUsage(TransactionCase):
         self.assertEqual(len(qweb_keys), 1, "lazy_load shouldn't create another entry")
 
 @tagged('-at_install', 'post_install')
+@unittest.skipIf(os.getenv("ODOO_FAKETIME_TEST_MODE"), "This test cannot work with faketime")
 class TestErrorManagement(HttpCase):
 
     def test_assets_bundle_css_error_backend(self):


### PR DESCRIPTION
For a strange reason, this test can get stuck while compiling the sources with libsass when faketime is active. Some more investigation is needed but disabling it for now to avoid having builds stuck during the nightly

