### PR TITLE
[FIX] website_sale_wishlist: refresh header count on mobile

### DIFF
--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist_utils.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist_utils.js
@@ -47,13 +47,17 @@ function removeWishlistProduct(productId) {
  */
 function updateWishlistNavBar() {
     const wishlistProductIds = getWishlistProductIds();
-    const wishButton = document.querySelector('.o_wsale_my_wish');
-    if (wishButton.classList.contains('o_wsale_my_wish_hide_empty')) {
-        wishButton.classList.toggle('d-none', !wishlistProductIds.length);
-    }
-    wishButton.querySelector('.my_wish_quantity').textContent = `${wishlistProductIds.length}`;
-    const wishlistQuantity = document.querySelector('.my_wish_quantity');
-    wishlistQuantity.classList.toggle('d-none', !wishlistProductIds.length);
+    const wishButtons = document.querySelectorAll('.o_wsale_my_wish');
+    wishButtons.forEach(button => {
+        if (button.classList.contains('o_wsale_my_wish_hide_empty')) {
+            button.classList.toggle('d-none', !wishlistProductIds.length);
+        }
+        button.querySelector('.my_wish_quantity').textContent = `${wishlistProductIds.length}`;
+    });
+    const wishlistQuantities = document.querySelectorAll('.my_wish_quantity');
+    wishlistQuantities.forEach(quantity => {
+        quantity.classList.toggle('d-none', !wishlistProductIds.length);
+    });
 }
 
 /**


### PR DESCRIPTION
On website there are two headers, one for desktop and one for smaller viewports.

In commit[1] the wishlist was converted to Interaction but refreshing the quantity of the wishlist button in the navbar took in account only the desktop header.

This commit uses a querySelectorAll to update the quantity on both headers.

[1]: odoo/odoo@3d719831e1341741465b05b0dce8c7ff382fdf69

task-5047743



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
