### PR TITLE
[FIX] survey: fix leaderboard score display

### DIFF
--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -436,7 +436,7 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
         }
 
         .o_survey_session_leaderboard_bar {
-            min-width: 3rem;
+            min-width: 3.7rem;
             background-color: #007A77;
             z-index: 2;
         }


### PR DESCRIPTION
The way the score bars were animated was a bit confusing. We simplify the
animation by:
- Showing the score accumulated so far without the question
- Animating the score bar towards the accumulated score with the question
- Animating the numerical score on the left towards the accumulated score with the question while fading the numerical score increment on the bar ("+ x p")
- (reordering participants)

We also fix the size of the leaderboard as it was too small to display the score correctly.

How to reproduce
- Create a scored survey with time reward
- Add a question to get the name and toggle the nickname option
- Add a question with an answer that grants n points
- Start a live session
- After a user has completed the question
- Display the leaderboard

The score animation is confusion as it was going through:
- Showing the score accumulated so far without the question
- Animating towards 0: showing a minimal bar due to the minimum size of the score bar
- Animating towards the score question (on top of the minimal bar)
- And finally adding the score accumulated so far without the question

Task-4893763