### PR TITLE
[FIX] stock_account: stock account variable typo error.

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -249,8 +249,8 @@ class ResCompany(models.Model):
         accounts = accounting_data_today.keys() | accounting_data_last_period.keys()
 
         for account in accounts:
-            variation_acc = account.account_variation_id
-            expense_acc = account.account_expense_id
+            variation_acc = account.account_stock_variation_id
+            expense_acc = account.account_stock_expense_id
 
             if not variation_acc or not expense_acc:
                 continue


### PR DESCRIPTION
**Problem**
The scheduled action `_cron_post_stock_valuation` crashed because of
wrong field names used when fetching accounts:
- `account.account_variation_id`
- `account.account_expense_id`

These fields do not exist in the `account.account` model.

**Cause**
A typo was introduced in the code. The correct fields are:
- `account.account_stock_variation_id`
- `account.account_stock_expense_id`

**Solution**
Replaced the wrong field names with the correct ones.

**Result**
- `_cron_post_stock_valuation` no longer crashes.
- Stock valuation posting uses the correct variation and expense accounts.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
