### PR TITLE
[FIX] hr,hr_org_chart: fixing employee onboarding helper

### DIFF
--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -17,6 +17,7 @@
         'phone_validation',
         'resource_mail',
         'web',
+        'web_hierarchy',
     ],
     'data': [
         'security/hr_security.xml',
@@ -56,6 +57,12 @@
     'assets': {
         'web.assets_backend': [
             'hr/static/src/**/*',
+            ('remove', 'hr/static/src/views/employee_pivot_view.*'),
+            ('remove', 'hr/static/src/views/employee_graph_view.*'),
+        ],
+        'web.assets_backend_lazy': [
+            'hr/static/src/views/employee_pivot_view.*',
+            'hr/static/src/views/employee_graph_view.*',
         ],
         'web.qunit_suite_tests': [
             'hr/static/tests/legacy/**/*',

--- a/addons/hr/static/src/core/common/onboarding/employee_onboarding_helper.js
+++ b/addons/hr/static/src/core/common/onboarding/employee_onboarding_helper.js
@@ -1,0 +1,71 @@
+import { user } from "@web/core/user";
+
+export async function getEmployeeHelper(orm) {
+    const isMainCompany = await orm.call("hr.employee", "is_main_company", [
+        user.context.allowed_company_ids,
+    ]);
+    const isSampleLoaded = await orm.call("hr.employee", "has_demo_data");
+    return new EmployeeOnboardingHelper(!isMainCompany, isSampleLoaded);
+}
+
+export class EmployeeOnboardingHelper {
+    constructor(notOnboarding, isSampleLoaded) {
+        this._notOnboarding = notOnboarding;
+        this._isSampleLoaded = isSampleLoaded;
+    }
+
+    /**
+     * @param {Array<String>} employeeNames Names of the displayed employees (after applying search filters)
+     * @param {Boolean} isSearching Wether there are active search filters or not
+     * @returns {EmployeeOnboardingHelperState}
+     */
+    getState(employeeNames, isSearching) {
+        if (this._notOnboarding) {
+            return new EmployeeOnboardingHelperState("notOnboarding");
+        }
+
+        const employeeNbr = employeeNames.length;
+        if (employeeNbr > 1) {
+            return new EmployeeOnboardingHelperState("hide");
+        }
+        if (employeeNbr == 1) {
+            const adminCount = employeeNames.filter(
+                (employee) => employee == "Administrator"
+            ).length;
+
+            if (adminCount == 0 || this._isSampleLoaded || isSearching) {
+                return new EmployeeOnboardingHelperState("hide");
+            }
+            return new EmployeeOnboardingHelperState("showLoadSample");
+        }
+        if (!this._isSampleLoaded && !isSearching) {
+            return new EmployeeOnboardingHelperState("showLoadSample");
+        }
+        return new EmployeeOnboardingHelperState("showEmpty");
+    }
+}
+
+/**
+ * Class that wraps on of the following values: "notOnboarding", "showEmpty", "showLoadSample" or "hide"
+ */
+export class EmployeeOnboardingHelperState {
+    constructor(state) {
+        this._state = state;
+    }
+
+    get notOnboarding() {
+        return this._state == "notOnboarding";
+    }
+
+    get showLoadSample() {
+        return this._state == "showLoadSample";
+    }
+
+    get showEmpty() {
+        return this._state == "showEmpty";
+    }
+
+    get hideHelper() {
+        return this._state == "hide";
+    }
+}

--- a/addons/hr/static/src/views/employee_graph_view.js
+++ b/addons/hr/static/src/views/employee_graph_view.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+import { graphView } from "@web/views/graph/graph_view";
+import { GraphController } from "@web/views/graph/graph_controller";
+
+export class HrEmployeeGraphController extends GraphController {
+    static template = "hr.EmployeeGraphController";
+}
+
+export const hrEmployeeGraphView = {
+    ...graphView,
+    Controller: HrEmployeeGraphController,
+};
+
+registry.category("views").add("hr_employee_graph", hrEmployeeGraphView);

--- a/addons/hr/static/src/views/employee_graph_view.xml
+++ b/addons/hr/static/src/views/employee_graph_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr.EmployeeGraphController" t-inherit="web.GraphView" t-inherit-mode="primary">
+        <ActionHelper position="replace">
+            <t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp">
+                <ActionHelper noContentHelp="props.noContentHelp" showRibbon="false"/>
+            </t>
+        </ActionHelper>
+    </t>
+</odoo>

--- a/addons/hr/static/src/views/employee_kanban_view.xml
+++ b/addons/hr/static/src/views/employee_kanban_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr.EmployeeKanbanRenderer" t-inherit="web.KanbanRenderer" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_kanban_renderer')]" position="attributes">
+            <attribute name="t-if">!showOnboarding</attribute>
+        </xpath>
+        <xpath expr="." position="inside">
+            <EmployeeOnboarding t-if="showOnboarding" showLoadSample="showLoadSample"/>
+        </xpath>
+        <ActionHelper position="replace">
+            <t t-if="showNoContentHelper">
+                <ActionHelper noContentHelp="props.noContentHelp" showRibbon="false"/>
+            </t>
+        </ActionHelper>
+    </t>
+</odoo>

--- a/addons/hr/static/src/views/employee_list_view.xml
+++ b/addons/hr/static/src/views/employee_list_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr.EmployeeListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
+        <xpath expr="//thead" position="attributes">
+            <attribute name="t-if">!showOnboarding</attribute>
+        </xpath>
+        <xpath expr="//tbody" position="attributes">
+            <attribute name="t-if">!showOnboarding</attribute>
+        </xpath>
+        <xpath expr="//div[hasclass('o_list_renderer')]" position="inside">
+            <div class="o_view_nocontent">
+                <EmployeeOnboarding t-if="showOnboarding" showLoadSample="showLoadSample" />
+            </div>
+        </xpath>
+        <ActionHelper position="replace">
+            <t t-if="showNoContentHelper">
+                <ActionHelper noContentHelp="props.noContentHelp" showRibbon="false" />
+            </t>
+        </ActionHelper>
+    </t>
+</odoo>

--- a/addons/hr/static/src/views/employee_onboarding_view.js
+++ b/addons/hr/static/src/views/employee_onboarding_view.js
@@ -1,0 +1,38 @@
+import { Component } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+import { OnboardingHelperBlocks } from "./onboarding/onboarding_helper_blocks";
+
+export class EmployeeOnboarding extends Component {
+    static template = "hr.EmployeeOnboarding";
+    static props = {
+        showLoadSample: { type: Boolean },
+    };
+    static components = { OnboardingHelperBlocks };
+
+    setup() {
+        super.setup();
+        this.actionService = useService("action");
+    }
+
+    get showLoadSample() {
+        return this.props.showLoadSample;
+    }
+
+    loadDemoData() {
+        this.actionService.doAction("hr.action_hr_employee_load_demo_data");
+    }
+
+    loadCreateEmployee() {
+        this.actionService.doAction({
+            name: _t("Employees"),
+            res_model: "hr.employee",
+            type: "ir.actions.act_window",
+            views: [[false, "form"]],
+            view_mode: "form",
+            target: "current",
+        });
+    }
+}

--- a/addons/hr/static/src/views/employee_onboarding_view.xml
+++ b/addons/hr/static/src/views/employee_onboarding_view.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr.EmployeeOnboarding">
+        <div class="o_nocontent_help">
+            <div t-if="showLoadSample">
+                <p class="text-center fs-1">
+                    Ready to start your experience?
+                </p>
+                <div class="px-2 py-2 row justify-content-center g-2 column-gap-3 mb-3">
+                    <div class="col-auto align-self-center">
+                        <a class="btn btn-primary text-nowrap text-overflow-ellipsis px-3"
+                            t-on-click="loadDemoData" id="loadSampleDataBtn">
+                            Load sample data
+                        </a>
+                    </div>
+                    <div class="col-auto">
+                        <div class="d-flex flex-column gap-1 align-items-center">
+                            <div class="d-flex align-items-center">
+                                <div class="vr" />
+                            </div>
+                            <p class="fst-italic m-0">
+                                or
+                            </p>
+                            <div class="d-flex align-items-center">
+                                <div class="vr" />
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-auto align-self-center">
+                        <a class="btn btn-primary text-nowrap text-overflow-ellipsis px-3"
+                            t-on-click="loadCreateEmployee">Create a new employee</a>
+                    </div>
+                </div>
+                <hr class="my-4 container mt-2 d-none d-md-block" />
+            </div>
+            <OnboardingHelperBlocks />
+        </div>
+    </t>
+</odoo>

--- a/addons/hr/static/src/views/employee_pivot_view.js
+++ b/addons/hr/static/src/views/employee_pivot_view.js
@@ -1,0 +1,15 @@
+import { pivotView } from "@web/views/pivot/pivot_view";
+import { registry } from "@web/core/registry";
+import { PivotController } from "@web/views/pivot/pivot_controller";
+
+export class HrEmployeePivotController extends PivotController {
+    static template = "hr.EmployeePivotController";
+}
+
+const viewRegistry = registry.category("views");
+
+const hrEmployeePivotView = {
+    ...pivotView,
+    Controller: HrEmployeePivotController,
+};
+viewRegistry.add("hr_employee_pivot", hrEmployeePivotView);

--- a/addons/hr/static/src/views/employee_pivot_view.xml
+++ b/addons/hr/static/src/views/employee_pivot_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr.EmployeePivotController" t-inherit="web.PivotView" t-inherit-mode="primary">
+        <ActionHelper position="replace">
+            <t t-if="model.isReady and displayNoContent">
+                <ActionHelper noContentHelp="props.noContentHelp" showRibbon="false"/>
+            </t>
+        </ActionHelper>
+    </t>
+</odoo>

--- a/addons/hr/static/src/views/kanban_view.js
+++ b/addons/hr/static/src/views/kanban_view.js
@@ -1,9 +1,15 @@
-import { registry } from "@web/core/registry";
+import { onWillStart } from "@odoo/owl";
 
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
 import { kanbanView } from "@web/views/kanban/kanban_view";
+import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
 import { KanbanController } from "@web/views/kanban/kanban_controller";
 
-import { useArchiveEmployee } from "@hr/views/archive_employee_hook";
+import { getEmployeeHelper } from "@hr/core/common/onboarding/employee_onboarding_helper";
+import { EmployeeOnboarding } from "./employee_onboarding_view";
+import { useArchiveEmployee } from "./archive_employee_hook";
+import { OnboardingHelperBlocks } from "./onboarding/onboarding_helper_blocks";
 
 export class EmployeeKanbanController extends KanbanController {
     setup() {
@@ -23,7 +29,50 @@ export class EmployeeKanbanController extends KanbanController {
     }
 }
 
+export class EmployeeKanbanRenderer extends KanbanRenderer {
+    static template = "hr.EmployeeKanbanRenderer";
+    static components = {
+        ...KanbanRenderer.components,
+        EmployeeOnboarding,
+        OnboardingHelperBlocks,
+    };
+
+    setup() {
+        super.setup();
+        this.state.helper = null;
+        this.orm = useService("orm");
+        onWillStart(async () => {
+            this.state.helper = await getEmployeeHelper(this.orm);
+        });
+    }
+
+    get _employeeNames() {
+        return this.env.model.root.records.map((record) => record.data.name);
+    }
+
+    get _isSearching() {
+        return this.env.searchModel.searchDomain?.length > 1;
+    }
+
+    get showOnboarding() {
+        const state = this.state.helper.getState(this._employeeNames, this._isSearching);
+        return !(state.notOnboarding || state.hideHelper);
+    }
+
+    get showLoadSample() {
+        return this.state.helper.getState(this._employeeNames, this._isSearching).showLoadSample;
+    }
+
+    get showNoContentHelper() {
+        if (this.showOnboarding) {
+            return false;
+        }
+        return super.showNoContentHelper;
+    }
+}
+
 registry.category("views").add("hr_employee_kanban", {
     ...kanbanView,
+    Renderer: EmployeeKanbanRenderer,
     Controller: EmployeeKanbanController,
 });

--- a/addons/hr/static/src/views/list_view.js
+++ b/addons/hr/static/src/views/list_view.js
@@ -1,9 +1,14 @@
-import { registry } from '@web/core/registry';
+import { onWillStart } from "@odoo/owl";
 
-import { listView } from '@web/views/list/list_view';
-import { ListController } from '@web/views/list/list_controller';
+import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
+import { ListRenderer } from "@web/views/list/list_renderer";
+import { useService } from "@web/core/utils/hooks";
+import { ListController } from "@web/views/list/list_controller";
 
-import { useArchiveEmployee } from '@hr/views/archive_employee_hook';
+import { EmployeeOnboarding } from "./employee_onboarding_view";
+import { getEmployeeHelper } from "@hr/core/common/onboarding/employee_onboarding_helper";
+import { useArchiveEmployee } from "./archive_employee_hook";
 
 export class EmployeeListController extends ListController {
     setup() {
@@ -17,8 +22,8 @@ export class EmployeeListController extends ListController {
 
         menuItems.archive.callback = this.archiveEmployee.bind(
             this,
-            selectedRecords.map(({resId}) => resId),
-        )
+            selectedRecords.map(({ resId }) => resId)
+        );
         return menuItems;
     }
 
@@ -27,7 +32,49 @@ export class EmployeeListController extends ListController {
     }
 }
 
-registry.category('views').add('hr_employee_list', {
+export class EmployeeListRenderer extends ListRenderer {
+    static template = "hr.EmployeeListRenderer";
+    static components = {
+        ...ListRenderer.components,
+        EmployeeOnboarding,
+    };
+
+    setup() {
+        super.setup();
+        this.state.helper = null;
+        this.orm = useService("orm");
+        onWillStart(async () => {
+            this.state.helper = await getEmployeeHelper(this.orm);
+        });
+    }
+
+    get _employeeNames() {
+        return this.env.model.root.records.map((record) => record.data.name);
+    }
+
+    get _isSearching() {
+        return this.env.searchModel.searchDomain?.length > 1;
+    }
+
+    get showOnboarding() {
+        const state = this.state.helper.getState(this._employeeNames, this._isSearching);
+        return !(state.notOnboarding || state.hideHelper);
+    }
+
+    get showLoadSample() {
+        return this.state.helper.getState(this._employeeNames, this._isSearching).showLoadSample;
+    }
+
+    get showNoContentHelper() {
+        if (this.showOnboarding) {
+            return false;
+        }
+        return super.showNoContentHelper;
+    }
+}
+
+registry.category("views").add("hr_employee_list", {
     ...listView,
+    Renderer: EmployeeListRenderer,
     Controller: EmployeeListController,
 });

--- a/addons/hr/static/src/views/onboarding/onboarding_helper_blocks.js
+++ b/addons/hr/static/src/views/onboarding/onboarding_helper_blocks.js
@@ -1,0 +1,8 @@
+import { Component } from "@odoo/owl";
+import { OnboardingIconCard } from "./onboarding_icon_card";
+
+export class OnboardingHelperBlocks extends Component {
+    static template = "hr.OnboardingHelperBlocks";
+    static props = {};
+    static components = { OnboardingIconCard };
+}

--- a/addons/hr/static/src/views/onboarding/onboarding_helper_blocks.xml
+++ b/addons/hr/static/src/views/onboarding/onboarding_helper_blocks.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr.OnboardingHelperBlocks">
+        <div class="container mt-2 d-none d-md-block">
+            <div class="row justify-content-md-center text-center gx-5">
+                <div class="col-md-auto align-items-center mb-4 mx-5">
+                    <p class="fs-2 mb-3">
+                        Hiring
+                    </p>
+                    <div class="d-flex flex-column gap-2 flex-nowrap">
+                        <OnboardingIconCard label.translate="Hiring" iconPath="'/hr_recruitment/static/description/icon.png'"/>
+                        <OnboardingIconCard label.translate="Sign" iconPath="'/sign/static/description/icon.png'"/>
+                        <OnboardingIconCard label.translate="Referral" iconPath="'/hr_referral/static/description/icon.png'"/>
+                    </div>
+                </div>
+                <div class="col-md-auto justify-content-center mb-4 mx-2">
+                    <p class="fs-2 mb-3">
+                        Experience
+                    </p>
+                    <div class="d-flex flex-row flex-nowrap">
+                        <div class="d-flex flex-column gap-2 flex-nowrap me-4">
+                            <OnboardingIconCard label.translate="AI" iconPath="'/ai/static/description/icon.png'"/>
+                            <OnboardingIconCard label.translate="Planning" iconPath="'/planning/static/description/icon.png'"/>
+                            <OnboardingIconCard label.translate="Fleet" iconPath="'/fleet/static/description/icon.png'"/>
+                        </div>
+                        <div class="d-flex flex-column gap-2 flex-nowrap">
+                            <OnboardingIconCard label.translate="Payroll" iconPath="'/hr_payroll/static/description/icon.png'"/>
+                            <OnboardingIconCard label.translate="Leaves" iconPath="'/hr_holidays/static/description/icon.png'"/>
+                            <OnboardingIconCard label.translate="Lunch" iconPath="'/lunch/static/description/icon.png'"/>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-auto justify-content-center mb-4 mx-2">
+                    <p class="fs-2 mb-3">
+                        Development
+                    </p>
+                    <div class="d-flex flex-row flex-nowrap">
+                        <div class="d-flex flex-column gap-2 flex-nowrap me-3">
+                            <OnboardingIconCard label.translate="Performance" iconPath="'/hr_appraisal/static/description/icon.png'"/>
+                            <OnboardingIconCard label.translate="eLearning" iconPath="'/website_slides/static/description/icon.png'"/>
+                            <OnboardingIconCard label.translate="Documents" iconPath="'/documents/static/description/icon.png'"/>
+                        </div>
+                        <div class="d-flex flex-column gap-2 flex-nowrap">
+                            <OnboardingIconCard label.translate="Talent" iconPath="'/hr_skills/static/description/icon.png'"/>
+                            <OnboardingIconCard label.translate="Trainings" iconPath="'/event/static/description/icon.png'"/>
+                            <OnboardingIconCard label.translate="Dashboard" iconPath="'/board/static/description/icon.png'"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</odoo>

--- a/addons/hr/static/src/views/onboarding/onboarding_icon_card.js
+++ b/addons/hr/static/src/views/onboarding/onboarding_icon_card.js
@@ -1,0 +1,9 @@
+import { Component } from "@odoo/owl";
+
+export class OnboardingIconCard extends Component {
+    static template = "hr.OnboardingIconCard";
+    static props = {
+        label: { type: String },
+        iconPath: { type: String },
+    };
+}

--- a/addons/hr/static/src/views/onboarding/onboarding_icon_card.xml
+++ b/addons/hr/static/src/views/onboarding/onboarding_icon_card.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr.OnboardingIconCard">
+        <div class="vstack">
+            <div class="col align-self-center mb-1">
+                <img t-att-src="props.iconPath" width="60" />
+            </div>
+            <small t-esc="props.label"/>
+        </div>
+    </t>
+</odoo>

--- a/addons/hr/static/tests/tours/hr_employee_sample_data_tour.js
+++ b/addons/hr/static/tests/tours/hr_employee_sample_data_tour.js
@@ -1,0 +1,20 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("load_employee_sample_data_tour", {
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Employees app",
+            trigger: ".o_app[data-menu-xmlid='hr.menu_hr_root']",
+            run: "click",
+        },
+        {
+            content: "Click on 'Load Sample data' button",
+            trigger: ".o_nocontent_help a#loadSampleDataBtn",
+            run: "click",
+            expectUnloadPage: true,
+        },
+    ],
+});

--- a/addons/hr/static/tests/web/test_employee_load_sample_data.test.js
+++ b/addons/hr/static/tests/web/test_employee_load_sample_data.test.js
@@ -1,0 +1,46 @@
+import { test, expect } from "@odoo/hoot";
+import { EmployeeOnboardingHelper } from "@hr/core/common/onboarding/employee_onboarding_helper";
+
+test("EmployeeOnboardingHelperState test", () => {
+    // Case 1: we are not on onboarding (not on the main_company)
+    let stateGetter = new EmployeeOnboardingHelper(true, false);
+    let result = stateGetter.getState(["Administrator"], false);
+    _testHelperState(result, "notOnboarding");
+
+    // Case 2: on onboarding, no searching filters, only administrator being displayed, sample data still haven't been loaded
+    stateGetter = new EmployeeOnboardingHelper(false, false);
+    result = stateGetter.getState(["Administrator"], false);
+    _testHelperState(result, "showLoadSample");
+
+    // Case 3: same as case 2, but sample data have already been loaded -> hideHelper
+    stateGetter = new EmployeeOnboardingHelper(false, true);
+    result = stateGetter.getState(["Administrator"], false);
+    _testHelperState(result, "hideHelper");
+
+    // Case 4: same as case 2, but there's too many employee -> hideHelper
+    stateGetter = new EmployeeOnboardingHelper(false, false);
+    result = stateGetter.getState(["Administrator", "Lancelot"], false);
+    _testHelperState(result, "hideHelper");
+
+    // Case 5: same as case 2, but the only employee is not the Administrator -> hideHelper
+    stateGetter = new EmployeeOnboardingHelper(false, false);
+    result = stateGetter.getState(["Lancelot"], false);
+    _testHelperState(result, "hideHelper");
+
+    // Case 6: same as case 2, but there are searching filters in the view -> showEmpty (show onboarding helper blocks)
+    stateGetter = new EmployeeOnboardingHelper(false, false);
+    result = stateGetter.getState([], true);
+    _testHelperState(result, "showEmpty");
+
+    // Case 7: on onboarding, sample data loaded, no employee -> showEmpty
+    stateGetter = new EmployeeOnboardingHelper(false, true);
+    result = stateGetter.getState([], false);
+    _testHelperState(result, "showEmpty");
+});
+
+function _testHelperState(state, expected) {
+    expect(state.notOnboarding).toBe(expected == "notOnboarding");
+    expect(state.showLoadSample).toBe(expected == "showLoadSample");
+    expect(state.hideHelper).toBe(expected == "hideHelper");
+    expect(state.showEmpty).toBe(expected == "showEmpty");
+}

--- a/addons/hr/tests/__init__.py
+++ b/addons/hr/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_scenario
 from . import test_hr_department
 from . import test_hr_version
 from . import test_hr_contract_versions
+from . import test_onboarding_employee

--- a/addons/hr/tests/test_onboarding_employee.py
+++ b/addons/hr/tests/test_onboarding_employee.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged, users
+
+
+@tagged('-at_install', 'post_install')
+class TestOnboardingEmployee(HttpCase):
+    @users('admin')
+    def test_load_sample_data(self):
+        """
+        Assert that the 'Load sample button' of the onboarding action helper is displayed and works
+        It should only be displayed when on 'base.main_company', when the sample data have not been
+        loaded and when there is 0 or 1 (the admin) employee
+        """
+        self.assertFalse(self.env['hr.employee'].has_demo_data(), "This method should be run when sample data still haven't been loaded")
+
+        self.start_tour('/odoo', 'load_employee_sample_data_tour', login=self.env.user.login)
+        employees = self.env["hr.employee"].search([
+            ['company_id', '=', self.env.ref('base.main_company').id],
+            ['name', '!=', 'Administrator'],
+        ])
+        # 3 sample employees
+        self.assertEqual(len(employees), 3, "The 3 sample employees should've been loaded.")

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -234,7 +234,7 @@
                                             <field name="private_street" placeholder="Street..." class="o_address_street"/>
                                             <field name="private_street2" placeholder="Street 2..." class="o_address_street"/>
                                             <field name="private_city" placeholder="City" class="o_address_city"/>
-                                            <field name="private_state_id" class="o_address_state" placeholder="State" 
+                                            <field name="private_state_id" class="o_address_state" placeholder="State"
                                                 options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}"
                                                 domain="[('country_id', '=', private_country_id)]"/>
                                             <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
@@ -332,7 +332,7 @@
             <field name="name">hr.employee.view.graph</field>
             <field name="model">hr.employee</field>
             <field name="arch" type="xml">
-                <graph string="New Employees Over Time" type="line" sample="1">
+                <graph string="New Employees Over Time" type="line" sample="1" js_class="hr_employee_graph">
                     <field name="contract_date_start" interval="month"/>
                     <field name="id"/>
                     <field name="color" type="measure" invisible="1"/>
@@ -347,7 +347,7 @@
             <field name="name">hr.employee.view.pivot</field>
             <field name="model">hr.employee</field>
             <field name="arch" type="xml">
-                <pivot string="New Employees Over Time" sample="1">
+                <pivot string="New Employees Over Time" sample="1" js_class="hr_employee_pivot">
                     <field name="job_id" type="row"/>
                     <field name="contract_date_start" interval="year" type="col"/>
                     <field name="id"/>
@@ -419,7 +419,7 @@
             <field name="model">hr.employee</field>
             <field name="priority">10</field>
             <field name="arch" type="xml">
-                <kanban class="o_hr_employee_kanban" sample="1" duplicate="false">
+                <kanban class="o_hr_employee_kanban" sample="1" duplicate="false" js_class="hr_employee_kanban">
                     <field name="show_hr_icon_display"/>
                     <field name="image_128" />
                     <field name="company_id"/>
@@ -551,107 +551,9 @@
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="view_employee_filter"/>
             <field name="help" type="html">
-                <div class="o_view_nocontent">
-                    <div class="o_nocontent_help">
-                        <div>
-                            <p class="text-center fs-1">
-                                Ready to start your experience?
-                            </p>
-                            <div class="px-2 py-2 row justify-content-center g-2">
-                                <div class="col-12 col-md-3">
-                                    <a class="btn btn-primary w-100 text-nowrap text-overflow-ellipsis" type="action" name="%(action_hr_employee_load_demo_data)d" tabindex="-1">Load sample data.</a>
-                                </div>
-                            </div>
-                            <hr class="my-4"/>
-                        </div>
-                        <div>
-                            <div class="container">
-                                <div class="row text-center">
-                                    <div class="col-12 col-sm-4">
-                                        <p class="fs-2 mb-0">Hiring</p>
-                                    </div>
-                                    <div class="col-12 col-sm-4">
-                                        <p class="fs-2 mb-0">Experience</p>
-                                    </div>
-                                    <div class="col-12 col-sm-4">
-                                        <p class="fs-2 mb-0">Development</p>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="container mt-4 d-none d-md-block">
-                                <div class="row text-center">
-                                    <div class="col-md-4 d-flex flex-column align-items-center gap-4 mb-4">
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/hr_recruitment/static/description/icon.png" width="60"/>
-                                            <small>Hiring</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/sign/static/description/icon.png" width="60"/>
-                                            <small>Sign</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/hr_referral/static/description/icon.png" width="60"/>
-                                            <small>Referral</small>
-                                        </div>
-                                    </div>
-                                    <div class="col-md-4 d-flex flex-wrap justify-content-center gap-4 mb-4">
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/ai/static/description/icon.png" width="60"/>
-                                            <small>AI</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/hr_payroll/static/description/icon.png" width="60"/>
-                                            <small>Payroll</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/planning/static/description/icon.png" width="60"/>
-                                            <small>Planning</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/hr_holidays/static/description/icon.png" width="60"/>
-                                            <small>Leaves</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/fleet/static/description/icon.png" width="60"/>
-                                            <small>Fleet</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/lunch/static/description/icon.png" width="60"/>
-                                            <small>Lunch</small>
-                                        </div>
-                                    </div>
-                                    <div class="col-md-4 d-flex flex-wrap justify-content-center gap-4 mb-4">
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/hr_appraisal/static/description/icon.png" width="60"/>
-                                            <small>Performance</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/hr_skills/static/description/icon.png" width="60"/>
-                                            <small>Talent</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/website_slides/static/description/icon.png" width="60"/>
-                                            <small>eLearning</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/event/static/description/icon.png" width="60"/>
-                                            <small>Trainings</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/documents/static/description/icon.png" width="60"/>
-                                            <small>Documents</small>
-                                        </div>
-                                        <div class="d-flex flex-column align-items-center">
-                                            <img src="/board/static/description/icon.png" width="60"/>
-                                            <small>Dashboard</small>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <p class="o_view_nocontent_smiling_face">
+                    Create New Employee
+                </p>
             </field>
         </record>
 

--- a/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_controller.js
+++ b/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_controller.js
@@ -1,0 +1,32 @@
+import { onWillStart, useState } from "@odoo/owl";
+import { HierarchyController } from "@web_hierarchy/hierarchy_controller";
+import { useService } from "@web/core/utils/hooks";
+import { getEmployeeHelper } from "@hr/core/common/onboarding/employee_onboarding_helper";
+
+export class HrEmployeeHierarchyController extends HierarchyController {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.state = useState({ helper: null });
+        onWillStart(async () => {
+            this.state.helper = await getEmployeeHelper(this.orm);
+        });
+    }
+
+    get employeeNames() {
+        return this.model.root.rootNodes.map((node) => node.data.name);
+    }
+
+    get showOnboarding() {
+        const isSearching = this.env.searchModel.searchDomain?.length > 1;
+        const state = this.state.helper.getState(this.employeeNames, isSearching);
+        return !(state.notOnboarding || state.hideHelper);
+    }
+
+    get displayNoContent() {
+        if (this.showOnboarding) {
+            return false;
+        }
+        return super.displayNoContent;
+    }
+}

--- a/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.js
+++ b/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.js
@@ -1,13 +1,44 @@
 import { Avatar } from "@mail/views/web/fields/avatar/avatar";
+import { onWillStart, useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
 
+import { getEmployeeHelper } from "@hr/core/common/onboarding/employee_onboarding_helper";
 import { HierarchyRenderer } from "@web_hierarchy/hierarchy_renderer";
 import { HrEmployeeHierarchyCard } from "./hr_employee_hierarchy_card";
+import { EmployeeOnboarding } from "@hr/views/employee_onboarding_view";
 
 export class HrEmployeeHierarchyRenderer extends HierarchyRenderer {
     static template = "hr_org_chart.HrEmployeeHierarchyRenderer";
     static components = {
         ...HierarchyRenderer.components,
+        EmployeeOnboarding,
         HierarchyCard: HrEmployeeHierarchyCard,
         Avatar,
     };
+
+    setup() {
+        super.setup();
+        this.state = useState({ helper: null });
+        this.orm = useService("orm");
+        onWillStart(async () => {
+            this.state.helper = await getEmployeeHelper(this.orm);
+        });
+    }
+
+    get _employeeNames() {
+        return this.props.model.root.rootNodes.map((node) => node.data.name);
+    }
+
+    get _isSearching() {
+        return this.env.searchModel.searchDomain?.length > 1;
+    }
+
+    get showLoadSample() {
+        return this.state.helper.getState(this._employeeNames, this._isSearching).showLoadSample;
+    }
+
+    get showOnboarding() {
+        const state = this.state.helper.getState(this._employeeNames, this._isSearching);
+        return !(state.notOnboarding || state.hideHelper);
+    }
 }

--- a/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.xml
+++ b/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.xml
@@ -9,6 +9,11 @@
                 displayName="row.parentNode.data.display_name || row.parentNode.data.name"
             />
         </xpath>
+        <xpath expr="//div[hasclass('o_hierarchy_renderer')]" position="attributes">
+            <attribute name="t-if">!showOnboarding</attribute>
+        </xpath>
+        <xpath expr="." position="inside">
+            <EmployeeOnboarding t-if="showOnboarding" showLoadSample="showLoadSample"/>
+        </xpath>
     </t>
-
 </templates>

--- a/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_view.js
+++ b/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_view.js
@@ -2,10 +2,12 @@ import { registry } from "@web/core/registry";
 
 import { hierarchyView } from "@web_hierarchy/hierarchy_view";
 import { HrEmployeeHierarchyRenderer } from "./hr_employee_hierarchy_renderer";
+import { HrEmployeeHierarchyController } from "./hr_employee_hierarchy_controller";
 
 export const hrEmployeeHierarchyView = {
     ...hierarchyView,
     Renderer: HrEmployeeHierarchyRenderer,
+    Controller: HrEmployeeHierarchyController,
 };
 
 registry.category("views").add("hr_employee_hierarchy", hrEmployeeHierarchyView);

--- a/addons/hr_org_chart/static/tests/hr_employee_hierarchy_view.test.js
+++ b/addons/hr_org_chart/static/tests/hr_employee_hierarchy_view.test.js
@@ -24,6 +24,14 @@ class Employee extends models.Model {
         return false;
     }
 
+    has_demo_data() {
+        return false;
+    }
+
+    is_main_company(companyIds) {
+        return false;
+    }
+
     _views = {
         hierarchy: `
             <hierarchy js_class="hr_employee_hierarchy">


### PR DESCRIPTION
## Issue
The load sample data button of the employee onboarding helper doesn't work.

## PR Purpose

1) Add a "New employee" button to the onboarding view

2) Display the onboarding employee view only when :
    - 'My Company' is being displayed
    - There is 0 or 1 (Administrator) employee in 'My Company'
    - The demo data have not been loaded

3) When you jump on an empty screen due to a search, display only the onboarding "helper blocks" (design)

Task: #4879557

Signed-off by thha
