### PR TITLE
[FIX] base: Adapt opening_info in web_read_group to date(time) properties

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -1188,6 +1188,7 @@ class Base(models.AbstractModel):
 
                 # Date / Datetime are not JSONifiable, so they are stored as raw text
                 db_format = '%Y-%m-%d' if property_type == 'date' else '%Y-%m-%d %H:%M:%S'
+                fmt = DEFAULT_SERVER_DATE_FORMAT if property_type == 'date' else DEFAULT_SERVER_DATETIME_FORMAT
 
                 if func == 'week':
                     # the value is the first day of the week (based on local)
@@ -1202,7 +1203,7 @@ class Base(models.AbstractModel):
                     format=READ_GROUP_DISPLAY_FORMAT[func],
                     locale=get_lang(self.env).code,
                 )
-                return (value, label), [(fullname, '>=', start), (fullname, '<', end)]
+                return (value.strftime(fmt), label), [(fullname, '>=', start), (fullname, '<', end)]
 
             return formatter_property_datetime
 


### PR DESCRIPTION
Steps:
- Install a random module with properties (example: crm)
- Add a properties to the form view (date or datetime)
- Set the field to today
- Make sure you have another record with the new properties field unset
- Go to list view
- Group by -> properties -> year
- Open a group which is not False
- Via the breadcrumb navigate back to the list view
- Traceback

When opening_info is set to unfold with datetime properties, web_read_group returns no records, which crashes the web client.

To resolve this, we modify the `formatter_property_datetime` to return the date(time) object as a string. This should match the behavior of normal date(time) fields, ensuring the `_open_groups` algorithm can correctly identify and match the appropriate group(s).

opw-5016891

Co-authored-by: @ryv-odoo 