### PR TITLE
[ADD] spreadsheet_dashboard_voip: add voip dashboard

### DIFF
--- a/addons/spreadsheet_dashboard/data/dashboard.xml
+++ b/addons/spreadsheet_dashboard/data/dashboard.xml
@@ -36,4 +36,9 @@
         <field name="sequence">600</field>
     </record>
 
+    <record id="spreadsheet_dashboard_group_voip" model="spreadsheet.dashboard.group">
+        <field name="name">Voip</field>
+        <field name="sequence">900</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
  **Purpose:**
  Add a spreadsheet-based VOIP dashboard to visualize VOIP-related metrics
  and performance data, decoupled from CRM/sales dependencies.

  **Specification:**
  - Created a new spreadsheet dashboard for VOIP metrics.
  - Includes data such as call count, call duration, and agent activity.

  **Task**-4922103