### PR TITLE
[FIX] discuss: call - prevent traceback with track race condition

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -645,6 +645,9 @@ export class Rtc extends Record {
      * @param {Boolean} [param2.important] if the log is important and should be kept even if logRtc is disabled
      */
     log(session, entry, { error, step, state, important, ...data } = {}) {
+        if (!session) {
+            return;
+        }
         session.logStep = entry;
         if (!this.store.settings.logRtc && !important) {
             return;


### PR DESCRIPTION
Before this commit, since https://github.com/odoo/odoo/pull/200981, a race condition could occur where the call is over when the the rtc session matching a track event is obtained.

This could occur if you crash or leave at the moment another user arrives. You could get a track event from the SFU, wait for the rtc session record from Odoo, leave te call, finally get the rtc session from odoo. This would lead to a traceback as this handler expected that the call was still ongoing.


