### PR TITLE
[REM] *: twitter:* meta tags

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -51,11 +51,6 @@
                 <meta property="og:image:width" content="300"/>
                 <meta property="og:image:height" content="200"/>
                 <meta name="twitter:card" content="summary_large_image"/>
-                <meta property="twitter:title" t-att-content="preview_object.name"/>
-                <meta property="twitter:description" t-att-content="preview_object.description.striptags() if preview_object.description else ''"/>
-                <t t-if="not_uses_default_logo">
-                    <meta property="twitter:image" t-attf-content="/web/binary/company_logo?company={{ company.id }}"/>
-                </t>
             </t>
         </xpath>
     </template>

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -147,11 +147,6 @@
                 <meta property="og:image" t-attf-content="/web/image/{{ preview_object.displayed_image_id.id }}/300x200?access_token={{ preview_object.displayed_image_id.generate_access_token()[0] }}"/>
             </t>
         </xpath>
-        <xpath expr="//t[@t-if='not_uses_default_logo'][2]" position="before">
-            <t t-if="preview_object.displayed_image_id">
-                <meta property="twitter:image" t-attf-content="/web/image/{{ preview_object.displayed_image_id.id }}/300x200?access_token={{ preview_object.displayed_image_id.generate_access_token()[0] }}"/>
-            </t>
-        </xpath>
     </template>
 
     <template id="task_link_preview_portal_layout" inherit_id="portal.portal_layout" primary="True">

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -42,7 +42,6 @@ class WebsiteSeoMetadata(models.AbstractModel):
             images instead of default images
         """
         self.ensure_one()
-        company = request.website.company_id.sudo()
         title = request.website.name
         if 'name' in self:
             title = '%s | %s' % (self.name, title)
@@ -57,14 +56,9 @@ class WebsiteSeoMetadata(models.AbstractModel):
             'og:url': url_join(request.website.domain or request.httprequest.url_root, self.env['ir.http']._url_for(request.httprequest.path)),
             'og:image': request.website.image_url(request.website, img_field),
         }
-        # Default meta for Twitter
         default_twitter = {
             'twitter:card': 'summary_large_image',
-            'twitter:title': title,
-            'twitter:image': request.website.image_url(request.website, img_field, size='300x300'),
         }
-        if company.social_twitter:
-            default_twitter['twitter:site'] = "@%s" % company.social_twitter.split('/')[-1]
 
         return {
             'default_opengraph': default_opengraph,
@@ -85,12 +79,9 @@ class WebsiteSeoMetadata(models.AbstractModel):
         opengraph_meta, twitter_meta = default_meta['default_opengraph'], default_meta['default_twitter']
         if self.website_meta_title:
             opengraph_meta['og:title'] = self.website_meta_title
-            twitter_meta['twitter:title'] = self.website_meta_title
         if self.website_meta_description:
             opengraph_meta['og:description'] = self.website_meta_description
-            twitter_meta['twitter:description'] = self.website_meta_description
         opengraph_meta['og:image'] = url_join(root_url, self.env['ir.http']._url_for(self.website_meta_og_img or opengraph_meta['og:image']))
-        twitter_meta['twitter:image'] = url_join(root_url, self.env['ir.http']._url_for(self.website_meta_og_img or twitter_meta['twitter:image']))
         return {
             'opengraph_meta': opengraph_meta,
             'twitter_meta': twitter_meta,

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -198,9 +198,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     # menu and layout
                     'website_menu': 1,
                     'ir_ui_view': 2,
-                    'res_company': 1,
                 }
-                expected_query_count = 10
+                expected_query_count = 9
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
                 self.assertEqual(self._get_url_hot_query(self.page.url), expected_query_count)
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
@@ -223,9 +222,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     # menu and layout
                     'website_menu': 1,
                     'ir_ui_view': 2,
-                    'res_company': 1,
                 }
-                expected_query_count = 10
+                expected_query_count = 9
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     insert_tables_perf = {
@@ -254,9 +252,8 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     'website': 1,
                     # layout
                     'ir_ui_view': 2,
-                    'res_company': 1,
                 }
-                expected_query_count = 8
+                expected_query_count = 7
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     insert_tables_perf = {
@@ -305,12 +302,9 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             'website': 1,
             'website_menu': 1,
             'ir_ui_view': 2,
-            # Check if `view.track` to track visitor or not
-            # layout content (company name, logo)
-            'res_company': 1,
         }
-        self._check_url_hot_query(self.page.url, 10, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url), 10)
+        self._check_url_hot_query(self.page.url, 9, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url), 9)
 
 @tagged('-at_install', 'post_install')
 class TestWebsitePerformancePost(UtilPerf):

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -316,14 +316,14 @@ class BlogPost(models.Model):
 
     def _default_website_meta(self):
         res = super(BlogPost, self)._default_website_meta()
-        res['default_opengraph']['og:description'] = res['default_twitter']['twitter:description'] = self.subtitle
+        res['default_opengraph']['og:description'] = self.subtitle
         res['default_opengraph']['og:type'] = 'article'
         res['default_opengraph']['article:published_time'] = self.post_date
         res['default_opengraph']['article:modified_time'] = self.write_date
         res['default_opengraph']['article:tag'] = self.tag_ids.mapped('name')
         # background-image might contain single quotes eg `url('/my/url')`
-        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = json_scriptsafe.loads(self.cover_properties).get('background-image', 'none')[4:-1].strip("'")
-        res['default_opengraph']['og:title'] = res['default_twitter']['twitter:title'] = self.name
+        res['default_opengraph']['og:image'] = json_scriptsafe.loads(self.cover_properties).get('background-image', 'none')[4:-1].strip("'")
+        res['default_opengraph']['og:title'] = self.name
         res['default_meta_description'] = self.subtitle
         return res
 

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -503,9 +503,9 @@ class EventEvent(models.Model):
         res = super()._default_website_meta()
         event_cover_properties = json.loads(self.cover_properties)
         # background-image might contain single quotes eg `url('/my/url')`
-        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = event_cover_properties.get('background-image', 'none')[4:-1].strip("'")
-        res['default_opengraph']['og:title'] = res['default_twitter']['twitter:title'] = self.name
-        res['default_opengraph']['og:description'] = res['default_twitter']['twitter:description'] = self.subtitle
+        res['default_opengraph']['og:image'] = event_cover_properties.get('background-image', 'none')[4:-1].strip("'")
+        res['default_opengraph']['og:title'] = self.name
+        res['default_opengraph']['og:description'] = self.subtitle
         res['default_twitter']['twitter:card'] = 'summary'
         res['default_meta_description'] = self.subtitle
         return res

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -296,9 +296,9 @@ class ForumPost(models.Model):
 
     def _default_website_meta(self):
         res = super()._default_website_meta()
-        res['default_opengraph']['og:title'] = res['default_twitter']['twitter:title'] = self.name
-        res['default_opengraph']['og:description'] = res['default_twitter']['twitter:description'] = self.plain_content
-        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = self.env['website'].image_url(self.create_uid, 'image_1024')
+        res['default_opengraph']['og:title'] = self.name
+        res['default_opengraph']['og:description'] = self.plain_content
+        res['default_opengraph']['og:image'] = self.env['website'].image_url(self.create_uid, 'image_1024')
         res['default_twitter']['twitter:card'] = 'summary'
         res['default_meta_description'] = self.plain_content
         return res

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -801,9 +801,9 @@ class ProductTemplate(models.Model):
 
     def _default_website_meta(self):
         res = super()._default_website_meta()
-        res['default_opengraph']['og:description'] = res['default_twitter']['twitter:description'] = self.description_sale
-        res['default_opengraph']['og:title'] = res['default_twitter']['twitter:title'] = self.name
-        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = self.env['website'].image_url(self, 'image_1024')
+        res['default_opengraph']['og:description'] = self.description_sale
+        res['default_opengraph']['og:title'] = self.name
+        res['default_opengraph']['og:image'] = self.env['website'].image_url(self, 'image_1024')
         res['default_meta_description'] = self.description_sale
         return res
 

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -1239,9 +1239,9 @@ class SlideSlide(models.Model):
 
     def _default_website_meta(self):
         res = super()._default_website_meta()
-        res['default_opengraph']['og:title'] = res['default_twitter']['twitter:title'] = self.name
-        res['default_opengraph']['og:description'] = res['default_twitter']['twitter:description'] = html2plaintext(self.description)
-        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = self.env['website'].image_url(self, 'image_1024')
+        res['default_opengraph']['og:title'] = self.name
+        res['default_opengraph']['og:description'] = html2plaintext(self.description)
+        res['default_opengraph']['og:image'] = self.env['website'].image_url(self, 'image_1024')
         res['default_meta_description'] = html2plaintext(self.description)
         return res
 


### PR DESCRIPTION
According to https://getoutofmyhead.dev/link-preview-meta-tags/#which-meta-tags-work-on-which-apps pretty much every social site supports opengraph including twitter, while a much more limited fraction of sites supports twitter meta tags.

As such, twitter meta tags are redundant and unnecessary computation and data.

Notes:

- keeps the `twitter:card` stanzas because it's not clear what effect they have in combination with opengraph tags
- does not remove `twitter_meta` from `_default_website_meta` because we have a bunch of overrides to those, and that means partners for sure do as well... might make sense to use some sort of weirdo dict which says to not update that tho...
