### PR TITLE
[FIX] website_sale: display prices with currency precision

### DIFF
--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -21,6 +21,7 @@ class WebsiteSaleVariantController(Controller):
             add_qty=add_qty and float(add_qty) or 1.0,
             parent_combination=request.env['product.template.attribute.value'].browse(parent_combination),
         )
+        combination_info['currency_precision'] = combination_info['currency'].decimal_places
 
         # Pop data only computed to ease server-side computations.
         for key in ('product_taxes', 'taxes', 'currency', 'date'):

--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -535,8 +535,10 @@ var VariantMixin = {
         var $price = $parent.find(".oe_price:first .oe_currency_value");
         var $default_price = $parent.find(".oe_default_price:first .oe_currency_value");
         var $optional_price = $parent.find(".oe_optional:first .oe_currency_value");
-        $price.text(self._priceToStr(combination.price));
-        $default_price.text(self._priceToStr(combination.list_price));
+        const precision = combination.currency_precision;
+        $price.parent().addClass('decimal_precision').attr('data-precision', precision);
+        $price.text(self._priceToStr(combination.price, precision));
+        $default_price.text(self._priceToStr(combination.list_price, precision));
 
         var isCombinationPossible = true;
         if (typeof combination.is_combination_possible !== "undefined") {
@@ -615,12 +617,12 @@ var VariantMixin = {
      *
      * @private
      * @param {float} price
+     * @param {integer} precision
+     * @returns {string}
      */
-    _priceToStr: function (price) {
-        var precision = 2;
-
-        if ($('.decimal_precision').length) {
-            precision = parseInt($('.decimal_precision').last().data('precision'));
+    _priceToStr: function (price, precision) {
+        if (!Number.isInteger(precision)) {
+            precision = parseInt($('.decimal_precision:last').data('precision') ?? 2);
         }
         var formatted = price.toFixed(precision).split(".");
         const { thousandsSep, decimalPoint, grouping } = localization;

--- a/addons/website_sale/static/src/js/variant_mixin.js
+++ b/addons/website_sale/static/src/js/variant_mixin.js
@@ -8,7 +8,9 @@ VariantMixin._onChangeCombination = function (ev, $parent, combination) {
     if ($pricePerUom) {
         if (combination.is_combination_possible !== false && combination.base_unit_price != 0) {
             $pricePerUom.parents(".o_base_unit_price_wrapper").removeClass("d-none");
-            $pricePerUom.text(this._priceToStr(combination.base_unit_price));
+            $pricePerUom.text(
+                this._priceToStr(combination.base_unit_price, combination.currency_precision)
+            );
             $parent.find(".oe_custom_base_unit:first").text(combination.base_unit_name);
         } else {
             $pricePerUom.parents(".o_base_unit_price_wrapper").addClass("d-none");

--- a/addons/website_sale_product_configurator/static/src/js/sale_product_configurator_modal.js
+++ b/addons/website_sale_product_configurator/static/src/js/sale_product_configurator_modal.js
@@ -508,7 +508,8 @@ export const OptionalProductsModal = Dialog.extend(VariantMixin, {
      * we need to refresh the total price row
      */
     _computePriceTotal: function () {
-        if (this.$modal.find('.js_price_total').length) {
+        const $priceTotal = this.$modal.find('.js_price_total');
+        if ($priceTotal.length) {
             var price = 0;
             this.$modal.find('.js_product.in_cart').each(function () {
                 var quantity = parseFloat($(this).find('input[name="add_qty"]').first().val().replace(',', '.') || 1);
@@ -516,7 +517,7 @@ export const OptionalProductsModal = Dialog.extend(VariantMixin, {
             });
 
             this.$modal.find('.js_price_total .oe_currency_value').text(
-                this._priceToStr(parseFloat(price))
+                this._priceToStr(parseFloat(price), $priceTotal.data('precision'))
             );
         }
     },

--- a/addons/website_sale_product_configurator/views/templates.xml
+++ b/addons/website_sale_product_configurator/views/templates.xml
@@ -123,7 +123,9 @@
             <tr class="o_total_row">
                 <td colspan="4" class="text-end">
                     <strong>Total:</strong>
-                    <span class="js_price_total fw-bold" style="white-space: nowrap;"
+                    <span class="js_price_total fw-bold decimal_precision"
+                        style="white-space: nowrap;"
+                        t-att-data-precision="combination_info['currency'].decimal_places"
                         t-att-data-product-id="product.id"
                         t-out="combination_info['price'] * (add_qty or 1)"
                         t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Set currency rounding of EUR to 1.0;
2. use the currency on a website pricelist;
3. go to a product page in /shop;
4. open the url in a new session.

Issue
-----
From the editor, the price gets displayed as expected, with no decimals. In the new session, the price gets displayed with two decimals.

Cause
-----
The `_priceToStr` method used, always uses a `precision` of 2, except in editor mode when it will retrieve a different value from a hidden `.decimal_precision` element.

Solution
--------
Add the website's currency precision to `combination_info` via the controller, and use this value in `_priceToStr`.

For the product configurator, store the currency precision in the `.js_price_total` element's dataset.

Also insert the precision in the `.oe_price` element's dataset, allowing it to be used as a fallback in case the configurator template isn't up to date.

opw-4996878