### PR TITLE
[FIX] hr_presence: prevent mobile cog menu traceback

### DIFF
--- a/addons/hr_presence/static/src/search/hr_presence_cog_menu/hr_presence_cog_menu.js
+++ b/addons/hr_presence/static/src/search/hr_presence_cog_menu/hr_presence_cog_menu.js
@@ -11,6 +11,8 @@ export class HrPresenceCogMenu extends FormCogMenu {
     setup() {
         super.setup();
 
+        this.presenceActionItems = [];
+
         onWillStart(async () => {
             await super.onWillStart;
             this.records = await getActionRecords(this.orm);


### PR DESCRIPTION
Opening the Employee form on mobile and tapping the gear icon could crash because `PresenceActionItems` was undefined. Initialize it and guard the template.

task-5055564