### PR TITLE
[FIX] web: Prevent navigation_hook updates when hotkey overlay is shown

### DIFF
--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -214,14 +214,19 @@ export class Navigator {
         const elements = this._options.getItems();
         this.items = [];
 
+        let didUpdate = elements.length !== oldItems.size;
         for (let index = 0; index < elements.length; index++) {
             const element = elements[index];
 
             let item = oldItems.get(element);
             if (item) {
-                item.index = index;
+                if (item.index !== index) {
+                    item.index = index;
+                    didUpdate = true;
+                }
                 oldItems.delete(element);
             } else {
+                didUpdate = true;
                 item = new NavigationItem({
                     index,
                     el: element,
@@ -236,20 +241,22 @@ export class Navigator {
             item._removeListeners();
         }
 
-        const activeItemIndex =
-            oldActiveItem && oldActiveItem.el.isConnected
-                ? this.items.findIndex((item) => item.el === oldActiveItem.el)
-                : -1;
-        if (activeItemIndex > -1) {
-            this._updateActiveItemIndex(activeItemIndex);
-        } else if (this.activeItemIndex >= 0) {
-            const closest = Math.min(this.activeItemIndex, elements.length - 1);
-            this._updateActiveItemIndex(closest);
-        } else {
-            this._updateActiveItemIndex(-1);
-        }
+        if (didUpdate) {
+            const activeItemIndex =
+                oldActiveItem && oldActiveItem.el.isConnected
+                    ? this.items.findIndex((item) => item.el === oldActiveItem.el)
+                    : -1;
+            if (activeItemIndex > -1) {
+                this._updateActiveItemIndex(activeItemIndex);
+            } else if (this.activeItemIndex >= 0) {
+                const closest = Math.min(this.activeItemIndex, elements.length - 1);
+                this._updateActiveItemIndex(closest);
+            } else {
+                this._updateActiveItemIndex(-1);
+            }
 
-        this._options.onUpdated?.(this);
+            this._options.onUpdated?.(this);
+        }
     }
 
     /**


### PR DESCRIPTION
This commit fixes an issue where the update of the navigation_hook would trigger for any dom modification (including hotkey overlay) which could cause unwanted re-focus on some elements.

Backport of 6939e29b2bf9d943fa82a5969a2472cdc3c81c8a to 18.4

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
