### PR TITLE
[IMP] im_livechat: make invite link available on closed conversations

### DIFF
--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -88,6 +88,8 @@ class DiscussChannelMember(models.Model):
             member.agent_expertise_ids = member.livechat_member_history_ids.agent_expertise_ids
 
     def _create_or_update_history(self, values_by_member):
+        if self.channel_id.livechat_end_dt:
+            return
         members_without_history = self.filtered(lambda m: not m.livechat_member_history_ids)
         history_domain = Domain.OR(
             [

--- a/addons/im_livechat/static/src/core/common/channel_member_list_patch.xml
+++ b/addons/im_livechat/static/src/core/common/channel_member_list_patch.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<templates xml:space="preserve">
-    <t t-name="im_livechat.ChannelMemberList" t-inherit="discuss.ChannelMemberList" t-inherit-mode="extension">
-        <xpath expr="//button[@name='inviteButton']" position="attributes">
-            <attribute name="t-if">!this.props.channel.livechat_end_dt</attribute>
-        </xpath>
-    </t>
-</templates>

--- a/addons/im_livechat/static/src/core/common/thread_actions_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_actions_patch.js
@@ -25,15 +25,6 @@ patch(ThreadAction.prototype, {
     },
 });
 
-patch(threadActionsRegistry.get("invite-people"), {
-    condition({ channel }) {
-        if (channel?.channel_type === "livechat") {
-            return super.condition(...arguments) && !channel.livechat_end_dt;
-        }
-        return super.condition(...arguments);
-    },
-});
-
 patch(threadActionsRegistry.get("notification-settings"), {
     condition({ channel }) {
         if (channel?.channel_type === "livechat") {

--- a/addons/im_livechat/tests/test_member_history.py
+++ b/addons/im_livechat/tests/test_member_history.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import fields
 from odoo.addons.im_livechat.tests import chatbot_common
 from odoo.exceptions import ValidationError
 from odoo.tests.common import new_test_user
@@ -7,9 +8,10 @@ from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 
 
 class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCase):
-    def test_get_session_create_history(self):
+    def test_history_modified_only_for_active_livechat(self):
         john = self._create_operator("fr_FR")
         bob = self._create_operator("fr_FR")
+        michel = self._create_operator("fr_FR")
         livechat_channel = self.env["im_livechat.channel"].create(
             {
                 "name": "Livechat Channel",
@@ -41,6 +43,9 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
             ).livechat_member_type,
             "agent",
         )
+        channel.livechat_end_dt = fields.Datetime.now()
+        channel.add_members(partner_ids=michel.partner_id.ids)
+        self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 3)
 
     def test_get_session_create_history_with_bot(self):
         john = self._create_operator("fr_FR")
@@ -125,6 +130,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
 
     def test_update_history_on_second_join(self):
         john = self._create_operator("fr_FR")
+        bob = self._create_operator("fr_FR")
         livechat_channel = self.env["im_livechat.channel"].create(
             {"name": "Livechat Channel", "user_ids": [john.id]},
         )
@@ -139,6 +145,8 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
         john_member = channel.channel_member_ids.filtered(lambda m: m.partner_id == john.partner_id)
         self.assertEqual(og_history.livechat_member_type, "agent")
         self.assertEqual(og_history.member_id, john_member)
+        # Add another agent so the channel stays active and the history can be updated.
+        channel.add_members(partner_ids=bob.partner_id.ids)
         channel.with_user(john).action_unfollow()
         john_history = channel.channel_member_ids.livechat_member_history_ids.filtered(
             lambda m: m.partner_id == john.partner_id


### PR DESCRIPTION
Before this commit, closed live chat conversations were only accessible to users
with live chat access rights.

This commit makes the invite link available on closed conversations and ensures
the conversation history is not updated when a user joins an ended live chat
channel.

Task-4873812