### PR TITLE
[FIX] html_editor: fix css unit conversion precision

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_number_input.js
@@ -81,13 +81,14 @@ export class BuilderNumberInput extends Component {
             if (savedUnit || this.props.saveUnit) {
                 // Convert value from saveUnit to unit
                 value = convertNumericToUnit(
-                    savedValue,
+                    parseFloat(savedValue),
                     savedUnit || this.props.saveUnit,
                     unit,
                     getHtmlStyle(this.env.getEditingElement().ownerDocument)
                 );
             }
-            return value;
+            // Put *at most* 3 decimal digits
+            return parseFloat(parseFloat(value).toFixed(3)).toString();
         });
     }
 

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -16,7 +16,7 @@ import {
 } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
 import { xml } from "@odoo/owl";
-import { contains } from "@web/../tests/web_test_helpers";
+import { contains, defineModels, models } from "@web/../tests/web_test_helpers";
 import { delay } from "@web/core/utils/concurrency";
 
 describe.current.tags("desktop");
@@ -933,5 +933,20 @@ describe("sanitized values", () => {
         await contains(".options-container input").edit("1.284778323");
         expect(".options-container input").toHaveValue("1.285");
         expect(":iframe .test-options-target").toHaveAttribute("data-number", "1.285");
+    });
+    test("should save font with full precision in rem and display to correct value in px", async () => {
+        class WebEditorAssets extends models.Model {
+            _name = "web_editor.assets";
+            make_scss_customization() {}
+        }
+        defineModels([WebEditorAssets]);
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'" unit="'px'" saveUnit="'rem'"/>`,
+        });
+        await setupHTMLBuilder(`<div class="test-options-target">Test</div>`);
+        await contains(":iframe .test-options-target").click();
+        await contains(".options-container input").edit("19");
+        expect(".options-container input").toHaveValue("19");
     });
 });

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -205,7 +205,7 @@ export function convertNumericToUnit(value, unitFrom, unitTo, htmlStyle) {
     if (converter === undefined) {
         throw new Error(`Cannot convert '${unitFrom}' units into '${unitTo}' units !`);
     }
-    return parseFloat((value * converter(htmlStyle)).toFixed(3));
+    return value * converter(htmlStyle);
 }
 
 export function getHtmlStyle(document) {

--- a/addons/html_editor/static/tests/utils/numeric_to_unit_converter.test.js
+++ b/addons/html_editor/static/tests/utils/numeric_to_unit_converter.test.js
@@ -1,8 +1,14 @@
-import { convertNumericToUnit } from "@html_editor/utils/formatting";
+import { convertNumericToUnit, getHtmlStyle } from "@html_editor/utils/formatting";
 import { describe, expect, test } from "@odoo/hoot";
 
 describe("NumericToUnitConverter", () => {
-    test("displays the correct value (no floating point precision error)", () => {
-        expect(convertNumericToUnit(1400, "ms", "s")).toBe(1.4);
+    test("Convert with maximum float precision", () => {
+        // The conversion might give a result off by exactly `Number.EPSILON`.
+        // However `toBeCloseTo` only succeed if the result margin is strictly
+        // less than the expected margin. So `2 * Number.EPSILON` is used.
+        expect(convertNumericToUnit(1400, "ms", "s")).toBeCloseTo(1.4, {
+            margin: 2 * Number.EPSILON,
+        });
+        expect(convertNumericToUnit(19, "px", "rem", getHtmlStyle(document))).toBe(1.1875);
     });
 });


### PR DESCRIPTION
__Current behavior before commit:__
When typing an integer value in the font size input, some decimals are
added automatically because the value entered in `px` is first converted
to `rem` then it's converted back to `px` but some precision is lost in
`convertNumericToUnit` because `toFixed(3)` is called on the result.

__Description of the fix:__
`toFixed` is removed from `convertNumericToUnit` to avoid any loss of
precision on the value saved. However it's now used in `formatRawValue`
so that the value displayed to the user is stays clean. This way we keep
the behavior intended by [this PR].


__Steps to reproduce the issue on runbot:__
1. Open the website builder.
2. Go to the *Theme* tab.
3. In Paragraph section, set the Font Size to 19px.
=> It gets changed to 19.008px automatically.

[this PR]: https://github.com/odoo/odoo/pull/221754