### PR TITLE
[FIX] marketing_card: raise on failed image render

### DIFF
--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -181,7 +181,7 @@ class CardCampaign(models.Model):
     def write(self, vals):
         link_tracker_vals = {}
         if vals.keys() & set(self._get_render_fields()):
-            self.env['card.card'].search([('campaign_id', 'in', self.ids)]).requires_sync = True
+            self.env['card.card'].with_context(active_test=False).search([('campaign_id', 'in', self.ids)]).requires_sync = True
         if 'target_url' in vals:
             link_tracker_vals['url'] = vals['target_url'] or self.env['card.campaign'].get_base_url()
         if link_tracker_vals:

--- a/addons/marketing_card/models/card_campaign.py
+++ b/addons/marketing_card/models/card_campaign.py
@@ -2,7 +2,7 @@ import base64
 import pytz
 from datetime import date, datetime
 
-from odoo import _, api, fields, models, exceptions
+from odoo import _, api, exceptions, fields, models, modules
 
 from .card_template import TEMPLATE_DIMENSIONS
 
@@ -332,6 +332,15 @@ class CardCampaign(models.Model):
             [self._render_field('body_html', record.ids, add_context={'card_campaign': self})[record.id]],
             *TEMPLATE_DIMENSIONS
         )[0]
+
+        # None means there was a logged error at image rendering time.
+        # Tests also do not render by default, in that case ignore.
+        if image_bytes is None and not modules.module.current_test:
+            raise exceptions.UserError(_(
+                'An error occured while rendering a card for %(record_name)s. '
+                'Try again or check the server logs for more details.',
+                record_name=record.display_name
+            ))
         return image_bytes and base64.b64encode(image_bytes)
 
     # ==========================================================================

--- a/addons/marketing_card/tests/test_campaign.py
+++ b/addons/marketing_card/tests/test_campaign.py
@@ -173,6 +173,7 @@ class TestMarketingCardRender(MarketingCardCommon):
         ])
         self.assertEqual(len(card), 1)
         self.assertTrue(card.image)
+        self.assertTrue(card.requires_sync)
         self.assertEqual(card.res_id, self.partners[0].id)
 
         # second record, modified tags
@@ -193,6 +194,8 @@ class TestMarketingCardRender(MarketingCardCommon):
             ('campaign_id', '=', campaign.id),
             ('active', '=', False)
         ])
+        self.assertEqual(cards.mapped('requires_sync'), [True] * 2)
+        self.assertEqual(cards.mapped('active'), [False] * 2)
         self.assertTrue(cards.mapped('res_id'), self.partners.ids)
 
         # update previewed record fields

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -5,7 +5,7 @@ from contextlib import ExitStack
 from markupsafe import Markup
 from urllib.parse import urlparse
 
-from odoo import api, fields, models, tools, SUPERUSER_ID, _
+from odoo import api, fields, models, modules, tools, _
 from odoo.exceptions import UserError, AccessError, RedirectWarning
 from odoo.service import security
 from odoo.tools.safe_eval import safe_eval, time
@@ -462,7 +462,7 @@ class IrActionsReport(models.Model):
         :param image_format union['jpg', 'png']: format of the image
         :return list[bytes|None]:
         """
-        if (tools.config['test_enable'] or tools.config['test_file']) and not self.env.context.get('force_image_rendering'):
+        if modules.module.current_test:
             return [None] * len(bodies)
         if not wkhtmltoimage_version or wkhtmltoimage_version < parse_version('0.12.0'):
             raise UserError(_('wkhtmltoimage 0.12.0^ is required in order to render images from html'))


### PR DESCRIPTION
If wkhtmltoimage fails for any reason we currently keep going as if an image was actually rendered. Instead if the result of the image render is `None`, raise a generic error.

This avoids issues with cards being marked "synced" even though they are actually empty.

Additionally, when the campaign gets reused:
- preview two records
- update cards on a mailing
- preview a record again
- modify one of the fields on the card
- update the cards on a mailing again
- the card that was previewed is not updated

ALL cards must require sync after a change to the campaign
not just active ones. Otherwise they will keep their "synced"
status and not be synced when they're selected for update later
on.

task-5048534