### PR TITLE
[FIX] web: fix SelectMenu positioning with fit variant

### DIFF
--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -121,7 +121,16 @@ export class Popover extends Component {
         this.popoverRef = useRef("ref");
         this.position = usePosition("ref", () => this.props.target, this.positioningOptions);
 
-        onMounted(() => POPOVERS.set(this.props.target, this.popoverRef.el));
+        const resizeObserver = new ResizeObserver(() => {
+            if (!this.props.fixedPosition && this.animationDone) {
+                this.position.unlock();
+            }
+        });
+
+        onMounted(() => {
+            POPOVERS.set(this.props.target, this.popoverRef.el);
+            resizeObserver.observe(this.popoverRef.el);
+        });
         onWillDestroy(() => POPOVERS.delete(this.props.target));
 
         if (this.props.target.isConnected) {

--- a/addons/web/static/src/core/position/utils.js
+++ b/addons/web/static/src/core/position/utils.js
@@ -109,6 +109,12 @@ function computePosition(popper, target, { container, flip, margin, position }) 
         container = container();
     }
 
+    if (variant === "fit") {
+        // make sure the popper has the desired dimensions during the computation of the position
+        const styleProperty = ["top", "bottom"].includes(direction) ? "width" : "height";
+        popper.style[styleProperty] = getComputedStyle(target)[styleProperty];
+    }
+
     // Account for popper actual margins
     const popperStyle = getComputedStyle(popper);
     const { marginTop, marginLeft, marginRight, marginBottom } = popperStyle;
@@ -254,13 +260,9 @@ export function reposition(popper, target, options) {
     const solution = computePosition(popper, target, { ...DEFAULTS, ...options });
 
     // Apply it
-    const { top, left, direction, variant } = solution;
+    const { top, left } = solution;
     popper.style.top = `${top}px`;
     popper.style.left = `${left}px`;
-    if (variant === "fit") {
-        const styleProperty = ["top", "bottom"].includes(direction) ? "width" : "height";
-        popper.style[styleProperty] = target.getBoundingClientRect()[styleProperty] + "px";
-    }
 
     return solution;
 }

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -1,8 +1,13 @@
 import { expect, getFixture, test } from "@odoo/hoot";
 import { queryOne, queryRect, resize, scroll, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
-import { Component, useRef, xml } from "@odoo/owl";
-import { defineStyle, mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { Component, useRef, useState, xml } from "@odoo/owl";
+import {
+    contains,
+    defineStyle,
+    mountWithCleanup,
+    waitForSteps,
+} from "@web/../tests/web_test_helpers";
 import { Popover } from "@web/core/popover/popover";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { patch } from "@web/core/utils/patch";
@@ -363,6 +368,41 @@ test("popover with arrow and onPositioned", async () => {
     expect(".o_popover").toHaveClass("o_popover popover mw-100 bs-popover-auto");
     expect(".o_popover").toHaveAttribute("data-popper-placement", "bottom");
     expect(".o_popover > .popover-arrow").toHaveClass("position-absolute z-n1");
+});
+
+test("popover position is updated when the content dimensions change", async () => {
+    class DynamicContent extends Component {
+        setup() {
+            this.state = useState({
+                showMore: false,
+            });
+        }
+        static props = ["*"];
+        static template = xml`<div id="popover">
+        Click on this <button t-on-click="() => this.state.showMore = true">button</button> to read more
+        <span t-if="state.showMore">
+            This tooltip gives your more information on this topic!
+        </span>
+    </div>`;
+    }
+
+    await mountWithCleanup(Popover, {
+        props: {
+            close: () => {},
+            target: getFixture(),
+            position: "top-fit",
+            component: DynamicContent,
+            onPositioned() {
+                expect.step("onPositioned");
+            },
+        },
+    });
+
+    expect(".o_popover").toHaveCount(1);
+    expect.verifySteps(["onPositioned"]);
+    await contains("#popover button").click();
+    expect("#popover span").toHaveCount(1);
+    await waitForSteps(["onPositioned"]);
 });
 
 test("arrow follows target and can get sucked", async () => {

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -969,3 +969,37 @@ test("bottom-fit has the same width as the target", getFittingTest("bottom-fit",
 test("top-fit has the same width as the target", getFittingTest("top-fit", "width"));
 test("left-fit has the same height as the target", getFittingTest("left-fit", "height"));
 test("right-fit has the same height as the target", getFittingTest("right-fit", "height"));
+
+test("popper with the fit variant and a large content inside is resized to match the toggler - horizontally", async () => {
+    const TestComp = getTestComponent(
+        { position: "bottom-fit" },
+        {
+            content: {
+                width: "500px",
+            },
+            popper: {
+                width: "unset",
+            },
+        }
+    );
+    await mountWithCleanup(TestComp);
+    expect(queryOne("#target").getBoundingClientRect().left).toBe(225);
+    expect("#popper").toHaveStyle({ left: "225px", width: "50px" });
+});
+
+test("popper with the fit variant and a large content inside is resized to match the toggler - vertically", async () => {
+    const TestComp = getTestComponent(
+        { position: "right-fit" },
+        {
+            content: {
+                height: "500px",
+            },
+            popper: {
+                height: "unset",
+            },
+        }
+    );
+    await mountWithCleanup(TestComp);
+    expect(queryOne("#target").getBoundingClientRect().top).toBe(225);
+    expect("#popper").toHaveStyle({ top: "225px", height: "50px" });
+});


### PR DESCRIPTION
This commit fixes the position of the SelectMenu, that was not aligned properly when the content of the menu is larger than the toggler width before applying any maxWidth.

Because the 'fit' variant sets the same width to the popper by default, and the code was applying this width after the computation of the position of the popper, the menu was displaced.

Now, the width is applied before positioning the menu, which then computes accordingly.

A test has been added as well.

task-4674144