### PR TITLE
[FIX] html_editor: remove unnecessary t-name directive

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.xml
+++ b/addons/html_editor/static/src/main/media/image_crop.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.ImageCrop">
-        <div t-name="html_editor.ImageCrop"
+        <div
              class="o_we_crop_widget"
              contenteditable="false"
              t-ref="el"


### PR DESCRIPTION
This directive allows to declare a template, so using it inside a template is useless. It doesn't cause any issue, it simply has no effect. This commit removes it for the sake of clarity.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
