### PR TITLE
[FIX] web: datetime_picker: missing cursor-pointer in grid

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -75,7 +75,7 @@
             <t t-foreach="items" t-as="itemInfo" t-key="itemInfo.id">
                 <t t-set="arInfo" t-value="getActiveRangeInfo(itemInfo)" />
                 <div
-                    class="o_date_item_cell o_datetime_button o_center"
+                    class="o_date_item_cell o_datetime_button o_center cursor-pointer"
                     t-att-class="{
                         o_selected: arInfo.isSelected,
                         o_select_start: arInfo.isSelectStart,


### PR DESCRIPTION
Before this commit, users didn’t get any cursor feedback showing that months or years in the date picker grid view were clickable.

task-4900904

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
