### PR TITLE
[FIX] website_sale: allow description edition

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -133,7 +133,6 @@
 
         // Hide empty dropzones when no dropzone are dragged.
         @at-root body:where(:not(.oe_dropzone_active)) {
-            #category_header,
             #oe_structure_products_header_shop {
                 &:has(> br:first-child:last-child), &:empty {
                     display: none;


### PR DESCRIPTION
In commit[1] the change allowing to edit the description field directly on the category page didn't go through.

follow-up task-4711722

[1]: odoo/odoo@f207c7644400228a2ee10dcb3f2731250fcbea08





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
