### PR TITLE
[FIX] website_sale_wishlist: scope add wishlist styling

### DIFF
--- a/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.options.scss
+++ b/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.options.scss
@@ -2,7 +2,7 @@
 
 // By default, hide `o_add_wishlist` buttons when inside a product
 // entry. Show them when `o_wsale_products_opt_has_wishlist` is applied.
-.o_add_wishlist {
+:where(.oe_product_cart) .o_add_wishlist {
     display: var(--o-wsale-wishlist-btn-display, none);
 }
 


### PR DESCRIPTION
The styling used on the product tiles and in the wishlist was applied in the `/cart` page, making the "Save for later" display: none;

This commit scopes this styling to apply on the `oe_product_cart`.

task-5045492

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
