### PR TITLE
[IMP] mrp: prevent deleting user with Workcenter Productivity Log

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -508,7 +508,7 @@ class MrpWorkcenterProductivity(models.Model):
     workorder_id = fields.Many2one('mrp.workorder', 'Work Order', check_company=True, index=True)
     user_id = fields.Many2one(
         'res.users', "User",
-        default=lambda self: self.env.uid)
+        default=lambda self: self.env.uid, ondelete="restrict")
     loss_id = fields.Many2one(
         'mrp.workcenter.productivity.loss', "Loss Reason",
         ondelete='restrict', required=True)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
prevent deleting user with Workcenter Productivity Log

**Current behavior before PR:**
If user is deleted, there is no user on the Workcenter Productivity Log. 





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
