### PR TITLE
[FIX] hr_recruitment : fix faulty template field assignment due to scope issue

### DIFF
--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -328,10 +328,14 @@ class TestRecruitment(TransactionCase):
         ])
 
         applicant_get_refuse_reason = self.env['applicant.get.refuse.reason'].create([{
-            'refuse_reason_id': refuse_reason.id,
+            'refuse_reason_id': self.env.ref('hr_recruitment.refuse_reason_2').id,
             'applicant_ids': [app_1.id],
             'duplicates': True
         }])
+
+        with Form(applicant_get_refuse_reason) as wizard:
+            wizard.refuse_reason_id = refuse_reason
+
         applicant_get_refuse_reason.action_refuse_reason_apply()
         self.assertFalse(self.env['hr.applicant'].search([('email_from', 'ilike', 'laurie.poiret@aol.ru')]))
         self.assertEqual(

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -98,10 +98,13 @@ class ApplicantGetRefuseReason(models.TransientModel):
         }
         for wizard in self:
             if wizard.template_id:
-                for wizard_field_name, template_field_name in fields_to_copy_name_mapping.items():
-                    wizard[wizard_field_name] = wizard.template_id[template_field_name]
+                values = {
+                    wizard_field: wizard.template_id[template_field]
+                    for wizard_field, template_field in fields_to_copy_name_mapping.items()
+                }
             else:
-                wizard[wizard_field_name] = False
+                values = {wizard_field: False for wizard_field in fields_to_copy_name_mapping}
+            wizard.update(values)
 
     def action_refuse_reason_apply(self):
         if self.send_mail:


### PR DESCRIPTION
**Step to reproduce:**
- install `hr_recruitment`
- open recruitment -> refuse reason
- from any record say rec1, remove its email template
- from recruitment, open a job application
- refuse it, a wizard opens for reason, select rec1

**Observation:**
- we receive a traceback

**Cause:**
- there is oversight in `_compute_from_template_id` method
- `wizard_field_name` is refrenced outside of its scope

**Fix:**
- fix the method, to correctly assign the template values to wizard

opw-5031197


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
