### PR TITLE
[FIX] resource, hr_holidays: expand multi-day leaves in flexible schedules

### DIFF
--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -220,3 +220,37 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             ('holiday_id', '=', partially_covered_leave.id)
         ])
         self.assertTrue(resource_leaves, 'Resource leaves linked to the employee leave should exist.')
+
+    def test_multi_day_public_holidays_for_flexible_schedule(self):
+        """
+        Test that _get_unusual_days return correct value for
+        multi-day holidays in flexible schedules
+        """
+
+        flex_cal = self.env['resource.calendar'].create({
+            'name': 'Flexible', 'tz': 'UTC', 'flexible_hours': True, 'hours_per_day': 8.0
+        })
+
+        # tuesday to thursday
+        self.env['resource.calendar.leaves'].create({
+            'name': '3 day holiday', 'calendar_id': flex_cal.id,
+            'date_from': datetime(2024, 3, 5), 'date_to': date(2024, 3, 7)
+        })
+
+        # monday to saturday
+        start = datetime(2024, 3, 4)
+        end = datetime(2024, 3, 10)
+
+        flex_days = flex_cal._get_unusual_days(start, end)
+
+        expected = {
+            '2024-03-04': False,
+            '2024-03-05': True,
+            '2024-03-06': True,
+            '2024-03-07': True,
+            '2024-03-08': False,
+            '2024-03-09': False,
+            '2024-03-10': False,
+        }
+        for day, value in expected.items():
+            self.assertEqual(flex_days.get(day), value, f"Day {day} should be {'unusual' if value else 'normal'}")

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -681,7 +681,10 @@ class ResourceCalendar(models.Model):
         if company_id:
             domain = [('company_id', 'in', (company_id.id, False))]
         if self.flexible_hours:
-            works = {d[0].date() for d in self._leave_intervals_batch(start_dt, end_dt, domain=domain)[False]}
+            leave_intervals = self._leave_intervals_batch(start_dt, end_dt, domain=domain)[False]
+            works = set()
+            for start_int, end_int, _ in leave_intervals:
+                works.update(start_int.date() + timedelta(days=i) for i in range((end_int.date() - start_int.date()).days + 1))
             return {fields.Date.to_string(day.date()): (day.date() in works) for day in rrule(DAILY, start_dt, until=end_dt)}
         works = {d[0].date() for d in self._work_intervals_batch(start_dt, end_dt, domain=domain)[False]}
         return {fields.Date.to_string(day.date()): (day.date() not in works) for day in rrule(DAILY, start_dt, until=end_dt)}


### PR DESCRIPTION
**Issue**:

Multi-day public holidays only display as single days in calendar views when using flexible working schedules. A 3-day holiday appears as only 1 day blocked, though time-off requests are still correctly prevented for all 3 days.

**Cause:**

In `_get_unusual_days()`, the implementation for flexible schedules only captures the start date of each leave interval

https://github.com/odoo/odoo/blob/132938929d46c8248a9e3a7e2972174ae38eacfa/addons/resource/models/resource_calendar.py#L683-L685

**Steps to reproduce:**

1. Configure a flexible working schedule for an employee or company
2. Go to Time Off > Public Holidays
3. Create a 3 day public holiday
4. Check Time Off calendar view

Only 1 day appears blocked instead of all 3 days

opw-4997757