### PR TITLE
[CLA] Signature for dimaurosalvatore

### DIFF
--- a/doc/cla/individual/dimaurosalvatore.md
+++ b/doc/cla/individual/dimaurosalvatore.md
@@ -1,0 +1,11 @@
+Italy, 29/08/2025
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Di Mauro Salvatore Igor i.dimauro@pixora.it https://github.com/dimaurosalvatore


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Sign the Odoo Individual Contributor License Agreement (CLA) for GitHub user dimaurosalvatore.
Current behavior before PR:
CLA not signed
Desired behavior after PR is merged:
CLA signed and recorded in doc/cla/individual/ under dimaurosalvatore.md.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
