### PR TITLE
[FIX] website_sale: improve image carousel highlight

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale_frontend.scss
+++ b/addons/website_sale/static/src/scss/website_sale_frontend.scss
@@ -32,11 +32,19 @@
                 width: 128px;
             }
 
-            li img{
-                border: 1px solid #CED4DA;
+            li > div {
+                background: $body-bg;
 
-                &.active {
-                    border-color: #35979c;
+                img {
+                    border: 4px solid transparent;
+
+                    &:not(.active, :hover) {
+                        opacity: 0.5;
+                    }
+
+                    &.active {
+                        border-color: $primary;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Steps
-----
1. Have a published product with multiple images;
2. go to its website page;
3. open website editor;
4. set Images Ratio to Wide;
5. enable pop-up on click;
6. save;
7. browse through the images.

Issue
-----
- While there is a border around the active thumbnail in the bottom row, it is barely visible, making it difficult to see which image is currently being shown.

Cause
-----
- The border is only 1 pixel wide.

Solution
--------
- Increase the width of the border to 4 pixels, change the color to `$primary`, and hide the border for inactive images.
- Set opacity of thumbnails that aren't selected or hovered over to 0.5.

opw-4908881