### PR TITLE
[FIX] html_editor: improve CSS numeric unit conversion precision

### DIFF
--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -203,7 +203,7 @@ export function convertNumericToUnit(value, unitFrom, unitTo, htmlStyle) {
     if (converter === undefined) {
         throw new Error(`Cannot convert '${unitFrom}' units into '${unitTo}' units !`);
     }
-    return parseFloat((value * converter(htmlStyle)).toFixed(3));
+    return parseFloat((value * converter(htmlStyle)).toFixed(5));
 }
 
 export function getHtmlStyle(document) {


### PR DESCRIPTION
Before this commit:
The generic CSS unit converter was rounding intermediate values to three decimal places, which caused a slight discrepancy when converting values back and forth between units. As a result, the values shown upon saving differed from the originally entered values. For example, converting 19px yielded 1.188rem, which then converted back to 19.008px.

After this commit:
By increasing the rounding precision from three to five decimal places, round-trip conversions across all supported CSS units now maintain the expected values.
For instance, 19px will convert to 1.18750rem and back to 19px.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
