### PR TITLE
[FIX] payment, website_sale: delay token payment until after validation

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -353,7 +353,7 @@ class PaymentPortal(portal.CustomerPortal):
             **(custom_create_values or {}),
         })  # In sudo mode to allow writing on callback fields
 
-        if flow == 'token':
+        if flow == 'token' and not request.env.context.get('delay_payment_request'):
             tx_sudo._send_payment_request()  # Payments by token process transactions immediately
         else:
             tx_sudo._log_sent_message()

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -2080,6 +2080,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
         if compare_amounts(order_sudo.amount_paid, order_sudo.amount_total) == 0:
             raise UserError(_("The cart has already been paid. Please refresh the page."))
 
+        if delay_payment_request := kwargs.get('flow') == 'token':
+            request.update_context(delay_payment_request=True)  # wait until after tx validation
         tx_sudo = self._create_transaction(
             custom_create_values={'sale_order_ids': [Command.set([order_id])]}, **kwargs,
         )
@@ -2089,6 +2091,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
         request.session['__website_sale_last_tx_id'] = tx_sudo.id
 
         self._validate_transaction_for_order(tx_sudo, order_id)
+        if delay_payment_request:
+            tx_sudo._send_payment_request()
 
         return tx_sudo._get_processing_values()
 


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have a saved Stripe payment token;
2. create a discount coupon program & a coupon;
3. go to /shop & add a product to your cart;
4. go to checkout;
5. apply coupon;
6. before finalizing payment, set coupon program expiration to yesterday;
7. finalize payment.

Issue
-----
An error appears, because of the reward change, but a payment request has already been sent.

Cause
-----
For token transactions, `_send_payment_request` is called immediately upon creation, i.e. before the `WebsiteSale` controller is able to validate the transaction using `_validate_transaction_for_order`.

Solution
--------
If the payment flow happens via token, add a `delay_payment_request` context value. When creating a token transaction in `PaymentPortal`, only call `_send_payment_request` if this value is not set in the current context.

opw-5013284