### PR TITLE
[FIX] sale_pdf_quote_builder: skip pdf encrypted check if empty

### DIFF
--- a/addons/sale_pdf_quote_builder/models/product_document.py
+++ b/addons/sale_pdf_quote_builder/models/product_document.py
@@ -43,7 +43,8 @@ class ProductDocument(models.Model):
                 ))
             if doc.datas and not doc.mimetype.endswith('pdf'):
                 raise ValidationError(_("Only PDF documents can be attached inside a quote."))
-            utils._ensure_document_not_encrypted(base64.b64decode(doc.datas))
+            if doc.datas:
+                utils._ensure_document_not_encrypted(base64.b64decode(doc.datas))
 
     # === COMPUTE METHODS === #
 


### PR DESCRIPTION
If the document is empty we don't need to check for encryption. Otherwise we risk getting an error.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/18.0/odoo/tools/convert.py", line 544, in _tag_root
    f(rec)
  File "/home/odoo/src/odoo/18.0/odoo/tools/convert.py", line 444, in _tag_record
    record = model._load_records([data], self.mode == 'update')
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5500, in _load_records
    data['record']._load_records_write(data['values'])
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5418, in _load_records_write
    self.write(values)
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 4827, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "/home/odoo/src/odoo/18.0/odoo/models.py", line 1631, in _validate_fields
    check(self)
  File "/home/odoo/src/odoo/18.0/addons/sale_pdf_quote_builder/models/product_document.py", line 46, in _check_attached_on_and_datas_compatibility
    utils._ensure_document_not_encrypted(base64.b64decode(doc.datas))
  File "/home/odoo/src/odoo/18.0/addons/sale_pdf_quote_builder/utils.py", line 12, in _ensure_document_not_encrypted
    if pdf.PdfFileReader(io.BytesIO(document), strict=False).isEncrypted:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/18.0/odoo/tools/pdf/__init__.py", line 91, in __init__
    super().__init__(stream, strict)
  File "/home/odoo/.local/lib/python3.12/site-packages/PyPDF2/_reader.py", line 317, in __init__
    self.read(stream)
  File "/home/odoo/.local/lib/python3.12/site-packages/PyPDF2/_reader.py", line 1408, in read
    self._basic_validation(stream)
  File "/home/odoo/.local/lib/python3.12/site-packages/PyPDF2/_reader.py", line 1449, in _basic_validation
    raise EmptyFileError("Cannot read an empty file")
PyPDF2.errors.EmptyFileError: Cannot read an empty file
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
