### PR TITLE
[FIX] website_sale_slides: make course products visible in the shop

### DIFF
--- a/addons/website_sale_slides/models/product_template.py
+++ b/addons/website_sale_slides/models/product_template.py
@@ -22,3 +22,7 @@ class ProductTemplate(models.Model):
 
     def _service_tracking_blacklist(self):
         return super()._service_tracking_blacklist() + ['course']
+
+    @api.model
+    def _get_saleable_tracking_types(self):
+        return super()._get_saleable_tracking_types() + ['course']


### PR DESCRIPTION
Currently, course-related products do not appear in the e-commerce.

### Steps to Reproduce

1. Create a product with type 'Service'.
2. Configure the product to grant access to a course.
3. Publish the product
4. Navigate to the shop as a public user.

The course product does not appear, even if you search its exact name

### Cause

Since fbbd0aae7b8a6bd9ef35566e712772e3170e31bd, a product's type needs to be explicitly defined as "saleable" for it to be visible on the website shop. The 'course' service tracking type was not included in this list of saleable types.

opw-4995639