### PR TITLE
[FIX] website_sale: ensure MegaMenuOption fetch categories from current website

### DIFF
--- a/addons/website_sale/static/src/website_builder/mega_menu_option.js
+++ b/addons/website_sale/static/src/website_builder/mega_menu_option.js
@@ -6,11 +6,16 @@ import { patch } from "@web/core/utils/patch";
 patch(MegaMenuOption.prototype, {
     setup() {
         this.orm = useService("orm");
+        this.website = useService('website');
         super.setup();
         this.productCategories = [];
 
         onWillStart(async () => {
-            this.productCategories = await this.orm.call("product.public.category", "search", [[]]);
+            this.productCategories = await this.orm.call("product.public.category", "search", [[
+                "|",
+                ["website_id", "=", false],
+                ["website_id", "=", this.website.currentWebsiteId],
+            ]]);
         });
     },
 });


### PR DESCRIPTION
Before this commit, when configuring eCommerce categories in the mega-menu, categories from all websites were fetched and applied to the mega-menu template, leading to incorrect assignments

After this commit, the mega-menu only fetches and displays eCommerce categories belonging to the current website.