### PR TITLE
[FIX] im_livechat: use data-* attributes for test

### DIFF
--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -64,26 +64,19 @@ test("editing livechat note is synced between tabs", async () => {
     const tab2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: tab1 });
     await openDiscuss(channelId, { target: tab2 });
-    await contains(
-        ".o-livechat-ChannelInfoList textarea",
-        { value: "Initial note" },
-        { target: tab1 }
-    );
-    await contains(
-        ".o-livechat-ChannelInfoList textarea",
-        { value: "Initial note" },
-        { target: tab2 }
-    );
-    await insertText(".o-livechat-ChannelInfoList textarea", "Updated note", {
-        target: tab1,
+    await contains(`${tab1.selector} .o-livechat-ChannelInfoList textarea`, {
+        value: "Initial note",
+    });
+    await contains(`${tab2.selector} .o-livechat-ChannelInfoList textarea`, {
+        value: "Initial note",
+    });
+    await insertText(`${tab1.selector} .o-livechat-ChannelInfoList textarea`, "Updated note", {
         replace: true,
     });
-    await click(".o-mail-ActionPanel-header", { target: tab1 }); // Trigger the blur event to save the note
-    await contains(
-        ".o-livechat-ChannelInfoList textarea",
-        { value: "Updated note" },
-        { target: tab2 }
-    ); // Note should be synced with bus
+    document.querySelector(`${tab1.selector} .o-livechat-ChannelInfoList textarea`).blur(); // Trigger the blur event to save the note
+    await contains(`${tab2.selector} .o-livechat-ChannelInfoList textarea`, {
+        value: "Updated note",
+    }); // Note should be synced with bus
 });
 
 test("shows live chat status in discuss sidebar", async () => {

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -350,7 +350,8 @@ export async function start(options) {
         target.dataset.asTabId = discussAsTabId;
         rootTarget.appendChild(target);
         addSwitchTabDropdownItem(rootTarget, target);
-        env = await makeMockEnv({ discussAsTabId }, { makeNew: true });
+        const selector = `.o-mail-Discuss-asTabContainer[data-as-tab-id="${target.dataset.asTabId}"]`;
+        env = await makeMockEnv({ discussAsTabId, selector }, { makeNew: true });
     } else {
         env = getMockEnv() || (await makeMockEnv({}));
     }


### PR DESCRIPTION
This commit updates the test selectors in
`livechat_channel_info_list.test.js` to use `data-as-tab-id` to avoid ambiguity. This change enhances the robustness of the tests by reducing their dependency on CSS classes.
Using `data-as-tab-id` attributes provides a more stable and reliable way to select elements in the DOM for testing purposes.

runbot-231494


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
