### PR TITLE
[FIX] account: make journal entry number read-only in list view

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -474,7 +474,7 @@
                     <field name="made_sequence_gap" column_invisible="True"/>
                     <field name="invoice_date" string="Invoice Date" optional="hide" readonly="state != 'draft'"/>
                     <field name="date" readonly="state in ['cancel', 'posted']"/>
-                    <field name="name" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field" placeholder="/"/>
+                    <field name="name" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field" placeholder="/" readonly="state != 'draft'"/>
                     <field name="partner_id" optional="show" readonly="state != 'draft'"/>
                     <field name="ref" optional="show"/>
                     <field name="journal_id"/>


### PR DESCRIPTION
**Issue**
It was possible to edit the journal entry number in the list view even when the entry state was not 'draft'.

**Steps to Reproduce**
1. Go to Accounting > Accounting > Journal Entries.
2. Select any journal entry.
3. Double-click on the Journal Number field and attempt to edit it.

**Root Cause**
The 'name' field in the list view did not have a readonly attribute, allowing inline editing regardless of the journal entry's state.

Opw-5009421
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
