### PR TITLE
[FIX] point_of_sale: prevent error when loading pos config data

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -260,7 +260,7 @@ class PosConfig(models.Model):
         return self.search_read(domain, fields, load=False)
 
     def _post_read_pos_data(self, data):
-        if not data[0]['use_pricelist']:
+        if data and not data[0]['use_pricelist']:
             data[0]['pricelist_id'] = False
         return super()._post_read_pos_data(data)
 


### PR DESCRIPTION
When the user tries to start a pos session or load pos config data, 
a traceback appears.

In this [commit](https://github.com/odoo/odoo/commit/fd8845b393fcc0a7e9ae65437b1ec5ba5d334eb5#diff-4c6e412c7d8f4df2a05831547e7df93d0b91f510d03b7b3ed0d689a18f5dae44R244-R245), condition [1] shows that the data can be empty.
However, when the user starts the pos session or loads the data, 
a traceback occurs if the data is empty.

Traceback:
`IndexError: list index out of range`

This commit ensures that the data elements are accessed only if 
the data is present.

[1]- https://github.com/odoo/odoo/blob/8e1e4f68763af141c97647fd3e3a2d3a64654a13/addons/point_of_sale/models/pos_config.py#L257-L262

sentry-6838885724


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
