### PR TITLE
[FIX] website_sale: checkout step work with rewrite


### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -792,15 +792,20 @@ class Website(models.Model):
         return steps
 
     def _get_checkout_step_values(self, href=None):
-        href = href or request.httprequest.path
+        def rewrite(path):
+            return self.env['ir.http'].url_rewrite(path)[0]
+        href = rewrite(href) if href else request.httprequest.path
         # /shop/address is associated with the delivery step
-        if href == '/shop/address':
-            href = '/shop/checkout'
+        if href == rewrite('/shop/address'):
+            href = rewrite('/shop/checkout')
 
         allowed_steps_domain = self._get_allowed_steps_domain()
-        current_step = request.env['website.checkout.step'].sudo().search(
-            Domain.AND([allowed_steps_domain, [('step_href', '=', href)]]), limit=1
-        )
+        current_step = request.env['website.checkout.step'].sudo()
+        for step in current_step.search(allowed_steps_domain):
+            if rewrite(step.step_href) == href:
+                current_step = step
+                href = step.step_href
+                break
         next_step = current_step._get_next_checkout_step(allowed_steps_domain)
         previous_step = current_step._get_previous_checkout_step(allowed_steps_domain)
 
@@ -809,7 +814,7 @@ class Website(models.Model):
         if next_step.step_href == '/shop/checkout':
             next_href = '/shop/checkout?try_skip_step=true'
         # redirect handled by '/shop/address/submit' route when all values are properly filled
-        if request.httprequest.path == '/shop/address':
+        if request.httprequest.path == rewrite('/shop/address'):
             next_href = False
 
         return {


### PR DESCRIPTION
Steps:

- create a 308 rewrite from /shop/cart to /test/cart
- go to /shop/cart

Result:

An error 500 is shown with this traceback in server log:

  odoo.addons.base.models.ir_qweb.QWebException: Error while render the
  template
  KeyError: 'current_step'
  Template: website.step_wizard
  Path: /t/div/div[1]/div/div/a/span
  Node: <span t-field="current_step.name"/>

Cause:

The code of website()._get_checkout_step_values doesn't take into
account possible URL rewrite, so we get an error when showing
website.step_wizard template that expect to have found a current_step.

Fix: use url_rewrite to match the current URL to the current step and
use the step_href of the step as current_website_checkout_step_href to
have it not rewritten.

Note: without the fix, the added test fail with the error shown above.

opw-5037289
