### PR TITLE
[FIX] hr_expense: self.env.su is always True in _compute_is_editable and _compute_can_reset

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -271,9 +271,9 @@ class HrExpense(models.Model):
     )
 
     # Security fields
-    is_editable = fields.Boolean(string="Is Editable By Current User", compute='_compute_is_editable', readonly=True, compute_sudo=True)
-    can_reset = fields.Boolean(string='Can Reset', compute='_compute_can_reset', readonly=True, compute_sudo=True)
-    can_approve = fields.Boolean(string='Can Approve', compute='_compute_can_approve', readonly=True, compute_sudo=True)
+    is_editable = fields.Boolean(string="Is Editable By Current User", compute='_compute_is_editable', readonly=True)
+    can_reset = fields.Boolean(string='Can Reset', compute='_compute_can_reset', readonly=True)
+    can_approve = fields.Boolean(string='Can Approve', compute='_compute_can_approve', readonly=True)
 
     # Legacy sheet field, allow grouping of expenses to keep the grouping mechanic data and allow it to be re-used when re-implemented
     former_sheet_id = fields.Integer(string='Former Report')
@@ -355,7 +355,7 @@ class HrExpense(models.Model):
             managers = (
                 expense.manager_id
                 | employee.expense_manager_id
-                | employee.department_id.manager_id.user_id
+                | employee.sudo().department_id.manager_id.user_id.sudo(self.env.su)
             )
             if is_all_approver:
                 managers |= self.env.user
@@ -1383,7 +1383,7 @@ class HrExpense(models.Model):
             elif not is_hr_admin:
                 current_managers = (
                         expense_employee.expense_manager_id
-                        | expense_employee.department_id.manager_id.user_id
+                        | expense_employee.sudo().department_id.manager_id.user_id.sudo(self.env.su)
                         | expense.manager_id
                 )
                 if expense_employee.id in expenses_employee_ids_under_user_ones:

--- a/addons/hr_expense/tests/test_expenses_access_rights.py
+++ b/addons/hr_expense/tests/test_expenses_access_rights.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.tests import HttpCase, tagged, new_test_user
 
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
@@ -49,3 +49,37 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
         })
         self.start_tour("/odoo", 'hr_expense_access_rights_test_tour', login="test-expense")
         self.assertRecordValues(expense, [{'state': 'submitted'}])
+
+    def test_expense_user_cant_approve_own_expense(self):
+        expense = self.env['hr.expense'].with_user(self.expense_user_employee).create({
+            'name': "Superboy costume washing",
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_a.id,
+            'quantity': 1,
+            'price_unit': 1,
+        })
+        expense.with_user(self.expense_user_employee).action_submit()
+        with self.assertRaises(UserError):
+            expense.with_user(self.expense_user_employee).action_approve()
+
+    def test_expense_team_approver_cant_approve_expense_of_employee_he_does_not_manage(self):
+        another_standard_user = new_test_user(self.env, login='another_standard_user', groups='base.group_user')
+        another_standard_user_team_approver = new_test_user(self.env, login='another_standard_user_manager', groups='base.group_user,hr_expense.group_hr_expense_team_approver')
+
+        another_employee = self.env['hr.employee'].create({
+            'name': 'another_employee',
+            'user_id': another_standard_user.id,
+            'work_contact_id': another_standard_user.partner_id.id,
+            'expense_manager_id': self.expense_user_manager.id,
+        })
+
+        expense = self.env['hr.expense'].with_user(another_standard_user).create({
+            'name': "Superboy costume washing",
+            'employee_id': another_employee.id,
+            'product_id': self.product_a.id,
+            'quantity': 1,
+            'price_unit': 1,
+        })
+        expense.with_user(another_standard_user).action_submit()
+        with self.assertRaises(AccessError):
+            expense.with_user(another_standard_user_team_approver).action_approve()


### PR DESCRIPTION
The field is_editable which used the compute method _compute_is_editable and the field can_reset which used the compute method _compute_can_reset, where called with the argument compute_sudo=True. Those 2 method then used the self.env.su which was always True.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
