### PR TITLE
[FIX] web: Allow users to use '&' as value in condition tree type

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector.js
@@ -87,7 +87,7 @@ export class DomainSelector extends Component {
         this.showArchivedCheckbox = Boolean(this.fieldDefs.active);
         this.includeArchived = false;
         if (this.showArchivedCheckbox) {
-            if (this.tree.value === "&") {
+            if (this.tree.type === "connector" && this.tree.value === "&") {
                 this.tree.children = this.tree.children.filter((child) => {
                     if (deepEqual(child, ARCHIVED_CONDITION)) {
                         this.includeArchived = true;

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -810,7 +810,8 @@ export class SearchModel extends EventBus {
         }
 
         const tree = treeFromDomain(domain, { distributeNot: !this.isDebugMode });
-        const trees = !tree.negate && tree.value === "&" ? tree.children : [tree];
+        const containsChildren = !tree.negate && tree.type === "connector" && tree.value == "&";
+        const trees = containsChildren ? tree.children : [tree];
         const promises = trees.map(async (tree) => {
             const description = await this.getDomainTreeDescription(this.resModel, tree);
             const preFilter = {


### PR DESCRIPTION
Example of steps:
- Open any domain selector with an archive checkbox (via custom filter for example)
- Try to add char `&` in value input
- focus out or try to apply the filter
- Traceback

```
UncaughtPromiseError > OwlError
Uncaught Promise > The following error occurred in onWillUpdateProps: "Cannot read properties of undefined (reading 'filter')"
```

The problem comes from the fact that we expect to have multiple nodes in our domain if we have an `&` as a value.

However, there is a difference between using `&` in a text search for example (type `condition`), and using `&` as an AND between two nodes (type `connector`).

The solution is to restrict the condition so that it not only checks that the value is equal to `&`, but also checks that the tree type is indeed a connector and not a condition.

opw-5015281