### PR TITLE
[IMP] mail: rename 'Notifications' to 'All'/'Home' in messaging menu

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -169,7 +169,7 @@ export class Store extends BaseStore {
                 threads = threads.filter(({ channel_type }) =>
                     this.tabToThreadType("mailbox").includes(channel_type)
                 );
-            } else if (tab !== "notification") {
+            } else if (tab !== "all") {
                 threads = threads.filter(({ channel_type }) =>
                     this.tabToThreadType(tab).includes(channel_type)
                 );

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -8,8 +8,8 @@ export const LAST_DISCUSS_ACTIVE_ID_LS = "mail.user_setting.discuss_last_active_
 export class DiscussApp extends Record {
     INSPECTOR_WIDTH = 300;
     COMPACT_SIDEBAR_WIDTH = 60;
-    /** @type {'notification'|'channel'|'chat'|'livechat'|'inbox'} */
-    activeTab = "notification";
+    /** @type {'all'|'channel'|'chat'|'livechat'|'inbox'} */
+    activeTab = "all";
     searchTerm = "";
     isActive = false;
     isMemberPanelOpenByDefault = fields.Attr(true, {

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -76,7 +76,7 @@
                             <t t-component="threadActions.activeAction.actionPanelComponent" thread="thread" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                         </div>
                     </t>
-                    <div t-elif="(!ui.isSmall or store.discuss.activeTab === 'notification') and store.discuss.hasRestoredThread" class="d-flex flex-grow-1 align-items-center justify-content-center w-100">
+                    <div t-elif="(!ui.isSmall or store.discuss.activeTab === 'all') and store.discuss.hasRestoredThread" class="d-flex flex-grow-1 align-items-center justify-content-center w-100">
                         <h4 class="text-muted"><b><i>No conversation selected.</i></b></h4>
                     </div>
                 </t>

--- a/addons/mail/static/src/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/core/public_web/store_service_patch.js
@@ -12,7 +12,7 @@ patch(Store.prototype, {
     },
     onStarted() {
         super.onStarted(...arguments);
-        this.discuss = { activeTab: "notification" };
+        this.discuss = { activeTab: "all" };
         this.env.bus.addEventListener(
             "discuss.channel/new_message",
             ({ detail: { channel, message, silent } }) => {
@@ -34,7 +34,7 @@ patch(storeService, {
         }
         store.discuss.isActive ||= discussActionIds.includes(router.current.action);
         services.ui.bus.addEventListener("resize", () => {
-            store.discuss.activeTab = "notification";
+            store.discuss.activeTab = "all";
             if (services.ui.isSmall && store.discuss.thread?.channel_type) {
                 store.discuss.activeTab = store.discuss.thread.channel_type;
             }

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -61,7 +61,7 @@ patch(Thread.prototype, {
         }
         this.store.discuss.thread = this;
         this.store.discuss.activeTab = !this.store.env.services.ui.isSmall
-            ? "notification"
+            ? "all"
             : this.model === "mail.box"
             ? "inbox"
             : ["chat", "group"].includes(this.channel_type)

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -64,9 +64,9 @@ patch(MessagingMenu.prototype, {
     get hasPreviews() {
         return (
             this.threads.length > 0 ||
-            (this.store.failures.length > 0 && this.store.discuss.activeTab === "notification") ||
-            (this.shouldAskPushPermission && this.store.discuss.activeTab === "notification") ||
-            (this.canPromptToInstall && this.store.discuss.activeTab === "notification")
+            (this.store.failures.length > 0 && this.store.discuss.activeTab === "all") ||
+            (this.shouldAskPushPermission && this.store.discuss.activeTab === "all") ||
+            (this.canPromptToInstall && this.store.discuss.activeTab === "all")
         );
     },
     get installationRequest() {
@@ -78,7 +78,7 @@ patch(MessagingMenu.prototype, {
             },
             iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
-            isShown: this.store.discuss.activeTab === "notification" && this.canPromptToInstall,
+            isShown: this.store.discuss.activeTab === "all" && this.canPromptToInstall,
         };
     },
     get notificationRequest() {
@@ -87,16 +87,15 @@ patch(MessagingMenu.prototype, {
             displayName: _t("Turn on notifications"),
             iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
-            isShown:
-                this.store.discuss.activeTab === "notification" && this.shouldAskPushPermission,
+            isShown: this.store.discuss.activeTab === "all" && this.shouldAskPushPermission,
         };
     },
     get _tabs() {
         return [
             {
-                icon: "fa fa-envelope",
-                id: "notification",
-                label: _t("Notifications"),
+                icon: this.ui.isSmall ? "fa fa-home" : "fa fa-envelope",
+                id: "all",
+                label: this.ui.isSmall ? _t("Home") : _t("All"),
                 sequence: 10,
             },
             {

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -5,7 +5,7 @@
             <div t-if="!env.inDiscussApp" t-att-class="discussSystray.class">
                 <Dropdown state="dropdown" beforeOpen.bind="beforeOpen" position="'bottom-end'" menuClass="discussSystray.menuClass" bottomSheet="false">
                     <button class="bg-transparent">
-                        <i class="fa fa-lg fa-comments" role="img" aria-label="Messages" t-on-click="() => store.discuss.activeTab = ui.isSmall and store.discuss.activeTab === 'notification' ? 'notification' : store.discuss.activeTab"></i>
+                        <i class="fa fa-lg fa-comments" role="img" aria-label="Messages" t-on-click="() => store.discuss.activeTab = ui.isSmall and store.discuss.activeTab === 'all' ? 'all' : store.discuss.activeTab"></i>
                         <span t-if="counter" class="o-mail-MessagingMenu-counter badge rounded-pill"><t t-esc="counter"/></span>
                     </button>
                     <t t-set-slot="content">
@@ -22,7 +22,7 @@
                 <t t-if="!ui.isSmall">
                     <MessagingMenuQuickSearch t-if="state.searchOpen" onClose.bind="toggleSearch"/>
                     <t t-else="">
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'notification' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'notification'">Notifications</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'all' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'all'">All</button>
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
                         <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
@@ -88,7 +88,7 @@
                 </NotificationItem>
                 <t t-set="itemIndex" t-value="itemIndex + 1"/>
             </t>
-            <t t-if="store.discuss.activeTab === 'notification' and !store.discuss.searchTerm">
+            <t t-if="store.discuss.activeTab === 'all' and !store.discuss.searchTerm">
                 <t t-foreach="store.failures" t-as="failure" t-key="failure.id">
                     <NotificationItem
                         important="1"


### PR DESCRIPTION
It was recently renamed to 'Notifications' because this looks like an item to see notifications in mobile mailbox in the navbar.

However these items are filters and conceptually shouldn't really be a navbar in mobile... But that's kind of the look we went with and would likely stay for version 19.

This commit reverts to 'All' in desktop, but in mobile this item becomes "Home" with the `fa-home` icon. This gives a better sense this is the main screen of discuss app in mobile and fits more as a category at the bottom of screen in mobile than 'All'.

Before / After (mobile)
<img width="406" height="706" alt="mobile-0" src="https://github.com/user-attachments/assets/1ce22b84-970d-4230-b710-8520586b71e0" /> <img width="399" height="701" alt="mobile-1" src="https://github.com/user-attachments/assets/41d1f102-2abd-4acf-bca6-d33b09f342ad" />


Before / After (desktop)
<img width="477" height="634" alt="desktop-0" src="https://github.com/user-attachments/assets/4fc0f216-9b24-4b7d-a766-48e57cc78e70" /> <img width="477" height="635" alt="desktop-1" src="https://github.com/user-attachments/assets/bfc753e6-6412-4f4a-87ba-2f62870e00f2" />
