### PR TITLE
[FIX] point_of_sale: reset sequence_number when changing login

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1494,7 +1494,7 @@ export class Order extends PosModel {
             this.sequence_number = json.sequence_number;
             this.pos_session_id = json.pos_session_id;
         } else if (json.pos_session_id !== this.pos.pos_session.id) {
-            this.sequence_number = this.pos.pos_session.sequence_number++;
+            this.sequence_number = json.sequence_number;
         } else {
             this.sequence_number = json.sequence_number;
             this.updateSequenceNumber(json);
@@ -1589,7 +1589,7 @@ export class Order extends PosModel {
     }
     updateSequenceNumber(json) {
         this.pos.pos_session.sequence_number = Math.max(
-            this.sequence_number + 1,
+            this.sequence_number,
             this.pos.pos_session.sequence_number
         );
     }


### PR DESCRIPTION
**Problem:**
In 17, when we reload the pos, the login_number will be incremented. When this login is incremented, it makes sense for the sequence_number to be reset, as to not continue counting from where the last session left. But right now this sequence_number is not reset and does not behave as intended.

**Steps to reproduce:**
- Easier with demo data
- Go to the PoS restaurant, make a purchase
- Reload the page
- Make another purchase
- Go to the orders in the backend and look at the Receipt Number
- The last part of the second order (the sequence_number)  was not reset

**Why the fix:**
The problem lies in the fact that when loading the PoS, we load orders from the backend in the init_from_json function. When doing so, for each order that is not finished, we increment the sequence_number, even if it was done in another session. This is wrong, as a new session or even a new login_number should have it's sequence number start from 00001.

We now only set the sequence_number from the json, and stop incrementing it for every order we load.

opw-4977966