### PR TITLE
[ADD] pos_self_order_hardware: allow handling hardware for kiosk

### DIFF
--- a/addons/pos_self_order_hardware/__init__.py
+++ b/addons/pos_self_order_hardware/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/pos_self_order_hardware/__manifest__.py
+++ b/addons/pos_self_order_hardware/__manifest__.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'PoS Hardware API integration',
+    'version': '1.0.0',
+    'category': 'Sales/Point of Sale',
+    'sequence': 40,
+    'summary': 'Allows the use of various hardware, such as an LED screen.',
+    'depends': ['pos_self_order'],
+    'uninstall_hook': 'uninstall_hook',
+    'data': [
+        'views/res_config_settings_views.xml',
+    ],
+    'demo': [],
+    'installable': True,
+    'application': False,
+    'assets': {
+        "pos_self_order.assets": [
+            'pos_self_order_hardware/static/src/**/*.js',
+        ],
+    },
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/pos_self_order_hardware/models/__init__.py
+++ b/addons/pos_self_order_hardware/models/__init__.py
@@ -1,0 +1,2 @@
+from . import pos_config
+from . import res_config_settings

--- a/addons/pos_self_order_hardware/models/pos_config.py
+++ b/addons/pos_self_order_hardware/models/pos_config.py
@@ -1,0 +1,8 @@
+from odoo import models, fields, api
+from odoo.fields import Domain
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    module_pos_hardware = fields.Boolean('Use POS Hardware', help="Use available hardware, such as LED strips")

--- a/addons/pos_self_order_hardware/models/res_config_settings.py
+++ b/addons/pos_self_order_hardware/models/res_config_settings.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from odoo import fields, models, api
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    pos_module_pos_hardware = fields.Boolean(related='pos_config_id.module_pos_hardware', readonly=False)

--- a/addons/pos_self_order_hardware/static/src/app/class/led_controller.js
+++ b/addons/pos_self_order_hardware/static/src/app/class/led_controller.js
@@ -1,0 +1,20 @@
+/**
+ * These methods must be overridden by the various hardware providers.
+ *
+ * Available providers:
+ * - pos_hardware/static/src/common/class/providers/led_controller_boxapos.js
+ **/
+
+export default class LedController {
+    constructor(config) {
+        this.config = config;
+        this.setup();
+    }
+    setup() {}
+    setColor(r, g, b, luminance) {}
+    setDanger(intensity = 255) {}
+    setWarning(intensity = 255) {}
+    setSuccess(intensity = 255) {}
+    setDefault(intensity = 255) {}
+    off() {}
+}

--- a/addons/pos_self_order_hardware/static/src/app/class/providers/led_controller_boxapos.js
+++ b/addons/pos_self_order_hardware/static/src/app/class/providers/led_controller_boxapos.js
@@ -1,0 +1,62 @@
+import { patch } from "@web/core/utils/patch";
+import LedController from "../led_controller";
+
+// The default color codes do not exactly match the colors that can be found on a screen.
+const ODOO_COLOR = { r: 255, g: 1, b: 188 };
+const SUCCESS_COLOR = { r: 61, g: 255, b: 0 };
+const WARNING_COLOR = { r: 255, g: 58, b: 0 };
+const DANGER_COLOR = { r: 255, g: 0, b: 0 };
+
+patch(LedController.prototype, {
+    setup() {
+        super.setup();
+        this.isBoxapos = Boolean(window.Kiosk) && this.config.module_pos_hardware;
+    },
+    _setBoxaposColor(r, g, b, luminance) {
+        try {
+            window.Kiosk.postMessage(
+                JSON.stringify({
+                    action: "setColor",
+                    value: `${r} ${g} ${b} ${luminance}`,
+                })
+            );
+        } catch {
+            console.warn("Failed to set color, the provider is not available");
+        }
+    },
+    setDanger(intensity = 255) {
+        if (!this.isBoxapos) {
+            return super.setDanger(intensity);
+        }
+
+        this._setBoxaposColor(DANGER_COLOR.r, DANGER_COLOR.g, DANGER_COLOR.b, intensity);
+    },
+    setWarning(intensity = 255) {
+        if (!this.isBoxapos) {
+            return super.setWarning(intensity);
+        }
+
+        this._setBoxaposColor(WARNING_COLOR.r, WARNING_COLOR.g, WARNING_COLOR.b, intensity);
+    },
+    setSuccess(intensity = 255) {
+        if (!this.isBoxapos) {
+            return super.setSuccess(intensity);
+        }
+
+        this._setBoxaposColor(SUCCESS_COLOR.r, SUCCESS_COLOR.g, SUCCESS_COLOR.b, intensity);
+    },
+    setDefault(intensity = 255) {
+        if (!this.isBoxapos) {
+            return super.setDefault(intensity);
+        }
+
+        this._setBoxaposColor(ODOO_COLOR.r, ODOO_COLOR.g, ODOO_COLOR.b, intensity);
+    },
+    off() {
+        if (!this.isBoxapos) {
+            return super.off();
+        }
+
+        this._setBoxaposColor(ODOO_COLOR.r, ODOO_COLOR.g, ODOO_COLOR.b, 0);
+    },
+});

