### PR TITLE
[IMP] portal,http_routing: allow portal users to update their preferred language

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -105,7 +105,7 @@ class IrHttp(models.AbstractModel):
             url: str | None = None,
             lang_code: str | None = None,
             canonical_domain: str | tuple[str, str, str, str, str] | None = None,
-            prefetch_langs: bool = False, force_default_lang: bool = False) -> str:
+            prefetch_langs: bool = False, force_default_lang: bool = False, change_in_user: bool = False) -> str:
         """ Returns the given URL adapted for the given lang, meaning that:
 
         1. It will have the lang suffixed to it
@@ -152,6 +152,9 @@ class IrHttp(models.AbstractModel):
             path = werkzeug.urls.url_quote_plus(url, safe='/')
         if force_default_lang or lang != request.env['ir.http']._get_default_lang():
             path = f'/{lang.url_code}{path if path != "/" else ""}'
+
+        if change_in_user and not request.env.user._is_public() and request.env.user.lang != lang.code:
+            request.env.user.lang = lang.code
 
         if canonical_domain:
             # canonical URLs should not have qs

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -81,7 +81,7 @@
             </button>
             <div t-attf-class="dropdown-menu #{_dropdown_menu_class}" role="menu">
                 <t t-foreach="frontend_languages.values()" t-as="lg">
-                    <a class="dropdown-item" t-att-href="url_localized(lang_code=lg.code, prefetch_langs=True, force_default_lang=True)"
+                    <a class="dropdown-item" t-att-href="url_localized(lang_code=lg.code, prefetch_langs=True, force_default_lang=True, change_in_user=change_in_user)"
                     t-attf-class="dropdown-item js_change_lang #{active_lang == lg and 'active'}"
                     t-att-data-url_code="lg.url_code" t-att-title="lg.name.split('/').pop()"
                     role="menuitem">
@@ -409,6 +409,16 @@
                 <i class="fa fa-map-marker fa-fw me-1 text-600"/>
                 <span t-esc="sales_user.city"/>
             </div>
+            <t t-if="len(frontend_languages) &gt; 1">
+                <h5 class="pt-2">Language</h5>
+                <hr class="mt-1"/>
+                <div class="d-flex flex-nowrap align-items-center mb-1">
+                    <i class="fa fa-language fa-fw me-1 text-600"/>
+                    <t t-call="portal.language_selector">
+                        <t t-set="change_in_user" t-value="True"/>
+                    </t>
+                </div>
+            </t>
         </div>
     </template>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently, when a user registers on the portal, their account language is set based on the website language at the time of registration. After that, there is no option for the user to change their preferred language directly from their account.  

Current behavior before PR:
- The account language is fixed after registration.  
- Users cannot update their preferred language themselves.  
- If they want to receive communications (emails, documents, notifications) in another language, they must request it through the customer support team.  

Desired behavior after PR is merged:
- Portal users can change their account language directly from their portal account settings.  
- This ensures they can receive emails and communications in their preferred language without involving customer support.  
- Reduces the workload of the support team, allowing them to focus on more important issues... and if the world were perfect, maybe even have a coffee break ☕😉.  

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
