### PR TITLE
[FIX] web: datepicker: can set pm time

### DIFF
--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -502,6 +502,12 @@ export function parseDateTime(value, options = {}) {
     // Base case: try parsing with the given format and options
     let result = DateTime.fromFormat(value, fmt, parseOpts);
 
+    // Try parsing with the short time format (without seconds)
+    if (!isValidDate(result)) {
+        const format = `${localization.dateFormat} ${localization.shortTimeFormat}`;
+        result = DateTime.fromFormat(value, format, parseOpts);
+    }
+
     // Try parsing as a smart date
     if (!isValidDate(result)) {
         result = parseSmartDateInput(value);

--- a/addons/web/static/tests/core/components/datetime/datetime_hook.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_hook.test.js
@@ -2,7 +2,7 @@ import { test, expect } from "@odoo/hoot";
 import { click, edit } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { Component, reactive, useState, xml } from "@odoo/owl";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { contains, defineParams, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { useDateTimePicker } from "@web/core/datetime/datetime_hook";
 import { DateTimeInput } from "@web/core/datetime/datetime_input";
 
@@ -142,4 +142,33 @@ test("value is not updated if it did not change", async () => {
 
     expect(getShortDate(pickerProps.value)).toBe("2023-07-07");
     expect.verifySteps(["2023-07-07"]);
+});
+
+test("select time in the afternoon with pm format (showSeconds = false)", async () => {
+    defineParams({
+        lang_parameters: {
+            date_format: "%d/%m/%Y",
+            time_format: "%I:%M:%S %p",
+            short_time_format: "%I:%M %p",
+        },
+    });
+
+    const defaultPickerProps = {
+        value: DateTime.fromSQL("2023-06-06 08:00:00"),
+        type: "datetime",
+    };
+
+    await mountInput(() => {
+        useDateTimePicker({
+            pickerProps: defaultPickerProps,
+            showSeconds: false,
+        }).state;
+    });
+
+    expect(".datetime_hook_input").toHaveValue("06/06/2023 08:00 AM");
+
+    await click(".datetime_hook_input");
+    await contains(".o_time_picker input").edit("10:00pm");
+    await click(document.body);
+    expect(".datetime_hook_input").toHaveValue("06/06/2023 10:00 PM");
 });

--- a/addons/web/static/tests/core/l10n/dates.test.js
+++ b/addons/web/static/tests/core/l10n/dates.test.js
@@ -246,6 +246,32 @@ test("parseDateTime with escaped characters (eg. Basque locale)", async () => {
     );
 });
 
+test("parseDateTime in am/pm format", async () => {
+    const dateFormat = strftimeToLuxonFormat("%m/%d/%Y");
+    const timeFormat = strftimeToLuxonFormat("%I:%M:%S %p");
+    const dateTimeFormat = `${dateFormat} ${timeFormat}`;
+    const shortTimeFormat = strftimeToLuxonFormat("%I:%M %p");
+    patchWithCleanup(localization, {
+        dateFormat,
+        timeFormat,
+        dateTimeFormat,
+        shortTimeFormat,
+    });
+
+    expect(parseDateTime("01/31/1985 08:30:15 am").toFormat(dateTimeFormat)).toBe(
+        "01/31/1985 08:30:15 AM"
+    );
+    expect(parseDateTime("01/31/1985 08:30:15 pm").toFormat(dateTimeFormat)).toBe(
+        "01/31/1985 08:30:15 PM"
+    );
+    expect(parseDateTime("01/31/1985 08:30 am").toFormat(dateTimeFormat)).toBe(
+        "01/31/1985 08:30:00 AM"
+    );
+    expect(parseDateTime("01/31/1985 08:30 pm").toFormat(dateTimeFormat)).toBe(
+        "01/31/1985 08:30:00 PM"
+    );
+});
+
 test("parse smart date input", async () => {
     mockDate("2020-01-01 00:00:00", 0);
 

--- a/addons/web/static/tests/mock_server/mock_server.test.js
+++ b/addons/web/static/tests/mock_server/mock_server.test.js
@@ -5,7 +5,9 @@ import {
     makeMockServer,
     models,
     onRpc,
+    patchWithCleanup,
 } from "@web/../tests/web_test_helpers";
+import { localization } from "@web/core/l10n/localization";
 
 class Partner extends models.Model {
     _name = "res.partner";
@@ -392,6 +394,11 @@ test("performRPC: formatted_read_group, group by boolean", async () => {
 });
 
 test("performRPC: formatted_read_group, group by date", async () => {
+    patchWithCleanup(localization, {
+        dateFormat: "MM/dd/yyyy",
+        dateTimeFormat: "MM/dd/yyyy HH:mm:ss",
+        shortTimeFormat: "HH:mm",
+    });
     await makeMockServer();
     let result = await ormRequest({
         model: "bar",
@@ -624,6 +631,11 @@ test("performRPC: formatted_read_group, group by date with number granularity", 
 });
 
 test("performRPC: formatted_read_group, group by datetime", async () => {
+    patchWithCleanup(localization, {
+        dateFormat: "MM/dd/yyyy",
+        dateTimeFormat: "MM/dd/yyyy HH:mm:ss",
+        shortTimeFormat: "HH:mm",
+    });
     await makeMockServer();
 
     let result = await ormRequest({
@@ -1365,6 +1377,11 @@ test("performRPC: read_progress_bar grouped by boolean", async () => {
 });
 
 test("performRPC: read_progress_bar grouped by datetime", async () => {
+    patchWithCleanup(localization, {
+        dateFormat: "MM/dd/yyyy",
+        dateTimeFormat: "MM/dd/yyyy HH:mm:ss",
+        shortTimeFormat: "HH:mm",
+    });
     await makeMockServer();
 
     await expect(


### PR DESCRIPTION
Be in (or configure) a language with the 12 hour time format (i.e. such that times are displayed with am/pm). In a datetime field, open the datepicker and set the time in the afternoon (e.g. 6pm).

Before this commit, the value that was actually set in the input was in the morning (6am in this case).

The cause of the issue came from the date parsing. As we do not display the seconds in the input, the value was "06:00 pm", which couldn't be parsed properly. This commit fixes the issue by adding a step in parseDateTime, to try to parse with the short time format.

opw~4996133

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
