### PR TITLE
[FIX] html_editor: preserve image inside empty inline placeholder

### DIFF
--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -1129,6 +1129,42 @@ test("MediaDialog does not contain 'Videos' tab when sanitize = true", async () 
     ]);
 });
 
+test("Image should not be inserted in a formatted empty node", async () => {
+    Partner._records = [
+        {
+            id: 1,
+            txt: `<div class="o-paragraph"><strong>test</strong></div>
+                    <div class="o-paragraph">
+                        <strong data-oe-zws-empty-inline="">\u200b</strong><br />
+                    </div>`,
+        },
+    ];
+
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+    setSelection({
+        anchorNode: queryOne("div.o-paragraph strong[data-oe-zws-empty-inline]"),
+        anchorOffset: 0,
+    });
+    await insertText(htmlEditor, "/media");
+    await waitFor(".o-we-powerbox");
+    expect(queryAllTexts(".o-we-command-name")[0]).toBe("Media");
+
+    await press("Enter");
+    await animationFrame();
+    await click(queryOne(".o_we_media_dialog_img_wrapper"));
+    await animationFrame();
+    const img = htmlEditor.editable.querySelector("div.o-paragraph img");
+    expect(img.parentElement.nodeName).toBe("DIV");
+});
+
 test("MediaDialog contains 'Videos' tab when sanitize_tags = true and 'allowMediaDialogVideo' = true", async () => {
     class SanitizePartner extends models.Model {
         _name = "sanitize.partner";


### PR DESCRIPTION
Problem:
When an image is added inside a `data-oe-zws-empty-inline`, it is removed along with its parent during normalization.

Solution:
During normalization, replace `data-oe-zws-empty-inline` with the image inside instead of removing both.

Steps to reproduce:
- Press CTRL+B in an empty line
- Press Enter
- Click on "Insert image, ..." from the placeholder
- Choose an image
- Click in the previous paragraph
- The image disappears without this fix

task-5051343

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
