### PR TITLE
[FIX] point_of_sale: use correct timezone for pricelist validity

### DIFF
--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,4 +1,4 @@
-import { parseDateTime, deserializeDate } from "@web/core/l10n/dates";
+import { parseDateTime, deserializeDateTime } from "@web/core/l10n/dates";
 import { roundDecimals, floatIsZero } from "@web/core/utils/numbers";
 
 /*
@@ -198,8 +198,8 @@ export function computeProductPricelistCache(service, data = []) {
 
     for (const item of pricelistItems) {
         if (
-            (item.date_start && deserializeDate(item.date_start) > date) ||
-            (item.date_end && deserializeDate(item.date_end) < date)
+            (item.date_start && deserializeDateTime(item.date_start) > date) ||
+            (item.date_end && deserializeDateTime(item.date_end) < date)
         ) {
             continue;
         }


### PR DESCRIPTION
Currently, when entering a validity period on a pricelist, it can happen that a pricelist rule is not applied while being before the end period.

Steps to reproduce (for BE timezone):
-------------------------------------
* Create a pricelist
* Add a pricelist rule for a product (min qty=1, price=5$)
* Add a validity period for the rule, set the end date 30minutes after your current time
* In the settings of the pos add the pricelist to the list of available pricelists
* Open session
* Add the product related to the rule
* Change the pricelist
> Observation: The rule is not applied

Why the fix:
------------
Let's say on the computer it's 15h. The rule is thus set to end at 15h30.

`luxon.DateTime.now()` -> 15h, the zone name is brussels. `deserializeDate(item.date_end)` -> 13h30, zone name is brussels as well.
And 15h in brussels is greater then 13h30 in brussels.

`date_end` is already in UTC format, so we need to specify it. Now, `deserializeDate(item.date_end, { zone: "utc" })` -> 13h30, zone name is utc And 15h in brussels is before 13h30 in utc (since 13h30 is 15h30 in BXL)

opw-4992892