### PR TITLE
[FIX] discuss: race condition in meeting tests

### DIFF
--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -104,9 +104,9 @@ class PublicPageController(http.Controller):
     def _response_discuss_public_template(self, store: Store, channel):
         store.add_global_values(
             companyName=request.env.company.name,
-            discuss_public_thread=Store.One(channel),
             inPublicPage=True,
         )
+        store.add_singleton_values("DiscussApp", {"thread": store.One(channel)})
         return request.render(
             "mail.discuss_public_channel_template",
             {

--- a/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
@@ -16,7 +16,7 @@ patch(DiscussClientAction.prototype, {
             browser.history.replaceState(
                 browser.history.state,
                 null,
-                `/discuss/channel/${this.store.discuss_public_thread.id}${browser.location.search}`
+                `/discuss/channel/${this.store.discuss.thread.id}${browser.location.search}`
             );
         }
         browser.addEventListener("popstate", () => this.restoreDiscussThread(this.props));

--- a/addons/mail/static/src/discuss/core/public/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/public/store_service_patch.js
@@ -1,4 +1,3 @@
-import { fields } from "@mail/core/common/record";
 import { Store } from "@mail/core/common/store_service";
 
 import { patch } from "@web/core/utils/patch";
@@ -13,7 +12,6 @@ const storeServicePatch = {
         this.inPublicPage;
         /** @type {boolean|undefined} */
         this.isChannelTokenSecret;
-        this.discuss_public_thread = fields.One("Thread");
         /** @type {boolean|undefined} */
         this.shouldDisplayWelcomeViewInitially;
     },

--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -26,7 +26,7 @@ export class WelcomePage extends Component {
         this.audioRef = useRef("audio");
         this.videoRef = useRef("video");
         onMounted(() => {
-            if (this.store.discuss_public_thread.default_display_mode === "video_full_screen") {
+            if (this.store.discuss.thread.default_display_mode === "video_full_screen") {
                 this.enableMicrophone();
                 this.enableVideo();
             }

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -4,12 +4,12 @@
 <t t-name="mail.WelcomePage">
     <div class="o-mail-WelcomePage h-100 w-100 d-flex flex-column justify-content-center align-items-center bg-light">
         <h1 class="fw-light">
-            <span t-if="this.store.discuss_public_thread.default_display_mode === 'video_full_screen'">You've been invited to a meeting!</span>
+            <span t-if="this.store.discuss.thread.default_display_mode === 'video_full_screen'">You've been invited to a meeting!</span>
             <span t-else="">You've been invited to a chat!</span>
         </h1>
         <h2 class="m-5" t-esc="store.companyName"/>
         <div class="d-flex justify-content-center gap-5" t-att-class="{'flex-column': ui.isSmall}">
-            <div t-if="this.store.discuss_public_thread.default_display_mode === 'video_full_screen'" class="position-relative d-flex justify-content-center" t-ref="root">
+            <div t-if="this.store.discuss.thread.default_display_mode === 'video_full_screen'" class="position-relative d-flex justify-content-center" t-ref="root">
                 <video class="shadow rounded-3 bg-dark" t-attf-height="{{ui.isSmall ? 240 : 480}}" t-attf-width="{{ui.isSmall ? 320 : 640}}" autoplay="" t-ref="video"/>
                 <p t-if="hasRtcSupport and !state.videoStream" class="position-absolute bottom-50 text-light">
                     Camera is off

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -66,6 +66,7 @@ def get_sfu_key(env) -> str | None:
 ids_by_model = defaultdict(lambda: ("id",))
 ids_by_model.update(
     {
+        "DiscussApp": (),
         "mail.thread": ("model", "id"),
         "MessageReactions": ("message", "content"),
         "Rtc": (),


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/223356, the welcome page relies on `store.discuss.thread` which was initialized asynchronously and caused a race condition where we tried to use it too early.

This commit fixes this issue by setting `store.discuss.thread` as part of the initial data of the meeting page. The commit also removes the now redundant `discuss_public_thread` field and uses `store.discuss.thread` instead.

https://runbot.odoo.com/odoo/error/231202
