### PR TITLE
[FIX] sale_project: Clear deleted analytic accounts from so lines

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -144,7 +144,7 @@ class SaleOrderLine(models.Model):
             if line.analytic_distribution:
                 applied_root_plans = self.env['account.analytic.account'].browse(
                     list({int(account_id) for ids in line.analytic_distribution for account_id in ids.split(",")})
-                ).root_plan_id
+                ).exists().root_plan_id
                 if accounts_to_add := project._get_analytic_accounts().filtered(
                     lambda account: account.root_plan_id not in applied_root_plans
                 ):

--- a/doc/cla/corporate/pacific-erp.md
+++ b/doc/cla/corporate/pacific-erp.md
@@ -1,0 +1,15 @@
+French Polynesia, 29/08/2025
+
+Pacific ERP agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Matt Marcha matt@pacific-erp.com https://github.com/MattMarcha
+
+List of contributors:
+
+Matt Marcha matt@pacific-erp.com https://github.com/MattMarcha


### PR DESCRIPTION
# Issue:
In a sale order, if any of the so lines contains the ID of a deleted analytic account in its analytic_distribution field, then updating the project_id field is impossible as it raises an error.

# Cause
This is caused because _compute_analytic_distribution() tries to retrieve 'root_plan_id' from all ids without checking if records exists.

# Fix
This commit add an exists() check on analytic.accounts retrieved from analytic_distribution field and clear the non-existing records ids from the field.

# Steps to reproduce
- Install sale_project and accountant modules
- Check "Analytic Accounting" in the Accounting settings
- Create a new project "Test P", set it up "Billable", with a new Analytic account "Test AC" (field "Project" tab "Analytic")
- Create a new sale order "Test SO", add a few products and set up the Project field to "Test P". Save the sale order.
- Delete the analytic.account "Test AC"
- Go back on "Test SO", try to change the field "Project" - a Missing error is thrown

---

Current behavior before PR: When creating a sale order and binding it to a project with an analytic account, then deleting the analytic account, the field "Project" on the sale order can't be updated anymore.

Desired behavior after PR is merged: When creating a sale order and binding it to a project with an analytic account, then deleting the analytic account, the field "Project" on the sale order can be updated.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
