### PR TITLE
[IMP] Fleet: added split on service type to the pivot view of cost report

### DIFF
--- a/addons/fleet/views/fleet_board_view.xml
+++ b/addons/fleet/views/fleet_board_view.xml
@@ -15,6 +15,8 @@
                 <group>
                     <filter string="Vehicle" name="vehicle" context="{'group_by':'vehicle_id'}"/>
                     <filter string="Driver" name="driver" context="{'group_by':'driver_id'}"/>
+                    <filter string="Cost Type" name="cost_type" context="{'group_by':'cost_type'}"/>
+                    <filter string="Service Type" name="service_type" context="{'group_by':'service_type'}"/>
                 </group>
             </search>
         </field>


### PR DESCRIPTION
- changed the sql query of the report to include service type (for both contracts and services)
- added custom filter on cost type, service type

task-id: 5049107
