### PR TITLE
[IMP] l10n_kh: add logic to compute Proxy Type in EMV QR Settings

### DIFF
--- a/addons/l10n_kh/models/res_bank.py
+++ b/addons/l10n_kh/models/res_bank.py
@@ -47,6 +47,12 @@ class ResPartnerBank(models.Model):
         bank_kh.display_qr_setting = self.env.company.qr_code
         super(ResPartnerBank, self - bank_kh)._compute_display_qr_setting()
 
+    @api.depends('country_code')
+    def _compute_country_proxy_keys(self):
+        bank_kh = self.filtered(lambda b: b.country_code == 'KH')
+        bank_kh.country_proxy_keys = 'bakong_id_solo,bakong_id_merchant'
+        super(ResPartnerBank, self - bank_kh)._compute_country_proxy_keys()
+
     def _get_merchant_account_info(self):
         if self.country_code == 'KH':
             if self.proxy_type == 'bakong_id_solo':


### PR DESCRIPTION
- Added missing `available_field` for "Proxy Type" field's `dynamic_selection` by setting `country_proxy_keys`.
- Previously had no selection. Now it has "None","Bakong Account ID (Corporate Merchant)", and "Bakong Account ID (Solo Merchant)"

Task-5054800