### PR TITLE
[FIX] analytic: process analytic plans in parent-first order

### DIFF
--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -306,7 +306,8 @@ class AccountAnalyticPlan(models.Model):
 
     def _sync_plan_column(self, model):
         # Create/delete a new field/column on related models for this plan, and keep the name in sync.
-        for plan in self:
+        # Sort by parent_path to ensure parents are processed before children
+        for plan in self.sorted('parent_path'):
             prev_stored = plan._find_plan_column(model)
             depth, name_related = plan._hierarchy_name()
             prev_related = plan._find_related_field(model)


### PR DESCRIPTION
When installing the `project` module, `_sync_plan_column(self, model)` is called for all existing analytic plans. The method iterates through `self` in arbitrary order, which means a child plan can be processed before its parent. In such a case, the code tries to create a related field pointing to a parent-level column that does not yet exist, leading to errors like: `Field name "x_plan26_id" unknown for related field "x_plan26_id.plan_id"`

This happened because `self` was iterated without guaranteeing that parents are processed first. As a result, the related field chain (`.plan_id.parent_id...`) could reference missing intermediate fields.

The fix is ordering the recordset by `parent_path`.

Steps to reproduce:
1. In Odoo Inspector, search for model `account.analytic.plan`. and go to records.
2. Create a first plan.
3. Create a second plan and set the first plan as its parent.
4. Install the `project` app (triggers `_sync_plan_column`).
5. Observe the crash due to an unknown related field.

OPW-5006494

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
