### PR TITLE
[IMP] sale_timesheet: Analyze billing targets vs. actual billable time in timesheets dashboard

### DIFF
--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -10,13 +10,10 @@
                     <field name="order_id" string="Sales Order" filter_domain="['|', ('so_line', 'ilike', self), ('order_id', 'ilike', self)]"/>
                 </xpath>
                 <xpath expr="//filter[@name='month']" position="before">
-                    <filter name="billable_fixed" string="Billed at a Fixed Price" domain="[('billable_type', '=', '02_billable_fixed')]"
-                        groups="sales_team.group_sale_salesman"/>
-                    <filter name="billable_time" string="Billed on Timesheets" domain="[('billable_type', '=', '04_billable_time')]"
-                        groups="sales_team.group_sale_salesman"/>
-                    <filter name="billable_milestones" string="Billed on Milestones" domain="[('billable_type', '=', '06_billable_milestones')]"
-                        groups="sales_team.group_sale_salesman"/>
-                    <filter name="billable_manual" string="Billed Manually" domain="[('billable_type', '=', '08_billable_manual')]"
+                    <filter name="billable" string="Billable" domain="[
+                        ('billable_type', 'in', ['02_billable_fixed', '04_billable_time', '06_billable_milestones', '08_billable_manual']),
+                    ]"
+                        context="{'show_target_left': True}"
                         groups="sales_team.group_sale_salesman"/>
                     <filter name="non_billable" string="Non-Billable" domain="[('billable_type', '=', '09_non_billable')]"
                         groups="sales_team.group_sale_salesman"/>

