### PR TITLE
[FIX] mail: allow marking user_notification as read from notification menu

### DIFF
--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -38,12 +38,12 @@ export class MessagingMenu extends Component {
     }
 
     onClickThread(isMarkAsRead, thread, message) {
-        if (message?.needaction && message.message_type === "user_notification") {
-            this.store.inbox.highlightMessage = message;
-            this.store.inbox.open();
-            return;
-        }
         if (!isMarkAsRead) {
+            if (message?.needaction && message.message_type === "user_notification") {
+                this.store.inbox.highlightMessage = message;
+                this.store.inbox.open();
+                return;
+            }
             thread.open({ focus: true, fromMessagingMenu: true, bypassCompact: true });
             this.dropdown.close();
             return;


### PR DESCRIPTION
After 94ccec375e989cde1f1201ce647be1ce19687c69, clicking on a user_notification from notification menu redirects to Inbox even when clicking the green tick intended to mark notification as read.

This PR fixes the behaviour so that users can mark user_notification as read directly from the notification menu.