### PR TITLE
[IMP] hr_work_entry: improve work entry description handling and display

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -148,7 +148,6 @@ class HrVersion(models.Model):
             work_entry_type = self._get_interval_work_entry_type(interval)
             # All benefits generated here are using datetimes converted from the employee's timezone
             vals += [dict([
-                      ('name', "%s: %s" % (work_entry_type.name, employee.name)),
                       ('date_start', interval[0].astimezone(pytz.utc).replace(tzinfo=None)),
                       ('date_stop', interval[1].astimezone(pytz.utc).replace(tzinfo=None)),
                       ('work_entry_type_id', work_entry_type.id),
@@ -285,7 +284,6 @@ class HrVersion(models.Model):
                 work_entry_type = version._get_interval_leave_work_entry_type(interval, worked_leaves, bypassing_work_entry_type_codes)
                 # All benefits generated here are using datetimes converted from the employee's timezone
                 version_vals += [dict([
-                    ('name', "%s: %s" % (work_entry_type.name, employee.name)),
                     ('date_start', interval[0].astimezone(pytz.utc).replace(tzinfo=None)),
                     ('date_stop', interval[1].astimezone(pytz.utc).replace(tzinfo=None)),
                     ('work_entry_type_id', work_entry_type.id),
@@ -311,7 +309,6 @@ class HrVersion(models.Model):
                     interval_start = leave_interval[0].astimezone(pytz.utc).replace(tzinfo=None)
                     interval_stop = leave_interval[1].astimezone(pytz.utc).replace(tzinfo=None)
                     version_vals += [dict([
-                        ('name', "%s%s" % (leave_entry_type.name + ": " if leave_entry_type else "", employee.name)),
                         ('date_start', interval_start),
                         ('date_stop', interval_stop),
                         ('work_entry_type_id', leave_entry_type.id),

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -19,7 +19,7 @@ class HrWorkEntry(models.Model):
     _description = 'HR Work Entry'
     _order = 'create_date'
 
-    name = fields.Char()
+    name = fields.Char("Description")
     active = fields.Boolean(default=True)
     employee_id = fields.Many2one('hr.employee', required=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", index=True)
     version_id = fields.Many2one('hr.version', string="Employee Record", required=True)
@@ -55,14 +55,6 @@ class HrWorkEntry(models.Model):
         for work_entry in self:
             duration = str(timedelta(hours=work_entry.duration)).split(":")
             work_entry.display_name = "%s - %sh%s" % (work_entry.work_entry_type_id.name, duration[0], duration[1])
-
-    @api.depends('work_entry_type_id', 'employee_id')
-    def _compute_name(self):
-        for work_entry in self:
-            if not work_entry.employee_id:
-                work_entry.name = _('Undefined')
-            else:
-                work_entry.name = "%s: %s" % (work_entry.work_entry_type_id.name or _('Undefined Type'), work_entry.employee_id.name)
 
     @api.depends('state')
     def _compute_conflict(self):

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -93,9 +93,9 @@
                 <sheet>
                     <group>
                         <group>
-                            <field name="name" string="Description" placeholder="Additional Description..." readonly="state == 'validated'"/>
                             <field name="work_entry_type_id" readonly="state == 'validated'" options="{'no_create': True, 'no_open': True}" widget="many2one_work_entry_type"/>
                             <field name="employee_id" readonly="state != 'draft'" widget="many2one_avatar_employee"/>
+                            <field name="name" placeholder="Additional Description..." readonly="state == 'validated'"/>
                         </group>
                         <group>
                             <field name="date" readonly="state != 'draft'"/>
@@ -190,6 +190,8 @@
                 <filter name="current_month" string="Current Month" domain="[
                     ('date', '&gt;=', '=1d'),
                     ('date', '&lt;', '=1d +1m')]"/>
+                <separator/>
+                <filter name="name" string="With Description" domain="[('name', '!=', False)]"/>
                 <separator/>
                 <filter name="group_employee" string="Employee" context="{'group_by': 'employee_id'}"/>
                 <filter name="group_department" string="Department" context="{'group_by': 'department_id'}"/>

--- a/addons/l10n_fr_hr_work_entry_holidays/models/hr_version.py
+++ b/addons/l10n_fr_hr_work_entry_holidays/models/hr_version.py
@@ -54,7 +54,6 @@ class HrVersion(models.Model):
                     employee_dates.add(vals['date_stop'].date())
                 leave_work_entry_type = leave.holiday_status_id.work_entry_type_id
                 result += [{
-                    'name': '%s%s' % (leave_work_entry_type.name + ': ' if leave_work_entry_type else "", employee.name),
                     'date_start': interval[0].astimezone(pytz.utc).replace(tzinfo=None),
                     'date_stop': interval[1].astimezone(pytz.utc).replace(tzinfo=None),
                     'work_entry_type_id': leave_work_entry_type.id,


### PR DESCRIPTION
This PR aims to:

- Label field `name` as *Description*
- Prevent generated work entries from being pre-filled with a description
- Move description field to the bottom of the modal window
- Add "With Description" filter in search view for work entries with a description

task-5026021

