### PR TITLE
[IMP] sale: copy the SO name in invoice ref field

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -145,10 +145,7 @@ class PaymentTransaction(models.Model):
         """
         self.ensure_one()
 
-        reference = (f'{self.reference} - '
-                     f'{self.partner_id.display_name or ""} - '
-                     f'{self.provider_reference or ""}'
-                    )
+        reference = f'{self.reference} - {self.provider_reference or ""}'
 
         payment_method_line = self.provider_id.journal_id.inbound_payment_method_line_ids\
             .filtered(lambda l: l.payment_provider_id == self.provider_id)

--- a/addons/l10n_it_edi/tests/export_xmls/test_export_invoice_with_two_downpayments.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/test_export_invoice_with_two_downpayments.xml
@@ -62,6 +62,10 @@
         <ImportoTotaleDocumento>94.00</ImportoTotaleDocumento>
       </DatiGeneraliDocumento>
       <DatiFattureCollegate>
+         <IdDocumento>SO-IT0001</IdDocumento>
+         <DataDocumento>2025-02-03</DataDocumento>
+      </DatiFattureCollegate>
+      <DatiFattureCollegate>
         <IdDocumento>INV/2025/00001</IdDocumento>
         <Data>2025-02-03</Data>
       </DatiFattureCollegate>

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -479,6 +479,7 @@ class TestItEdiExport(TestItEdi):
                 Command.create({'product_id': self.service_product.id, 'price_unit': 200.00}),
             ],
         })
+        sale_order.name = 'SO-IT0001'
         sale_order.action_confirm()
 
         for amount in (50, 100):

--- a/addons/l10n_it_edi_ndd_account_dn/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi_ndd_account_dn/data/invoice_it_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="account_invoice_it_FatturaPA_export_debit_note" inherit_id="l10n_it_edi.account_invoice_it_FatturaPA_export">
-        <xpath expr="//DatiOrdineAcquisto" position="after">
+        <xpath expr="//DatiOrdineAcquisto[last()]" position="after">
             <Datifatturecollegate t-elif="record.debit_origin_id">
                 <IdDocumento t-out="format_alphanumeric(record.ref, 20)"/>
                 <Data t-out="format_date(record.debit_origin_id.date)"/>

--- a/addons/l10n_it_stock_ddt/tests/expected_xmls/deferred_invoice.xml
+++ b/addons/l10n_it_stock_ddt/tests/expected_xmls/deferred_invoice.xml
@@ -60,6 +60,10 @@
                 <Numero>INV/2020/00001</Numero>
                 <ImportoTotaleDocumento>2427.80</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
+            <DatiFattureCollegate>
+               <IdDocumento>SO-ITDDT0001</IdDocumento>
+               <DataDocumento>2020-02-03</DataDocumento>
+            </DatiFattureCollegate>
             <DatiDDT>
                 <NumeroDDT>compa/OUT/DDT00001</NumeroDDT>
                 <DataDDT>2020-02-02</DataDDT>

--- a/addons/l10n_it_stock_ddt/tests/test_edi.py
+++ b/addons/l10n_it_stock_ddt/tests/test_edi.py
@@ -110,6 +110,7 @@ class TestItEdiDDT(TestItEdi):
                 ],
                 'pricelist_id': self.default_pricelist.id,
                 'picking_policy': 'direct',
+                'name': 'SO-ITDDT0001',
             })
             self.sale_order.action_confirm()
 

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -254,6 +254,14 @@ class TestEdiZatca(TestSaEdiCommon):
             final.invoice_date_due = '2022-09-22'
 
         # Test invoices
+        additional_xpath = f'''
+            <xpath expr="(//*[local-name()='OrderReference']/*[local-name()='ID'])" position="replace">
+                <cbc:ID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">{sale_order.name}</cbc:ID>
+            </xpath>
+            <xpath expr="(//*[local-name()='PaymentMeans']/*[local-name()='InstructionID'])" position="after">
+                <cbc:InstructionNote xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">{sale_order.name}</cbc:InstructionNote>
+            </xpath>
+        '''
         for move, test_file in [
             (downpayment, "downpayment_invoice"),
             (final, "final_invoice")
@@ -262,6 +270,7 @@ class TestEdiZatca(TestSaEdiCommon):
                 self._test_document_generation(
                     test_file_path=f'l10n_sa_edi/tests/test_files/{test_file}.xml',
                     expected_xpath=self.invoice_applied_xpath,
+                    additional_xpath=additional_xpath,
                     freeze_time_at=freeze,
                     move=move,
                 )

--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -275,11 +275,11 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
         self.assertRecordValues(
             account_move.line_ids.sorted('balance'),
             [
-                {'name': 'product_a',                           'debit': 0.0,       'credit': 1800.0},
-                {'name': 'product_a',                           'debit': 0.0,       'credit': 1680.0},
-                {'name': '15% (Copy)',                          'debit': 0.0,       'credit': 270.0},
-                {'name': f'{account_move.name} installment #1', 'debit': 621.0,     'credit': 0.0},
-                {'name': f'{account_move.name} installment #2', 'debit': 1449.0,    'credit': 0.0},
-                {'name': 'product_a',                           'debit': 1680.0,    'credit': 0.0},
+                {'name': 'product_a',                                               'debit': 0.0,       'credit': 1800.0},
+                {'name': 'product_a',                                               'debit': 0.0,       'credit': 1680.0},
+                {'name': '15% (Copy)',                                              'debit': 0.0,       'credit': 270.0},
+                {'name': f'{sale_order.name} - {account_move.name} installment #1', 'debit': 621.0,     'credit': 0.0},
+                {'name': f'{sale_order.name} - {account_move.name} installment #2', 'debit': 1449.0,    'credit': 0.0},
+                {'name': 'product_a',                                               'debit': 1680.0,    'credit': 0.0},
             ]
         )

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1368,7 +1368,7 @@ class SaleOrder(models.Model):
         )
 
         values = {
-            'ref': self.client_order_ref or '',
+            'ref': self.client_order_ref or self.name,
             'move_type': 'out_invoice',
             'narration': self.note,
             'currency_id': self.currency_id.id,


### PR DESCRIPTION
Unless there's already a customer reference, we need the SO name to be able to match any prepayment





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
