### PR TITLE
[FIX] project_timesheet_holidays: skip validation for flexible hours

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -382,7 +382,7 @@
                                                 domain="['|', ('country_id', '=', False), ('country_id', '=', company_country_id)]"/>
 
                                         <separator name="schedule" string="Schedule"/>
-                                        <field name="resource_calendar_id" help="The default working hours are set in configuration."/>
+                                        <field name="resource_calendar_id" help="The default working hours are set in configuration." placeholder="Flexible"/>
                                     </group>
                                 </group>
                             </page>

--- a/addons/project_timesheet_holidays/models/hr_leave.py
+++ b/addons/project_timesheet_holidays/models/hr_leave.py
@@ -34,6 +34,10 @@ class HrLeave(models.Model):
                 continue
 
             calendar = leave.employee_id.resource_calendar_id
+
+            if not calendar or not calendar.tz:
+                continue
+
             calendar_timezone = pytz.timezone(calendar.tz)
 
             if calendar.flexible_hours and (leave.request_unit_hours or leave.request_unit_half or leave.date_from.date() == leave.date_to.date()):


### PR DESCRIPTION
#### Steps to Reproduce
- Go to Time Off > Management > Time Off
- Create a Time Off for an employee with empty "Working Hours" (Payroll tab on profile).
- Ensure the Time Off Type has "Requires allocation" unchecked so it appears in the dropdown.
- Save and then try to Validate.

#### Issue
During validation, `_validate_leave_request` assumes the employee has a working calendar and tries to access `calendar.tz`. When "Working Hours" is empty, `resource_calendar_id` is False, leading to the traceback.

#### Fix
Skip timesheet generation and upper bound check when the employee has no working calendar (fully flexible case).

task-5048761
