### PR TITLE
[IMP] mail, *: use count pseudo in tests when it's possible

### DIFF
--- a/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
@@ -1,5 +1,4 @@
 import { registry } from "@web/core/registry";
-import { contains } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
     steps: () => [
@@ -31,13 +30,8 @@ registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
             run: "fill @",
         },
         {
-            trigger: ".o-mail-DiscussCommand",
-            async run() {
-                await contains(".fa-hashtag", {
-                    parent: [".o-mail-DiscussCommand", { text: "Test channel" }],
-                });
-                await contains(".fa-user", { count: 0 });
-            },
+            trigger:
+                ".o-mail-DiscussCommand:not(:has(.fa-user)):has(.fa-hashtag):contains(/^Test channel$/)",
         },
     ],
 });

--- a/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
@@ -37,14 +37,15 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             run: "click",
         },
         {
-            trigger: ".o-mail-SubChannelList",
-            async run() {
+            trigger: ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(30)",
+            async run({ waitFor }) {
                 // 30 newest sub channels are loaded initially.
                 for (let i = 99; i > 69; i--) {
                     await contains(".o-mail-SubChannelPreview", {
                         text: `Sub Channel ${i}`,
                     });
-                    await contains(".o-mail-SubChannelPreview", { count: 30 });
+                    // If any sub channel was added or removed during the previous await, this fails.
+                    await waitFor(".o-mail-SubChannelPreview:count(30)");
                 }
             },
         },
@@ -58,9 +59,9 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             run: "click",
         },
         {
-            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 10)",
+            trigger:
+                ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(1):contains(Sub Channel 10)",
             async run() {
-                await contains(".o-mail-SubChannelPreview", { count: 1 });
                 waitForLoadMoreToDisappearDef = new Deferred();
             },
         },
