### PR TITLE
[IMP] spreadsheet: untranslate list headers

### DIFF
--- a/addons/spreadsheet/static/src/list/list_functions.js
+++ b/addons/spreadsheet/static/src/list/list_functions.js
@@ -39,14 +39,17 @@ const ODOO_LIST_HEADER = {
     description: _t("Get the header of a list."),
     args: [
         arg("list_id (string)", _t("ID of the list.")),
-        arg("field_name (string)", _t("Name of the field.")),
+        arg("field_name (string)", _t("Technical field name.")),
+        arg("field_display_name (string, optional)", _t("Name of the field.")),
     ],
     category: "Odoo",
-    compute: function (listId, fieldName) {
+    compute: function (listId, fieldName, fieldDisplayName) {
         const id = toString(listId);
         const field = toString(fieldName);
         assertListsExists(id, this.getters);
-        return this.getters.getListHeaderValue(id, field);
+        const displayName = toString(fieldDisplayName);
+        const translatedDisplayName = this.getters.getListHeaderValue(id, field);
+        return displayName || translatedDisplayName;
     },
     returns: ["NUMBER", "STRING"],
 };

--- a/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
@@ -235,11 +235,14 @@ export class ListCorePlugin extends OdooCorePlugin {
     _insertHeaders(sheetId, anchor, id, columns) {
         let [col, row] = anchor;
         for (const column of columns) {
+            const content = column.string
+                ? `=ODOO.LIST.HEADER(${id},"${column.name}", "${column.string}")`
+                : `=ODOO.LIST.HEADER(${id},"${column.name}")`;
             this.dispatch("UPDATE_CELL", {
                 sheetId,
                 col,
                 row,
-                content: `=ODOO.LIST.HEADER(${id},"${column.name}")`,
+                content,
             });
             col++;
         }

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -70,6 +70,13 @@ test("List field name should not be empty", async () => {
     expect(getEvaluatedCell(model, "A1").message).toBe("The field name should not be empty.");
 });
 
+test("ODOO.LIST.HEADER with a custom header string", async () => {
+    const { model } = await createSpreadsheetWithList();
+    setCellContent(model, "A1", '=ODOO.LIST.HEADER(1,"foo","My custom header")');
+    await waitForDataLoaded(model);
+    expect(getCellValue(model, "A1")).toBe("My custom header");
+});
+
 test("Return display name of selection field", async () => {
     const { model } = await createSpreadsheetWithList({
         model: "res.currency",


### PR DESCRIPTION
Current issue:

Alice's language is in English and Bob is in French. Alice inserts a list in a spreadsheet, and create a pivot with the dataset being the list.
Alice chooses the pivot dimensions based on the columns headers, which are the translated(!) field display names.

Now Bob opens the spreadsheet.
=> the pivot doesn't work because the dimension are specified using the field names in English, but they cannot be found because they are in French in the spreadsheet.

The issue is that `ODOO.LIST.HEADER` returns the translated field string. One solution would be drop `ODOO.LIST.HEADER` completely and just hard-code the string values when the list is inserted.
But users use it to add fields after, and then auto-fill it. Also, being easily able to know which cells are list headers is helpful to display "widget" like the sorting widget (task 4543812)

Other thing to consider: currently, when users are creating their own spreadsheet/dashboard, there's a mix of languages: what they manually type in cells, in their language (untranslated obviously) and the result of ODOO.LIST.HEADER, which is translated.

Task: 4805206

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
