### PR TITLE
[FIX] spreadsheet: filter out json fields from groupable fields

### DIFF
--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -620,7 +620,7 @@ pivotRegistry.add("ODOO", {
         ((MEASURES_TYPES.includes(field.type) && field.aggregator) || field.type === "many2one") &&
         field.name !== "id" &&
         field.store,
-    isGroupable: (field) => field.groupable,
+    isGroupable: (field) => field.groupable && field.type !== "json",
 });
 
 supportedPivotPositionalFormulaRegistry.add("ODOO", true);


### PR DESCRIPTION
Steps to reproduce:
- Create a spreadsheet with a pivot on Sales Order Lines
- Add "Analytic Distribution" as column => Boom

Note that the test for this fix is add in the enterprise codebase

Task-5055300

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
