### PR TITLE
[FIX] web: correctly handle closing twice a dialog

### DIFF
--- a/addons/web/static/src/core/dialog/dialog_service.js
+++ b/addons/web/static/src/core/dialog/dialog_service.js
@@ -49,6 +49,7 @@ export const dialogService = {
             deactivate();
             stack.push(subEnv);
             document.body.classList.add("modal-open");
+            let isBeingClosed = false;
 
             const scrollOrigin = { top: window.scrollY, left: window.scrollX };
             subEnv.scrollToOrigin = () => {
@@ -66,6 +67,10 @@ export const dialogService = {
                 },
                 {
                     onRemove: async (closeParams) => {
+                        if (isBeingClosed) {
+                            return;
+                        }
+                        isBeingClosed = true;
                         await options.onClose?.(closeParams);
                         stack.splice(
                             stack.findIndex((d) => d.id === id),

--- a/addons/web/static/tests/core/dialog_service.test.js
+++ b/addons/web/static/tests/core/dialog_service.test.js
@@ -232,3 +232,47 @@ test("two dialogs, close the first one, closeAll", async () => {
     await animationFrame();
     expect(".o_dialog").toHaveCount(0);
 });
+
+test("two dialogs, close the first one twice, then closeAll", async () => {
+    class CustomDialog extends Component {
+        static components = { Dialog };
+        static template = xml`<Dialog title="props.title">content</Dialog>`;
+        static props = ["*"];
+    }
+    expect(".o_dialog").toHaveCount(0);
+    getService("dialog").add(
+        CustomDialog,
+        { title: "Hello" },
+        {
+            onClose: () => expect.step("close dialog 1"),
+        }
+    );
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(1);
+    expect("header .modal-title").toHaveText("Hello");
+    expect(document.body).toHaveClass("modal-open");
+
+    const close = getService("dialog").add(
+        CustomDialog,
+        { title: "Sauron" },
+        {
+            onClose: () => expect.step("close dialog 2"),
+        }
+    );
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(2);
+    expect(queryAllTexts("header .modal-title")).toEqual(["Hello", "Sauron"]);
+
+    close();
+    close();
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(1);
+    expect("header .modal-title").toHaveText("Hello");
+    expect(document.body).toHaveClass("modal-open");
+    expect.verifySteps(["close dialog 2"]);
+
+    getService("dialog").closeAll();
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(0);
+    expect.verifySteps(["close dialog 1"]);
+});


### PR DESCRIPTION
Have two dialogs opened, call twice `close` on one of them. From that point, the `stack` in dialog_service is empty (because the second time, the dialog can't be found in `stack`, so its index is -1, and calling `splice` with -1 removes from the end of the array), even though one of the 2 dialogs is still displayed. From that point, calling closeAll does not close the remaining dialog.

In practice, this can be reproduced in Employees > Laurie Poiret (must be in BE company). In the cog menu, click on "Departure: Holiday Attest". In the dialog, click on the external button of the many2one. Close the second dialog by clicking on the X. At this point, `close` has been called twice for that dialog (once by the click on the cross, and once by an override of `dialogData.dismiss` in FormViewDialog), and `stack` is thus empty. Clicking on an action button in the first dialog (e.g. "Validate & Compute holiday attests") then no longer closes the remaining dialog as it should (as `closeAll` is called by the action service). Then, a crash can occur when manually trying to close that dialog, as the view in the background no longer exists, and closing the dialog calls its `onClose` callback, which tries to reload the view, thus leading to the "Component is destroyed" error.

Issue introduced by https://github.com/odoo/odoo/pull/203169

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
