### PR TITLE
[ADD] point_of_sale: pre-fill partner form with search query

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -183,6 +183,7 @@
             ('remove', 'web/static/src/webclient/actions/reports/layout_assets/**/*'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
             'web/static/src/webclient/company_service.js',
+            'point_of_sale/static/src/backend/pos_res_partner_view/*',
         ],
         'point_of_sale.base_tests': [
             "web/static/lib/hoot-dom/**/*",

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -34,9 +34,16 @@ export class PartnerList extends Component {
         useHotkey("enter", () => this.onEnter());
     }
     async editPartner(p = false) {
-        const partner = await this.pos.editPartner(p);
-        if (partner) {
-            this.clickPartner(partner);
+        if (this.state.query) {
+            this.pos.partnerSearchContext = this.state.query;
+        }
+        try {
+            const partner = await this.pos.editPartner(p);
+            if (partner) {
+                this.clickPartner(partner);
+            }
+        } finally {
+            delete this.pos.partnerSearchContext;
         }
     }
     async onEnter() {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1855,7 +1855,20 @@ export class PosStore extends Reactive {
         });
     }
     editPartnerContext(partner) {
-        return {};
+        const context = {};
+        if (this.partnerSearchContext) {
+            const isPhoneNumber = /^[0-9]+$/.test(
+                this.partnerSearchContext.replace(/[+\s().-]/g, "")
+            );
+            if (isPhoneNumber) {
+                context.default_phone = this.partnerSearchContext;
+                context.default_focus = "phone";
+            } else {
+                context.default_name = this.partnerSearchContext;
+                context.default_focus = "name";
+            }
+        }
+        return context;
     }
     /**
      * @param {import("@point_of_sale/app/models/res_partner").ResPartner?} partner leave undefined to create a new partner

--- a/addons/point_of_sale/static/src/backend/pos_res_partner_view/res_partner_form_focus.js
+++ b/addons/point_of_sale/static/src/backend/pos_res_partner_view/res_partner_form_focus.js
@@ -1,0 +1,21 @@
+import { FormRenderer } from "@web/views/form/form_renderer";
+import { patch } from "@web/core/utils/patch";
+import { onMounted } from "@odoo/owl";
+
+patch(FormRenderer.prototype, {
+    setup() {
+        super.setup();
+
+        onMounted(() => {
+            const context = this.props.record.context || {};
+            const focusFieldName = context.default_focus;
+
+            if (focusFieldName) {
+                const input = document.querySelector(`[name=${focusFieldName}] input`);
+                if (input) {
+                    input.focus();
+                }
+            }
+        });
+    },
+});

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -16,6 +16,7 @@ import {
 } from "@point_of_sale/../tests/tours/utils/common";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/utils/product_configurator_util";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
+import * as Utils from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
     steps: () =>
@@ -709,5 +710,23 @@ registry.category("web_tour.tours").add("test_pos_ui_round_globally", {
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
             Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosCustomerSearchPrefilledOnCreate", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.searchCustomer("test customer"),
+            Utils.selectButton("Create"),
+            PartnerList.checkInputForm("name", "test customer"),
+            PartnerList.selectFormDiscard(),
+
+            PartnerList.searchCustomer("+(123) 45.67-89"),
+            Utils.selectButton("Create"),
+            PartnerList.checkInputForm("phone", "+(123) 45.67-89"),
+            PartnerList.selectFormDiscard(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
@@ -56,8 +56,7 @@ export function checkContactValues(name, address = "", phone = "", mobile = "", 
 
     return steps;
 }
-
-export function searchCustomerValue(val) {
+export function searchCustomer(val) {
     return [
         {
             isActive: ["mobile"],
@@ -70,6 +69,11 @@ export function searchCustomerValue(val) {
             trigger: `.modal-dialog .input-group input`,
             run: `edit ${val}`,
         },
+    ];
+}
+export function searchCustomerValue(val) {
+    return [
+        ...searchCustomer(val),
         {
             content: `Click on search more if present`,
             trigger: `.search-more-button > button, .partner-list .partner-info:nth-child(1):contains("${val}")`,
@@ -80,6 +84,36 @@ export function searchCustomerValue(val) {
         {
             content: `Check "${val}" is shown`,
             trigger: `.partner-list .partner-info:nth-child(1):contains("${val}")`,
+        },
+    ];
+}
+export function selectFormDiscard() {
+    return [
+        {
+            trigger: "button.o_form_button_cancel",
+            content: "Click on discard the customer form",
+            run: "click",
+        },
+    ];
+}
+
+export function checkInputForm(fieldName, expectedValue) {
+    return [
+        {
+            trigger: `div[name="${fieldName}"] .o_input`,
+            content: `Check if "${expectedValue}" in form div "${fieldName}"`,
+            run: function () {
+                const input = document.querySelector(`div[name="${fieldName}"] .o_input`);
+                if (!input) {
+                    console.error(`Element div[name="${fieldName}"] .o_input not found`);
+                    return;
+                }
+                if (input.value !== expectedValue) {
+                    console.error(
+                        `Validation failed: expected "${expectedValue}", got "${input.value}"`
+                    );
+                }
+            },
         },
     ];
 }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -71,6 +71,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
                 (4, cls.env.ref('base.group_user').id),
                 (4, cls.env.ref('point_of_sale.group_pos_user').id),
                 (4, cls.env.ref('stock.group_stock_user').id),
+                (4, cls.env.ref('base.group_partner_manager').id),
             ],
             'tz': 'America/New_York',
         })
@@ -2115,6 +2116,10 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertAlmostEqual(lines[2].balance, 56.41)
         self.assertAlmostEqual(lines[3].balance, 352.59)
         self.assertAlmostEqual(lines[4].balance, 7771.01)
+
+    def test_customer_search_prefilled_on_create(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('PosCustomerSearchPrefilledOnCreate')
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
If a user searches for a partner and no match is found, clicking "Create" will now automatically transfer the search term into the appropriate field (name or phone) in the creation form. The matched input is also auto-focused.

Task-4991076

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
