### PR TITLE
[FIX] purchase_stock: create different pol for similar mtso sales

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -377,6 +377,7 @@ class PurchaseOrderLine(models.Model):
         lines = self.filtered(
             lambda l: l.propagate_cancel == values['propagate_cancel']
             and (l.orderpoint_id == values['orderpoint_id'] if values['orderpoint_id'] and not values['move_dest_ids'] else True)
+            and ((not values.get('group_id') or self['move_dest_ids']) or l.group_id == values.get('group_id'))
         )
 
         # In case 'product_description_variants' is in the values, we also filter on the PO line


### PR DESCRIPTION
When selling a product that use the mtso procurements, It will only link one SO to the PO, if several SO need to be linked to the same PO it will only keep the first one.
which break the smart button.

### Steps to reproduce:

* Activate Multi-step routes in inventory settings
* Unarchive MTO route
* Set "Take from stock, if unavailable, trigger an other route" on mto (mtso)
* create product with: buy and mtso routes, set up vendors.
* create and confirm a quotation for this products (smart button and link works)
* recreate and confirm a new quotation for this product
* smart button doesn't appears and the link don't exist.

### Observation:

This solution is a follow up on those pr:
MTSO behavior change:
https://github.com/odoo/odoo/pull/177185
First fix:
https://github.com/odoo/odoo/pull/180997

During the MTSO behavior change the link between po <-> so was broken, the first fix recreated a link between the two but only for one so.
The problem is that the field create (inside pol) to link po <-> so is a m2o.
We can not use it to link more than one so per pol.
https://github.com/odoo/odoo/commit/73e34cc6fa77fbdb6b40232d99c140c2e5770650#diff-c3231f0c5829f511c10589fc2c2298fe1c03d59f59a04a1ba8a60c85383ffa42R33

#### The proposition for the fix:
Is to create different pol for each so that originate form a mtso, which allow to link one so per pol.

opw-5026734