### PR TITLE
[FIX] hr_expense: Employee cant use chatter on his own expenses

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -272,9 +272,9 @@ class HrExpense(models.Model):
     )
 
     # Security fields
-    is_editable = fields.Boolean(string="Is Editable By Current User", compute='_compute_is_editable', readonly=True, compute_sudo=True)
-    can_reset = fields.Boolean(string='Can Reset', compute='_compute_can_reset', readonly=True, compute_sudo=True)
-    can_approve = fields.Boolean(string='Can Approve', compute='_compute_can_approve', readonly=True, compute_sudo=True)
+    is_editable = fields.Boolean(string="Is Editable By Current User", compute='_compute_is_editable', readonly=True)
+    can_reset = fields.Boolean(string='Can Reset', compute='_compute_can_reset', readonly=True)
+    can_approve = fields.Boolean(string='Can Approve', compute='_compute_can_approve', readonly=True)
 
     # Legacy sheet field, allow grouping of expenses to keep the grouping mechanic data and allow it to be re-used when re-implemented
     former_sheet_id = fields.Integer(string='Former Report')
@@ -356,7 +356,7 @@ class HrExpense(models.Model):
             managers = (
                 expense.manager_id
                 | employee.expense_manager_id
-                | employee.department_id.manager_id.user_id
+                | employee.sudo().department_id.manager_id.user_id
             )
             if is_all_approver:
                 managers |= self.env.user
@@ -1386,7 +1386,7 @@ class HrExpense(models.Model):
             elif not is_hr_admin:
                 current_managers = (
                         expense_employee.expense_manager_id
-                        | expense_employee.department_id.manager_id.user_id
+                        | expense_employee.sudo().department_id.manager_id.user_id
                         | expense.manager_id
                 )
                 if expense_employee.id in expenses_employee_ids_under_user_ones:

--- a/addons/hr_expense/static/src/views/expense_attach_documents.js
+++ b/addons/hr_expense/static/src/views/expense_attach_documents.js
@@ -1,0 +1,38 @@
+import { registry } from "@web/core/registry";
+import { checkFileSize } from "@web/core/utils/files";
+import { AttachDocumentWidget } from "@web/views/widgets/attach_document/attach_document";
+
+export class ExpenseAttachDocumentWidget extends AttachDocumentWidget {
+    async onInputChange() {
+        const ufile = [...this.fileInput.files];
+        for (const file of ufile) {
+            if (!checkFileSize(file.size, this.notification)) {
+                return null;
+            }
+        }
+        const fileData = await this.http.post("/mail/attachment/upload", {
+            csrf_token: odoo.csrf_token,
+            ufile: ufile,
+            thread_model: this.props.record.resModel,
+            thread_id: this.props.record.resId,
+        });
+        if (fileData.error) {
+            throw new Error(fileData.error);
+        }
+        await this.onFileUploaded(fileData.data["ir.attachment"] || []);
+    }
+}
+
+export const attachDocumentWidget = {
+    component: ExpenseAttachDocumentWidget,
+    extractProps: ({ attrs }) => {
+        const { action, highlight, string } = attrs;
+        return {
+            action,
+            highlight: !!highlight,
+            string,
+        };
+    },
+};
+
+registry.category("view_widgets").add("expense_attach_document", attachDocumentWidget);

--- a/addons/hr_expense/tests/test_expenses_access_rights.py
+++ b/addons/hr_expense/tests/test_expenses_access_rights.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
+from odoo import http
 from odoo.exceptions import AccessError
 from odoo.tests import HttpCase, tagged, new_test_user
 
@@ -49,3 +49,90 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
         })
         self.start_tour("/odoo", 'hr_expense_access_rights_test_tour', login="test-expense")
         self.assertRecordValues(expense, [{'state': 'submitted'}])
