### PR TITLE
[IMP] html_editor: allow removing format from block elements

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -616,6 +616,7 @@ export class DomPlugin extends Plugin {
                 if (newCandidate.matches(baseContainerGlobalSelector) && isListItemElement(block)) {
                     continue;
                 }
+                this.dispatchTo("before_set_tag_handlers", block);
                 const newEl = this.setTagName(block, tagName);
                 cursors.remapNode(block, newEl);
                 // We want to be able to edit the case `<h2 class="h3">`
@@ -639,7 +640,6 @@ export class DomPlugin extends Plugin {
             }
         }
         cursors.restore();
-        this.dispatchTo("set_tag_handlers", newEls);
         this.dependencies.history.addStep();
     }
 

--- a/addons/html_editor/static/src/core/format_plugin.scss
+++ b/addons/html_editor/static/src/core/format_plugin.scss
@@ -1,0 +1,7 @@
+.o_default_color {
+    color: $body-color;
+}
+
+.o_default_font_size {
+    font-size: $font-size-base;
+}

--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -6,14 +6,6 @@ li * {
     color: inherit;
 }
 
-.o_default_color {
-    color: $body-color;
-}
-
-.o_default_font_size {
-    font-size: $font-size-base;
-}
-
 // Checklist
 ul.o_checklist {
     > li {

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -156,7 +156,7 @@ describe("to paragraph", () => {
             contentBefore:
                 '<h3 class="h4-fs" style="text-align: center;">[abc<span style="font-size: 32px;">de</span><strong>fg</strong>]</h3>',
             stepFunction: setTag("p"),
-            contentAfter: '<p style="text-align: center;">[abcde<strong>fg]</strong></p>',
+            contentAfter: '<p style="text-align: center;">[abcde<strong>fg</strong>]</p>',
         });
     });
 });
@@ -276,7 +276,7 @@ describe("to heading 1", () => {
             contentBefore:
                 '<h2 class="h4-fs" style="text-align: center;">[abc<span style="font-size: 32px;">de</span><strong>fg</strong>]</h2>',
             stepFunction: setTag("h1"),
-            contentAfter: '<h1 style="text-align: center;">[abcde<strong>fg]</strong></h1>',
+            contentAfter: '<h1 style="text-align: center;">[abcde<strong>fg</strong>]</h1>',
         });
     });
 });
@@ -346,7 +346,7 @@ describe("to heading 2", () => {
             contentBefore:
                 '<h3 class="h4-fs" style="text-align: center;">[abc<span style="font-size: 32px;">de</span><strong>fg</strong>]</h3>',
             stepFunction: setTag("h2"),
-            contentAfter: '<h2 style="text-align: center;">[abcde<strong>fg]</strong></h2>',
+            contentAfter: '<h2 style="text-align: center;">[abcde<strong>fg</strong>]</h2>',
         });
     });
 });
@@ -492,7 +492,7 @@ describe("to pre", () => {
             contentBefore:
                 '<h3 class="h4-fs" style="text-align: center;">[abc<span style="font-size: 32px;">de</span><strong>fg</strong>]</h3>',
             stepFunction: setTag("pre"),
-            contentAfter: '<pre style="text-align: center;">[abcde<strong>fg]</strong></pre>',
+            contentAfter: '<pre style="text-align: center;">[abcde<strong>fg</strong>]</pre>',
         });
     });
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

Styles applied via typography classes such as `display-1-fs`, `display-2-fs`, etc. could not be removed from block elements.
eg: `<h1 class="display-1-fs">t[es]t</h1>`.

Desired behavior after PR is merged:

- HTML tags (`<p>`, `<h1>`, etc.) represent the base typography.
- Typography classes (display-*) should be treated like equivalent HTML tags, not as removable styles.
- Only display classes (*-fs) are considered for format removal.
- When removing format, the editor now restores the font style of the underlying HTML tag.
eg: `<h1 class="display-1-fs">t<span class="h1">[es]</span>t</h1>`

task-4981275

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
