### PR TITLE
[FIX] website_sale: center the active image in the thumbnail row

### DIFF
--- a/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
+++ b/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
@@ -2,9 +2,10 @@
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
-import { onRendered, useRef, useEffect, useState } from "@odoo/owl";
+import { onMounted, onRendered, useRef, useEffect, useState } from "@odoo/owl";
 
 const ZOOM_STEP = 0.1;
+const TOUCHMOVE_STEP = 96;
 
 export class ProductImageViewer extends Dialog {
     static template = "website_sale.ProductImageViewer";
@@ -51,9 +52,16 @@ export class ProductImageViewer extends Dialog {
             },
             () => [document],
         );
+        onMounted(() => {
+            const carousel = document.querySelector('.o_wsale_image_viewer_carousel');
+            carousel.addEventListener('touchstart', this._onTouchstartCarousel.bind(this));
+            carousel.addEventListener('touchmove', this._onTouchmoveCarousel.bind(this));
+            this._updateCarousel();
+        });
         // For some reason the styling does not always update properly.
         onRendered(() => {
             this.updateImage();
+            this._updateCarousel();
         })
     }
 
@@ -92,6 +100,26 @@ export class ProductImageViewer extends Dialog {
         this.imageContainerRef.el.style = this.imageContainerStyle;
     }
 
+    /**
+     * Centers the thumbnail row element on the currently selected image.
+     *
+     * @private
+     */
+    _updateCarousel() {
+        const thumbnailList = document.querySelector('.o_wsale_image_viewer_carousel ol');
+        const viewWidth = window.visualViewport.width;
+        if (!thumbnailList || thumbnailList.scrollWidth <= viewWidth) {
+            return;
+        }
+        const { selectedImageIdx } = this.state;
+        const thumbnail = thumbnailList.childNodes[selectedImageIdx];
+
+        const thumbWidth = thumbnail.clientWidth;
+        const parentOffset = thumbnailList.parentElement.offsetLeft;
+        const offset = (viewWidth - thumbWidth) / 2 - thumbWidth * selectedImageIdx  - parentOffset;
+        thumbnailList.style.transform = `translate(${offset}px)`;
+    }
+
     onGlobalClick(ev) {
         if (ev.target.tagName === "IMG") {
             // Only zoom if the image did not move
@@ -117,6 +145,10 @@ export class ProductImageViewer extends Dialog {
     }
 
     onWheelImage(ev) {
+        if (!ev.deltaY) {
+            return;
+        }
+        ev.preventDefault();
         if (ev.deltaY > 0) {
             this.zoomOut();
         } else {
@@ -141,6 +173,36 @@ export class ProductImageViewer extends Dialog {
         this.imageTranslate.x = ev.clientX - this.dragStartPos.x;
         this.imageTranslate.y = ev.clientY - this.dragStartPos.y;
         this.updateImage();
+    }
+
+    _onTouchstartCarousel(ev) {
+        const touch = ev.touches?.item(0);
+        if (!touch) {
+            return;
+        }
+        this.state.touchClientX = touch.clientX;
+        if (!this.state.touchmoveStep) {
+            const thumbnail = document.querySelector('img.o_wsale_image_viewer_thumbnail');
+            this.state.touchmoveStep = 0.75 * thumbnail?.clientWidth;
+        }
+    }
+
+    _onTouchmoveCarousel(ev) {
+        const touch = ev.touches?.item(0);
+        if (!touch) {
+            return;
+        }
+        ev.preventDefault();
+        const { selectedImageIdx, touchmoveStep, touchClientX } = this.state;
+        const deltaX = touch.clientX - touchClientX;
+        const step = touchmoveStep || TOUCHMOVE_STEP;
+        if (deltaX > step && selectedImageIdx > 0) {
+            this.state.touchClientX += step;
+            this.previousImage();
+        } else if (deltaX < -step && selectedImageIdx < this.images.length - 1) {
+            this.state.touchClientX -= step;
+            this.nextImage();
+        }
     }
 }
 delete ProductImageViewer.props.slots;

--- a/addons/website_sale/static/src/scss/website_sale_frontend.scss
+++ b/addons/website_sale/static/src/scss/website_sale_frontend.scss
@@ -26,6 +26,7 @@
 
         ol {
             list-style: none;
+            transition: transform 250ms ease-out;
 
             .o_wsale_image_viewer_thumbnail {
                 aspect-ratio: 1/1;


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Add a bunch of extra images to a published product;
2. enable zoom-on-click via editor;
3. click on an image to zoom it;
4. scroll through images.

Issue
-----
With too many images added, the thumbnails on the bottom are cut off on the edges of the screen, making it impossible to click on them.

Cause
-----
The thumbnail row element doesn't get updated when selecting a new image.

Solution
--------
Define a `_updateCarousel` method which adds a `transform: translate` operation to the thumbnails, moving them such that the currently selected image's thumbnail gets centered on the screen.

Call this method on mounting, and again on any render (image change).

Bonus: add `touchstart` & `touchmove` hooks to enable easy swiping through the carousel on mobile.

opw-4937009
opw-4908881