### PR TITLE
[FIX] web: hide range button in picker if not a date range

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -112,7 +112,8 @@ export class DateTimeField extends Component {
                 value,
                 type: this.field.type,
                 range: this.isRange(value),
-                showRangeToggler: !this.props.required && !this.props.alwaysRange,
+                showRangeToggler:
+                    this.relatedField && !this.props.required && !this.props.alwaysRange,
                 onToggleRange: () => {
                     this.state.range = !this.state.range;
 

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -70,6 +70,22 @@ beforeEach(() => {
     disableAnimations();
 });
 
+test("Datetime field without daterange widget", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <field name="datetime"/>
+            </form>`,
+    });
+
+    await contains("button[data-field=datetime]").click();
+    expect(".o_datetime_picker").toBeDisplayed();
+    expect(".o_toggle_range").toHaveCount(0);
+});
+
 test.tags("desktop");
 test("Datetime field - interaction with the datepicker", async () => {
     Partner._records[0].datetime_end = "2017-03-13 00:00:00";


### PR DESCRIPTION
Before this commit, the range button toggle was displayed even when a date field did not use the date range widget.

Steps to reproduce:
- Open "Sales"
- Create a new one
- Check "Expiration" field (´validity_date´)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
