### PR TITLE
[FIX] website: fix submenu colors with sidebar header

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -405,20 +405,21 @@ body {
     background: var(--NavLinkWithBackground-bg-color, rgba(var(--#{$variable-prefix}emphasis-color-rgb), .05));
 }
 
-// Apply background color to the offcanvas menu
-.o_navbar_mobile {
-    $-navbar-mobile-bg-color: o-color('menu-custom') or o-color('menu');
-    height: 100dvh;
-    background-color: $-navbar-mobile-bg-color;
+$-navbar-mobile-bg-color: o-color('menu-custom') or o-color('menu');
 
-    // Make offcanvas close btn above mega menu
-    .btn-close {
-        z-index: $o-mega-menu-btn-close-zindex;
-    }
-
+// Mixin for accordion style in vertical menu (e.g. mobile menu, sidebar header)
+@mixin accordion-style-vertical-menu {
     .top_menu > .accordion {
         ul > li > a.nav-link {
             background-color: inherit;
+
+            &.active {
+                color: var(--navbar-active-color);
+            }
+
+            &:hover {
+                color: var(--nav-link-hover-color);
+            }
         }
 
         .accordion-button {
@@ -437,6 +438,25 @@ body {
                 content: '\e839';
             }
         }
+    }
+}
+
+// Apply background color to the offcanvas menu
+.o_navbar_mobile {
+    height: 100dvh;
+    background-color: $-navbar-mobile-bg-color;
+
+    // Make offcanvas close btn above mega menu
+    .btn-close {
+        z-index: $o-mega-menu-btn-close-zindex;
+    }
+
+    @include accordion-style-vertical-menu;
+}
+
+@if o-website-value('header-template') == 'sidebar' {
+    @include media-breakpoint-up(lg) {
+        @include accordion-style-vertical-menu;
     }
 }
 
@@ -1722,10 +1742,6 @@ header {
 
     .o_mega_menu_left .o_mega_menu {
         inset: 0 auto 0 0 !important;
-    }
-
-    .list-group-item-action.active {
-        color: var(--o-cc1-btn-primary-text) !important;
     }
 }
 


### PR DESCRIPTION
Steps to reproduce:

- Install the "Website" app.
- Go to the homepage.
- Click on "Site > Menu Editor" in the backend navbar.
- Create a submenu.
- Save the dialog.
- Enter edit mode.
- Click on the header.
- Choose a dark background in the header options.
- Choose the "Sidebar" template in the header options.
- Open the submenu.
- Bug: The submenu is not visible because the background and text have the same light color, so nothing can be seen.

The bug was introduced by commit [1], which made visual improvements to the menu. This commit fixes it by making sure the colors of the problematic elements adapt to the theme colors.

[1]: https://github.com/odoo/odoo/commit/dc1a15539227c4c21837a7bce3fc4d81858d60b9

opw-5043010