+
+    def test_expense_create_and_post_message_on_submitted(self):
+        """ Test than different users can post (or not) a message and an attachment when the expense is submitted.
+        """
+
+        standard_user = self.expense_user_employee
+        another_standard_user = new_test_user(self.env, login='another_standard_user', groups='base.group_user')
+        standard_user_manager = self.expense_user_manager
+        admin_user = self.env.ref('base.user_admin')
+        admin_user.company_ids |= self.env.companies
+
+        expense = self.env['hr.expense'].with_user(standard_user).create({
+            'name': "Superboy costume washing",
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_a.id,
+            'quantity': 1,
+            'price_unit': 1,
+        })
+
+        expense.with_user(standard_user).action_submit()
+
+        expense.with_user(standard_user).message_post(body="Standard user posts a message on his own expense.")
+        with self.assertRaises(AccessError):
+            expense.with_user(another_standard_user).message_post(body="Another standard user tries to post a message on the expense.")
+        expense.with_user(standard_user_manager).message_post(body="Manager user posts a message on the expense.")
+        expense.with_user(admin_user).message_post(body="Admin user posts a message on the expense.")
+
+        self.assertEqual(len(expense.message_ids), 3)
+
+        # When testing for uploading the attachments, we cant simulate it through a tour as using inputFiles isn't possible
+        # with a AttachDocumentWidget since the input isn't added to the DOM.
+        self.authenticate(standard_user.login, standard_user.login)
+        response_user = self.url_open("/mail/attachment/upload",
+            {
+            "csrf_token": http.Request.csrf_token(self),
+            "thread_id": expense.id,
+            "thread_model": "hr.expense",
+            },
+            files={'ufile': ('salut.txt', b"Salut !\n", 'text/plain')},
+        )
+        expense.with_user(standard_user).attach_document(attachment_ids=[data['id'] for data in response_user.json()['data']['ir.attachment']])
+        self.assertEqual(response_user.status_code, 200)
+        self.assertEqual(len(expense.attachment_ids), 1)
+        self.assertEqual(expense.message_main_attachment_id.id, response_user.json()['data']['ir.attachment'][0]['id'])
+
+        self.authenticate(another_standard_user.login, another_standard_user.login)
+        response_user2 = self.url_open("/mail/attachment/upload",
+            {
+            "csrf_token": http.Request.csrf_token(self),
+            "thread_id": expense.id,
+            "thread_model": "hr.expense",
+            },
+            files={'ufile': ('fail.txt', b"Fail\n", 'text/plain')},
+        )
+        with self.assertRaises(AccessError):
+            expense.with_user(another_standard_user).attach_document(attachment_ids=None)
+        self.assertEqual(response_user2.status_code, 404)
+        self.assertEqual(len(expense.attachment_ids), 1)  # No new attachment
+        self.assertEqual(expense.message_main_attachment_id.id, response_user.json()['data']['ir.attachment'][0]['id'])
+
+        self.authenticate(standard_user_manager.login, standard_user_manager.login)
+        response_manager = self.url_open("/mail/attachment/upload",
+            {
+            "csrf_token": http.Request.csrf_token(self),
+            "thread_id": expense.id,
+            "thread_model": "hr.expense",
+            },
+            files={'ufile': ('manager.txt', b"Manager\n", 'text/plain')},
+        )
+        expense.with_user(standard_user_manager).attach_document(attachment_ids=[data['id'] for data in response_manager.json()['data']['ir.attachment']])
+        self.assertEqual(response_manager.status_code, 200)
+        self.assertEqual(len(expense.attachment_ids), 2)
+        self.assertEqual(expense.message_main_attachment_id.id, response_manager.json()['data']['ir.attachment'][0]['id'])
+
+        self.authenticate(admin_user.login, admin_user.login)
+        response_admin = self.url_open("/mail/attachment/upload",
+            {
+            "csrf_token": http.Request.csrf_token(self),
+            "thread_id": expense.id,
+            "thread_model": "hr.expense",
+            },
+            files={'ufile': ('admin.txt', b"Admin\n", 'text/plain')},
+        )
+        expense.with_user(admin_user).attach_document(attachment_ids=[data['id'] for data in response_admin.json()['data']['ir.attachment']])
+        self.assertEqual(response_admin.status_code, 200)
+        self.assertEqual(len(expense.attachment_ids), 3)
+        self.assertEqual(expense.message_main_attachment_id.id, response_admin.json()['data']['ir.attachment'][0]['id'])

