### PR TITLE
[IMP] hr: make the 'new contract' button useful

### DIFF
--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.js
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.js
@@ -1,0 +1,68 @@
+import { useDateTimePicker } from "@web/core/datetime/datetime_picker_hook";
+import { serializeDate } from "@web/core/l10n/dates";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { Component } from "@odoo/owl";
+
+export class ButtonNewContractWidget extends Component {
+    static template = "hr.ButtonNewContract";
+    static props = {
+        ...standardWidgetProps,
+    };
+
+    /** @override **/
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+
+        this.dateTimePicker = useDateTimePicker({
+            target: `datetime-picker-target-new-contract`,
+            onApply: (date) => {
+                if (date) {
+                    this.tryAndCreateContract(serializeDate(date));
+                }
+            },
+            get pickerProps() {
+                return { type: "date" };
+            },
+        });
+    }
+
+    async onClickNewContractBtn() {
+        await this.props.record.save();
+        await this.orm.call("hr.version", "check_contract_finished", [
+            [this.props.record.data.version_id.id],
+        ]);
+        this.dateTimePicker.open();
+    }
+
+    async tryAndCreateContract(date) {
+        await this.orm.call("hr.employee", "check_no_existing_contract", [
+            [this.props.record.resId],
+            date,
+        ]);
+        const contract = await this.orm.call("hr.employee", "create_contract", [
+            [this.props.record.resId],
+            date,
+        ]);
+        await this.loadVersion(contract);
+    }
+
+    async loadVersion(version_id) {
+        const { record } = this.props;
+        await record.save();
+        await this.props.record.model.load({
+            context: {
+                ...this.props.record.model.env.searchModel.context,
+                version_id: version_id,
+            },
+        });
+    }
+}
+
+export const buttonNewContractWidget = {
+    component: ButtonNewContractWidget,
+};
+
+registry.category("view_widgets").add("button_new_contract", buttonNewContractWidget);

--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<template>
+    <t t-name="hr.ButtonNewContract">
+        <span class="w-100 d-flex justify-content-end">
+            <button class="btn btn-link p-0 o_field_widget text-end w-auto" t-on-click="onClickNewContractBtn"
+                    t-ref="datetime-picker-target-new-contract">New Contract</button>
+        </span>
+    </t>
+</template>

--- a/addons/hr/static/src/components/versions_timeline/versions_timeline.js
+++ b/addons/hr/static/src/components/versions_timeline/versions_timeline.js
@@ -38,17 +38,13 @@ export class VersionsTimeline extends StatusBarField {
             });
         }
 
-        const pickerProps = {
-            type: "date",
-        };
-
         this.dateTimePicker = useDateTimePicker({
             target: `datetime-picker-target-version`,
             onApply: (date) => {
                 if (date) this.createVersion(date);
             },
             get pickerProps() {
-                return pickerProps;
+                return { type: "date" };
             },
         });
     }
@@ -59,7 +55,6 @@ export class VersionsTimeline extends StatusBarField {
             { date_version: date },
         ]);
 
-        // TODO: why chat button and org chart button disappear
         const { record } = this.props;
         await record.save();
         await this.props.record.model.load({

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -290,8 +290,7 @@
                                             <span invisible="not contract_date_start">to</span>
                                             <field name="contract_date_end" string="End Date" placeholder="Indefinite"
                                                 class="o_hr_narrow_field ms-3" invisible="not contract_date_start"/>
-                                            <button name="action_new_contract" type="object" string="New Contract" class="btn btn-link p-0 ms-auto"
-                                                invisible="not contract_date_start and not contract_date_end"/>
+                                            <widget name="button_new_contract"/>
                                         </div>
                                         <label for="wage"/>
                                         <div class="o_row" name="wage">


### PR DESCRIPTION
The new contract button only raises errors. It's not intuitive. Instead it should open a datepicker and create a version with a contract according to some logic.

Task: 5047579
