### PR TITLE
[FIX] point_of_sale: change combo quantity bb

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -377,6 +377,9 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
             const currentQuantity = selectedLine.get_quantity();
             if (newQuantity >= currentQuantity) {
                 selectedLine.set_quantity(newQuantity);
+                for (const line of selectedLine.comboLines ?? []) {
+                    line.set_quantity(newQuantity, true);
+                }
             } else if (newQuantity >= selectedLine.saved_quantity) {
                 await this.handleDecreaseUnsavedLine(newQuantity);
             } else {
@@ -391,8 +394,14 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
         const selectedLine = order.get_selected_orderline();
         const decreaseQuantity = selectedLine.get_quantity() - newQuantity;
         selectedLine.set_quantity(newQuantity);
+        for (const line of selectedLine.comboLines ?? []) {
+            line.set_quantity(newQuantity, true);
+        }
         if (newQuantity == 0) {
             order._unlinkOrderline(selectedLine);
+            for (const line of selectedLine.comboLines ?? []) {
+                order._unlinkOrderline(line);
+            }
         }
         return decreaseQuantity;
     }

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1072,7 +1072,7 @@ export class Orderline extends PosModel {
         var taxes_ids = this.tax_ids || product.taxes_id;
         taxes_ids = taxes_ids.filter((t) => t in this.pos.taxes_by_id);
         var taxdetail = {};
-        var product_taxes = this.pos.get_taxes_after_fp(taxes_ids, this.order.fiscal_position);
+        var product_taxes = this.pos.get_taxes_after_fp(taxes_ids, this.order?.fiscal_position);
 
         var all_taxes = this.compute_all(
             product_taxes,

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1361,7 +1361,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'list_price': 1000,
             'taxes_id': [(6, 0, [tax.id])],
         })
-        
+
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PaymentScreenInvoiceOrder', login="pos_user")
 
@@ -1372,7 +1372,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         invoice = self.env['account.move'].search([('invoice_origin', '=', order.name)], limit=1)
         self.assertTrue(invoice)
-        self.assertFalse(invoice.invoice_payment_term_id) 
+        self.assertFalse(invoice.invoice_payment_term_id)
 
         self.assertAlmostEqual(order.amount_total, invoice.amount_total, places=2, msg="Order and Invoice amounts do not match.")
 
@@ -1381,6 +1381,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         setup_pos_combo_items(self)
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_combo_with_custom_attribute', login="pos_user")
+
+    def test_combo_disallowLineQuantityChange(self):
+        setup_pos_combo_items(self)
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_combo_disallowLineQuantityChange', login="pos_user")
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_combo_disallowLineQuantityChange_2', login="pos_user")
 
     def test_draft_order_deletion_with_printer(self):
         self.env['pos.printer'].create({


### PR DESCRIPTION
When changing the quantity of a combo parent product in a PoS that
doesn't allow changing quantity (like when using blackbox), the children
of the combo would not be updated correctly.

Steps to reproduce:
-------------------
* Open any PoS and use this command to change the behavior of changing
  quantity : `posmodel.disallowLineQuantityChange = () => true;`
* Add any combo product to the order.
* Change the quantity of the combo parent product to 0
> Observation: The children of the combo are still there.

Why the fix:
------------
We make sure to adapt the quantity of the combo children when the parent
quantity is changed.

opw-4876979