### PR TITLE
[FIX] survey: disable embedded components for survey messages

### DIFF
--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -184,10 +184,10 @@
                             </group>
                         </page>
                         <page string="Description" name="description">
-                            <field name="description" placeholder="e.g. &quot;The following Survey will help us...&quot;" nolabel="1"></field>
+                            <field name="description" placeholder="e.g. &quot;The following Survey will help us...&quot;" options="{'embedded_components': false}" nolabel="1"></field>
                         </page>
                         <page string="End Message" name="description_done">
-                            <field name="description_done" placeholder="e.g. &quot;Thank you very much for your feedback!&quot;" nolabel="1"></field>
+                            <field name="description_done" placeholder="e.g. &quot;Thank you very much for your feedback!&quot;" options="{'embedded_components': false}" nolabel="1"></field>
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
Embedded components do not render when the html field content is displayed outside the editor, as their mechanism relies on the editor plugin.

Solution:
---------
Disable embedded components for the survey messages (Description and End Message).

Steps to reproduce:
-------------------
* Create a new survey
* Add a video as End Message or Description
* Use the share link to view de survey
* Video not showing

Cause of the issue:
-------------------
The new web_editor has a plugin system, and one option that is enabled by default is embedded_components.

This option has been introduced in:

https://github.com/odoo/odoo/commit/03f495c696030214c17e6479076571823513f60e

According to the description:
"It is forcibly set to false in HtmlMailField since embedded
components can only be rendered inside Odoo."

Observation :
------------
similar fix:
https://github.com/odoo/odoo/commit/1446167e482745c71725563e56411948c3dd1f41

opw-5005752
