### PR TITLE
[FIX] html_editor: use document selection to compute hint targets

### DIFF
--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -91,7 +91,10 @@ export class ColumnPlugin extends Plugin {
         move_node_whitelist_selectors: ".o_text_columns",
         move_node_blacklist_selectors: ".o_text_columns *",
         hint_targets_providers: (selectionData) => {
-            const anchorNode = selectionData.editableSelection.anchorNode;
+            if (!selectionData.documentSelection) {
+                return [];
+            }
+            const anchorNode = selectionData.documentSelection.anchorNode;
             const columnContainer = closestElement(anchorNode, "div.o_text_columns");
             if (!columnContainer) {
                 return [];

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -19,10 +19,10 @@ export class HintPlugin extends Plugin {
         content_updated_handlers: this.updateHints.bind(this),
 
         hint_targets_providers: (selectionData, editable) => {
-            if (!selectionData.currentSelectionIsInEditable) {
+            if (!selectionData.currentSelectionIsInEditable || !selectionData.documentSelection) {
                 return [];
             }
-            const blockEl = closestBlock(selectionData.editableSelection.anchorNode);
+            const blockEl = closestBlock(selectionData.documentSelection.anchorNode);
             if (this.dependencies.selection.isNodeEditable(blockEl)) {
                 return [blockEl];
             } else {


### PR DESCRIPTION
Some hint target providers were using the editable selection to determine which elements should receive hints. But we only want the hints when the selection is effectively in these elements (ie, we don't want the hints if we leave the editable).

task-4585835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
