### PR TITLE
[FIX] account: use case-insensitive exact name match when resolving products

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -291,7 +291,7 @@ class ProductProduct(models.Model):
         if default_code:
             domains.append([('default_code', '=', default_code)])
         if name:
-            domains += [[('name', '=', name)], [('name', 'ilike', name)]]
+            domains += [[('name', '=', name)], [('name', '=ilike', name)]]
 
         company = company or self.env.company
         for company_domain in (


### PR DESCRIPTION
The product resolver appended a fuzzy domain ('name', 'ilike', name). With XML imports this can bind unrelated products when the item name is generic or punctuation (e.g., '-' matches any name containing a hyphen, like the demo “[FURN_8999] Three-Seat Sofa”).

This is because fallback uses 'ilike' (substring match), causing false positives.

This commit replaces the fallback with a case-insensitive *exact* match: ('name', '=ilike', name). Barcode and default_code lookups are unchanged; exact case-sensitive ('name', '=', name) remains first.

Steps to reproudce:
Accounting -> Invoices
upload an XML with a product name liek `-`
See the product attched to the invoice line.


Note: When uploading the xml you'll see that the invoice lines have no product_id, just the label, here is the PR for that: https://github.com/odoo/odoo/pull/224921

opw-5046573


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
