### PR TITLE
[FIX] stock: filter Current Stock by selected location

### DIFF
--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -25,7 +25,7 @@
                                 type="action" name="stock.act_product_location_open"/>
                         <button string="Current Stock"
                                 class="oe_stat_button"
-                                icon="fa-cubes" name="%(stock_quant_action)d" type="action"/>
+                                icon="fa-cubes" name="%(stock_quant_action)d" type="action" context="{'search_default_location_id': id}"/>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <label for="name"/>


### PR DESCRIPTION
From this [commit](https://github.com/odoo/odoo/commit/81acb532a45cf7ab2837634e4d347b216c95f07a), clicking the "Current Stock" button on a location form opened the stock quant list without filtering by the selected location, showing all products.

After this commit, the context `search_default_location_id` is added so that the stock quant list is properly filtered by the active location.

**Before fix**
<img width="1919" height="951" alt="2025-09-01_12-15" src="https://github.com/user-attachments/assets/93a6034b-0d07-4668-b67d-a84df2285a48" />


**After fix**
<img width="1913" height="862" alt="2025-09-01_12-20" src="https://github.com/user-attachments/assets/03eb5b48-0799-4a73-a826-b3c9971b4a85" />

opw-5033643
upg-3117055

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
