### PR TITLE
[FIX] point_of_sale: prevent missing recursive infinite loop

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1189,11 +1189,14 @@ class PosOrder(models.Model):
         return pos_order_ids.read_pos_data(orders, config_id)
 
     @api.model
+    def read_pos_orders(self, domain=False):
+        orders = self.search(domain)
+        config_id = orders[0].config_id.id if orders else False
+        return orders.read_pos_data([], config_id)
+
+    @api.model
     def read_pos_data_uuid(self, uuid):
-        order = self.search([('uuid', '=', uuid)], limit=1)
-        if not order:
-            return {}
-        return order.read_pos_data([], order.config_id.id)
+        return self.read_pos_orders([('uuid', '=', uuid)])
 
     def read_pos_data(self, data, config_id):
         # If the previous session is closed, the order will get a new session_id due to _get_valid_session in _process_order

--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -65,6 +65,8 @@ export class DataServiceOptions {
 
     get pohibitedAutoLoadedModels() {
         return [
+            "pos.order", // Cannot be auto-loaded can cause infinite loop
+            "pos.order.line", // Cannot be auto-loaded can cause infinite loop
             "pos.session",
             "pos.config",
             "res.users",

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.js
@@ -34,10 +34,15 @@ export class InvoiceButton extends Component {
     }
     async _downloadInvoice(orderId) {
         try {
-            const orderWithInvoice = await this.pos.data.read("pos.order", [orderId], [], {
-                load: false,
-            });
-            const order = orderWithInvoice[0];
+            const result = await this.pos.data.callRelated(
+                "pos.order",
+                "read_pos_orders",
+                [[["id", "=", orderId]]],
+                {},
+                false,
+                true
+            );
+            const order = result["pos.order"][0];
             const accountMoveId = order.raw.account_move;
             if (accountMoveId) {
                 await this.invoiceService.downloadPdf(accountMoveId);

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -156,7 +156,15 @@ export class TicketScreen extends Component {
     async onClickScanOrder(qrcode) {
         if (qrcode) {
             const uuid = new URL(qrcode).searchParams.get("order_uuid");
-            const [order] = await this.pos.data.searchRead("pos.order", [["uuid", "=", uuid]]);
+            const results = await this.pos.data.callRelated(
+                "pos.order",
+                "read_pos_orders",
+                [[["uuid", "=", uuid]]],
+                {},
+                false,
+                true
+            );
+            const order = results["pos.order"][0];
             if (order) {
                 this.state.filter = "SYNCED";
                 this.state.selectedOrder = order;
@@ -810,7 +818,14 @@ export class TicketScreen extends Component {
             .map((info) => info[0]);
 
         if (idsNotInCacheOrOutdated.length > 0) {
-            await this.pos.data.read("pos.order", Array.from(new Set(idsNotInCacheOrOutdated)));
+            await this.pos.data.callRelated(
+                "pos.order",
+                "read_pos_orders",
+                [[["id", "in", Array.from(new Set(idsNotInCacheOrOutdated))]]],
+                {},
+                false,
+                true
+            );
         }
     }
     //#endregion

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -661,8 +661,14 @@ export class PosStore extends WithLazyGetterTrap {
         const orderPathUuid = this.router.state.params.orderUuid;
         const order = this.models["pos.order"].find((order) => order.uuid === orderPathUuid);
         if (orderPathUuid && !order) {
-            const result = await this.data.call("pos.order", "read_pos_data_uuid", [orderPathUuid]);
-            this.models.loadConnectedData(result);
+            await this.data.callRelated(
+                "pos.order",
+                "read_pos_orders",
+                [[["uuid", "=", orderPathUuid]]],
+                {},
+                false,
+                true
+            );
             const order = this.models["pos.order"].find((order) => order.uuid === orderPathUuid);
             if (order) {
                 this.setOrder(order);
@@ -1542,7 +1548,15 @@ export class PosStore extends WithLazyGetterTrap {
         ]);
     }
     async loadServerOrders(domain) {
-        const orders = await this.data.searchRead("pos.order", domain);
+        const result = await this.data.callRelated(
+            "pos.order",
+            "read_pos_orders",
+            [domain],
+            {},
+            false,
+            true
+        );
+        const orders = result["pos.order"] || [];
         for (const order of orders) {
             order.config_id = this.config;
             order.session_id = this.session;
@@ -2127,10 +2141,13 @@ export class PosStore extends WithLazyGetterTrap {
             resModel: "pos.order",
             resId: order.id,
             onRecordSaved: async (record) => {
-                await this.data.read("pos.order", [record.evalContext.id]);
-                await this.data.read(
-                    "pos.payment",
-                    order.payment_ids.map((p) => p.id)
+                await this.data.callRelated(
+                    "pos.order",
+                    "read_pos_orders",
+                    [[["id", "=", record.evalContext.id]]],
+                    {},
+                    false,
+                    true
                 );
                 this.action.doAction({
                     type: "ir.actions.act_window_close",

--- a/addons/point_of_sale/static/tests/unit/data/pos_order.data.js
+++ b/addons/point_of_sale/static/tests/unit/data/pos_order.data.js
@@ -11,6 +11,12 @@ export class PosOrder extends models.ServerModel {
         };
     }
 
+    read_pos_orders(domain) {
+        const results = this.search(domain, this._load_pos_data_fields(), false);
+        const ids = results.filter((record) => record.state === "draft").map((record) => record.id);
+        return this.read_pos_data(ids);
+    }
+
     _load_pos_data_fields() {
         return [];
     }

--- a/addons/pos_online_payment/static/src/app/services/pos_store.js
+++ b/addons/pos_online_payment/static/src/app/services/pos_store.js
@@ -11,7 +11,15 @@ patch(PosStore.prototype, {
             // notification to invite the local browser to do a safe RPC to
             // the server to check the new state of the order.
             const order = this.models["pos.order"].find((o) => o.id == id);
-            const updatedOrder = await this.data.read("pos.order", [id])[0];
+            const result = await this.data.callRelated(
+                "pos.order",
+                "read_pos_orders",
+                [[["id", "=", id]]],
+                {},
+                false,
+                true
+            );
+            const updatedOrder = result["pos.order"][0];
             if (updatedOrder) {
                 order.state = updatedOrder.state;
             }


### PR DESCRIPTION
*: pos_online_payment

The `pos.order` model was missing from pohibitedAutoLoadedModels which
was causing infinite loop when validating an order.

This commit add this models to the pohibitedAutoLoadedModels variable.

Now when downloading an order from the PoS the `read_pos_orders`
method should be used, it will returns all related order data.