### PR TITLE
[IMP] website_sale_comparison: product comparison redesign follow-up

### DIFF
--- a/addons/website_sale_comparison/static/src/js/product_comparison_bottom_bar/product_comparison_bottom_bar.xml
+++ b/addons/website_sale_comparison/static/src/js/product_comparison_bottom_bar/product_comparison_bottom_bar.xml
@@ -7,21 +7,46 @@
                 class="o_wsale_comparison_bottom_bar sticky-bottom flex-shrink-0 w-100 bg-body shadow-lg pe-auto"
                 name="comparison_bottom_bar"
             >
-                <div class="container d-flex align-items-center gap-3 py-3">
-                    <ul class="list-unstyled d-none d-xl-flex flex-grow-1 flex-shrink-1 gap-3 overflow-hidden me-auto mb-0">
-                        <li
-                            t-foreach="state.products.values()"
-                            t-as="product"
-                            t-key="product.id"
-                            class="flex-basis-25 overflow-hidden"
-                            t-att-class="{'border-end pe-3': !product_last}"
+                <div class="container">
+                    <div class="collapse d-xl-none" id="comparisonCollapse">
+                        <ul class="list-group list-group-flush">
+                            <li
+                                t-foreach="state.products.values()"
+                                t-as="product"
+                                t-key="product.id"
+                                class="list-group-item d-flex align-items-start justify-content-between gap-2 px-0 py-3"
+                            >
+                                <ProductRow t-props="product"/>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="d-flex align-items-center gap-3 py-3">
+                        <button
+                            class="btn btn-light d-xl-none me-auto"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#comparisonCollapse"
+                            aria-expanded="false"
+                            aria-controls="comparisonCollapse"
+                            aria-label="Show products added to comparison"
                         >
-                            <ProductRow t-props="product"/>
-                        </li>
-                    </ul>
+                            <i class="oi oi-chevron-up" role="presentation"/>
+                        </button>
+                        <ul class="list-unstyled d-none d-xl-flex flex-grow-1 flex-shrink-1 gap-3 overflow-hidden me-auto mb-0">
+                            <li
+                                t-foreach="state.products.values()"
+                                t-as="product"
+                                t-key="product.id"
+                                class="flex-basis-25 overflow-hidden"
+                                t-att-class="{'border-end pe-3': !product_last}"
+                            >
+                                <ProductRow t-props="product"/>
+                            </li>
+                        </ul>
 
-                    <div class="d-flex gap-2 justify-content-end flex-grow-1 flex-xl-grow-0 flex-shrink-0">
-                        <t t-call="website_sale_comparison.ProductComparisonBottomBar.Actions"/>
+                        <div class="d-flex gap-2 justify-content-end flex-grow-1 flex-xl-grow-0 flex-shrink-0">
+                            <t t-call="website_sale_comparison.ProductComparisonBottomBar.Actions"/>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -38,7 +63,7 @@
             title="Compare products"
         >
             Compare
-            <span t-if="productCount" t-out="productCount" class="badge ms-2 bg-black-25"/>
+            <span t-if="productCount" t-out="productCount" class="badge ms-2"/>
         </a>
         <button
             t-on-click="clearAllProducts"

--- a/addons/website_sale_comparison/static/src/js/product_row/product_row.xml
+++ b/addons/website_sale_comparison/static/src/js/product_row/product_row.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
     <t t-name="website_sale_comparison.ProductRow">
         <div
-            class="d-flex align-items-center gap-2 flex-grow-1 text-truncate"
-            name="product_comparison_popover_row"
+            class="d-flex align-items-center gap-2 flex-grow-1 p-1 rounded text-truncate"
+            name="product_comparison_bottom_bar_row"
         >
             <a
                 t-att-href="props.website_url"
@@ -14,7 +14,7 @@
                     class="o_image_40_cover border rounded"
                     alt="Product Image"
                 />
-                <h6 class="flex-grow-1 text-truncate">
+                <h6 class="flex-grow-1 mb-0 text-truncate">
                     <span t-out="props.display_name" class="d-block mb-0 small text-truncate"/>
                     <small t-if="!props.prevent_zero_price_sale" class="mb-0 text-body">
                         <span t-out="formattedPrice" class="me-1 text-nowrap"/>

--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
@@ -114,8 +114,26 @@
         width: 2.5rem;
     }
 
