### PR TITLE
[FIX] account: flexible name search on taxes

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -106,7 +106,7 @@ class AccountTax(models.Model):
     _check_company_domain = models.check_company_domain_parent_of
 
     name = fields.Char(string='Tax Name', required=True, translate=True, tracking=True)
-    name_searchable = fields.Char(store=False, search='_search_name',
+    name_searchable = fields.Char(store=False, search='_search_name',  # TODO remove in master
           help="This dummy field lets us use another search method on the field 'name'."
                "This allows more freedom on how to search the 'name' compared to 'filter_domain'."
                "See '_search_name' and '_parse_name_search' for why this is not possible with 'filter_domain'.")
@@ -554,8 +554,12 @@ class AccountTax(models.Model):
         when using `like` or `ilike`.
         """
         def preprocess_name(cond):
-            if cond.field_expr == 'name' and cond.operator in ('like', 'ilike') and isinstance(cond.value, str):
-                return Domain('name', cond.operator, AccountTax._parse_name_search(cond.value))
+            if (
+                cond.field_expr in ('name', 'display_name')
+                and cond.operator in ('like', 'ilike')
+                and isinstance(cond.value, str)
+            ):
+                return Domain(cond.field_expr, cond.operator, AccountTax._parse_name_search(cond.value))
             return cond
         domain = Domain(domain).map_conditions(preprocess_name)
         return super()._search(domain, offset, limit, order)


### PR DESCRIPTION
Issue:
- Searching for a tax by its name is not flexible.
- Users have to type the exact name of a tax to find it.

Fix:
- Override the 'search' function in the 'Many2XTaxTagsAutocomplete' component

Impact:
- Improves user experience by allowing tax searches using partial or approximate name inputs.
- For example, typing '21s' will return all relevant results like '21% S' and similar matches.

Task: 5046098
