### PR TITLE
[FIX] stock: avoid table row page split in reception report

### DIFF
--- a/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
+++ b/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
@@ -13,7 +13,7 @@
                 </div>
             </t>
         </ControlPanel>
-        <div class="o_report_reception container-fluid justify-content-between">
+        <div class="o_report_reception o_report_reception_no_print container-fluid justify-content-between">
             <div class="o_report_reception_header my-4">
                 <h1>
                     <t t-if="data.docs">

--- a/addons/stock/static/src/scss/report_stock_reception.scss
+++ b/addons/stock/static/src/scss/report_stock_reception.scss
@@ -1,6 +1,5 @@
 .o_report_reception {
 
-    overflow-y: auto;
     .o_priority {
         &.o_priority_star {
             font-size: 1.35em;
@@ -30,6 +29,10 @@
     & thead{
         display: table-row-group;
     }
+}
+
+.o_report_reception_no_print {
+    overflow-y: auto;
 }
 
 .o_label_page {


### PR DESCRIPTION
### Issue:

- In the settings enable reception report.
- Create a storable product with a product name of length 60.
- Create and confirm a delivery with 20+ lines of 1 x that product.
- Create and confirm a PO with 20+ lines referring to 1 x that product.
- Validate the receipt > Allocation smart button > Assign all.
- Click on print and open the PDF.
#### > The last row of the first page is cut in half at the end of the page and the beginning of the next one.

### Cause of the issue:

The class `o_report_reception` is used both in the view of the reception report `ReceptionReportMain`:
https://github.com/odoo/odoo/blob/25b8e651c439d688bd05dd0d9619d74fa749597d/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml#L16 and its printed version:
https://github.com/odoo/odoo/blob/25b8e651c439d688bd05dd0d9619d74fa749597d/addons/stock/report/report_stock_reception.xml#L43-L44 However, when the report becomes too big (many lines), the class did not allow the user to scroll down the view and a fix has been implemented adding the overflow-y style to the class see https://github.com/odoo/odoo/commit/d8a19285939fb31f6d34290cb8138d402e93024b https://github.com/odoo/odoo/blob/25b8e651c439d688bd05dd0d9619d74fa749597d/addons/stock/static/src/scss/report_stock_reception.scss#L3 The issue being that wkhtmltopdf relies on the size of the table to determine if a row should be displayed on a page or an other one and if you can scroll down he will apparently not do his job correctly.

opw-4824221
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
