### PR TITLE
[IMP] l10n_at: update austria tax report UI

### DIFF
--- a/addons/l10n_at/data/account_tax_report_data.xml
+++ b/addons/l10n_at/data/account_tax_report_data.xml
@@ -9,22 +9,30 @@
         <field name="availability_condition">country</field>
         <field name="column_ids">
             <record id="tax_report_balance" model="account.report.column">
-                <field name="name">Balance</field>
-                <field name="expression_label">balance</field>
+                <field name="name">Base</field>
+                <field name="name@de">Bemessungsgrundlage</field>
+                <field name="expression_label">base</field>
+            </record>
+            <record id="tax_report_vat" model="account.report.column">
+                <field name="name">VAT</field>
+                <field name="name@de">Umsatzsteuer</field>
+                <field name="expression_label">vat</field>
             </record>
         </field>
         <field name="line_ids">
             <record id="tax_report_line_l10n_at_non_tva_sale_report_title" model="account.report.line">
-                <field name="name">3. Aufschlüsselung für die Zusammenfassende Meldung (ZM)</field>
+                <field name="name">3. Breakdown for the recapitulative statement (ZM)</field>
+                <field name="name@de">3. Aufschlüsselung für die Zusammenfassende Meldung (ZM)</field>
                 <field name="sequence" eval="5"/>
-                <field name="aggregation_formula">(AT_ZM_IGL.balance + AT_ZM_IGL3.balance + AT_ZM_DL.balance)</field>
+                <field name="aggregation_formula">AT_ZM_IGL.base + AT_ZM_IGL3.base + AT_ZM_DL.base</field>
                 <field name="children_ids">
                     <record id="tax_report_line_l10n_at_tva_line_3_zm_igl" model="account.report.line">
-                        <field name="name">Innergemeinschaftliche Lieferungen</field>
+                        <field name="name">Intra-Community supplies</field>
+                        <field name="name@de">Innergemeinschaftliche Lieferungen</field>
                         <field name="code">AT_ZM_IGL</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_3_zm_igl_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">AT_ZM_IGL</field>
                             </record>
@@ -32,11 +40,12 @@
                         <field name="sequence" eval="10"/>
                     </record>
                     <record id="tax_report_line_l10n_at_tva_line_3_zm_igl3" model="account.report.line">
-                        <field name="name">Innergemeinschaftliche Lieferungen (Dreiecksgeschäfte)</field>
+                        <field name="name">Intra-Community supplies (triangular transactions)</field>
+                        <field name="name@de">Innergemeinschaftliche Lieferungen (Dreiecksgeschäfte)</field>
                         <field name="code">AT_ZM_IGL3</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_3_zm_igl3_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">AT_ZM_IGL3</field>
                             </record>
@@ -44,11 +53,12 @@
                         <field name="sequence" eval="20"/>
                     </record>
                     <record id="tax_report_line_l10n_at_tva_line_3_zm_dl" model="account.report.line">
-                        <field name="name">Grenzüberschreitende Dienstleistungen (Sonstige Leistungen)</field>
+                        <field name="name">Cross-border services (other services)</field>
+                        <field name="name@de">Grenzüberschreitende Dienstleistungen (Sonstige Leistungen)</field>
                         <field name="code">AT_ZM_DL</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_3_zm_dl_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">AT_ZM_DL</field>
                             </record>
@@ -60,8 +70,16 @@
             <record id="tax_report_line_l10n_at_tva_sale_report_title" model="account.report.line">
                 <field name="name">4. VAT Computation (U1/U30)</field>
                 <field name="name@de">4. Berechnung der Umsatzsteuer (U1/U30)</field>
-                <field name="aggregation_formula">(AT_022_tax.balance + AT_029_tax.balance + AT_006_tax.balance + AT_037_tax.balance + AT_052_tax.balance + AT_007_tax.balance + AT_056.balance + AT_057.balance + AT_048.balance + AT_044.balance + AT_032.balance + AT_072_tax.balance + AT_073_tax.balance + AT_008_tax.balance + AT_088_tax.balance)</field>
+                <field name="aggregation_formula"></field>
+                <field name="code">AT_0004</field>
                 <field name="hierarchy_level">0</field>
