### PR TITLE
[FIX] account: avoid writing trusted bank accounts in base document layout wizard

### DIFF
--- a/addons/account/wizard/base_document_layout.py
+++ b/addons/account/wizard/base_document_layout.py
@@ -65,7 +65,9 @@ class BaseDocumentLayout(models.TransientModel):
     def _inverse_account_number(self):
         for record in self:
             if record.partner_id.bank_ids and record.account_number:
-                record.partner_id.bank_ids[0].acc_number = record.account_number
+                bank = record.partner_id.bank_ids[0]
+                if bank.acc_number != record.account_number:
+                    bank.acc_number = record.account_number
             elif record.account_number:
                 record.partner_id.bank_ids = [
                     Command.create({


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The document layout wizard (base.document.layout) attempts to write the partner’s bank account number even if it has not been changed. If the first bank account is marked as trusted, Odoo blocks the write and raises an error. This PR prevents that error by only writing the account number when it has actually changed.

Current behavior before PR:
- The wizard shows the account_number field.
- On saving, _inverse_account_number always writes to the first partner bank account.
- Trusted bank accounts trigger an error: “You cannot change the account number or partner of a trusted bank account.”

Desired behavior after PR is merged:
- The wizard still shows the account_number field.
- On saving, _inverse_account_number only writes if the value changed.
- Trusted bank accounts that are not modified do not cause an error.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
