### PR TITLE
[IMP] web: preview while modifying custom colorpicker sliders

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -61,19 +61,17 @@ export function useColorPickerBuilderComponent() {
             : colorValue;
     }
 
-    let preventNextPreview = false;
+    let previewValue = null;
     function onApply(colorValue) {
-        preventNextPreview = false;
+        previewValue = null;
         callOperation(applyOperation.commit, { userInputValue: getColor(colorValue) });
     }
     let onPreview = (colorValue) => {
-        // Avoid previewing the same color twice. It won't block previewing
-        // another color, as in that case the mouseout/focusout will call an
-        // explicit revert and set the flag to false.
-        if (preventNextPreview) {
+        // Avoid previewing the same color twice.
+        if (previewValue === colorValue) {
             return;
         }
-        preventNextPreview = true;
+        previewValue = colorValue;
         callOperation(applyOperation.preview, {
             preview: true,
             userInputValue: getColor(colorValue),
@@ -92,7 +90,7 @@ export function useColorPickerBuilderComponent() {
         onApply,
         onPreview,
         onPreviewRevert: () => {
-            preventNextPreview = false;
+            previewValue = null;
             // The `next` will cancel the previous operation, which will revert
             // the operation in case of a preview.
             comp.env.editor.shared.operation.next();

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -37,7 +37,7 @@
                 t-on-click="onColorApply"
                 t-on-mouseover="onColorHover"
                 t-on-mouseout="onColorHoverOut"
-                t-on-mouseleave="() => this.props.applyColorResetPreview()"
+                t-on-mouseleave="() => this.applyColorResetPreview()"
                 t-on-focusin="onColorFocusin"
                 t-on-focusout="onColorFocusout"
                 >
@@ -75,7 +75,7 @@
                 t-on-focusout="onColorFocusout">
                 <div class="o_colorpicker_section">
                     <t t-foreach="DEFAULT_THEME_COLOR_VARS" t-as="color" t-key="color">
-                        <button t-att-data-color="color" t-att-class="{'selected': color === defaultColorSet}" 
+                        <button t-att-data-color="color" t-att-class="{'selected': color === defaultColorSet}"
                             t-att-style="`background-color: var(--${props.themeColorPrefix + color})` + (color_index === 3 ? '; grid-column: 5' : '')" class="btn p-0 o_color_button"/>
                     </t>
                 </div>
@@ -96,6 +96,7 @@
                         <button t-if="color !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn p-0" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                     </t>
                     <button t-if="!defaultColorSet" class="o_color_button btn p-0" t-att-class="{'selected': defaultColorSet === false}" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
+                    <button t-if="!!state.currentColorPreview" class="o_color_button btn p-0" t-att-class="{ 'selected': !!state.currentColorPreview }" t-att-data-color="this.state.currentColorPreview" t-attf-style="background-color: {{this.state.currentColorPreview}}"/>
                 </div>
                 <t t-foreach="Object.values(this.grayscales)" t-as="grayscaleColors" t-key="grayscaleColors">
                     <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
@@ -106,8 +107,10 @@
                 </t>
                 <CustomColorPicker
                     selectedColor="this.state.currentCustomColor"
+                    setOnCloseCallback.bind="props.setOnCloseCallback"
+                    setOperationCallbacks.bind="setOperationCallbacks"
                     onColorSelect.bind="(color) => this.applyColor(color.hex)"
-                    onColorPreview.bind="onCustomColorPreview"
+                    onColorPreview.bind="onColorPreview"
                     showRgbaField="props.showRgbaField"
                     noTransparency="props.noTransparency"
                     defaultOpacity="props.defaultOpacity" />
@@ -128,7 +131,12 @@
                     class="w-50 border btn mb-2 o_custom_gradient_button" t-att-class="{'selected': currentGradient and !gradientsWithOpacity.includes(currentGradient)}" t-att-data-color="currentGradient" t-on-click="this.toggleGradientPicker" title="Define a custom gradient">
                     Custom
                 </button>
-                <GradientPicker t-if="state.showGradientPicker" onGradientChange.bind="applyColor" selectedGradient="getCurrentGradientColor()"/>
+                <GradientPicker t-if="state.showGradientPicker"
+                    onGradientChange.bind="applyColor"
+                    onGradientPreview.bind="onColorPreview"
+                    setOnCloseCallback.bind="props.setOnCloseCallback"
+                    setOperationCallbacks.bind="setOperationCallbacks"
+                    selectedGradient="getCurrentGradientColor()"/>
             </div>
         </t>
     </div>

--- a/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.js
+++ b/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.js
@@ -12,6 +12,9 @@ export class GradientPicker extends Component {
     static template = "web.GradientPicker";
     static props = {
         onGradientChange: { type: Function, optional: true },
+        onGradientPreview: { type: Function, optional: true },
+        setOnCloseCallback: { type: Function, optional: true },
+        setOperationCallbacks: { type: Function, optional: true },
         selectedGradient: { type: String, optional: true },
         noTransparency: { type: Boolean, optional: true },
     };
@@ -113,6 +116,12 @@ export class GradientPicker extends Component {
         this.onColorGradientChange();
     }
 
+    onColorPreview(color) {
+        const hex = rgbaToHex(color.cssColor);
+        this.colors[this.state.currentColorIndex].hex = hex;
+        this.onColorGradientPreview();
+    }
+
     onSizeChange(size) {
         this.state.size = size;
         this.onColorGradientChange();
@@ -207,6 +216,11 @@ export class GradientPicker extends Component {
     onColorGradientChange() {
         this.updateCssGradients();
         this.props?.onGradientChange(this.cssGradients[this.state.type]);
+    }
+
+    onColorGradientPreview() {
+        this.updateCssGradients();
+        this.props.onGradientPreview?.({ gradient: this.cssGradients[this.state.type] });
     }
 
     get currentColorHex() {

--- a/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.xml
+++ b/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.xml
@@ -131,7 +131,9 @@
 
             <ColorPicker
                 onColorSelect.bind="onColorChange"
-                onColorPreview.bind="onColorChange"
+                onColorPreview.bind="onColorPreview"
+                setOnCloseCallback.bind="props.setOnCloseCallback"
+                setOperationCallbacks.bind="props.setOperationCallbacks"
                 defaultColor="this.currentColorHex"
                 selectedColor="this.currentColorHex"
                 showRgbaField="false"


### PR DESCRIPTION
*: html_builder, html_editor, website

Modifying the custom colorpicker hue/lightness/saturation by clicking
on it used to apply the color immediately. Since [7bbe05b], in some
cases (e.g. on the website builder "Theme" tab colorpickers), this lead
to multiple reloads each time the user modifies a color, instead of
allowing readjustments before applying the color.

This commit changes that behavior: we now simply preview on `pointerup`,
and fully apply the color once the user closes the popover by clicking
outside of it. It can still be cancelled by pressing `Escape`.

Additionnally, commit [8ab4b1a] introduced keyboard support for the
custom colorpicker, but it wasn't fully functional, as the color was
not applied. This is also modified in this commit: we preview on keydown
(with the arrows) and apply on "Enter" keydown.

This commit also allows previews for the custom part of the gradient
color picker.

[7bbe05b]: https://github.com/odoo/odoo/commit/7bbe05b34541d641dd431662e835d2a26e1adfab
[8ab4b1a]: https://github.com/odoo/odoo/commit/8ab4b1a9fbb2f292b1509065a1e24062d5aaa3ce