--- a/addons/spreadsheet_dashboard_sale_timesheet/data/files/timesheet_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale_timesheet/data/files/timesheet_dashboard.json
@@ -1,789 +1,1897 @@
 {
-  "version": "18.5.10",
-  "sheets": [
-    {
-      "id": "sheet1",
-      "name": "Dashboard",
-      "colNumber": 9,
-      "rowNumber": 57,
-      "rows": {
-        "6": { "size": 40 },
-        "22": { "size": 40 },
-        "23": { "size": 40 },
-        "24": { "size": 31 },
-        "25": { "size": 31 },
-        "26": { "size": 31 },
-        "27": { "size": 31 },
-        "28": { "size": 31 },
-        "29": { "size": 31 },
-        "30": { "size": 31 },
-        "31": { "size": 31 },
-        "32": { "size": 31 },
-        "33": { "size": 31 },
-        "35": { "size": 40 },
-        "36": { "size": 40 },
-        "37": { "size": 31 },
-        "38": { "size": 31 },
-        "39": { "size": 31 },
-        "40": { "size": 31 },
-        "41": { "size": 31 },
-        "42": { "size": 31 },
-        "43": { "size": 31 },
-        "44": { "size": 31 },
-        "45": { "size": 31 },
-        "46": { "size": 31 }
-      },
-      "cols": {
-        "0": { "size": 175 },
-        "1": { "size": 100 },
-        "2": { "size": 100 },
-        "3": { "size": 100 },
-        "4": { "size": 50 },
-        "5": { "size": 175 },
-        "6": { "size": 100 },
-        "7": { "size": 100 },
-        "8": { "size": 100 }
-      },
-      "merges": [],
-      "cells": {
-        "A7": "[Time Billed by Week](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"project_id\",\"!=\",false]],\"context\":{\"group_by\":[\"date:week\"],\"graph_measure\":\"billable_time\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:week\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Timesheets by Billing Type\"})",
-        "A23": "[Top Projects](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"project_id\",\"!=\",false]],\"context\":{\"group_by\":[\"project_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"project_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Projects\"})",
-        "A24": "=PIVOT(1, 10, FALSE, FALSE)",
-        "A37": "=PIVOT(3, 10, FALSE, FALSE)",
-        "F23": "[Top Tasks](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"task_id\",\"!=\",false]],\"context\":{\"group_by\":[\"task_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"task_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Tasks\"})",
-        "F24": "=PIVOT(2, 10, FALSE, FALSE)",
-        "F36": "[Top Employees](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"employee_id\",\"!=\",false]],\"context\":{\"group_by\":[\"employee_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"employee_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Employees\"})",
-        "F37": "=PIVOT(4, 10, FALSE, FALSE)"
-      },
-      "styles": {
-        "A7": 1,
-        "A23": 1,
-        "A36": 1,
-        "F23": 1,
-        "F36": 1,
-        "A24": 2,
-        "A37": 2,
-        "F24": 2,
-        "F37": 2,
-        "A25:D34": 3,
-        "A38:D47": 3,
-        "F25:I34": 3,
-        "F38:I47": 3,
-        "B24:D24": 4,
-        "B37:D37": 4,
-        "G24:I24": 4,
-        "G37:I37": 4
-      },
-      "formats": {},
-      "borders": {
-        "A23:D23": 1,
-        "A36:D36": 1,
-        "A7:I7": 1,
-        "F23:I23": 1,
-        "F36:I36": 1,
-        "A24:D24": 2,
-        "A37:D37": 2,
-        "A8:I8": 2,
-        "F24:I24": 2,
-        "F37:I37": 2,
-        "A25:D25": 3,
-        "A38:D38": 3,
-        "F25:I25": 3,
-        "F38:I38": 3,
-        "A26:D34": 4,
-        "A39:D47": 4,
-        "F26:I34": 4,
-        "F39:I47": 4,
-        "A35:D35": 5,
-        "A48:D48": 5,
-        "F35:I35": 5,
-        "F48:I48": 5
-      },
-      "conditionalFormats": [
+    "version": "19.1.2",
+    "sheets": [
         {
-          "rule": { "type": "DataBarRule", "color": 15531509, "rangeValues": "C25:C34" },
-          "id": "d7e93c71-7dd3-4aa2-99c9-2acee1759c1b",
-          "ranges": ["A25:A34"]
-        },
-        {
-          "rule": { "type": "DataBarRule", "color": 16708338, "rangeValues": "H25:H34" },
-          "id": "c5128bdf-0225-43b6-be2d-b391b50972b7",
-          "ranges": ["F25:F34"]
-        },
-        {
-          "rule": { "type": "DataBarRule", "color": 15726335, "rangeValues": "C38:C47" },
-          "id": "0235598f-93e2-41ad-a3a3-6005c0682bb2",
-          "ranges": ["A38:A47"]
-        },
-        {
-          "rule": { "type": "DataBarRule", "color": 16775149, "rangeValues": "H38:H47" },
-          "id": "0258b472-cd0b-435a-a756-53684989745a",
-          "ranges": ["F38:F47"]
-        }
-      ],
-      "dataValidationRules": [],
-      "figures": [
-        {
-          "id": "14907ee1-177b-4dda-97d7-223b1b00abe5",
-          "width": 200,
-          "height": 109,
-          "tag": "chart",
-          "data": {
-            "baselineColorDown": "#DC6965",
-            "baselineColorUp": "#00A04A",
-            "baselineMode": "percentage",
-            "title": { "text": "Billable Hours", "bold": true, "color": "#434343" },
-            "type": "scorecard",
-            "background": "#FEF2F2",
-            "baseline": "Data!E5",
-            "baselineDescr": { "text": "since last period" },
-            "keyValue": "Data!D5",
-            "humanize": false,
-            "chartId": "14907ee1-177b-4dda-97d7-223b1b00abe5"
-          },
-          "offset": { "x": 0, "y": 9 },
-          "col": 0,
-          "row": 0
-        },
-        {
-          "id": "c484c691-bb4a-4a9d-8a25-8464162ee96a",
-          "width": 200,
-          "height": 109,
-          "tag": "chart",
-          "data": {
-            "baselineColorDown": "#DC6965",
-            "baselineColorUp": "#00A04A",
-            "baselineMode": "percentage",
-            "title": { "text": "Non-billable Hours", "bold": true, "color": "#434343" },
-            "type": "scorecard",
-            "background": "#FEF2F2",
-            "baseline": "Data!E6",
-            "baselineDescr": { "text": "since last period" },
-            "keyValue": "Data!D6",
-            "humanize": false,
-            "chartId": "c484c691-bb4a-4a9d-8a25-8464162ee96a"
-          },
-          "offset": { "x": 210, "y": 9 },
-          "col": 0,
-          "row": 0
-        },
-        {
-          "id": "0b033641-2a0f-4db7-893d-f14fbb320b94",
-          "width": 200,
-          "height": 109,
-          "tag": "chart",
-          "data": {
-            "baselineColorDown": "#DC6965",
-            "baselineColorUp": "#00A04A",
-            "baselineMode": "text",
-            "title": { "text": "Billable Rate", "bold": true, "color": "#434343" },
-            "type": "scorecard",
-            "background": "#ECFDF5",
-            "baseline": "Data!E8",
-            "baselineDescr": { "text": "last period" },
-            "keyValue": "Data!D8",
-            "humanize": false,
-            "chartId": "0b033641-2a0f-4db7-893d-f14fbb320b94"
-          },
-          "offset": { "x": 420, "y": 9 },
-          "col": 0,
-          "row": 0
-        },
-        {
-          "id": "39c6667b-b74a-478e-87e9-75c22de5ea1f",
-          "width": 1000,
-          "height": 344,
-          "tag": "chart",
-          "data": {
-            "title": { "text": "" },
-            "background": "#FFFFFF",
-            "legendPosition": "none",
-            "metaData": {
-              "groupBy": ["date:week"],
-              "measure": "billable_time",
-              "order": null,
-              "resModel": "timesheets.analysis.report",
-              "mode": "line",
-              "cumulatedStart": false
+            "id": "sheet1",
+            "name": "Dashboard",
+            "colNumber": 9,
+            "rowNumber": 78,
+            "rows": {
+                "6": {
+                    "size": 40
+                },
+                "22": {
+                    "size": 40
+                },
+                "39": {
+                    "size": 40
+                },
+                "40": {
+                    "size": 40
+                },
+                "41": {
+                    "size": 31
+                },
+                "42": {
+                    "size": 31
+                },
+                "43": {
+                    "size": 31
+                },
+                "44": {
+                    "size": 31
+                },
+                "45": {
+                    "size": 31
+                },
+                "46": {
+                    "size": 31
+                },
+                "47": {
+                    "size": 31
+                },
+                "48": {
+                    "size": 31
+                },
+                "49": {
+                    "size": 31
+                },
+                "50": {
+                    "size": 31
+                },
+                "52": {
+                    "size": 40
+                },
+                "53": {
+                    "size": 40
+                },
+                "54": {
+                    "size": 31
+                },
+                "55": {
+                    "size": 31
+                },
+                "56": {
+                    "size": 31
+                },
+                "57": {
+                    "size": 31
+                },
+                "58": {
+                    "size": 31
+                },
+                "59": {
+                    "size": 31
+                },
+                "60": {
+                    "size": 31
+                },
+                "61": {
+                    "size": 31
+                },
+                "62": {
+                    "size": 31
+                },
+                "63": {
+                    "size": 31
+                },
+                "65": {
+                    "size": 40
+                },
+                "66": {
+                    "size": 40
+                },
+                "67": {
+                    "size": 31
+                },
+                "68": {
+                    "size": 31
+                },
+                "69": {
+                    "size": 31
+                },
+                "70": {
+                    "size": 31
+                },
+                "71": {
+                    "size": 31
+                },
+                "72": {
+                    "size": 31
+                },
+                "73": {
+                    "size": 31
+                },
+                "74": {
+                    "size": 31
+                },
+                "75": {
+                    "size": 31
+                },
+                "76": {
+                    "size": 31
+                }
             },
-            "searchParams": {
-              "comparison": null,
-              "context": {},
-              "domain": [
-                ["project_id", "!=", false]
-              ],
-              "groupBy": ["date:week"],
-              "orderBy": []
+            "cols": {
+                "0": {
+                    "size": 175
+                },
+                "1": {
+                    "size": 100
+                },
+                "2": {
+                    "size": 100
+                },
+                "3": {
+                    "size": 100
+                },
+                "4": {
+                    "size": 50
+                },
+                "5": {
+                    "size": 175
+                },
+                "6": {
+                    "size": 100
+                },
+                "7": {
+                    "size": 100
+                },
+                "8": {
+                    "size": 100
+                }
             },
-            "type": "odoo_line",
-            "dataSets": [
-              {}
+            "merges": [],
+            "cells": {
+                "A7": "[Time Billed by Week](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"project_id\",\"!=\",false]],\"context\":{\"group_by\":[\"date:week\"],\"graph_measure\":\"billable_time\",\"graph_mode\":\"line\",\"graph_groupbys\":[\"date:week\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Timesheets by Billing Type\"})",
+                "A23": "[Billed by Month](odoo://view/{\"viewType\":\"graph\",\"action\":{\"domain\":[[\"project_id\",\"!=\",false]],\"context\":{\"group_by\":[\"date:month\"],\"graph_measure\":\"billable_time\",\"graph_mode\":\"bar\",\"graph_groupbys\":[\"date:month\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Timesheets by Billing Type\"})",
+                "A40": "[Top Departments](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"department_id\",\"!=\",false]],\"context\":{\"group_by\":[\"department_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"department_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Departments\"})",
+                "A41": "=_t(\"Department\")",
+                "A42": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 1), \"[^/]+$\"))",
+                "A43": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 2), \"[^/]+$\"))",
+                "A44": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 3), \"[^/]+$\"))",
+                "A45": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 4), \"[^/]+$\"))",
+                "A46": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 5), \"[^/]+$\"))",
+                "A47": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 6), \"[^/]+$\"))",
+                "A48": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 7), \"[^/]+$\"))",
+                "A49": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 8), \"[^/]+$\"))",
+                "A50": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 9), \"[^/]+$\"))",
+                "A51": "=TRIM(REGEXEXTRACT(PIVOT.HEADER(3, \"#department_id\", 10), \"[^/]+$\"))",
+                "A53": "[Top Projects](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"project_id.allow_billable\",\"!=\",false]],\"context\":{\"group_by\":[\"project_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"project_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Projects\"})",
+                "A54": "=_t(\"Project\")",
+                "A55": "=PIVOT.HEADER(1,\"#project_id\",1)",
+                "A56": "=PIVOT.HEADER(1,\"#project_id\",2)",
+                "A57": "=PIVOT.HEADER(1,\"#project_id\",3)",
+                "A58": "=PIVOT.HEADER(1,\"#project_id\",4)",
+                "A59": "=PIVOT.HEADER(1,\"#project_id\",5)",
+                "A60": "=PIVOT.HEADER(1,\"#project_id\",6)",
+                "A61": "=PIVOT.HEADER(1,\"#project_id\",7)",
+                "A62": "=PIVOT.HEADER(1,\"#project_id\",8)",
+                "A63": "=PIVOT.HEADER(1,\"#project_id\",9)",
+                "A64": "=PIVOT.HEADER(1,\"#project_id\",10)",
+                "A66": "[Non-Billable Projects Costs](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"project_id.allow_billable\",\"=\",false]],\"context\":{\"group_by\":[\"project_id\"],\"pivot_measures\":[\"amount\",\"non_billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"project_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Non-Billable Projects Costs\"})",
+                "A67": "=_t(\"Project\")",
+                "A68": "=PIVOT.HEADER(7, \"#project_id\", 1)",
+                "A69": "=PIVOT.HEADER(7,\"#project_id\",2)",
+                "A70": "=PIVOT.HEADER(7,\"#project_id\",3)",
+                "A71": "=PIVOT.HEADER(7,\"#project_id\",4)",
+                "A72": "=PIVOT.HEADER(7,\"#project_id\",5)",
+                "A73": "=PIVOT.HEADER(7,\"#project_id\",6)",
+                "A74": "=PIVOT.HEADER(7,\"#project_id\",7)",
+                "A75": "=PIVOT.HEADER(7,\"#project_id\",8)",
+                "A76": "=PIVOT.HEADER(7,\"#project_id\",9)",
+                "A77": "=PIVOT.HEADER(7,\"#project_id\",10)",
+                "B41": "=IF(Data!B15=\"Hours\", _t(\"Hours spent\"), _t(\"Days spent\"))",
+                "B42": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 1)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 1),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",1\n)))",
+                "B43": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 2)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 2),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",2\n)))",
+                "B44": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 3)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 3),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",3\n)))",
+                "B45": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 4)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 4),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",4\n)))",
+                "B46": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 5)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 5),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",5\n)))",
+                "B47": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 6)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 6),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",6\n)))",
+                "B48": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 7)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 7),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",7\n)))",
+                "B49": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 8)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 8),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",8\n)))",
+                "B50": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 9)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 9),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",9\n)))",
+                "B51": "=IF(\n\tPIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 10)=\"\", \n\t\"\", \n\tIF(Data!B15=\"Hours\",PIVOT.VALUE(3, \"unit_amount\", \"#department_id\", 10),PIVOT.VALUE(3,\"Days Spent\",\"#department_id\",10\n)))",
+                "B54": "=IF(Data!B15=\"Hours\", _t(\"Hours spent\"), _t(\"Days spent\"))",
+                "B55": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 1)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 1), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 1)\n\t)\n)",
+                "B56": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 2)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 2), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 2)\n\t)\n)",
+                "B57": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 3)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 3), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 3)\n\t)\n)",
+                "B58": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 4)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 4), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 4)\n\t)\n)",
+                "B59": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 5)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 5), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 5)\n\t)\n)",
+                "B60": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 6)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 6), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 6)\n\t)\n)",
+                "B61": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 7)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 7), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 7)\n\t)\n)",
+                "B62": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 8)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 8), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 8)\n\t)\n)",
+                "B63": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 9)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 9), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 9)\n\t)\n)",
+                "B64": "=IF(\n\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 10)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"unit_amount\", \"#project_id\", 10), \n\t\tPIVOT.VALUE(1, \"Days Spent\", \"#project_id\", 10)\n\t)\n)",
+                "C41": "=IF(Data!B15=\"Hours\", _t(\"Hours billed\"), _t(\"Days billed\"))",
+                "C42": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 1)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 1), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 1)\n\t)\n)",
+                "C43": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 2)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 2), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 2)\n\t)\n)",
+                "C44": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 3)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 3), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 3)\n\t)\n)",
+                "C45": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 4)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 4), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 4)\n\t)\n)",
+                "C46": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 5)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 5), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 5)\n\t)\n)",
+                "C47": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 6)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 6), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 6)\n\t)\n)",
+                "C48": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 7)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 7), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 7)\n\t)\n)",
+                "C49": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 8)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 8), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 8)\n\t)\n)",
+                "C50": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 9)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 9), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 9)\n\t)\n)",
+                "C51": "=IF(\n\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 10)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(3, \"billable_time\", \"#department_id\", 10), \n\t\tPIVOT.VALUE(3, \"Billable Days\", \"#department_id\", 10)\n\t)\n)",
+                "C54": "=IF(Data!B15=\"Hours\", _t(\"Hours billed\"), _t(\"Days billed\"))",
+                "C55": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 1)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 1), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 1)\n\t)\n)",
+                "C56": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 2)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 2), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 2)\n\t)\n)",
+                "C57": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 3)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 3), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 3)\n\t)\n)",
+                "C58": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 4)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 4), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 4)\n\t)\n)",
+                "C59": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 5)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 5), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 5)\n\t)\n)",
+                "C60": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 6)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 6), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 6)\n\t)\n)",
+                "C61": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 7)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 7), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 7)\n\t)\n)",
+                "C62": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 8)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 8), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 8)\n\t)\n)",
+                "C63": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 9)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 9), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 9)\n\t)\n)",
+                "C64": "=IF(\n\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 10)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(1, \"billable_time\", \"#project_id\", 10), \n\t\tPIVOT.VALUE(1, \"Billable Days\", \"#project_id\", 10)\n\t)\n)",
+                "C67": "=IF(Data!B15=\"Hours\", _t(\"Hours spent\"), _t(\"Days spent\"))",
+                "C68": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 1)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 1), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 1)\n\t)\n)",
+                "C69": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 2)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 2), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 2)\n\t)\n)",
+                "C70": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 3)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 3), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 3)\n\t)\n)",
+                "C71": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 4)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 4), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 4)\n\t)\n)",
+                "C72": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 5)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 5), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 5)\n\t)\n)",
+                "C73": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 6)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 6), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 6)\n\t)\n)",
+                "C74": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 7)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 7), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 7)\n\t)\n)",
+                "C75": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 8)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 8), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 8)\n\t)\n)",
+                "C76": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 9)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 9), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 9)\n\t)\n)",
+                "C77": "=IF(\n\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 10)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(7, \"non_billable_time\", \"#project_id\", 10), \n\t\tPIVOT.VALUE(7, \"NonBillable Days\", \"#project_id\", 10)\n\t)\n)",
+                "D41": "=_t(\"Billable rate\")",
+                "D42": "=IFERROR(C42/B42, \"\")",
+                "D43": "=IFERROR(C43/B43, \"\")",
+                "D44": "=IFERROR(C44/B44, \"\")",
+                "D45": "=IFERROR(C45/B45, \"\")",
+                "D46": "=IFERROR(C46/B46, \"\")",
+                "D47": "=IFERROR(C47/B47, \"\")",
+                "D48": "=IFERROR(C48/B48, \"\")",
+                "D49": "=IFERROR(C49/B49, \"\")",
+                "D50": "=IFERROR(C50/B50, \"\")",
+                "D51": "=IFERROR(C51/B51, \"\")",
+                "D54": "=_t(\"Billable rate\")",
+                "D55": "=IFERROR(C55/B55, \"\")",
+                "D56": "=IFERROR(C56/B56, \"\")",
+                "D57": "=IFERROR(C57/B57, \"\")",
+                "D58": "=IFERROR(C58/B58, \"\")",
+                "D59": "=IFERROR(C59/B59, \"\")",
+                "D60": "=IFERROR(C60/B60, \"\")",
+                "D61": "=IFERROR(C61/B61, \"\")",
+                "D62": "=IFERROR(C62/B62, \"\")",
+                "D63": "=IFERROR(C63/B63, \"\")",
+                "D64": "=IFERROR(C64/B64, \"\")",
+                "D67": "=_t(\"Costs\")",
+                "D68": "=IF(C68=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 1)))",
+                "D69": "=IF(C69=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 2)))",
+                "D70": "=IF(C70=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 3)))",
+                "D71": "=IF(C71=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 4)))",
+                "D72": "=IF(C72=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 5)))",
+                "D73": "=IF(C73=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 6)))",
+                "D74": "=IF(C74=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 7)))",
+                "D75": "=IF(C75=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 8)))",
+                "D76": "=IF(C76=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 9)))",
+                "D77": "=IF(C77=\"\", \"\", ABS(PIVOT.VALUE(7, \"amount\", \"#project_id\", 10)))",
+                "F40": "[Top Employees](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",[\"project_id\",\"!=\",false],[\"employee_id\",\"!=\",false]],\"context\":{\"group_by\":[\"employee_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"employee_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Employees\"})",
+                "F41": "=_t(\"Employee\")",
+                "F42": "=PIVOT.HEADER(4,\"#employee_id\",1)",
+                "F43": "=PIVOT.HEADER(4,\"#employee_id\",2)",
+                "F44": "=PIVOT.HEADER(4,\"#employee_id\",3)",
+                "F45": "=PIVOT.HEADER(4,\"#employee_id\",4)",
+                "F46": "=PIVOT.HEADER(4,\"#employee_id\",5)",
+                "F47": "=PIVOT.HEADER(4,\"#employee_id\",6)",
+                "F48": "=PIVOT.HEADER(4,\"#employee_id\",7)",
+                "F49": "=PIVOT.HEADER(4,\"#employee_id\",8)",
+                "F50": "=PIVOT.HEADER(4,\"#employee_id\",9)",
+                "F51": "=PIVOT.HEADER(4,\"#employee_id\",10)",
+                "F53": "[Top Tasks](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",\"&\",\"&\",[\"project_id\",\"!=\",false],[\"task_id\",\"!=\",false],[\"project_id.allow_billable\",\"!=\",false],[\"project_id.sale_line_id\",\"!=\",false]],\"context\":{\"group_by\":[\"task_id\"],\"pivot_measures\":[\"unit_amount\",\"billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"task_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Top Tasks\"})",
+                "F54": "=_t(\"Task\")",
+                "F55": "=PIVOT.HEADER(2,\"#task_id\",1)",
+                "F56": "=PIVOT.HEADER(2,\"#task_id\",2)",
+                "F57": "=PIVOT.HEADER(2,\"#task_id\",3)",
+                "F58": "=PIVOT.HEADER(2,\"#task_id\",4)",
+                "F59": "=PIVOT.HEADER(2,\"#task_id\",5)",
+                "F60": "=PIVOT.HEADER(2,\"#task_id\",6)",
+                "F61": "=PIVOT.HEADER(2,\"#task_id\",7)",
+                "F62": "=PIVOT.HEADER(2,\"#task_id\",8)",
+                "F63": "=PIVOT.HEADER(2,\"#task_id\",9)",
+                "F64": "=PIVOT.HEADER(2,\"#task_id\",10)",
+                "F66": "[Non-Billable Tasks Costs](odoo://view/{\"viewType\":\"pivot\",\"action\":{\"domain\":[\"&\",\"&\",[\"project_id\",\"!=\",false],[\"task_id\",\"!=\",false],\"|\",[\"project_id.allow_billable\",\"=\",false],[\"so_line\",\"=\",false]],\"context\":{\"group_by\":[\"task_id\"],\"pivot_measures\":[\"amount\",\"non_billable_time\"],\"pivot_column_groupby\":[],\"pivot_row_groupby\":[\"task_id\"]},\"modelName\":\"timesheets.analysis.report\",\"views\":[[false,\"pivot\"],[false,\"graph\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Non-Billable Tasks Costs\"})",
+                "F67": "=_t(\"Task\")",
+                "F68": "=PIVOT.HEADER(8, \"#task_id\", 1)",
+                "F69": "=PIVOT.HEADER(8, \"#task_id\", 2)",
+                "F70": "=PIVOT.HEADER(8,\"#task_id\",3)",
+                "F71": "=PIVOT.HEADER(8,\"#task_id\",4)",
+                "F72": "=PIVOT.HEADER(8,\"#task_id\",5)",
+                "F73": "=PIVOT.HEADER(8,\"#task_id\",6)",
+                "F74": "=PIVOT.HEADER(8,\"#task_id\",7)",
+                "F75": "=PIVOT.HEADER(8,\"#task_id\",8)",
+                "F76": "=PIVOT.HEADER(8,\"#task_id\",9)",
+                "F77": "=PIVOT.HEADER(8,\"#task_id\",10)",
+                "G41": "=IF(Data!B15=\"Hours\", _t(\"Hours spent\"), _t(\"Days spent\"))",
+                "G42": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 1)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 1), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 1)\n\t)\n)",
+                "G43": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 2)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 2), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 2)\n\t)\n)",
+                "G44": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 3)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 3), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 3)\n\t)\n)",
+                "G45": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 4)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 4), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 4)\n\t)\n)",
+                "G46": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 5)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 5), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 5)\n\t)\n)",
+                "G47": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 6)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 6), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 6)\n\t)\n)",
+                "G48": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 7)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 7), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 7)\n\t)\n)",
+                "G49": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 8)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 8), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 8)\n\t)\n)",
+                "G50": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 9)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 9), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 9)\n\t)\n)",
+                "G51": "=IF(\n\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 10)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"unit_amount\", \"#employee_id\", 10), \n\t\tPIVOT.VALUE(4, \"Days Spent\", \"#employee_id\", 10)\n\t)\n)",
+                "G54": "=IF(Data!B15=\"Hours\", _t(\"Hours spent\"), _t(\"Days spent\"))",
+                "G55": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 1)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 1), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 1)\n\t)\n)",
+                "G56": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 2)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 2), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 2)\n\t)\n)",
+                "G57": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 3)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 3), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 3)\n\t)\n)",
+                "G58": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 4)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 4), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 4)\n\t)\n)",
+                "G59": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 5)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 5), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 5)\n\t)\n)",
+                "G60": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 6)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 6), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 6)\n\t)\n)",
+                "G61": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 7)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 7), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 7)\n\t)\n)",
+                "G62": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 8)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 8), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 8)\n\t)\n)",
+                "G63": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 9)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 9), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 9)\n\t)\n)",
+                "G64": "=IF(\n\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 10)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"unit_amount\", \"#task_id\", 10), \n\t\tPIVOT.VALUE(2, \"Days Spent\", \"#task_id\", 10)\n\t)\n)",
+                "H41": "=IF(Data!B15=\"Hours\", _t(\"Hours billed\"), _t(\"Days billed\"))",
+                "H42": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 1)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 1), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 1)\n\t)\n)",
+                "H43": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 2)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 2), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 2)\n\t)\n)",
+                "H44": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 3)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 3), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 3)\n\t)\n)",
+                "H45": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 4)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 4), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 4)\n\t)\n)",
+                "H46": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 5)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 5), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 5)\n\t)\n)",
+                "H47": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 6)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 6), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 6)\n\t)\n)",
+                "H48": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 7)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 7), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 7)\n\t)\n)",
+                "H49": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 8)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 8), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 8)\n\t)\n)",
+                "H50": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 9)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 9), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 9)\n\t)\n)",
+                "H51": "=IF(\n\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 10)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(4, \"billable_time\", \"#employee_id\", 10), \n\t\tPIVOT.VALUE(4, \"Billable Days\", \"#employee_id\", 10)\n\t)\n)",
+                "H54": "=IF(Data!B15=\"Hours\", _t(\"Hours billed\"), _t(\"Days billed\"))",
+                "H55": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 1)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 1), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 1)\n\t)\n)",
+                "H56": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 2)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 2), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 2)\n\t)\n)",
+                "H57": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 3)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 3), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 3)\n\t)\n)",
+                "H58": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 4)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 4), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 4)\n\t)\n)",
+                "H59": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 5)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 5), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 5)\n\t)\n)",
+                "H60": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 6)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 6), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 6)\n\t)\n)",
+                "H61": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 7)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 7), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 7)\n\t)\n)",
+                "H62": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 8)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 8), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 8)\n\t)\n)",
+                "H63": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 9)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 9), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 9)\n\t)\n)",
+                "H64": "=IF(\n\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 10)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(2, \"billable_time\", \"#task_id\", 10), \n\t\tPIVOT.VALUE(2, \"Billable Days\", \"#task_id\", 10)\n\t)\n)",
+                "H67": "=IF(Data!B15=\"Hours\", _t(\"Hours spent\"), _t(\"Days spent\"))",
+                "H68": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 1)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 1), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 1)\n\t)\n)",
+                "H69": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 2)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 2), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 2)\n\t)\n)",
+                "H70": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 3)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 3), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 3)\n\t)\n)",
+                "H71": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 4)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 4), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 4)\n\t)\n)",
+                "H72": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 5)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 5), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 5)\n\t)\n)",
+                "H73": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 6)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 6), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 6)\n\t)\n)",
+                "H74": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 7)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 7), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 7)\n\t)\n)",
+                "H75": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 8)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 8), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 8)\n\t)\n)",
+                "H76": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 9)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 9), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 9)\n\t)\n)",
+                "H77": "=IF(\n\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 10)=\"\", \n\t\"\", \n\tIF(\n\t\tData!B15=\"Hours\", \n\t\tPIVOT.VALUE(8, \"non_billable_time\", \"#task_id\", 10), \n\t\tPIVOT.VALUE(8, \"NonBillable Days\", \"#task_id\", 10)\n\t)\n)",
+                "I41": "=_t(\"Billable rate\")",
+                "I42": "=IFERROR(H42/G42, \"\")",
+                "I43": "=IFERROR(H43/G43, \"\")",
+                "I44": "=IFERROR(H44/G44, \"\")",
+                "I45": "=IFERROR(H45/G45, \"\")",
+                "I46": "=IFERROR(H46/G46, \"\")",
+                "I47": "=IFERROR(H47/G47, \"\")",
+                "I48": "=IFERROR(H48/G48, \"\")",
+                "I49": "=IFERROR(H49/G49, \"\")",
+                "I50": "=IFERROR(H50/G50, \"\")",
+                "I51": "=IFERROR(H51/G51, \"\")",
+                "I54": "=_t(\"Billable rate\")",
+                "I55": "=IFERROR(H55/G55, \"\")",
+                "I56": "=IFERROR(H56/G56, \"\")",
+                "I57": "=IFERROR(H57/G57, \"\")",
+                "I58": "=IFERROR(H58/G58, \"\")",
+                "I59": "=IFERROR(H59/G59, \"\")",
+                "I60": "=IFERROR(H60/G60, \"\")",
+                "I61": "=IFERROR(H61/G61, \"\")",
+                "I62": "=IFERROR(H62/G62, \"\")",
+                "I63": "=IFERROR(H63/G63, \"\")",
+                "I64": "=IFERROR(H64/G64, \"\")",
+                "I67": "=_t(\"Costs\")",
+                "I68": "=IF(H68=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 1)))",
+                "I69": "=IF(H69=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 2)))",
+                "I70": "=IF(H70=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 3)))",
+                "I71": "=IF(H71=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 4)))",
+                "I72": "=IF(H72=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 5)))",
+                "I73": "=IF(H73=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 6)))",
+                "I74": "=IF(H74=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 7)))",
+                "I75": "=IF(H75=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 8)))",
+                "I76": "=IF(H76=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 9)))",
+                "I77": "=IF(H77=\"\", \"\", ABS(PIVOT.VALUE(8, \"amount\", \"#task_id\", 10)))"
+            },
+            "styles": {
+                "A7": 1,
+                "A23": 1,
+                "A40": 1,
+                "A53": 1,
+                "A65:A66": 1,
+                "F40": 1,
+                "F53": 1,
+                "F65:F66": 1,
+                "A41": 2,
+                "A54": 2,
+                "A67": 2,
+                "F41": 2,
+                "F54": 2,
+                "F67": 2,
+                "A42:A51": 3,
+                "A55:A64": 3,
+                "A68:A78": 3,
+                "B78:C78": 3,
+                "D42:D51": 3,
+                "D55:D64": 3,
+                "D68:D78": 3,
+                "F42:F51": 3,
+                "F55:F64": 3,
+                "F68:G77": 3,
+                "I42:I51": 3,
+                "I55:I64": 3,
+                "I68:I78": 3,
+                "B41:D41": 4,
+                "B54:D54": 4,
+                "C67:D67": 4,
+                "G41:I41": 4,
+                "G54:I54": 4,
+                "H67:I67": 4,
+                "B42:C51": 5,
+                "B55:C64": 5,
+                "C68:C77": 5,
+                "G42:H51": 5,
+                "G55:H64": 5,
+                "H68:H77": 5,
+                "E55:E64": 6
+            },
+            "formats": {
+                "B42:C51": 1,
+                "B55:C64": 1,
+                "C68:C77": 1,
+                "G42:H51": 1,
+                "G55:H64": 1,
+                "H68:H77": 1,
+                "D42:D51": 2,
+                "D55:D64": 2,
+                "D78": 2,
+                "I42:I51": 2,
+                "I55:I64": 2,
+                "I78": 2,
+                "D68:D77": 3,
+                "I68:I77": 3,
+                "G68:G77": 4
+            },
+            "borders": {
+                "C41": 1,
+                "A41:B41": 1,
+                "D41": 1,
+                "A8:I8": 1,
+                "H41": 1,
+                "G41": 1,
+                "F41": 1,
+                "I41": 1,
+                "D55:D64": 2,
+                "I55:I64": 2,
+                "A43:A51": 3,
+                "F43:F51": 3,
+                "A52:D52": 3,
+                "F52:I52": 3,
+                "A53": 4,
+                "D53": 4,
+                "A66:B66": 4,
+                "D66": 4,
+                "F53": 4,
+                "I53": 4,
+                "F66:G66": 4,
+                "I66": 4,
+                "A23": 4,
+                "B23:I23": 4,
+                "C54": 1,
+                "B54": 1,
+                "H54": 1,
+                "G54": 1,
+                "C67": 1,
+                "H67": 1
+            },
+            "conditionalFormats": [
+                {
+                    "rule": {
+                        "type": "DataBarRule",
+                        "color": 15531509,
+                        "rangeValues": "C55:C64"
+                    },
+                    "id": "d7e93c71-7dd3-4aa2-99c9-2acee1759c1b",
+                    "ranges": [
+                        "A55:A64"
+                    ]
+                },
+                {
+                    "rule": {
+                        "type": "DataBarRule",
+                        "color": 16708338,
+                        "rangeValues": "H55:H64"
+                    },
+                    "id": "c5128bdf-0225-43b6-be2d-b391b50972b7",
+                    "ranges": [
+                        "F55:F64"
+                    ]
+                },
+                {
+                    "rule": {
+                        "type": "DataBarRule",
+                        "color": 15726335,
+                        "rangeValues": "C42:C51"
+                    },
+                    "id": "0235598f-93e2-41ad-a3a3-6005c0682bb2",
+                    "ranges": [
+                        "A42:A51"
+                    ]
+                },
+                {
+                    "rule": {
+                        "type": "DataBarRule",
+                        "color": 16775149,
+                        "rangeValues": "H42:H51"
+                    },
+                    "id": "0258b472-cd0b-435a-a756-53684989745a",
+                    "ranges": [
+                        "F42:F51"
+                    ]
+                },
+                {
+                    "rule": {
+                        "type": "DataBarRule",
+                        "color": 14275305,
+                        "rangeValues": "D68:D77"
+                    },
+                    "id": "dce4d42b-d5a4",
+                    "ranges": [
+                        "A68:A77"
+                    ]
+                },
+                {
+                    "rule": {
+                        "type": "DataBarRule",
+                        "color": 16573901,
+                        "rangeValues": "I68:I77"
+                    },
+                    "id": "ee1cdfd6-4500",
+                    "ranges": [
+                        "F68:F77"
+                    ]
+                }
             ],
