### PR TITLE
[IMP] stock: improve UX when splitting picking

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1024,11 +1024,7 @@ class MrpProduction(models.Model):
                     production.date_finished = new_date_start + datetime.timedelta(hours=1)
         if moves_to_reassign:
             moves_to_reassign._do_unreserve()
-            moves_to_reassign = moves_to_reassign.filtered(
-                lambda move: move.state in ('confirmed', 'partially_available')
-                and (move._should_bypass_reservation()
-                    or move.picking_type_id.reservation_method == 'at_confirm'
-                    or (move.reservation_date and move.reservation_date <= fields.Date.today())))
+            moves_to_reassign = moves_to_reassign._filtered_for_assign()
             moves_to_reassign._action_assign()
         return res
 
@@ -2116,11 +2112,7 @@ class MrpProduction(models.Model):
         self.env['stock.move'].browse(assigned_moves).write({'state': 'assigned'})
         self.env['stock.move'].browse(partially_assigned_moves).write({'state': 'partially_available'})
         self.env['stock.move.line'].create(move_lines_vals)
-        move_to_assign = move_to_assign.filtered(
-            lambda move: move.state in ('confirmed', 'partially_available')
-            and (move._should_bypass_reservation()
-                or move.picking_type_id.reservation_method == 'at_confirm'
-                or (move.reservation_date and move.reservation_date <= fields.Date.today())))
+        move_to_assign = move_to_assign._filtered_for_assign()
         move_to_assign._action_assign()
 
         # Avoid triggering a useless _recompute_state

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -315,9 +315,7 @@ class StockMove(models.Model):
                     and all(m.state == 'done' for m in move.move_orig_ids):
                 continue
             if move.product_uom.compare(move.product_uom_qty, 0) > 0:
-                if move._should_bypass_reservation() \
-                        or move.picking_type_id.reservation_method == 'at_confirm' \
-                        or (move.reservation_date and move.reservation_date <= fields.Date.today()):
+                if move._should_assign_at_confirm():
                     to_assign |= move
 
             if move.procure_method == 'make_to_order' or move.rule_id.procure_method == 'mts_else_mto':

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -407,11 +407,7 @@ class RepairOrder(models.Model):
                 repair._update_sale_order_line_price()
         if moves_to_reassign:
             moves_to_reassign._do_unreserve()
-            moves_to_reassign = moves_to_reassign.filtered(
-                lambda move: move.state in ('confirmed', 'partially_available')
-                and (move._should_bypass_reservation()
-                    or move.picking_type_id.reservation_method == 'at_confirm'
-                    or (move.reservation_date and move.reservation_date <= fields.Date.today())))
+            moves_to_reassign = moves_to_reassign._filtered_for_assign()
             moves_to_reassign._action_assign()
         return res
 

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -1600,11 +1600,16 @@ class TestPacking(TestPackingCommon):
         picking.action_confirm()
         picking.action_split_transfer()
         self.assertEqual(len(picking.move_ids), 1)
-        self.assertEqual(picking.move_ids[0].product_uom_qty, 8)
+        # Since the reservation method is set to 'manual' for the internal picking type,
+        # So, both original picking and it's backorder should also follow the 'manual' reservation.
+        self.assertRecordValues(picking.move_ids, [
+            {'product_id': self.productA.id, 'product_uom_qty': 8, 'quantity': 0},
+        ])
         backorder = self.env['stock.picking'].search([('backorder_id', '=', picking.id)])
-        self.assertEqual(len(backorder.move_ids), 2)
-        self.assertEqual(backorder.move_ids[0].product_uom_qty, 2)
-        self.assertEqual(backorder.move_ids[1].product_uom_qty, 10)
+        self.assertRecordValues(backorder.move_ids.sorted('product_id'), [
+            {'product_id': self.productA.id, 'product_uom_qty': 2, 'quantity': 0},
+            {'product_id': self.productB.id, 'product_uom_qty': 10, 'quantity': 0},
+        ])
 
     def test_put_in_pack_partial_different_destinations(self):
         """ Test putting some of the move lines of a pikcing with different destinations in a package """

--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -174,13 +174,13 @@ class StockPicking(models.Model):
 
         return res
 
-    def _create_backorder(self, backorder_moves=None):
+    def _create_backorder(self, backorder_moves=None, from_manual_backorder=False):
         pickings_to_detach = self.env['stock.picking'].browse(self.env.context.get('pickings_to_detach'))
         for picking in self:
             # Avoid inconsistencies in states of the same batch when validating a single picking in a batch.
             if picking.batch_id and picking.state != 'done' and any(p not in self for p in picking.batch_id.picking_ids - pickings_to_detach):
                 picking.batch_id = None
-        return super()._create_backorder(backorder_moves)
+        return super()._create_backorder(backorder_moves, from_manual_backorder)
 
     def action_cancel(self):
         res = super().action_cancel()


### PR DESCRIPTION
When splitting a picking, users often need to configure the backorder,
such as adjusting the quantity to keep, setting a scheduled date, or
preparing it for further splits. Currently, after the split, the system
remains on the original picking. In practice, however, users primarily
need to continue working on the backorder, not the original picking.

This forces users to find the backorder or follow the chatter link manually,
which is not smooth and wastes time.

Additionally, the reservation of the picking now follows based on the operation’s reservation method
for both the original picking and the backorder created from it (already follow it).

This commit improves usability by directly redirecting to the backorder and adding a log note
of the original picking, reduces unnecessary clicks, and makes it easier to track and manage backorders.

Task Id:- 5003505