--- a/addons/pos_self_order_hardware/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order_hardware/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -1,0 +1,9 @@
+import { patch } from "@web/core/utils/patch";
+import { ConfirmationPage } from "@pos_self_order/app/pages/confirmation_page/confirmation_page";
+
+patch(ConfirmationPage.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.selfOrder.ledController.setSuccess();
+    },
+});

--- a/addons/pos_self_order_hardware/static/src/app/pages/landing_page/landing_page.js
+++ b/addons/pos_self_order_hardware/static/src/app/pages/landing_page/landing_page.js
@@ -1,0 +1,9 @@
+import { patch } from "@web/core/utils/patch";
+import { LandingPage } from "@pos_self_order/app/pages/landing_page/landing_page";
+
+patch(LandingPage.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.selfOrder.ledController.setDefault();
+    },
+});

--- a/addons/pos_self_order_hardware/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order_hardware/static/src/app/services/self_order_service.js
@@ -1,0 +1,18 @@
+import { patch } from "@web/core/utils/patch";
+import { SelfOrder } from "@pos_self_order/app/services/self_order_service";
+import LedController from "../class/led_controller";
+
+patch(SelfOrder.prototype, {
+    async setup() {
+        await super.setup(...arguments);
+        this.ledController = new LedController(this.config);
+    },
+    handleErrorNotification() {
+        super.handleErrorNotification(...arguments);
+        this.ledController.setDanger();
+
+        setTimeout(() => {
+            this.ledController.setDefault();
+        }, 2000);
+    },
+});

--- a/addons/pos_self_order_hardware/views/res_config_settings_views.xml
+++ b/addons/pos_self_order_hardware/views/res_config_settings_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="res_config_settings_view_form_menu" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.pos_hardware.view</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="pos_self_order.res_config_settings_view_form_menu"/>
+        <field name="arch" type="xml">
+            <block id="self_ordering_section" position="inside">
+                <setting string="Use PoS hardware" help="Use available hardware, such as LED strips">
+                    <field name="pos_module_pos_hardware"/>
+                </setting>
+            </block>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Addition of a “catch-all” module that will contain the API management
for the various hardware providers. For example, BoxAPoS supplies
screens equipped with LED strips, which are managed from this module.

The decision to have a single module containing all these APIs was made
because each API requires very few modifications, so it would be
overkill to create a module for each one.

led_controller.js is the default class; it contains the methods that can
be called to play with the LEDs.

Exposed methods:
- `setup`
- `setColor`
- `setDanger`
- `setWarning`
- `setSuccess`
- `setDefault`
- `off`

These methods are available via the `ledController` variable available
in the selfOrder service.

BoxAPoS color codes (RGB):
- Odoo: 255, 1, 188
- Success: 61, 255, 0
- Warning: 255, 58, 0,
- Danger: 255, 0, 0

taskId: 5049526