### PR TITLE
[FIX] stock_dropshipping: add CoA setup

### DIFF
--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -4,11 +4,13 @@
 from odoo import Command
 
 from odoo.tests import common, tagged, Form
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tools import mute_logger
 from datetime import datetime
 
 
-class TestDropship(common.TransactionCase):
+@tagged('post_install', '-at_install')
+class TestDropship(AccountTestInvoicingCommon):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
The test `test_dropship_return_backorders_bill_on_order` failed when running without demo data because no chart of accounts was installed, so no Purchase journal existed. As a result, `purchase_order.action_create_invoice()` raised:

  UserError: No journal could be found in company ... for any of those types: purchase

This change inherits from `AccountTestInvoicingCommon` to have the necessary charts.

[runbot-231285](https://runbot.odoo.com/odoo/error/231285)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
