### PR TITLE
[FIX] website: do not merge megamenu links after duplication

### DIFF
--- a/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
@@ -22,6 +22,8 @@ export class MegaMenuOptionPlugin extends Plugin {
         save_handlers: this.saveMegaMenuClasses.bind(this),
         no_parent_containers: ".o_mega_menu",
         is_unremovable_selector: ".o_mega_menu > section",
+        unsplittable_node_predicates: (node) =>
+            node?.nodeType === Node.ELEMENT_NODE && node.matches(".o_mega_menu .nav > .nav-link"), //avoid merge
     };
 
     getTemplatePrefix() {


### PR DESCRIPTION
Before this commit, if the user clicks the "Duplicate" button on a mega menu link and saves the page without changing the href of the newly generated link, the new link is merged with the previous one. This doesn't happen in 18.3.

The problem origins from the normalize handler of  `FormatPlugin`. The function `mergeAdjacentInlines` merges the links if they are found to be identical.

This commit introduces an `unsplittable_node_predicates` in `MegaMenuOptionPlugin` which prevents the mega menu links from being merged, even if they are consecutive and have the same href.

How to reproduce the problem:
1. Create a new mega menu (click on navbar link -> edit menu -> add mega menu item)
2. Open the mega menu, click on a link, click on "Duplicate" at least twice
3. Save
4. PROBLEM: after saving, the new links have been merged with the previous

Task-4367641

