### PR TITLE
[FIX] mail: Make the copy button appear last

### DIFF
--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -198,7 +198,7 @@ registerMessageAction("copy-message", {
     name: _t("Copy to Clipboard"),
     icon: "fa fa-copy",
     iconLarge: "fa fa-lg fa-copy",
-    sequence: 25,
+    sequence: 30,
 });
 registerMessageAction("copy-link", {
     condition: (component) =>


### PR DESCRIPTION
The copy button appears in between the 'Send as Message' and 'Log as Note' buttons. It should appear last (after both buttons). This commit along with the corresponding enterprise commit update the sequence of these buttons to make the copy button appear last.

See https://github.com/odoo/enterprise/pull/93487