### PR TITLE
[FIX] point_of_sale: send order to PD also when skipping receipt screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -388,6 +388,10 @@ export class PaymentScreen extends Component {
         if (switchScreen) {
             this.pos.showScreen(nextScreen);
         }
+
+        if (!this.pos.config.module_pos_restaurant) {
+            this.pos.checkPreparationStateAndSentOrderInPreparation(this.currentOrder);
+        }
     }
     selectNextOrder() {
         if (this.currentOrder.originalSplittedOrder) {

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -2,7 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useErrorHandlers, useTrackedAsync } from "@point_of_sale/app/utils/hooks";
 import { registry } from "@web/core/registry";
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
-import { useState, Component, onMounted } from "@odoo/owl";
+import { useState, Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -28,13 +28,6 @@ export class ReceiptScreen extends Component {
         this.sendReceipt = useTrackedAsync(this._sendReceiptToCustomer.bind(this));
         this.doFullPrint = useTrackedAsync(() => this.pos.printReceipt());
         this.doBasicPrint = useTrackedAsync(() => this.pos.printReceipt({ basic: true }));
-        onMounted(() => {
-            const order = this.pos.get_order();
-
-            if (!this.pos.config.module_pos_restaurant) {
-                this.pos.checkPreparationStateAndSentOrderInPreparation(order);
-            }
-        });
     }
 
     _addNewOrder() {


### PR DESCRIPTION
Steps to reproduce:
-------------------
- Enable "Automatic Receipt Printing"
- Make a PoS order, with "Invoiced" checked, and validate it

-> Observe that the command is not sent to the preparation display.

Reason:
-------
When skipping the receipt screen, we don't call
`checkPreparationStateAndSentOrderInPreparation`, which then doesn't send the new command to the preparation display.

The fix:
--------
Backporting 26425ab712a3269beec98722 but without any refactoring.

opw-5000406