### PR TITLE
[FIX] point_of_sale: fix receipt shipping date for UTC- timezones

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -30,6 +30,7 @@ export class PosOrder extends Base {
         this.name = vals.name || "/";
         this.nb_print = vals.nb_print || 0;
         this.to_invoice = vals.to_invoice || false;
+        this.setShippingDate(vals.shipping_date);
         this.state = vals.state || "draft";
         this.uuid = vals.uuid ? vals.uuid : uuidv4();
         this.last_order_preparation_change = vals.last_order_preparation_change

--- a/addons/point_of_sale/static/tests/pos/tours/shipping_date_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/shipping_date_tour.js
@@ -1,6 +1,7 @@
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
@@ -10,7 +11,10 @@ registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Whiteboard Pen", "1"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Partner Test with Address"),
             ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
             {
                 content: "click ship later button",
                 trigger: ".button:contains('Ship Later')",
@@ -43,6 +47,19 @@ registry.category("web_tour.tours").add("test_pos_order_shipping_date", {
                     const expectedDate = `05/30/${nextYear}`;
                     if (!spans.some((span) => span.innerText === expectedDate)) {
                         throw new Error("Expected shipping date is not set");
+                    }
+                },
+            },
+            PaymentScreen.clickValidate(),
+            {
+                content: "Assert shipping date in receipt",
+                trigger: ".pos-receipt-order-data",
+                run: () => {
+                    const dateDiv = document.querySelector(".pos-receipt-order-data div");
+                    const nextYear = new Date().getFullYear() + 1;
+                    const expectedDate = `5/30/${nextYear}`;
+                    if (dateDiv.innerText !== expectedDate) {
+                        throw new Error("Expected shipping date is not set in receipt");
                     }
                 },
             },

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2574,6 +2574,13 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertIn(children_categs[1].id, category_id, "Child category is available and should appear in the POS")
 
     def test_pos_order_shipping_date(self):
+        self.env['res.partner'].create({
+            'name': 'Partner Test with Address',
+            'street': 'test street',
+            'zip': '1234',
+            'city': 'test city',
+            'country_id': self.env.ref('base.us').id
+        })
         self.main_pos_config.write({'ship_later': True})
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(


### PR DESCRIPTION
In this bug, the shipping date in pos receipt is set to previous dates.

To reproduce the bug:
1- Setup a database with point_of_sale app installed
2- In configuration -> Setting, check Allow Ship Later option for a pos shop.
3- Change the browser timezone to a US timezone. In chrome it can be in Console -> Sensors -> Location.
4- Open POS register, select a product, choose payment and use Ship Later, to pick a date.
5- After validating the order, you can see the wrong shipping date is shown in the recipt.

This is related to #215140 in which the shipping date bug is fixed when the date is picked.
However, in generation of receipt a new PosOrder object is created, in which there is a need to explictly deserilizing shippingDate to avoid unwanted timezone effects.

opw-5009476