@@ -69,9 +70,9 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             run: "clear",
         },
         {
-            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 99)",
+            trigger:
+                ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(31):contains(Sub Channel 99)",
             async run() {
-                await contains(".o-mail-SubChannelPreview", { count: 31 });
                 // Already fetched sub channels are shown in addition to the one
                 // that was fetched during the search.
                 for (let i = 99; i > 69; i--) {
@@ -87,9 +88,9 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             },
         },
         {
-            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 40)",
+            trigger:
+                ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(61):contains(Sub Channel 40)",
             async run() {
-                await contains(".o-mail-SubChannelPreview", { count: 61 });
                 for (let i = 99; i > 39; i--) {
                     await contains(".o-mail-SubChannelPreview", {
                         text: `Sub Channel ${i}`,
@@ -101,9 +102,9 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             },
         },
         {
-            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 11)",
+            trigger:
+                ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(90):contains(Sub Channel 11)",
             async run() {
-                await contains(".o-mail-SubChannelPreview", { count: 90 });
                 for (let i = 99; i > 9; i--) {
                     await contains(".o-mail-SubChannelPreview", {
                         text: `Sub Channel ${i}`,
@@ -114,10 +115,10 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             },
         },
         {
-            trigger: ".o-mail-SubChannelPreview:contains(Sub Channel 0)",
+            trigger:
+                ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(100):contains(Sub Channel 0)",
             async run() {
-                await contains(".o-mail-SubChannelPreview", { count: 100 });
-                for (let i = 99; i > 0; i--) {
+                for (let i = 99; i >= 0; i--) {
                     await contains(".o-mail-SubChannelPreview", {
                         text: `Sub Channel ${i}`,
                     });

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -1,5 +1,5 @@
 import { registry } from "@web/core/registry";
-import { contains, dragenterFiles, dropFiles, inputFiles } from "@web/../tests/utils";
+import { dragenterFiles, dropFiles, inputFiles } from "@web/../tests/utils";
 
 /**
  * This tour depends on data created by python test in charge of launching it.
@@ -11,10 +11,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
     steps: () => [
         {
             content: "Wait for the chatter to be fully loaded",
-            trigger: ".o-mail-Chatter",
-            async run() {
-                await contains(".o-mail-Message", { count: 1 });
-            },
+            trigger: ".o-mail-Chatter .o-mail-Message:count(1)",
         },
         {
             content: "Click on Send Message",

--- a/addons/mail/static/tests/tours/mail_message_load_order_tour.js
+++ b/addons/mail/static/tests/tours/mail_message_load_order_tour.js
@@ -8,9 +8,8 @@ registry.category("web_tour.tours").add("mail_message_load_order_tour", {
             run: "click",
         },
         {
-            trigger: ".o-mail-Thread .o-mail-Message",
+            trigger: ".o-mail-Thread .o-mail-Message:count(30)",
             async run() {
-                await contains(".o-mail-Thread .o-mail-Message", { count: 30 });
                 await contains(".o-mail-Thread", { scroll: "bottom" });
             },
         },
@@ -29,9 +28,8 @@ registry.category("web_tour.tours").add("mail_message_load_order_tour", {
             // will be (31 - 60). This trigger ensures the next messages
             // are fetched after jumping to the message.
             trigger:
-                ".o-mail-Thread .o-mail-Message:first .o-mail-Message-textContent:not(:contains(31))",
+                ".o-mail-Thread .o-mail-Message:count(31):first .o-mail-Message-textContent:not(:contains(31))",
             async run() {
-                await contains(".o-mail-Thread .o-mail-Message", { count: 31 });
                 await contains(".o-mail-Thread", { scroll: 0 });
                 // ensure 1 - 31 are loaded in order: 30 below and the
                 // one we're loading messages around.
@@ -51,9 +49,9 @@ registry.category("web_tour.tours").add("mail_message_load_order_tour", {
             // was (1 -31): 30 before (but none were found), 30 after
             // and the pinned message itself. This trigger ensures the
             // next messages are fetched after scrolling to the bottom.
-            trigger: ".o-mail-Thread .o-mail-Message .o-mail-Message-textContent:contains(17)",
+            trigger:
+                ".o-mail-Thread .o-mail-Message:count(60) .o-mail-Message-textContent:contains(17)",
             async run() {
-                await contains(".o-mail-Thread .o-mail-Message", { count: 60 });
                 // ensure 1 - 60  are loaded in order.
                 const messages = Array.from(
                     document.querySelectorAll(".o-mail-Thread .o-mail-Message-content")

--- a/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
+++ b/addons/mail/static/tests/tours/user_modify_own_profile_tour.js
@@ -1,5 +1,4 @@
 import { registry } from "@web/core/registry";
-import { click, contains } from "@web/../tests/utils";
 
 /**
  * Verify that a user can modify their own profile information.
@@ -19,10 +18,10 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own
         {
             content: "Update the notification type",
             trigger: '.modal div[name="notification_type"] input[data-value="inbox"]',
-            async run() {
-                await click('.modal div[name="notification_type"] input[data-value="inbox"]');
-                await contains(".o_form_dirty", { count: 1 });
-            },
+            run: "click",
+        },
+        {
+            trigger: "body .o_form_dirty:count(1)",
         },
         {
             content: "Save the form",
@@ -31,10 +30,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/user_modify_own
         },
         {
             content: "Wait until the modal is closed",
-            trigger: "body:not(.modal-open)",
-            async run() {
-                await contains(".o_form_dirty", { count: 0 });
-            },
+            trigger: "body:not(.modal-open):not(:has(.o_form_dirty))",
         },
     ],
 });

--- a/addons/test_mail_full/static/tests/tours/load_more_tour.js
+++ b/addons/test_mail_full/static/tests/tours/load_more_tour.js
@@ -1,16 +1,9 @@
 import { registry } from "@web/core/registry";
-import { contains } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("load_more_tour", {
     steps: () => [
         {
-            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message",
-            run: async function () {
-                await contains(".o-mail-Thread .o-mail-Message", {
-                    count: 30,
-                    target: document.querySelector("#chatterRoot").shadowRoot,
-                });
-            },
+            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message:count(30)",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Thread button:contains(Load More):not(:visible)",

--- a/addons/test_mail_full/static/tests/tours/message_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/message_actions_tour.js
@@ -1,5 +1,4 @@
 import { registry } from "@web/core/registry";
-import { contains } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("star_message_tour", {
     steps: () => [
@@ -17,13 +16,7 @@ registry.category("web_tour.tours").add("star_message_tour", {
 registry.category("web_tour.tours").add("message_actions_tour", {
     steps: () => [
         {
-            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message",
-            run: async function () {
-                await contains(".o-mail-Thread .o-mail-Message", {
-                    count: 1,
-                    target: document.querySelector("#chatterRoot").shadowRoot,
-                });
-            },
+            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message:count(1)",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Composer-input",
@@ -34,13 +27,7 @@ registry.category("web_tour.tours").add("message_actions_tour", {
             run: "click",
         },
         {
-            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message",
-            run: async function () {
-                await contains(".o-mail-Thread .o-mail-Message", {
-                    count: 2,
-                    target: document.querySelector("#chatterRoot").shadowRoot,
-                });
-            },
+            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message:count(2)",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message[data-persistent]:contains(New message)",
@@ -79,13 +66,7 @@ registry.category("web_tour.tours").add("message_actions_tour", {
             run: "click",
         },
         {
-            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message",
-            run: async function () {
-                await contains(".o-mail-Thread .o-mail-Message", {
-                    count: 1,
-                    target: document.querySelector("#chatterRoot").shadowRoot,
-                });
-            },
+            trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message:count(1)",
         },
     ],
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -1,5 +1,4 @@
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
-import { contains } from "@web/../tests/utils";
 import { registry } from "@web/core/registry";
 import { Deferred } from "@web/core/utils/concurrency";
 import { Chatbot } from "@im_livechat/core/common/chatbot_model";
@@ -48,15 +47,10 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
                 run: "click",
             },
             {
-                trigger: ".o-livechat-root:shadow .o-mail-ChatWindow",
                 // check selected option is posted and reactions are available since
                 // the thread has been persisted in the process
-                async run() {
-                    await contains(".o-mail-Message-actions [title='Add a Reaction']", {
-                        target: this.anchor.getRootNode(),
-                        parent: [".o-mail-Message", { text: "I'd like to buy the software" }],
-                    });
-                },
+                trigger:
+                    ".o-livechat-root:shadow .o-mail-ChatWindow .o-mail-Message:has(.o-mail-Message-actions [title='Add a Reaction']):contains('I\\'d like to buy the software')",
             },
             {
                 // check ask email step following selecting option A

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
@@ -1,20 +1,12 @@
 import { registry } from "@web/core/registry";
-import { contains } from "@web/../tests/utils";
 
 const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour", {
     steps: () => [
         {
-            trigger: messagesContain("Hello! I'm a bot!"),
-            async run() {
-                const ChatHub = this.anchor.closest(".o-mail-ChatHub");
-                await contains(".o-mail-ChatWindow", {
-                    text: "Testing Bot",
-                    count: 1,
-                    target: ChatHub,
-                });
-            },
+            trigger:
+                ".o-livechat-root:shadow .o-mail-ChatHub:has(.o-mail-ChatWindow .o-mail-ChatWindow-header:contains(/^Testing Bot$/)):count(1) .o-mail-Message-body:contains(/^Hello! I'm a bot!$/)",
         },
         {
             trigger: messagesContain("I help lost visitors find their way."),
@@ -36,15 +28,8 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
             expectUnloadPage: true,
         },
         {
-            trigger: messagesContain("Hello! I'm a bot!"),
-            async run() {
-                const ChatHub = this.anchor.closest(".o-mail-ChatHub");
-                await contains(".o-mail-ChatWindow", {
-                    text: "Testing Bot",
-                    count: 1,
-                    target: ChatHub,
-                });
-            },
+            trigger:
+                ".o-livechat-root:shadow .o-mail-ChatHub:has(.o-mail-ChatWindow .o-mail-ChatWindow-header:contains(/^Testing Bot$/)):count(1) .o-mail-Message-body:contains(/^Hello! I'm a bot!$/)",
         },
         {
             trigger: '.o-livechat-root:shadow button:contains("Other & Documentation")',
@@ -63,15 +48,8 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow p:contains('Did we correctly answer your question?')",
-            async run() {
-                await contains("button", { target: this.anchor.getRootNode(), text: "Close" });
-                await contains("button", {
-                    target: this.anchor.getRootNode(),
-                    text: "New Session",
-                    count: 0,
-                });
-            },
+            trigger:
+                ".o-livechat-root:shadow .o-mail-ChatWindow:has(p:contains('Did we correctly answer your question?')):has(button:contains('Close')):not(:has(button:contains('New Session')))",
         },
         {
             trigger: ".o-livechat-root:shadow button:contains('Close')",

--- a/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_no_new_session_with_hide_rule.js
@@ -1,5 +1,4 @@
 import { registry } from "@web/core/registry";
-import { contains } from "@web/../tests/utils";
 
 const sendFirstMessageSteps = [
     {
@@ -52,15 +51,8 @@ registry.category("web_tour.tours").add("website_livechat_no_session_with_hide_r
             run: "click",
         },
         {
-            trigger: ".o-livechat-root:shadow p:contains('Did we correctly answer your question?')",
-            async run() {
-                await contains("button", { target: this.anchor.getRootNode(), text: "Close" });
-                await contains("button", {
-                    target: this.anchor.getRootNode(),
-                    text: "New Session",
-                    count: 0,
-                });
-            },
+            trigger:
+                ".o-livechat-root:shadow .o-mail-ChatWindow:has(p:contains('Did we correctly answer your question?')):has(button:contains('Close')):not(:has(button:contains('New Session')))",
         },
     ],
 });


### PR DESCRIPTION
 *: test_mail_full, website_livechat  
 
 It's now possible to use the count pseudo class in selectors since [this commit](https://github.com/odoo/odoo/pull/231355/commits/56c772fff011ae99c54c0d66708691c27a24499d). This change converts some parts of the tests to use this new pseudo.
 
 task-5106412