### PR TITLE
[IMP] l10n_es_reports: modelo 303 line 65 default 100%

### DIFF
--- a/addons/l10n_es/data/mod303.xml
+++ b/addons/l10n_es/data/mod303.xml
@@ -946,7 +946,8 @@
                             <record id="mod_303_casilla_65_balance" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">external</field>
-                                <field name="formula">sum</field>
+                                <field name="formula">most_recent</field>
+                                <field name="date_scope">from_beginning</field>
                                 <field name="figure_type">percentage</field>
                                 <field name="subformula">editable;rounding=2</field>
                             </record>


### PR DESCRIPTION
[IMP] l10n_es_reports: modelo 303 line 65 history

In most case, people will put 100% in box [65] of the modelo 303, with
this commit once the user set any value for one period, this value will
be applied to every next period. If the user modifies the value in
another next period, this new value will be applied from this date.

task-4960125

