### PR TITLE
[FIX] spreadsheet: freeze carousel data

### DIFF
--- a/addons/spreadsheet/static/src/helpers/model.js
+++ b/addons/spreadsheet/static/src/helpers/model.js
@@ -143,6 +143,24 @@ export async function freezeOdooData(model) {
                     path: img,
                     size: { width: figure.width, height: figure.height },
                 };
+            } else if (figure.tag === "carousel") {
+                const hasImageChart = figure.data.items.some((item) => {
+                    if (item.type !== "chart") {
+                        return false;
+                    }
+                    const chartDefinition = model.getters.getChartDefinition(item.chartId);
+                    return (
+                        chartDefinition.type.startsWith("odoo_") || chartDefinition.type === "geo"
+                    );
+                });
+                if (hasImageChart) {
+                    const chartId = figure.data.items.find((item) => item.type === "chart").chartId;
+                    figure.tag = "image";
+                    figure.data = {
+                        path: odooChartToImage(model, figure, chartId),
+                        size: { width: figure.width, height: figure.height },
+                    };
+                }
             }
         }
     }

--- a/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
@@ -7,6 +7,8 @@ import {
     setCellFormat,
     setCellStyle,
     setGlobalFilterValue,
+    createCarousel,
+    addChartFigureToCarousel,
 } from "@spreadsheet/../tests/helpers/commands";
 import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { getCell, getEvaluatedCell } from "@spreadsheet/../tests/helpers/getters";
@@ -161,6 +163,18 @@ test("geo charts are replaced with an image", async function () {
             legendPosition: "none",
         },
     });
+
+    const data = await freezeOdooData(model);
+    expect(data.sheets[0].figures.length).toBe(1);
+    expect(data.sheets[0].figures[0].tag).toBe("image");
+});
+
+test("Carousels figure with odoo data is converted to an image", async function () {
+    const { model } = await createSpreadsheetWithChart({ type: "odoo_bar" });
+    const sheetId = model.getters.getActiveSheetId();
+    const chartFigureId = model.getters.getFigures(sheetId)[0].id;
+    createCarousel(model, { items: [] }, "carouselId");
+    addChartFigureToCarousel(model, "carouselId", chartFigureId);
 
     const data = await freezeOdooData(model);
     expect(data.sheets[0].figures.length).toBe(1);


### PR DESCRIPTION
When we freeze a spreadsheet and freeze the data, we convert odoo charts into images. This doesn't work for charts inside carousels, as the carousels do no support images.

In this commit, we'll do a simple workaround to convert the whole carousel into an image of a chart. This can be improved in the future when (if) the carousels support images.

Task: [5056183](https://www.odoo.com/odoo/2328/tasks/5056183)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
