### PR TITLE
[FIX] sale_mrp: propagate analytic distribution from SO line to MTO MO

### DIFF
--- a/addons/sale_mrp/models/stock_move.py
+++ b/addons/sale_mrp/models/stock_move.py
@@ -10,7 +10,9 @@ class StockMove(models.Model):
     def _prepare_procurement_values(self):
         res = super()._prepare_procurement_values()
         res['analytic_account_id'] = self.sale_line_id.order_id.analytic_account_id
-        if self.sale_line_id.order_id.analytic_account_id:
+        if self.sale_line_id.analytic_distribution:
+            res['analytic_distribution'] = self.sale_line_id.analytic_distribution
+        elif self.sale_line_id.order_id.analytic_account_id:
             res['analytic_distribution'] = {self.sale_line_id.order_id.analytic_account_id.id: 100}
         return res
 

--- a/addons/sale_mrp/tests/test_sale_mrp_account.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_account.py
@@ -21,3 +21,14 @@ class TestSaleMrpAccount(test_multistep_manufacturing.TestMultistepManufacturing
         self.sale_order.action_confirm()
         self.assertTrue(self.sale_order.mrp_production_ids.analytic_distribution)
         self.assertTrue(self.sale_order.mrp_production_ids.analytic_account_ids)
+
+    def test_mo_analytic_distribution_from_sol(self):
+        """ ensure analytic account/distribution is inherited from the SO lines
+            when none is set on the bom and without analytic_account_id
+        """
+        analytic_plan = self.env['account.analytic.plan'].create({
+            'name': 'Plan',
+        })
+        self.sale_order.order_line.analytic_distribution = {analytic_plan.id: 100.0}
+        self.sale_order.action_confirm()
+        self.assertEqual(self.sale_order.mrp_production_ids.analytic_distribution, self.sale_order.order_line.analytic_distribution)


### PR DESCRIPTION
## Issue:
Confirming a Sale Order for a product with MTO + Manufacturing routes fails (Validation Error) when Analytic Accounting is enabled and an Analytic Plan is mandatory

## Cause:
The analytic_distribution is first validated one time for the Sale Order line

When the MO will is created later, the `_compute_analytic_distribution()` function in `mrp_account` is triggered
Since no `account.analytic.distribution.model` is defined, the analytic_distribution field is recomputed as {}

This trigger a second validation, which fails because `{}` is invalid when an analytic plan is mandatory

## Steps to reproduce:
- Enable Analytic Accounting and Multi-Step Routes in Settings
- In Accounting > Configuration > Analytic Accounting > Analytic Plans set Projects as Mandatory
- Unarchive the MTO route
- Create a Product with MTO + Manufacturing routes
- Create a Sale Order for this product and set an Analytic Distribution for Projects
- Confirm the SO to get the Validation Error

opw-4863498