### PR TITLE
[FIX] base_automation: fixed trashed files still appearing in search.

### DIFF
--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -145,7 +145,7 @@
                                     name="action_server_ids"
                                     widget="one2many"
                                     class="o_base_automation_actions_field"
-                                    context="{'default_model_id': model_id, 'form_view_ref': 'base_automation.ir_actions_server_view_form_automation'}"
+                                    context="{'default_model_id': model_id, 'active_test': True, 'form_view_ref': 'base_automation.ir_actions_server_view_form_automation'}"
                                 >
                                     <kanban>
                                         <control>


### PR DESCRIPTION
This PR addresses an issue where trashed files in documents would still appear when clicking on 'search more' when searching for documents.document in a scheduled action's action. The issue is that the base_automation_act view sets active_test context to False. This context is propagated to view_base_automation_form and results in the context for the field action_server_ids to be active_test = False. The fix for this issue will just be setting active_test to True for the action_server_ids field. This will make it such that the 'search more' action will no longer display anything archived but archived automation rules will still be displayed which was probably the original intention of setting active_test to False in base_automation_act.

Steps to reproduce bug on empty DB:
1) Install base_automation and documents modules.
2) Create a new automation rule targeting the documents module. Make sure to add a trigger.
3) Click on 'Add an action' in the page 'Actions To Do'.
4) In the wizard under action details, set the targeted field to 'folder' (folder_id). Leave the action as 'Update'.
5) Click on the 'Choose a value' drop down.
6) Click on 'Search more'.
7) Notice the number of documents that show up. The numbers on the top right hand side of the wizard should be 1-y/x where x is the total number of documents.
8) Go to the documents module and select any document.
9) Move the document to the trash with the actions button.
10) Repeat steps 4-7. Notice how the number of documents did not change.

Behavior after bug fix:
Upon completing step 10 of steps to reproduce on empty DB, the number of documents will be one less than what it was originally since we trashed one of the documents.

task-4886487


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
