### PR TITLE
[FIX] website: avoid showing language name when "code" is selected

### DIFF
--- a/addons/website/static/src/builder/plugins/options/language_selector_option.xml
+++ b/addons/website/static/src/builder/plugins/options/language_selector_option.xml
@@ -39,7 +39,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 actionParam="{
-                    views: ['website.header_language_selector_code']
+                    views: ['website.header_language_selector_code', 'website.header_language_selector_no_text']
                 }">
                 Code
             </BuilderSelectItem>


### PR DESCRIPTION
During the initial [website builder refactor], a mistake happened when porting the option for the label of the language selector. This commit adds the missing key in the views parameter when the "Code" is choosen

Steps to reproduce:
- Open website builder, on a multi-language website
- Click on the language selector in the header
- Select "Code" for the "Label" of "Language Selector"
- Bug: Instead of showing the code (for example "FR"), it shows the language name (for example "Français")

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
