### PR TITLE
[FIX] l10n_in,l10n_in_sale: fix read-only company attribute error

### DIFF
--- a/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
+++ b/addons/l10n_in_sale/tests/test_l10n_in_sale_fiscal_position.py
@@ -96,7 +96,7 @@ class TestSaleFiscal(L10nInTestInvoicingCommon):
 
     def test_foreign_partner_without_state_fiscal_position(self):
         """ Verify foreign partner without state gets export fiscal position """
-        self.env.company = self.default_company
+        self.env = self.env['base'].with_company(self.default_company).env
 
         self._assert_order_fiscal_position(
             fpos_ref='fiscal_position_in_export_sez_in',


### PR DESCRIPTION
In this PR:
- Replaced direct assignment `self.env.company = self.default_company` with proper odoo environment switching pattern to avoid AttributeError when company attribute becomes read-only after initialization.