### PR TITLE
[FIX] im_livechat: chatwindow pops up when closing the ai_livechat snippet

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -605,7 +605,6 @@ class DiscussChannel(models.Model):
             # Notify that the visitor has left the conversation
             # sudo: mail.message - posting visitor leave message is allowed
             self.sudo().message_post(
-                author_id=self.env.ref('base.partner_root').id,
                 body=Markup('<div class="o_mail_notification o_hide_author">%s</div>') % message,
                 message_type='notification',
                 subtype_xmlid='mail.mt_comment'


### PR DESCRIPTION
closing the chat with the ai agent on the ai_livechat snippet results in a chatwindow popping up which gives a bad user experience.

Steps to reproduce:
- Log in as Mitchell Admin.
- Go to website.
- Click on edit and choose `Contact & Forms`.
- Add the AI Livechat website snippet.
- From the snippet options, add an AI Agent and choose a livechat team.
  Make sure that Mitchell Admin is configured as an operator for that
  livechat team (livechat channel).
- Click on save.
- Open an incognito tab. Log in as Marc Demo.
- Go to Website.
- Type a message inside the `ASK AI` text area and press enter.
- Wait until you receive a response and then click close.
- A chat window will popup with the messages of the conversation with
  the AI along with a message saying `Visitor has left the channel`.
This happens because `close` button will call `closeConversation`
=> `livechatService.leave()` => `visitor_leave_session` =>
`_close_livechat_session` that posts a message that the visitor has
left the channel.

This commit solves the issue by setting the user who left the channel as the author of the `visitor left chat` message instead of OdooBot.