-            "verticalAxisPosition": "left",
-            "stacked": false,
-            "cumulatedStart": false,
-            "fillArea": true,
-            "chartId": "39c6667b-b74a-478e-87e9-75c22de5ea1f",
-            "fieldMatching": {
-              "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": { "chain": "date", "type": "date", "offset": 0 },
-              "65e4bccf-3035-47a0-a268-9a4e5b48037f": { "chain": "project_id", "type": "many2one" },
-              "22a76320-0363-4391-9121-65e1db51b671": { "chain": "task_id", "type": "many2one" },
-              "541de762-4a6c-435e-a5ff-e94d393cf6df": { "chain": "department_id", "type": "many2one" },
-              "4788ea63-ee8f-4082-a118-a26b4b6f1a71": { "chain": "employee_id", "type": "many2one" }
-            }
-          },
-          "offset": { "x": 0, "y": 178 },
-          "col": 0,
-          "row": 0
+            "dataValidationRules": [],
+            "figures": [
+                {
+                    "id": "14907ee1-177b-4dda-97d7-223b1b00abe5",
+                    "width": 200,
+                    "height": 109,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Billable Time",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FEF2F2",
+                        "baseline": "Data!E6",
+                        "baselineDescr": {
+                            "text": "last period"
+                        },
+                        "keyValue": "Data!D6",
+                        "humanize": false,
+                        "chartId": "14907ee1-177b-4dda-97d7-223b1b00abe5"
+                    },
+                    "offset": {
+                        "x": 35,
+                        "y": 9
+                    },
+                    "col": 1,
+                    "row": 0
+                },
+                {
+                    "id": "0b033641-2a0f-4db7-893d-f14fbb320b94",
+                    "width": 200,
+                    "height": 109,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Billable Rate",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#ECFDF5",
+                        "baseline": "Data!E9",
+                        "baselineDescr": {
+                            "text": "last period"
+                        },
+                        "keyValue": "Data!D9",
+                        "humanize": false,
+                        "chartId": "0b033641-2a0f-4db7-893d-f14fbb320b94"
+                    },
+                    "offset": {
+                        "x": 0,
+                        "y": 9
+                    },
+                    "col": 0,
+                    "row": 0
+                },
+                {
+                    "id": "39c6667b-b74a-478e-87e9-75c22de5ea1f",
+                    "width": 1000,
+                    "height": 344,
+                    "tag": "chart",
+                    "data": {
+                        "title": {
+                            "text": ""
+                        },
+                        "background": "#FFFFFF",
+                        "legendPosition": "none",
+                        "metaData": {
+                            "groupBy": [
+                                "date:week"
+                            ],
+                            "measure": "billable_time",
+                            "order": null,
+                            "resModel": "timesheets.analysis.report",
+                            "mode": "line",
+                            "cumulatedStart": false
+                        },
+                        "searchParams": {
+                            "comparison": null,
+                            "context": {},
+                            "domain": [
+                                [
+                                    "project_id",
+                                    "!=",
+                                    false
+                                ]
+                            ],
+                            "groupBy": [
+                                "date:week"
+                            ],
+                            "orderBy": []
+                        },
+                        "type": "odoo_line",
+                        "dataSets": [
+                            {}
+                        ],
+                        "humanize": true,
+                        "verticalAxisPosition": "left",
+                        "stacked": false,
+                        "cumulatedStart": false,
+                        "fillArea": true,
+                        "chartId": "39c6667b-b74a-478e-87e9-75c22de5ea1f",
+                        "fieldMatching": {
+                            "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                                "chain": "date",
+                                "type": "date",
+                                "offset": 0
+                            },
+                            "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                                "chain": "project_id",
+                                "type": "many2one"
+                            },
+                            "22a76320-0363-4391-9121-65e1db51b671": {
+                                "chain": "task_id",
+                                "type": "many2one"
+                            },
+                            "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                                "chain": "department_id",
+                                "type": "many2one"
+                            },
+                            "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                                "chain": "employee_id",
+                                "type": "many2one"
+                            }
+                        }
+                    },
+                    "offset": {
+                        "x": 0,
+                        "y": 178
+                    },
+                    "col": 0,
+                    "row": 0
+                },
+                {
+                    "id": "a9474712-a843",
+                    "col": 3,
+                    "row": 0,
+                    "offset": {
+                        "x": 45,
+                        "y": 9
+                    },
+                    "width": 200,
+                    "height": 109,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Non-billable Time",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FEF2F2",
+                        "baseline": "Data!E7",
+                        "baselineDescr": {
+                            "text": "last period"
+                        },
+                        "keyValue": "Data!D7",
+                        "humanize": false,
+                        "chartId": "741013eb-c06f"
+                    }
+                },
+                {
+                    "id": "72245151-400f",
+                    "col": 5,
+                    "row": 0,
+                    "offset": {
+                        "x": 104,
+                        "y": 9
+                    },
+                    "width": 200,
+                    "height": 109,
+                    "tag": "chart",
+                    "data": {
+                        "baselineColorDown": "#DC6965",
+                        "baselineColorUp": "#00A04A",
+                        "baselineMode": "text",
+                        "title": {
+                            "text": "Total Time",
+                            "bold": true,
+                            "color": "#434343"
+                        },
+                        "type": "scorecard",
+                        "background": "#FEF2F2",
+                        "baseline": "Data!E8",
+                        "baselineDescr": {
+                            "text": "expected"
+                        },
+                        "keyValue": "Data!D8",
+                        "humanize": false,
+                        "chartId": "cd0cf706-f8bd"
+                    }
+                },
+                {
+                    "id": "87108d25-4071",
+                    "col": 0,
+                    "row": 23,
+                    "offset": {
+                        "x": 0,
+                        "y": 0
+                    },
+                    "width": 1000,
+                    "height": 367,
+                    "tag": "chart",
+                    "data": {
+                        "title": {
+                            "text": ""
+                        },
+                        "background": "#FFFFFF",
+                        "legendPosition": "none",
+                        "metaData": {
+                            "groupBy": [
+                                "date:month"
+                            ],
+                            "measure": "billable_time",
+                            "order": null,
+                            "resModel": "timesheets.analysis.report",
+                            "mode": "bar"
+                        },
+                        "searchParams": {
+                            "comparison": null,
+                            "context": {},
+                            "domain": [
+                                [
+                                    "project_id",
+                                    "!=",
+                                    false
+                                ]
+                            ],
+                            "groupBy": [
+                                "date:month"
+                            ],
+                            "orderBy": []
+                        },
+                        "type": "odoo_bar",
+                        "dataSets": [
+                            {}
+                        ],
+                        "humanize": true,
+                        "verticalAxisPosition": "left",
+                        "stacked": false,
+                        "horizontal": false,
+                        "chartId": "26ef5620-3a5c",
+                        "fieldMatching": {
+                            "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                                "chain": "date",
+                                "type": "date",
+                                "offset": 0
+                            },
+                            "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                                "chain": "project_id",
+                                "type": "many2one"
+                            },
+                            "22a76320-0363-4391-9121-65e1db51b671": {
+                                "chain": "task_id",
+                                "type": "many2one"
+                            },
+                            "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                                "chain": "department_id",
+                                "type": "many2one"
+                            },
+                            "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                                "chain": "employee_id",
+                                "type": "many2one"
+                            }
+                        }
+                    }
+                }
+            ],
+            "tables": [
+                {
+                    "range": "A54:D77",
+                    "type": "static",
+                    "config": {
+                        "hasFilters": false,
+                        "totalRow": false,
+                        "firstColumn": false,
+                        "lastColumn": false,
+                        "numberOfHeaders": 1,
+                        "bandedRows": true,
+                        "bandedColumns": false,
+                        "automaticAutofill": true,
+                        "styleId": "None"
+                    }
+                },
+                {
+                    "range": "A41:D51",
+                    "type": "static",
+                    "config": {
+                        "hasFilters": false,
+                        "totalRow": false,
+                        "firstColumn": false,
+                        "lastColumn": false,
+                        "numberOfHeaders": 1,
+                        "bandedRows": true,
+                        "bandedColumns": false,
+                        "automaticAutofill": true,
+                        "styleId": "None"
+                    }
+                },
+                {
+                    "range": "F54:I77",
+                    "type": "static",
+                    "config": {
+                        "hasFilters": false,
+                        "totalRow": false,
+                        "firstColumn": false,
+                        "lastColumn": false,
+                        "numberOfHeaders": 1,
+                        "bandedRows": true,
+                        "bandedColumns": false,
+                        "automaticAutofill": true,
+                        "styleId": "None"
+                    }
+                },
+                {
+                    "range": "F41:I51",
+                    "type": "static",
+                    "config": {
+                        "hasFilters": false,
+                        "totalRow": false,
+                        "firstColumn": false,
+                        "lastColumn": false,
+                        "numberOfHeaders": 1,
+                        "bandedRows": true,
+                        "bandedColumns": false,
+                        "automaticAutofill": true,
+                        "styleId": "None"
+                    }
+                }
+            ],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "comments": {}
         },
         {
-          "id": "06cfdf4c-cd29",
-          "col": 0,
-          "row": 35,
-          "offset": { "x": 0, "y": 6 },
-          "width": 478,
-          "height": 405,
-          "tag": "carousel",
-          "data": {
-            "chartDefinitions": {
-              "683ee3e0-6ce4": {
-                "title": {},
-                "background": "#FFFFFF",
-                "legendPosition": "top",
-                "metaData": {
-                  "groupBy": ["department_id"],
-                  "measure": "billable_time",
-                  "order": null,
-                  "resModel": "timesheets.analysis.report",
-                  "mode": "bar"
+            "id": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+            "name": "Data",
+            "colNumber": 26,
+            "rowNumber": 101,
+            "rows": {},
+            "cols": {
+                "0": {
+                    "size": 159
                 },
-                "searchParams": {
-                  "context": {},
-                  "domain": [
-                    ["project_id", "!=", false]
-                  ],
-                  "groupBy": ["department_id"],
-                  "orderBy": []
+                "1": {
+                    "size": 93
                 },
-                "type": "odoo_treemap",
-                "actionXmlId": "sale_timesheet.timesheet_action_billing_report",
-                "dataSets": [
-                  {}
+                "2": {
+                    "size": 93
+                },
+                "3": {
+                    "size": 93
+                },
+                "4": {
+                    "size": 93
+                }
+            },
+            "merges": [],
+            "cells": {
+                "A1": "=_t(\"KPI\")",
+                "A2": "=_t(\"Billed fixed price\")",
+                "A3": "=_t(\"Billed manually\")",
+                "A4": "=_t(\"Billed timesheets\")",
+                "A5": "=_t(\"Billed milestones\")",
+                "A6": "=_t(\"Billable hours\")",
+                "A7": "=_t(\"Non-billable hours\")",
+                "A8": "=_t(\"Grand total\")",
+                "A9": "=_t(\"Billable rate\")",
+                "A15": "=_t(\"Time Encoding:\")",
+                "B1": "=_t(\"Current\")",
+                "B2": "=PIVOT.VALUE(5,\"unit_amount\",\"billable_type\",\"02_billable_fixed\")",
+                "B3": "=PIVOT.VALUE(5,\"unit_amount\",\"billable_type\",\"08_billable_manual\")",
+                "B4": "=PIVOT.VALUE(5,\"unit_amount\",\"billable_type\",\"04_billable_time\")",
+                "B5": "=PIVOT.VALUE(5, \"unit_amount\", \"billable_type\", \"06_billable_milestones\")",
+                "B6": "=SUM(B2:B5)",
+                "B7": "=PIVOT.VALUE(5,\"unit_amount\",\"billable_type\",\"09_non_billable\")",
+                "B8": "=PIVOT.VALUE(5,\"unit_amount\")",
+                "B9": "=IFERROR(B6/B8)",
+                "B15": "=PIVOT.HEADER(9, \"#company_id.timesheet_encode_uom_id\",1)",
+                "C1": "=_t(\"Previous\")",
+                "C2": "=PIVOT.VALUE(6,\"unit_amount\",\"billable_type\",\"02_billable_fixed\")",
+                "C3": "=PIVOT.VALUE(6,\"unit_amount\",\"billable_type\",\"08_billable_manual\")",
+                "C4": "=PIVOT.VALUE(6,\"unit_amount\",\"billable_type\",\"04_billable_time\")",
+                "C5": "=PIVOT.VALUE(6, \"unit_amount\", \"billable_type\", \"06_billable_milestones\")",
+                "C6": "=SUM(C2:C4)",
+                "C7": "=PIVOT.VALUE(6,\"unit_amount\",\"billable_type\",\"09_non_billable\")",
+                "C8": "=PIVOT.VALUE(6,\"unit_amount\")",
+                "C9": "=IFERROR(C6/C8)",
+                "D1": "=_t(\"Current Score\")",
+                "D2": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", B2, F2))",
+                "D3": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", B3, F3))",
+                "D4": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", B4, F4))",
+                "D5": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", B5, F5))",
+                "D6": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", B6, F6))",
+                "D7": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", B7, F7))",
+                "D8": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", B8, F8))",
+                "D9": "=IF(B15=\"Hours\", B9, F9)",
+                "E1": "=_t(\"Previous Score\")",
+                "E2": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", C2, G2))",
+                "E3": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", C3, G3))",
+                "E4": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", C4, G4))",
+                "E5": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", C5, G5))",
+                "E6": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", C6, G6))",
+                "E7": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", C7, G7))",
+                "E8": "=FORMAT.LARGE.NUMBER(IF(B15=\"Hours\", C8, G8))",
+                "E9": "=IF(B15=\"Hours\", C9, G9)",
+                "F1": "=_t(\"Current Days\")",
+                "F2": "=PIVOT.VALUE(5, \"Days\", \"billable_type\", \"02_billable_fixed\")",
+                "F3": "=PIVOT.VALUE(5, \"Days\", \"billable_type\", \"08_billable_manual\")",
+                "F4": "=PIVOT.VALUE(5, \"Days\", \"billable_type\", \"04_billable_time\")",
+                "F5": "=PIVOT.VALUE(5, \"Days\", \"billable_type\", \"06_billable_milestones\")",
+                "F6": "=SUM(F2:F5)",
+                "F7": "=PIVOT.VALUE(5, \"Days\", \"billable_type\", \"09_non_billable\")",
+                "F8": "=PIVOT.VALUE(5, \"Days\")",
+                "F9": "=B9",
+                "G1": "=_t(\"Previous Days\")",
+                "G2": "=PIVOT.VALUE(6, \"Days\", \"billable_type\", \"02_billable_fixed\")",
+                "G3": "=PIVOT.VALUE(6, \"Days\", \"billable_type\", \"08_billable_manual\")",
+                "G4": "=PIVOT.VALUE(6, \"Days\", \"billable_type\", \"04_billable_time\")",
+                "G5": "=PIVOT.VALUE(6, \"Days\", \"billable_type\", \"06_billable_milestones\")",
+                "G6": "=SUM(G2:G4)",
+                "G7": "=PIVOT.VALUE(6, \"Days\", \"billable_type\", \"09_non_billable\")",
+                "G8": "=PIVOT.VALUE(6, \"Days\")",
+                "G9": "=C9"
+            },
+            "styles": {
+                "A15": 7,
+                "A1:G1": 7,
+                "B15": 8,
+                "A2:G9": 8
+            },
+            "formats": {
+                "D9:G9": 2
+            },
+            "borders": {},
+            "conditionalFormats": [],
+            "dataValidationRules": [],
+            "figures": [],
+            "tables": [],
+            "areGridLinesVisible": true,
+            "isVisible": true,
+            "headerGroups": {
+                "ROW": [],
+                "COL": []
+            },
+            "comments": {}
+        }
+    ],
+    "styles": {
+        "1": {
+            "textColor": "#01666b",
+            "bold": true,
+            "fontSize": 16
+        },
+        "2": {
+            "textColor": "#434343",
+            "fontSize": 11,
+            "bold": true
+        },
+        "3": {
+            "textColor": "#434343",
+            "verticalAlign": "middle"
+        },
+        "4": {
+            "textColor": "#434343",
+            "fontSize": 11,
+            "bold": true,
+            "align": "center"
+        },
+        "5": {
+            "textColor": "#434343",
+            "verticalAlign": "middle",
+            "align": "right"
+        },
+        "6": {
+            "verticalAlign": "middle"
+        },
+        "7": {
+            "bold": true
+        },
+        "8": {
+            "fillColor": "#f2f2f2"
+        }
+    },
+    "formats": {
+        "1": "#,##0",
+        "2": "0%",
+        "3": "[$$]#,##0",
+        "4": "#,##0.00"
+    },
+    "borders": {
+        "1": {
+            "top": {
+                "color": "#CCCCCC",
+                "style": "thin"
+            }
+        },
+        "2": {
+            "bottom": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "3": {
+            "top": {
+                "style": "thick",
+                "color": "#FFFFFF"
+            }
+        },
+        "4": {
+            "bottom": {
+                "color": "#CCCCCC",
+                "style": "thin"
+            }
+        }
+    },
+    "revisionId": "1f9dd7d9-2a44-4371-bffd-e356a4e9cf4e",
+    "uniqueFigureIds": true,
+    "settings": {
+        "locale": {
+            "name": "English (US)",
+            "code": "en_US",
+            "thousandsSeparator": ",",
+            "decimalSeparator": ".",
+            "dateFormat": "mm/dd/yyyy",
+            "timeFormat": "hh:mm:ss",
+            "formulaArgSeparator": ",",
+            "weekStart": 7
+        }
+    },
+    "pivots": {
+        "1": {
+            "type": "ODOO",
+            "fieldMatching": {
+                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                    "chain": "date",
+                    "type": "date",
+                    "offset": 0
+                },
+                "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                    "chain": "project_id",
+                    "type": "many2one"
+                },
+                "22a76320-0363-4391-9121-65e1db51b671": {
+                    "chain": "task_id",
+                    "type": "many2one"
+                },
+                "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                    "chain": "department_id",
+                    "type": "many2one"
+                },
+                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                    "chain": "employee_id",
+                    "type": "many2one"
+                }
+            },
+            "context": {},
+            "domain": [
+                "&",
+                [
+                    "project_id",
+                    "!=",
+                    false
+                ],
+                [
+                    "project_id.allow_billable",
+                    "!=",
+                    false
                 ]
-              }
-            },
-            "items": [
-              { "type": "chart", "chartId": "683ee3e0-6ce4" },
-              { "type": "carouselDataView", "title": "Top 10" }
             ],
-            "title": {
-              "text": "Top Departments",
-              "fontSize": 21,
-              "color": "#01666B",
-              "bold": true
+            "id": "1",
+            "measures": [
+                {
+                    "id": "unit_amount",
+                    "fieldName": "unit_amount"
+                },
+                {
+                    "id": "billable_time",
+                    "fieldName": "billable_time"
+                },
+                {
+                    "id": "Days Spent",
+                    "fieldName": "Days Spent",
+                    "aggregator": "sum",
+                    "userDefinedName": "Days Spent",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=unit_amount/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                },
+                {
+                    "id": "Billable Days",
+                    "fieldName": "Billable Days",
+                    "aggregator": "sum",
+                    "userDefinedName": "Billable Days",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=billable_time/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                }
+            ],
+            "model": "timesheets.analysis.report",
+            "name": "Timesheets Analysis by Project",
+            "sortedColumn": {
+                "measure": "billable_time",
+                "order": "desc",
+                "domain": []
             },
+            "formulaId": "1",
+            "columns": [],
+            "rows": [
+                {
+                    "fieldName": "project_id"
+                },
+                {
+                    "fieldName": "company_id.resource_calendar_id.hours_per_day"
+                }
+            ]
+        },
+        "2": {
+            "type": "ODOO",
             "fieldMatching": {
-              "683ee3e0-6ce4": {
-                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": { "chain": "date", "type": "date" },
-                "65e4bccf-3035-47a0-a268-9a4e5b48037f": { "chain": "project_id", "type": "many2one" },
-                "22a76320-0363-4391-9121-65e1db51b671": { "chain": "task_id", "type": "many2one" },
-                "541de762-4a6c-435e-a5ff-e94d393cf6df": { "chain": "department_id", "type": "many2one" },
-                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": { "chain": "employee_id", "type": "many2one" }
-              }
-            }
-          }
+                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                    "chain": "date",
+                    "type": "date",
+                    "offset": 0
+                },
+                "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                    "chain": "project_id",
+                    "type": "many2one"
+                },
+                "22a76320-0363-4391-9121-65e1db51b671": {
+                    "chain": "task_id",
+                    "type": "many2one"
+                },
+                "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                    "chain": "department_id",
+                    "type": "many2one"
+                },
+                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                    "chain": "employee_id",
+                    "type": "many2one"
+                }
+            },
+            "context": {},
+            "domain": [
+                "&",
+                "&",
+                "&",
+                [
+                    "project_id",
+                    "!=",
+                    false
+                ],
+                [
+                    "task_id",
+                    "!=",
+                    false
+                ],
+                [
+                    "project_id.allow_billable",
+                    "!=",
+                    false
+                ],
+                [
+                    "project_id.sale_line_id",
+                    "!=",
+                    false
+                ]
+            ],
+            "id": "2",
+            "measures": [
+                {
+                    "id": "unit_amount",
+                    "fieldName": "unit_amount"
+                },
+                {
+                    "id": "billable_time",
+                    "fieldName": "billable_time"
+                },
+                {
+                    "id": "Days Spent",
+                    "fieldName": "Days Spent",
+                    "aggregator": "sum",
+                    "userDefinedName": "Days Spent",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=unit_amount/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                },
+                {
+                    "id": "Billable Days",
+                    "fieldName": "Billable Days",
+                    "aggregator": "sum",
+                    "userDefinedName": "Billable Days",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=billable_time/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                }
+            ],
+            "model": "timesheets.analysis.report",
+            "name": "Timesheets Analysis by Task",
+            "sortedColumn": {
+                "measure": "billable_time",
+                "order": "desc",
+                "domain": []
+            },
+            "formulaId": "2",
+            "columns": [],
+            "rows": [
+                {
+                    "fieldName": "task_id"
+                },
+                {
+                    "fieldName": "company_id.resource_calendar_id.hours_per_day"
+                }
+            ]
+        },
+        "3": {
+            "type": "ODOO",
+            "fieldMatching": {
+                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                    "chain": "date",
+                    "type": "date",
+                    "offset": 0
+                },
+                "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                    "chain": "project_id",
+                    "type": "many2one"
+                },
+                "22a76320-0363-4391-9121-65e1db51b671": {
+                    "chain": "task_id",
+                    "type": "many2one"
+                },
+                "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                    "chain": "department_id",
+                    "type": "many2one"
+                },
+                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                    "chain": "employee_id",
+                    "type": "many2one"
+                }
+            },
+            "context": {},
+            "domain": [
+                "&",
+                [
+                    "project_id",
+                    "!=",
+                    false
+                ],
+                [
+                    "department_id",
+                    "!=",
+                    false
+                ]
+            ],
+            "id": "3",
+            "measures": [
+                {
+                    "id": "unit_amount",
+                    "fieldName": "unit_amount"
+                },
+                {
+                    "id": "billable_time",
+                    "fieldName": "billable_time"
+                },
+                {
+                    "id": "Days Spent",
+                    "fieldName": "Days Spent",
+                    "aggregator": "sum",
+                    "userDefinedName": "Days Spent",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=unit_amount/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                },
+                {
+                    "id": "Billable Days",
+                    "fieldName": "Billable Days",
+                    "aggregator": "sum",
+                    "userDefinedName": "Billable Days",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=billable_time/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                }
+            ],
+            "model": "timesheets.analysis.report",
+            "name": "Timesheets Analysis by Department",
+            "sortedColumn": {
+                "measure": "billable_time",
+                "order": "desc",
+                "domain": []
+            },
+            "formulaId": "3",
+            "columns": [],
+            "rows": [
+                {
+                    "fieldName": "department_id"
+                },
+                {
+                    "fieldName": "company_id.resource_calendar_id.hours_per_day"
+                }
+            ]
+        },
+        "4": {
+            "type": "ODOO",
+            "fieldMatching": {
+                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                    "chain": "date",
+                    "type": "date",
+                    "offset": 0
+                },
+                "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                    "chain": "project_id",
+                    "type": "many2one"
+                },
+                "22a76320-0363-4391-9121-65e1db51b671": {
+                    "chain": "task_id",
+                    "type": "many2one"
+                },
+                "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                    "chain": "department_id",
+                    "type": "many2one"
+                },
+                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                    "chain": "employee_id",
+                    "type": "many2one"
+                }
+            },
+            "context": {},
+            "domain": [
+                "&",
+                [
+                    "project_id",
+                    "!=",
+                    false
+                ],
+                [
+                    "employee_id",
+                    "!=",
+                    false
+                ]
+            ],
+            "id": "4",
+            "measures": [
+                {
+                    "id": "unit_amount",
+                    "fieldName": "unit_amount"
+                },
+                {
+                    "id": "billable_time",
+                    "fieldName": "billable_time"
+                },
+                {
+                    "id": "Days Spent",
+                    "fieldName": "Days Spent",
+                    "aggregator": "sum",
+                    "userDefinedName": "Days Spent",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=unit_amount/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                },
+                {
+                    "id": "Billable Days",
+                    "fieldName": "Billable Days",
+                    "aggregator": "sum",
+                    "userDefinedName": "Billable Days",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=billable_time/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                }
+            ],
+            "model": "timesheets.analysis.report",
+            "name": "Timesheets Analysis by Employee",
+            "sortedColumn": {
+                "measure": "billable_time",
+                "order": "desc",
+                "domain": []
+            },
+            "formulaId": "4",
+            "columns": [],
+            "rows": [
+                {
+                    "fieldName": "employee_id"
+                },
+                {
+                    "fieldName": "company_id.resource_calendar_id.hours_per_day"
+                }
+            ]
+        },
+        "5": {
+            "type": "ODOO",
+            "fieldMatching": {
+                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                    "chain": "date",
+                    "type": "date",
+                    "offset": 0
+                },
+                "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                    "chain": "project_id",
+                    "type": "many2one"
+                },
+                "22a76320-0363-4391-9121-65e1db51b671": {
+                    "chain": "task_id",
+                    "type": "many2one"
+                },
+                "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                    "chain": "department_id",
+                    "type": "many2one"
+                },
+                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                    "chain": "employee_id",
+                    "type": "many2one"
+                }
+            },
+            "context": {
+                "grid_anchor": "2022-09-12",
+                "group_expand": true
+            },
+            "domain": [
+                [
+                    "project_id",
+                    "!=",
+                    false
+                ]
+            ],
+            "id": "5",
+            "measures": [
+                {
+                    "id": "unit_amount",
+                    "fieldName": "unit_amount"
+                },
+                {
+                    "id": "Days",
+                    "fieldName": "Days",
+                    "aggregator": "sum",
+                    "userDefinedName": "Days",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=unit_amount/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                }
+            ],
+            "model": "account.analytic.line",
+            "name": "stats - current",
+            "sortedColumn": null,
+            "formulaId": "5",
+            "columns": [],
+            "rows": [
+                {
+                    "fieldName": "billable_type"
+                },
+                {
+                    "fieldName": "company_id.resource_calendar_id.hours_per_day"
+                }
+            ]
+        },
+        "6": {
+            "type": "ODOO",
+            "fieldMatching": {
+                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                    "chain": "date",
+                    "type": "date",
+                    "offset": -1
+                },
+                "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                    "chain": "project_id",
+                    "type": "many2one"
+                },
+                "22a76320-0363-4391-9121-65e1db51b671": {
+                    "chain": "task_id",
+                    "type": "many2one"
+                },
+                "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                    "chain": "department_id",
+                    "type": "many2one"
+                },
+                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                    "chain": "employee_id",
+                    "type": "many2one"
+                }
+            },
+            "context": {
+                "grid_anchor": "2022-09-12",
+                "group_expand": true
+            },
+            "domain": [
+                [
+                    "project_id",
+                    "!=",
+                    false
+                ]
+            ],
+            "id": "6",
+            "measures": [
+                {
+                    "id": "unit_amount",
+                    "fieldName": "unit_amount"
+                },
+                {
+                    "id": "Days",
+                    "fieldName": "Days",
+                    "aggregator": "sum",
+                    "userDefinedName": "Days",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=unit_amount/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                }
+            ],
+            "model": "account.analytic.line",
+            "name": "stats - previous",
+            "sortedColumn": null,
+            "formulaId": "6",
+            "columns": [],
+            "rows": [
+                {
+                    "fieldName": "billable_type"
+                },
+                {
+                    "fieldName": "company_id.resource_calendar_id.hours_per_day"
+                }
+            ]
+        },
+        "7": {
+            "type": "ODOO",
+            "fieldMatching": {
+                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                    "chain": "date",
+                    "type": "date",
+                    "offset": 0
+                },
+                "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                    "chain": "project_id",
+                    "type": "many2one"
+                },
+                "22a76320-0363-4391-9121-65e1db51b671": {
+                    "chain": "task_id",
+                    "type": "many2one"
+                },
+                "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                    "chain": "department_id",
+                    "type": "many2one"
+                },
+                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                    "chain": "employee_id",
+                    "type": "many2one"
+                }
+            },
+            "context": {},
+            "domain": [
+                "&",
+                [
+                    "project_id",
+                    "!=",
+                    false
+                ],
+                [
+                    "project_id.allow_billable",
+                    "=",
+                    false
+                ]
+            ],
+            "id": "1",
+            "measures": [
+                {
+                    "id": "non_billable_time",
+                    "fieldName": "non_billable_time",
+                    "aggregator": "sum",
+                    "isHidden": false
+                },
+                {
+                    "id": "amount",
+                    "fieldName": "amount",
+                    "aggregator": "sum"
+                },
+                {
+                    "id": "NonBillable Days",
+                    "fieldName": "NonBillable Days",
+                    "aggregator": "sum",
+                    "userDefinedName": "NonBillable Days",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=non_billable_time/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                }
+            ],
+            "model": "timesheets.analysis.report",
+            "name": "Timesheets Analysis by Non-billable Project",
+            "sortedColumn": {
+                "measure": "amount",
+                "order": "asc",
+                "domain": []
+            },
+            "formulaId": "7",
+            "columns": [],
+            "rows": [
+                {
+                    "fieldName": "project_id"
+                },
+                {
+                    "fieldName": "company_id.resource_calendar_id.hours_per_day"
+                }
+            ]
+        },
+        "8": {
+            "type": "ODOO",
+            "fieldMatching": {
+                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                    "chain": "date",
+                    "type": "date",
+                    "offset": 0
+                },
+                "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                    "chain": "project_id",
+                    "type": "many2one"
+                },
+                "22a76320-0363-4391-9121-65e1db51b671": {
+                    "chain": "task_id",
+                    "type": "many2one"
+                },
+                "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                    "chain": "department_id",
+                    "type": "many2one"
+                },
+                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                    "chain": "employee_id",
+                    "type": "many2one"
+                }
+            },
+            "context": {},
+            "domain": [
+                "&",
+                "&",
+                [
+                    "project_id",
+                    "!=",
+                    false
+                ],
+                [
+                    "task_id",
+                    "!=",
+                    false
+                ],
+                "|",
+                [
+                    "project_id.allow_billable",
+                    "=",
+                    false
+                ],
+                [
+                    "so_line",
+                    "=",
+                    false
+                ]
+            ],
+            "id": "2",
+            "measures": [
+                {
+                    "id": "non_billable_time",
+                    "fieldName": "non_billable_time",
+                    "aggregator": "sum"
+                },
+                {
+                    "id": "amount",
+                    "fieldName": "amount",
+                    "aggregator": "sum"
+                },
+                {
+                    "id": "NonBillable Days",
+                    "fieldName": "NonBillable Days",
+                    "aggregator": "sum",
+                    "userDefinedName": "NonBillable Days",
+                    "computedBy": {
+                        "sheetId": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
+                        "formula": "=non_billable_time/'company_id.resource_calendar_id.hours_per_day'"
+                    }
+                }
+            ],
+            "model": "timesheets.analysis.report",
+            "name": "Timesheets Analysis by Non-billable Task",
+            "sortedColumn": {
+                "measure": "amount",
+                "order": "asc",
+                "domain": []
+            },
+            "formulaId": "8",
+            "columns": [],
+            "rows": [
+                {
+                    "fieldName": "task_id"
+                },
+                {
+                    "fieldName": "company_id.resource_calendar_id.hours_per_day"
+                }
+            ]
+        },
+        "9": {
+            "type": "ODOO",
+            "fieldMatching": {
+                "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": {
+                    "chain": "date",
+                    "type": "date",
+                    "offset": 0
+                },
+                "65e4bccf-3035-47a0-a268-9a4e5b48037f": {
+                    "chain": "project_id",
+                    "type": "many2one"
+                },
+                "22a76320-0363-4391-9121-65e1db51b671": {
+                    "chain": "task_id",
+                    "type": "many2one"
+                },
+                "541de762-4a6c-435e-a5ff-e94d393cf6df": {
+                    "chain": "department_id",
+                    "type": "many2one"
+                },
+                "4788ea63-ee8f-4082-a118-a26b4b6f1a71": {
+                    "chain": "employee_id",
+                    "type": "many2one"
+                }
+            },
+            "context": {},
+            "domain": [],
+            "id": "1",
+            "measures": [],
+            "model": "timesheets.analysis.report",
+            "name": "Timesheet Encoding Unit",
+            "formulaId": "9",
+            "columns": [],
+            "rows": [
+                {
+                    "fieldName": "company_id.timesheet_encode_uom_id"
+                }
+            ]
         }
