### PR TITLE
[FIX] orm: inversing relational condition using comodel

### DIFF
--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -495,7 +495,7 @@ class Many2one(_Relational):
         if left_join:
             comodel, coalias = self.join(model, alias, query)
             if not positive:
-                value = (~value).optimize_full(model)
+                value = (~value).optimize_full(comodel)
             sql = value._to_sql(comodel, coalias, query)
             if self.company_dependent:
                 sql = self._condition_to_sql_company(sql, field_expr, operator, value, model, alias, query)


### PR DESCRIPTION
When inverting the domain, none of the tests were handling this edge-case. A new test is added with the fix. Probably badly renamed variables during a refactor.

Fix for 2b4c3c554b5d89e78caacf066cac3ace0f0610ea


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
