### PR TITLE
[FIX] website: fix incorrect <p> wrapping for custom button snippet

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -4330,7 +4330,7 @@ options.registry.Button = options.Class.extend({
                 } else if (siblingButtonEl.classList.contains("btn-lg")) {
                     this.$target[0].classList.add("btn-lg");
                 }
-            } else {
+            } else if (!siblingButtonEl) {
                 // To align with the editor's behavior, we need to enclose the
                 // button in a <p> tag if it's not dropped within a <p> tag. We only
                 // put the dropped button in a <p> if it's not next to another

--- a/addons/website/static/tests/tours/adapt_custom_button.js
+++ b/addons/website/static/tests/tours/adapt_custom_button.js
@@ -1,0 +1,37 @@
+/** @odoo-module */
+
+import wTourUtils from "@website/js/tours/tour_utils";
+
+wTourUtils.registerWebsitePreviewTour(
+    "adapt_custom_button_on_drop",
+    {
+        test: true,
+        url: "/",
+        edition: true,
+    },
+    () => [
+        {
+            content: "Check that the custom button snippet is present",
+            trigger: "#snippet_custom_body span:contains('Custom Button')",
+            run: () => null,
+        },
+        {
+            content: "Drag the Custom Button and drop it near the header Contact us button",
+            trigger:
+                "#oe_snippets .oe_snippet[name='Custom Button'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",
+            run: "drag_and_drop_native iframe header [data-snippet='s_text_block']",
+        },
+        {
+            content: "Check that the custom button is NOT wrapped in <p>",
+            trigger: "iframe header .s_custom_snippet:not(.s_custom_button)",
+            run() {
+                const customButtonEl = this.$anchor[0];
+                if (customButtonEl.parentNode.tagName === "P") {
+                    throw new Error(
+                        "Custom button should not be wrapped in <p> when sibling button is present"
+                    );
+                }
+            },
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -715,3 +715,14 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_website_custom_colors_picking(self):
         self.start_tour('/', 'website_custom_colors_picking', login='admin')
+
+    def test_adapt_custom_button_on_drop(self):
+        default_website = self.env.ref('website.default_website')
+        self.env['ir.ui.view'].with_context(website_id=default_website.id).save_snippet(
+            name='Custom Button',
+            arch="""<a class="btn btn-primary o_default_snippet_text s_custom_snippet o_snippet_drop_in_only s_custom_button" href="#" data-bs-original-title="" title="">Button</a>""",
+            thumbnail_url='/website/static/src/img/snippets_thumbs/s_button.svg',
+            snippet_key='s_custom_button',
+            template_key='website.snippets'
+        )
+        self.start_tour('/', 'adapt_custom_button_on_drop', login='admin')


### PR DESCRIPTION
### Issue:
When a custom button snippet was dropped next to an existing button 
wrapped in a `<div>`, it was incorrectly and unconditionally wrapped in 
a paragraph `<p>` tag. This issue did not occur with standard button 
snippets or when the buttons were wrapped in a `<p>` tag.

### Steps to reproduce:
1. Drag a standard "Button" snippet next to an existing button (e.g., in
   the navbar). The structure is correctly `<a/><a/>`.
2. Save a button as a custom snippet.
3. Drag this new custom button snippet next to a button wrapped in a 
   `<div>` (navbar in our example).
4. Observe the structure: 
   `<div><a/><p><a class="s_custom_snippet"/></p></div>`,
   but it should be like `<div><a/><a class="s_custom_snippet"/></div>`.

### Fix
The logic has been corrected to only wrap a button snippet in a 
paragraph tag if it has no sibling buttons and is not already inside a 
`<p>`. This ensures consistent behaviour between standard and 
custom button snippets. A tour test is also added, ensuring the 
behaviour is correct.

Backport of https://github.com/odoo/odoo/commit/3a8f2cc418510c3b91f8b9086bb4a89a1745e40d

task-[5032130](https://www.odoo.com/odoo/project/974/tasks/5032130)