### PR TITLE
[FIX] l10n_in_pos: prevent error when cash In/Out in restaurant

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/store/pos_store.js
+++ b/addons/l10n_in_pos/static/src/overrides/store/pos_store.js
@@ -7,7 +7,7 @@ patch(PosStore.prototype, {
     getReceiptHeaderData() {
         return {
             ...super.getReceiptHeaderData(...arguments),
-            partner: this.selectedOrder.partner_id,
+            partner: this.selectedOrder?.partner_id,
         };
     },
 });


### PR DESCRIPTION
Before this commit, performing a Cash In/Out operation in a restaurant while not on the product screen caused an error, as there was no selected order in that context.

opw-5042755

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
