### PR TITLE
[IMP] website_blog,website_crm_partner_assign,*: remove href=#

### DIFF
--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -83,7 +83,7 @@ $o-wblog-loader-size: 50px;
         object-fit: cover;
     }
 
-    .o_wblog_social_links > a {
+    .o_wblog_social_links > button {
         width: 3em;
         height: 3em;
         > i {

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -207,10 +207,10 @@
 <template id='index_filter_by_industry' customize_show="True" active='False' name="Filter Industries" inherit_id="index">
     <xpath expr="//t[@t-set='all_categories_label']" position="before">
         <div class="dropdown d-none d-lg-block">
-            <a role="button" href="#" data-bs-toggle="dropdown" class="dropdown-toggle btn btn-light" aria-expanded="true" aria-label="Open industries dropdown">
+            <button data-bs-toggle="dropdown" class="dropdown-toggle btn btn-light" aria-expanded="true" aria-label="Open industries dropdown">
                 <t t-set="all_industries_label">All Industries</t>
                 <span t-out="current_industry and current_industry.name or all_industries_label"/>
-            </a>
+            </button>
             <div class="dropdown-menu">
                 <t t-if='current_industry'>
                     <a t-attf-href="/partners#{ current_grade and '/grade/%s' % slug(current_grade) or '' }#{ current_country and '/country/%s' % slug(current_country) or '' }?#{ keep_query('search', 'country_all')}"
@@ -578,8 +578,8 @@
                 </tbody>
             </table>
             <div class='d-flex justify-content-center gap-2 mt-3'>
-                <a role="button" title="I'm interested" href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target=".modal_partner_assign_interested">I'm interested</a>
-                <a role="button" title="I'm not interested" href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target=".modal_partner_assign_desinterested"> I'm not interested</a>
+                <button title="I'm interested" class="btn btn-primary" data-bs-toggle="modal" data-bs-target=".modal_partner_assign_interested">I'm interested</button>
+                <button title="I'm not interested" class="btn btn-primary" data-bs-toggle="modal" data-bs-target=".modal_partner_assign_desinterested"> I'm not interested</button>
                 <div class="modal fade modal_partner_assign_interested" role="form">
                     <div class="modal-dialog">
                         <form method="POST" class="js_accept_json modal-content js_website_submit_form interested_partner_assign_form">

--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -84,7 +84,7 @@
                                 <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
                                     <h5 class="my-0">Location</h5>
                                     <div t-if="event.exhibition_map" class="ms-2 small">
-                                        <a class="text-decoration-none text-center" href="#" data-bs-toggle="modal" data-bs-target="#mapModal"><i class="fa fa-map-o me-1"/>View Plan</a>
+                                        <button type="button" class="text-decoration-none text-center btn btn-link p-0" data-bs-toggle="modal" data-bs-target="#mapModal"><i class="fa fa-map-o me-1"/>View Plan</button>
                                         <div role="dialog" id="mapModal" class="modal" tabindex="-1">
                                             <div class="modal-dialog modal-lg">
                                                 <div class="modal-content">

--- a/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
+++ b/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
@@ -62,7 +62,7 @@
             text-align: center;
             background-color: rgba(0,0,0,0);
 
-            a {
+            button {
                 display: none;
             }
             @include media-breakpoint-up(md) {
@@ -71,7 +71,7 @@
                     transition: background-color .2s linear;
                     background-color: rgba(0,0,0,.1);
 
-                    a {
+                    button {
                         display: inline-block;
                     }
                 }

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -78,9 +78,9 @@
     active="True">
     <xpath expr="//div[hasclass('o_wesponsor_topbar_filters')]" position="inside">
         <div class="dropdown flex-grow-1">
-            <a href="#" role="button" class="btn btn-light dropdown-toggle w-100" data-bs-toggle="dropdown">
+            <button class="btn btn-light dropdown-toggle w-100" data-bs-toggle="dropdown">
                 By Country
-            </a>
+            </button>
             <div class="dropdown-menu">
                 <span t-att-data-post="'/event/%s/exhibitors?%s' % (slug(event), keep_query('*', countries=''))"
                      t-attf-class="post_link cursor-pointer dropdown-item d-flex align-items-center justify-content-between #{'active' if not search_countries else ''}">
@@ -143,9 +143,9 @@
     active="True">
     <xpath expr="//div[hasclass('o_wesponsor_topbar_filters')]" position="inside">
         <div class="dropdown flex-grow-1">
-            <a href="#" role="button" class="btn btn-light dropdown-toggle w-100" data-bs-toggle="dropdown">
+            <button class="btn btn-light dropdown-toggle w-100" data-bs-toggle="dropdown">
                 By Level
-            </a>
+            </button>
             <div class="dropdown-menu">
                 <span t-att-data-post="'/event/%s/exhibitors?%s' % (slug(event), keep_query('*', sponsorships=''))"
                      t-attf-class="post_link cursor-pointer dropdown-item d-flex align-items-center justify-content-between #{'active' if not search_sponsorships else ''}">
@@ -284,12 +284,12 @@
             t-att-data-event-is-ongoing="sponsor.event_id.is_ongoing"
             t-att-data-sponsor-is-ongoing="sponsor.is_in_opening_hours"
             t-att-data-user-event-manager="is_event_user">
-            <a href="#" class="btn btn-primary h3">
+            <button class="btn btn-primary h3">
                 <t t-if="sponsor.exhibitor_type != 'online'">
                     More info
                 </t>
                 <t t-else="">Connect</t>
-            </a>
+            </button>
         </div>
     </article>
 </template>

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -32,9 +32,9 @@
             <h1 class="my-0 me-auto pe-sm-4 h3-fs">Talks</h1>
             <!-- Optional wishlist filter -->
             <div t-if="option_track_wishlist" class="dropdown d-none d-lg-block">
-                <a href="#" role="button" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown">
+                <button class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown">
                     Favorites
-                </a>
+                </button>
                 <div class="dropdown-menu">
                     <a t-att-href="'/event/%s/track?%s' % (
                             slug(event),
@@ -150,9 +150,9 @@
     <xpath expr="//div[hasclass('o_wevent_search')]" position="before">
         <t t-foreach="tag_categories" t-as="tag_category">
             <div t-if="tag_category.tag_ids and any(tag.color for tag in tag_category.tag_ids)" class="dropdown d-none d-lg-block my-1">
-                <a href="#" role="button" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown">
+                <button class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown">
                     <t t-out="tag_category.name"/>
-                </a>
+                </button>
                 <div class="dropdown-menu">
                     <t t-foreach="tag_category.tag_ids" t-as="tag">
                         <span t-att-data-post="'/event/%s/track?%s' % (

--- a/addons/website_event_track_live/static/src/xml/website_event_track_live_templates.xml
+++ b/addons/website_event_track_live/static/src/xml/website_event_track_live_templates.xml
@@ -9,9 +9,9 @@
             <div class="text-white">You just watched:</div>
             <div class="h1 text-white" t-out="current_track.name"/>
             <div>
-                <a href="#" class="owevent_track_suggestion_replay fw-bold">
+                <button class="owevent_track_suggestion_replay fw-bold btn btn-link p-0">
                     <span>Replay Video</span>
-                </a>
+                </button>
             </div>
         </div>
     </div>
@@ -26,9 +26,9 @@
             <div class="text-white">You just watched:</div>
             <div class="h1 text-white" t-out="current_track.name"/>
             <div>
-                <a href="#" class="owevent_track_suggestion_replay fw-bold">
+                <button class="owevent_track_suggestion_replay fw-bold btn btn-link p-0">
                     <span>Replay Video</span>
-                </a>
+                </button>
             </div>
         </div>
         <div class="d-flex w-100 flex-column align-items-end">

--- a/addons/website_event_track_live_quiz/static/src/xml/website_event_track_live_templates.xml
+++ b/addons/website_event_track_live_quiz/static/src/xml/website_event_track_live_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <t t-inherit="website_event_track_live.website_event_track_suggestion" t-inherit-mode="extension">
-    <xpath expr="//a[hasclass('owevent_track_suggestion_replay')]" position="before">
+    <xpath expr="//button[hasclass('owevent_track_suggestion_replay')]" position="before">
         <a t-if="current_track.show_quiz" class="btn btn-primary btn-lg me-2 owevent_track_suggestion_quiz"
            href="#we_track_quiz_container">
             <span>Take the Quiz</span>

--- a/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
+++ b/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
@@ -11,7 +11,7 @@
                     </div>
                     <div class="list-group">
                         <t t-foreach="question.answer_ids" t-as="answer" t-key="answer_index">
-                            <a t-att-data-answer-id="answer.id" href="#"
+                            <button t-att-data-answer-id="answer.id"
                                 t-att-data-text="answer.text_value"
                                 t-attf-class="o_quiz_quiz_answer list-group-item d-flex align-items-center list-group-item-action #{widget.track.completed  &amp;&amp; answer.is_correct ? 'list-group-item-success' : '' }">
 
@@ -25,7 +25,7 @@
                                     <i t-att-class="'fa fa-check-circle text-success' + (widget.track.completed &amp;&amp; answer.is_correct ? '' :  ' d-none')"></i>
                                 </label>
                                 <span t-out="answer.text_value"/>
-                            </a>
+                            </button>
                         </t>
                     </div>
                 </div>

--- a/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
+++ b/addons/website_event_track_quiz/views/event_leaderboard_templates.xml
@@ -111,7 +111,7 @@
                 <div class="btn-group w-100 position-relative" role="group" aria-label="Mobile sub-nav">
 
                     <div class="btn-group ms-1 position-static me-2">
-                        <a class="btn bg-black-25 text-white dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></a>
+                        <button class="btn bg-black-25 text-white dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-search"></i></button>
                         <div class="dropdown-menu dropdown-menu-end w-100" style="right: 10px;">
                             <form class="px-3" t-attf-action="#{'/event/%s/community/leaderboard' % (slug(event))}" role="search" method="get">
                                 <div class="input-group">

--- a/addons/website_event_track_quiz/views/event_quiz_templates.xml
+++ b/addons/website_event_track_quiz/views/event_quiz_templates.xml
@@ -28,7 +28,7 @@
             </div>
             <div class="list-group">
                 <t t-foreach="question['answer_ids']" t-as="answer">
-                    <a t-att-data-answer-id="answer['id']" href="#"
+                    <button t-att-data-answer-id="answer['id']"
                         t-att-data-text="answer['text_value']"
                         class="o_quiz_quiz_answer list-group-item list-group-item-action d-flex align-items-center">
                         <label class="my-0 d-flex align-items-center justify-content-center me-2">
@@ -42,7 +42,7 @@
                             <i t-att-class="'fa fa-check-circle text-success %s' % ('d-none' if not (quiz_completed and answer['is_correct']) else '')"></i>
                         </label>
                         <span t-out="answer['text_value']"/>
-                    </a>
+                    </button>
                 </t>
             </div>
         </div>


### PR DESCRIPTION
*website_event_booth,website_event_exhibitor,website_event_track, website_event_track_live,website_event_track_live_quiz,website_event_track_quiz

We use `href=#` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href=#` and replaces it with the appropriate element or class to activate the <a> elements correctly.

task-4380519


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
