### PR TITLE
[FIX] pos_self_order: combo always variant products

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
@@ -4,7 +4,7 @@ import { AttributeSelectionHelper } from "./attribute_selection_helper";
 
 export class AttributeSelection extends Component {
     static template = "pos_self_order.AttributeSelection";
-    static props = ["productTemplate", "onSelection?"];
+    static props = ["productTemplate", "onSelection?", "hideAlwaysVariants?"];
 
     setup() {
         this.selfOrder = useSelfOrder();
@@ -96,5 +96,14 @@ export class AttributeSelection extends Component {
         const priceExtra = value.price_extra;
         const sign = priceExtra < 0 ? "- " : "+ ";
         return sign + this.selfOrder.formatMonetary(Math.abs(priceExtra));
+    }
+    get validAttributeLineIds() {
+        if (this.props.hideAlwaysVariants) {
+            return this.props.productTemplate.attribute_line_ids.filter(
+                (line) => line.attribute_id.create_variant !== "always"
+            );
+        } else {
+            return this.props.productTemplate.attribute_line_ids;
+        }
     }
 }

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.AttributeSelection">
-         <t t-foreach="props.productTemplate.attribute_line_ids" t-as="attribute" t-key="attribute.id">
-             <h2 class="text-start py-3 m-0" t-out="attribute.attribute_id.name"/>
-             <div class="self_order_attribute_selection row pb-3">
+         <t t-foreach="validAttributeLineIds" t-as="attribute" t-key="attribute.id">
+            <h2 class="text-start py-3 m-0" t-out="attribute.attribute_id.name"/>
+            <div class="self_order_attribute_selection row pb-3">
                 <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">
                     <t t-set="valueSelected" t-value="isValueSelected(attribute,value)"/>
                     <div class="d-flex col-12 col-md-6 col-lg-4">
@@ -13,15 +13,15 @@
                             t-attf-class="{{ valueSelected ? 'o_self_box_selected text-bg-primary': '' }}">
                             <span t-esc="value.name" class="fs-4"/>
                             <span t-if="shouldShowPriceExtra(value)" t-esc="formatExtraPrice(value)" class="fs-5  "
-                                 t-att-class="{ 'text-reset opacity-75' : valueSelected, 'text-primary': !valueSelected  }"/>
+                                t-att-class="{ 'text-reset opacity-75' : valueSelected, 'text-primary': !valueSelected  }"/>
                         </button>
                     </div>
                 </t>
-                 <t t-set="customValue" t-value="getCustomSelectedValue(attribute)"/>
-                 <div t-if="customValue">
-                     <input type="text" t-model="selectedValues.getCustomValue(attribute,customValue).custom_value" class="form-control px-3 py-3 rounded-4 bg-white shadow-sm mt-2" t-ref="customValueInput" placeholder="Enter your custom value" />
-                 </div>
+                <t t-set="customValue" t-value="getCustomSelectedValue(attribute)"/>
+                <div t-if="customValue">
+                    <input type="text" t-model="selectedValues.getCustomValue(attribute,customValue).custom_value" class="form-control px-3 py-3 rounded-4 bg-white shadow-sm mt-2" t-ref="customValueInput" placeholder="Enter your custom value" />
+                </div>
             </div>
-          </t>
+        </t>
     </t>
 </templates>

--- a/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.xml
+++ b/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.xml
@@ -3,7 +3,7 @@
     <t t-name="pos_self_order.ProductNameWidget">
        <div class="self_order_product_name d-inline-block">
            <t t-set="product" t-value="props.product"/>
-           <span t-esc="product.name" class="align-middle fs-4 fw-bold text-break"/>
+           <span t-esc="product.display_name" class="align-middle fs-4 fw-bold text-break"/>
            <div t-if="product.public_description or product.product_tag_ids.length > 0"
                 class="product_info_icon d-inline-flex justify-content-center align-items-center border border-dark rounded-circle text-center"
                 t-on-click.stop="()=>this.displayProductInfo()">

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -103,13 +103,13 @@
                                 <img class="object-fit-cover" t-attf-src="/web/image/product.product/{{ product.id }}/image_512?unique=#{product.write_date}"  loading="lazy"/>
                             </div>
                             <div class="o_self_variant_description d-flex flex-column justify-content-center">
-                                <h2 t-esc="product.name" class="mb-0 text-white"/>
+                                <h2 t-esc="product.display_name" class="mb-0 text-white"/>
                                 <span t-if="product.public_description" t-out="product.productDescriptionMarkup" class="product-description mt-1"/>
                             </div>
                         </div>
                         <!-- Attributes -->
                         <div class="">
-                            <AttributeSelection t-if="product.attribute_line_ids.length" productTemplate="product" onSelection="onAttributeSelection" />
+                            <AttributeSelection t-if="getValidAttributeLineIds(product).length" productTemplate="product" onSelection="onAttributeSelection" hideAlwaysVariants="true" />
                         </div>
                     </div>
 

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -9,11 +9,8 @@ registry.category("web_tour.tours").add("self_combo_selector", {
         ProductPage.clickProduct("Office Combo"),
         ...ProductPage.setupCombo([
             {
-                product: "Desk Organizer",
-                attributes: [
-                    { name: "Size", value: "M" },
-                    { name: "Fabric", value: "Leather" },
-                ],
+                product: "Desk Organizer (Leather)",
+                attributes: [{ name: "Size", value: "M" }],
             },
             {
                 product: "Combo Product 5",

--- a/addons/pos_self_order/tests/self_order_common_test.py
+++ b/addons/pos_self_order/tests/self_order_common_test.py
@@ -104,9 +104,9 @@ class SelfOrderCommonTest(odoo.tests.HttpCase):
         desk_fabrics_attribute = cls.env['product.attribute'].create({
             'name': 'Fabric',
             'display_type': 'select',
-            'create_variant': 'no_variant',
+            'create_variant': 'always',
         })
-        desk_fabrics_leather = cls.env['product.attribute.value'].create({
+        cls.desk_fabrics_leather = cls.env['product.attribute.value'].create({
             'name': 'Leather',
             'attribute_id': desk_fabrics_attribute.id,
         })
@@ -118,7 +118,7 @@ class SelfOrderCommonTest(odoo.tests.HttpCase):
         cls.env['product.template.attribute.line'].create({
             'product_tmpl_id': cls.desk_organizer.product_tmpl_id.id,
             'attribute_id': desk_fabrics_attribute.id,
-            'value_ids': [(6, 0, [desk_fabrics_leather.id, desk_fabrics_other.id])]
+            'value_ids': [(6, 0, [cls.desk_fabrics_leather.id, desk_fabrics_other.id])]
         })
 
     def _add_tax_to_product_from_different_company(self):

--- a/addons/pos_self_order/tests/test_self_order_combo.py
+++ b/addons/pos_self_order/tests/test_self_order_combo.py
@@ -10,9 +10,12 @@ from odoo.fields import Command
 class TestSelfOrderCombo(SelfOrderCommonTest):
     def test_self_order_combo(self):
         setup_product_combo_items(self)
+        leather_desk_organizer = self.desk_organizer.product_variant_ids.filtered(
+            lambda v: self.desk_fabrics_leather.id in v.product_template_attribute_value_ids.mapped('product_attribute_value_id').ids
+        )
         self.env["product.combo.item"].create(
             {
-                "product_id": self.desk_organizer.id,
+                "product_id": leather_desk_organizer.id,
                 "extra_price": 0,
                 "combo_id": self.desk_accessories_combo.id,
             }


### PR DESCRIPTION
Issue:
The products that had a variant creation set to "always" was not displayed like in the pos. (see task)

This commit fixes issue by applying the same display logic as used in the POS, introduced in PR: https://github.com/odoo/odoo/pull/222252

Task-5005158

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
