### PR TITLE
[FIX] website: correctly assign dynamic svg colors

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -9,7 +9,7 @@ import {
     useDomState,
     useHasPreview,
 } from "../utils";
-import { isColorGradient } from "@web/core/utils/colors";
+import { isCSSColor, isColorGradient } from "@web/core/utils/colors";
 import { getAllUsedColors } from "@html_builder/utils/utils_css";
 
 // TODO replace by useInputBuilderComponent after extract unit by AGAU
@@ -159,7 +159,10 @@ export class BuilderColorPicker extends Component {
             if (isColorGradient(this.state.selectedColor)) {
                 return `background-image: ${this.state.selectedColor}`;
             }
-            return `background-color: ${this.state.selectedColor}`;
+            if (isCSSColor(this.state.selectedColor)) {
+                return `background-color: ${this.state.selectedColor}`;
+            }
+            return `background-color: var(--${this.state.selectedColor})`;
         }
         if (this.state.selectedColorCombination) {
             const colorCombination = this.state.selectedColorCombination.replace("_", "-");

--- a/addons/web/static/src/core/utils/colors.js
+++ b/addons/web/static/src/core/utils/colors.js
@@ -217,7 +217,7 @@ export function convertRgbaToCSSColor(r, g, b, a) {
  */
 export function convertCSSColorToRgba(cssColor = "") {
     // Check if cssColor is a rgba() or rgb() color
-    const rgba = cssColor.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/);
+    const rgba = cssColor.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*(?:\.\d+)?))?\)$/);
     if (rgba) {
         if (rgba[4] === undefined) {
             rgba[4] = 1;

--- a/addons/website/static/src/builder/plugins/dynamic_svg_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/dynamic_svg_option_plugin.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import { Plugin } from "@html_editor/plugin";
 import { DynamicSvgOption } from "./dynamic_svg_option";
 import { normalizeCSSColor } from "@web/core/utils/colors";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { loadImage } from "@html_editor/utils/image_processing";
 import { withSequence } from "@html_editor/utils/resource";
 import { DYNAMIC_SVG } from "@html_builder/utils/option_sequence";
@@ -27,11 +28,26 @@ export class SvgColorAction extends BuilderAction {
     static id = "svgColor";
     getValue({ editingElement: imgEl, params: { mainParam: colorName } }) {
         const searchParams = new URL(imgEl.src, window.location.origin).searchParams;
-        return searchParams.get(colorName);
+        const color = searchParams.get(colorName);
+        return /^o-color-[1-5]$/.test(color)
+            ? getCSSVariableValue(color, getHtmlStyle(this.document))
+            : normalizeCSSColor(color);
+    }
+    colorToSearchParams(color) {
+        const cssVarMatch = color.match(/var\(--(.+)\)/);
+        if (cssVarMatch === null) {
+            return normalizeCSSColor(color);
+        }
+        // If it is a palette color, return the variable name
+        if (/^o-color-[1-5]$/.test(cssVarMatch[1])) {
+            return cssVarMatch[1];
+        }
+        // If it is a CSS variable, extract the color value
+        return getCSSVariableValue(cssVarMatch[1], getHtmlStyle(this.document));
     }
     async load({ editingElement: imgEl, params: { mainParam: colorName }, value: color }) {
         const newURL = new URL(imgEl.src, window.location.origin);
-        newURL.searchParams.set(colorName, normalizeCSSColor(color));
+        newURL.searchParams.set(colorName, this.colorToSearchParams(color));
         const src = newURL.pathname + newURL.search;
         await loadImage(src);
         return src;

--- a/addons/website/static/tests/builder/website_builder/dynamic_svg_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/dynamic_svg_option.test.js
@@ -1,0 +1,49 @@
+import { expect, test } from "@odoo/hoot";
+import { waitFor } from "@odoo/hoot-dom";
+import { contains } from "@web/../tests/web_test_helpers";
+import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+
+defineWebsiteModels();
+
+test("Change dynamic SVG colors", async () => {
+    const imgPath = "/html_editor/shape/website/s_attributes_1.svg";
+    await setupWebsiteBuilder(`<img src="${imgPath}?c1=%23000000">`, {
+        styleContent: `
+            :root {
+                --o-color-1: #111111;
+                --white: #FFFFFF;
+            }`,
+    });
+
+    const svg = await waitFor(":iframe img");
+    await contains(svg).click();
+
+    // The bigger timeout is there to prevent undetermistic behaviors linked to
+    // SVG being downloaded from the server when the <img> src attribute is modified.
+    const colorPreviewButton = await waitFor(
+        '[data-label="Dynamic Colors"] button.o_we_color_preview',
+        { timeout: 1000 }
+    );
+    const expectColors = async (expectedHex, expectedRgb, expectedParam) => {
+        await waitFor(
+            `[data-label="Dynamic Colors"] button.o_we_color_preview[style="background-color: ${expectedHex}"]`,
+            { timeout: 1000 }
+        );
+        expect(svg).toHaveAttribute("src", `${imgPath}?c1=${expectedParam}`);
+        expect(colorPreviewButton).toHaveStyle({ backgroundColor: expectedRgb });
+    };
+    await expectColors("#000000", "rgb(0, 0, 0)", "%23000000");
+
+    await contains(colorPreviewButton).click();
+    await contains(".o_colorpicker_section button[data-color='o-color-1']").click();
+    await expectColors("#111111", "rgb(17, 17, 17)", "o-color-1");
+
+    await contains(colorPreviewButton).click();
+    await contains(".o_color_section button[data-color='#FF0000']").click();
+    await expectColors("#FF0000", "rgb(255, 0, 0)", "%23FF0000");
+
+    await contains(colorPreviewButton).click();
+    await contains(".o_font_color_selector .btn-tab:not(.active)").click();
+    await contains(".o_colorpicker_section button[data-color='white']").click();
+    await expectColors("#FFFFFF", "rgb(255, 255, 255)", "%23FFFFFF");
+});


### PR DESCRIPTION
__Current behavior before commit:__
The color palette for SVG Dynamic Colors doesn't work properly.
The color preview doesn't show the current color and some colors make
the SVG disappear.

__Description of the fix:__
- The [`_update_svg_colors`] backend method only works with rgb, hex and
the palette colors matching `/^o-color-[1-5]$/`. So all other custom CSS
variables (e.g. `var(--white)`) are converted to hex notation in the SVG
URL search params.
- Furthermore, to show the correct color in the little color preview
circle, [`getValue`] now always returns a normalized CSS color value.
- The regex matching rgba color in [`convertCSSColorToRgba`] has been
fixed to include alpha values that don't have the 0 before the decimals
(e.g. `rgba(255, 255, 255, .5)`).

__Steps to reproduce:__
1. Open the website builder
2. Switch to "Artists" theme
2. Drop a Horizontal Attributes snippet
3. Click on one of the SVG icon => the color previews in
Image > Dynamic Colors don't correspond to the SVG colors
4. Click on one of the color to open the palette
5. Choose one in the top row => the SVG disappears
6. Go in the "Custom" tab of the color palette => the current color is
not the correct one
7. Choose one of the grey shade at the top => the SVG disappears

[`_update_svg_colors`]: https://github.com/odoo/odoo/blob/64efa6b7dc7/addons/html_editor/controllers/main.py#L92
[`getValue`]: https://github.com/odoo/odoo/blob/64efa6b7dc7/addons/website/static/src/builder/plugins/dynamic_svg_option_plugin.js#L29
[`convertCSSColorToRgba`]: https://github.com/odoo/odoo/blob/64efa6b7dc7/addons/web/static/src/core/utils/colors.js#L218