+    .btn[data-bs-toggle="collapse"] {
+        .oi-chevron-up {
+            transition: transform 0.2s ease-in-out;
+        }
+        &[aria-expanded="true"] .oi-chevron-up {
+            transform: rotate(180deg);
+        }
+    }
+
     .o_wsale_comparison_offcanvas_image {
         width: 5rem;
+    }
+
+    a[title="Compare products"] .badge {
+        --badge-color: var(--btn-hover-bg);
+        --badge-bg: var(--btn-color);
+    }
+
+    div[name="product_comparison_bottom_bar_row"]:where(:has(button[aria-label="Remove product from comparison"]:hover)) {
+        background: $light;
     }
 
 }

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -26,20 +26,20 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
     },
     {
         content: "check products name are correct in the comparelist",
-        trigger: '[name="product_comparison_popover_row"]:contains("Color T-Shirt")',
+        trigger: '[name="product_comparison_bottom_bar_row"]:contains("Color T-Shirt")',
     },
     {
         content: "check products name are correct in the comparelist",
-        trigger: '[name="product_comparison_popover_row"]:contains("Color Pants")',
+        trigger: '[name="product_comparison_bottom_bar_row"]:contains("Color Pants")',
     },
     {
         content: "remove product",
-        trigger: '[name="product_comparison_popover_row"]:contains("Color T-Shirt") button:has(i.oi-close)',
+        trigger: '[name="product_comparison_bottom_bar_row"]:contains("Color T-Shirt") button:has(i.oi-close)',
         run: "click",
     },
     {
         content: "wait for 'Color T-Shirt' to be removed from the popover",
-        trigger: '[name="product_comparison_popover_row"]:not(:contains("Color T-Shirt"))',
+        trigger: '[name="product_comparison_bottom_bar_row"]:not(:contains("Color T-Shirt"))',
     },
     {
         content: "re-add 'Color T-Shirt' in comparison list",
@@ -64,7 +64,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
     },
     {
         content: "check the comparelist is now open and contains 3rd product with correct variant",
-        trigger: '[name="product_comparison_popover_row"]:contains("Color Shoes (Red)")',
+        trigger: '[name="product_comparison_bottom_bar_row"]:contains("Color Shoes (Red)")',
     },
     {
         content: "select 2nd variant(Pink Color)",
@@ -84,7 +84,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
     },
     {
         content: "comparelist contains 4th product with correct variant",
-        trigger: '[name="product_comparison_popover_row"]:contains("Color Shoes (Red)")',
+        trigger: '[name="product_comparison_bottom_bar_row"]:contains("Color Shoes (Red)")',
     },
     {
         content: "check limit is not reached",

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -217,7 +217,7 @@
             <t t-set="additional_title">Shop Comparator</t>
             <div id="wrap" class="js_sale">
                 <div class="oe_structure oe_empty" id="oe_structure_website_sale_comparison_product_compare_1"/>
-                <div t-attf-class="oe_website_sale o_wsale_comparison_page pb-5 #{is_view_active('website_sale.shop_fullwidth') and 'container-fluid' or 'container'}">
+                <div t-attf-class="oe_website_sale o_wsale_comparison_page pb-5 #{website.shop_page_container == 'fluid' and 'container-fluid' or 'container'}">
                     <h1 class="h4 mt-4 mb-3">Compare Products</h1>
                     <t
                         t-set="img_ratio_class"
@@ -236,7 +236,7 @@
                         class="o_wsale_comparison_mini_sticky fixed-top d-none bg-body"
                         id="miniStickyComparison"
                     >
-                        <div t-attf-class="px-3 #{is_view_active('website_sale.shop_fullwidth') and 'container-fluid' or 'container'}">
+                        <div t-attf-class="px-3 #{website.shop_page_container == 'fluid' and 'container-fluid' or 'container'}">
                             <div class="o_wsale_comparison_scroll_container overflow-x-auto">
                                 <ul class="list-unstyled d-flex align-items-stretch mb-0 py-3">
                                     <li
@@ -455,7 +455,7 @@
                 <div class="oe_structure" id="oe_structure_website_sale_comparison_product_compare_2"/>
                 <div class="align-items-end bottom-0 d-flex end-0 justify-content-end o_not_editable p-0 position-absolute top-0 start-0 pe-none">
                     <div class="o_wsale_comparison_bottom_bar sticky-bottom flex-shrink-0 w-100 bg-body shadow-lg pe-auto">
-                        <div t-attf-class="d-flex align-items-center py-3 #{is_view_active('website_sale.shop_fullwidth') and 'container-fluid' or 'container'}">
+                        <div t-attf-class="d-flex align-items-center py-3 #{website.shop_page_container == 'fluid' and 'container-fluid' or 'container'}">
                             <button
                                 class="btn btn-link ps-0 text-decoration-none"
                                 aria-label="Continue shopping"


### PR DESCRIPTION
This PR addresses three issues introduced after Commit[^1]:

### Full-width inheritance:

The comparison elements (sticky bottom bar and page) no longer inherited the `/shop` full-width option. This was caused by the new way we handle the `width` setting on the `/shop` page, which invalidated the previous `is_view_active` check. The logic now properly verifies the setting and applies the correct class.

### Mobile comparison visibility:

On mobile, users could not see the product they added to the comparison. Commit [^1] replaced the previous offcanvas implementation, but since offcanvas elements are positioned relative to the `<body>`, it caused a mismatch: the comparison bar appeared at the bottom of `<main>` while the offcanvas stayed at the bottom of the viewport.

To fix this, we replaced the offcanvas with a collapse. This solution expands the bar upward, avoids duplicate action buttons in the DOM, and ensures a consistent display across devices.

- Improve `:focus-visible` state:

Fix an issue about the `:focus-visible` states being cut off by the
`overflow: hidden` rules.


task-5052232
follow-up of task-4911142

[^1]: https://github.com/odoo/odoo/commit/524c968eb647a65119a935ed820602b57820a418
---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
