### PR TITLE
[FIX] base: race attachment create and gc_file_store

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -243,17 +243,31 @@ class IrAttachment(models.Model):
         self._set_attachment_data(lambda attach: base64.b64decode(attach.datas or b''))
 
     def _set_attachment_data(self, asbytes):
+        old_fnames = []
+        checksum_raw_map = {}
+
         for attach in self:
             # compute the fields that depend on datas
             bin_data = asbytes(attach)
             vals = self._get_datas_related_values(bin_data, attach.mimetype)
+            if bin_data:
+                checksum_raw_map[vals['checksum']] = bin_data
 
             # take current location in filestore to possibly garbage-collect it
-            fname = attach.store_fname
+            if attach.store_fname:
+                old_fnames.append(attach.store_fname)
+
             # write as superuser, as user probably does not have write access
             super(IrAttachment, attach.sudo()).write(vals)
-            if fname:
+
+        if self._storage() != 'db':
+            # before touching the filestore, flush to prevent the GC from
+            # running until the end of the transaction
+            self.flush_recordset(['checksum', 'store_fname'])
+            for fname in old_fnames:
                 self._file_delete(fname)
+            for checksum, raw in checksum_raw_map.items():
+                self._file_write(raw, checksum)
 
     def _get_datas_related_values(self, data, mimetype):
         checksum = self._compute_checksum(data)
@@ -269,7 +283,7 @@ class IrAttachment(models.Model):
             'db_datas': data,
         }
         if data and self._storage() != 'db':
-            values['store_fname'] = self._file_write(data, values['checksum'])
+            values['store_fname'], _full_path = self._get_path(data, checksum)
             values['db_datas'] = False
         return values
 
@@ -632,6 +646,7 @@ class IrAttachment(models.Model):
             in vals.items()
             if key not in ('file_size', 'checksum', 'store_fname')
         } for vals in vals_list]
+        checksum_raw_map = {}
 
         for values in vals_list:
             values = self._check_contents(values)
@@ -640,10 +655,11 @@ class IrAttachment(models.Model):
                 if isinstance(raw, str):
                     # b64decode handles str input but raw needs explicit encoding
                     raw = raw.encode()
-                values.update(self._get_datas_related_values(
-                    raw or base64.b64decode(datas or b''),
-                    values['mimetype']
-                ))
+                elif not raw:
+                    raw = base64.b64decode(datas or b'')
+                values.update(self._get_datas_related_values(raw, values['mimetype']))
+                if raw:
+                    checksum_raw_map[values['checksum']] = raw
 
             # 'check()' only uses res_model and res_id from values, and make an exists.
             # We can group the values by model, res_id to make only one query when
@@ -656,6 +672,9 @@ class IrAttachment(models.Model):
         for res_model, res_id in record_tuple_set:
             Attachments.check('create', values={'res_model':res_model, 'res_id':res_id})
         records = super().create(vals_list)
+        if self._storage() != 'db':
+            for checksum, raw in checksum_raw_map.items():
+                self._file_write(raw, checksum)
         records._check_serving_attachments()
         return records
 

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -423,6 +423,7 @@ class TestHttpStatic(TestHttpStaticCommon):
         for field in ('glyph_attach', 'glyph_inline', 'glyph_related', 'glyph_compute'):
             earth[field] = data
             res = self.url_open(f'/web/image/test_http.stargate/{earth.id}/{field}')
+            res.raise_for_status()
             self.assertEqual(res.headers['Content-Type'], 'application/octet-stream')  # Shouldn't be text/html
             self.assertEqual(res.headers['Content-Security-Policy'], "default-src 'none'")
 


### PR DESCRIPTION
Should ideally land in 13.0... Let's merge it in 18.3 where we need it first... Then backport it to 16.0 if deemed useful/necessary.

---

There is a race condition between `ir.attachment.create` and `ir.attachment._gc_file_store` that can lead to the creation of an attachment with no related file in the file store.

Race
----

The race runs as follow:

1) `_gc_file_store` acquires a write exlusif lock on the ir_attachment table, but is interrupted by the OS before it can load the file gc checklist.
2) `create` kicks in, write a new file on file-system, adds an entry in the checklist, but can't create the ir.attachment record yet as the table is locked.
3) `_gc_file_store` resumes, load the checklist, see that `create`'s file as no attachment and removes it. It then releases the write exclusif table lock.
4) `create` resumes, it creates the `ir.attachment` record.

Subsequent access on the ir.attachment created record `raw` or `datas` fields fails because the file doesn't exist on disk.

Test
----

https://gist.github.com/Julien00859/512cfbad47c15febbfd667a017df7c8b

The `test_attachment_concurrency_create_gc` test reproduces the above steps to reproduce the bug. It does so by mocking the appropriate functions and using `threading.Event` to synchronize the execution plan between the two threads. Run it using the following command:

    --test-tags database_breaking.test_attachment_concurrency_create_gc

It is database breaking because the ir.attachment file created during the test may not cleaned after the test run (in case the power goes down at the wrong moment).

Description
-----------

The bug was introduced by commit afdfdbfa5b36b in 13.0. Before that commit the create override in ir.attachment would first create the record, and only then write the file on disk. This way the `create` function acquired first a row exclusif lock and only then wrote the file and the checklist.

That the error went undercover for several years can be explained as follow:

1. The ir.autovacuum model and its cron has been unreliable for many years, it was often reported that the `_gc_file_store` (being the last in the list) did not run.
2. That the cron did not run made for a huge checklist that couldn't be processed all at once.
3. The cron usually only run once per night, when there are less people connected on the database to create attachments.
4. Finally, embarassing, we did discard some "missing file" reports and instead blamed the customers who reported them.

That we discover the error now is another chain of events:

1. The ir.autovacuum model now makes an advanced usage of the cron progress API. The cron is now automatically scheduled to run again "as soon as possible" when an exception occured in one of the `@api.autovacuum` methods.
2. The documents autovacuum is failing in 18.3 100% of the time (this is being addressed in another PR). This forces the "run again as soon as possible" condition permanent. The cron is basically always running.
3. The Odoo employees are all paid at the same time, and we all receive a PDF payslip as attachment. As many attachments as there are employees are created at a same time.

Some of us couldn't download our August payslip :-(