### PR TITLE
[FIX] html_builder: fix flatten save's groupBy

### DIFF
--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -29,7 +29,7 @@ export class SavePlugin extends Plugin {
             //     root is the clone of a node that was o_dirty
             // }
         ],
-        group_element_save_handlers: withSequence(30, this.groupElementHandler.bind(this)),
+        group_element_save_handlers: withSequence(30, () => ""),
         save_element_handlers: [
             // async (el) => {
             //     called when saving an element (in parallel to saving the view)
@@ -65,7 +65,6 @@ export class SavePlugin extends Plugin {
         }
     }
     async _save() {
-        // TODO: implement the "group by" feature for save
         const dirtyEls = [];
         for (const getDirtyEls of this.getResource("get_dirty_els")) {
             dirtyEls.push(...getDirtyEls());
@@ -73,6 +72,7 @@ export class SavePlugin extends Plugin {
         // Group elements to save if possible
         const groupedElements = groupBy(dirtyEls, (dirtyEl) => {
             const model = dirtyEl.dataset.oeModel;
+            const recordId = dirtyEl.dataset.oeId;
             const field = dirtyEl.dataset.oeField;
 
             // There are elements which have no linked model as something
@@ -82,12 +82,11 @@ export class SavePlugin extends Plugin {
                 return uniqueId("special-element-to-save-");
             }
 
+            // TODO In master: remove this resource.
             const groupElementHandler = this.getResource("group_element_save_handlers")[0];
             // If not defined, group elements which are from the same field of
             // the same record.
-            return (
-                groupElementHandler(model, field) || `${model}::${dirtyEl.dataset.oeId}::${field}`
-            );
+            return groupElementHandler(model, field, recordId) || `${model}::${recordId}::${field}`;
         });
         const saveProms = Object.values(groupedElements).map(async (dirtyEls) => {
             const cleanedEls = dirtyEls.map((dirtyEl) => {
@@ -101,13 +100,11 @@ export class SavePlugin extends Plugin {
                     return;
                 }
             }
-            const proms = this.getResource("save_element_handlers")
-                .map((saveElementHandler) => saveElementHandler(cleanedEls[0]))
-                .filter(Boolean);
-            if (!proms.length) {
-                console.warn("no save_element_handlers for dirty element", cleanedEls[0]);
+            for (const cleanedEl of cleanedEls) {
+                for (const saveElementHandler of this.getResource("save_element_handlers")) {
+                    await saveElementHandler(cleanedEl);
+                }
             }
-            await Promise.all(proms);
         });
         // used to track dirty out of the editable scope, like header, footer or wrapwrap
         const willSaves = this.getResource("save_handlers").map((c) => c());
@@ -115,7 +112,8 @@ export class SavePlugin extends Plugin {
         this.dependencies.history.reset();
     }
 
-    groupElementHandler(model, field) {
+    // TODO Dead code: remove in master
+    groupElementHandler(model, field, recordId) {
         return model === "ir.ui.view" && field === "arch" ? uniqueId("view-part-to-save-") : "";
     }
 


### PR DESCRIPTION
The default groupBy is on a unique ID. Because of this, when several changes need to be saved inside a single element, they get saved in parallel.

This commit makes the default groupBy the actual default which combines model, record id and field, and sequentializes all saves within a single group.

Steps to reproduce:
- Go to a product page
- Edit
- Add text along the "+" icon
- Add text along the "-" icon
- Save

=> The "+/-" icons became duplicated - because saving each of them did create a distinct copy-on-write version of the template.

task-4367641
