### PR TITLE
[FIX] pos_online_payment: tb while processing online payment

### DIFF
--- a/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
+++ b/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
@@ -231,7 +231,7 @@ patch(OrderPaymentValidation.prototype, {
             }
         }
 
-        await this.beforePostPushOrderResolve([this.order.id]);
+        await this.postPushOrderResolve([this.order.id]);
 
         await this.afterOrderValidation(true);
         const nextPage = this.nextPage;


### PR DESCRIPTION
Steps:

- Install pos_loyalty without a pos_restaurant.
- Open PoS config with loyalty and online payment method configured.
- Process Order with online payment.

Issue:

- Traceback appears after payment validation on the payment screen.

Cause:

- In https://github.com/odoo/odoo/pull/216523 PR, while replacing `_postPushOrderResolve` with `beforePostPushOrderResolve`, in pos_online_payment, `postPushOrderResolve` has been replaced with `beforePostPushOrderResolve`.

Fix:

- Replaced `beforePostPushOrderResolve` method with `postPushOrderResolve`
