### PR TITLE
[FIX] l10n_sa: remove legal text warning from vendor bill

### DIFF
--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -20,7 +20,7 @@
             </div>
         </xpath>
         <xpath expr="//t[@t-set='address']" position="after">
-            <t t-if="o.company_id.country_id.code == 'SA' and not o._l10n_sa_is_legal() " t-set="custom_header">
+            <t t-if="o.company_id.country_id.code == 'SA' and o.is_sale_document() and not o._l10n_sa_is_legal() " t-set="custom_header">
                 <div class="fw-bold text-center mt-2">
                     <h5>THIS IS NOT A LEGAL DOCUMENT</h5>
                     <h5>هذا المستند ليس مستنداً قانونياً</h5>


### PR DESCRIPTION
Before this commit:
- The message "THIS IS NOT A LEGAL DOCUMENT" was also displayed on Vendor
  Debit Notes, Vendor Credit Notes, Purchase Receipt and Sales Receipt.
- The warning should only appear on Customer Invoices, Credit Notes, and Debit
  Notes when the QR code is missing

After this commit:
- The warning message is no longer displayed on all Vendor Debit Notes,
  Vendor Credit Notes, Purchase Receipt and Sales Receipt.

Task-5044870

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
