### PR TITLE
[FIX] hr_attendance: replace dead onboarding RFID link

### DIFF
--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -104,7 +104,7 @@
                         <div>
                             Connect an RFID reader, and scan a token.
                             <DocumentationLink path="'/applications/hr/attendances/hardware.html'" label.translate="'Read the Documentation'" alertLink="true"/>/
-                            <DocumentationLink path="'https://neuftech.net/Neuftech-USB-RFID-Reader-ID-Kartenleseger%C3%A4t-Kartenleser-Kontaktlos-Card-Reader-f%C3%BCr-EM4100'" label.translate="'Buy an RFID Device'" alertLink="true"/>
+                            <DocumentationLink path="'https://www.amazon.fr/s?i=merchant-items&amp;me=A8A1OT6EFYV9W'" label.translate="'Buy an RFID Device'" alertLink="true"/>
                         </div>
                         <button t-on-click="removeDemoMessage" type="button" class="btn-close float-end ms-2" title="Close"/>
                 </div>


### PR DESCRIPTION
The public kiosk onboarding ("Buy an RFID Device") pointed to a tinyurl that is now dead, breaking the help CTA during setup. Replace it with the Amazon merchant listing to provide a working purchase path.

task-5051875