### PR TITLE
[IMP] mail,*: use data-* attributes for test

### DIFF
--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -66,26 +66,19 @@ test("editing livechat note is synced between tabs", async () => {
     const tab2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: tab1 });
     await openDiscuss(channelId, { target: tab2 });
-    await contains(
-        ".o-livechat-ChannelInfoList textarea",
-        { value: "Initial note" },
-        { target: tab1 }
-    );
-    await contains(
-        ".o-livechat-ChannelInfoList textarea",
-        { value: "Initial note" },
-        { target: tab2 }
-    );
-    await insertText(".o-livechat-ChannelInfoList textarea", "Updated note", {
-        target: tab1,
+    await contains(`${tab1.selector} .o-livechat-ChannelInfoList textarea`, {
+        value: "Initial note",
+    });
+    await contains(`${tab2.selector} .o-livechat-ChannelInfoList textarea`, {
+        value: "Initial note",
+    });
+    await insertText(`${tab1.selector} .o-livechat-ChannelInfoList textarea`, "Updated note", {
         replace: true,
     });
-    await click(".o-mail-ActionPanel-header", { target: tab1 }); // Trigger the blur event to save the note
-    await contains(
-        ".o-livechat-ChannelInfoList textarea",
-        { value: "Updated note" },
-        { target: tab2 }
-    ); // Note should be synced with bus
+    document.querySelector(`${tab1.selector} .o-livechat-ChannelInfoList textarea`).blur(); // Trigger the blur event to save the note
+    await contains(`${tab2.selector} .o-livechat-ChannelInfoList textarea`, {
+        value: "Updated note",
+    }); // Note should be synced with bus
 });
 
 test("shows live chat status in discuss sidebar", async () => {
@@ -145,25 +138,20 @@ test("editing livechat status is synced between tabs", async () => {
     const tab2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: tab1 });
     await openDiscuss(channelId, { target: tab2 });
-    await contains(".o-livechat-ChannelInfoList button.active", {
+    await contains(`${tab1.selector} .o-livechat-ChannelInfoList button.active`, {
         text: "In progress",
-        target: tab1,
     });
-    await contains(".o-livechat-ChannelInfoList button.active", {
+    await contains(`${tab2.selector} .o-livechat-ChannelInfoList button.active`, {
         text: "In progress",
-        target: tab2,
     });
-    await click(".o-livechat-ChannelInfoList button", {
+    await click(`${tab1.selector} .o-livechat-ChannelInfoList button`, {
         text: "Waiting for customer",
-        target: tab1,
     });
-    await contains(".o-livechat-ChannelInfoList button.active", {
+    await contains(`${tab1.selector} .o-livechat-ChannelInfoList button.active`, {
         text: "Waiting for customer",
-        target: tab1,
     });
-    await contains(".o-livechat-ChannelInfoList button.active", {
+    await contains(`${tab2.selector} .o-livechat-ChannelInfoList button.active`, {
         text: "Waiting for customer",
-        target: tab2,
     }); // Status should be synced with bus
 });
 

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -474,11 +474,11 @@ test("Local sidebar category state is shared between tabs", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(undefined, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
-    await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-down", { target: env1 });
-    await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-down", { target: env2 });
-    await click(".o-mail-DiscussSidebarCategory-livechat .btn", { target: env1 });
-    await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-right", { target: env1 });
-    await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-right", { target: env2 });
+    await contains(`${env1.selector} .o-mail-DiscussSidebarCategory-livechat .oi-chevron-down`);
+    await contains(`${env2.selector} .o-mail-DiscussSidebarCategory-livechat .oi-chevron-down`);
+    await click(`${env1.selector} .o-mail-DiscussSidebarCategory-livechat .btn`);
+    await contains(`${env1.selector} .o-mail-DiscussSidebarCategory-livechat .oi-chevron-right`);
+    await contains(`${env2.selector} .o-mail-DiscussSidebarCategory-livechat .oi-chevron-right`);
 });
 
 test("live chat is displayed below its category", async () => {

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -220,15 +220,15 @@ test("chat bubbles are synced between tabs", async () => {
     setupChatHub({ folded: [channelId] });
     const tab1 = await start({ asTab: true });
     const tab2 = await start({ asTab: true });
-    await contains(".o-mail-ChatBubble", { target: tab1 });
-    await contains(".o-mail-ChatBubble", { target: tab2 });
+    await contains(`${tab1.selector} .o-mail-ChatBubble`);
+    await contains(`${tab2.selector} .o-mail-ChatBubble`);
     await runAllTimers(); // Wait for bus service to fully load
-    await click(".o-mail-ChatBubble[name='Marc']", { target: tab1 });
-    await contains(".o-mail-ChatWindow", { target: tab2 }); // open sync
-    await click(".o-mail-ChatWindow-command[title='Fold']", { target: tab2 });
-    await contains(".o-mail-ChatWindow", { target: tab1, count: 0 }); // fold sync
-    await click(".o-mail-ChatBubble[name='Marc'] .o-mail-ChatBubble-close", { target: tab1 });
-    await contains(".o-mail-ChatBubble[name='Marc']", { target: tab2, count: 0 }); // close sync
+    await click(`${tab1.selector} .o-mail-ChatBubble[name='Marc']`);
+    await contains(`${tab2.selector} .o-mail-ChatWindow`); // open sync
+    await click(`${tab2.selector} .o-mail-ChatWindow-command[title='Fold']`);
+    await contains(`${tab1.selector} .o-mail-ChatWindow`, { count: 0 }); // fold sync
+    await click(`${tab1.selector} .o-mail-ChatBubble[name='Marc'] .o-mail-ChatBubble-close`);
+    await contains(`${tab2.selector} .o-mail-ChatBubble[name='Marc']`, { count: 0 }); // close sync
 });
 
 test("Chat bubbles do not fetch messages until becoming open", async () => {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -206,18 +206,18 @@ test.skip("Fold state of chat window is sync among browser tabs", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const env1 = await start({ asTab: true });
     const env2 = await start({ asTab: true });
-    await click(".o_menu_systray i[aria-label='Messages']", { target: env1 });
-    await click(".o-mail-NotificationItem", { target: env1 });
-    await contains(".o-mail-ChatWindow-header", { target: env2 });
-    await click(".o-mail-ChatWindow-header", { target: env1 }); // Fold
-    await contains(".o-mail-Thread", { count: 0, target: env1 });
-    await contains(".o-mail-Thread", { count: 0, target: env2 });
-    await click(".o-mail-ChatBubble", { target: env2 }); // Unfold
-    await contains(".o-mail-ChatWindow .o-mail-Thread", { target: env1 });
-    await contains(".o-mail-ChatWindow .o-mail-Thread", { target: env2 });
-    await click("[title*='Close Chat Window']", { target: env1 });
-    await contains(".o-mail-ChatWindow", { count: 0, target: env1 });
-    await contains(".o-mail-ChatWindow", { count: 0, target: env2 });
+    await click(`${env1.selector} .o_menu_systray i[aria-label='Messages']`);
+    await click(`${env1.selector} .o-mail-NotificationItem`);
+    await contains(`${env2.selector} .o-mail-ChatWindow-header`);
+    await click(`${env1.selector} .o-mail-ChatWindow-header`); // Fold
+    await contains(`${env1.selector} .o-mail-Thread`, { count: 0 });
+    await contains(`${env2.selector} .o-mail-Thread`, { count: 0 });
+    await click(`${env2.selector} .o-mail-ChatBubble`); // Unfold
+    await contains(`${env1.selector} .o-mail-ChatWindow .o-mail-Thread`);
+    await contains(`${env2.selector} .o-mail-ChatWindow .o-mail-Thread`);
+    await click(`${env1.selector} [title*='Close Chat Window']`);
+    await contains(`${env1.selector} .o-mail-ChatWindow`, { count: 0 });
+    await contains(`${env2.selector} .o-mail-ChatWindow`, { count: 0 });
 });
 
 test("chat window: fold", async () => {

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -156,11 +156,11 @@ test("Chat is pinned on other tabs when joined", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(undefined, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
-    await click("input[placeholder='Find or start a conversation']", { target: env1 });
-    await insertText("input[placeholder='Search a conversation']", "Jer", { target: env1 });
-    await click("a", { text: "Jerry Golay", target: env1 });
-    await contains(".o-mail-DiscussSidebar-item", { target: env1, text: "Jerry Golay" });
-    await contains(".o-mail-DiscussSidebar-item", { target: env2, text: "Jerry Golay" });
+    await click(`${env1.selector} input[placeholder='Find or start a conversation']`);
+    await insertText(`${env1.selector} input[placeholder='Search a conversation']`, "Jer");
+    await click(`${env1.selector} a`, { text: "Jerry Golay" });
+    await contains(`${env1.selector} .o-mail-DiscussSidebar-item`, { text: "Jerry Golay" });
+    await contains(`${env2.selector} .o-mail-DiscussSidebar-item`, { text: "Jerry Golay" });
 });
 
 test("no conversation selected when opening non-existing channel in discuss", async () => {

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -299,6 +299,8 @@ async function addSwitchTabDropdownItem(rootTarget, tabTarget) {
     dropdownDiv.querySelector(".dropdown-menu").appendChild(li);
 }
 
+let discussAsTabId = 0;
+
 /**
  * @param {{
  *  asTab?: boolean;
@@ -342,13 +344,16 @@ export async function start(options) {
     }
     let env;
     if (options?.asTab) {
+        discussAsTabId++;
         restoreRegistry(registry);
         const rootTarget = target;
         target = document.createElement("div");
         target.classList.add("o-mail-Discuss-asTabContainer");
+        target.dataset.asTabId = discussAsTabId;
         rootTarget.appendChild(target);
         addSwitchTabDropdownItem(rootTarget, target);
-        env = await makeMockEnv({}, { makeNew: true });
+        const selector = `.o-mail-Discuss-asTabContainer[data-as-tab-id="${target.dataset.asTabId}"]`;
+        env = await makeMockEnv({ discussAsTabId, selector }, { makeNew: true });
     } else {
         env = getMockEnv() || (await makeMockEnv({}));
     }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1290,9 +1290,8 @@ test("Toggle star should update starred counter on all tabs", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
-    await click(".o-mail-Message [title='Mark as Todo']", { target: env1 });
-    await contains("button", {
-        target: env2,
+    await click(`${env1.selector} .o-mail-Message [title='Mark as Todo']`);
+    await contains(`${env2.selector} button`, {
         text: "Starred",
         contains: [".badge", { text: "1" }],
     });


### PR DESCRIPTION
This commit updates the test selectors to use data-as-tab-id to avoid ambiguity. This change enhances the robustness of the tests by reducing their dependency on CSS classes.

Using data-as-tab-id attributes provides a more stable and reliable way to select elements in the DOM for testing purposes.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
