### PR TITLE
FIX: point_of_sale: Prevent image stretching in (POS) product grid

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.scss
@@ -8,7 +8,7 @@
 
 .product-img img {
     aspect-ratio: 1 / 1;
-    object-fit: cover;
+    object-fit: contain;
     border-top-right-radius: $border-radius-lg;
     border-top-left-radius: $border-radius-lg;
 }


### PR DESCRIPTION
This fix modifies the CSS to use object-fit: contain;. This property scales the image to fit entirely within the container while preserving its aspect ratio. This ensures all product images display correctly, without stretching maintaining a consistent and clean look for the user interface.

Steps to reproduce:
1. Install Point of Sale.
2. Open POS session.
3. Notice product images are stretched in the grid.


Description of the issue/feature this PR addresses:

Current behavior before PR:
<img width="1902" height="907" alt="image" src="https://github.com/user-attachments/assets/a2dc2855-c984-4dec-9922-45ff5f1c2ca3" />

Desired behavior after PR is merged:
<img width="1910" height="913" alt="image" src="https://github.com/user-attachments/assets/1f13a1bb-ea8e-4de1-8287-06566037a63a" />


opw-5028767


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
