### PR TITLE
[FIX] mail: align the 'New Meeting' dropdown

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_search.xml
+++ b/addons/mail/static/src/core/public_web/discuss_search.xml
@@ -12,7 +12,7 @@
         </Dropdown>
         <t t-else="" t-call="mail.DiscussSearch.inputContainer"/>
         <t t-if="store.self.main_user_id">
-            <Dropdown t-if="store.discuss.isSidebarCompact and !ui.isSmall" state="meetingFloating" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu o-discuss-dropdownMenu border-secondary px-2 mx-2 my-0 min-w-0'" manual="true">
+            <Dropdown t-if="store.discuss.isSidebarCompact and !ui.isSmall" state="meetingFloating" position="'right-middle'" menuClass="'o-mail-DiscussSidebar-floatingMenu o-discuss-dropdownMenu border-secondary px-2 mx-2 my-0 min-w-0'" manual="true">
                 <t t-call="mail.DiscussSearch.newMeeting"/>
                 <t t-set-slot="content">
                     <div t-ref="meeting-floating">


### PR DESCRIPTION
### Purpose of this commit:
The 'New Meeting' action dropdown was align in the poisition 'right-start', while the other actions in the category was aligned in the 'right-middle' position. This PR fixes that position to 'right-middle' to create a uniform look.

Before:
<img width="276" height="146" alt="image" src="https://github.com/user-attachments/assets/73578f6d-066e-4e7d-b470-d886203ba27c" />

After:
<img width="217" height="185" alt="image" src="https://github.com/user-attachments/assets/7d3258ce-78ad-466c-a40b-d8a01f9648f1" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
