### PR TITLE
[FIX] website: apply header border width and radius correctly

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header_option_plugin.js
@@ -110,6 +110,8 @@ export class StyleActionHeaderAction extends StyleAction {
         const value = super.getValue(...args);
         if (params.mainParam === "border-width") {
             return value.replace(/(^|\s)0px/gi, "").trim() || value;
+        } else if (params.mainParam === "--box-border-width") {
+            return value.replace(/(^|\s)0px/gi, "").trim() || value;
         }
         return value;
     }
@@ -119,6 +121,14 @@ export class StyleActionHeaderAction extends StyleAction {
         if (styleName === "border-color") {
             return this.dependencies.customizeWebsite.customizeWebsiteColors({
                 "menu-border-color": value,
+            });
+        } else if (styleName === "--box-border-width") {
+            return this.dependencies.customizeWebsite.customizeWebsiteVariables({
+                "menu-border-width": value,
+            });
+        } else if (styleName === "--box-border-radius") {
+            return this.dependencies.customizeWebsite.customizeWebsiteVariables({
+                "menu-border-radius": value,
             });
         }
         return this.dependencies.customizeWebsite.customizeWebsiteVariables({


### PR DESCRIPTION
Setting a border or round corners value on the header were not taking effect header because the proper css variables were not updated. This commit ensures the correct css variables are updated.

Steps to reproduce:
1. Enter edit mode in Website Builder.
2. Select the navbar and change its border or round corners value.
3. Notice that the changes have no visible effect.

Related to task 4367641.