-      ],
-      "tables": [
-        {
-          "range": "A24:D34",
-          "type": "static",
-          "config": {
-            "hasFilters": false,
-            "totalRow": false,
-            "firstColumn": false,
-            "lastColumn": false,
-            "numberOfHeaders": 1,
-            "bandedRows": true,
-            "bandedColumns": false,
-            "automaticAutofill": true,
-            "styleId": "None"
-          }
-        },
-        {
-          "range": "A37:D47",
-          "type": "static",
-          "config": {
-            "hasFilters": false,
-            "totalRow": false,
-            "firstColumn": false,
-            "lastColumn": false,
-            "numberOfHeaders": 1,
-            "bandedRows": true,
-            "bandedColumns": false,
-            "automaticAutofill": true,
-            "styleId": "None"
-          }
-        },
-        {
-          "range": "F24:I34",
-          "type": "static",
-          "config": {
-            "hasFilters": false,
-            "totalRow": false,
-            "firstColumn": false,
-            "lastColumn": false,
-            "numberOfHeaders": 1,
-            "bandedRows": true,
-            "bandedColumns": false,
-            "automaticAutofill": true,
-            "styleId": "None"
-          }
-        },
-        {
-          "range": "F37:I47",
-          "type": "static",
-          "config": {
-            "hasFilters": false,
-            "totalRow": false,
-            "firstColumn": false,
-            "lastColumn": false,
-            "numberOfHeaders": 1,
-            "bandedRows": true,
-            "bandedColumns": false,
-            "automaticAutofill": true,
-            "styleId": "None"
-          }
-        }
-      ],
-      "areGridLinesVisible": true,
-      "isVisible": true,
-      "headerGroups": {
-        "ROW": [],
-        "COL": []
-      },
-      "comments": {}
     },
