### PR TITLE
[FIX] web_editor: restore partial border-radius classes

### DIFF
--- a/addons/html_builder/static/src/scss/utilities_custom.scss
+++ b/addons/html_builder/static/src/scss/utilities_custom.scss
@@ -1,21 +1,6 @@
 // Extend utilities
 // See BORDER_VARIABLES_RULES_EXTENSION
 
-$rounded-sizes: () !default;
-$rounded-sizes: map-merge(
-    $rounded-sizes,
-    (
-        null: var(--#{$prefix}border-radius),
-        0: 0,
-        1: var(--#{$prefix}border-radius-sm),
-        2: var(--#{$prefix}border-radius),
-        3: var(--#{$prefix}border-radius-lg),
-        4: var(--#{$prefix}border-radius-xl),
-        5: var(--#{$prefix}border-radius-xxl),
-        circle: 50%,
-        pill: var(--#{$prefix}border-radius-pill)
-    )
-);
 $utilities: () !default;
 $utilities: map-merge(
     $utilities,
@@ -23,27 +8,21 @@ $utilities: map-merge(
         "rounded": (
             property: --box-border-radius,
             class: rounded,
-            values: $rounded-sizes,
-        ),
-        "rounded-top": (
-            property: --box-border-top-left-radius --box-border-top-right-radius,
-            class: rounded-top,
-            values: $rounded-sizes,
-        ),
-        "rounded-end": (
-            property: --box-border-top-right-radius --box-border-bottom-right-radius,
-            class: rounded-end,
-            values: $rounded-sizes,
-        ),
-        "rounded-bottom": (
-            property: --box-border-bottom-right-radius --box-border-bottom-left-radius,
-            class: rounded-bottom,
-            values: $rounded-sizes,
-        ),
-        "rounded-start": (
-            property: --box-border-bottom-left-radius --box-border-top-left-radius,
-            class: rounded-start,
-            values: $rounded-sizes,
+            // FIXME addons/web/static/src/scss/utilities_custom.scss is
+            // forcing non CSS values (and actually less values) for partial
+            // direction class (e.g. rounded-end)... probably to review.
+            values: (
+                // Default values of bootstrap
+                null: var(--#{$prefix}border-radius),
+                0: 0,
+                1: var(--#{$prefix}border-radius-sm),
+                2: var(--#{$prefix}border-radius),
+                3: var(--#{$prefix}border-radius-lg),
+                4: var(--#{$prefix}border-radius-xl),
+                5: var(--#{$prefix}border-radius-xxl),
+                circle: 50%,
+                pill: var(--#{$prefix}border-radius-pill)
+            ),
         ),
     ),
 );

--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -166,9 +166,10 @@ body.editor_enable:not(.o_basic_theme) .odoo-editor-editable {
         var(--box-border-bottom-width)
         var(--box-border-left-width) !important;
 }
-// TODO this should probably be done for all bootstrap "border" classes like
-// "rounded" classes below? At the moment, it was not done because builder
-// options do not allow to set those but layouts could?
+// TODO this should probably be done for all bootstrap "border" *sizes* classes
+// like "rounded" classes below. At the moment, it was not done because builder
+// options do not allow to set those yet, but layouts could(?).
+// See ROUNDED_SIZES_CLASSES_ONLY.
 .border {
     @extend %box-border-width-rules;
 }
@@ -196,12 +197,16 @@ body.editor_enable:not(.o_basic_theme) .odoo-editor-editable {
         var(--box-border-bottom-right-radius)
         var(--box-border-bottom-left-radius) !important;
 }
-$utilities-radius-keys: ("rounded", "rounded-top", "rounded-end", "rounded-bottom", "rounded-start") !default;
-@each $direction in $utilities-radius-keys {
-    @each $size, $value in $rounded-sizes {
-        $class-suffix: if($size == null, "", "-#{$size}");
-        .#{$direction}#{$class-suffix} {
-            @extend %box-border-radius-rules;
-        }
+// Note: we do not support partial border-radius classes using CSS variables
+// just yet. We could (at the cost of dividing the `%box-border-radius-rules`
+// into 4 or 5 parts), but this is not necessary at the moment. They can be used
+// in layouts but we do not allow edition of their radius via the builder: when
+// we do, we normally should always prefer to give the user full control over
+// the 4 directions, by switching to the `rounded` or a `rounded-{SIZE}` class.
+// See ROUNDED_SIZES_CLASSES_ONLY.
+@each $size, $value in map-get(map-get($utilities, 'rounded'), 'values') {
+    $class-suffix: if($size == null, "", "-#{$size}");
+    .rounded#{$class-suffix} {
+        @extend %box-border-radius-rules;
     }
-};
+}


### PR DESCRIPTION
Commit [1] (which was patched by multiple other commits since then already) needs yet another patch: the `rounded-start`, `rounded-end`, `rounded-top`, `rounded-bottom` and all their size variants were not working anymore: the direction they were not supposed to control were forced to the default border-radius value. E.g. the class rounded-end-4 was forcing `border-radius: default big big default` instead of just forcing "big" on the top-right and bottom-right.

This could be fixed while keeping the improvement added by [1] (which is allowing the value to use CSS variable, allowing to auto-adapt children with the right border-radius when needed) but it is fact better/simpler to just revert the improvement just for those classes (while keeping it for the base `rounded` and `rounded-{SIZE}` classes). Indeed, this is not necessary at the moment. They can be used in layouts but we do not allow edition of their radius via the builder: when we do, we normally should always prefer to give the user full control over the 4 directions, by switching to the `rounded` or a `rounded-{SIZE}` class.

This bug could be visible in different standard ways:
- Notifications
- Cards Grid snippet
- ...

Note: this also actually revealed that [1] re-introduced the 4 and 5 sizes which were actually disabled by the /web/.../utilities_custom.scss file. This commit re-disable them for those partial classes... but they probably should be restored to respect Bootstrap's default. The 1-2-3 sizes are also not using CSS variable of Bootstrap. This commit adds a FIXME comment about this.

[1]: https://github.com/odoo/odoo/commit/d0daf3990079477ef7552d769b944b55d9be4366

Related to task-3358501