### PR TITLE
[IMP] pos_self_order: display network lost popup with auto-retry

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -242,20 +242,20 @@ class PosSelfOrderController(http.Controller):
         amount_total = sum(lines.mapped('price_subtotal_incl'))
         return amount_total, amount_untaxed
 
-    def _verify_pos_config(self, access_token):
+    def _verify_pos_config(self, access_token, check_active_session=True):
         """
         Finds the pos.config with the given access_token and returns a record with reduced privileges.
         The record is has no sudo access and is in the context of the record's company and current pos.session's user.
         """
         pos_config_sudo = request.env['pos.config'].sudo().search([('access_token', '=', access_token)], limit=1)
-        if self._verify_config_constraint(pos_config_sudo):
+        if self._verify_config_constraint(pos_config_sudo, check_active_session):
             raise Unauthorized("Invalid access token")
         company = pos_config_sudo.company_id
         user = pos_config_sudo.self_ordering_default_user_id
         return pos_config_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids)
 
-    def _verify_config_constraint(self, pos_config_sudo):
-        return not pos_config_sudo or (pos_config_sudo.self_ordering_mode != 'mobile' and pos_config_sudo.self_ordering_mode != 'kiosk') or not pos_config_sudo.has_active_session
+    def _verify_config_constraint(self, pos_config_sudo, check_active_session=True):
+        return not pos_config_sudo or (pos_config_sudo.self_ordering_mode != 'mobile' and pos_config_sudo.self_ordering_mode != 'kiosk') or (check_active_session and not pos_config_sudo.has_active_session)
 
     def _verify_authorization(self, access_token, table_identifier, order):
         """
@@ -273,3 +273,8 @@ class PosSelfOrderController(http.Controller):
         user = pos_config.self_ordering_default_user_id
         table = table_sudo.sudo(False).with_company(company).with_user(user).with_context(allowed_company_ids=company.ids)
         return pos_config, table
+
+    @http.route(['/pos-self/ping'], type='jsonrpc', auth='public')
+    def pos_ping(self, access_token):
+        self._verify_pos_config(access_token, check_active_session=False)
+        return {'response': 'pong'}

--- a/addons/pos_self_order/static/src/app/components/network_connectionLost_popup/network_connectionLost_popup.js
+++ b/addons/pos_self_order/static/src/app/components/network_connectionLost_popup/network_connectionLost_popup.js
@@ -1,0 +1,80 @@
+import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import { ConnectionLostError, rpc } from "@web/core/network/rpc";
+import { _t } from "@web/core/l10n/translation";
+
+export class NetworkConnectionLostPopup extends Component {
+    static template = "pos_self_order.NetworkConnectionLostPopup";
+    static props = ["close", "access_token"];
+
+    setup() {
+        this.state = useState({
+            time: 5,
+            online: navigator.onLine,
+            retrying: false,
+        });
+
+        this.checkConnectivity = this.checkConnectivity.bind(this);
+        this.resetTimer = this.resetTimer.bind(this);
+
+        onMounted(() => {
+            this.interval = setInterval(() => {
+                if (this.state.online) {
+                    return;
+                }
+                if (this.state.retrying) {
+                    this.resetTimer();
+                } else {
+                    this.state.time -= 1;
+                    if (this.state.time === 0) {
+                        this.state.retrying = true;
+                    }
+                }
+            }, 1000);
+
+            browser.addEventListener("online", this.checkConnectivity);
+            browser.addEventListener("offline", this.checkConnectivity);
+        });
+
+        onWillUnmount(() => {
+            clearInterval(this.interval);
+            browser.removeEventListener("online", this.checkConnectivity);
+            browser.removeEventListener("offline", this.checkConnectivity);
+        });
+    }
+
+    resetTimer() {
+        this.state.time = 5;
+        this.state.retrying = false;
+    }
+
+    async checkConnectivity() {
+        try {
+            clearTimeout(this.checkConnectivityTimeout);
+            await rpc("/pos-self/ping", { access_token: this.props.access_token });
+
+            clearInterval(this.interval);
+            this.state.online = true;
+
+            this.checkConnectivityTimeout = setTimeout(() => {
+                this.props.close();
+            }, 2000);
+        } catch (error) {
+            if (error instanceof ConnectionLostError) {
+                this.state.online = false;
+                if (navigator.onLine) {
+                    this.checkConnectivityTimeout = setTimeout(
+                        () => this.checkConnectivity(),
+                        2000
+                    );
+                }
+            }
+        }
+    }
+    getRetryText(time) {
+        if (time > 1) {
+            return _t("Retrying in %s seconds...", time);
+        }
+        return _t("Retrying in %s second...", time);
+    }
+}

--- a/addons/pos_self_order/static/src/app/components/network_connectionLost_popup/network_connectionLost_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/network_connectionLost_popup/network_connectionLost_popup.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_self_order.NetworkConnectionLostPopup">
+        <div class="self_order_network_popup o_dialog">
+            <div role="dialog" class="modal d-block" tabindex="-1">
+                <div class="modal-dialog modal-dialog-centered" role="document">
+                    <div class="modal-content">
+                        <div class="modal-body p-4 overflow-visible">
+                            <div class="position-absolute top-0 start-50 translate-middle px-4 py-3 rounded-4 border border-white border-5"
+                                t-att-class="state.online ? 'text-bg-success' : 'text-bg-danger'">
+                                <i t-att-class="state.online ? 'fa fa-check-circle' : 'fa fa-wifi'" aria-hidden="true"/>
+                            </div>
+                            <div class="mt-4 text-center">
+                                <h1>
+                                    <t t-if="state.online">Connection restored</t>
+                                    <t t-else="">Internet Connection Lost</t>
+                                </h1>
+                                <span class="text-muted">
+                                    <t t-if="state.online">
+                                        You are back online. You can complete your order now.
+                                    </t>
+                                    <t t-else="">
+                                        It seems that the network connection was lost.<br/>Do not refresh the page.
+                                    </t>
+                                </span>
+                                <div class="display-6 my-3 pb-3 fw-bold text-center"
+                                    t-att-class="state.online ? 'text-success' : 'text-danger'">
+                                    <t t-if="state.online"><i class="fa fa-check-circle"/> Online</t>
+                                    <t t-elif="state.retrying">
+                                        <i class="fa fa-spinner fa-spin"></i> Retrying...
+                                    </t>
+                                    <t t-else="">
+                                        <t t-esc="getRetryText(state.time)"/>
+                                    </t>
+                                </div>
+
+                            </div>
+                            <div class="d-flex align-items-center justify-content-center w-100">
+                                <button type="button" class="btn btn-primary btn-lg popup_button" t-on-click="() => props.close()">Close</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -13,6 +13,7 @@ import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/
 import { HWPrinter } from "@point_of_sale/app/utils/printer/hw_printer";
 import { renderToElement } from "@web/core/utils/render";
 import { TimeoutPopup } from "@pos_self_order/app/components/timeout_popup/timeout_popup";
+import { NetworkConnectionLostPopup } from "@pos_self_order/app/components/network_connectionLost_popup/network_connectionLost_popup";
 import { UnavailableProductsDialog } from "@pos_self_order/app/components/unavailable_product_dialog/unavailable_product_dialog";
 import { constructFullProductName, deduceUrl, random5Chars } from "@point_of_sale/utils";
 import { getOrderLineValues } from "./card_utils";
@@ -723,7 +724,11 @@ export class SelfOrder extends Reactive {
                 this.resetTableIdentifier();
             }
         } else if (error instanceof ConnectionLostError) {
-            message = _t("Connection lost, please try again later");
+            this.dialog.add(NetworkConnectionLostPopup, {
+                close: () => this.dialog.closeAll(),
+                access_token: this.access_token,
+            });
+            return;
         }
 
         this.notification.add(message, {


### PR DESCRIPTION
In this commit:
===============
When a user goes offline while placing an order, a "Network Lost" popup is now displayed.
 - The popup starts a 5-second timer to recheck the connection status.
 - If still offline, the timer restarts until the connection is restored.
 - Once back online, the popup shows a "Connected" message and closes automatically (or can be closed manually).

Task-5039088


| Before this PR | After this PR |
|----------------|---------|
| <img width="250" alt="video preview" src="https://github.com/user-attachments/assets/00aa9b4a-1bd0-4aad-93a6-332740a535ce" /> | <img width="250" alt="video preview" src="https://github.com/user-attachments/assets/0f8ba6a9-6529-48d1-a71d-1e46070ba26c" /> |



