### PR TITLE
[IMP] base_automation: only decrease cron interval

### DIFF
--- a/addons/base_automation/tests/test_automation.py
+++ b/addons/base_automation/tests/test_automation.py
@@ -217,15 +217,15 @@ class TestAutomation(TransactionCaseWithUserDemo):
         self.assertRecordValues(cron, [{
             'active': True,
             'interval_type': 'minutes',
-            'interval_number': 12,  # 10% of automation1 delay
+            'interval_number': 6,  # did not change as the new delay is higher
         }])
 
         # Disable automation1
         automation1.active = False
         self.assertRecordValues(cron, [{
             'active': False,
-            'interval_type': 'hours',
-            'interval_number': 4,
+            'interval_type': 'minutes',
+            'interval_number': 6,  # did not change as the new delay is higher
         }])
 
         # Enable automation1 and automation2
@@ -234,7 +234,7 @@ class TestAutomation(TransactionCaseWithUserDemo):
         self.assertRecordValues(cron, [{
             'active': True,
             'interval_type': 'minutes',
-            'interval_number': 6,  # 10% of least delay (automation2)
+            'interval_number': 6,  # still 10% of automation2 delay
         }])
 
         # Create another automation with no delay
@@ -249,7 +249,7 @@ class TestAutomation(TransactionCaseWithUserDemo):
         self.assertRecordValues(cron, [{
             'active': True,
             'interval_type': 'minutes',
-            'interval_number': 6,  # should have not changed
+            'interval_number': 6,  # should have not changed either
         }])
 
     def test_computed_on_scheduled_action(self):


### PR DESCRIPTION
**Before this commit**
The run inteval for the cron that checks for time based automations is _always updated_ whenever a time based automation rule is created or updated.

**After this commit**
The run inteval for the cron that checks for time based automations is _only updated whenever the new cron interval is shorter_. That means that this cron interval _would no more increase automatically_.
This is the chosen solution to allow users to manually change the cron interval without never seeing it change to a higher value.

Task-id: opw-4936558