### PR TITLE
[IMP] stock: Move Serial Number view

### DIFF
--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -166,4 +166,49 @@
     <menuitem action="action_production_lot_form" id="menu_action_production_lot_form"
         parent="menu_stock_inventory_control" groups="stock.group_production_lot"
         sequence="101"/>
+
+    <!-- - - - - - - - - - - Move Serial Numbers  - - - - - - - - - - -->
+
+    <record id="view_production_sn_kanban" model="ir.ui.view">
+        <field name="name">stock.production.lot.kanban</field>
+        <field name="model">stock.lot</field>
+        <field name="arch" type="xml">
+            <kanban group_create="false" group_delete="false">
+                <templates>
+                    <t t-name="card">
+                        <field name="name" class="fw-bolder fs-5"/>
+                        <field name="product_id" class="small"/>
+                        <field name="lot_properties" widget="properties"/>
+                        <field name="activity_ids" widget="kanban_activity"/>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="action_production_sn_form" model="ir.actions.act_window">
+        <field name="name">Move Serial Numbers</field>
+        <field name="res_model">stock.lot</field>
+        <field name="path">move-sn</field>
+        <field name="view_mode">kanban,form</field>
+        <field name="view_ids"
+                   eval="[(5, 0, 0),
+                          (0, 0, {'view_mode': 'kanban', 'view_id': ref('view_production_sn_kanban')})]"/>
+        <field name="search_view_id" ref="search_product_lot_filter"/>
+        <field name="context">{'search_default_group_by_location': 1}</field>
+        <field name="domain">[('product_id.tracking', '=', 'serial'),'|', ('location_id', '=', False), ('location_id.company_id', 'in', allowed_company_ids + [False])]
+        </field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Add a serial number
+          </p><p>
+            Lots/Serial numbers help you tracking the path followed by your products.
+            From their traceability report you will see the full history of their use, as well as their composition.
+          </p>
+        </field>
+    </record>
+
+    <menuitem action="action_production_sn_form" id="menu_action_production_sn_form"
+        parent="menu_stock_inventory_control" groups="stock.group_production_lot"
+        sequence="102"/>
 </odoo>


### PR DESCRIPTION
Adds an Inventory view, for users to move SN
between locations.

task #4894529

Description of the issue/feature this PR addresses:

Users need an easy way to move Serial Numbers between locations (eg. as a vendor of big medtech machinery 
I need to assign machines to specific locations by SN.)

Current behavior before PR:

The view "Lot / Serial Numbers" of the Inventory app allows for such a use case but 
poorly as the view also includes lots. Furthermore, it is quite hard to find, as the view's 
name is not super explicit.  

Desired behavior after PR is merged:

Adds a new "Move Serial Numbers" menu item, with only a Kanban view with the sole 
purpose of moving serial numbers to different locations. The view filters to only display
serial numbers, and brings a few UI improvement to Kanban cards.

task [4894529](https://www.odoo.com/odoo/project/966/tasks/4894529) 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
