### PR TITLE
[FIX] sale_timesheet_margin: compute purchase price SOL added after S…

### DIFF
--- a/addons/sale_timesheet_margin/models/sale_order_line.py
+++ b/addons/sale_timesheet_margin/models/sale_order_line.py
@@ -7,12 +7,13 @@ class SaleOrderLine(models.Model):
 
     @api.depends('analytic_line_ids.amount', 'qty_delivered_method')
     def _compute_purchase_price(self):
-        # filter out the ale.order.lines called by this override of _compute_purchase_price for which
+        # filter out the sale.order.lines called by this override of _compute_purchase_price for which
         # we don't want the purchase price to be recomputed. Without filtring out the sale.order.lines
         # for which the recomputation was triggered by a depency from another override of _compute_purchase_price
         service_non_timesheet_sols = self.filtered(
             lambda sol: not sol.is_expense and sol.is_service and
-            sol.product_id.service_policy == 'ordered_prepaid' and sol.state == 'sale'
+            sol.product_id.service_policy == 'ordered_prepaid' and
+            sol.state == 'sale' and sol.purchase_price != 0
         )
         timesheet_sols = self.filtered(
             lambda sol: sol.qty_delivered_method == 'timesheet' and not sol.product_id.standard_price


### PR DESCRIPTION
…O confirmation

**Problem:**
When a service is added on a SO after the confirmation the cost column (purchase_price) is 0

**Steps to reproduce:**
- make sure that sale_timesheet_margin is installed
- create a service with a positive cost
- create a SO for 1 unit of this service
- confirm
- add a new line on the SO for the same service

**Current behavior:**
the cost is 0

**Expected behavior:**
the cost should be the cost you set on the product form

**Cause of the issue:**
since this PR https://github.com/odoo/odoo/pull/207228 services that are "ordered_prepaid" on confirmed sale order are filtered out the purchase price computation
https://github.com/odoo/odoo/blob/5f6d2afa8c09fe72c01d056ebef01214567a4a99/addons/sale_timesheet_margin/models/sale_order_line.py#L9-L15

opw-5016622