### PR TITLE
[IMP] loyalty: add name to group for easying xml xpath

### DIFF
--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -61,7 +61,7 @@
                             </div>
                         </group>
                     </group>
-                    <group>
+                    <group name="description_group">
                         <field name="description" string="Description on order"/>
                     </group>
                 </sheet>

--- a/addons/loyalty/views/loyalty_rule_views.xml
+++ b/addons/loyalty/views/loyalty_rule_views.xml
@@ -28,7 +28,7 @@
                             <field name="product_category_id"/>
                             <field name="product_tag_id"/>
                         </group>
-                        <group invisible="not user_has_debug and program_type not in ('loyalty', 'buy_x_get_y')">
+                        <group name="rule_points_group" invisible="not user_has_debug and program_type not in ('loyalty', 'buy_x_get_y')">
                             <separator string="Point(s)" colspan="2"/>
                             <span colspan="2" invisible="program_type != 'coupons'">Grant the amount of coupon points defined as the coupon value</span>
                             <label for="reward_point_amount" string="Grant" invisible="program_type not in ('promotion', 'promo_code', 'next_order_coupons', 'loyalty', 'buy_x_get_y')"/>


### PR DESCRIPTION
This commit adds the names 'description_group' to the loyalty reward view form and "rule_points_group" to the loyalty rule view form for easying the xml override process in inherited modules. Related to odoo/enterprise#92375.

task-4878917