-    {
-      "id": "7802fc6d-c96b-452f-86d8-1c69816bebdc",
-      "name": "Data",
-      "colNumber": 26,
-      "rowNumber": 100,
-      "rows": {},
-      "cols": {
-        "0": { "size": 159 },
-        "1": { "size": 93 },
-        "2": { "size": 93 },
-        "3": { "size": 93 },
-        "4": { "size": 93 }
-      },
-      "merges": [],
-      "cells": {
-        "A1": "=_t(\"KPI\")",
-        "A2": "=_t(\"Billed fixed price\")",
-        "A3": "=_t(\"Billed manually\")",
-        "A4": "=_t(\"Billed timesheets\")",
-        "A5": "=_t(\"Billable hours\")",
-        "A6": "=_t(\"Non-billable hours\")",
-        "A7": "=_t(\"Grand total\")",
-        "A8": "=_t(\"Billable rate\")",
-        "B1": "=_t(\"Current\")",
-        "B2": "=PIVOT.VALUE(5,\"unit_amount\",\"billable_type\",\"02_billable_fixed\")",
-        "B3": "=PIVOT.VALUE(5,\"unit_amount\",\"billable_type\",\"08_billable_manual\")",
-        "B4": "=PIVOT.VALUE(5,\"unit_amount\",\"billable_type\",\"04_billable_time\")",
-        "B5": "=SUM(B2:B4)",
-        "B6": "=PIVOT.VALUE(5,\"unit_amount\",\"billable_type\",\"09_non_billable\")",
-        "B7": "=PIVOT.VALUE(5,\"unit_amount\")",
-        "B8": "=IFERROR(B5/B7)",
-        "C1": "=_t(\"Previous\")",
-        "C2": "=PIVOT.VALUE(6,\"unit_amount\",\"billable_type\",\"02_billable_fixed\")",
-        "C3": "=PIVOT.VALUE(6,\"unit_amount\",\"billable_type\",\"08_billable_manual\")",
-        "C4": "=PIVOT.VALUE(6,\"unit_amount\",\"billable_type\",\"04_billable_time\")",
-        "C5": "=SUM(C2:C4)",
-        "C6": "=PIVOT.VALUE(6,\"unit_amount\",\"billable_type\",\"09_non_billable\")",
-        "C7": "=PIVOT.VALUE(6,\"unit_amount\")",
-        "C8": "=IFERROR(C5/C7)",
-        "D1": "=_t(\"Current\")",
-        "D2": "=FORMAT.LARGE.NUMBER(B2)",
-        "D3": "=FORMAT.LARGE.NUMBER(B3)",
-        "D4": "=FORMAT.LARGE.NUMBER(B4)",
-        "D5": "=FORMAT.LARGE.NUMBER(B5)",
-        "D6": "=FORMAT.LARGE.NUMBER(B6)",
-        "D7": "=FORMAT.LARGE.NUMBER(B7)",
-        "D8": "=B8",
-        "E1": "=_t(\"Previous\")",
-        "E2": "=FORMAT.LARGE.NUMBER(C2)",
-        "E3": "=FORMAT.LARGE.NUMBER(C3)",
-        "E4": "=FORMAT.LARGE.NUMBER(C4)",
-        "E5": "=FORMAT.LARGE.NUMBER(C5)",
-        "E6": "=FORMAT.LARGE.NUMBER(C6)",
-        "E7": "=FORMAT.LARGE.NUMBER(C7)",
-        "E8": "=C8"
-      },
-      "styles": { "A1:E1": 5, "A2:E8": 6 },
-      "formats": { "D8:E8": 1 },
-      "borders": {},
-      "conditionalFormats": [],
-      "dataValidationRules": [],
-      "figures": [],
-      "tables": [],
-      "areGridLinesVisible": true,
-      "isVisible": true,
-      "headerGroups": {
-        "ROW": [],
-        "COL": []
-      },
-      "comments": {}
+    "pivotNextId": 10,
+    "customTableStyles": {},
+    "globalFilters": [
+        {
+            "id": "fb3700b0-4ee9-4086-86ac-6c62a7d33d37",
+            "type": "date",
+            "label": "Period",
+            "defaultValue": "last_30_days"
+        },
+        {
+            "id": "65e4bccf-3035-47a0-a268-9a4e5b48037f",
+            "type": "relation",
+            "label": "Project",
+            "modelName": "project.project",
+            "defaultValueDisplayNames": []
+        },
+        {
+            "id": "22a76320-0363-4391-9121-65e1db51b671",
+            "type": "relation",
+            "label": "Task",
+            "modelName": "project.task",
+            "defaultValueDisplayNames": []
+        },
+        {
+            "id": "541de762-4a6c-435e-a5ff-e94d393cf6df",
+            "type": "relation",
+            "label": "Department",
+            "modelName": "hr.department",
+            "defaultValueDisplayNames": []
+        },
+        {
+            "id": "4788ea63-ee8f-4082-a118-a26b4b6f1a71",
+            "type": "relation",
+            "label": "Employee",
+            "modelName": "hr.employee",
+            "defaultValueDisplayNames": []
+        }
+    ],
+    "lists": {},
+    "listNextId": 1,
+    "odooLinkReferences": {
+        "711b3ea3-d7f4-4fa9-85a4-0fa7d46d3811": {
+            "type": "odooMenu",
+            "odooMenuId": "hr_timesheet.timesheet_menu_root"
+        },
+        "6eba1314-09d2-4821-af97-ad22f43a87fa": {
+            "type": "odooMenu",
+            "odooMenuId": "hr_timesheet.timesheet_menu_root"
+        },
+        "39c6667b-b74a-478e-87e9-75c22de5ea1f": {
+            "type": "odooMenu",
+            "odooMenuId": "hr_timesheet.timesheet_menu_root"
+        },
+        "14907ee1-177b-4dda-97d7-223b1b00abe5": {
+            "type": "odooMenu",
+            "odooMenuId": "hr_timesheet.timesheet_menu_activity_all"
+        },
+        "0b033641-2a0f-4db7-893d-f14fbb320b94": {
+            "type": "odooMenu",
+            "odooMenuId": "hr_timesheet.timesheet_menu_activity_all"
+        },
+        "741013eb-c06f": {
+            "type": "odooMenu",
+            "odooMenuId": "hr_timesheet.timesheet_menu_activity_all"
+        },
+        "cd0cf706-f8bd": {
+            "type": "odooMenu",
+            "odooMenuId": "hr_timesheet.timesheet_menu_activity_all"
+        },
+        "26ef5620-3a5c": {
+            "type": "odooMenu",
+            "odooMenuId": "hr_timesheet.timesheet_menu_root"
+        }
     }
-  ],
-  "styles": {
-    "1": { "textColor": "#01666b", "bold": true, "fontSize": 16 },
-    "2": { "textColor": "#434343", "fontSize": 11, "bold": true },
-    "3": { "textColor": "#434343", "verticalAlign": "middle" },
-    "4": {
-      "textColor": "#434343",
-      "fontSize": 11,
-      "bold": true,
-      "align": "center"
-    },
-    "5": { "bold": true },
-    "6": { "fillColor": "#f2f2f2" }
-  },
-  "formats": { "1": "0%" },
-  "borders": {
-    "1": {
-      "bottom": { "style": "thin", "color": "#CCCCCC" }
-    },
-    "2": {
-      "top": { "style": "thin", "color": "#CCCCCC" }
-    },
-    "3": {
-      "bottom": { "style": "thick", "color": "#FFFFFF" }
-    },
-    "4": {
-      "top": { "style": "thick", "color": "#FFFFFF" },
-      "bottom": { "style": "thick", "color": "#FFFFFF" }
-    },
-    "5": {
-      "top": { "style": "thick", "color": "#FFFFFF" }
-    }
-  },
-  "revisionId": "START_REVISION",
-  "uniqueFigureIds": true,
-  "settings": {
-    "locale": {
-      "name": "English (US)",
-      "code": "en_US",
-      "thousandsSeparator": ",",
-      "decimalSeparator": ".",
-      "dateFormat": "mm/dd/yyyy",
-      "timeFormat": "hh:mm:ss",
-      "formulaArgSeparator": ",",
-      "weekStart": 7
-    }
-  },
-  "pivots": {
-    "1": {
-      "type": "ODOO",
-      "fieldMatching": {
-        "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": { "chain": "date", "type": "date", "offset": 0 },
-        "65e4bccf-3035-47a0-a268-9a4e5b48037f": { "chain": "project_id", "type": "many2one" },
-        "22a76320-0363-4391-9121-65e1db51b671": { "chain": "task_id", "type": "many2one" },
-        "541de762-4a6c-435e-a5ff-e94d393cf6df": { "chain": "department_id", "type": "many2one" },
-        "4788ea63-ee8f-4082-a118-a26b4b6f1a71": { "chain": "employee_id", "type": "many2one" }
-      },
-      "context": {},
-      "domain": [
-        "&",
-        ["project_id", "!=", false],
-        ["project_id", "!=", false]
-      ],
-      "id": "1",
-      "measures": [
-        {
-          "id": "unit_amount",
-          "fieldName": "unit_amount",
-          "userDefinedName": "Hours spent"
-        },
-        {
-          "id": "billable_time",
-          "fieldName": "billable_time",
-          "userDefinedName": "Hours billed"
-        },
-        {
-          "id": "Billable rate:sum",
-          "fieldName": "Billable rate",
-          "aggregator": "sum",
-          "userDefinedName": "Billable rate",
-          "computedBy": { "sheetId": "sheet1", "formula": "=IFERROR(billable_time/unit_amount)" },
-          "format": "0%"
-        }
-      ],
-      "model": "timesheets.analysis.report",
-      "name": "Project",
-      "sortedColumn": {
-        "measure": "billable_time",
-        "order": "desc",
-        "domain": []
-      },
-      "formulaId": "1",
-      "columns": [],
-      "rows": [
-        { "fieldName": "project_id" }
-      ]
-    },
-    "2": {
-      "type": "ODOO",
-      "fieldMatching": {
-        "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": { "chain": "date", "type": "date", "offset": 0 },
-        "65e4bccf-3035-47a0-a268-9a4e5b48037f": { "chain": "project_id", "type": "many2one" },
-        "22a76320-0363-4391-9121-65e1db51b671": { "chain": "task_id", "type": "many2one" },
-        "541de762-4a6c-435e-a5ff-e94d393cf6df": { "chain": "department_id", "type": "many2one" },
-        "4788ea63-ee8f-4082-a118-a26b4b6f1a71": { "chain": "employee_id", "type": "many2one" }
-      },
-      "context": {},
-      "domain": [
-        "&",
-        ["project_id", "!=", false],
-        ["task_id", "!=", false]
-      ],
-      "id": "2",
-      "measures": [
-        {
-          "id": "unit_amount",
-          "fieldName": "unit_amount",
-          "userDefinedName": "Hours spent",
-          "format": ""
-        },
-        {
-          "id": "billable_time",
-          "fieldName": "billable_time",
-          "userDefinedName": "Hours billed",
-          "format": ""
-        },
-        {
-          "id": "Billable rate:sum",
-          "fieldName": "Billable rate",
-          "aggregator": "sum",
-          "userDefinedName": "Billable rate",
-          "computedBy": { "sheetId": "sheet1", "formula": "=IFERROR(billable_time/unit_amount)" },
-          "format": "0%"
-        }
-      ],
-      "model": "timesheets.analysis.report",
-      "name": "Task",
-      "sortedColumn": {
-        "measure": "billable_time",
-        "order": "desc",
-        "domain": []
-      },
-      "formulaId": "2",
-      "columns": [],
-      "rows": [
-        { "fieldName": "task_id" }
-      ]
-    },
-    "3": {
-      "type": "ODOO",
-      "fieldMatching": {
-        "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": { "chain": "date", "type": "date", "offset": 0 },
-        "65e4bccf-3035-47a0-a268-9a4e5b48037f": { "chain": "project_id", "type": "many2one" },
-        "22a76320-0363-4391-9121-65e1db51b671": { "chain": "task_id", "type": "many2one" },
-        "541de762-4a6c-435e-a5ff-e94d393cf6df": { "chain": "department_id", "type": "many2one" },
-        "4788ea63-ee8f-4082-a118-a26b4b6f1a71": { "chain": "employee_id", "type": "many2one" }
-      },
-      "context": {},
-      "domain": [
-        "&",
-        ["project_id", "!=", false],
-        ["department_id", "!=", false]
-      ],
-      "id": "3",
-      "measures": [
-        {
-          "id": "unit_amount",
-          "fieldName": "unit_amount",
-          "userDefinedName": "Hours spent"
-        },
-        {
-          "id": "billable_time",
-          "fieldName": "billable_time",
-          "userDefinedName": "Hours billed"
-        },
-        {
-          "id": "Billable rate:sum",
-          "fieldName": "Billable rate",
-          "aggregator": "sum",
-          "userDefinedName": "Billable rate",
-          "computedBy": { "sheetId": "sheet1", "formula": "=IFERROR(billable_time/unit_amount)" },
-          "format": "0%"
-        }
-      ],
-      "model": "timesheets.analysis.report",
-      "name": "Department",
-      "sortedColumn": {
-        "measure": "billable_time",
-        "order": "desc",
-        "domain": []
-      },
-      "formulaId": "3",
-      "columns": [],
-      "rows": [
-        { "fieldName": "department_id" }
-      ]
-    },
-    "4": {
-      "type": "ODOO",
-      "fieldMatching": {
-        "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": { "chain": "date", "type": "date", "offset": 0 },
-        "65e4bccf-3035-47a0-a268-9a4e5b48037f": { "chain": "project_id", "type": "many2one" },
-        "22a76320-0363-4391-9121-65e1db51b671": { "chain": "task_id", "type": "many2one" },
-        "541de762-4a6c-435e-a5ff-e94d393cf6df": { "chain": "department_id", "type": "many2one" },
-        "4788ea63-ee8f-4082-a118-a26b4b6f1a71": { "chain": "employee_id", "type": "many2one" }
-      },
-      "context": {},
-      "domain": [
-        "&",
-        ["project_id", "!=", false],
-        ["employee_id", "!=", false]
-      ],
-      "id": "4",
-      "measures": [
-        {
-          "id": "unit_amount",
-          "fieldName": "unit_amount",
-          "userDefinedName": "Hours spent"
-        },
-        {
-          "id": "billable_time",
-          "fieldName": "billable_time",
-          "userDefinedName": "Hours billed"
-        },
-        {
-          "id": "Billable rate:sum",
-          "fieldName": "Billable rate",
-          "aggregator": "sum",
-          "userDefinedName": "Billable rate",
-          "computedBy": { "sheetId": "sheet1", "formula": "=IFERROR(billable_time/unit_amount)" },
-          "format": "0%"
-        }
-      ],
-      "model": "timesheets.analysis.report",
-      "name": "Employee",
-      "sortedColumn": {
-        "measure": "billable_time",
-        "order": "desc",
-        "domain": []
-      },
-      "formulaId": "4",
-      "columns": [],
-      "rows": [
-        { "fieldName": "employee_id" }
-      ]
-    },
-    "5": {
-      "type": "ODOO",
-      "fieldMatching": {
-        "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": { "chain": "date", "type": "date", "offset": 0 },
-        "65e4bccf-3035-47a0-a268-9a4e5b48037f": { "chain": "project_id", "type": "many2one" },
-        "22a76320-0363-4391-9121-65e1db51b671": { "chain": "task_id", "type": "many2one" },
-        "541de762-4a6c-435e-a5ff-e94d393cf6df": { "chain": "department_id", "type": "many2one" },
-        "4788ea63-ee8f-4082-a118-a26b4b6f1a71": { "chain": "employee_id", "type": "many2one" }
-      },
-      "context": { "grid_anchor": "2022-09-12", "group_expand": true },
-      "domain": [
-        "&",
-        ["project_id", "!=", false],
-        ["user_id", "=", 2]
-      ],
-      "id": "5",
-      "measures": [
-        { "id": "unit_amount", "fieldName": "unit_amount" }
-      ],
-      "model": "account.analytic.line",
-      "name": "stats - current",
-      "sortedColumn": null,
-      "formulaId": "5",
-      "columns": [],
-      "rows": [
-        { "fieldName": "billable_type" }
-      ]
-    },
-    "6": {
-      "type": "ODOO",
-      "fieldMatching": {
-        "fb3700b0-4ee9-4086-86ac-6c62a7d33d37": { "chain": "date", "type": "date", "offset": -1 },
-        "65e4bccf-3035-47a0-a268-9a4e5b48037f": { "chain": "project_id", "type": "many2one" },
-        "22a76320-0363-4391-9121-65e1db51b671": { "chain": "task_id", "type": "many2one" },
-        "541de762-4a6c-435e-a5ff-e94d393cf6df": { "chain": "department_id", "type": "many2one" },
-        "4788ea63-ee8f-4082-a118-a26b4b6f1a71": { "chain": "employee_id", "type": "many2one" }
-      },
-      "context": { "grid_anchor": "2022-09-12", "group_expand": true },
-      "domain": [
-        "&",
-        ["project_id", "!=", false],
-        ["user_id", "=", 2]
-      ],
-      "id": "6",
-      "measures": [
-        { "id": "unit_amount", "fieldName": "unit_amount" }
-      ],
-      "model": "account.analytic.line",
-      "name": "stats - previous",
-      "sortedColumn": null,
-      "formulaId": "6",
-      "columns": [],
-      "rows": [
-        { "fieldName": "billable_type" }
-      ]
-    }
-  },
-  "pivotNextId": 7,
-  "customTableStyles": {},
-  "globalFilters": [
-    {
-      "id": "fb3700b0-4ee9-4086-86ac-6c62a7d33d37",
-      "type": "date",
-      "label": "Period",
-      "defaultValue": "last_30_days"
-    },
-    {
-      "id": "65e4bccf-3035-47a0-a268-9a4e5b48037f",
-      "type": "relation",
-      "label": "Project",
-      "modelName": "project.project",
-      "defaultValueDisplayNames": []
-    },
-    {
-      "id": "22a76320-0363-4391-9121-65e1db51b671",
-      "type": "relation",
-      "label": "Task",
-      "modelName": "project.task",
-      "defaultValueDisplayNames": []
-    },
-    {
-      "id": "541de762-4a6c-435e-a5ff-e94d393cf6df",
-      "type": "relation",
-      "label": "Department",
-      "modelName": "hr.department",
-      "defaultValueDisplayNames": []
-    },
-    {
-      "id": "4788ea63-ee8f-4082-a118-a26b4b6f1a71",
-      "type": "relation",
-      "label": "Employee",
-      "modelName": "hr.employee",
-      "defaultValueDisplayNames": []
-    }
-  ],
-  "lists": {},
-  "listNextId": 1,
-  "chartOdooMenusReferences": {
-    "711b3ea3-d7f4-4fa9-85a4-0fa7d46d3811": "hr_timesheet.timesheet_menu_root",
-    "6eba1314-09d2-4821-af97-ad22f43a87fa": "hr_timesheet.timesheet_menu_root",
-    "39c6667b-b74a-478e-87e9-75c22de5ea1f": "hr_timesheet.timesheet_menu_root",
-    "14907ee1-177b-4dda-97d7-223b1b00abe5": "hr_timesheet.timesheet_menu_activity_all",
-    "c484c691-bb4a-4a9d-8a25-8464162ee96a": "hr_timesheet.timesheet_menu_activity_all",
-    "0b033641-2a0f-4db7-893d-f14fbb320b94": "hr_timesheet.timesheet_menu_activity_all"
-  }
 }


### PR DESCRIPTION
- make all the billable filters into one `Billable` search filter
- pass context when `Billable` is selected to control the Overtime Indicator Props
- switched rows in the dashboard
- fixed the 0.00% format issue
- fix some text formatting issues
- fix appearing 0 in empty cells
- create `Non-billable projects/tasks` sections
- create `Total Hours` scoreboard
- only show lowest department level
- adjusted links in the dashboard
- adjusted the time encoding to days and hours

---

Task-4969380
