### PR TITLE
[FIX] packaging: fix fedora packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'idna',
         'Jinja2',
         'lxml',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
+        'lxml_html_clean',
         'libsass',
         'MarkupSafe',
         'num2words',

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -1,11 +1,10 @@
 # Please note that this Dockerfile is used for testing nightly builds and should
 # not be used to deploy Odoo
-FROM fedora:38
+FROM fedora:42
 MAINTAINER Odoo S.A. <info@odoo.com>
 
 # Dependencies and postgres
-RUN dnf update -d 0 -e 0 -y && \
-    dnf install -d 0 -e 0 \
+RUN dnf install \
         createrepo \
         libsass \
         postgresql \
@@ -31,6 +30,7 @@ RUN dnf update -d 0 -e 0 -y && \
         python3-jinja2 \
         python3-libsass \
         python3-lxml \
+        python3-lxml-html-clean \
         python3-magic \
         python3-markupsafe \
         python3-mock \
@@ -60,12 +60,12 @@ RUN dnf update -d 0 -e 0 -y && \
         python3-xlsxwriter \
         python3-xlwt \
         python3-zeep \
-        rpmdevtools -y && \
+        rpmdevtools -y -q && \
     dnf clean all
 
 # Postgres configuration
-RUN mkdir -p /var/lib/postgres/data
-RUN chown -R postgres:postgres /var/lib/postgres/data
+RUN mkdir -p /var/lib/postgres/data /var/run/postgresql
+RUN chown -R postgres:postgres /var/lib/postgres/data /var/run/postgresql
 RUN su postgres -c "initdb -D /var/lib/postgres/data -E UTF-8"
 RUN cp /usr/share/pgsql/postgresql.conf.sample /var/lib/postgres/data/postgresql.conf
 

--- a/setup/rpm/odoo.spec
+++ b/setup/rpm/odoo.spec
@@ -1,5 +1,4 @@
 %global name odoo
-%global release 1
 %global unmangled_version %{version}
 %global __requires_exclude ^.*odoo/addons/mail/static/scripts/odoo-mailgate.py$
 
@@ -102,8 +101,14 @@ KillMode=mixed
 WantedBy=multi-user.target
 EOF
 
-
 %files
 %{_bindir}/odoo
 %{python3_sitelib}/%{name}-*.egg-info
 %{python3_sitelib}/%{name}
+%pycached %exclude %{python3_sitelib}/doc/cla/stats.py
+%pycached %exclude %{python3_sitelib}/setup/*.py
+%exclude %{python3_sitelib}/setup/odoo
+
+%changelog
+* %{build_date} Christophe Monniez <moc@odoo.com> - %{version}-%{release}
+- Latest updates


### PR DESCRIPTION
- Bump Fedora version in build Dockerfile to 42
- Adapt `dnf`commands to `dnf5` which is now the default
- Adapt `lxml-html-clean` dependency
- Fix postgresql missing directories
- Adapt rpmbuild command with appropriate variables
- Fix rpm spec to exclude unneeded files
- Add a mandatory minimal changelog in spec file

