### PR TITLE
[FIX] website, html_builder: fix preview of footer and header visibility

### DIFF
--- a/addons/html_builder/static/src/core/visibility_plugin.js
+++ b/addons/html_builder/static/src/core/visibility_plugin.js
@@ -8,7 +8,7 @@ const deviceInvisibleSelector = ".o_snippet_mobile_invisible, .o_snippet_desktop
 
 export class VisibilityPlugin extends Plugin {
     static id = "visibility";
-    static dependencies = ["builderOptions", "disableSnippets"];
+    static dependencies = ["builderOptions", "disableSnippets", "history"];
     static shared = ["toggleTargetVisibility", "onOptionVisibilityUpdate", "hideElement"];
     resources = {
         on_mobile_preview_clicked: withSequence(10, this.onMobilePreviewClicked.bind(this)),
@@ -112,6 +112,9 @@ export class VisibilityPlugin extends Plugin {
      * @param {Boolean} show true/false if the element was shown/hidden
      */
     onOptionVisibilityUpdate(editingEl, show) {
+        if (this.dependencies.history.getIsPreviewing()) {
+            return;
+        }
         const isShown = this.toggleVisibilityStatus(editingEl, show);
         if (!isShown) {
             this.dependencies.builderOptions.setNextTarget(false);

--- a/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
@@ -3,7 +3,7 @@
 
 <t t-name="website.TopMenuVisibilityOption">
     <BuilderRow label.translate="Header Position" t-if="!this.isActiveItem('header_sidebar_opt')">
-        <BuilderSelect preview="false" action="'setWebsiteHeaderVisibility'">
+        <BuilderSelect action="'setWebsiteHeaderVisibility'">
             <BuilderSelectItem actionValue="'overTheContent'" id="'overTheContent'" t-if="props.doesPageOptionExist('header_overlay')">Over The Content</BuilderSelectItem>
             <BuilderSelectItem actionValue="'regular'">Regular</BuilderSelectItem>
             <BuilderSelectItem actionValue="'hidden'">Hidden</BuilderSelectItem>

--- a/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
@@ -67,7 +67,10 @@ class WebsitePageConfigOptionPlugin extends Plugin {
         return matchingClass || rgbaToHex(headerEl.style.getPropertyValue(attribute));
     }
 
-    setDirty() {
+    setDirty(isPreviewing) {
+        if (isPreviewing) {
+            return;
+        }
         this.isDirty = true;
     }
 
@@ -176,14 +179,14 @@ export class BaseWebsitePageConfigAction extends BuilderAction {
 }
 export class SetWebsiteHeaderVisibilityAction extends BaseWebsitePageConfigAction {
     static id = "setWebsiteHeaderVisibility";
-    apply({ editingElement, value: headerPositionValue }) {
+    apply({ editingElement, value: headerPositionValue, isPreviewing }) {
         const lastValue = this.websitePageConfig.getVisibilityItem();
         this.history.applyCustomMutation({
             apply: () => this.visibilityHandlers[headerPositionValue](),
             revert: () => this.visibilityHandlers[lastValue](),
         });
 
-        this.websitePageConfig.setDirty();
+        this.websitePageConfig.setDirty(isPreviewing);
     }
     isApplied({ editingElement, value }) {
         return this.websitePageConfig.getVisibilityItem() === value;
@@ -194,20 +197,20 @@ export class SetWebsiteFooterVisibleAction extends BaseWebsitePageConfigAction {
     isApplied({ editingElement }) {
         return !this.websitePageConfig.getFooterVisibility();
     }
-    apply({ editingElement }) {
+    apply({ editingElement, isPreviewing }) {
         this.websitePageConfig.setFooterVisible(true);
-        this.websitePageConfig.setDirty();
+        this.websitePageConfig.setDirty(isPreviewing);
     }
-    clean({ editingElement }) {
+    clean({ editingElement, isPreviewing }) {
         this.websitePageConfig.setFooterVisible(false);
-        this.websitePageConfig.setDirty();
+        this.websitePageConfig.setDirty(isPreviewing);
     }
 }
 
 export class SetPageWebsiteDirtyAction extends BaseWebsitePageConfigAction {
     static id = "setPageWebsiteDirty";
-    apply({ editingElement }) {
-        this.websitePageConfig.setDirty();
+    apply({ editingElement, isPreviewing }) {
+        this.websitePageConfig.setDirty(isPreviewing);
     }
 }
 


### PR DESCRIPTION
With the [re-introduction of preview on checkboxes], the visibility
option on the footer was made previewable, and this causes issues with
the "Invisible Elements" panel and excessive saving.

The issues were fixed by skipping updates of "Invisible Elements" panel
during previews, and also not setting the dirty flag. These changes are
sufficient to make the preview for the visibility option of the header
work, so it is enabled as well.

Steps to reproduce:
- Open website builder
- Click on the footer
- Hover the checkbox of "Page Visibility"
- Bug: the "Invisible Elements" panel appears (and stays)

[re-introduction of preview on checkboxes]: 6cc63c31378b8acfdb419727a71f38fd00ea37dd
task-4367641