### PR TITLE
[FIX] website: fix SEO on google suggestions and empty description

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -796,7 +796,7 @@ class Website(Home):
             req.raise_for_status()
             response = req.content
         except IOError:
-            return []
+            return json.dumps([])
         xmlroot = ET.fromstring(response)
         return json.dumps([sugg[0].attrib['data'] for sugg in xmlroot if len(sugg) and sugg[0].attrib['data']])
 

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -253,10 +253,10 @@ MetaKeywords.components = {
 
 class SEOPreview extends Component {
     get description() {
-        if (this.props.description.length > 160) {
+        if (this.props.description?.length > 160) {
             return this.props.description.substring(0, 159) + '…';
         }
-        return this.props.description;
+        return this.props.description || "";
     }
 }
 SEOPreview.template = 'website.SEOPreview';


### PR DESCRIPTION
Ensure the Google suggest fallback always returns a JSON list, even on IOError, instead of raising a serialization traceback.

JS (SEOPreview): guard against undefined/empty descriptions with optional chaining and default empty string to avoid runtime errors.

opw-4963552
