### PR TITLE
[FIX] l10n_cl: use standard report for vendor bills

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -131,7 +131,13 @@ class AccountMove(models.Model):
 
     def _get_name_invoice_report(self):
         self.ensure_one()
-        if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == 'CL':
+        if (
+            self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == "CL"
+            and (
+                self.move_type in {"out_invoice", "out_refund"}
+                or self.l10n_latam_document_type_id.code == "46"
+            )
+        ):
             return 'l10n_cl.report_invoice_document'
         return super()._get_name_invoice_report()
 


### PR DESCRIPTION
steps to reproduce:
-------------------
1. Install `l10n_cl`.
2. Create a new company and set Chile as the country.
3. Go to Accounting > Configuration > Journals.
4. Create a journal with type Purchase and enable Use Documents.
5. Go to Accounting > Vendors > Bills and create a bill.
6. Print Invoices / Invoices without payments.

issue:
------
The customer and company data are swapped (interchanged), and It is wrong from vendor bills point of view.

solution:
---------
The l10n_cl reports layout should only be applied to: 
- out_invoice or out_refund
- or when l10n_latam_document_type_id = (46) Electronic Purchase Invoice

**Before:**
<img width="762" height="425" alt="image" src="https://github.com/user-attachments/assets/e042485b-5d82-455f-9f34-03a0a9cdf5cc" />
**After:**
<img width="770" height="624" alt="image" src="https://github.com/user-attachments/assets/c5d09e58-bcf0-48ab-a0ae-0e37c0473a67" />



opw-4937097

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
