### PR TITLE
[FIX] google_address_autocomplete: prevent error when typing address

### DIFF
--- a/addons/google_address_autocomplete/controllers/google_address_autocomplete.py
+++ b/addons/google_address_autocomplete/controllers/google_address_autocomplete.py
@@ -108,7 +108,7 @@ class AutoCompleteController(http.Controller):
             }
 
         if results.get('error_message'):
-            _logger.error(results['error_message'])
+            _logger.warning(results['error_message'])
 
         results = results.get('predictions', [])
 
@@ -140,7 +140,7 @@ class AutoCompleteController(http.Controller):
             return {'address': None}
 
         if results.get('error_message'):
-            _logger.error(results['error_message'])
+            _logger.warning(results['error_message'])
 
         try:
             html_address = results['result']['adr_address']


### PR DESCRIPTION
Currently, an error occurs when a user enters an address using `Google Address Autocomplete` without the `Places API` being enabled.

**Steps to replicate:**
* Install `google_address_autocomplete` and `contacts`
* Settings > `Google Address Autocomplete` > Enter API key
* Go to contacts > New > Type out address field
* Error should occur in the terminal as shown in [1].

**Error:**
`You’re calling a legacy API, which is not enabled for your project. To get newer features and more functionality, switch to the Places API (New) or Routes API. Learn more: https://developers.google.com/maps/legacy#LegacyApiNotActivatedMapError`

**Root cause:**
This error happens because the user has not enabled the `Places API` in their Google dashboard, as illustrated in [2].

**Solution:**
* Since the issue originates from an external API rather than our system, it would be more appropriate to log it as a warning instead of an error.

[1]:
https://drive.google.com/file/d/151cBpS7nBhmtgxsYNmtCY_So8jcrWBs6/view?usp=sharing 
[2]:
https://drive.google.com/file/d/1WDZHLYSrwKp-53JycF07TcAUvrI5lljQ/view?usp=sharing

sentry-6845158852