### PR TITLE
[FIX] website: account for keyboard accessibility on snippets

### DIFF
--- a/addons/website/static/src/snippets/s_ecomm_categories_showcase/000.scss
+++ b/addons/website/static/src/snippets/s_ecomm_categories_showcase/000.scss
@@ -67,11 +67,13 @@
             transition: flex 0.3s ease-out;
         }
 
-        .s_ecomm_categories_showcase_wrapper:hover .s_ecomm_categories_showcase_block {
+        .s_ecomm_categories_showcase_wrapper:hover .s_ecomm_categories_showcase_block,
+        .s_ecomm_categories_showcase_wrapper:focus-within .s_ecomm_categories_showcase_block:not(:focus-within) {
             flex: var(--ecomm-categories-showcase-flex-base);
         }
 
-        .s_ecomm_categories_showcase_wrapper:hover .s_ecomm_categories_showcase_block:hover {
+        .s_ecomm_categories_showcase_wrapper:hover .s_ecomm_categories_showcase_block:hover
+        .s_ecomm_categories_showcase_wrapper .s_ecomm_categories_showcase_block:focus-within {
             flex: 3;
         }
 

--- a/addons/website/static/src/snippets/s_ecomm_categories_showcase/categories_showcase.scss
+++ b/addons/website/static/src/snippets/s_ecomm_categories_showcase/categories_showcase.scss
@@ -23,12 +23,12 @@
         }
     }
 
-    &:hover [data-snippet="s_ecomm_categories_showcase"] {
+    &:is(:hover, :focus-visible) [data-snippet="s_ecomm_categories_showcase"] {
         .s_ecomm_categories_showcase_wrapper {
             .s_ecomm_categories_showcase_block {
                 flex: 1;
 
-                &:nth-child(2):hover, &:nth-child(2) {
+                &:nth-child(2) {
                     flex: 3;
                 }
             }

--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.js
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.js
@@ -1,3 +1,5 @@
+import { convertNumericToUnit, getHtmlStyle } from "@html_editor/utils/formatting";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
 
@@ -15,6 +17,7 @@ export class FloatingBlocks extends Interaction {
                 "top": this.boxesTops.get(blockEl),
                 "transform": this.boxesTransforms.get(blockEl),
             }),
+            "t-on-keydown": this.onKeydown,
         },
     };
 
@@ -169,6 +172,25 @@ export class FloatingBlocks extends Interaction {
      */
     onScroll() {
         this.updateZoom();
+    }
+    /**
+     * Support Shift+Tab navigation
+     *
+     * @param {KeyboardEvent} ev
+     */
+    onKeydown(ev) {
+        const hotkey = getActiveHotkey(ev);
+        if (hotkey === "shift+tab") {
+            this.addListener(ev.currentTarget, "focusout", this.onShiftTabFocusout.bind(this), { once: true });
+        }
+    }
+    onShiftTabFocusout(ev) {
+        if (!ev.relatedTarget || ev.relatedTarget.closest(".s_floating_blocks_block") === ev.currentTarget) {
+            return;
+        }
+        // Account for `.gap-5` on the container.
+        const gap = convertNumericToUnit(3, "rem", "px", getHtmlStyle(document));
+        scrollTo(0, window.scrollY - (this.snippetHeight + gap));
     }
 }
 

--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.scss
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.scss
@@ -25,7 +25,7 @@
             }
         }
     }
-    &:hover [data-snippet="s_floating_blocks"] .s_floating_blocks_block:nth-child(1) {
+    &:is(:hover, :focus-visible) [data-snippet="s_floating_blocks"] .s_floating_blocks_block:nth-child(1) {
         margin: 3% 0 -30%;
         transform: scale(.95);
     }


### PR DESCRIPTION
Snippets `.s_floating_blocks` added in [493ea3e] and `.s_ecomm_categories_showcase` added in [efe5de2] work nicely on mobile and with a mouse, but have some shortcomings when it comes to keyboard navigation:

- Floating blocks are properly scrolled when using "Tab", but failed to scroll back up when pressing "Shift+Tab".
- Categories showcase did not expand when going through the cards with "Tab".

Additionnally, [9ae02d8] made the snippet previews focusable, and the hover effects of both those snippets where not rendered on focus. This is now the case.

[493ea3e]: https://github.com/odoo/odoo/commit/493ea3e43a18e8ad5e33a165f760851ae26a70e9
[efe5de2]: https://github.com/odoo/odoo/commit/efe5de268e5914723986c045289e6db22c8c07a9
[9ae02d8]: https://github.com/odoo/odoo/commit/9ae02d80894d4043e49d8e2cad068f8018e6f113
