### PR TITLE
[FIX] hr_holidays_attendance: fix infinite extra hours time off bug

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -56,11 +56,11 @@ class HRLeave(models.Model):
                 continue
             employee = leave.employee_id.sudo()
             duration = leave.number_of_hours
-            if duration > employee.total_overtime:
-                if employee.user_id == self.env.user:
-                    raise ValidationError(_('You do not have enough extra hours to request this leave'))
-                raise ValidationError(_('The employee does not have enough extra hours to request this leave.'))
             if not leave.sudo().overtime_id:
+                if duration > employee.total_overtime:
+                    if employee.user_id == self.env.user:
+                        raise ValidationError(_('You do not have enough extra hours to request this leave'))
+                    raise ValidationError(_('The employee does not have enough extra hours to request this leave.'))
                 leave.sudo().overtime_id = self.env['hr.attendance.overtime'].sudo().create({
                     'employee_id': employee.id,
                     'date': leave.date_from,
@@ -70,12 +70,12 @@ class HRLeave(models.Model):
 
     def action_reset_confirm(self):
         overtime_leaves = self.filtered('overtime_deductible')
-        res = super().action_reset_confirm()
         self._check_overtime_deductible(self)
+        res = super().action_reset_confirm()
         return res
-    
-    def action_confirm(self):
-        res = super().action_confirm()
+
+    def action_approve(self, check_state=True):
+        res = super().action_approve(check_state)
         self._check_overtime_deductible(self)
         return res
 

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -265,3 +265,24 @@ class TestHolidaysOvertime(TransactionCase):
 
         self.assertEqual(self.employee.total_overtime, 0, "Should have 0 hours of overtime as the public holiday doesn't impact his company")
         self.assertEqual(self.manager.total_overtime, 8, 'Should have 8 hours of overtime (there is one hour of lunch)')
+
+    def test_overtime_approval_after_refusal(self):
+        self.new_attendance(check_in=datetime(2021, 1, 2, 8), check_out=datetime(2021, 1, 2, 16))
+        self.new_attendance(check_in=datetime(2021, 1, 3, 8), check_out=datetime(2021, 1, 3, 16))
+        self.assertEqual(self.employee.total_overtime, 16)
+
+        leave = self.env['hr.leave'].create({
+            'name': 'no overtime',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type_no_alloc.id,
+            'request_date_from': '2022-1-6',
+            'request_date_to': '2022-1-6',
+        })
+        leave.with_user(self.user_manager).action_approve()
+        self.assertEqual(self.employee.total_overtime, 8)
+
+        leave.with_user(self.user_manager).action_refuse()
+        self.assertEqual(self.employee.total_overtime, 16)
+
+        leave.with_user(self.user_manager).action_approve(check_state=False)
+        self.assertEqual(self.employee.total_overtime, 8)


### PR DESCRIPTION
Steps to reproduce:
- On the time off dashboard, create a new leave with the type "Extra hours"
- Click on the request again, refuse the request
- Click on the request, and now approve the time off -If you now try to create a new time off with the type "Extra hours", you'll notice that the duration of the previously "refused then approved" time off is not taken into account

Reason:
The action tied to the "Approve" button was wrongly named in the inherited hr_leave model of the hr_holidays_attendance module, which prevented the computation for the approval to be taken into account.

How it was fixed:
Correcting the name allowed the function to be called properly and the calculation is now performed correctly.

Task ID: 5051271