+                <field name="expression_ids">
+                    <record id="tax_report_line_l10n_at_tva_total" model="account.report.expression">
+                        <field name="label">vat</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">AT_022.vat + AT_029.vat + AT_006.vat + AT_037.vat + AT_052.vat + AT_007.vat + AT_056.base + AT_057.base + AT_048.base + AT_044.base + AT_032.base + AT_072.vat + AT_073.vat + AT_008.vat + AT_088.vat</field>
+                    </record>
+                </field>
                 <field name="children_ids">
                     <record id="tax_report_line_l10n_at_tva_line_4_1" model="account.report.line">
                         <field name="name">4.1 Total amount of the taxable base for deliveries and other services [000]</field>
@@ -69,7 +87,7 @@
                         <field name="code">AT_000</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_1_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 000</field>
                             </record>
@@ -81,7 +99,7 @@
                         <field name="code">AT_001</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_2_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 001</field>
                             </record>
@@ -93,7 +111,7 @@
                         <field name="code">AT_021</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_3_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 021</field>
                             </record>
@@ -102,12 +120,12 @@
                     <record id="tax_report_line_l10n_at_tva_line_4_4" model="account.report.line">
                         <field name="name">4.4 Total</field>
                         <field name="name@de">4.4 Summe</field>
-                        <field name="aggregation_formula">AT_000.balance + AT_001.balance - AT_021.balance</field>
+                        <field name="aggregation_formula">AT_000.base + AT_001.base - AT_021.base</field>
                     </record>
                     <record id="tax_report_line_l10n_at_tva_sale_01_report_title" model="account.report.line">
                         <field name="name">Tax-exempt WITH input tax deduction according to</field>
                         <field name="name@de">Davon steuerfrei MIT Vorsteuerabzug gemäß</field>
-                        <field name="aggregation_formula">AT_011.balance + AT_012.balance + AT_015.balance + AT_017.balance + AT_018.balance</field>
+                        <field name="aggregation_formula">AT_011.base + AT_012.base + AT_015.base + AT_017.base + AT_018.base</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_5" model="account.report.line">
                                 <field name="name">4.5 Section 6(1)(1) in conjunction with Section 7 (export deliveries) [011]</field>
@@ -115,7 +133,7 @@
                                 <field name="code">AT_011</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_5_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 011</field>
                                     </record>
@@ -127,7 +145,7 @@
                                 <field name="code">AT_012</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_6_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 012</field>
                                     </record>
@@ -139,7 +157,7 @@
                                 <field name="code">AT_015</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_7_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 015</field>
                                     </record>
@@ -151,7 +169,7 @@
                                 <field name="code">AT_017</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_8_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 017</field>
                                     </record>
@@ -163,7 +181,7 @@
                                 <field name="code">AT_018</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_9_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 018</field>
                                     </record>
@@ -174,7 +192,7 @@
                     <record id="tax_report_line_l10n_at_tva_sale_02_report_title" model="account.report.line">
                         <field name="name">Tax-exempt WITHOUT input tax deduction according to</field>
                         <field name="name@de">Davon steuerfrei OHNE Vorsteuerabzug gemäß</field>
-                        <field name="aggregation_formula">AT_019.balance + AT_016.balance + AT_020.balance</field>
+                        <field name="aggregation_formula">AT_019.base + AT_016.base + AT_020.base</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_10" model="account.report.line">
                                 <field name="name">4.10 Section 6(1)(9)(a) (land sales) [019]</field>
@@ -182,7 +200,7 @@
                                 <field name="code">AT_019</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_10_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 019</field>
                                     </record>
@@ -194,7 +212,7 @@
                                 <field name="code">AT_016</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_11_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 016</field>
                                     </record>
@@ -206,7 +224,7 @@
                                 <field name="code">AT_020</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_12_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 020</field>
                                     </record>
@@ -217,159 +235,120 @@
                     <record id="tax_report_line_l10n_at_tva_line_4_13" model="account.report.line">
                         <field name="name">4.13 Total amount of taxable deliveries, other services and own consumption (including taxable advance payments)</field>
                         <field name="name@de">4.13 Gesamtbetrag der steuerpflichtigen Lieferungen, sonstigen Leistungen und Eigenverbrauch (einschließlich steuerpflichtiger Anzahlungen)</field>
-                        <field name="aggregation_formula">(AT_000.balance + AT_001.balance - AT_021.balance) - AT_011.balance - AT_012.balance - AT_015.balance - AT_017.balance - AT_018.balance - AT_019.balance - AT_016.balance - AT_020.balance</field>
+                        <field name="aggregation_formula">AT_000.base + AT_001.base - AT_021.base - AT_011.base - AT_012.base - AT_015.base - AT_017.base - AT_018.base - AT_019.base - AT_016.base - AT_020.base</field>
                     </record>
