### PR TITLE
[FIX] l10n_es_edi_verifactu: prevent error when nif is missing

### DIFF
--- a/addons/l10n_es_edi_verifactu/models/verifactu_document.py
+++ b/addons/l10n_es_edi_verifactu/models/verifactu_document.py
@@ -314,7 +314,7 @@ class L10nEsEdiVerifactuDocument(models.Model):
     def _check_record_values(self, vals):
         errors = []
 
-        company_NIF = vals['company'].partner_id._l10n_es_edi_verifactu_get_values()['NIF']
+        company_NIF = vals['company'].partner_id._l10n_es_edi_verifactu_get_values().get('NIF')
         if not company_NIF or len(company_NIF) != 9:  # NIFType
             errors.append(_("The NIF '%(company_NIF)s' of the company is not exactly 9 characters long.",
                             company_NIF=company_NIF))
@@ -1162,7 +1162,7 @@ class L10nEsEdiVerifactuDocument(models.Model):
         errors = []
         company = self.env.company  # sending company
 
-        company_NIF = company.partner_id._l10n_es_edi_verifactu_get_values()['NIF']
+        company_NIF = company.partner_id._l10n_es_edi_verifactu_get_values().get('NIF')
         if not company_NIF or len(company_NIF) != 9:  # NIFType
             errors.append(_("The NIF '%(company_NIF)s' of the company is not exactly 9 characters long.",
                             company_NIF=company_NIF))


### PR DESCRIPTION
Replaced `['NIF']` with `.get('NIF')` to avoid a `KeyError` when the company does not have a NIF.

When the VAT value is not set on the company and the `_send_as_batch_check` method is executed, the system raises an error from [1].

This PR updates the code to use `.get('NIF')` instead of direct access, making it more robust.

[1]: https://github.com/odoo/odoo/blob/dff2423ac320fdb97d6bf1f106dc84be1d71cac2/addons/l10n_es_edi_verifactu/models/verifactu_document.py#L1165

**sentry-6829500308**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
