### PR TITLE
[FIX] html_editor: list structure break on Shift+Tab

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -531,8 +531,7 @@ export class ListPlugin extends Plugin {
             (compareListTypes(previousSibling, element) ||
                 (element.tagName === "LI" &&
                     isListItem(previousSibling) &&
-                    (isListElement(previousSibling.lastChild) ||
-                        isListElement(element.firstChild))))
+                    isListElement(element.firstChild)))
         ) {
             const cursors = this.dependencies.selection.preserveSelection();
             cursors.update(callbacksForCursorUpdate.merge(element));

--- a/addons/html_editor/static/tests/list/outdent.test.js
+++ b/addons/html_editor/static/tests/list/outdent.test.js
@@ -534,6 +534,56 @@ describe("with selection collapsed", () => {
                 <p>[]<br></p>`),
         });
     });
+    test("should correctly merge list items when outdenting nested list", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <ol>
+                    <li>
+                        <div>abc</div>
+                        <ol>
+                            <li>def</li>
+                            <li class="oe-nested">
+                                <div>[]ghi</div>
+                                <ol>
+                                    <li>jkl</li>
+                                </ol>
+                            </li>
+                            <li>mno</li>
+                        </ol>
+                    </li>
+                    <li>pqr</li>
+                </ol>
+            `),
+            stepFunction: (editor) => {
+                keydownShiftTab(editor);
+                keydownShiftTab(editor);
+            },
+            contentAfter: unformat(`
+                <ol>
+                    <li>
+                        <div>abc</div>
+                        <ol>
+                            <li>def</li>
+                        </ol>
+                    </li>
+                </ol>
+                <div>[]ghi</div>
+                <ol>
+                    <li class="oe-nested">
+                        <ol>
+                            <li class="oe-nested">
+                                <ol>
+                                    <li>jkl</li>
+                                </ol>
+                            </li>
+                            <li>mno</li>
+                        </ol>
+                    </li>
+                    <li>pqr</li>
+                </ol>
+            `),
+        });
+    });
 });
 
 describe("with selection", () => {


### PR DESCRIPTION
### Steps to reproduce:

- Open the To-Do.
- Use the following HTML:
```html
<ol>
    <li>
        <div class='o-paragraph'>abc</div>
        <ol>
            <li>def</li>
            <li class='oe-nested'>
                <div class='o-paragraph'>ghi</div>
                <ol>
                    <li>jkl</li>
                </ol>
            </li>
            <li>mno</li>
        </ol>
    </li>
    <li>pqr</li>
</ol>
```
- Place the cursor inside []ghi.
- Press Shift + Tab twice.
- Observe that after two outdents, the list structure breaks.

### Description of the issue/feature this PR addresses:

- While merging similar list items, we checked the last child of the previous sibling or the first child of the current list item.

**This caused merging like:**
```html
<li><div>abc</div><ol><li>def</li></ol></li>
<li><div>ghi</div></li>
```
**Producing invalid structure:**
```html
<li><div>abc</div><ol><li>def</li></ol><div>ghi</div></li>
```

### Desired behavior after PR is merged:

- Checks if the first child of the current element is a list item.

task-5048387

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
