### PR TITLE
[FIX] html_editor: do not set default selection in root if prohibited

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -336,16 +336,19 @@ export class SelectionPlugin extends Plugin {
         let range;
         let activeSelection;
         if (!selection || !selection.rangeCount) {
+            const [targetNode, targetOffset] = this.config.allowInlineAtRoot
+                ? [this.editable, 0]
+                : getDeepestPosition(this.editable, 0);
             activeSelection = {
-                anchorNode: this.editable,
-                anchorOffset: 0,
-                focusNode: this.editable,
-                focusOffset: 0,
-                startContainer: this.editable,
-                startOffset: 0,
-                endContainer: this.editable,
-                endOffset: 0,
-                commonAncestorContainer: this.editable,
+                anchorNode: targetNode,
+                anchorOffset: targetOffset,
+                focusNode: targetNode,
+                focusOffset: targetOffset,
+                startContainer: targetNode,
+                startOffset: targetOffset,
+                endContainer: targetNode,
+                endOffset: targetOffset,
+                commonAncestorContainer: targetNode,
                 isCollapsed: true,
                 direction: DIRECTIONS.RIGHT,
                 textContent: () => "",

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -100,7 +100,9 @@ describe("should position the cursor outside the link", () => {
     test("clicking at the start of the link when format is applied on link", async () => {
         const { el } = await setupEditor('<p><strong><a href="#/">test</a></strong></p>');
         expect(getContent(el)).toBe(
-            '<p><strong>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>'
+            // The editable selection is in the link (first leaf of the editable
+            // upon initialization).
+            '<p><strong>\ufeff<a href="#/" class="o_link_in_selection">\ufefftest\ufeff</a>\ufeff</strong></p>'
         );
 
         const aElement = queryOne("p a");
@@ -108,7 +110,7 @@ describe("should position the cursor outside the link", () => {
         // Simulate the selection with mousedown
         setSelection({ anchorNode: aElement.childNodes[0], anchorOffset: 0 });
         expect(getContent(el)).toBe(
-            '<p><strong>\ufeff<a href="#/">[]\ufefftest\ufeff</a>\ufeff</strong></p>'
+            '<p><strong>\ufeff<a href="#/" class="o_link_in_selection">[]\ufefftest\ufeff</a>\ufeff</strong></p>'
         );
         await animationFrame(); // selection change
         await pointerUp(el);
@@ -343,7 +345,10 @@ test("should not zwnbsp-pad link with image", async () => {
 test("should remove zwnbsp from middle of the link", async () => {
     await testEditor({
         contentBefore: '<p><a href="#/">content</a></p>',
-        contentBeforeEdit: '<p>\ufeff<a href="#/">\ufeffcontent\ufeff</a>\ufeff</p>',
+        contentBeforeEdit:
+            // The editable selection is in the link (first leaf of the editable
+            // upon initialization).
+            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffcontent\ufeff</a>\ufeff</p>',
         stepFunction: async (editor) => {
             // Cursor before the FEFF text node
             setSelection({ anchorNode: editor.editable.querySelector("a"), anchorOffset: 0 });
@@ -358,7 +363,10 @@ test("should remove zwnbsp from middle of the link", async () => {
 test("should remove zwnbsp from middle of the link (2)", async () => {
     await testEditor({
         contentBefore: '<p><a href="#/">content</a></p>',
-        contentBeforeEdit: '<p>\ufeff<a href="#/">\ufeffcontent\ufeff</a>\ufeff</p>',
+        contentBeforeEdit:
+            // The editable selection is in the link (first leaf of the editable
+            // upon initialization).
+            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffcontent\ufeff</a>\ufeff</p>',
         stepFunction: async (editor) => {
             // Cursor inside the FEFF text node
             setSelection({

--- a/addons/website/static/tests/builder/linkpopover_website.test.js
+++ b/addons/website/static/tests/builder/linkpopover_website.test.js
@@ -112,6 +112,7 @@ test("LinkPopover opens in full composer", async () => {
     await mailClick("button", { text: "Log note" });
     await mailClick("button[title='Open Full Composer']");
     await waitFor(".odoo-editor-editable");
+    htmlEditor.editable.focus();
     await insertText(htmlEditor, "test");
     const node = queryOne(".odoo-editor-editable div.o-paragraph");
     setSelection({ anchorNode: node, anchorOffset: 0, focusNode: node, focusOffset: 1 });


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/93936

When setting the active selection, if no document selection existed, we were setting it at (editable, 0). However, if the configuration has the property `allowInlineAtRoot` isn't true, this is prohibited.

This sets that selection in the deepest first position in the editable in that case.

task-4585835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
