### PR TITLE
[FIX] im_livechat: no newline in channel history for empty messages

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, tools
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tools import email_normalize, email_split, html2plaintext, plaintext2html
 
@@ -179,11 +179,12 @@ class DiscussChannel(models.Model):
         for message in (self.message_ids - self.message_ids.sudo()._filter_empty()).sorted("id"):
             if message.author_id == chatbot_op and not last_msg_from_chatbot:
                 parts.append(Markup("<br/>"))
-            if message.author_id == chatbot_op:
-                parts.append(Markup("<strong>%s</strong><br/>") % html2plaintext(message.body))
-            else:
-                parts.append(Markup("%s<br/>") % html2plaintext(message.body))
-            last_msg_from_chatbot = message.author_id == chatbot_op
+            if not tools.is_html_empty(message.body):
+                if message.author_id == chatbot_op:
+                    parts.append(Markup("<strong>%s</strong><br/>") % html2plaintext(message.body))
+                else:
+                    parts.append(Markup("%s<br/>") % html2plaintext(message.body))
+                last_msg_from_chatbot = message.author_id == chatbot_op
         return Markup("").join(parts)
 
 

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -1,3 +1,4 @@
+from odoo import Command
 from odoo.tests import new_test_user, tagged
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 
@@ -21,3 +22,26 @@ class TestDiscussChannel(TestImLivechatCommon):
         self.assertTrue(chat.livechat_active)
         chat.with_user(chat.livechat_operator_id.user_ids[0]).action_unfollow()
         self.assertFalse(chat.livechat_active)
+
+    def test_livechat_conversation_history(self):
+        """Test livechat conversation history formatting"""
+        self.authenticate(self.operators[0].login, self.password)
+        channel = self.env["discuss.channel"].create(
+            {
+                "name": "test",
+                "channel_type": "livechat",
+                "livechat_operator_id": self.operators[0].partner_id.id,
+                "channel_member_ids": [
+                    Command.create({"partner_id": self.operators[0].partner_id.id}),
+                    Command.create({"partner_id": self.visitor_user.partner_id.id}),
+                ],
+            }
+        )
+        attachment1 = self.env["ir.attachment"].create({"name": "test.txt"})
+        attachment2 = self.env["ir.attachment"].with_user(self.visitor_user).create({"name": "test2.txt"})
+        channel.message_post(body="Operator Here")
+        channel.message_post(body="", attachment_ids=[attachment1.id])
+        channel.with_user(self.visitor_user).message_post(body="Visitor Here")
+        channel.with_user(self.visitor_user).message_post(body="", attachment_ids=[attachment2.id])
+        channel_history = channel._get_channel_history()
+        self.assertEqual(channel_history, 'Operator Here<br/>Visitor Here<br/>')


### PR DESCRIPTION
When a chatbot conversation contains messages with empty body, this empty body would be converted into a newline which is not desired.

This commit ensures that empty messages are not converted into newlines in the channel history.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
