### PR TITLE
[FIX] website: add constraint to ensure one view variant per website

### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -34,6 +34,11 @@ class IrUiView(models.Model):
     visibility_password = fields.Char(groups='base.group_system', copy=False)
     visibility_password_display = fields.Char(compute='_get_pwd', inverse='_set_pwd', groups='website.group_website_designer')
 
+    _uniq_per_website = models.Constraint(
+        'unique (key, website_id)',
+        'You cannot have twice the same view in the same website',
+    )
+
     @api.depends('visibility_password')
     def _get_pwd(self):
         for r in self:

--- a/odoo/orm/model_classes.py
+++ b/odoo/orm/model_classes.py
@@ -161,7 +161,7 @@ def add_to_registry(registry: Registry, model_def: type[BaseModel]) -> type[Base
                         "please use @api.constrains on methods instead.")
     if hasattr(model_def, '_sql_constraints'):
         _logger.warning("Model attribute '_sql_constraints' is no longer supported, "
-                        "please define model.Constraint on the model.")
+                        "please define models.Constraint on the model.")
 
     # all models except 'base' implicitly inherit from 'base'
     name = model_def._name


### PR DESCRIPTION
The views per website are expected to be unique, as they are accessed like this:
```
search([('key', '=', ...), ('website_id', '=', ...)], limit=1)
```

But there was no constraints to prevent duplicates. This commit adds that constraint.

Steps to reproduce:
- On `/shop/<product>`, open website builder
- On the product to add counter, edit both the "+" and "-" buttons
- Save
- Bug: the counter is duplicated

task-4367641