-                    <record id="tax_report_line_at_base_title_umsatz_base_4_14_19" model="account.report.line">
-                        <field name="name">Taxable base</field>
-                        <field name="name@de">Bemessungsgrundlage</field>
-                        <field name="aggregation_formula">AT_022_base.balance + AT_029_base.balance + AT_006_base.balance + AT_037_base.balance + AT_052_base.balance + AT_007_base.balance</field>
+                    <record id="tax_report_line_l10n_at_tva_line_4_14_19_title" model="account.report.line">
+                        <field name="name">Of which taxable with</field>
+                        <field name="expression_ids">
+                            <record id="tax_report_line_at_base_title_4_14_19" model="account.report.expression">
+                                <field name="label">base</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AT_022.base + AT_029.base + AT_006.base + AT_037.base + AT_052.base + AT_007.base</field>
+                            </record>
+                            <record id="tax_report_line_at_tax_title_4_14_19" model="account.report.expression">
+                                <field name="label">vat</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AT_022.vat + AT_029.vat + AT_006.vat + AT_037.vat + AT_052.vat + AT_007.vat</field>
+                            </record>
+                        </field>
                         <field name="children_ids">
-                            <record id="tax_report_line_l10n_at_tva_line_4_14_base" model="account.report.line">
+                            <record id="tax_report_line_l10n_at_tva_line_4_14" model="account.report.line">
                                 <field name="name">4.14 20% Standard rate [022]</field>
                                 <field name="name@de">4.14 20% Normalsteuersatz [022]</field>
-                                <field name="code">AT_022_base</field>
+                                <field name="code">AT_022</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_14_base_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 022 Bemessungsgrundlage</field>
                                     </record>
-                                </field>
-                            </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_15_base" model="account.report.line">
-                                <field name="name">4.15 10% Reduced rate [029]</field>
-                                <field name="name@de">4.15 10% ermäßigter Steuersatz [029]</field>
-                                <field name="code">AT_029_base</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_l10n_at_tva_line_4_15_base_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">KZ 029 Bemessungsgrundlage</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_16_base" model="account.report.line">
-                                <field name="name">4.16 13% Reduced rate [006]</field>
-                                <field name="name@de">4.16 13% ermäßigter Steuersatz [006]</field>
-                                <field name="code">AT_006_base</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_l10n_at_tva_line_4_16_base_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">KZ 006 Bemessungsgrundlage</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_17_base" model="account.report.line">
-                                <field name="name">4.17 19% for Jungholz and Mittelberg [037]</field>
-                                <field name="name@de">4.17 19% für Jungholz und Mittelberg [037]</field>
-                                <field name="code">AT_037_base</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_l10n_at_tva_line_4_17_base_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">KZ 037 Bemessungsgrundlage</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_18_base" model="account.report.line">
-                                <field name="name">4.18 10% Additional tax for flat-rate agricultural and forestry holdings [052]</field>
-                                <field name="name@de">4.18 10% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe [052]</field>
-                                <field name="code">AT_052_base</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_l10n_at_tva_line_4_18_base_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">KZ 052 Bemessungsgrundlage</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_19_base" model="account.report.line">
-                                <field name="name">4.19 7% Additional tax for flat-rate agricultural and forestry holdings [007]</field>
-                                <field name="name@de">4.19 7% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe [007]</field>
-                                <field name="code">AT_007_base</field>
-                                <field name="expression_ids">
-                                    <record id="tax_report_line_l10n_at_tva_line_4_19_base_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">KZ 007 Bemessungsgrundlage</field>
-                                    </record>
-                                </field>
-                            </record>
-                        </field>
-                    </record>
-                    <record id="tax_report_line_at_tax_title_4_14_19" model="account.report.line">
-                        <field name="name">VAT</field>
-                        <field name="name@de">Umsatzsteuer</field>
-                        <field name="aggregation_formula">AT_022_tax.balance + AT_029_tax.balance + AT_006_tax.balance + AT_037_tax.balance + AT_052_tax.balance + AT_007_tax.balance</field>
-                        <field name="children_ids">
-                            <record id="tax_report_line_l10n_at_tva_line_4_14_tax" model="account.report.line">
-                                <field name="name">4.14 20% Standard rate</field>
-                                <field name="name@de">4.14 20% Normalsteuersatz</field>
-                                <field name="code">AT_022_tax</field>
-                                <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_14_tax_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">vat</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 022 Umsatzsteuer</field>
                                     </record>
                                 </field>
                             </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_15_tax" model="account.report.line">
