### PR TITLE
[FIX] mail: no soft-deleted records in Model.records and Model.get()

### DIFF
--- a/addons/mail/static/src/model/misc.js
+++ b/addons/mail/static/src/model/misc.js
@@ -21,6 +21,7 @@ export const OR_SYM = Symbol("or");
 const AND_SYM = Symbol("and");
 export const IS_RECORD_SYM = Symbol("isRecord");
 export const IS_FIELD_SYM = Symbol("isField");
+/** @deprecated equivalent to IS_DELETED_SYM */
 export const IS_DELETING_SYM = Symbol("isDeleting");
 export const IS_DELETED_SYM = Symbol("isDeleted");
 export const STORE_SYM = Symbol("store");

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -2,7 +2,7 @@
 /** @typedef {import("./record_list").RecordList} RecordList */
 
 import { onChange } from "@mail/utils/common/misc";
-import { IS_DELETED_SYM, IS_DELETING_SYM, IS_RECORD_SYM, isRelation } from "./misc";
+import { IS_DELETED_SYM, IS_RECORD_SYM, isRelation } from "./misc";
 import { RecordList } from "./record_list";
 import { reactive, toRaw } from "@odoo/owl";
 import { RecordUses } from "./record_uses";
@@ -150,7 +150,7 @@ export class RecordInternal {
     }
 
     requestCompute(record, fieldName, { force = false } = {}) {
-        if (record._[IS_DELETING_SYM]) {
+        if (record._[IS_DELETED_SYM]) {
             return;
         }
         const Model = record.Model;
@@ -169,7 +169,7 @@ export class RecordInternal {
         }
     }
     requestSort(record, fieldName, { force } = {}) {
-        if (record._[IS_DELETING_SYM]) {
+        if (record._[IS_DELETED_SYM]) {
             return;
         }
         const Model = record.Model;

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -1,5 +1,5 @@
 import { Record } from "./record";
-import { IS_DELETED_SYM, STORE_SYM } from "./misc";
+import { STORE_SYM } from "./misc";
 import { reactive, toRaw } from "@odoo/owl";
 
 /** @typedef {import("./record_list").RecordList} RecordList */
@@ -24,6 +24,7 @@ export class Store extends Record {
         this._.UPDATE++;
         const res = fn();
         this._.UPDATE--;
+        const deletingRecordsByLocalId = new Map();
         if (this._.UPDATE === 0) {
             // pretend an increased update cycle so that nothing in queue creates many small update cycles
             this._.UPDATE++;
@@ -117,7 +118,9 @@ export class Store extends Record {
                     RD_QUEUE.delete(record);
                     for (const [localId, names] of record._.uses.data.entries()) {
                         for (const [name2, count] of names.entries()) {
-                            const usingRecord2 = toRaw(this.recordByLocalId).get(localId);
+                            const usingRecord2 =
+                                toRaw(this.recordByLocalId).get(localId) ||
+                                deletingRecordsByLocalId.get(localId);
                             if (!usingRecord2) {
                                 // record already deleted, clean inverses
                                 record._.uses.data.delete(localId);
@@ -132,6 +135,8 @@ export class Store extends Record {
                             }
                         }
                     }
+                    deletingRecordsByLocalId.set(record.localId, record);
+                    this.recordByLocalId.delete(record.localId);
                     this._.ADD_QUEUE("hard_delete", toRaw(record));
                 }
                 while (RHD_QUEUE.size > 0) {
@@ -139,9 +144,7 @@ export class Store extends Record {
                     /** @type {Record} */
                     const record = RHD_QUEUE.keys().next().value;
                     RHD_QUEUE.delete(record);
-                    record._[IS_DELETED_SYM] = true;
-                    delete record.Model.records[record.localId];
-                    this.recordByLocalId.delete(record.localId);
+                    deletingRecordsByLocalId.delete(record.localId);
                 }
             }
             this._.UPDATE--;

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -4,7 +4,7 @@
 import { markup, toRaw } from "@odoo/owl";
 import { RecordInternal } from "./record_internal";
 import { deserializeDate, deserializeDateTime } from "@web/core/l10n/dates";
-import { IS_DELETING_SYM, Markup, isCommand, isMany } from "./misc";
+import { IS_DELETED_SYM, IS_DELETING_SYM, Markup, isCommand, isMany } from "./misc";
 
 export class StoreInternal extends RecordInternal {
     /**
@@ -124,6 +124,8 @@ export class StoreInternal extends RecordInternal {
                 /** @type {import("./record").Record} */
                 const [record] = params;
                 record._[IS_DELETING_SYM] = true;
+                record._[IS_DELETED_SYM] = true;
+                delete record.Model.records[record.localId];
                 if (!this.RHD_QUEUE.has(record)) {
                     this.RHD_QUEUE.set(record, true);
                 }

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -1080,3 +1080,111 @@ test("Can assign new record on Many field with One inverse", async () => {
     expectRecord(file2.thread).toEqual(thread);
     expect(file1.thread).toBe(undefined);
 });
+
+test("Deleted records are not returned by 'Model.records' nor 'Model.get()'", async () => {
+    /**
+     * Record has a 2-step record deletion:
+     * - "soft" deletion, where the record is flagged for deletion but object is not removed from the store system structurally
+     * - "hard" deletion, where the object is fully removed from store system structurally
+     * The soft "deletion" is useful for stuffs like onDelete() hooks that tell which record has been removed from a relation,
+     * with object reference, even when the record will be hard-deleted as a consequence.
+     * `Model.records` and `Model.get()` are intended for business-code uses, therefore they should make sure to not return
+     * records that are soft-deleted, as this could lead to critical section where business code is using a deleted record.
+     */
+    function assertExists(store) {
+        const msg = store.Message.get("msg-1");
+        if (msg) {
+            expect(toRaw(msg).exists()).toBe(true);
+        }
+        for (const msg of Object.values(store.Message.records)) {
+            expect(toRaw(msg).exists()).toBe(true);
+        }
+    }
+    let deleting = false;
+    (class Thread extends Record {
+        static id = "name";
+        name;
+        messages = Record.many("Message", { inverse: "thread" });
+        get hasMessages() {
+            return this.messages.length > 0;
+        }
+    }).register(localRegistry);
+    (class Message extends Record {
+        static id = "content";
+        content;
+        thread = Record.one("Thread");
+    }).register(localRegistry);
+    (class DiscussApp extends Record {
+        static id = "id";
+        id;
+        thread = Record.one("Thread");
+        allMessagesInStore = Record.many("Message", {
+            compute() {
+                if (deleting) {
+                    expect.step("allMessagesInStore:compute");
+                    expect(this._lastAllMessagesInStore.some((m) => m.exists())).toBe(false);
+                }
+                expect(this.thread.hasMessages).toBe(
+                    Boolean(Object.values(store.Message.records).length > 0)
+                );
+                assertExists(this.store);
+                const allMessagesInStore = Object.values(store.Message.records);
+                toRaw(this)._raw._lastAllMessagesInStore = allMessagesInStore;
+                return allMessagesInStore;
+            },
+            eager: true,
+        });
+        _lastAllMessagesInStore;
+    }).register(localRegistry);
+    const store = await start();
+    const thread = store.Thread.insert({ name: "General" });
+    store.DiscussApp.insert({ thread });
+    const message = store.Message.insert({ content: "msg-1", thread });
+    expectRecord(thread.messages[0]).toEqual(message);
+    expectRecord(store.Message.get("msg-1")).toEqual(message);
+    expectRecord(store.Message.records[message.localId]).toEqual(message);
+    deleting = true;
+    message.delete();
+    deleting = false;
+    expect.verifySteps(["allMessagesInStore:compute"]);
+    assertExists(store);
+    expect(thread.messages.length).toEqual(0);
+});
+
+test("Delete record with side-effect compute to insert it should have resulting record with only insert data (old data is removed)'", async () => {
+    /**
+     * Record has a 2-step record deletion:
+     * - "soft" deletion, where the record is flagged for deletion but object is not removed from the store system structurally
+     * - "hard" deletion, where the object is fully removed from store system structurally
+     * The soft "deletion" is useful for stuffs like onDelete() hooks that tell which record has been removed from a relation,
+     * with object reference, even when the record will be hard-deleted as a consequence.
+     * `Model.records` and `Model.get()` are intended for business-code uses, therefore they should make sure to not return
+     * records that are soft-deleted, as this could lead to critical section where business code is using a deleted record.
+     */
+    (class DiscussApp extends Record {
+        static id;
+        state = Record.one("DiscussAppState", {
+            compute: () => ({}),
+            onDelete() {
+                this.state = {};
+            },
+        });
+    }).register(localRegistry);
+    (class DiscussAppState extends Record {
+        static id;
+        status = "init";
+        thread = Record.one("Thread");
+    }).register(localRegistry);
+    (class Thread extends Record {
+        static id = "name";
+        name;
+    }).register(localRegistry);
+    const store = await start();
+    const discussApp = store.DiscussApp.insert();
+    discussApp.state = { thread: "General", status: "ready" };
+    expect(discussApp.state.status).toEqual("ready");
+    expectRecord(discussApp.state.thread).toEqual(store.Thread.get("General"));
+    discussApp.state.delete();
+    expect(discussApp.state.status).toEqual("init");
+    expect(discussApp.state.thread).toBe(undefined);
+});


### PR DESCRIPTION
Before this commit, business code could leak records that are soft deleted, i.e. the representation of the record is still in the store but conceptually this record is deleted.

These soft-deleted records are present in the code for a very short time, just enough time to warn business code in the onDelete() hooks.

The problem for Model.records and Model.get() to return these records, is that the business code thinks these records are not deleted, which can lead to misuses and crashes.

For example: if a computed field returns this soft-deleted record, then the field value has this soft-deleted record. When the record is hard-deleted, this field will be recomputed, but when diffing with its old this will crash because it will still have a trace of the record in the internal code.

This commit fixes the issue by removing the record from Model.records when soft-deleted, so that Model.records and Model.get() doesn't return this record. The onDelete() hooks will returned the soft-deleted like before because the deleted records are stored in the data queue of the hooks.

This solution also solves another problem: if a record is deleted and there's an immediate side-effect computed field to insert this record, the previous implementation would hard-delete the record at the end which is wrong: the record should be deleted but the insert part should apply, thus the resulting record is a fresh one with same identity but only partial data from the insert. All other field values must be lost from the deletion. The changes in this commit also fixes this issue.

Commit also fixes issue for `.exists()` that should be `false` for soft-deleted records.

Task-4860196