### PR TITLE
[FIX] mail: make res_model required if activity_user_id not the current user

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -50,7 +50,7 @@
                             </group>
                             <group>
                                 <field name="res_model" widget="activity_model_selector" string="Link to"
-                                    invisible="id or context.get('active_model')"/>
+                                    invisible="id or context.get('active_model')" required="activity_user_id != context.get('uid')"/>
                                 <field name="date_deadline" string="Due Date"/>
                                 <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
                             </group>


### PR DESCRIPTION
An `AccessError` occurs when a user tries to schedule an activity assigned 
to another internal user without linking it to a record.

**Steps to reproduce**:
1) Install a module
2) Click on the `View all activities` from activities (Top right corner) 
3) Create a new activity without setting a "Link to" record, and assign it
   to another user.

**Issue**:
An AccessError will be raised.

**Cause**:
When the activity has no res_model, the `_action_schedule_activities_personal` 
method is triggered:
https://github.com/odoo/odoo/blob/8e1e4f68763af141c97647fd3e3a2d3a64654a13/addons/mail/wizard/mail_activity_schedule.py#L400-L402 https://github.com/odoo/odoo/blob/8e1e4f68763af141c97647fd3e3a2d3a64654a13/addons/mail/wizard/mail_activity_schedule.py#L415-L424

In this method, both `res_id` and `res_model_id` are passing False, 
and since `activity_user_id` is not the current user, this leads to an `AccessError` 
when trying to create the activity.

**Solution**:
Make res_model required when the assigned user (activity_user_id) is not the current user.

opw-5032100
