### PR TITLE
[FIX] website_sale: consider rate limit on GMC shipping prices

### DIFF
--- a/addons/website_sale/controllers/gmc.py
+++ b/addons/website_sale/controllers/gmc.py
@@ -52,10 +52,7 @@ class GoogleMerchantCenter(Controller):
         website_homepage = website._get_website_pages(
             [('url', '=', homepage_url), ('website_id', '!=', False)], limit=1,
         )
-        products = request.env['product.product'].search(expression.AND([
-            [('is_published', '=', True), ('type', 'in', ('consu', 'combo'))],
-            website.website_domain(),
-        ]))
+        products = request.env['product.product']
         gmc_data = {
             'title': website_homepage.website_meta_title or website.name,
             'link': urljoin(website.get_base_url(), request.env['ir.http']._url_lang(homepage_url)),

--- a/addons/website_sale/tests/test_website_sale_gmc.py
+++ b/addons/website_sale/tests/test_website_sale_gmc.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta
 from lxml import etree
 from werkzeug.exceptions import NotFound
+from unittest import skip
 from urllib.parse import urlparse
 
 from odoo import Command
@@ -12,6 +13,7 @@ from odoo.addons.website_sale.tests.common import MockRequest
 from odoo.addons.website_sale.tests.common_gmc import WebsiteSaleGMCCommon
 
 
+@skip("GMC feature disabled")
 @tagged('post_install', '-at_install')
 class TestWebsiteSaleGMC(WebsiteSaleGMCCommon, HttpCase):
 

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -304,6 +304,7 @@
                     id="google_merchant_center_setting"
                     help="Connect your eCommerce to Google Merchant Center via a product file."
                     documentation="/applications/websites/ecommerce/products/catalog.html#multi-channel-promotion"
+                    invisible="1"
                 >
                     <field name="enabled_gmc_src"/>
                     <field


### PR DESCRIPTION
### Issue:

The `Google Merchant Center` calls the method
`_prepare_gmc_shipping_info` in order to compute the best shipping price for each published product in each possible country: https://github.com/odoo/odoo/blob/1ac89eb71aab48fa8d50fbae01d96bec23d88418/addons/website_sale/models/product_product.py#L352-L361 To achieve this, the method will request the shipping rate for each possible carrier, product, country. However, for external carriers, each such combination will require a request to the external api via the `rate_shipment`:
https://github.com/odoo/odoo/blob/1ac89eb71aab48fa8d50fbae01d96bec23d88418/addons/website_sale/models/delivery_carrier.py#L44-L53 This is problematic as external carriers have a standard rate limit (maximal amount of rate requests allowed per day). For instance DHL standard rate limit is 250 requests per day.

opw-5048969

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
