### PR TITLE
[IMP] hr_attendance: add Device & Location Tracking setting

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -77,6 +77,7 @@ class HrAttendance(models.Model):
                                 readonly=True,
                                 default='manual')
     expected_hours = fields.Float(compute="_compute_expected_hours", store=True, aggregator="sum")
+    device_tracking_enabled = fields.Boolean(related="employee_id.company_id.attendance_device_tracking")
 
     @api.depends("worked_hours", "overtime_hours")
     def _compute_expected_hours(self):

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -38,6 +38,7 @@ class ResCompany(models.Model):
     auto_check_out = fields.Boolean(string="Automatic Check Out", default=False)
     auto_check_out_tolerance = fields.Float(default=2, export_string_translation=False)
     absence_management = fields.Boolean(string="Absence Management", default=False)
+    attendance_device_tracking = fields.Boolean(string="Device & Location Tracking", default=True)
 
     @api.depends("attendance_kiosk_key")
     def _compute_attendance_kiosk_url(self):

--- a/addons/hr_attendance/models/res_config_settings.py
+++ b/addons/hr_attendance/models/res_config_settings.py
@@ -22,6 +22,7 @@ class ResConfigSettings(models.TransientModel):
     auto_check_out = fields.Boolean(related="company_id.auto_check_out", readonly=False)
     auto_check_out_tolerance = fields.Float(related="company_id.auto_check_out_tolerance", readonly=False)
     absence_management = fields.Boolean(related="company_id.absence_management", readonly=False)
+    attendance_device_tracking = fields.Boolean(related="company_id.attendance_device_tracking", readonly=False)
 
     @api.model
     def get_values(self):

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -62,7 +62,9 @@ export class ActivityMenu extends Component {
 
     async signInOut() {
         this.dropdown.close();
-        if (!isIosApp()) { // iOS app lacks permissions to call `getCurrentPosition`
+        const trackingEnabled = this.employee && this.employee.device_tracking_enabled;
+        if (trackingEnabled && !isIosApp() && navigator.geolocation) {
+            // iOS app lacks permissions to call `getCurrentPosition`
             navigator.geolocation.getCurrentPosition(
                 async ({coords: {latitude, longitude}}) => {
                     this.employee = await rpc("/hr_attendance/systray_check_in_out", {

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -145,11 +145,11 @@
                             <group>
                                 <group>
                                     <field name="in_mode"/>
-                                    <field name="in_ip_address" invisible="in_mode == 'manual'"/>
-                                    <field name="in_browser" invisible="in_mode == 'manual'"/>
+                                    <field name="in_ip_address" invisible="in_mode == 'manual' or not device_tracking_enabled"/>
+                                    <field name="in_browser" invisible="in_mode == 'manual' or not device_tracking_enabled"/>
                                 </group>
                             </group>
-                            <group invisible="in_mode == 'manual'">
+                            <group invisible="in_mode == 'manual' or not device_tracking_enabled">
                                 <field name="in_location"/>
                                 <label for="in_latitude" string="GPS Coordinates"/>
                                 <div>
@@ -176,11 +176,11 @@
                             <group>
                                 <group>
                                     <field name="out_mode" string="Mode"/>
-                                    <field name="out_ip_address" string="IP Address" invisible="in_mode == 'manual'"/>
-                                    <field name="out_browser" string="Browser" invisible="in_mode == 'manual'"/>
+                                    <field name="out_ip_address" string="IP Address" invisible="in_mode == 'manual' or not device_tracking_enabled"/>
+                                    <field name="out_browser" string="Browser" invisible="in_mode == 'manual' or not device_tracking_enabled"/>
                                 </group>
                             </group>
-                            <group invisible="out_mode == 'manual'">
+                            <group invisible="out_mode == 'manual' or not device_tracking_enabled">
                                 <field name="out_location"/>
                                 <label for="out_latitude" string="GPS Coordinates"/>
                                 <div>

--- a/addons/hr_attendance/views/res_config_settings_views.xml
+++ b/addons/hr_attendance/views/res_config_settings_views.xml
@@ -28,6 +28,9 @@
                         <setting string="Absence Management" company_dependent="1" help="If checked, days not covered by an attendance will be visible in the Report. Does not apply to employees with a flexible working schedule.">
                             <field name="absence_management"/>
                         </setting>
+                        <setting string="Device &amp; Location Tracking" company_dependent="1" help="Allow the collection of GPS location, IP address, and browser/device details used to track employee access and attendance">
+                            <field name="attendance_device_tracking"/>
+                        </setting>
                     </block>
                     <block title="Kiosk Settings">
                         <setting invisible="attendance_kiosk_mode == 'manual'" company_dependent="1" help="Define the camera used for the barcode scan.">


### PR DESCRIPTION
Some countries have strict data protection laws regarding location capture, so companies need the ability to disable GPS coordinates collection during employee check-in/check-out.

When Device & Location Tracking is disabled:
- No GPS coordinates, IP addresses, or browser details are collected
- Related fields are hidden from form  view
- Geolocation API calls are skipped in frontend
- Attendance functionality remains fully operational

Task-5044938