### PR TITLE
[IMP] web, base, crm: convert mixed-currency totals using exchange rates

### DIFF
--- a/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
+++ b/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
@@ -27,7 +27,7 @@
                     value="rrmAggregate.value"
                     title="rrmAggregate.title"
                     duration="1000"
-                    currencyId="rrmAggregate.currency"
+                    currencies="[rrmAggregate.currency]"
                     animationClass="'o_animated_grow_huge'"
                 >
                     <t t-set-slot="prefix" t-if="props.aggregate.value != 0">

--- a/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
+++ b/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
@@ -27,7 +27,7 @@
                     value="rrmAggregate.value"
                     title="rrmAggregate.title"
                     duration="1000"
-                    currency="rrmAggregate.currency"
+                    currencyId="rrmAggregate.currency"
                     animationClass="'o_animated_grow_huge'"
                 >
                     <t t-set-slot="prefix" t-if="props.aggregate.value != 0">

--- a/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field.test.js
+++ b/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field.test.js
@@ -188,27 +188,36 @@ test("Progressbar: ensure correct MRR updation after state change", async () => 
     });
 
     //MRR before state change
-    expect(queryAllTexts(".o_animated_number[title='Recurring Revenue']")).toEqual(["+30", "+35"], {
-        message: "counter should display the sum of recurring_revenue_monthly values",
-    });
+    expect(queryAllTexts(".o_animated_number[data-tooltip='Recurring Revenue']")).toEqual(
+        ["+30", "+35"],
+        {
+            message: "counter should display the sum of recurring_revenue_monthly values",
+        }
+    );
 
     // Drag the first kanban record from 1st column to the top of the last column
     await contains(".o_kanban_record:first").dragAndDrop(".o_kanban_record:last");
 
     //check MRR after drag&drop
-    expect(queryAllTexts(".o_animated_number[title='Recurring Revenue']")).toEqual(["+25", "+40"], {
-        message:
-            "counter should display the sum of recurring_revenue_monthly correctly after drag and drop",
-    });
+    expect(queryAllTexts(".o_animated_number[data-tooltip='Recurring Revenue']")).toEqual(
+        ["+25", "+40"],
+        {
+            message:
+                "counter should display the sum of recurring_revenue_monthly correctly after drag and drop",
+        }
+    );
 
     //Activate "planned" filter on first column
     await contains('.o_kanban_group:eq(1) .progress-bar[aria-valuenow="2"]').click();
 
     //check MRR after applying filter
-    expect(queryAllTexts(".o_animated_number[title='Recurring Revenue']")).toEqual(["+25", "+25"], {
-        message:
-            "counter should display the sum of recurring_revenue_monthly only of overdue filter in 1st column",
-    });
+    expect(queryAllTexts(".o_animated_number[data-tooltip='Recurring Revenue']")).toEqual(
+        ["+25", "+25"],
+        {
+            message:
+                "counter should display the sum of recurring_revenue_monthly only of overdue filter in 1st column",
+        }
+    );
 });
 
 test.tags("desktop");

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -149,6 +149,7 @@ class IrHttp(models.AbstractModel):
                             'sequence': comp.sequence,
                             'child_ids': (comp.child_ids & user_companies).ids,
                             'parent_id': comp.parent_id.id,
