### PR TITLE
[FIX] website: fix sub-options level in header options

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
@@ -10,10 +10,10 @@
         </BuilderSelect>
     </BuilderRow>    
     <t t-if="isActiveItem('overTheContent')">
-        <BuilderRow label.translate="Background" level="2" t-if="props.doesPageOptionExist('header_color')">
+        <BuilderRow label.translate="Background" level="1" t-if="props.doesPageOptionExist('header_color')">
             <BuilderColorPicker action="'setPageWebsiteDirty'" styleAction="'background-color'" enabledTabs="['custom']"/>
         </BuilderRow>
-        <BuilderRow label.translate="Text Color" level="2" t-if="props.doesPageOptionExist('header_text_color')">
+        <BuilderRow label.translate="Text Color" level="1" t-if="props.doesPageOptionExist('header_text_color')">
             <BuilderColorPicker action="'setPageWebsiteDirty'" styleAction="'color'" enabledTabs="['solid', 'custom']"/>
         </BuilderRow>
     </t>

--- a/addons/website/static/tests/builder/options/top_menu_visibility_option.test.js
+++ b/addons/website/static/tests/builder/options/top_menu_visibility_option.test.js
@@ -91,7 +91,7 @@ test("undo and comeback to a custom overTheContent color", async () => {
     await contains(":iframe #wrapwrap > header").click();
     await contains("[data-label='Header Position'] .dropdown").click();
     await contains(".o-overlay-container [data-action-value='overTheContent']").click();
-    await contains("[data-label='Background'].hb-row-sublevel-2 .o_we_color_preview").click();
+    await contains("[data-label='Background'].hb-row-sublevel-1 .o_we_color_preview").click();
     await contains("[data-color='600']").click();
     const precedentWrapwrap = queryOne(":iframe #wrapwrap").outerHTML;
     await contains("[data-label='Header Position'] .dropdown").click();

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -25,7 +25,7 @@ registerWebsitePreviewTour('website_page_options', {
     ...clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
     {
         content: "Open the color picker to change the backaground color of the header",
-        trigger:"div[data-container-title='Header'] .hb-row-sublevel-2[data-label='Background'] button",
+        trigger:"div[data-container-title='Header'] .hb-row[data-label='Header Position'] + .hb-row-sublevel-1[data-label='Background'] button",
         run: "click",
     },
     {
@@ -42,7 +42,7 @@ registerWebsitePreviewTour('website_page_options', {
     ...clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
     {
         content: "Open the color picker to change the text color of the header",
-        trigger: "div[data-container-title='Header'] .hb-row-sublevel-2[data-label='Text Color'] button",
+        trigger: "div[data-container-title='Header'] .hb-row-sublevel-1[data-label='Text Color'] button",
         run: "click",
     },
     {


### PR DESCRIPTION
The sub-option levels under "Header Position" were not correct. Since the main option is not a "level 1" anymore, the sub-options should not be "level 2". This commit fixes this issue.

task-4556047