### PR TITLE
[FIX] html_editor: outdent nested list on enter

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -519,7 +519,7 @@ export class ListPlugin extends Plugin {
     mergeSimilarLists(element) {
         if (
             !element.matches("ul, ol, li.oe-nested") ||
-            (element.matches("li.oe-nested") && !element.querySelector("ul, ol"))
+            (element.matches("li.oe-nested") && ![...element.childNodes].every(isListElement))
         ) {
             return;
         }

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -920,7 +920,7 @@ export class ListPlugin extends Plugin {
         if (!closestLI || isBlockUnsplittable) {
             return;
         }
-        if (isEmptyBlock(closestLI)) {
+        if (isEmptyBlock(closestBlock(params.targetNode))) {
             this.outdentLI(closestLI);
             return true;
         }

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -156,6 +156,12 @@ describe("Selection collapsed", () => {
                     stepFunction: splitBlock,
                     contentAfter: "<p>[]<br></p>",
                 });
+                await testEditor({
+                    contentBefore: "<ol><li>ab</li><li><p>[]<br></p><ol><li>cd</li></ol></li></ol>",
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<ol><li>ab</li></ol><p>[]<br></p><ol><li class="oe-nested"><ol><li>cd</li></ol></li></ol>',
+                });
             });
 
             test("should remove a list set to bold", async () => {
@@ -327,6 +333,12 @@ describe("Selection collapsed", () => {
                     contentBefore: "<ul><li><p>[]<br></p></li></ul>",
                     stepFunction: splitBlock,
                     contentAfter: "<p>[]<br></p>",
+                });
+                await testEditor({
+                    contentBefore: "<ul><li>ab</li><li><p>[]<br></p><ul><li>cd</li></ul></li></ul>",
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<ul><li>ab</li></ul><p>[]<br></p><ul><li class="oe-nested"><ul><li>cd</li></ul></li></ul>',
                 });
             });
 
@@ -547,6 +559,13 @@ describe("Selection collapsed", () => {
                         '<ul class="o_checklist"><li class="o_checked"><p>[]<br></p></li></ul>',
                     stepFunction: splitBlock,
                     contentAfter: "<p>[]<br></p>",
+                });
+                await testEditor({
+                    contentBefore:
+                        '<ul class="o_checklist"><li>ab</li><li><p>[]<br></p><ul class="o_checklist"><li>cd</li></ul></li></ul>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<ul class="o_checklist"><li>ab</li></ul><p>[]<br></p><ul class="o_checklist"><li class="oe-nested"><ul class="o_checklist"><li>cd</li></ul></li></ul>',
                 });
             });
 

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -124,6 +124,23 @@ describe("Selection collapsed", () => {
                         </ol>`),
                 });
             });
+
+            test("should add an empty nested list item after a nested list item", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<ol><li><p>a</p></li><li class="oe-nested"><p>b[]</p></li></ol>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<ol><li><p>a</p></li><li class="oe-nested"><p>b</p></li><li class="oe-nested"><p>[]<br></p></li></ol>',
+                });
+                await testEditor({
+                    contentBefore:
+                        '<ol><li><p>a</p></li><li class="oe-nested"><p>b[]</p><ol><li><p>c</p></li></ol></li></ol>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<ol><li><p>a</p></li><li class="oe-nested"><p>b</p></li><li class="oe-nested"><p>[]<br></p><ol><li><p>c</p></li></ol></li></ol>',
+                });
+            });
         });
         describe("Removing items", () => {
             test("should add an empty list item at the end of a list, then remove it", async () => {
@@ -169,6 +186,29 @@ describe("Selection collapsed", () => {
                     contentBefore: "<ol><li><p><b>[]<br></b></p></li></ol>",
                     stepFunction: splitBlock,
                     contentAfter: "<p><b>[]<br></b></p>",
+                });
+            });
+
+            test("should add an empty nested list item after a nested list item, then remove it", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<ol><li><p>a</p></li><li class="oe-nested"><p class="o-we-hint" o-we-hint-text="List">b[]<br></p></li></ol>',
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter:
+                        '<ol><li><p>a</p></li><li class="oe-nested"><p>b</p></li></ol><p>[]<br></p>',
+                });
+                await testEditor({
+                    contentBefore:
+                        '<ol><li><p>a</p></li><li class="oe-nested"><p>b[]</p><ol><li><p>c</p></li></ol></li></ol>',
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter:
+                        '<ol><li><p>a</p></li><li class="oe-nested"><p>b</p></li></ol><p>[]<br></p><ol><li class="oe-nested"><ol><li><p>c</p></li></ol></li></ol>',
                 });
             });
         });
@@ -302,6 +342,23 @@ describe("Selection collapsed", () => {
                     contentAfter: "<ul><li>abc</li><li>[]<br></li></ul>",
                 });
             });
+
+            test("should add an empty nested list item after a nested list item", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<ul><li><p>a</p></li><li class="oe-nested"><p>b[]</p></li></ul>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<ul><li><p>a</p></li><li class="oe-nested"><p>b</p></li><li class="oe-nested"><p>[]<br></p></li></ul>',
+                });
+                await testEditor({
+                    contentBefore:
+                        '<ul><li><p>a</p></li><li class="oe-nested"><p>b[]</p><ul><li><p>c</p></li></ul></li></ul>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<ul><li><p>a</p></li><li class="oe-nested"><p>b</p></li><li class="oe-nested"><p>[]<br></p><ul><li><p>c</p></li></ul></li></ul>',
+                });
+            });
         });
         describe("Removing items", () => {
             test("should add an empty list item at the end of a list, then remove it", async () => {
@@ -347,6 +404,29 @@ describe("Selection collapsed", () => {
                     contentBefore: "<ul><li><p><b>[]<br></b></p></li></ul>",
                     stepFunction: splitBlock,
                     contentAfter: "<p><b>[]<br></b></p>",
+                });
+            });
+
+            test("should add an empty nested list item after a nested list item, then remove it", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<ul><li><p>a</p></li><li class="oe-nested"><p class="o-we-hint" o-we-hint-text="List">b[]<br></p></li></ul>',
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter:
+                        '<ul><li><p>a</p></li><li class="oe-nested"><p>b</p></li></ul><p>[]<br></p>',
+                });
+                await testEditor({
+                    contentBefore:
+                        '<ul><li><p>a</p></li><li class="oe-nested"><p>b[]</p><ul><li><p>c</p></li></ul></li></ul>',
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter:
+                        '<ul><li><p>a</p></li><li class="oe-nested"><p>b</p></li></ul><p>[]<br></p><ul><li class="oe-nested"><ul><li><p>c</p></li></ul></li></ul>',
                 });
             });
         });
@@ -513,6 +593,23 @@ describe("Selection collapsed", () => {
                         '<ul class="o_checklist"><li class="o_checked">abc</li><li>[]<br></li></ul>',
                 });
             });
+
+            test("should add an empty nested list item after a nested list item", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<ul class="o_checklist"><li><p>a</p></li><li class="oe-nested"><p>b[]</p></li></ul>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<ul class="o_checklist"><li><p>a</p></li><li class="oe-nested"><p>b</p></li><li class="oe-nested"><p>[]<br></p></li></ul>',
+                });
+                await testEditor({
+                    contentBefore:
+                        '<ul class="o_checklist"><li><p>a</p></li><li class="oe-nested"><p>b[]</p><ul class="o_checklist"><li><p>c</p></li></ul></li></ul>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<ul class="o_checklist"><li><p>a</p></li><li class="oe-nested"><p>b</p></li><li class="oe-nested"><p>[]<br></p><ul class="o_checklist"><li><p>c</p></li></ul></li></ul>',
+                });
+            });
         });
         describe("Removing items", () => {
             test("should add an empty list item at the end of a checklist, then remove it", async () => {
@@ -575,6 +672,28 @@ describe("Selection collapsed", () => {
                         '<ul class="o_checklist"><li class="o_checked"><p><b>[]<br></b></p></li></ul>',
                     stepFunction: splitBlock,
                     contentAfter: "<p><b>[]<br></b></p>",
+                });
+            });
+            test("should add an empty nested list item after a nested list item, then remove it", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<ul class="o_checklist"><li><p>a</p></li><li class="oe-nested"><p class="o-we-hint" o-we-hint-text="List">b[]<br></p></li></ul>',
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter:
+                        '<ul class="o_checklist"><li><p>a</p></li><li class="oe-nested"><p>b</p></li></ul><p>[]<br></p>',
+                });
+                await testEditor({
+                    contentBefore:
+                        '<ul class="o_checklist"><li><p>a</p></li><li class="oe-nested"><p>b[]</p><ul class="o_checklist"><li><p>c</p></li></ul></li></ul>',
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter:
+                        '<ul class="o_checklist"><li><p>a</p></li><li class="oe-nested"><p>b</p></li></ul><p>[]<br></p><ul class="o_checklist"><li class="oe-nested"><ul class="o_checklist"><li><p>c</p></li></ul></li></ul>',
                 });
             });
         });


### PR DESCRIPTION
**Current behavior before PR:**

- Pressing Enter on an empty list item with a nested list as its child did not remove (outdent) the list item.
- When pressing Enter on an `oe-nested` list item, instead of creating a new `oe-nested` list, a new paragraph element was inserted inside the same `oe-nested` list. As a result, performing operations such as Delete, Tab, Shift+Tab, or pressing Enter on an empty list item could incorrectly affect all list items within that `oe-nested` list.

**Desired behavior after PR is merged:**

- Pressing Enter on an empty list item that contains a nested list will now remove (outdent) the list item, matching the behavior when no nested list is present.
- Pressing Enter on an `oe-nested` list item now creates a separate `oe-nested` list ensuring that operations such as Delete, Tab, Shift+Tab, or pressing Enter on an empty list item only affect the intended list item.

task: 5047551