+                            'currency_id': comp.currency_id.id,
                         } for comp in user_companies
                     },
                     'disallowed_ancestor_companies': {

--- a/addons/web/static/src/core/currency.js
+++ b/addons/web/static/src/core/currency.js
@@ -24,6 +24,7 @@ export function getCurrency(id) {
  * @param {boolean} [options.noSymbol] this currency has not a sympbol
  * @param {boolean} [options.humanReadable] if true, large numbers are formatted
  *   to a human readable format.
+ * @param {number} [options.minDigits] see @humanNumber
  * @param {boolean} [options.trailingZeros] if false, numbers will have zeros
  *  to the right of the last non-zero digit hidden
  * @param {[number, number]} [options.digits] the number of digits that should
@@ -37,7 +38,10 @@ export function formatCurrency(amount, currencyId, options = {}) {
 
     let formattedAmount;
     if (options.humanReadable) {
-        formattedAmount = humanNumber(amount, { decimals: digits ? digits[1] : 2 });
+        formattedAmount = humanNumber(amount, {
+            decimals: digits ? digits[1] : 2,
+            minDigits: options.minDigits,
+        });
     } else {
         formattedAmount = formatFloat(amount, { digits, trailingZeros: options.trailingZeros });
     }

--- a/addons/web/static/src/core/currency.js
+++ b/addons/web/static/src/core/currency.js
@@ -1,6 +1,10 @@
+import { reactive } from "@odoo/owl";
+import { serializeDate } from "@web/core/l10n/dates";
+import { rpc } from "@web/core/network/rpc";
+import { user } from "@web/core/user";
 import { formatFloat, humanNumber } from "@web/core/utils/numbers";
-import { session } from "@web/session";
 import { nbsp } from "@web/core/utils/strings";
+import { session } from "@web/session";
 
 export const currencies = session.currencies || {};
 // to make sure code is reading currencies from here
@@ -8,6 +12,42 @@ delete session.currencies;
 
 export function getCurrency(id) {
     return currencies[id];
+}
+
+export async function getCurrencyRates() {
+    const rates = reactive({});
+
+    function recordsToRates(records) {
+        return Object.fromEntries(records.map((r) => [r.id, r.inverse_rate]));
+    }
+
+    const model = "res.currency";
+    const method = "read";
+    const url = `/web/dataset/call_kw/${model}/${method}`;
+    const context = {
+        ...user.context,
+        to_currency: user.activeCompany.currency_id,
+        date: serializeDate(luxon.DateTime.now()),
+    };
+    const params = {
+        model,
+        method,
+        args: [Object.keys(currencies).map(Number), ["inverse_rate"]],
+        kwargs: { context },
+    };
+    const records = await rpc(url, params, {
+        cache: {
+            type: "disk",
+            update: "once",
+            callback: (records, hasChanged) => {
+                if (hasChanged) {
+                    Object.assign(rates, recordsToRates(records));
+                }
+            },
+        },
+    });
+    Object.assign(rates, recordsToRates(records));
+    return rates;
 }
 
 /**

--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -166,7 +166,7 @@ export class SampleServer {
     _aggregateFields(measures, records) {
         const group = {};
         for (const { fieldName, func, name } of measures) {
-            if (["sum", "avg", "max", "min"].includes(func)) {
+            if (["sum", "sum_currency", "avg", "max", "min"].includes(func)) {
                 if (!records.length) {
                     group[name] = false;
                 } else {

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -7,7 +7,6 @@ import {
     lightenColor,
     darkenColor,
 } from "@web/core/colors/colors";
-import { Domain } from "@web/core/domain";
 import { registry } from "@web/core/registry";
 import { formatFloat, formatMonetary } from "@web/views/fields/formatters";
 import { SEP } from "./graph_model";
@@ -23,8 +22,6 @@ import { cookie } from "@web/core/browser/cookie";
 import { createElementWithContent } from "@web/core/utils/html";
 import { ReportViewMeasures } from "@web/views/view_components/report_view_measures";
 import { Widget } from "@web/views/widgets/widget";
-import { getCurrency } from "@web/core/currency";
-import { rpc } from "@web/core/network/rpc";
 
 const NO_DATA = _t("No data");
 const formatters = registry.category("formatters");
@@ -599,29 +596,6 @@ export class GraphRenderer extends Component {
             suggestedMin: 0,
         };
         return { x: xAxe, y: yAxe };
-    }
-
-    getCurrency(currency) {
-        return getCurrency(currency).name;
-    }
-
-    async filterCurrency(currency) {
-        let domainString = `[("${this.model.currencyState.currencyField}", "=", ${currency})]`;
-        let isValid = await rpc("/web/domain/validate", {
-            model: this.model.metaData.resModel,
-            domain: new Domain(domainString).toList(),
-        });
-        if (!isValid) {
-            domainString = `[("company_id.currency_id", "=", ${currency})]`;
-            isValid = await rpc("/web/domain/validate", {
-                model: this.model.metaData.resModel,
-                domain: new Domain(domainString).toList(),
-            });
-            if (!isValid) {
-                return;
-            }
-        }
-        this.env.searchModel.splitAndAddDomain(domainString);
     }
 
     loadAll() {

--- a/addons/web/static/src/views/graph/graph_renderer.xml
+++ b/addons/web/static/src/views/graph/graph_renderer.xml
@@ -31,17 +31,6 @@
 
     <t t-name="web.GraphRenderer">
         <div t-att-class="'o_graph_renderer o_renderer h-100 d-flex flex-column border-top ' + props.class" t-ref="root">
-            <t t-if="model.currencyState?.currencies.length > 1">
-                <div class="alert alert-info o_graph_alert p-2 m-3 mb-2" role="status">
-                    The graph is mixing several currencies. Select one of them to perform an accurate analysis:
-                    <t t-foreach="model.currencyState.currencies" t-as="currency" t-key="currency_index">
-                        <t t-if="currency_index > 0">
-                            -
-                        </t>
-                        <a t-if="currency" class="px-1" t-out="getCurrency(currency)" href="#" t-on-click="() => this.filterCurrency(currency)"/>
-                    </t>
-                </div>
-            </t>
             <t t-if="model.data.exceeds">
                 <div class="alert alert-info text-center o_graph_alert m-3 mb-2" role="status">
                     There are too many data. The graph only shows a sample. Use the filters to refine the scope.

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -1,5 +1,4 @@
 import { reactive } from "@odoo/owl";
-import { getCurrency } from "@web/core/currency";
 import { Domain } from "@web/core/domain";
 import { _t } from "@web/core/l10n/translation";
 import {
@@ -163,14 +162,14 @@ class ProgressBarState {
                 return {
                     title: `${title}: ${_t("different currencies cannot be aggregated")}`,
                     value,
-                    currency: false,
+                    currencyId: false,
                 };
             }
             if (currencies?.[0]) {
                 return {
                     title,
                     value,
-                    currency: getCurrency(currencies[0]),
+                    currencyId: currencies[0],
                 };
             }
         }

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -160,16 +160,15 @@ class ProgressBarState {
             const currencies = group.aggregates?.[aggregateField.currency_field];
             if (currencies?.length > 1) {
                 return {
-                    title: `${title}: ${_t("different currencies cannot be aggregated")}`,
                     value,
-                    currencyId: false,
+                    currencies,
                 };
             }
             if (currencies?.[0]) {
                 return {
                     title,
                     value,
-                    currencyId: currencies[0],
+                    currencies: [currencies[0]],
                 };
             }
         }

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -72,6 +72,7 @@ export class ListController extends Component {
     setup() {
         this.actionService = useService("action");
         this.dialogService = useService("dialog");
+        this.orm = useService("orm");
         this.rootRef = useRef("root");
 
         this.archInfo = this.props.archInfo;
@@ -103,7 +104,6 @@ export class ListController extends Component {
         onWillStart(async () => {
             this.isExportEnable = await user.hasGroup("base.group_allow_export");
         });
-
         let { rendererScrollPositions } = this.props.state || {};
         useEffect(() => {
             if (rendererScrollPositions) {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -119,7 +119,12 @@
                         <td t-foreach="getAggregateColumns()" t-as="column" t-key="column.id" t-att-class="{'o_list_number': column.type === 'field'}">
                             <span t-if="column.type === 'field' and aggregates[column.name]" t-att-data-tooltip="aggregates[column.name].help">
                                 <t t-esc="aggregates[column.name].value"/>
-                                <sup t-if="aggregates[column.name].warning" class="ms-1 fw-bolder text-info">?</sup>
+                                <sup
+                                    t-if="aggregates[column.name].multiCurrency"
+                                    class="p-1 fw-bolder text-info"
+                                    t-on-mouseover.stop="(ev) => this.openMultiCurrencyPopover(ev, aggregates[column.name].rawValue, column.name)"
+                                    t-on-touchstart.stop="(ev) => this.openMultiCurrencyPopover(ev, aggregates[column.name].rawValue, column.name)"
+                                >?</sup>
                             </span>
                         </td>
                         <td t-if="hasOpenFormViewColumn" class="w-print-0 p-print-0"/>
@@ -243,9 +248,14 @@
             <td t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-foreach="getAggregateColumns(group)" t-as="column" t-key="column.id" t-att-class="{'o_list_number': column.type === 'field'}">
                 <t t-if="column.type === 'field'">
                     <t t-set="groupAggregate" t-value="formatGroupAggregate(group, column)"/>
-                    <span t-att-data-tooltip="groupAggregate.help || ''">
+                    <span class="fw-bold" t-att-data-tooltip="groupAggregate.help">
                         <t t-esc="groupAggregate.value"/>
-                        <sup t-if="groupAggregate.warning" class="ms-1 fw-bolder text-info">?</sup>
+                        <sup
+                            t-if="groupAggregate.multiCurrency"
+                            class="p-1 fw-bolder text-info"
+                            t-on-mouseover.stop="(ev) => this.openMultiCurrencyPopover(ev, groupAggregate.rawValue, column.name)"
+                            t-on-touchstart.stop="(ev) => this.openMultiCurrencyPopover(ev, groupAggregate.rawValue, column.name)"
+                        >?</sup>
                     </span>
                 </t>
             </td>

--- a/addons/web/static/src/views/pivot/pivot_renderer.xml
+++ b/addons/web/static/src/views/pivot/pivot_renderer.xml
@@ -46,7 +46,12 @@
                                             <t t-set="formattedValue" t-value="getFormattedValue(cell)"/>
                                             <span t-att-data-tooltip="formattedValue.help">
                                                 <t t-esc="formattedValue.value"/>
-                                                <sup t-if="formattedValue.warning" class="ms-1 fw-bolder text-info">?</sup>
+                                                <sup
+                                                    t-if="formattedValue.currencies"
+                                                    class="p-1 fw-bolder text-info"
+                                                    t-on-mouseover.stop="(ev) => this.openMultiCurrencyPopover(ev, formattedValue.rawValue, formattedValue.currencies)"
+                                                    t-on-touchstart.stop="(ev) => this.openMultiCurrencyPopover(ev, formattedValue.rawValue, formattedValue.currencies)"
+                                                >?</sup>
                                             </span>
                                         </div>
                                     </t>

--- a/addons/web/static/src/views/view_components/animated_number.js
+++ b/addons/web/static/src/views/view_components/animated_number.js
@@ -1,8 +1,10 @@
 import { browser } from "@web/core/browser/browser";
 import { formatInteger, formatMonetary } from "@web/views/fields/formatters";
 
-import { Component, onWillUpdateProps, onWillUnmount, useState } from "@odoo/owl";
-import { _t } from "@web/core/l10n/translation";
+import { Component, onWillUnmount, onWillUpdateProps, useState } from "@odoo/owl";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { user } from "@web/core/user";
+import { MultiCurrencyPopover } from "@web/views/view_components/multi_currency_popover";
 
 export class AnimatedNumber extends Component {
     static template = "web.AnimatedNumber";
@@ -10,7 +12,7 @@ export class AnimatedNumber extends Component {
         value: Number,
         duration: Number,
         animationClass: { type: String, optional: true },
-        currencyId: { type: [Number, Boolean], optional: true },
+        currencies: { type: Array, optional: true },
         title: { type: String, optional: true },
         slots: {
             type: Object,
@@ -25,6 +27,9 @@ export class AnimatedNumber extends Component {
     setup() {
         this.state = useState({ value: this.props.value });
         this.handle = null;
+        this.multiCurrencyPopover = usePopover(MultiCurrencyPopover, {
+            position: "right",
+        });
         onWillUpdateProps((nextProps) => {
             const { value: from } = this.props;
             const { value: to, duration } = nextProps;
@@ -50,9 +55,9 @@ export class AnimatedNumber extends Component {
     }
 
     format(value) {
-        if (this.props.currencyId) {
+        if (this.currencyId) {
             return formatMonetary(value, {
-                currencyId: this.props.currencyId,
+                currencyId: this.currencyId,
                 humanReadable: true,
                 digits: [null, 0],
                 minDigits: 3,
@@ -61,7 +66,21 @@ export class AnimatedNumber extends Component {
         return formatInteger(value, { humanReadable: true, minDigits: 3 });
     }
 
-    get invalidAggregateTooltip() {
-        return _t("Different currencies cannot be aggregated");
+    openMultiCurrencyPopover(ev) {
+        if (!this.multiCurrencyPopover.isOpen) {
+            this.multiCurrencyPopover.open(ev.target, {
+                currencyIds: this.props.currencies,
+                target: ev.target,
+                value: this.props.value,
+            });
+        }
+    }
+
+    get currencyId() {
+        const { currencies } = this.props;
+        if (currencies?.length) {
+            return currencies.length > 1 ? user.activeCompany.currency_id : currencies[0];
+        }
+        return false;
     }
 }

--- a/addons/web/static/src/views/view_components/animated_number.js
+++ b/addons/web/static/src/views/view_components/animated_number.js
@@ -1,5 +1,5 @@
 import { browser } from "@web/core/browser/browser";
-import { formatInteger } from "@web/views/fields/formatters";
+import { formatInteger, formatMonetary } from "@web/views/fields/formatters";
 
 import { Component, onWillUpdateProps, onWillUnmount, useState } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
@@ -10,7 +10,7 @@ export class AnimatedNumber extends Component {
         value: Number,
         duration: Number,
         animationClass: { type: String, optional: true },
-        currency: { type: [Object, Boolean], optional: true },
+        currencyId: { type: [Number, Boolean], optional: true },
         title: { type: String, optional: true },
         slots: {
             type: Object,
@@ -23,7 +23,6 @@ export class AnimatedNumber extends Component {
     static enableAnimations = true;
 
     setup() {
-        this.formatInteger = formatInteger;
         this.state = useState({ value: this.props.value });
         this.handle = null;
         onWillUpdateProps((nextProps) => {
@@ -51,7 +50,15 @@ export class AnimatedNumber extends Component {
     }
 
     format(value) {
-        return this.formatInteger(value, { humanReadable: true, decimals: 0, minDigits: 3 });
+        if (this.props.currencyId) {
+            return formatMonetary(value, {
+                currencyId: this.props.currencyId,
+                humanReadable: true,
+                digits: [null, 0],
+                minDigits: 3,
+            });
+        }
+        return formatInteger(value, { humanReadable: true, minDigits: 3 });
     }
 
     get invalidAggregateTooltip() {

--- a/addons/web/static/src/views/view_components/animated_number.xml
+++ b/addons/web/static/src/views/view_components/animated_number.xml
@@ -4,10 +4,8 @@
     <t t-name="web.AnimatedNumber">
         <div class="o_animated_number ms-2 text-900 text-nowrap cursor-default" t-att-class="state.value !== props.value ? props.animationClass : ''" t-att-title="props.title">
             <t t-slot="prefix"/>
-            <b t-if="props.currency and props.currency.position === 'before'" t-esc="props.currency.symbol" class="me-1"/>
             <b t-esc="format(state.value)" />
-            <b t-if="props.currency and props.currency.position === 'after'" t-esc="props.currency.symbol" class="ms-1"/>
-            <sup t-elif="props.currency === false" class="ms-1 fw-bolder text-info">?</sup>
+            <sup t-if="props.currencyId === false" class="ms-1 fw-bolder text-info">?</sup>
         </div>
     </t>
 

--- a/addons/web/static/src/views/view_components/animated_number.xml
+++ b/addons/web/static/src/views/view_components/animated_number.xml
@@ -2,10 +2,15 @@
 <templates xml:space="preserve">
 
     <t t-name="web.AnimatedNumber">
-        <div class="o_animated_number ms-2 text-900 text-nowrap cursor-default" t-att-class="state.value !== props.value ? props.animationClass : ''" t-att-title="props.title">
+        <div class="o_animated_number ms-2 text-900 text-nowrap cursor-default" t-att-class="state.value !== props.value ? props.animationClass : ''" t-att-data-tooltip="props.title">
             <t t-slot="prefix"/>
             <b t-esc="format(state.value)" />
-            <sup t-if="props.currencyId === false" class="ms-1 fw-bolder text-info">?</sup>
+            <sup
+                t-if="props.currencies?.length > 1"
+                class="p-1 fw-bolder text-info"
+                t-on-mouseover.stop="openMultiCurrencyPopover"
+                t-on-touchstart.stop="openMultiCurrencyPopover"
+            >?</sup>
         </div>
     </t>
 

--- a/addons/web/static/src/views/view_components/column_progress.xml
+++ b/addons/web/static/src/views/view_components/column_progress.xml
@@ -27,7 +27,7 @@
                 value="props.aggregate.value"
                 title="props.aggregate.title"
                 duration="1000"
-                currencyId="props.aggregate.currencyId"
+                currencies="props.aggregate.currencies"
                 animationClass="props.aggregate.value > 999 ? 'o_animated_grow' : 'o_animated_grow_huge'"
             />
         </t>

--- a/addons/web/static/src/views/view_components/column_progress.xml
+++ b/addons/web/static/src/views/view_components/column_progress.xml
@@ -27,7 +27,7 @@
                 value="props.aggregate.value"
                 title="props.aggregate.title"
                 duration="1000"
-                currency="props.aggregate.currency"
+                currencyId="props.aggregate.currencyId"
                 animationClass="props.aggregate.value > 999 ? 'o_animated_grow' : 'o_animated_grow_huge'"
             />
         </t>

--- a/addons/web/static/src/views/view_components/multi_currency_popover.js
+++ b/addons/web/static/src/views/view_components/multi_currency_popover.js
@@ -1,0 +1,47 @@
+import { Component, onWillStart, useExternalListener, useState } from "@odoo/owl";
+import { getCurrency, getCurrencyRates } from "@web/core/currency";
+import { user } from "@web/core/user";
+import { useService } from "@web/core/utils/hooks";
+import { formatMonetary } from "../fields/formatters";
+
+export class MultiCurrencyPopover extends Component {
+    static template = "web.MultiCurrencyPopover";
+    static props = {
+        close: Function,
+        currencyIds: Array,
+        target: HTMLElement,
+        value: Number,
+    };
+
+    setup() {
+        this.orm = useService("orm");
+        this.defaultCurrency = user.activeCompany.currency_id;
+        this.state = useState({ rates: null });
+        onWillStart(async () => {
+            this.state.rates = await getCurrencyRates();
+        });
+        useExternalListener(window, "mouseover", (ev) => {
+            if (ev.target !== this.props.target) {
+                this.props.close();
+            }
+        });
+    }
+
+    get currencies() {
+        return this.props.currencyIds.reduce((currencies, currencyId) => {
+            if (currencyId !== this.defaultCurrency) {
+                currencies.push({
+                    ...getCurrency(currencyId),
+                    id: currencyId,
+                    rate: this.state.rates[currencyId],
+                    value: this.props.value / this.state.rates[currencyId],
+                });
+            }
+            return currencies;
+        }, []);
+    }
+
+    formatedValue(value, currencyId) {
+        return formatMonetary(value, { currencyId });
+    }
+}

--- a/addons/web/static/src/views/view_components/multi_currency_popover.xml
+++ b/addons/web/static/src/views/view_components/multi_currency_popover.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.MultiCurrencyPopover">
+        <div class="o_multi_currency_popover">
+            <div class="popover-body">
+                <t t-foreach="currencies" t-as="currency" t-key="currency.id">
+                    <div>
+                        <t t-out="formatedValue(currency.value, currency.id)"/> at <t t-out="formatedValue(currency.rate, defaultCurrency)"/>
+                    </div>
+                </t>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -561,8 +561,6 @@ function isValidFieldValue(record, fieldDef) {
         case "integer": {
             return Number.isInteger(value);
         }
-        case "json":
-            return typeof value === "string" || Array.isArray(value) || isObject(value);
         case "many2many":
         case "one2many": {
             return (
@@ -1340,6 +1338,14 @@ function sum(records, fieldName) {
     return records.reduce((acc, record) => acc + record[fieldName], 0);
 }
 
+/** @type {AggregatorFunction} */
+function sum_currency(records, fieldName) {
+    if (!records.length) {
+        return false;
+    }
+    return records.reduce((acc, record) => acc + record[fieldName], 0);
+}
+
 //-----------------------------------------------------------------------------
 // Local constants
 //-----------------------------------------------------------------------------
@@ -1355,6 +1361,7 @@ const AGGREGATOR_FUNCTIONS = {
     max,
     min,
     sum,
+    sum_currency,
 };
 /** @type {Record<string, (date: luxon["DateTime"]["prototype"]) => string | number>} */
 const DATE_FORMAT = {

--- a/addons/web/static/tests/_framework/mock_server_state.hoot.js
+++ b/addons/web/static/tests/_framework/mock_server_state.hoot.js
@@ -38,6 +38,7 @@ const SERVER_STATE_VALUES = {
         {
             id: 1,
             name: "Hermit",
+            currency_id: 1,
         },
     ],
     currencies: [

--- a/addons/web/static/tests/mock_server/mock_server_state.test.js
+++ b/addons/web/static/tests/mock_server/mock_server_state.test.js
@@ -12,7 +12,7 @@ test("default state", () => {
     expect(s).toInclude("view_info");
     delete s.view_info;
     expect(s).toEqual({
-        companies: [{ id: 1, name: "Hermit" }],
+        companies: [{ id: 1, name: "Hermit", currency_id: 1 }],
         currencies: [
             { id: 1, name: "USD", position: "before", symbol: "$" },
             { id: 2, name: "EUR", position: "after", symbol: "€" },

--- a/addons/web/static/tests/views/fields/monetary_field.test.js
+++ b/addons/web/static/tests/views/fields/monetary_field.test.js
@@ -44,15 +44,17 @@ class Currency extends models.Model {
             ["before", "B"],
         ],
     });
+    inverse_rate = fields.Float();
 
     _records = [
-        { id: 1, name: "USD", symbol: "$", position: "before" },
-        { id: 2, name: "EUR", symbol: "€", position: "after" },
+        { id: 1, name: "USD", symbol: "$", position: "before", inverse_rate: 1 },
+        { id: 2, name: "EUR", symbol: "€", position: "after", inverse_rate: 0.5 },
         {
             id: 3,
             name: "VEF",
             symbol: "Bs.F",
             position: "after",
+            inverse_rate: 0.3,
         },
     ];
 }

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -9424,7 +9424,7 @@ test("progress bar with false aggregate value", async () => {
 
     expect(".o_kanban_counter .o_animated_number").toHaveCount(2);
 
-    expect(".o_kanban_counter:last .o_animated_number").toHaveText("$3,722");
+    expect(".o_kanban_counter:last .o_animated_number").toHaveText("$ 3,722");
     expect(".o_kanban_counter:first .o_animated_number").toHaveText("3,750?");
     expect(".o_kanban_counter:first .o_animated_number").toHaveAttribute(
         "title",

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -116,10 +116,11 @@ class Currency extends models.Model {
             ["before", "B"],
         ],
     });
+    inverse_rate = fields.Float();
 
     _records = [
-        { id: 1, name: "USD", symbol: "$", position: "before" },
-        { id: 2, name: "EUR", symbol: "€", position: "after" },
+        { id: 1, name: "USD", symbol: "$", position: "before", inverse_rate: 1 },
+        { id: 2, name: "EUR", symbol: "€", position: "after", inverse_rate: 0.5 },
     ];
 }
 

--- a/addons/web/tests/test_session_info.py
+++ b/addons/web/tests/test_session_info.py
@@ -53,6 +53,7 @@ class TestSessionInfo(common.HttpCase):
                 'name': company.name,
                 'sequence': company.sequence,
                 'child_ids': company.child_ids.ids,
+                'currency_id': company.currency_id.id,
                 'parent_id': company.parent_id.id,
             } for company in self.allowed_companies
         }


### PR DESCRIPTION
First commit makes AnimatedNumber use formatMonetary logic instead of replicating it (i.e. currency symbol position). 

Second commit improves how mixed-currency totals are handled across views: list, kanban, pivot, and graph. Instead of displaying misleading or invalid values, mixed totals are now automatically converted into the active company's default currency using the latest available exchange rates.

- In list, kanban, and pivot views, mixed totals are converted into the default currency. A “?” tooltip appears to indicate the conversion, showing:
    - The converted totals in the other currencies involved
    - The exchange rates used for the conversion
- In the graph view, whenever multiple currencies are present in the data, all values are converted into the company's default currency to ensure consistent aggregation.

Totals that are already in a single non-default currency remain unchanged
outside of graph view.

This provides clearer, more consistent, and more meaningful information
to users working with multi-currency data.

task-5048462