--- a/addons/hr_expense/tests/test_expenses_access_rights.py
+++ b/addons/hr_expense/tests/test_expenses_access_rights.py
@@ -89,10 +89,10 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
             },
             files={'ufile': ('salut.txt', b"Salut !\n", 'text/plain')},
         )
-        expense.with_user(standard_user).attach_document(attachment_ids=[data['id'] for data in response_user.json()['data']['ir.attachment']])
+        expense.with_user(standard_user).attach_document(attachment_ids=[data['id'] for data in response_user.json()['data']['store_data']['ir.attachment']])
         self.assertEqual(response_user.status_code, 200)
         self.assertEqual(len(expense.attachment_ids), 1)
-        self.assertEqual(expense.message_main_attachment_id.id, response_user.json()['data']['ir.attachment'][0]['id'])
+        self.assertEqual(expense.message_main_attachment_id.id, response_user.json()['data']['store_data']['ir.attachment'][0]['id'])
 
         self.authenticate(another_standard_user.login, another_standard_user.login)
         response_user2 = self.url_open("/mail/attachment/upload",
@@ -107,7 +107,7 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
             expense.with_user(another_standard_user).attach_document(attachment_ids=None)
         self.assertEqual(response_user2.status_code, 404)
         self.assertEqual(len(expense.attachment_ids), 1)  # No new attachment
-        self.assertEqual(expense.message_main_attachment_id.id, response_user.json()['data']['ir.attachment'][0]['id'])
+        self.assertEqual(expense.message_main_attachment_id.id, response_user.json()['data']['store_data']['ir.attachment'][0]['id'])
 
         self.authenticate(standard_user_manager.login, standard_user_manager.login)
         response_manager = self.url_open("/mail/attachment/upload",
@@ -118,10 +118,10 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
             },
             files={'ufile': ('manager.txt', b"Manager\n", 'text/plain')},
         )
-        expense.with_user(standard_user_manager).attach_document(attachment_ids=[data['id'] for data in response_manager.json()['data']['ir.attachment']])
+        expense.with_user(standard_user_manager).attach_document(attachment_ids=[data['id'] for data in response_manager.json()['data']['store_data']['ir.attachment']])
         self.assertEqual(response_manager.status_code, 200)
         self.assertEqual(len(expense.attachment_ids), 2)
-        self.assertEqual(expense.message_main_attachment_id.id, response_manager.json()['data']['ir.attachment'][0]['id'])
+        self.assertEqual(expense.message_main_attachment_id.id, response_manager.json()['data']['store_data']['ir.attachment'][0]['id'])
 
         self.authenticate(admin_user.login, admin_user.login)
         response_admin = self.url_open("/mail/attachment/upload",
@@ -132,10 +132,10 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
             },
             files={'ufile': ('admin.txt', b"Admin\n", 'text/plain')},
         )
-        expense.with_user(admin_user).attach_document(attachment_ids=[data['id'] for data in response_admin.json()['data']['ir.attachment']])
+        expense.with_user(admin_user).attach_document(attachment_ids=[data['id'] for data in response_admin.json()['data']['store_data']['ir.attachment']])
         self.assertEqual(response_admin.status_code, 200)
         self.assertEqual(len(expense.attachment_ids), 3)
