### PR TITLE
[IMP] account_edi_proxy_client,*: move unique edi_id constraints

### DIFF
--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -59,24 +59,19 @@ class AccountEdiProxyClientUser(models.Model):
 
     _sql_constraints = [
         ('unique_id_client', 'unique(id_client)', 'This id_client is already used on another user.'),
-        ('unique_active_edi_identification', '', 'This edi identification is already assigned to an active user'),
         ('unique_active_company_proxy', '', 'This company has an active user already created for this EDI type'),
     ]
 
     def _auto_init(self):
         super()._auto_init()
-        if not index_exists(self.env.cr, 'account_edi_proxy_client_user_unique_active_edi_identification'):
-            self.env.cr.execute("""
-                CREATE UNIQUE INDEX account_edi_proxy_client_user_unique_active_edi_identification
-                                 ON account_edi_proxy_client_user(edi_identification, proxy_type, edi_mode)
-                              WHERE (active = True)
-            """)
         if not index_exists(self.env.cr, 'account_edi_proxy_client_user_unique_active_company_proxy'):
             self.env.cr.execute("""
                 CREATE UNIQUE INDEX account_edi_proxy_client_user_unique_active_company_proxy
                                  ON account_edi_proxy_client_user(company_id, proxy_type, edi_mode)
                               WHERE (active = True)
             """)
+
+        self.env.cr.execute("DROP INDEX IF EXISTS account_edi_proxy_client_user_unique_active_edi_identification")
 
     def _compute_private_key_filename(self):
         for record in self:
@@ -132,7 +127,8 @@ class AccountEdiProxyClientUser(models.Model):
                 _('The url that this service requested returned an error. The url it tried to contact was %s', url))
 
         if 'error' in response:
-            message = _('The url that this service requested returned an error. The url it tried to contact was %s. %s', url, response['error']['message'])
+            error_detail = response['error'].get('data', {}).get('message') or response['error']['message']
+            message = _('The url that this service requested returned an error. The url it tried to contact was %s. %s', url, error_detail)
             if response['error']['code'] == 404:
                 message = _('The url that this service tried to contact does not exist. The url was %r', url)
             raise AccountEdiProxyError('connection_error', message)

--- a/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
+++ b/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
@@ -27,6 +27,10 @@ class PeppolSettingsButtons extends Component {
         });
     }
 
+    get useParentCompany() {
+        return Boolean(this.props.record.data.peppol_use_parent_company);
+    }
+
     get proxyState() {
         return this.props.record.data.account_peppol_proxy_state;
     }

--- a/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.xml
+++ b/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.xml
@@ -40,7 +40,7 @@
                     <button type="button"
                             class="btn btn-primary"
                             t-on-click="sendCode"
-                            t-if="proxyState === 'not_verified'">
+                            t-if="proxyState === 'not_verified' and useParentCompany === false">
                             Verify mobile number
                     </button>
                 </div>

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -137,14 +137,6 @@ class TestPeppolParticipant(TransactionCase):
         with self.assertRaises(ValidationError), self.cr.savepoint():
             settings.button_create_peppol_proxy_user()
 
-    def test_create_participant_already_exists(self):
-        # creating a participant that already exists on Peppol network should not be possible
-        vals = self._get_participant_vals()
-        vals['account_peppol_eas'] = '0208'
-        settings = self.env['res.config.settings'].create(vals)
-        with self.assertRaises(UserError), self.cr.savepoint():
-            settings.button_create_peppol_proxy_user()
-
     def test_create_success_participant(self):
         # should be possible to apply with all data
         # the account_peppol_proxy_state should correctly change to pending

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -9,6 +9,7 @@
                 <div id="account_peppol">
                     <div class="col-12 col-lg-12 o_setting_box">
                         <field name="account_peppol_proxy_state" invisible="1"/>
+                        <field name="peppol_use_parent_company" invisible="1"/>
                         <div class="o_setting_right_pane border-0">
                             <div class="mb-2">
                                 <span class="o_form_label">


### PR DESCRIPTION
This commit removes the `unique_active_edi_identification` constraints from the _auto_init of `account_edi_proxy_client` client user model, and adds back the constraint on `l10n_my_edi` and `l10n_it_edi` to make it apply only to those localizations.

task-4852830