### PR TITLE
[FIX] mail, web_editor: preserve last style when hiding for Outlook

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -1871,7 +1871,11 @@ function _getHeight(element) {
  */
 function _hideForOutlook(node, onlyHideTag = false) {
     if (!onlyHideTag) {
-        node.setAttribute("style", `${node.getAttribute("style") || ""} mso-hide: all;`.trim());
+        let style = (node.getAttribute("style") || "").trim();
+        if (style && !style.endsWith(";")) {
+            style += ";";
+        }
+        node.setAttribute("style", `${style} mso-hide: all;`);
     }
     node[onlyHideTag === "closing" ? "append" : "before"](document.createComment("[if !mso]><!"));
     node[onlyHideTag === "opening" ? "prepend" : "after"](document.createComment("<![endif]"));

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1725,7 +1725,11 @@ function _getHeight(element) {
  */
 function _hideForOutlook(node, onlyHideTag = false) {
     if (!onlyHideTag) {
-        node.setAttribute('style', `${node.getAttribute('style') || ''} mso-hide: all;`.trim());
+        let style = (node.getAttribute("style") || "").trim();
+        if (style && !style.endsWith(";")) {
+            style += ";";
+        }
+        node.setAttribute("style", `${style} mso-hide: all;`);
     }
     node[onlyHideTag === 'closing' ? 'append' : 'before'](document.createComment('[if !mso]><!'));
     node[onlyHideTag === 'opening' ? 'prepend' : 'after'](document.createComment('<![endif]'));


### PR DESCRIPTION
Problem:
`_hideForOutlook` breaks the last style when appending `mso-hide: all;` if the style string does not end with `;`.

Example:
`width: 100%` → `width: 100% mso-hide: all;`

Solution:
Ensure the new attribute is appended correctly at the end of the styles, regardless of whether the last style ends with `;`.

Note:
The problem might be only observed on `18.4` because the composer doesn't use the user signature before `18.4`.

Steps to reproduce in 18.4:
1. Open "My Profile".
2. Add an image to "email signature" with reduced scaling (25%, 50%).
3. Open any record with chatter (task, SO, invoice, etc.).
4. Type a message in chatter and click "Send".
5. Click "Open Full Compositor" and send a message from the email compositor.
6. Open the runbot's MailHog and observe the differences between the two emails.

opw-5046573

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
