### PR TITLE
[IMP] mail: add shortcut to minimize the meeting full screen

### DIFF
--- a/addons/mail/static/src/discuss/call/common/meeting.js
+++ b/addons/mail/static/src/discuss/call/common/meeting.js
@@ -13,6 +13,7 @@ import { Component, onMounted, onWillUnmount } from "@odoo/owl";
 
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useService } from "@web/core/utils/hooks";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { MeetingSideActions } from "./meeting_side_actions";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { useMessageSearch } from "@mail/core/common/message_search_hook";
@@ -68,6 +69,7 @@ export class Meeting extends Component {
         });
         onMounted(() => (this.store.meetingViewOpened = true));
         onWillUnmount(() => (this.store.meetingViewOpened = false));
+        useHotkey("escape", () => this.onEscape());
     }
 
     get channel() {
@@ -79,5 +81,17 @@ export class Meeting extends Component {
             return [];
         }
         return this.threadActions.actions.filter((a) => PIP_EXTRA_ACTION_IDS.includes(a.id));
+    }
+
+    onEscape() {
+        if (this.threadActions.activeAction) {
+            this.threadActions.activeAction.actionPanelClose();
+            return true;
+        }
+        if (this.rtc.isFullscreen) {
+            this.rtc.exitFullscreen();
+            return true;
+        }
+        return false;
     }
 }

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -1360,3 +1360,28 @@ test("shows a presenter bar when screen-sharing in discuss calls and meetings", 
     }
     await contains(".o-discuss-CallPresentationBar", { count: 0 });
 });
+
+test("Escape closes meeting UI layers sequentially", async () => {
+    /** Escape closes overlay elements → action panel → fullscreen meeting view. */
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await contains(".o-discuss-Call");
+    await click("[title='Fullscreen']");
+    await contains(".o-mail-Meeting");
+    await click("[title='Chat']");
+    await contains(".o-mail-ActionPanel-header:text('In call messages')");
+    await click(".o-mail-DiscussContent-panelContainer [title='Add Emojis']");
+    await contains(".o-EmojiPicker");
+    triggerHotkey("Escape");
+    await contains(".o-EmojiPicker ", { count: 0 });
+    await contains(".o-mail-DiscussContent-panelContainer .o-mail-Composer.o-focused");
+    triggerHotkey("Escape");
+    await contains(".o-mail-ActionPanel-header:text('In call messages')", { count: 0 });
+    await contains(".o-mail-Meeting");
+    triggerHotkey("Escape");
+    await contains(".o-mail-Meeting", { count: 0 });
+    await contains(".o-discuss-Call");
+});


### PR DESCRIPTION

### Purpose of this PR:
Previously, exiting full screen in the call view was only possible through the call action buttons. This commit introduces a shortcut for quicker interaction: pressing the Escape key while in full screen mode will now minimize the call view.


task-5111181