### PR TITLE
[FIX] fields: use function to check manual name

### DIFF
--- a/odoo/orm/model_classes.py
+++ b/odoo/orm/model_classes.py
@@ -589,7 +589,7 @@ def add_field(model_cls: type[BaseModel], name: str, field: Field):
         isinstance(getattr(model, name, None), fields.Field)
         for model in [model_cls] + [model_cls.pool[inherit] for inherit in model_cls._inherits]
     )
-    if not (is_class_field or name.startswith('x_')):
+    if not (is_class_field or model_cls.pool['ir.model.fields']._is_manual_name(None, name)):
         raise ValidationError(  # pylint: disable=missing-gettext
             f"The field `{name}` is not defined in the `{model_cls._name}` Python class and does not start with 'x_'"
         )


### PR DESCRIPTION
The use of IrModelFields method `is_manual_name` was [reverted](https://github.com/odoo/odoo/pull/212579) for the sake of efficiency and avoiding instanciating models when not really needed.
The use of an overridable method is still needed ([reference](https://github.com/odoo/odoo/pull/145154)).


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
