### PR TITLE
[IMP] account_peppol: token desychronization

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_auth.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_auth.py
@@ -2,8 +2,10 @@ import base64
 import hashlib
 import hmac
 import json
-import requests
 import time
+from typing import Literal
+
+import requests
 import werkzeug.urls
 
 
@@ -15,16 +17,14 @@ class OdooEdiProxyAuth(requests.auth.AuthBase):
         3) to avoid that multiple database use the same credentials, via a refresh_token that expire after 24h.
     """
 
-    def __init__(self, user=False):
+    def __init__(self, user=False, auth_type: Literal['hmac', 'asymmetric'] = 'hmac'):
         self.id_client = user and user.id_client or False
+        self.auth_type = auth_type
         self.refresh_token = user and user.sudo().refresh_token or False
+        self.private_key = user and user.sudo().private_key_id or False
 
-    def __call__(self, request):
-        # We don't sign request that still don't have a id_client/refresh_token
-        if not self.id_client or not self.refresh_token:
-            return request
+    def __get_payload(self, request, msg_timestamp):
         # craft the message (timestamp|url path|id_client|query params|body content)
-        msg_timestamp = int(time.time())
         parsed_url = werkzeug.urls.url_parse(request.path_url)
 
         body = request.body
@@ -32,17 +32,43 @@ class OdooEdiProxyAuth(requests.auth.AuthBase):
             body = body.decode()
         body = json.loads(body)
 
-        message = '%s|%s|%s|%s|%s' % (
+        return '%s|%s|%s|%s|%s' % (
             msg_timestamp,  # timestamp
             parsed_url.path,  # url path
             self.id_client,
             json.dumps(werkzeug.urls.url_decode(parsed_url.query), sort_keys=True),  # url query params sorted by key
             json.dumps(body, sort_keys=True))  # http request body
+
+    def __sign_request_with_token(self, message):
         h = hmac.new(base64.b64decode(self.refresh_token), message.encode(), digestmod=hashlib.sha256)
 
+        return h.hexdigest()
+
+    def __sign_with_private_key(self, message):
+        # this is a fallback to resync the token in case of of multiple database desynchronization problem
+        # this happens when a database is restored from a backup or when it is copied without neutralization
+        return self.private_key._sign(message.encode(), formatting='base64').decode()
+
+    def __call__(self, request):
+        if not self.id_client:
+            return request
+
+        timestamp = int(time.time())
         request.headers.update({
             'odoo-edi-client-id': self.id_client,
-            'odoo-edi-signature': h.hexdigest(),
-            'odoo-edi-timestamp': msg_timestamp,
+            'odoo-edi-timestamp': timestamp,
         })
+        message = self.__get_payload(request, timestamp)
+
+        if self.auth_type == 'asymmetric' and self.private_key:
+            request.headers.update({
+                'odoo-edi-signature': self.__sign_with_private_key(message),
+                'odoo-edi-signature-type': 'asymmetric'
+            })
+        elif self.refresh_token:
+            request.headers.update({
+                'odoo-edi-signature': self.__sign_request_with_token(message),
+                'odoo-edi-signature-type': 'hmac'
+            })
+
         return request

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -121,25 +121,28 @@ class ResCompany(models.Model):
         parent_company = self.peppol_parent_company_id
         return parent_company and parent_company not in self.env.user.company_ids
 
-    def _reset_peppol_configuration(self):
+    def _reset_peppol_configuration(self, soft=False):
         """
         Reset all peppol configuration fields to their default value before registering.
         The EAS, endpoint, email, and phone number will be recomputed so that branch companies that uses
         their parent configuration can have their default values back
         (as these fields will be overwritten for them when they register as parent).
