### PR TITLE
[FIX] website[_sale]: make megamenu links draggable without website_sale

### DIFF
--- a/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
@@ -19,6 +19,11 @@ export class MegaMenuOptionPlugin extends Plugin {
                 },
             }),
         ],
+        dropzone_selector: {
+            selector: ".o_mega_menu .nav > .nav-link",
+            dropIn: ".o_mega_menu nav",
+            dropNear: ".o_mega_menu .nav-link",
+        },
         save_handlers: this.saveMegaMenuClasses.bind(this),
         no_parent_containers: ".o_mega_menu",
         is_unremovable_selector: ".o_mega_menu > section",

--- a/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/mega_menu_option_plugin.js
@@ -27,11 +27,6 @@ class WebsiteSaleMegaMenuOptionPlugin extends Plugin {
         builder_actions: {
             ToggleFetchEcomCategoriesAction,
         },
-        dropzone_selector: {
-            selector: ".o_mega_menu .nav > .nav-link",
-            dropIn: ".o_mega_menu nav",
-            dropNear: ".o_mega_menu .nav-link",
-        },
     };
 }
 


### PR DESCRIPTION
Before this commit, mega-menus links were draggable only if `website_sale` was installed. This happened because the `dropzone_selector` resource was defined in the `WebsiteSaleMegaMenuOptionPlugin` instead of`MegaMenuOptionPlugin`.

This commit moves the `dropzone_selector` resource to `MegaMenuOptionPlugin`, making mega-menus links always draggable, regardless of `website_sale`.

How to reproduce the problem:
1. Start Odoo on a database without `website_sale` installed
2. Create a mega-menu (click on navbar element -> Edit Menu -> Create a Mega Menu Item)
3. Open the mega-menu
4. Click on a link in the mega-menu
5. PROBLEM: The link is not draggable (only the column is)
6. Install the `website_sale` app
7. The links are now draggable

Task-4367641
