### PR TITLE
[FIX] hr_holidays_attendance : Show Extra Hours on Dashboard

### DIFF
--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -80,6 +80,10 @@ class TestHolidaysOvertime(TransactionCase):
 
             self.new_attendance(check_in=datetime(2021, 1, 2, 8), check_out=datetime(2021, 1, 2, 16))
             self.assertEqual(self.employee.total_overtime, 8, 'Should have 8 hours of overtime')
+
+            overtime_leave_data = self.leave_type_no_alloc.get_allocation_data(self.employee)
+            self.assertEqual(overtime_leave_data[self.employee][0][1]['virtual_remaining_leaves'], 8.0)
+
             leave = self.env['hr.leave'].create({
                 'name': 'no overtime',
                 'employee_id': self.employee.id,


### PR DESCRIPTION
### Steps to reproduce:
	- Install Attendance and Time off apps
	- Create some attendance with extra hours for the employee
	- Go to the employee's time off dashboard
	- Notice Extra Hours allocation is not shown

### Cause:
When we are getting the allocation data we check for the leave types that require allocation

https://github.com/odoo/odoo/blob/5f6d2afa8c09fe72c01d056ebef01214567a4a99/addons/hr_holidays/models/hr_leave_type.py#L473

And then when checking the types that doesn't require allocation we are looping on the res that we got from the super which already excluded those types

https://github.com/odoo/odoo/blob/5f6d2afa8c09fe72c01d056ebef01214567a4a99/addons/hr_holidays_attendance/models/hr_leave_type.py#L41-L43

### Fix:
We loop over the self leave types to make sure we are getting all of the employee's leave data whether the type requires allocation or not.

opw-5042325