-                                <field name="name">4.15 10% Reduced rate</field>
-                                <field name="name@de">4.15 10% ermäßigter Steuersatz</field>
-                                <field name="code">AT_029_tax</field>
+                            <record id="tax_report_line_l10n_at_tva_line_4_15" model="account.report.line">
+                                <field name="name">4.15 10% Reduced rate [029]</field>
+                                <field name="name@de">4.15 10% ermäßigter Steuersatz [029]</field>
+                                <field name="code">AT_029</field>
                                 <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_15_base_tag" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 029 Bemessungsgrundlage</field>
+                                    </record>
                                     <record id="tax_report_line_l10n_at_tva_line_4_15_tax_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">vat</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 029 Umsatzsteuer</field>
                                     </record>
                                 </field>
                             </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_16_tax" model="account.report.line">
-                                <field name="name">4.16 13% Reduced rate</field>
-                                <field name="name@de">4.16 13% ermäßigter Steuersatz</field>
-                                <field name="code">AT_006_tax</field>
+                            <record id="tax_report_line_l10n_at_tva_line_4_16" model="account.report.line">
+                                <field name="name">4.16 13% Reduced rate [006]</field>
+                                <field name="name@de">4.16 13% ermäßigter Steuersatz [006]</field>
+                                <field name="code">AT_006</field>
                                 <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_16_base_tag" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 006 Bemessungsgrundlage</field>
+                                    </record>
                                     <record id="tax_report_line_l10n_at_tva_line_4_16_tax_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">vat</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 006 Umsatzsteuer</field>
                                     </record>
                                 </field>
                             </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_17_tax" model="account.report.line">
-                                <field name="name">4.17 19% for Jungholz and Mittelberg</field>
-                                <field name="name@de">4.17 19% für Jungholz und Mittelberg</field>
-                                <field name="code">AT_037_tax</field>
+                            <record id="tax_report_line_l10n_at_tva_line_4_17" model="account.report.line">
+                                <field name="name">4.17 19% for Jungholz and Mittelberg [037]</field>
+                                <field name="name@de">4.17 19% für Jungholz und Mittelberg [037]</field>
+                                <field name="code">AT_037</field>
                                 <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_17_base_tag" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 037 Bemessungsgrundlage</field>
+                                    </record>
                                     <record id="tax_report_line_l10n_at_tva_line_4_17_tax_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">vat</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 037 Umsatzsteuer</field>
                                     </record>
                                 </field>
                             </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_18_tax" model="account.report.line">
-                                <field name="name">4.18 10% Additional tax for flat-rate agricultural and forestry holdings</field>
-                                <field name="name@de">4.18 10% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe</field>
-                                <field name="code">AT_052_tax</field>
+                            <record id="tax_report_line_l10n_at_tva_line_4_18" model="account.report.line">
+                                <field name="name">4.18 10% Additional tax for flat-rate agricultural and forestry holdings [052]</field>
+                                <field name="name@de">4.18 10% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe [052]</field>
+                                <field name="code">AT_052</field>
                                 <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_18_base_tag" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 052 Bemessungsgrundlage</field>
+                                    </record>
                                     <record id="tax_report_line_l10n_at_tva_line_4_18_tax_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">vat</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 052 Umsatzsteuer</field>
                                     </record>
                                 </field>
                             </record>
-                            <record id="tax_report_line_l10n_at_tva_line_4_19_tax" model="account.report.line">
-                                <field name="name">4.19 7% Additional tax for flat-rate agricultural and forestry holdings</field>
-                                <field name="name@de">4.19 7% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe</field>
-                                <field name="code">AT_007_tax</field>
+                            <record id="tax_report_line_l10n_at_tva_line_4_19" model="account.report.line">
+                                <field name="name">4.19 7% Additional tax for flat-rate agricultural and forestry holdings [007]</field>
+                                <field name="name@de">4.19 7% Zusatzsteuer für pauschalierte land- und forstwirtschaftliche Betriebe [007]</field>
+                                <field name="code">AT_007</field>
                                 <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_19_base_tag" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 007 Bemessungsgrundlage</field>
+                                    </record>
                                     <record id="tax_report_line_l10n_at_tva_line_4_19_tax_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">vat</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 007 Umsatzsteuer</field>
                                     </record>
