### PR TITLE
[FIX] hr: allow activation of calendar view with studio

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -143,8 +143,8 @@ class HrVersion(models.Model):
         groups="hr.group_hr_manager")
     trial_date_end = fields.Date('End of Trial Period', help="End date of the trial period (if there is one).",
                                  groups="hr.group_hr_manager")
-    date_start = fields.Date(compute='_compute_dates', groups="hr.group_hr_manager")
-    date_end = fields.Date(compute='_compute_dates', groups="hr.group_hr_manager")
+    date_start = fields.Date(compute='_compute_dates', groups="hr.group_hr_manager", search="_search_start_date")
+    date_end = fields.Date(compute='_compute_dates', groups="hr.group_hr_manager", search="_search_end_date")
     is_current = fields.Boolean(compute='_compute_is_current', groups="hr.group_hr_manager")
     is_past = fields.Boolean(compute='_compute_is_past', groups="hr.group_hr_manager")
     is_future = fields.Boolean(compute='_compute_is_future', groups="hr.group_hr_manager")
@@ -520,6 +520,12 @@ class HrVersion(models.Model):
                 version.date_end = date_version_end
             else:
                 version.date_end = version.contract_date_end
+
+    def _search_start_date(self, operator, value):
+        return [('contract_date_start', operator, value)]
+
+    def _search_end_date(self, operator, value):
+        return [('contract_date_end', operator, value)]
 
     @api.model
     def _get_marital_status_selection(self):


### PR DESCRIPTION
Steps to reproduce:
- On the Employee app, activate Studio
- Switch to the "Views" menu
- Click on "Calendar" under the "Timeline views" group
- A traceback happens and you can not activate the view

Reason:
The calendar view tries to setup itself with the fields "date_start" and "date_end" of hr.version. However, those two fields are computed fields, and thus not stored, which causes an error when the fields are used in a SQL query.

How it was fixed:
By defining a search method for both hr.version.date_start and hr.version.date_end that overrides them with contract_date_start and contract_date_end which are not computed fields.

Task ID: 5043792
