### PR TITLE
[FIX] website: fix resize text box in a new floating card

### DIFF
--- a/addons/website/static/src/snippets/s_floating_blocks/options.xml
+++ b/addons/website/static/src/snippets/s_floating_blocks/options.xml
@@ -12,7 +12,7 @@
     <section data-name="Card" class="s_floating_blocks_block s_col_no_resize position-sticky d-flex py-5 o_cc o_cc1">
         <div class="container-fluid align-self-end">
             <div class="s_floating_blocks_block_grid row mx-0 o_grid_mode" data-row-count="8">
-                <div class="o_grid_item g-height-4 col-lg-8 order-lg-0" style="z-index: 1; grid-area: 1 / 1 / 5 / 9;">
+                <div class="o_grid_item g-height-4 g-col-lg-8 col-lg-8 order-lg-0" style="z-index: 1; grid-area: 1 / 1 / 5 / 9;">
                     <p class="lead">A great subtitle</p>
                     <h2 class="display-4-fs">Card Title</h2>
                 </div>


### PR DESCRIPTION
Steps to reproduce:

- In "Website" app.
- Create a "Floating cards" block using website editor.
- Add a new card.
- Adjust the text box size.
- Error occurs.

It was due to the XML structure of the new card, which was incorrect and caused the resize to crash in "grid" mode.

opw-5027795