### PR TITLE
[IMP] mail: html composer basic style

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -128,6 +128,37 @@
     }
 }
 
+.o-mail-Composer-html {
+    padding-top: 10px; // carefully crafted to have the text in the middle in chat window
+    padding-bottom: 10px;
+    padding-left: map-get($spacers, 1);
+    padding-right: map-get($spacers, 1);
+
+    line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
+
+    .o-mail-Composer.o-editing & {
+        padding-left: map-get($spacers, 2);
+        padding-right: map-get($spacers, 2);
+    }
+
+    .o-mail-Composer.o-extended & {
+        padding-left: map-get($spacers, 2) + map-get($spacers, 1);
+        padding-right: map-get($spacers, 2);
+    }
+
+    .o-mail-Composer.o-chatWindow & {
+        padding-top: 7px;
+        padding-bottom: 7px;
+        padding-left: map-get($spacers, 1) / 2;
+        padding-right: map-get($spacers, 1) / 2;
+    }
+
+    .o-mail-Composer.o-isUiSmall & {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+}
+
 .o-mail-Composer-input {
     max-height: Min(400px, 60vh);
     resize: none;

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -1,6 +1,7 @@
 import { fields, OR, Record } from "@mail/core/common/record";
 import { convertBrToLineBreak, prettifyMessageText } from "@mail/utils/common/format";
 import { markup } from "@odoo/owl";
+import { isHtmlEmpty } from "@web/core/utils/html";
 
 export class Composer extends Record {
     static id = OR("thread", "message");
@@ -8,7 +9,7 @@ export class Composer extends Record {
     clear() {
         this.attachments.length = 0;
         this.replyToMessage = undefined;
-        this.composerHtml = "";
+        this.composerHtml = markup("<p><br></p>");
         Object.assign(this.selection, {
             start: 0,
             end: 0,
@@ -53,7 +54,9 @@ export class Composer extends Record {
                 return;
             }
             this.updateFrom = "html";
-            this.composerText = convertBrToLineBreak(this.composerHtml);
+            this.composerText = isHtmlEmpty(this.composerHtml)
+                ? ""
+                : convertBrToLineBreak(this.composerHtml);
         },
     });
     thread = fields.One("Thread");


### PR DESCRIPTION
This commit improves the html composer basic style and fix the flickering.

The style should be polished when most features are implemented.

<img width="984" height="105" alt="image" src="https://github.com/user-attachments/assets/dc85d16a-e2a5-421b-8ce8-c12651dcf084" />

<img width="970" height="162" alt="image" src="https://github.com/user-attachments/assets/fef83c72-187e-4647-92ef-5d9a1be4f048" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
