### PR TITLE
[FIX] hr_payroll: fix error in modification of validated leave work entries

### DIFF
--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -84,8 +84,8 @@ class HrLeave(models.Model):
 
                 overlappping |= self.env['hr.work.entry']._from_intervals(outside_intervals)
                 included |= previous_employee_work_entries - overlappping
-            overlappping.write({'leave_id': False})
-            included.write({'active': False})
+            overlappping.filtered(lambda entry: entry.state != 'validated').write({'leave_id': False})
+            included.filtered(lambda entry: entry.state != 'validated').write({'active': False})
 
     def write(self, vals):
         if not self:


### PR DESCRIPTION
This logic of solving the overlapping between leave work entries has been adjusted to prevent editing the entries marked as validated.
This error appears in the installation in task #4921300.
You can refer to the error here:
https://runbot.odoo.com/runbot/build/87127472
To reproduce:
-Fake time a date in the future, for example :"2025-09-05 UTC".
-Install the needed modules with demo data: -i "hr_payroll,project_timesheet_holidays" --with-demo.