+
+        :param soft: If True, will only set state to unregistered, but keep peppol config intact, so the user can register again
         """
         self.account_peppol_proxy_state = 'not_registered'
         self.account_peppol_migration_key = False
-        self.peppol_external_provider = False
-        self.peppol_eas = False
-        self.peppol_endpoint = False
-        self.account_peppol_contact_email = False
-        self.account_peppol_phone_number = False
+        if not soft:
+            self.peppol_external_provider = False
+            self.peppol_eas = False
+            self.peppol_endpoint = False
+            self.account_peppol_contact_email = False
+            self.account_peppol_phone_number = False
 
+            self._compute_account_peppol_contact_email()
+            self._compute_account_peppol_phone_number()
         self.partner_id._compute_peppol_eas()
         self.partner_id._compute_peppol_endpoint()
-        self._compute_account_peppol_contact_email()
-        self._compute_account_peppol_phone_number()
 
     @api.model
     def _check_phonenumbers_import(self):

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -17,6 +17,7 @@ class ResConfigSettings(models.TransientModel):
     peppol_external_provider = fields.Char(related='company_id.peppol_external_provider', readonly=False)
     peppol_use_parent_company = fields.Boolean(compute='_compute_peppol_use_parent_company')
     peppol_parent_company_name = fields.Char(related='company_id.peppol_parent_company_id.name', string="Peppol Parent Company Name")
+    account_is_token_out_of_sync = fields.Boolean(related='account_peppol_edi_user.is_token_out_of_sync', readonly=False)
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
@@ -77,3 +78,16 @@ class ResConfigSettings(models.TransientModel):
                 }
             }
         return True
+
+    def button_reconnect_this_database(self):
+        """Re-establish an out-of-sync connection"""
+        self.ensure_one()
+        self.account_peppol_edi_user._peppol_out_of_sync_reconnect_this_database()
+
+    def button_disconnect_this_database(self):
+        """Disconnect the current database from the Peppol network.
+        This does not delete or affect the IAP connection, which will remain intact.
+        So don't use this to deregister the participant/connection.
+        """
+        self.ensure_one()
+        self.account_peppol_edi_user._peppol_out_of_sync_disconnect_this_database()

--- a/addons/account_peppol/tests/__init__.py
+++ b/addons/account_peppol/tests/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_peppol_messages
+from . import test_peppol_out_of_sync_resolution
 from . import test_peppol_participant

--- a/addons/account_peppol/tests/test_peppol_out_of_sync_resolution.py
+++ b/addons/account_peppol/tests/test_peppol_out_of_sync_resolution.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
+
+
+@tagged('-at_install', 'post_install')
+class TestTokenSyncResolution(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env['ir.config_parameter'].sudo().set_param('account_peppol.edi.mode', 'test')
+
+        cls.env.company.write({'peppol_eas': '0208', 'peppol_endpoint': '0239843188'})
+        edi_identification = cls.env['account_edi_proxy_client.user']._get_proxy_identification(
+            cls.env.company, 'peppol'
+        )
+        private_key = cls.env['certificate.key'].sudo()._generate_rsa_private_key(cls.env.company)
+        cls.user = cls.env['account_edi_proxy_client.user'].create({
+            'company_id': cls.env.company.id,
+            'id_client': 'mock-id-client',
+            'proxy_type': 'peppol',
+            'edi_mode': 'test',
+            'edi_identification': edi_identification,
+            'private_key_id': private_key.id,
+            'refresh_token': 'mock-refresh-token',
+        })
+
+    def test_peppol_out_of_sync_detection(self):
+        def fake_call(endpoint, params=None, auth_type=None):
+            if endpoint.endswith('/api/peppol/2/participant_status'):
+                raise AccountEdiProxyError('invalid_signature')
+            return {}
+
+        self.assertFalse(self.user.is_token_out_of_sync)
+
+        with patch(
+            'odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user.Account_Edi_Proxy_ClientUser._make_request',
+            side_effect=fake_call
+        ), self.assertRaises(UserError) as e:
+            self.user._peppol_get_participant_status()
+
+        self.assertIn("please go to Settings > Accounting > Peppol Settings and click on 'Reconnect this database'", e.exception.args[0])

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[@id='account_peppol_install']" position="replace">
                 <div id="account_peppol" class="col-12 o_setting_box">
-                    <div class="o_setting_right_pane border-0">
+                    <div class="o_setting_right_pane border-0" invisible="account_is_token_out_of_sync">
                         <!-- Info in case of sender. -->
                         <div invisible="peppol_use_parent_company or account_peppol_proxy_state != 'sender'">
                             You are sending your e-invoices via Odoo with this Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>.<br/>
@@ -72,6 +72,36 @@
                                         name="button_peppol_disconnect_branch_from_parent"
                                         type="object"
                                         class="btn-secondary me-1"/>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row mb-3" invisible="not account_is_token_out_of_sync">
+                        <div class="content-group">
+                            Your Peppol identification is:
+                            <field name="account_peppol_edi_identification" nolabel="1"/>
+                        </div>
+                        <div class="content-group mt-3 alert alert-danger" role="alert">
+                            <div class="d-flex align-items-start">
+                                <i class="fa fa-exclamation-triangle fa-lg me-3 mt-1" aria-hidden="true"></i>
+                                <div>
+                                    <span><strong>Disconnected from Peppol!</strong></span>
+                                    <p>
+                                        Your database is not linked to Peppol anymore. This might be due to a database duplication or restoration.
+                                        Make sure to reconnect the correct database.
+                                    </p>
+                                </div>
+                            </div>
+                            <div class="mt-3 d-flex gap-1">
+                                <button name="button_reconnect_this_database"
+                                    type="object"
+                                    string="Reconnect this database"
+                                    class="btn btn-primary"
+                                    icon="fa-refresh"/>
+                                <button name="button_disconnect_this_database"
+                                    type="object"
+                                    string="Disconnect this database"
+                                    class="btn btn-danger"
+                                    icon="fa-unlink"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
When an Odoo database is duplicated or restored from a backup, its IAP refresh token can become invalid because another copy of the database has refreshed it. This leads to token desynchronization and prevents the client from authenticating with the IAP server.

This commit introduces a fallback mechanism with asymmetric auth. Each database can now prove its identity with its own private key, even if its token is out of sync. This the client to re-establish a refresh token, and a normal authentication flow.

From the user perspective, when a disconnection occurs the system now signals that the database is out of sync and provides instructions/actions to either reconnect or disconnect.

```           DB1               Proxy
            │    hmac auth     │
            ├─────────────────►│
            │        ok        │
            │◄─────────────────┤                DB2
            │                  │ refreshes token │ (copied from db1)
            │                  │◄────────────────┤
            │    hmac auth     ├────────────────►│
            ├─────────────────►│                 │
            │invalid_signature │                 │
            │◄─────────────────┤                 │
            │asymmetric mark   │                 │
manual user │conn out of sync  │                 │
confirmation├─────────────────►│    hmac auth    │
          ┌─┤                  │◄────────────────┤
          │ │asymmetric resync │invalid_signature│
          └►│          request ├────────────────►│
            ├─────────────────►│                 ▼
            │  new temp token  │
            │◄─────────────────┤
            │    hmac auth     │
            ├─────────────────►│
            ▼                  ▼
```

IAP: https://github.com/odoo/iap-apps/pull/1135

task-4818239