### PR TITLE
[FIX] account: adapt how domestic fiscal positions are computed

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -13,6 +13,7 @@ from odoo.addons.account.models.account_move import MAX_HASH_VERSION
 from odoo.addons.account.models.product import ACCOUNT_DOMAIN
 from odoo.addons.account.models.partner import _ref_company_registry
 from odoo.addons.base_vat.models.res_partner import _ref_vat
+from odoo.fields import Domain
 
 
 MONTH_SELECTION = [
@@ -344,10 +345,16 @@ class ResCompany(models.Model):
         for company in self:
             company.force_restrictive_audit_trail = False
 
-    @api.depends('fiscal_position_ids', 'fiscal_position_ids.sequence', 'fiscal_position_ids.country_id')
+    @api.depends('fiscal_position_ids', 'fiscal_position_ids.sequence', 'fiscal_position_ids.country_id', 'fiscal_position_ids.country_group_id')
     def _compute_domestic_fiscal_position_id(self):
         for company in self:
-            potential_domestic_fps = company.fiscal_position_ids.filtered_domain([('country_id', '=', company.country_id.id)]).sorted('sequence')
+            potential_domestic_fps = company.fiscal_position_ids.filtered_domain(
+            Domain('country_id', '=', company.country_id.id)
+            | Domain([
+                    ('country_id', '=', False),
+                    ('country_group_id', 'in', company.country_id.country_group_ids.ids),
+                ]),
+            ).sorted(lambda x: x.country_id.id or float('inf')).sorted('sequence')
             company.domestic_fiscal_position_id = potential_domestic_fps[0] if potential_domestic_fps else False
 
     @api.depends('fiscal_position_ids.foreign_vat')


### PR DESCRIPTION
#### Issue:
No taxes appear in the replace field when creating a new tax in a company based in Switzerland.

#### Step to reproduce:
- In a company based in Switzerland (l10n_ch)
- Create a new tax
- Add a Fiscal position other than "Switzerland national (+ Liechtenstein)"
- Click on the "Replace" field

#### Current behavior:
- No records are found

#### Expected behavior:
- Taxes from the "Switzerland national (+Liechtenstein)" fiscal position should appear

#### Cause of the issue
The Replace field display domestic taxes. Domestic taxes are part of the same fiscal position which is computed as domestic. In the l10n_ch module no fiscal position is computed as `domestic_fiscal_position_id`. Indeed in `account.fiscal.position-ch.csv` the fiscal position we want to be domestic is linked to a `country_group_id`, but no `country_id`. However the domestic fiscal position is computed from `country_id` only. Therefore Switzerland has no `domestic_fiscal_position_id`.

#### Solution:
This issue already happened [once](https://github.com/odoo/odoo/pull/208810) for an other localization. To avoid the situation to happen again in the future this commit adapts the `_compute_domestic_fiscal_position_id` to include fiscal position with no `country_id` but a `country_group_id`.


opw-5011527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
