### PR TITLE
[FIX] l10n_in: remove dependency from gst treatment

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -120,7 +120,7 @@ class AccountMove(models.Model):
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
 
-    @api.depends('partner_id.vat', 'partner_id.country_id', 'partner_id.l10n_in_gst_treatment')
+    @api.depends('partner_id')
     def _compute_l10n_in_gst_treatment(self):
         for invoice in self.filtered(lambda m: m.country_code == 'IN' and m.state == 'draft'):
             partner = invoice.partner_id

--- a/addons/l10n_in/tests/test_partner_details_on_invoice.py
+++ b/addons/l10n_in/tests/test_partner_details_on_invoice.py
@@ -46,19 +46,6 @@ class TestReports(L10nInTestInvoicingCommon):
                 'l10n_in_state_id': expected_pos_id,
             }]
         )
-        self.partner_b.write({
-            'vat': False,
-            'l10n_in_gst_treatment': 'unregistered',
-            'state_id': self.state_in_hp,  # change state of partner
-        })
-        self.assertRecordValues(
-            self.invoice_b,
-            [{
-                'state': 'draft',
-                'l10n_in_gst_treatment': self.partner_b.l10n_in_gst_treatment,
-                'l10n_in_state_id': expected_pos_id, # POS doesn't change unless the partner changes
-            }]
-        )
         self.assertRecordValues(
             invoice_b_2,
             [{ # check gst treatment and pos doesn't change on posted invoice
@@ -75,14 +62,6 @@ class TestReports(L10nInTestInvoicingCommon):
             taxes=[self.igst_sale_18],
         )
 
-        self.assertRecordValues(
-            self.invoice_a,
-            [{
-                'state': 'draft',
-                'l10n_in_gst_treatment': self.partner_a.l10n_in_gst_treatment,
-                'l10n_in_state_id': self.state_in_gj.id,
-            }]
-        )
         self.invoice_a.partner_id = self.partner_foreign
         self.assertRecordValues(
             self.invoice_a,


### PR DESCRIPTION
The field fiscal_position_id in l10n_in was dependent on l10n_in_gst_treatment, which itself depended on partner.vat, partner.country_id, and partner.l10n_in_gst_treatment.

As a result, any change to the partner’s VAT triggered a recomputation of fiscal_position_id. This contradicts the generic behavior, since VAT changes should not affect fiscal position.

This fix removes the unnecessary dependency chain.

reference - https://github.com/odoo/odoo/pull/224511
