### PR TITLE
[IMP] account, web: design section and subsections

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -14,8 +14,7 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
 
     get sectionAndNoteClasses() {
         return {
-            "fw-bolder": this.isTopSection(),
-            "fw-bold": this.isSection() && !this.isTopSection(),
+            "fw-bold": this.isSection(),
             "fst-italic": this.isNote(),
             "text-warning": this.shouldShowWarning(),
         };

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -18,7 +18,7 @@
             <t t-elif="isSection()">
                 <input
                     type="text"
-                    class="o_input text-wrap border-0 fst-italic w-100"
+                    class="o_input text-wrap border-0 w-100"
                     placeholder="Enter a description"
                     t-att-class="sectionAndNoteClasses"
                     t-att-readonly="sectionAndNoteIsReadonly"

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
@@ -2,45 +2,70 @@
 // The goal of this file is to contain CSS hacks related to allowing
 // section and note on sale order and invoice.
 
-table.o_section_and_note_list_view tr.o_data_row {
-    &.o_is_line_note {
-        font-style: italic;
-    }
-    &.o_is_line_section {
-        font-weight: bold;
-        background-color: #DDDDDD;
-        --table-bg: var(--300);
-    }
-    &.o_is_line_subsection {
-        --table-bg: var(--200);
-    }
-    &.o_is_line_section, &.o_is_line_subsection {
-        border-top: 1px solid #BBB;
-        border-bottom: 1px solid #BBB;
-        .o_list_section_options {
-            width: 1px;  // to prevent the column to expand
-            button {
-                padding: 0px;
-                background: none;
-                border-style: none;
-                display: table-cell;
-                cursor: pointer;
+table.o_section_and_note_list_view {
+    --o-SectionAndNote-border-color: #{$gray-500};
+    $_SectionAndNote-transition: 0.1s ease-in-out;
+
+    tr {
+        &.o_is_line_note {
+            font-style: italic;
+        }
+
+        &.o_is_line_section, &.o_is_line_subsection {
+            --table-striped-bg: var(--table-bg-type);
+
+            .o_list_section_options {
+                width: 1px;  // to prevent the column to expand
+            }
+
+            td[name="price_subtotal"] {
+                color: $gray-700;
             }
         }
-        &.o_selected_row {
-            th:focus-within, td:focus-within {
-                background-color: var(--table-bg);
+
+        &.o_is_line_section {
+            --table-hover-bg: #{rgba($body-emphasis-color, .08)};
+            --table-bg-type: #{rgba($body-emphasis-color, .06)};
+
+            .o_handle_cell .o_row_handle {
+                transition: opacity $_SectionAndNote-transition;
+            }
+
+            &:where(:not(.o_selected_row)) {
+                div:has(> div.o_field_product_label_section_and_note_cell) {
+                    transition: transform $_SectionAndNote-transition;
+                    position: absolute;
+                }
+
+                &:not(:hover, .o_dragged) {
+                    div:has(> div.o_field_product_label_section_and_note_cell) {
+                        transform: translateX(($font-size-base + $table-cell-padding-x-sm * 2) * -1);
+                    }
+
+                    .o_handle_cell .o_row_handle {
+                        cursor: default;
+                        pointer-events: none;
+                        opacity: 0;
+                    }
+                }
             }
         }
-    }
-    &.o_is_line_note,
-    &.o_is_line_section,
-    &.o_is_line_subsection {
-        td {
-            // There is an undeterministic CSS behaviour in Chrome related to
-            // the combination of the row's and its children's borders.
-            border: none !important;
+
+        &.o_is_line_subsection {
+            --table-hover-bg: #{rgba($body-emphasis-color, .05)};
+            --table-bg-type: #{rgba($body-emphasis-color, .03)};
         }
+
+        // Check if next sibling is a section to apply a border-color.
+        &:where(:not(.o_dragged):has(+ .o_is_line_section:not(.o_dragged, .d-table-row))) {
+            border-color: var(--o-SectionAndNote-border-color);
+        }
+    }
+
+    // Check if first tr in the table is a section to apply a border-color on
+    // the <th> els.
+    &:where(:has(tbody > tr:first-child.o_is_line_section:not(.o_dragged, .d-table-row))) th {
+        border-color: var(--o-SectionAndNote-border-color);
     }
 }
 

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -12,7 +12,7 @@
         <xpath expr="//td[hasclass('o_list_record_remove')]" position="after">
             <td t-else="" class="o_list_section_options w-print-0 p-print-0 text-center">
                 <Dropdown position="'bottom-end'" t-if="!props.readonly">
-                    <button class="btn px-1 cursor-pointer">
+                    <button class="btn d-table-cell border-0 py-0 px-1 cursor-pointer">
                         <i class="fa fa-ellipsis-v"/>
                     </button>
                     <t t-set-slot="content">

--- a/addons/account/static/tests/section_and_note.test.js
+++ b/addons/account/static/tests/section_and_note.test.js
@@ -875,8 +875,7 @@ test("can resequence sections", async () => {
             </form>
         `,
     });
-
-    await contains(".o_data_row:eq(11) .o_row_handle").dragAndDrop(".o_data_row:eq(0)");
+    await contains(".o_data_row:eq(11) .o_row_handle", { visible: false }).dragAndDrop(".o_data_row:eq(0)");
     expect(queryAllTexts(".o_data_row")).toEqual(
         ["C", "r1", "r2", "A", "A1", "A2", "B", "B1", "B2", "Ba", "Ba1", "Ba2", "C1"],
         {

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -149,7 +149,7 @@
         }
 
         .o_field_x2many .o_list_table .o_handle_cell .o_row_handle {
-            padding: 0.3rem;
+            padding: $table-cell-padding-x-sm;
         }
 
         .o_row {
@@ -578,7 +578,7 @@
 
                             // use original padding-left for handle cell in editable list
                             tr > :first-child.o_handle_cell {
-                                padding-left: 0.3rem;
+                                padding-left: $table-cell-padding-x-sm;
                             }
                         }
                     }


### PR DESCRIPTION
Improve how the sections and subsections are displayed in the backend. Subsection and section have two distinct background for improved hierarchy. Both use a value just above the `table-striped` background
color.

Indentation and border is added on the sections to emphasise a visual separation from the regular table cells.

Note:
- removed the `border: 0 !important` on td because the sections are now using a border on its previous sibling.
- using the previous sibling for the border because the previous sibling's border-bottom is above the current row's border-top.

task-5000258

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
