### PR TITLE
[FIX] website: restore quotes around palette name

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -55,7 +55,7 @@
                                     <Img class="'h-100'" src="'/website/static/src/img/snippets_options/palette.svg'"/>
                                 </t>
                                 <t t-foreach="palettes" t-as="palette" t-key="palette.name">
-                                    <BuilderSelectItem actionValue="palette.name">
+                                    <BuilderSelectItem actionValue="`'${palette.name}'`">
                                         <div class="o-color-palette-pill d-flex flex-row border rounded-pill overflow-hidden">
                                             <t t-foreach="palette.colors" t-as="color" t-key="color">
                                                 <span class="w-100" t-attf-style="background-color: {{color}};"></span>

--- a/addons/website/static/tests/builder/theme_tab/palette.test.js
+++ b/addons/website/static/tests/builder/theme_tab/palette.test.js
@@ -27,7 +27,7 @@ test("theme tab: warning on palette change", async () => {
     await contains(
         ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
     ).click();
-    await contains("[data-action-value='default-light-1'] .o-color-palette-pill span").click();
+    await contains(`[data-action-value="'default-light-1'"] .o-color-palette-pill span`).click();
     expect(".o_dialog").toHaveCount(1);
     await contains(".o_dialog .btn-secondary").click();
     expect(".o_dialog").toHaveCount(0);
@@ -35,11 +35,11 @@ test("theme tab: warning on palette change", async () => {
     await contains(
         ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
     ).click();
-    await contains("[data-action-value='default-light-1'] .o-color-palette-pill span").click();
+    await contains(`[data-action-value="'default-light-1'"] .o-color-palette-pill span`).click();
     expect(".o_dialog").toHaveCount(1);
     await contains(".o_dialog .btn-primary").click();
     expect.verifySteps([
-        '/website/static/src/scss/options/user_values.scss {"color-palettes-name":"default-light-1"}',
+        `/website/static/src/scss/options/user_values.scss {"color-palettes-name":"'default-light-1'"}`,
     ]);
 });
 
@@ -63,9 +63,9 @@ test("theme tab: no warning on palette change", async () => {
     await contains(
         ".o_theme_tab [data-src='/website/static/src/img/snippets_options/palette.svg']"
     ).click();
-    await contains("[data-action-value='default-light-1'] .o-color-palette-pill span").click();
+    await contains(`[data-action-value="'default-light-1'"] .o-color-palette-pill span`).click();
     expect(".o_dialog").toHaveCount(0);
     expect.verifySteps([
-        '/website/static/src/scss/options/user_values.scss {"color-palettes-name":"default-light-1"}',
+        `/website/static/src/scss/options/user_values.scss {"color-palettes-name":"'default-light-1'"}`,
     ]);
 });


### PR DESCRIPTION
Since the refactoring, the `color-palettes-name` value is not surrounded by quotes in the `user_values.scss` anymore.

This commit restores the quotes upon selection.

task-4367641