@@ -383,7 +362,7 @@
                         <field name="code">AT_056</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_20_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 056</field>
                             </record>
@@ -395,7 +374,7 @@
                         <field name="code">AT_057</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_21_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 057</field>
                             </record>
@@ -407,7 +386,7 @@
                         <field name="code">AT_048</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_22_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 048</field>
                             </record>
@@ -419,7 +398,7 @@
                         <field name="code">AT_044</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_23_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 044</field>
                             </record>
@@ -431,7 +410,7 @@
                         <field name="code">AT_032</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_24_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">base</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 032</field>
                             </record>
@@ -440,7 +419,7 @@
                     <record id="tax_report_line_l10n_at_tva_sale_03_report_title" model="account.report.line">
                         <field name="name">Intra-Community acquisition</field>
                         <field name="name@de">Innergemeinschaftliche Erwerb</field>
-                        <field name="aggregation_formula">AT_070.balance + AT_071.balance</field>
+                        <field name="aggregation_formula">AT_070.base + AT_071.base</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_25" model="account.report.line">
                                 <field name="name">4.25 Total amount of taxable amounts for intra-Community acquisitions [070]</field>
@@ -448,7 +427,7 @@
                                 <field name="code">AT_070</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_25_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 070</field>
                                     </record>
@@ -460,7 +439,7 @@
                                 <field name="code">AT_071</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_26_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 071</field>
                                     </record>
@@ -469,121 +448,98 @@
                             <record id="tax_report_line_l10n_at_tva_line_4_27" model="account.report.line">
                                 <field name="name">4.27 Total amount of taxable intra-Community acquisitions</field>
                                 <field name="name@de">4.27 Gesamtbetrag der steuerpflichtigen innergemeinschaftlichen Erwerbe</field>
-                                <field name="aggregation_formula">AT_070.balance - AT_071.balance</field>
+                                <field name="aggregation_formula"></field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_27_total" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AT_070.base - AT_071.base</field>
+                                    </record>
+                                </field>
                             </record>
                         </field>
                     </record>
                     <record id="tax_report_line_l10n_at_tva_sale_04_report_title" model="account.report.line">
                         <field name="name">Of which taxable with</field> <!-- TODO: -->
-                        <field name="aggregation_formula">AT_072_base.balance + AT_073_base.balance + AT_008_base.balance + AT_088_base.balance</field>
+                        <field name="aggregation_formula"></field>
+                        <field name="expression_ids">
+                            <record id="tax_report_line_at_base_title_4_28_31" model="account.report.expression">
+                                <field name="label">base</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AT_072.base + AT_073.base + AT_008.base + AT_088.base</field>
+                            </record>
+                            <record id="tax_report_line_at_tax_title_4_28_31" model="account.report.expression">
+                                <field name="label">vat</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AT_072.vat + AT_073.vat + AT_008.vat + AT_088.vat</field>
+                            </record>
+                        </field>
                         <field name="children_ids">
-                            <record id="tax_report_line_at_base_title_umsatz_base_4_28_31" model="account.report.line">
-                                <field name="name">Taxable base</field>
-                                <field name="name@de">Bemessungsgrundlage</field>
-                                <field name="aggregation_formula">AT_072_base.balance + AT_073_base.balance + AT_008_base.balance + AT_088_base.balance</field>
-                                <field name="children_ids">
-                                    <record id="tax_report_line_l10n_at_tva_line_4_28_base" model="account.report.line">
-                                        <field name="name">4.28 20% Standard rate [072]</field>
-                                        <field name="name@de">4.28 20% Normalsteuersatz [072]</field>
-                                        <field name="code">AT_072_base</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_line_l10n_at_tva_line_4_28_base_tag" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">tax_tags</field>
-                                                <field name="formula">KZ 072 Bemessungsgrundlage</field>
-                                            </record>
-                                        </field>
+                            <record id="tax_report_line_l10n_at_tva_line_4_28" model="account.report.line">
+                                <field name="name">4.28 20% Standard rate [072]</field>
+                                <field name="name@de">4.28 20% Normalsteuersatz [072]</field>
+                                <field name="code">AT_072</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_28_base_tag" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 072 Bemessungsgrundlage</field>
                                     </record>
