### PR TITLE
[FIX] base: correctly generate default form view for ir.actions.client

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -883,14 +883,6 @@ class IrActionsActClient(models.Model):
             params = record.params
             record.params_store = repr(params) if isinstance(params, dict) else params
 
-    def _get_default_form_view(self):
-        doc = super(IrActionsActClient, self)._get_default_form_view()
-        params = doc.find(".//field[@name='params']")
-        params.getparent().remove(params)
-        params_store = doc.find(".//field[@name='params_store']")
-        params_store.getparent().remove(params_store)
-        return doc
-
 
     def _get_readable_fields(self):
         return super()._get_readable_fields() | {


### PR DESCRIPTION
Steps to reproduce
==================

- Install studio,contacts
- Go to contacts
- Open studio
- Click on "Edit menu"
- Click on the pencil next to a menu item
- Set the action type to ir.actions.client
- Type a random string next to it, for example "test123"
- Click on "Create and Edit"

=> No default view could be found

Cause of the issue
==================

The following commit removes the binary fields from the default view as it caused a traceback

https://github.com/odoo/odoo/commit/70d51d2103118287b1ebafdae396c7b86e6b9257

A more general fix has been made in

https://github.com/odoo/odoo/commit/e1edcb06ef2619835d07717f00cbf6f04f026366

Since the binary fields are already removed in the super call, the override doesn't find them.

Solution
========

There is no need for the override anymore

opw-5023188