### PR TITLE
[FIX] base: misused variable in _search_full_name for res.groups

### DIFF
--- a/odoo/addons/base/models/res_groups.py
+++ b/odoo/addons/base/models/res_groups.py
@@ -130,12 +130,13 @@ class ResGroups(models.Model):
 
         if isinstance(operand, str):
             def make_operand(val): return val
-            operand = [operand]
+            operands = [operand]
         else:
             def make_operand(val): return [val]
+            operands = operand
 
         where_domains = [Domain('name', operator, operand)]
-        for group in operand:
+        for group in operands:
             if not group:
                 continue
             domain = Domain('name', operator, make_operand(group))


### PR DESCRIPTION
Followup of #223210 .