### PR TITLE
[FIX] stock: prevent error when MTO route is missing in settings

### DIFF
--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -61,9 +61,9 @@ class ResConfigSettings(models.TransientModel):
             self.replenish_on_order = route.active
 
     def _inverse_replenish_on_order(self):
-        route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False).sudo()
+        route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False)
         if route:
-            route.active = self.replenish_on_order
+            route.sudo().active = self.replenish_on_order
 
     @api.onchange('group_stock_multi_locations')
     def _onchange_group_stock_multi_locations(self):


### PR DESCRIPTION
Currently, an error occurs when saving settings if the `Replenish on Order (MTO)` route has been deleted.

**Steps to reproduce:**

- Install the `stock` and `purchase` modules.
- Go to inventory settings > enable `Multi-Step Routes` and `Replenish on Order (MTO)`.
- Go to inventory > Configuration > Routes and delete the `Replenish on Order (MTO)` route.
- Open the Settings app and click `Save`.

**Error:**
`AttributeError: 'NoneType' object has no attribute 'sudo'`

**Root Cause:**
After PR [1], at [2], `self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False)` can return `None` if the MTO route is missing. The code then directly calls `.sudo()` on this `None` value, causing an error.

**Fix:**
This commit moves the `.sudo()` call inside the `if route:` block, ensuring it is only executed when the route exists. This prevents errors when the MTO route is deleted and allows users to save settings without an access error.

[1]:
https://github.com/odoo/odoo/pull/221757

[2]:
https://github.com/odoo/odoo/blob/dfb14be8b83e3c48c1b186b0d7d7a66753381c9e/addons/stock/models/res_config_settings.py#L64

sentry-6839993384