-                                    <record id="tax_report_line_l10n_at_tva_line_4_29_base" model="account.report.line">
-                                        <field name="name">4.29 10% Reduced rate [073]</field>
-                                        <field name="name@de">4.29 10% ermäßigter Steuersatz [073]</field>
-                                        <field name="code">AT_073_base</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_line_l10n_at_tva_line_4_29_base_tag" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">tax_tags</field>
-                                                <field name="formula">KZ 073 Bemessungsgrundlage</field>
-                                            </record>
-                                        </field>
-                                    </record>
-                                    <record id="tax_report_line_l10n_at_tva_line_4_30_base" model="account.report.line">
-                                        <field name="name">4.30 13% Reduced rate [008]</field>
-                                        <field name="name@de">4.30 13% ermäßigter Steuersatz [008]</field>
-                                        <field name="code">AT_008_base</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_line_l10n_at_tva_line_4_30_base_tag" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">tax_tags</field>
-                                                <field name="formula">KZ 008 Bemessungsgrundlage</field>
-                                            </record>
-                                        </field>
-                                    </record>
-                                    <record id="tax_report_line_l10n_at_tva_line_4_31_base" model="account.report.line">
-                                        <field name="name">4.31 19% for Jungholz and Mittelberg [088]</field>
-                                        <field name="name@de">4.31 19% für Jungholz und Mittelberg [088]</field>
-                                        <field name="code">AT_088_base</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_line_l10n_at_tva_line_4_31_base_tag" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">tax_tags</field>
-                                                <field name="formula">KZ 088 Bemessungsgrundlage</field>
-                                            </record>
-                                        </field>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_28_tax_tag" model="account.report.expression">
+                                        <field name="label">vat</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 072 Umsatzsteuer</field>
                                     </record>
                                 </field>
                             </record>
-                            <record id="tax_report_line_at_tax_title_4_28_31" model="account.report.line">
-                                <field name="name">VAT</field>
-                                <field name="name@de">Umsatzsteuer</field>
-                                <field name="aggregation_formula">AT_072_tax.balance + AT_073_tax.balance + AT_008_tax.balance + AT_088_tax.balance</field>
-                                <field name="children_ids">
-                                    <record id="tax_report_line_l10n_at_tva_line_4_28_tax" model="account.report.line">
-                                        <field name="name">4.28 20% Standard rate</field>
-                                        <field name="name@de">4.28 20% Normalsteuersatz</field>
-                                        <field name="code">AT_072_tax</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_line_l10n_at_tva_line_4_28_tax_tag" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">tax_tags</field>
-                                                <field name="formula">KZ 072 Umsatzsteuer</field>
-                                            </record>
-                                        </field>
+                            <record id="tax_report_line_l10n_at_tva_line_4_29" model="account.report.line">
+                                <field name="name">4.29 10% Reduced rate [073]</field>
+                                <field name="name@de">4.29 10% ermäßigter Steuersatz [073]</field>
+                                <field name="code">AT_073</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_29_base_tag" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 073 Bemessungsgrundlage</field>
                                     </record>
-                                    <record id="tax_report_line_l10n_at_tva_line_4_29_tax" model="account.report.line">
-                                        <field name="name">4.29 10% Reduced rate</field>
-                                        <field name="name@de">4.29 10% ermäßigter Steuersatz</field>
-                                        <field name="code">AT_073_tax</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_line_l10n_at_tva_line_4_29_tax_tag" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">tax_tags</field>
-                                                <field name="formula">KZ 073 Umsatzsteuer</field>
-                                            </record>
-                                        </field>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_29_tax_tag" model="account.report.expression">
+                                        <field name="label">vat</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 073 Umsatzsteuer</field>
                                     </record>
-                                    <record id="tax_report_line_l10n_at_tva_line_4_30_tax" model="account.report.line">
-                                        <field name="name">4.30 13% Reduced rate</field>
-                                        <field name="name@de">4.30 13% ermäßigter Steuersatz</field>
-                                        <field name="code">AT_008_tax</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_line_l10n_at_tva_line_4_30_tax_tag" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">tax_tags</field>
-                                                <field name="formula">KZ 008 Umsatzsteuer</field>
-                                            </record>
-                                        </field>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_30" model="account.report.line">
+                                <field name="name">4.30 13% Reduced rate [008]</field>
+                                <field name="name@de">4.30 13% ermäßigter Steuersatz [008]</field>
+                                <field name="code">AT_008</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_30_base_tag" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 008 Bemessungsgrundlage</field>
                                     </record>
