### PR TITLE
[FIX] html_builder: remove jank on builder scroll

### DIFF
--- a/addons/html_builder/static/src/builder.scss
+++ b/addons/html_builder/static/src/builder.scss
@@ -95,6 +95,7 @@
     border-top: $o-we-border-width solid $o-we-bg-lighter;
     scrollbar-color: $o-we-bg-lightest $o-we-bg-darker;
     scrollbar-width: thin;
+    will-change: scroll-position;
 }
 
 .o_theme_tab {


### PR DESCRIPTION
__Current behavior before commit:__
On Chrome, some elements of the builder, like the options headers, move
at different times when scrolling with the trackpad creating unpleasant
jank visual effect.

__Description of the fix:__
Use `will-change: scroll-position;` to tell the browser to optimize the
scroll rendering. 

__Steps to reproduce the issue on runbot:__
1. Open the website builder in Chrome
2. Scroll with the laptop trackpad in the *Edit* or *Theme* tab
