### PR TITLE
[IMP] l10n_*: compute use documents and allow purchase receipts

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -248,7 +248,7 @@ class AccountMove(models.Model):
     def _get_starting_sequence(self):
         """ If use documents then will create a new starting sequence using the document type code prefix and the
         journal document number with a 8 padding number """
-        if self.journal_id.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == "AR":
+        if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == "AR":
             if self.l10n_latam_document_type_id:
                 return self._get_formatted_sequence()
         return super()._get_starting_sequence()

--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -18,7 +18,7 @@ class AccountMove(models.Model):
     def _get_l10n_latam_documents_domain(self):
         self.ensure_one()
         if self.journal_id.company_id.account_fiscal_country_id != self.env.ref('base.cl') or not \
-                self.journal_id.l10n_latam_use_documents:
+                self.l10n_latam_use_documents:
             return super()._get_l10n_latam_documents_domain()
         if self.journal_id.type == 'sale':
             domain = [('country_id.code', '=', 'CL')]
@@ -67,13 +67,13 @@ class AccountMove(models.Model):
                                                   and latam_document_type_code not in ['35', '38', '39', '41']):
                 raise ValidationError(_('Tax payer type and vat number are mandatory for this type of '
                                         'document. Please set the current tax payer type of this customer'))
-            if rec.journal_id.type == 'sale' and rec.journal_id.l10n_latam_use_documents:
+            if rec.journal_id.type == 'sale' and rec.l10n_latam_use_documents:
                 if country_id.code != "CL":
                     if not ((tax_payer_type == '4' and latam_document_type_code in ['110', '111', '112']) or (
                             tax_payer_type == '3' and latam_document_type_code in ['39', '41', '61', '56'])):
                         raise ValidationError(_(
                             'Document types for foreign customers must be export type (codes 110, 111 or 112) or you should define the customer as an end consumer and use receipts (codes 39 or 41)'))
-            if rec.journal_id.type == 'purchase' and rec.journal_id.l10n_latam_use_documents:
+            if rec.journal_id.type == 'purchase' and rec.l10n_latam_use_documents:
                 if vat != SII_VAT and latam_document_type_code == '914':
                     raise ValidationError(_('The DIN document is intended to be used only with RUT 60805000-0'
                                             ' (Tesorería General de La República)'))
@@ -111,7 +111,7 @@ class AccountMove(models.Model):
     def _get_starting_sequence(self):
         """ If use documents then will create a new starting sequence using the document type code prefix and the
         journal document number with a 6 padding number """
-        if self.journal_id.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == "CL":
+        if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == "CL":
             if self.l10n_latam_document_type_id:
                 return self._l10n_cl_get_formatted_sequence()
         return super()._get_starting_sequence()

--- a/addons/l10n_ec/models/account_move.py
+++ b/addons/l10n_ec/models/account_move.py
@@ -149,7 +149,7 @@ class AccountMove(models.Model):
     def _get_l10n_latam_documents_domain(self):
         self.ensure_one()
         domain = super()._get_l10n_latam_documents_domain()
-        if self.country_code == 'EC' and self.journal_id.l10n_latam_use_documents:
+        if self.country_code == 'EC' and self.l10n_latam_use_documents:
             if self.debit_origin_id:  # show/hide the debit note document type
                 domain.extend([('internal_type', '=', 'debit_note')])
             elif self.move_type in ('out_invoice', 'in_invoice'):
@@ -170,7 +170,7 @@ class AccountMove(models.Model):
         """If use documents then will create a new starting sequence using the document type code prefix and the
         journal document number with a 8 padding number"""
         if (
-            self.journal_id.l10n_latam_use_documents
+            self.l10n_latam_use_documents
             and self.company_id.country_id.code == "EC"
         ):
             if self.l10n_latam_document_type_id:

--- a/addons/l10n_latam_invoice_document/models/account_move_line.py
+++ b/addons/l10n_latam_invoice_document/models/account_move_line.py
@@ -16,3 +16,4 @@ class AccountMoveLine(models.Model):
 
     l10n_latam_document_type_id = fields.Many2one(
         related='move_id.l10n_latam_document_type_id', bypass_search_access=True, store=True, index='btree_not_null')
+    l10n_latam_use_documents = fields.Boolean(related='move_id.l10n_latam_use_documents')

--- a/addons/l10n_pe/models/account_move.py
+++ b/addons/l10n_pe/models/account_move.py
@@ -8,7 +8,7 @@ class AccountMove(models.Model):
     def _get_l10n_latam_documents_domain(self):
         self.ensure_one()
         result = super()._get_l10n_latam_documents_domain()
-        if self.company_id.country_id.code != "PE" or not self.journal_id.l10n_latam_use_documents or self.journal_id.type != "sale":
+        if self.company_id.country_id.code != "PE" or not self.l10n_latam_use_documents or self.journal_id.type != "sale":
             return result
         result.append(("code", "in", ("01", "03", "07", "08", "20", "40")))
         if self.partner_id.l10n_latam_identification_type_id.l10n_pe_vat_code != '6' and self.move_type == 'out_invoice':

--- a/addons/l10n_uy/models/account_move.py
+++ b/addons/l10n_uy/models/account_move.py
@@ -18,7 +18,7 @@ class AccountMove(models.Model):
     def _get_starting_sequence(self):
         """ If use documents then will create a new starting sequence using the document type code prefix and the
         journal document number with a 8 padding number """
-        if self.journal_id.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == "UY" and self.l10n_latam_document_type_id:
+        if self.l10n_latam_use_documents and self.company_id.account_fiscal_country_id.code == "UY" and self.l10n_latam_document_type_id:
             return self._l10n_uy_get_formatted_sequence()
         return super()._get_starting_sequence()
 


### PR DESCRIPTION
*: latam_invoice_document, ar, cl, ec, pe, uy

The aim of this commit is to allow the use of purchase journals
that have `l10n_latam_use_documents` activated with purchase receipts.
We now have a computed field instead of a relational field, which exclude `in_receipts`
move type. We also add a related field in `account.move.line` to
be consistent with `account.move` in case of a search on amls.
This will allow to post purchase receipts, for example from an expense, on such journals.

Also several l10n were getting the value of `l10n_latam_use_documents`
from the journal_id instead of the relational field of `account.move`.
We now use the new computed field to get the right value.
