### PR TITLE
[FIX] spreadsheet_dashboard_sale_timesheet: fix filter for KPI cards

### DIFF
--- a/addons/spreadsheet_dashboard_sale_timesheet/data/files/timesheet_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale_timesheet/data/files/timesheet_dashboard.json
@@ -1562,16 +1562,10 @@
                 "group_expand": true
             },
             "domain": [
-                "&",
                 [
                     "project_id",
                     "!=",
                     false
-                ],
-                [
-                    "user_id",
-                    "=",
-                    2
                 ]
             ],
             "id": "5",
@@ -1595,16 +1589,10 @@
                 "group_expand": true
             },
             "domain": [
-                "&",
                 [
                     "project_id",
                     "!=",
                     false
-                ],
-                [
-                    "user_id",
-                    "=",
-                    2
                 ]
             ],
             "id": "6",


### PR DESCRIPTION
Steps to reproduce:
-
  1. Go to the dashboard app > Timesheets.
  2. Apply any global filter.

Issue:
-
The main KPI cards (Billable Hours, Non-billable Hours, Billable Rate) do not update correctly when any global filter is applied. Filtering by 'Employee' causes the cards to show zero. Other filters like 'Project' or 'Department' show incomplete and incorrect data, reflecting only the timesheets of a single hardcoded user.

Cause:
-
The pivot tables (`pivot 5` and `pivot 6`) that source the data for the KPI cards contained a hardcoded domain `['user_id', '=', 2]`. This condition changes any selection made in the global filter and shows incorrect data.

Fix:
-
The hardcoded `['user_id', '=', 2]` condition has been removed.

task-4782213
