### PR TITLE
[FIX] point_of_sale: replace frontend tour cash assertion with backend test

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -283,7 +283,6 @@ registry.category("web_tour.tours").add("CashClosingDetails", {
                 trigger: "body",
                 expectUnloadPage: true,
             },
-            ProductScreen.lastClosingCashIs("50.00"),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -189,7 +189,6 @@ registry.category("web_tour.tours").add("OrderPaidInCash", {
                 trigger: "body",
                 expectUnloadPage: true,
             },
-            ProductScreen.lastClosingCashIs("25.00"),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -628,14 +628,6 @@ export function productCardQtyIs(productName, qty) {
     ];
 }
 
-// Temporarily put it here. It should be in the utility methods for the backend views.
-export function lastClosingCashIs(val) {
-    return [
-        {
-            trigger: `[name=last_session_closing_cash]:contains(${val})`,
-        },
-    ];
-}
 export function checkFirstLotNumber(number) {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -835,6 +835,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         current_session.close_session_from_ui()
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'CashClosingDetails', login="pos_user")
+        self.assertEqual(self.main_pos_config.last_session_closing_cash, 50.0)
         cash_diff_line = self.env['account.bank.statement.line'].search([
             ('payment_ref', 'ilike', 'Cash difference observed during the counting (Loss)')
         ])
@@ -843,6 +844,7 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_cash_payments_should_reflect_on_next_opening(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'OrderPaidInCash', login="pos_user")
+        self.assertEqual(self.main_pos_config.last_session_closing_cash, 25.0)
 
     def test_pos_session_statistics_display(self):
         """Test that POS session statistics are properly displayed in the UI."""


### PR DESCRIPTION
Issue:
===================
- Tour `CashClosingDetails` and `test_cash_payments_should_reflect_on_next_opening` failed at the last step when checking `last_session_closing_cash` via UI before it loaded.

Fix:
======
- Removed `lastClosingCashIs` from the tour and added a backend assertion in Python.

Runbot Error: 231459