### PR TITLE
[IMP] l10n_fi: Rename Finnish Localization for Finland - Accounting

### DIFF
--- a/addons/l10n_fi/__manifest__.py
+++ b/addons/l10n_fi/__manifest__.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
-    'name': 'Finnish Localization',
+    'name': 'Finland - Accounting',
     'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['fi'],


### PR DESCRIPTION
The aim of this commit is having Finland in the module name to ease search on it in the application manager.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
