### PR TITLE
[IMP] mail: binding keydown event to html composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -291,6 +291,9 @@ export class Composer extends Component {
             content: this.props.composer.composerHtml,
             placeholder: this.placeholder,
             Plugins: this.ui.isSmall ? MAIL_SMALL_UI_PLUGINS : MAIL_PLUGINS,
+            composerPluginDependencies: {
+                onKeydown: this.onKeydown.bind(this),
+            },
             classList: ["o-mail-Composer-html"],
             onChange: () => this.onChangeWysiwygContent(),
             onEditorReady: () => {

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -28,4 +28,12 @@ export class MailComposerPlugin extends Plugin {
             }
         },
     };
+
+    setup() {
+        this.addDomListener(
+            this.editable,
+            "keydown",
+            this.config.composerPluginDependencies.onKeydown
+        );
+    }
 }


### PR DESCRIPTION
This commit binds the keydown event to the HTML composer, syncing the keydown posting behavior with the text composer.

task-5051234


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
