### PR TITLE
[FIX] sale_timesheet: TestSaleTimesheetUi test_ui tour

### DIFF
--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -51,7 +51,10 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     trigger: 'button.o_kanban_add',
     content: 'Click on Add button to create the column.',
     run: "click",
-}, {
+},{
+    content: "wait the new column is created",
+    trigger: ".o_kanban_renderer .o_kanban_group .o_kanban_header_title:contains(to do)",
+},{
     trigger: 'button.o-kanban-button-new',
     content: 'Click on Create button to create a task into your project.',
     run: "click",


### PR DESCRIPTION
In this commit, we fix the undeterministic behavior by adding a step to ensure kanban column is created before continue scenario.

runbot-error-id~181916

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