-        self.assertEqual(expense.message_main_attachment_id.id, response_admin.json()['data']['ir.attachment'][0]['id'])
+        self.assertEqual(expense.message_main_attachment_id.id, response_admin.json()['data']['store_data']['ir.attachment'][0]['id'])
 
     def test_expense_user_cant_approve_own_expense(self):
         expense = self.env['hr.expense'].with_user(self.expense_user_employee).create({

--- a/addons/hr_expense/tests/test_expenses_access_rights.py
+++ b/addons/hr_expense/tests/test_expenses_access_rights.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.tests import HttpCase, tagged, new_test_user
 
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
@@ -136,3 +136,37 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
         self.assertEqual(response_admin.status_code, 200)
         self.assertEqual(len(expense.attachment_ids), 3)
         self.assertEqual(expense.message_main_attachment_id.id, response_admin.json()['data']['ir.attachment'][0]['id'])
+
+    def test_expense_user_cant_approve_own_expense(self):
+        expense = self.env['hr.expense'].with_user(self.expense_user_employee).create({
+            'name': "Superboy costume washing",
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_a.id,
+            'quantity': 1,
+            'price_unit': 1,
+        })
+        expense.with_user(self.expense_user_employee).action_submit()
+        with self.assertRaises(UserError):
+            expense.with_user(self.expense_user_employee).action_approve()
+
+    def test_expense_team_approver_cant_approve_expense_of_employee_he_does_not_manage(self):
+        another_standard_user = new_test_user(self.env, login='another_standard_user', groups='base.group_user')
+        another_standard_user_team_approver = new_test_user(self.env, login='another_standard_user_manager', groups='base.group_user,hr_expense.group_hr_expense_team_approver')
+
+        another_employee = self.env['hr.employee'].sudo().create({
+            'name': 'another_employee',
+            'user_id': another_standard_user.id,
+            'work_contact_id': another_standard_user.partner_id.id,
+            'expense_manager_id': self.expense_user_manager.id,
+        }).sudo(False)
+
+        expense = self.env['hr.expense'].with_user(another_standard_user).create({
+            'name': "Superboy costume washing",
+            'employee_id': another_employee.id,
+            'product_id': self.product_a.id,
+            'quantity': 1,
+            'price_unit': 1,
+        })
+        expense.with_user(another_standard_user).action_submit()
+        with self.assertRaises(AccessError):
+            expense.with_user(another_standard_user_team_approver).action_approve()

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -111,7 +111,7 @@
                             invisible="nb_attachment == 0 or state != 'approved'" groups="account.group_account_invoice"/>
 
                     <!-- With attachments the attach document comes last-->
-                    <widget name="attach_document" string="Attach Receipt" action="attach_document" highlight="1" invisible="nb_attachment &gt;= 1"/>
+                    <widget name="expense_attach_document" string="Attach Receipt" action="attach_document" highlight="1" invisible="nb_attachment &gt;= 1"/>
                     <button name="action_submit" string="Submit" type="object" class="o_expense_submit"
                             invisible="nb_attachment &gt;= 1 or state != 'draft'" data-hotkey="v"/>
                     <button name="action_approve" string="Approve" type="object" data-hotkey="q" context="{'validate_analytic': True}"
@@ -133,7 +133,7 @@
                             groups="hr_expense.group_hr_expense_team_approver,account.group_account_invoice"/>
 
                     <!-- With attachments the attach_document comes last -->
-                    <widget name="attach_document" string="Attach Receipt" action="attach_document" invisible="nb_attachment == 0"/>
+                    <widget name="expense_attach_document" string="Attach Receipt" action="attach_document" invisible="nb_attachment == 0"/>
 
                     <!-- Statusbar -->
                     <field name="state" widget="statusbar" statusbar_visible="draft,approved,posted,paid"


### PR DESCRIPTION
An employee that created his expense was only able to add attachments
and post message in the chatter when the expense was in draft.

After this, it will still be able to attach attachment and post
message without having the right to edit the expense. This is better
as the employee will be able to answer questions that have been asked
or add more proof if required.

task-4966942

And also include a fix to a bug found which solving the previous issue

The field is_editable which used the compute method
_compute_is_editable and the field can_reset which used the compute
method _compute_can_reset, where called with the argument
compute_sudo=True. Those 2 method then used the self.env.su which was
always True.

And another one
<img width="303" height="316" alt="image" src="https://github.com/user-attachments/assets/e611947a-89d4-413d-8ca7-b2eb096786db" />

If a user tries to submit an expense without having a manager, this
will fail with "You are neither a Manager nor a HR Officer".
To fix this, we are not going to check when the manager is the user
that expense is linked to.