-                                    <record id="tax_report_line_l10n_at_tva_line_4_31_tax" model="account.report.line">
-                                        <field name="name">4.31 19% for Jungholz and Mittelberg</field>
-                                        <field name="name@de">4.31 19% für Jungholz und Mittelberg</field>
-                                        <field name="code">AT_088_tax</field>
-                                        <field name="expression_ids">
-                                            <record id="tax_report_line_l10n_at_tva_line_4_31_tax_tag" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">tax_tags</field>
-                                                <field name="formula">KZ 088 Umsatzsteuer</field>
-                                            </record>
-                                        </field>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_30_tax_tag" model="account.report.expression">
+                                        <field name="label">vat</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 008 Umsatzsteuer</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_l10n_at_tva_line_4_31" model="account.report.line">
+                                <field name="name">4.31 19% for Jungholz and Mittelberg [088]</field>
+                                <field name="name@de">4.31 19% für Jungholz und Mittelberg [088]</field>
+                                <field name="code">AT_088</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_l10n_at_tva_line_4_31_base_tag" model="account.report.expression">
+                                        <field name="label">base</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 088 Bemessungsgrundlage</field>
+                                    </record>
+                                    <record id="tax_report_line_l10n_at_tva_line_4_31_tax_tag" model="account.report.expression">
+                                        <field name="label">vat</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">KZ 088 Umsatzsteuer</field>
                                     </record>
                                 </field>
                             </record>
@@ -592,7 +548,7 @@
                     <record id="tax_report_line_l10n_at_tva_sale_05_report_title" model="account.report.line">
                         <field name="name">Non-taxable acquisitions</field>
                         <field name="name@de">Nicht zu versteuernde Erwerbe</field>
-                        <field name="aggregation_formula">AT_076.balance + AT_077.balance</field>
+                        <field name="aggregation_formula">AT_076.base + AT_077.base</field>
                         <field name="children_ids">
                             <record id="tax_report_line_l10n_at_tva_line_4_32" model="account.report.line">
                                 <field name="name">4.32 Acquisitions pursuant to Art. 3(8), second sentence, that have been taxed in the Member State of destination [076]</field>
@@ -600,7 +556,7 @@
                                 <field name="code">AT_076</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_32_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 076</field>
                                     </record>
@@ -612,7 +568,7 @@
                                 <field name="code">AT_077</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_l10n_at_tva_line_4_33_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
+                                        <field name="label">base</field>
                                         <field name="engine">tax_tags</field>
                                         <field name="formula">KZ 077</field>
                                     </record>
@@ -625,7 +581,15 @@
             <record id="tax_report_line_l10n_at_tva_purchase_report_title" model="account.report.line">
                 <field name="name">5. Deductible input tax computation</field>
                 <field name="name@de">5. Berechnung der abziehbaren Vorsteuer</field>
-                <field name="aggregation_formula">AT_060.balance + AT_061.balance + AT_083.balance + AT_065.balance + AT_066.balance + AT_082.balance + AT_087.balance + AT_089.balance + AT_064.balance + AT_062.balance + AT_063.balance + AT_067.balance</field>
+                <field name="aggregation_formula"></field>
+                <field name="code">AT_0005</field>
+                <field name="expression_ids">
+                    <record id="tax_report_line_l10n_at_tva_purchase_report_total" model="account.report.expression">
+                        <field name="label">vat</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">AT_060.vat + AT_061.vat + AT_083.vat + AT_065.vat + AT_066.vat + AT_082.vat + AT_087.vat + AT_089.vat + AT_064.vat + AT_062.vat + AT_063.vat + AT_067.vat</field>
+                    </record>
+                </field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_l10n_at_tva_line_5_1" model="account.report.line">
@@ -634,7 +598,7 @@
                         <field name="code">AT_060</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_1_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 060</field>
                             </record>
@@ -646,7 +610,7 @@
                         <field name="code">AT_061</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_2_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 061</field>
                             </record>
@@ -658,7 +622,7 @@
                         <field name="code">AT_083</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_3_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 083</field>
                             </record>
@@ -670,7 +634,7 @@
                         <field name="code">AT_065</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_4_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 065</field>
                             </record>
@@ -682,7 +646,7 @@
                         <field name="code">AT_066</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_5_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 066</field>
                             </record>
@@ -694,7 +658,7 @@
                         <field name="code">AT_082</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_6_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 082</field>
                             </record>
@@ -706,7 +670,7 @@
                         <field name="code">AT_087</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_7_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 087</field>
                             </record>
@@ -718,7 +682,7 @@
                         <field name="code">AT_089</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_8_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 089</field>
                             </record>
@@ -730,7 +694,7 @@
                         <field name="code">AT_064</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_9_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 064</field>
                             </record>
