### PR TITLE
[IMP] point_of_sale - Adding an payment seceen hook in order to enable JIT current order transformations before sync

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -288,6 +288,9 @@ export class PaymentScreen extends Component {
             await this._finalizeValidation();
         }
     }
+    async beforeSyncAllOrders(){
+        // A hook to perform potential additional localization operations and/or transfomrations on the currentOrder before running sync
+    }
     async _finalizeValidation() {
         if (this.currentOrder.is_paid_with_cash() || this.currentOrder.get_change()) {
             this.hardwareProxy.openCashbox();
@@ -306,6 +309,9 @@ export class PaymentScreen extends Component {
         this.env.services.ui.block();
         let syncOrderResult;
         try {
+            // 0. Execute before sync hook
+            await this.beforeSyncAllOrders();
+
             // 1. Save order to server.
             syncOrderResult = await this.pos.syncAllOrders({ throw: true });
             if (!syncOrderResult) {


### PR DESCRIPTION
Hi guys,

I hope you could help us with this very simple PR which targets `point_of_sale` module.

After implementing PoS localization module for Serbia and working with other teams on implementing countless more, we found that the `point_of_sale` module is missing a good place to perform just in time transformation/operation on the current order before syncing it with the backend.

People are managing to implement it in different ways with more or less success in covering some of the flows, but in our humble opinion we have found maybe the best point  and it's a simple hook on the payment screen which should be called before the order sync is invoked. 

Enterprise Support Ticket: 5057437

Cheers,
Petar

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
