### PR TITLE
[FIX] mail, test_mail_full: missing thread rpc params

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -625,6 +625,7 @@ export class Message extends Record {
         const data = await rpc("/mail/message/update_content", {
             message_id: this.id,
             update_data: this.removeParams,
+            ...this.thread.rpcParams,
         });
         this.store.insert(data);
         if (this.thread && removeFromThread) {

--- a/addons/test_mail_full/static/tests/tours/message_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/message_actions_tour.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { contains } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("star_message_tour", {
     steps: () => [
@@ -9,6 +10,78 @@ registry.category("web_tour.tours").add("star_message_tour", {
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message[data-starred]:contains(Test Message)",
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("message_actions_tour", {
+    steps: () => [
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message",
+            run: async function () {
+                await contains(".o-mail-Thread .o-mail-Message", {
+                    count: 1,
+                    target: document.querySelector("#chatterRoot").shadowRoot,
+                });
+            },
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Composer-input",
+            run: "edit New message",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Composer button:contains(Send):enabled",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message",
+            run: async function () {
+                await contains(".o-mail-Thread .o-mail-Message", {
+                    count: 2,
+                    target: document.querySelector("#chatterRoot").shadowRoot,
+                });
+            },
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message[data-persistent]:contains(New message)",
+            run: "hover && click #chatterRoot:shadow button[title='Add a Reaction']",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-QuickReactionMenu-emoji span:contains(❤️)",
+            run: "click",
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message:contains(New message) .o-mail-MessageReaction:contains(❤️)",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:contains(New message)",
+            run: "hover && click #chatterRoot:shadow button[title='Edit']",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Composer-input",
+            run: "edit Message content changed",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message button:contains(save)",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Message content changed)",
+            run: "hover && click #chatterRoot:shadow button[title='Delete']",
+        },
+        {
+            trigger: "#chatterRoot:shadow button:contains(Delete)",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message",
+            run: async function () {
+                await contains(".o-mail-Thread .o-mail-Message", {
+                    count: 1,
+                    target: document.querySelector("#chatterRoot").shadowRoot,
+                });
+            },
         },
     ],
 });

--- a/addons/test_mail_full/tests/test_ui.py
+++ b/addons/test_mail_full/tests/test_ui.py
@@ -62,3 +62,9 @@ class TestUIPortal(TestPortal):
             "load_more_tour",
             login=self.user_employee.login,
         )
+
+    def test_message_actions_without_login(self):
+        self.start_tour(
+            f"/my/test_portal_records/{self.record_portal.id}?token={self.record_portal._portal_ensure_token()}",
+            "message_actions_tour",
+        )


### PR DESCRIPTION
PR #219637 removes the thread `rpcParams` from the rpc params when removing a message. This is not an intended change. This PR restores the params as they were before.
