### PR TITLE
[FIX] portal: signature_form: check modal exists

### DIFF
--- a/addons/portal/static/src/signature_form/signature_form.js
+++ b/addons/portal/static/src/signature_form/signature_form.js
@@ -47,10 +47,13 @@ export class SignatureForm extends Component {
 
         // Correctly set up the signature area if it is inside a modal
         onMounted(() => {
-            this.rootRef.el.closest('.modal').addEventListener('shown.bs.modal', () => {
-                this.signature.resetSignature();
-                this.toggleSignatureFormVisibility();
-            });
+            const modal_el = this.rootRef.el.closest('.modal');
+            if (modal_el !== null) {
+                modal_el.addEventListener('shown.bs.modal', () => {
+                    this.signature.resetSignature();
+                    this.toggleSignatureFormVisibility();
+                });
+            }
         });
     }
 

--- a/doc/cla/corporate/AdvancedSystemsPuntoBit.md
+++ b/doc/cla/corporate/AdvancedSystemsPuntoBit.md
@@ -1,0 +1,19 @@
+Spain, 2025-09-08
+
+Avanced Systems Punto Bit S.L. agrees to the terms of the Odoo Corporate Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+José Vicente Ares Lorenzo vicenteares@grupoisonor.es https://github.com/jviares
+
+List of contributors:
+
+José Vicente Ares Lorenzo vicenteares@grupoisonor.es https://github.com/jviares
+Alexandre Daniel Díaz Cuadrado alexandrediaz@grupoisonor.es https://github.com/Tardo
+David Palanca Martínez davidpalanca@grupoisonor.es https://github.com/Neitherkx
+Abel Suárez Muíño abelsuarez@grupoisonor.es https://github.com/abelsrzz
+Antonia María Romero Jurado antoniaromero@grupoisonor.es https://github.com/torojur25
+Álvaro Alonso Bada alvaroalonso@grupoisonor.es https://github.com/Arubaru86


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Be able to use the portal signature form outside of a modal.

Current behavior before PR:
If the signature form (```<t t-call=“portal.signature_form”>```) is used outside of a modal, an error occurs:
```TypeError: Cannot read properties of null (reading 'addEventListener')```

Desired behavior after PR is merged:
The signature form can be used outside of a modal.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