@@ -742,7 +706,7 @@
                         <field name="code">AT_062</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_10_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 062</field>
                             </record>
@@ -754,7 +718,7 @@
                         <field name="code">AT_063</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_11_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 063</field>
                             </record>
@@ -766,7 +730,7 @@
                         <field name="code">AT_067</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_5_12_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 067</field>
                             </record>
@@ -775,14 +739,28 @@
                     <record id="tax_report_line_l10n_at_tva_line_5_13" model="account.report.line">
                         <field name="name">5.13 Total amount of deductible input tax</field>
                         <field name="name@de">5.13 Gesamtbetrag der abziehbaren Vorsteuer</field>
-                        <field name="aggregation_formula">AT_060.balance + AT_061.balance + AT_083.balance + AT_065.balance + AT_066.balance + AT_082.balance + AT_087.balance + AT_089.balance + AT_064.balance + AT_062.balance + AT_063.balance + AT_067.balance</field>
+                        <field name="aggregation_formula"></field>
+                        <field name="expression_ids">
+                            <record id="tax_report_line_l10n_at_tva_line_5_13_total" model="account.report.expression">
+                                <field name="label">vat</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AT_0005.vat</field>
+                            </record>
+                        </field>
                     </record>
                 </field>
             </record>
             <record id="tax_report_line_l10n_at_tva_final_report_title" model="account.report.line">
                 <field name="name">6. Other corrections</field>
                 <field name="name@de">6. Sonstige Berichtigungen</field>
-                <field name="aggregation_formula">AT_090.balance</field>
+                <field name="aggregation_formula"></field>
+                <field name="expression_ids">
+                    <record id="tax_report_line_l10n_at_tva_final_report_total" model="account.report.expression">
+                        <field name="label">vat</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">AT_090.vat</field>
+                    </record>
+                </field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="tax_report_line_l10n_at_tva_line_6" model="account.report.line">
@@ -791,7 +769,7 @@
                         <field name="code">AT_090</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_l10n_at_tva_line_6_tag" model="account.report.expression">
-                                <field name="label">balance</field>
+                                <field name="label">vat</field>
                                 <field name="engine">tax_tags</field>
                                 <field name="formula">KZ 090</field>
                             </record>
@@ -802,7 +780,14 @@
             <record id="tax_report_line_l10n_at_tva_line_7" model="account.report.line">
                 <field name="name">7. Prepayment/debit (-) or credit/surplus (+) [095]</field>
                 <field name="name@de">7. Zahllast (-) bzw. Gutschrift/Überschuss (+) [095]</field>
-                <field name="aggregation_formula">(AT_022_tax.balance + AT_029_tax.balance + AT_006_tax.balance + AT_037_tax.balance + AT_052_tax.balance + AT_007_tax.balance + AT_056.balance + AT_057.balance + AT_048.balance + AT_044.balance + AT_032.balance + AT_072_tax.balance + AT_073_tax.balance + AT_008_tax.balance + AT_088_tax.balance + AT_060.balance + AT_061.balance + AT_083.balance + AT_065.balance + AT_066.balance + AT_082.balance + AT_087.balance + AT_089.balance + AT_064.balance + AT_062.balance + AT_063.balance + AT_067.balance) + AT_090.balance</field>
+                <field name="aggregation_formula"></field>
+                <field name="expression_ids">
+                    <record id="tax_report_line_l10n_at_tva_line_7_total" model="account.report.expression">
+                        <field name="label">vat</field>
+                        <field name="engine">aggregation</field>
+                        <field name="formula">AT_0004.vat - AT_0005.vat + AT_090.vat</field>
+                    </record>
+                </field>
                 <field name="hierarchy_level">0</field>
             </record>
         </field>


### PR DESCRIPTION
Before:
- The Austrian tax report showed only balance column for each tax.
- For some given tax, VAT and taxable base were declared on separate lines.

After:
- Added a VAT column next to Balance for each relevant line.
- Taxes with both VAT and Balance no longer require duplicate lines.
- PDF export now matches the U30 official format.

Impact:
- Ensures compliance with Austria U30 form.
- Reduces duplicate lines and confusion for VAT and taxable base.

See [U30 Form](https://www.wko.at/oe/aussenwirtschaft/importhandbuch/u30-formular-umsatzsteuervoranmeldung.pdf)

Related Upgrade PR https://github.com/odoo/upgrade/pull/8357

TaskID-5046151