### PR TITLE
[FIX] website_sale_slides: traceback when adding course to cart in elearning

### DIFF
--- a/addons/website_sale_slides/static/src/js/slides_course_join.js
+++ b/addons/website_sale_slides/static/src/js/slides_course_join.js
@@ -26,7 +26,7 @@ CourseJoinWidget.include({
         if (this.channel.channelEnroll === 'payment' && !this.publicUser) {
             const self = this;
             this.beforeJoin().then(function () {
-                self.call('websiteSale', 'addToCart',
+                self.call('cart', 'add',
                     {
                         // TODO VCR Ensure productTemplateId is always provided to `addToCart`.
                         // Currently, this works because the product configurator check is bypassed


### PR DESCRIPTION

Steps to reproduce:
1) Install `website_sale_slides`.
2) Create a course with enroll policy 'On payment' and publish it. 
3)  Add a content allow preview it and add a quiz
4) Go to website, click Share button and open the generated link in incognito. 
5) Login as a portal user, pass the quiz and click "Buy this course".

Issue:
- A traceback occurred:
`Cannot read properties of undefined (reading 'addToCart')`.

Cause:
- The method call `self.call('websiteSale', 'addToCart', ...)` relied on the deprecated `call` service, which was removed in commit https://github.com/odoo/odoo/commit/b8d0ab4275b24510161de9db793020f3489b0446.
- The service and method `call('websiteSale', 'addToCart'` is not valid and was not updated here : 
https://github.com/odoo/odoo/blob/35161ecf0dd3fde47db9b2166718339c2e30ac92/addons/website_sale_slides/static/src/js/slides_course_join.js#L29
- As a result, `addToCart` was no longer accessible and triggered a JS error.

Solution:
- Update the code to use the new service and method: `call('cart', 'add',`


opw-5045424
