### PR TITLE
[REV] purchase: allow to search product from vendor code

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -245,7 +245,7 @@
                                         readonly="state in ('purchase', 'to approve', 'done', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
                                         optional="show"
-                                        context="{'quantity':product_qty, 'company_id': parent.company_id}"
+                                        context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
                                         force_save="1" domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"/>
                                     <field name="name" widget="section_and_note_text" optional="show"/>
                                     <field name="date_planned" optional="hide" required="not display_type and not is_downpayment" force_save="1" readonly="is_downpayment"/>


### PR DESCRIPTION
This reverts commit 28d53e0e565e266ca3fa2b67e359b4383fa42c36.

The commit displayed both product name and vendor name in a purchase order form. However, it breaks the search using the vendor code/name.

https://github.com/odoo/odoo/pull/223250


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
