### PR TITLE
[FIX] payment: keep inline form collapsed if elements are invisible

### DIFF
--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -250,9 +250,21 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
             providerId, providerCode, paymentOptionId, paymentMethodCode, flow
         );
 
-        // Display the prepared inline form if it is not empty.
+        // Display the prepared inline form if it contains visible elements.
+        const isVisible = element => {
+            if (
+                element.getAttribute('name') !== 'o_payment_inline_form' // Skip the container.
+                && element.classList.contains('d-none')
+            ) {
+                return false;
+            }
+            if (element.children.length === 0) {
+                return true; // The element is visible if it has no children.
+            }
+            return Array.from(element.children).some(child => isVisible(child));
+        };
         const inlineForm = this._getInlineForm(radio);
-        if (inlineForm && inlineForm.children.length > 0) {
+        if (inlineForm && isVisible(inlineForm)) {
             inlineForm.classList.remove('d-none');
         }
     },


### PR DESCRIPTION
When selecting a payment method for which the "Secured by" mention was hidden, a small empty space was added to the bottom of the card. This was due to the inline form incorrectly determining that it should expand to display its child elements, although all those elements are invisible.

This commit adapts the check for inner elements of the inline form to consider whether they are visible.
