### PR TITLE
[FIX] discuss: call - prevent traceback with track race condition

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1086,7 +1086,10 @@ export class Rtc extends Record {
                     const session = await this.store["discuss.channel.rtc.session"].getWhenReady(
                         sessionId
                     );
-                    if (!session || !this.state.channel) {
+                    if (!this.selfSession || !this.state.channel) {
+                        return;
+                    }
+                    if (!session) {
                         this.log(
                             this.selfSession,
                             `track received for unknown session ${sessionId} (${this.state.connectionType})`


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/202167,
a race condition could occur where the call is over when the the rtc 
session matching a track event is obtained.

This could occur if you crash or leave at the moment another user 
arrives. You could get a track event from the SFU, wait for the rtc
session record from Odoo, leave te call, finally get the rtc session
from odoo. This would lead to a traceback as this handler expected
that the call was still ongoing.