### PR TITLE
[FIX] hr_payroll: delete version of employee bug

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -358,7 +358,9 @@ class HrEmployee(models.Model):
     @api.depends('current_version_id')
     @api.depends_context('version_id')
     def _compute_version_id(self):
-        context_version = self.env['hr.version'].browse(self.env.context.get('version_id', False))
+        context_version_id = self.env.context.get('version_id', False)
+        context_version = self.env['hr.version'].browse(context_version_id).exists() if context_version_id else self.env['hr.version']
+
         for employee in self:
             if context_version.employee_id == self:
                 version = context_version

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -480,6 +480,27 @@ class TestHrVersion(TransactionCase):
             self.assertEqual(version.job_id.id, jobB.id)
             self.assertEqual(version.contract_date_end, date(2020, 9, 30))
 
+    def test_delete_version(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'John Doe',
+            'date_version': '2020-01-01',
+        })
+        v1 = employee.version_id
+        v2 = employee.create_version({
+            'date_version': '2021-01-01',
+        })
+        v3 = employee.create_version({
+            'date_version': '2022-01-01',
+        })
+        self.assertEqual(employee.current_version_id, v3)
+
+        v3.unlink()
+        self.assertEqual(employee.current_version_id, v2)
+        v1.unlink()
+        self.assertEqual(employee.current_version_id, v2)
+        with self.assertRaises(ValidationError):
+            v2.unlink()
+
     def test_multi_edit_multi_employees_no_contract(self):
         """
         Test the multi-edit when there is one version per employee, without contract


### PR DESCRIPTION
Issue/Current Behavior:
It is not possible to delete a version of an employee. Steps to Reproduce:
 1. Create an employee.
 2. Create a new version of the employee.
 3. Click on the smart button of versions and delete a record from the list view.
 4. It gives warning that the record doesn't exist or might be deleted. Solution:
Fixed the issue by checking that the context version exists or else the empty recordset.

task - 5002995

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
