### PR TITLE
[IMP] hr_payroll: Improve ui and add delete button for work entries

### DIFF
--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.xml
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
     <t t-name="hr_work_entry.WorkEntryCalendarMultiSelectionButtons" t-inherit="web.MultiSelectionButtons" t-inherit-mode="primary">
-        <button data-tooltip="Delete" position="replace">
+        <button data-tooltip="Delete" position="before">
             <button class="btn btn-secondary" data-tooltip="Reset Selected Work Entries" t-on-click="() => this.props.reactive.onQuickReset()">
                 <i class="fa fa-undo"/>
             </button>
         </button>
+
+        <button t-ref="addButton" position="replace">
+            <button class="btn btn-secondary" data-tooltip="Add" t-on-click="() => this.onAdd()" t-ref="addButton">
+                Set
+            </button>
+        </button>
+
         <button t-ref="addButton" position="after">
             <t t-foreach="favoritesWorkEntries" t-as="workEntry" t-key="workEntry.id">
                 <button class="small btn btn-secondary rounded-1"

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -33,8 +33,9 @@
         <field name="arch" type="xml">
             <form>
                 <group>
-                    <field name="duration" widget="float_time"/>
                     <field name="work_entry_type_id" widget="many2one_work_entry_type"/>
+                    <label for="duration" />
+                    <div class='d-flex'><field name="duration" widget="float_time"/>hours</div>
                     <field name="name" string="Description" placeholder="Additional Description..."/>
                 </group>
                 <field name="employee_id" invisible="1"/>


### PR DESCRIPTION
When operating on work entries, some UX changes needed to be made:
- The "Add" button needed to be renamed to "Set" since it can also edit (and not just add) a work entry
- Some fields in the popup menu of the "Set" button needed to be moved, and the unit was missing on the duration field.
- The delete button for work entries needed to be added back. Since the deletion logic was already implemented, it was easy to just put it back. The code used to check if the work entry is validated (to avoid deleting validated work entries) can be found at:

- [Work entries view from employees](https://github.com/odoo/odoo/blob/650dd0890688dad588110fa5b19a9ac0781fa1bd/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_controller.js#L148)

- [Work entries view from payroll](https://github.com/odoo/enterprise/blob/83f47370a78bd6945ef1e9a3482ad767a9e22a22/hr_work_entry_enterprise/static/src/work_entries_gantt_renderer.js#L272)

task-5042323


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
