### PR TITLE
[FIX] account_peppol: email address never updated

### DIFF
--- a/addons/account_peppol/wizard/peppol_config_wizard.py
+++ b/addons/account_peppol/wizard/peppol_config_wizard.py
@@ -114,17 +114,16 @@ class PeppolConfigWizard(models.TransientModel):
         """Interpret changes to the services, and add or remove them on the IAP accordingly."""
         self.ensure_one()
 
-        # Update company details
-        if self.account_peppol_contact_email != self.company_id.account_peppol_contact_email:
-            params = {
-                'update_data': {
-                    'peppol_contact_email': self.account_peppol_contact_email,
-                }
+        # Update email unconditionally. account_peppol_contact_email is a related field so changes can't be detected
+        params = {
+            'update_data': {
+                'peppol_contact_email': self.account_peppol_contact_email,
             }
-            self.account_peppol_edi_user._call_peppol_proxy(
-                endpoint='/api/peppol/1/update_user',
-                params=params,
-            )
+        }
+        self.account_peppol_edi_user._call_peppol_proxy(
+            endpoint='/api/peppol/1/update_user',
+            params=params,
+        )
 
         # Update services
         if self.account_peppol_proxy_state == 'receiver':


### PR DESCRIPTION
Due to the config wizard email address field being a related field, and the control flow triggering actual API update only on gets hit when the wizard's email is different from company's email, this control flow never triggered.

The email field in peppol config wizard is a related field to companies peppol email, so the API update ran only if the wizard's email differed from the company's email. Since both were always the same by definition, the update never triggered.

Depends on https://github.com/odoo/iap-apps/pull/1167

no-task