### PR TITLE
[FIX] mrp_account,mrp_landed_costs: unbuild MO with landed cost

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -52,10 +52,10 @@ class StockMove(models.Model):
         unbuild_svls = svls.filtered('stock_move_id.unbuild_id')
         unbuild_cost_correction_move_list = list()
         for svl in unbuild_svls:
-            build_time_unit_cost = svl.stock_move_id.unbuild_id.mo_id.move_finished_ids.filtered(
-                lambda m: m.product_id == svl.product_id
-            ).stock_valuation_layer_ids.unit_cost
-            unbuild_difference = svl.unit_cost - build_time_unit_cost
+            build_time_value = sum(
+                svl.stock_move_id.origin_returned_move_id.stock_valuation_layer_ids.mapped("value")
+            )
+            unbuild_difference = svl.value - build_time_value
             if svl.product_id.valuation == 'real_time' and not svl.currency_id.is_zero(unbuild_difference):
                 product_accounts = svl.product_id.product_tmpl_id.get_product_accounts()
                 valuation_account, production_account = (


### PR DESCRIPTION
**Problem:**
when an MO has a landed cost associated to it, unbuilding it leads to a traceback

**Steps to reproduce:**
- create a consumable product (the comp)
- create an avco storable product (the final product)
- create a BOM for the final product with 1 unit of the comp
- create, confirm and "produce all" an MO for the final product
- open inventory/operations/landed costs and click on new
- select a landed cost (or create a new one) and set a positive cost
- validate
- go back to the MO form
- unbuild it

**Current behavior:**
there's a traceback

**Cause of the issue:**
https://github.com/odoo/odoo/blob/9fdec467c68ec5d984c2f4fb76c810dab1277284/addons/mrp_account/models/stock_move.py#L55-L57 The svl created by the landed cost has the final product as its product_id.
As a result,
svl.stock_move_id.unbuild_id.mo_id.move_finished_ids.filtered( lambda m: m.product_id == svl.product_id
).stock_valuation_layer_ids
returns two svls which leads to an error when trying to get the unit_cost attribut

opw-5036574