### PR TITLE
[IMP] mrp: add new by-products to the bottom

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -121,7 +121,7 @@
                             invisible="type != 'normal'"
                             groups="mrp.group_mrp_byproducts">
                             <field name="byproduct_ids" context="{'form_view_ref' : 'mrp.mrp_bom_byproduct_form_view', 'default_bom_id': id}">
-                                <list string="By-products"  editable="top">
+                                <list string="By-products" editable="bottom">
                                     <control>
                                         <create string="Add a line"/>
                                         <button name="action_add_from_catalog" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- New BoM by-products were always added to the top,
which isn't convenient. Therefore, `editable` was modified
 to add to the bottom instead.

Task: 5016519





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
