### PR TITLE
[IMP] base: Merge stored computed fields with partner merge

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -261,7 +261,9 @@ class MergePartnerAutomatic(models.TransientModel):
         values_by_company = defaultdict(dict)   # {company: vals}
         for column in model_fields:
             field = dst_partner._fields[column]
-            if field.type not in ('many2many', 'one2many') and field.compute is None:
+            if field.type not in ("many2many", "one2many") and (
+                field.compute is None or (field.compute is not None and field.store)
+            ):
                 for item in itertools.chain(src_partners, [dst_partner]):
                     if item[column]:
                         if field.type == 'reference':


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When merging contacts if a field is computed it never passes to the new contact, even if the field is stored. My impression is that these type of fields are for when you need to compute a value to start with or if it's affected by some other field but you have free reign to change the value later on.
For example the salesperson `user_id` is a computed field because it automatically fills with the value of its parent but if the contact has no parent it acts like any normal many2one, but this field doesn't get merged because it's flagged as computed.

I've looked through issues and PRs but I haven't seen any discussion on this topic so there might be a way around this that I'm missing, however I think this is more just due to that base Odoo modules don't have many of these type of fields to really come into contact with the problem, the easiest ones to test are `user_id` from `base` and `team_id` from `crm` (this should be the full list of affected fields with most community+enterprise modules installed `["email_normalized","image_1024","image_512","image_256","image_128","complete_name","user_id","company_registry","partner_share","commercial_partner_id","commercial_company_name","contact_address_complete","team_id","phone_sanitized","ubl_cii_format","peppol_endpoint","peppol_ea"]`)

I'm pointing this PR to 17.0 since it's the version I'm using but I understand it might be a bit inappropriate for a stable version, perhaps it might be ok for master if there's no glaring issue I've missed

Current behavior before PR:

<details><summary>Screenshots of current merge without salesperson in 17.0 runbot</summary>
<p>

<img width="1216" height="578" alt="imagen" src="https://github.com/user-attachments/assets/a4a770b4-b547-4b91-8de3-8d67e2100db4" />
<img width="1216" height="578" alt="imagen" src="https://github.com/user-attachments/assets/1c29e130-62b0-47fc-94b5-65ccfedb6694" />
<img width="1437" height="541" alt="imagen" src="https://github.com/user-attachments/assets/d183be69-3052-4b90-9c20-3665dde52092" />
<img width="1240" height="600" alt="imagen" src="https://github.com/user-attachments/assets/d6c555d7-4e3a-4e9b-9429-47a2c9ee216b" />

</p>
</details> 


Desired behavior after PR is merged:

<details><summary>Screenshots from local clean 17.0 db with PR change applied</summary>
<p>

<img width="1240" height="600" alt="imagen" src="https://github.com/user-attachments/assets/c59c80b4-0fc5-40eb-b9be-67fcf150f967" />
<img width="1240" height="600" alt="imagen" src="https://github.com/user-attachments/assets/fa0fbf23-b06a-4408-b3c3-47fd128d6b1f" />
<img width="1422" height="637" alt="imagen" src="https://github.com/user-attachments/assets/b215b784-ce3f-4b75-a2cc-d5d49ff1cdd6" />
<img width="1233" height="578" alt="imagen" src="https://github.com/user-attachments/assets/a681dcad-2970-471e-9645-c065143e7e74" />


</p>
</details> 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
