### PR TITLE
[FIX] sale: keep sale order line units on variant update

### DIFF
--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -37,11 +37,14 @@ async function applyProduct(record, product) {
         ptal => ptal.create_variant === "no_variant"
     ).flatMap(ptal => ptal.selected_attribute_value_ids);
 
+    const { product_uom_id } = record.data;
     // We use `_update` (not locked) instead of `update` (locked) so that multiple records can be
     // updated in parallel (for performance).
     await record._update({
         product_id: [product.id, product.display_name],
         product_uom_qty: product.quantity,
+        // Preserve `product_uom_id` iff set
+        ...(product_uom_id ? { product_uom_id } : {}),
         product_no_variant_attribute_value_ids: [x2ManyCommands.set(noVariantPTAVIds)],
         product_custom_attribute_value_ids: customAttributesCommands,
     });

--- a/addons/sale/static/tests/tours/sale_order_product_uom_integrity.js
+++ b/addons/sale/static/tests/tours/sale_order_product_uom_integrity.js
@@ -1,0 +1,14 @@
+import { registry } from '@web/core/registry';
+import { stepUtils } from '@web_tour/tour_service/tour_utils';
+import productConfiguratorTourUtils from '@sale/js/tours/product_configurator_tour_utils';
+import tourUtils from '@sale/js/tours/tour_utils';
+
+registry.category('web_tour.tours').add('sale_order_keep_uom_on_variant_wizard_quantity_change', {
+    steps: () => [
+        tourUtils.editLineMatching("Sofa"),
+        tourUtils.editConfiguration(),
+        productConfiguratorTourUtils.increaseProductQuantity("Sofa"),
+        ...productConfiguratorTourUtils.saveConfigurator(),
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/sale/tests/__init__.py
+++ b/addons/sale/tests/__init__.py
@@ -15,6 +15,7 @@ from . import test_sale_order
 from . import test_sale_order_discount
 from . import test_sale_order_down_payment
 from . import test_sale_order_product_catalog
+from . import test_sale_order_ui
 from . import test_sale_prices
 from . import test_sale_product_attribute_value_config
 from . import test_sale_product_template

--- a/addons/sale/tests/test_sale_order_ui.py
+++ b/addons/sale/tests/test_sale_order_ui.py
@@ -1,0 +1,29 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.fields import Command
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.product.tests.common import ProductVariantsCommon
+
+
+@tagged('post_install', '-at_install')
+class TestSaleOrderUI(HttpCase, ProductVariantsCommon):
+
+    def test_sale_order_keep_uom_on_variant_wizard_quantity_change(self):
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'product_id': self.product_template_sofa.product_variant_ids[0].id,
+                'product_uom_id': self.uom_dozen.id,
+                'product_uom_qty': 1,
+            })],
+        })
+
+        self.start_tour(
+            f'/odoo/sales/{so.id}',
+            'sale_order_keep_uom_on_variant_wizard_quantity_change',
+            login="admin",
+        )
+
+        sol = so.order_line[0]
+        self.assertEqual(sol.product_uom_id, self.uom_dozen)


### PR DESCRIPTION
## Versions
18.2+
Note: 18.4 needs `product.uom_id` to be replaced by `product.uom.id` to work properly.

## Issue
On a SO, if a product has variants and packaging is allowed, modifying the variant resets the packaging to units.

## Steps to reproduce
*Ensure "Units of Measure & Packagings" is enables in Sales' app's settings*
- Create a new product
  - Under "Attributes & Variants" tab, add the following:
    - Color: add 2 colors;
    - Legs: add 2 legs;
  - Under "Sales" tab, select "Pack of 6" for "Packagings" (under "Upsell & Cross-Sell" section);
- Create a new quote and add that new product:
  - Change its "Unit" for "Pack of 6";
  - Modify the product variant by clicking the pen button next to the product name (appear on hover):
    - Click "Confirm" (no changes needed);
  - See the order line's product's units change back to "Units".

opw-4814166