### PR TITLE
[FIX] discuss: race condition in meeting mobile test

### DIFF
--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -341,6 +341,7 @@ test("'New Meeting' in mobile", async () => {
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Partner 2" });
     await click("button:not([disabled])", { text: "Invite to Group Chat" });
     await contains(".o-discuss-Call");
+    await click("[title='Exit Fullscreen']");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/223356, the meeting tests in mobile did not expect the fullscreen mode so it could lead to a race condition showing the call instead of the channel member list.

https://runbot.odoo.com/odoo/runbot.build.error/231206

