### PR TITLE
[FIX] website: fix label of color option in case of "on hover" animation

### DIFF
--- a/addons/website/static/src/builder/plugins/options/animate_option.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_option.xml
@@ -104,7 +104,9 @@
                     t-if="this.isActiveItems(['hover_effect_zoom_in_opt', 'hover_effect_zoom_out_opt', 'hover_effect_mirror_blur_opt', 'hover_effect_dolly_zoom_opt'])"
                     preview="false" min="1" max="100" step="1" displayRangeValue="true"/>
             </BuilderRow>
-            <BuilderRow label.translate="Color" level="2">
+            <t t-if="this.isActiveItems(['hover_effect_zoom_in_opt', 'hover_effect_zoom_out_opt', 'hover_effect_dolly_zoom_opt'])" t-set="color_label">Overlay</t>
+            <t t-else="" t-set="color_label">Color</t>
+            <BuilderRow label="color_label" level="2">
                 <BuilderColorPicker action="'setHoverEffectColor'"
                     enabledTabs="['custom']"
                     t-if="this.isActiveItems(['hover_effect_dolly_zoom_opt', 'hover_effect_overlay_opt', 'hover_effect_zoom_in_opt', 'hover_effect_zoom_out_opt', 'hover_effect_outline_opt'])"


### PR DESCRIPTION
The commit 80b5db99a3c26c3dd4fb5c55e04b8813dddb5b8d brought the options for "on hover" animations into the new website builder. The label for the "Color" option used to change depending on the current effect, and this was lost in the new builder. This commit brings it back

Steps to reproduce:
- Open website builder
- Add an animation "On Hover" (this can be done on images)
- Set the "Effect" to "Zoom Out"
- Bug: the label for the color is "Color" instead of "Overlay"

task-4367641
