### PR TITLE
[FIX] hr_org_chart: fix org chart public employee form

### DIFF
--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.js
@@ -4,7 +4,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { onEmployeeSubRedirect } from './hooks';
-import { Component, onWillStart, useState } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { useRecordObserver } from "@web/model/relational_model/utils";
 
 class HrOrgChartPopover extends Component {
@@ -46,30 +46,17 @@ export class HrOrgChart extends Component {
         this.max_level = null;
         this._onEmployeeSubRedirect = onEmployeeSubRedirect();
 
-        onWillStart(async () => {
-            this.employee = this.props.record.data;
-            // the widget is either dispayed in the context of a hr.employee form or a res.users form
-            this.state.employee_id =
-                this.employee.employee_ids !== undefined
-                    ? this.employee.employee_ids.resIds[0]
-                    : this.props.record.resId;
-            const parentId =
-                this.employee.parent_id && this.employee.parent_id[0]
-                    ? this.employee.parent_id[0]
-                    : false;
-            const forceReload =
-                this.lastRecord !== this.props.record || this.lastParent != parentId;
-            this.lastParent = parentId;
-            this.lastRecord = this.props.record;
-            await this.fetchEmployeeData(this.state.employee_id, forceReload);
-        });
-
         useRecordObserver(async (record) => {
+            // employee and parent IDs are based on the model context:
+            // - If the widget is used in the context of a `res.users` form:
+            //     - employee_id     = record.data.employee_id?.[0]
+            //     - parent_id       = record.data.employee_parent_id?.[0]
+            // - If the widget is used in the context of a `hr.employee` or `hr.employee.public` form:
+            //     - employee_id     = record.resId
+            //     - parent_id       = record.data.parent_id?.[0]
             const newParentId =
-                record.data.parent_id && record.data.parent_id[0]
-                    ? record.data.parent_id[0]
-                    : false;
-            const newEmployeeId = record.data.id || false;
+                record.data.employee_parent_id?.[0] || record.data.parent_id?.[0] || false;
+            const newEmployeeId = record.data.employee_id?.[0] || record.resId || false;
             if (this.lastParent !== newParentId || this.state.employee_id !== newEmployeeId) {
                 this.lastParent = newParentId;
                 this.max_level = null; // Reset max_level to default


### PR DESCRIPTION
This update ensures that the correct employee and parent IDs are fetched depending on whether the widget is displayed in a `res.users`, `hr.employee` or `hr.employee.public` form. The `onWillStart` was removed since `useRecordObserver` is triggered in `onWillStart`, and both used to have the same logic.

task-5039701

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
