### PR TITLE
[FIX] hr_work_entry: fix work entries split in calendar view

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -122,12 +122,20 @@ class HrWorkEntry(models.Model):
             return True
         return False
 
-    def action_split(self):
+    def action_split(self, vals):
         self.ensure_one()
         if self.duration < 1:
             raise UserError(self.env._("You can't split a work entry with less than 1 hour."))
-        self.duration /= 2
+        split_duration = vals['duration']
+        if self.duration <= split_duration:
+            raise UserError(
+                self.env._(
+                    "Split work entry duration has to be less than the existing work entry duration."
+                )
+            )
+        self.duration -= split_duration
         split_work_entry = self.copy()
+        split_work_entry.write(vals)
         return split_work_entry.id
 
     def _check_if_error(self):

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -114,6 +114,27 @@
         </field>
     </record>
 
+    <record id="hr_work_entry_calendar_gantt_view_form" model="ir.ui.view">
+        <field name="name">hr.work.entry.form</field>
+        <field name="model">hr.work.entry</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="hr_work_entry.hr_work_entry_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='employee_id']" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='date']" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='company_id']" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='state']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="hr_work_entry_view_tree" model="ir.ui.view">
         <field name="name">hr.work.entry.list</field>
         <field name="model">hr.work.entry</field>


### PR DESCRIPTION
This commit fixes how the split button behaves in the Calendar view of the work entry. Instead of calling the ORM function upon clicking the split button, the split button now opens a `FormViewDialog`. The save button in the dialog is modified so that, instead of saving the record data, it calls the `action_split` function that handles the splitting logic. The context is used to open the dialog with a custom form view that has read-only fields, and the form is populated with the
existing work entry data, except for the duration, which is set as half of the existing work entry duration. A new form view is created and used in the dialog.

task-5043857

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
