### PR TITLE
[FIX] point_of_sale, pos_restaurant: prevent finalized order edit

### DIFF
--- a/addons/point_of_sale/static/src/app/hooks/use_tracked_order.js
+++ b/addons/point_of_sale/static/src/app/hooks/use_tracked_order.js
@@ -1,0 +1,53 @@
+import { useEffect } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { usePos } from "../store/pos_hook";
+
+export const ALLOWED_SCREENS = ["ReceiptScreen", "TipScreen"];
+
+export const useTrackedOrder = (orderUuid) => {
+    const pos = usePos();
+    const order = pos.models["pos.order"].getBy("uuid", orderUuid);
+    const resetScreen = () => {
+        if (pos.firstScreen === pos.mainScreen.component.name) {
+            pos.add_new_order();
+        }
+
+        pos.showScreen(pos.firstScreen);
+        pos.notification.add(_t("Order has been finalized from another devices."), {
+            type: "warning",
+        });
+    };
+
+    useEffect(
+        (state) => {
+            // Loading do nothing
+            if (pos.env.services.ui.isBlocked) {
+                return;
+            }
+
+            const currentScreen = pos.mainScreen.component.name;
+            const orderFinalized = state === "paid" || state === "invoiced";
+            const screenIsAllowed = ALLOWED_SCREENS.includes(currentScreen);
+
+            if (!odoo.debug === "assets") {
+                console.debug(orderUuid, orderFinalized, screenIsAllowed);
+            }
+
+            // Everything is normal, do nothing
+            if (state === "draft") {
+                return;
+            }
+
+            // If the current screen is compatible with finalized orders, do nothing.
+            if (screenIsAllowed && orderFinalized) {
+                return;
+            }
+
+            // If the order is cancelled or finalized on a wrong screen, redirect the user
+            if (state === "cancel" || (!screenIsAllowed && orderFinalized)) {
+                return resetScreen();
+            }
+        },
+        () => [order.state]
+    );
+};

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -19,6 +19,7 @@ import { ask } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { handleRPCError } from "@point_of_sale/app/errors/error_handlers";
 import { sprintf } from "@web/core/utils/strings";
 import { serializeDateTime } from "@web/core/l10n/dates";
+import { useTrackedOrder } from "@point_of_sale/app/hooks/use_tracked_order";
 
 export class PaymentScreen extends Component {
     static template = "point_of_sale.PaymentScreen";
@@ -45,6 +46,7 @@ export class PaymentScreen extends Component {
         this.numberBuffer = useService("number_buffer");
         this.numberBuffer.use(this._getNumberBufferConfig);
         useErrorHandlers();
+        useTrackedOrder(this.props.orderUuid);
         this.payment_interface = null;
         this.error = false;
         this.validateOrder = useAsyncLockedMethod(this.validateOrder);

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -3,7 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { useBarcodeReader } from "@point_of_sale/app/barcode/barcode_reader_hook";
 import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
-import { Component, onMounted, useEffect, useState, reactive, onWillRender } from "@odoo/owl";
+import { Component, onMounted, useEffect, useState, reactive } from "@odoo/owl";
 import { CategorySelector } from "@point_of_sale/app/generic_components/category_selector/category_selector";
 import { Input } from "@point_of_sale/app/generic_components/inputs/input/input";
 import {
@@ -25,6 +25,7 @@ import {
 import { pick } from "@web/core/utils/objects";
 import { unaccent } from "@web/core/utils/strings";
 import { CameraBarcodeScanner } from "@point_of_sale/app/screens/product_screen/camera_barcode_scanner";
+import { useTrackedOrder } from "@point_of_sale/app/hooks/use_tracked_order";
 
 export class ProductScreen extends Component {
     static template = "point_of_sale.ProductScreen";
@@ -63,16 +64,10 @@ export class ProductScreen extends Component {
             this.numberBuffer.reset();
         });
 
-        onWillRender(() => {
-            // If its a shared order it can be paid from another POS
-            if (this.currentOrder?.state !== "draft") {
-                this.pos.add_new_order();
-            }
-        });
-
         this.barcodeReader = useService("barcode_reader");
         this.sound = useService("mail.sound_effects");
 
+        useTrackedOrder(this.currentOrder.uuid);
         useBarcodeReader({
             product: this._barcodeProductAction,
             quantity: this._barcodeProductAction,

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -6,6 +6,7 @@ import { useState, Component } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { useTrackedOrder } from "@point_of_sale/app/hooks/use_tracked_order";
 
 export class ReceiptScreen extends Component {
     static template = "point_of_sale.ReceiptScreen";
@@ -28,6 +29,7 @@ export class ReceiptScreen extends Component {
         this.sendReceipt = useTrackedAsync(this._sendReceiptToCustomer.bind(this));
         this.doFullPrint = useTrackedAsync(() => this.pos.printReceipt());
         this.doBasicPrint = useTrackedAsync(() => this.pos.printReceipt({ basic: true }));
+        useTrackedOrder(this.pos.get_order().uuid);
     }
 
     _addNewOrder() {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -425,12 +425,10 @@ export class PosStore extends Reactive {
                 return false;
             }
         }
-        const orderIsDeleted = await this.deleteOrders([order]);
-        if (orderIsDeleted) {
-            order.uiState.displayed = false;
-            this.afterOrderDeletion();
-        }
-        return orderIsDeleted;
+
+        this.deleteOrders([order]);
+        this.set_order(this.get_open_orders().at(-1) || this.createNewOrder());
+        return true;
     }
     afterOrderDeletion() {
         this.set_order(this.get_open_orders().at(-1) || this.createNewOrder());
@@ -470,9 +468,9 @@ export class PosStore extends Reactive {
 
         if (ids.size > 0) {
             await this.data.callRelated("pos.order", "action_pos_order_cancel", [Array.from(ids)]);
-            return true;
         }
 
+        this.afterOrderDeletion();
         return true;
     }
     /**

--- a/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/product_screen/order_summary/order_summary.js
@@ -22,8 +22,8 @@ patch(OrderSummary.prototype, {
     },
     async unbookTable() {
         const order = this.pos.get_order();
-        await this.pos.deleteOrders([order]);
         this.pos.showScreen(this.pos.firstScreen);
+        await this.pos.deleteOrders([order]);
     },
     showUnbookButton() {
         if (this.pos.selectedTable) {

--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -3,6 +3,7 @@ import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { Component, useState } from "@odoo/owl";
 import { Orderline } from "@point_of_sale/app/generic_components/orderline/orderline";
 import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
+import { useTrackedOrder } from "@point_of_sale/app/hooks/use_tracked_order";
 
 export class SplitBillScreen extends Component {
     static template = "pos_restaurant.SplitBillScreen";
@@ -13,6 +14,7 @@ export class SplitBillScreen extends Component {
         this.pos = usePos();
         this.qtyTracker = useState({});
         this.priceTracker = useState({});
+        useTrackedOrder(this.currentOrder.uuid);
     }
 
     get currentOrder() {


### PR DESCRIPTION
Before this commit when another device were finalizing an order (cancel, paid or invoiced) the current device was staying on its current screen which can be PaymentScreen, SplitScreen etc. But when the user was trying to edit the order a traceback was raised because the order is finalized.

Now when another device is finalizing an order, the current device will be notified and can take appropriate action, such as showing a warning message or preventing further edits to the order.

taskId: 4788430

