### PR TITLE
[FIX] spreadsheet: do not throw when pivot is loading

### DIFF
--- a/addons/spreadsheet/static/src/pivot/odoo_pivot.js
+++ b/addons/spreadsheet/static/src/pivot/odoo_pivot.js
@@ -440,7 +440,7 @@ export class OdooPivot {
      * @returns {{ value: string | number | boolean, label: string }[]}
      */
     getPossibleFieldValues(dimension) {
-        if (!this.isValid()) {
+        if (this.assertIsValid({ throwOnError: false })) {
             return [];
         }
         return this.model.getPossibleFieldValues(dimension);

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin.test.js
@@ -2063,6 +2063,28 @@ test("pivot.getPossibleFieldValues does not ignore falsy values", async function
     ]);
 });
 
+test("pivot.getPossibleFieldValues do not throw when the pivot is error", async function () {
+    const { model, pivotId } = await createSpreadsheetWithPivot({
+        arch: /* xml */ `
+                <pivot>
+                    <field name="product_id" type="col"/>
+                    <field name="bar" type="row"/>
+                    <field name="probability" type="measure"/>
+                </pivot>`,
+    });
+    const pivot = model.getters.getPivot(model.getters.getPivotIds()[0]);
+    updatePivot(model, pivotId, {
+        measures: [{ id: "__count:sum", fieldName: "__count", aggregator: "sum" }],
+    });
+    const barField = pivot.definition.rows[0];
+    expect(pivot.getPossibleFieldValues(barField)).toEqual([]);
+    await animationFrame();
+    expect(pivot.getPossibleFieldValues(barField)).toEqual([
+        { value: false, label: "No" },
+        { value: true, label: "Yes" },
+    ]);
+});
+
 test("Can change display type of a measure", async function () {
     const { model } = await createSpreadsheetWithPivot({
         arch: /* xml */ `


### PR DESCRIPTION
`getPossibleFieldValues` should not throw when the pivot is not loaded yet, as it is called by a component.
It implied that the component would crash when the pivot is in error instead of displaying an error message in the cell.

Task-5055300

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
