### PR TITLE
[FIX] purchase: harmonize product searching on order line

### DIFF
--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -63,6 +63,11 @@ class ProductProduct(models.Model):
     purchased_product_qty = fields.Float(compute='_compute_purchased_product_qty', string='Purchased',
         digits='Product Unit of Measure')
 
+    @api.model
+    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+        domain = ['|', ('default_code', operator, name), ('name', operator, name)]
+        return self._search(domain, limit=limit, order=order)
+
     def _compute_purchased_product_qty(self):
         date_from = fields.Datetime.to_string(fields.Date.context_today(self) - relativedelta(years=1))
         domain = [


### PR DESCRIPTION
## Versions
17.0+

## Issue
Inconsistent product lookup behavior between Sales Orders and Purchase Orders.
When searching for a product in a Sales Order line, all matching products are suggested, regardless of letter casing.
However, in Purchase Orders, the same search behaves differently. If "Variant Grid Entry" is **unchecked**, only an exact (case-sensitive) match is returned.

## Steps to reproduce
*Ensure Sales app is installed*
- Create 2 products:
  - Product 1:
    - Name: TEST;
    - Internal Reference: Aa1.
  - Product 2:
    - Name: TEST;
    - Internal Reference: aA1.
- Create a SO for any customer:
  - Add product by looking for "Aa1", and see both "TEST" products.
- Go to Purchase's settings:
  - Uncheck "Variant Grid Entry" if checked.
- Create a RFQ for any customer:
  - Add product by looking for "Aa1", and see only one "TEST" product.

## Cause
POs use `product_id` while SOs use `product_template_id`:
https://github.com/odoo/odoo/blob/777f4e8e716db0cdc30c7d7c593e1cbf4a7ae12c/addons/purchase/views/purchase_views.xml#L276
https://github.com/odoo/odoo/blob/777f4e8e716db0cdc30c7d7c593e1cbf4a7ae12c/addons/sale/views/sale_order_views.xml#L492

This means a PO calls `ProductTemplate`'s `_name_search` method while an SO calls `ProductProduct`'s `_name_search` method:
https://github.com/odoo/odoo/blob/777f4e8e716db0cdc30c7d7c593e1cbf4a7ae12c/addons/product/models/product_template.py#L549-L599
https://github.com/odoo/odoo/blob/777f4e8e716db0cdc30c7d7c593e1cbf4a7ae12c/addons/product/models/product_product.py#L543-L591

## Fix
These 2 methods are acting differently but are used in complex flows (like for Barcode app). Adding a more open domain only on Purchase's `ProductProduct` model allows to target specific spots to apply the `ilike` search.

opw-5025352