### PR TITLE
[FIX] mail: cleanup discuss_sidebar_call_participants override

### DIFF
--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.js
@@ -72,6 +72,12 @@ export class DiscussSidebarCallParticipants extends Component {
         return sessions[0];
     }
 
+    get attClass() {
+        return {
+            "justify-content-center bg-inherit": this.compact,
+        };
+    }
+
     get sessions() {
         const sessions = [...this.props.thread.rtc_session_ids];
         return sessions.sort((s1, s2) => {
@@ -104,4 +110,6 @@ export class DiscussSidebarCallParticipants extends Component {
     get title() {
         return this.state.expanded ? _t("Collapse participants") : _t("Expand participants");
     }
+
+    onClickParticipant(ev, session) {}
 }

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -65,7 +65,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCallParticipants.participant">
-        <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="{ 'justify-content-center bg-inherit': isCompact }">
+        <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="attClass" t-on-click="(ev) => this.onClickParticipant(ev, session)">
             <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px;margin:1px;">
                 <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle object-fit-cover" t-att-src="session.channel_member_id.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id.name"/>
             </div>

--- a/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.js
+++ b/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.js
@@ -11,6 +11,12 @@ patch(DiscussSidebarCallParticipants.prototype, {
             position: "right",
         });
     },
+    get attClass() {
+        return {
+            ...super.attClass,
+            "o-active cursor-pointer rounded-4": this.session.persona.main_user_id,
+        };
+    },
     onClickParticipant(ev, session) {
         if (!session.persona.main_user_id) {
             return;

--- a/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.xml
+++ b/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<templates xml:space="preserve">
-    <t t-inherit="mail.DiscussSidebarCallParticipants.participant" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('o-mail-DiscussSidebarCallParticipants-participant')]" position="attributes">
-            <attribute name="t-attf-class">{{ session.persona.main_user_id ? 'o-active cursor-pointer rounded-4' : '' }}</attribute>
-            <attribute name="t-on-click">(ev) => this.onClickParticipant(ev, session)</attribute>
-        </xpath>
-    </t>
-</templates>


### PR DESCRIPTION
### Purpose of this commit:
To prevent overrides from being canceled in patched templates, the change introduces patching via t-attf-class and JS with a super call, ensuring that all overrides are properly applied.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
