### PR TITLE
[IMP] sale: make _create_so classmethod

### DIFF
--- a/addons/sale/tests/common.py
+++ b/addons/sale/tests/common.py
@@ -47,17 +47,18 @@ class SaleCommon(
     def _enable_discounts(cls):
         cls.env.user.group_ids += cls.group_discount_per_so_line
 
-    def _create_so(self, **values):
+    @classmethod
+    def _create_so(cls, **values):
         default_values = {
-            'partner_id': self.partner.id,
+            'partner_id': cls.partner.id,
             'order_line': [
                 Command.create({
-                    'product_id': self.product.id,
+                    'product_id': cls.product.id,
                 }),
             ],
-            **values
+            **values,
         }
-        return self.env['sale.order'].create(default_values)
+        return cls.env['sale.order'].create(default_values)
 
 
 class TestSaleCommon(AccountTestInvoicingCommon):


### PR DESCRIPTION
This commit improves the common utility methods in sales. Specifically, it converts the `_create_so` method into a classmethod, making it available during `setUpClass`.

See also:
- https://github.com/odoo/enterprise/pull/88689