### PR TITLE
[FIX] pos_blackbox_be: fix saved orderline qty changes

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -250,14 +250,14 @@ export class OrderSummary extends Component {
             }
         }
         const newLine = this.getNewLine();
-        const decreasedQuantity = current_saved_quantity - newQuantity;
-        if (decreasedQuantity != 0) {
-            newLine.set_quantity(-decreasedQuantity + newLine.get_quantity(), true);
+        const decreasedSavedQuantity = current_saved_quantity - newQuantity;
+        if (decreasedSavedQuantity != 0) {
+            newLine.set_quantity(newQuantity, true);
         }
         if (newLine !== selectedLine && selectedLine.saved_quantity != 0) {
             selectedLine.set_quantity(selectedLine.saved_quantity);
         }
-        return decreasedQuantity;
+        return decreasedSavedQuantity;
     }
     getNewLine() {
         const selectedLine = this.currentOrder.get_selected_orderline();


### PR DESCRIPTION
Fix issue where the orderline qty changed unexpectedly after confirming the decrease qty popup.

Steps to reproduce:
- add a product with qty 5
- go to plan (save table)
- go back to previous table
- set qty 3 on the line
- set qty 1 on the line => qty is set to -1 (instead of 1)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
