### PR TITLE
[FIX] website_sale_wishlist: restore wishlist product design panel

### DIFF
--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -308,9 +308,8 @@
 
                         <div
                             id="o_comparelist_table"
-                            class="o_wishlist_table"
                             style="--o-wsale-products-grid-gap: 16px;"
-                            t-attf-class="grid table-comparator mb-5 {{website.wishlist_opt_products_design_classes}}"
+                            t-attf-class="o_wishlist_table grid table-comparator mb-5 {{website.wishlist_opt_products_design_classes}}"
                         >
                             <t t-foreach="wishes" t-as="wish">
                                 <t t-set="combination_info" t-value="wish.product_id._get_combination_info_variant()"/>


### PR DESCRIPTION
This PR fixes an issue introduced by Commit[1].

Commit[^1] redesigned the comparison feature and updated a selector in the wishlist options that was targeting `#o_comparelist_table`. However, this id` is shared between wishlist and comparison, causing conflicts.

To resolve this, we changed the selector to a class `.o_wishlist_table.` Unfortunately, we overlooked the existing `t-attf-class` attribute defined below, which overrides anything specified in the `class=""` attribute, rendering the new selector ineffective.

task-5055682

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

[^1]: https://github.com/odoo/odoo/commit/524c968eb647a65119a935ed820602b57820a418
