### PR TITLE
[FIX] sms_twilio: provide various fixes

### DIFF
--- a/addons/mass_mailing_sms/models/mailing_trace.py
+++ b/addons/mass_mailing_sms/models/mailing_trace.py
@@ -44,6 +44,11 @@ class MailingTrace(models.Model):
         ('sms_not_allowed', 'Not Allowed'),
         ('sms_not_delivered', 'Not Delivered'),
         ('sms_rejected', 'Rejected'),
+        # twilio specific: to move in bridge module in master
+        ('twilio_authentication', 'Authentication Error"'),
+        ('twilio_callback', 'Incorrect callback URL'),
+        ('twilio_from_missing', 'Missing From Number'),
+        ('twilio_from_to', 'From / To identic'),
     ])
 
     @api.depends('sms_id_int', 'trace_type')
@@ -64,6 +69,34 @@ class MailingTrace(models.Model):
             if values.get('trace_type') == 'sms' and not values.get('sms_code'):
                 values['sms_code'] = self._get_random_code()
         return super(MailingTrace, self).create(values_list)
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        # As we are adding keys in stable, better be sure no-one is getting crashes
+        # due to missing translations
+        # TODO: remove in master
+        res = super().fields_get(allfields=allfields, attributes=attributes)
+
+        existing_selection = res.get('failure_type', {}).get('selection')
+        if existing_selection is None:
+            return res
+
+        updated_stable = {
+            'twilio_authentication', 'twilio_callback',
+            'twilio_from_missing', 'twilio_from_to',
+        }
+        need_update = updated_stable - set(dict(self._fields['failure_type'].selection))
+        if need_update:
+            self.env['ir.model.fields'].invalidate_model(['selection_ids'])
+            self.env['ir.model.fields.selection']._update_selection(
+                self._name,
+                'failure_type',
+                self._fields['failure_type'].selection,
+            )
+            self.env.registry.clear_cache()
+            return super().fields_get(allfields=allfields, attributes=attributes)
+
+        return res
 
     def _get_random_code(self):
         """ Generate a random code for trace. Uniqueness is not really necessary

--- a/addons/sms/tests/common.py
+++ b/addons/sms/tests/common.py
@@ -237,6 +237,22 @@ class SMSCase(MockSMS):
         self.assertEqual(notifications.mapped('res_partner_id'), partners)
 
         for recipient_info in recipients_info:
+            # sanity check
+            extra_keys = recipient_info.keys() - {
+                # notification
+                'failure_reason',
+                'failure_type',
+                'state',
+                # sms
+                'sms_fields_values',
+                # recipient
+                'number',
+                'partner',
+                'recipient_check_sms',
+            }
+            if extra_keys:
+                raise ValueError(f'Unsupported values: {extra_keys}')
+
             partner = recipient_info.get('partner', self.env['res.partner'])
             number = recipient_info.get('number')
             state = recipient_info.get('state', 'pending')
@@ -255,20 +271,24 @@ class SMSCase(MockSMS):
             self.assertEqual(notif.author_id, notif.mail_message_id.author_id, 'SMS: Message and notification should have the same author')
             for field_name, expected_value in (mail_message_values or {}).items():
                 self.assertEqual(notif.mail_message_id[field_name], expected_value)
+            if 'failure_reason' in recipient_info:
+                self.assertEqual(notif.failure_reason, recipient_info['failure_reason'])
             if state not in {'process', 'sent', 'ready', 'canceled', 'pending'}:
                 self.assertEqual(notif.failure_type, recipient_info['failure_type'])
-            if check_sms:
+
+            if recipient_info.get('recipient_check_sms', check_sms):
+                fields_values = recipient_info.get('sms_fields_values') or {}
                 if state in {'process', 'pending', 'sent'}:
                     if sent_unlink:
                         self.assertSMSIapSent([number], content=content)
                     else:
-                        self.assertSMS(partner, number, state, content=content)
+                        self.assertSMS(partner, number, state, content=content, fields_values=fields_values)
                 elif state == 'ready':
-                    self.assertSMS(partner, number, 'outgoing', content=content)
+                    self.assertSMS(partner, number, 'outgoing', content=content, fields_values=fields_values)
                 elif state == 'exception':
-                    self.assertSMS(partner, number, 'error', failure_type=recipient_info['failure_type'], content=content)
+                    self.assertSMS(partner, number, 'error', failure_type=recipient_info['failure_type'], content=content, fields_values=fields_values)
                 elif state == 'canceled':
-                    self.assertSMS(partner, number, 'canceled', failure_type=recipient_info['failure_type'], content=content)
+                    self.assertSMS(partner, number, 'canceled', failure_type=recipient_info['failure_type'], content=content, fields_values=fields_values)
                 else:
                     raise NotImplementedError('Not implemented')
 

--- a/addons/sms/tools/sms_api.py
+++ b/addons/sms/tools/sms_api.py
@@ -18,7 +18,7 @@ class SmsApiBase:
 
     def _get_sms_api_error_messages(self):
         """Return a mapping of `_send_sms_batch` errors to an error message."""
-        raise NotImplementedError()
+        return {}
 
     def _send_sms_batch(self, messages, delivery_reports_url=False):
         raise NotImplementedError()
@@ -91,7 +91,8 @@ class SmsApi(SmsApiBase):  # TODO RIGR in master: rename SmsApi to SmsApiIAP, an
             _('Register now.')
         )
 
-        return {
+        error_dict = super()._get_sms_api_error_messages()
+        error_dict.update({
             'unregistered': _("You don't have an eligible IAP account."),
             'insufficient_credit': ' '.join([_("You don't have enough credits on your IAP account."), buy_credits]),
             'wrong_number_format': _("The number you're trying to reach is not correctly formatted."),
@@ -99,4 +100,5 @@ class SmsApi(SmsApiBase):  # TODO RIGR in master: rename SmsApi to SmsApiIAP, an
             'country_not_supported': _("The destination country is not supported."),
             'incompatible_content': _("The content of the message violates rules applied by our providers."),
             'registration_needed': ' '.join([_("Country-specific registration required."), register_now]),
-        }
+        })
+        return error_dict

--- a/addons/sms_twilio/models/__init__.py
+++ b/addons/sms_twilio/models/__init__.py
@@ -1,3 +1,4 @@
+from . import mail_notification
 from . import res_company
 from . import res_config_settings
 from . import sms_composer

--- a/addons/sms_twilio/models/mail_notification.py
+++ b/addons/sms_twilio/models/mail_notification.py
@@ -1,0 +1,45 @@
+from odoo import api, fields, models
+
+
+class MailNotification(models.Model):
+    _inherit = 'mail.notification'
+
+    failure_type = fields.Selection(
+        selection_add=[
+            ('twilio_authentication', 'Authentication Error"'),
+            ('twilio_callback', 'Incorrect callback URL'),
+            ('twilio_from_missing', 'Missing From Number'),
+            ('twilio_from_to', 'From / To identic'),
+        ],
+    )
+
+    # CRUD
+    # ------------------------------------------------------------
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        # As we are adding keys in stable, better be sure no-one is getting crashes
+        # due to missing translations
+        # TODO: remove in master
+        res = super().fields_get(allfields=allfields, attributes=attributes)
+
+        existing_selection = res.get('failure_type', {}).get('selection')
+        if existing_selection is None:
+            return res
+
+        updated_stable = {
+            'twilio_authentication', 'twilio_callback',
+            'twilio_from_missing', 'twilio_from_to',
+        }
+        need_update = updated_stable - set(dict(self._fields['failure_type'].selection))
+        if need_update:
+            self.env['ir.model.fields'].invalidate_model(['selection_ids'])
+            self.env['ir.model.fields.selection']._update_selection(
+                self._name,
+                'failure_type',
+                self._fields['failure_type'].selection,
+            )
+            self.env.registry.clear_cache()
+            return super().fields_get(allfields=allfields, attributes=attributes)
+
+        return res

--- a/addons/sms_twilio/models/sms_sms.py
+++ b/addons/sms_twilio/models/sms_sms.py
@@ -12,6 +12,8 @@ class SmsSms(models.Model):
         selection_add=[
             ('twilio_authentication', 'Authentication Error"'),
             ('twilio_callback', 'Incorrect callback URL'),
+            ('twilio_from_missing', 'Missing From Number'),
+            ('twilio_from_to', 'From / To identic'),
         ],
     )
 
@@ -23,6 +25,31 @@ class SmsSms(models.Model):
         for vals in vals_list:
             vals['record_company_id'] = vals.get('record_company_id') or self.env.company.id  # TODO RIGR in master: move this field to SmsSms, and populate it via vals_list from all flows
         return super().create(vals_list)
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        # As we are adding keys in stable, better be sure no-one is getting crashes
+        # due to missing translations
+        # TODO: remove in master
+        res = super().fields_get(allfields=allfields, attributes=attributes)
+
+        existing_selection = res.get('failure_type', {}).get('selection')
+        if existing_selection is None:
+            return res
+
+        updated_stable = {'twilio_from_missing', 'twilio_from_to'}
+        need_update = updated_stable - set(dict(self._fields['failure_type'].selection))
+        if need_update:
+            self.env['ir.model.fields'].invalidate_model(['selection_ids'])
+            self.env['ir.model.fields.selection']._update_selection(
+                self._name,
+                'failure_type',
+                self._fields['failure_type'].selection,
+            )
+            self.env.registry.clear_cache()
+            return super().fields_get(allfields=allfields, attributes=attributes)
+
+        return res
 
     # SEND
     # ------------------------------------------------------------

--- a/addons/sms_twilio/models/sms_twilio_number.py
+++ b/addons/sms_twilio/models/sms_twilio_number.py
@@ -4,7 +4,7 @@ from odoo import models, fields
 class SmsTwilioNumber(models.Model):
     _name = 'sms.twilio.number'
     _description = 'Twilio Number'
-    _order = 'sequence'
+    _order = 'sequence, id'
 
     company_id = fields.Many2one(
         'res.company', string='Company',

--- a/addons/sms_twilio/models/sms_twilio_number.py
+++ b/addons/sms_twilio/models/sms_twilio_number.py
@@ -6,7 +6,10 @@ class SmsTwilioNumber(models.Model):
     _description = 'Twilio Number'
     _order = 'sequence'
 
-    company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
+    company_id = fields.Many2one(
+        'res.company', string='Company',
+        required=True, ondelete='cascade',
+        default=lambda self: self.env.company)
     sequence = fields.Integer(default=1)
     number = fields.Char(string='Twilio Number', required=True)
     country_id = fields.Many2one("res.country", string='Country', required=True)

--- a/addons/sms_twilio/tests/common.py
+++ b/addons/sms_twilio/tests/common.py
@@ -23,9 +23,13 @@ class MockSmsTwilioApi(SMSCase):
         cls.twilio_invalid_phone_number = "+3212312312"
 
         # mock control
-        cls.mock_ok = True
+        cls.mock_error_type = False
+        cls.mock_error_number_to_type = {}
         cls.mock_body = False
+        if cls.env:  # in 17, classes is quite a bordel
+            cls.mock_company = cls.env.company
         cls.mock_number = False
+        cls.mock_sms_uuid = 'NA'
 
         # find details of outgoing requests
         cls.twilio_request_re = re.compile(r"https://api.twilio.com/2010-04-01/Accounts/(AC[\d]{32})/(.*)")
@@ -66,7 +70,6 @@ class MockSmsTwilioApi(SMSCase):
         }
         cls.request_send_nok_json = {
             'code': 21211,
-            'message': "Invalid 'To' Phone Number: +324863XXXX",
             'more_info': 'https://www.twilio.com/docs/errors/21211',
             'status': 400,
         }
@@ -89,15 +92,31 @@ class MockSmsTwilioApi(SMSCase):
                 }
                 return response
             elif right_part == "Messages.json":
-                if cls.mock_ok:
+                error_type = cls.mock_error_number_to_type.get(cls.mock_number) or cls.mock_error_type
+                if not error_type and not cls.mock_number:
+                    error_type = "sms_number_missing"
+                error_codes = {
+                    'wrong_number_format': 21211,
+                    'sms_number_missing': 21604,
+                    'twilio_acc_unverified': 21608,
+                    'twilio_callback': 21609,
+                    'unknown': 1,
+                    'other': 1,
+                }
+                if not error_type:
                     request_send_ok_json = cls.request_send_ok_json.copy()
                     request_send_ok_json['body'] = cls.mock_body or 'body'
                     request_send_ok_json['sid'] = f'twilio_{cls.mock_company.name}_{cls.mock_sms_uuid}' if cls.mock_sms_uuid else 'SMFake'
                     request_send_ok_json['to_number'] = cls.mock_number or 'to_number'
                     response.json = lambda: request_send_ok_json
                 else:
+                    if error_type not in error_codes:
+                        raise ValueError('Unsupported error code')
+                    error_code = error_codes.get(error_type) if error_type else False
+
                     request_send_nok_json = cls.request_send_nok_json.copy()
                     request_send_nok_json['body'] = cls.mock_body or 'body'
+                    request_send_nok_json['code'] = error_code
                     request_send_nok_json['to_number'] = cls.mock_number or 'to_number'
                     response.json = lambda: request_send_nok_json
                     response.status_code = 400
@@ -110,26 +129,57 @@ class MockSmsTwilioApi(SMSCase):
             "sms_provider": "twilio",
             "sms_twilio_account_sid": "AC12345678987654321234567898765432",
             "sms_twilio_auth_token": "grimgorironhide",
+            "sms_twilio_number_ids": [
+                (5, 0),
+                (0, 0, {
+                    "country_id": cls.env.ref("base.be").id,
+                    "number": "+32455998877",
+                    "sequence": 0,
+                }),
+                (0, 0, {
+                    "country_id": cls.env.ref("base.us").id,
+                    "number": "+15056998877",
+                    "sequence": 1,
+                }),
+            ],
         })
 
     @classmethod
-    def _update_mock(cls, mock_ok, mock_body, mock_number, mock_sms_uuid, mock_company):
-        cls.mock_ok = mock_ok
+    def _update_mock(cls, error_type=None, error_number_to_type=None,
+                     body=None, number=False, sms_uuid=False,
+                     company=False):
+        if error_type is not None:
+            cls.mock_error_type = error_type
+        if error_number_to_type is not None:
+            cls.mock_error_number_to_type = error_number_to_type
         # various data, used notably to forge better simulated responses
-        cls.mock_body = mock_body
-        cls.mock_company = mock_company
-        cls.mock_number = mock_number
-        cls.mock_sms_uuid = mock_sms_uuid or 'NA'
+        if body is not None:
+            cls.mock_body = body
+        if company is not False:
+            cls.mock_company = company
+        if number is not False:
+            cls.mock_number = number
+        if sms_uuid is not False:
+            cls.mock_sms_uuid = sms_uuid
 
     @contextmanager
-    def mock_sms_twilio_send(self, ok=True):
+    def mock_sms_twilio_send(self, error_type=False, error_number_to_type=None):
         self._clear_sms_sent()
-        self._update_mock(ok, False, False, False, False)
+        self._update_mock(
+            error_type=error_type,
+            error_number_to_type=error_number_to_type,
+            company=self.env.company,
+        )
         sms_twilio_send_request_origin = SmsApiTwilio._sms_twilio_send_request
 
         def _sms_api_twilio_sms_twilio_send_request(model, *args, **kwargs):
             (_session, to_number, body, uuid) = args
-            self._update_mock(self.mock_ok, body, to_number, uuid, model.company)
+            self._update_mock(
+                error_type=self.mock_error_type,
+                error_number_to_type=self.mock_error_number_to_type,
+                body=body, number=to_number, sms_uuid=uuid,
+                company=model.company,
+            )
             res = sms_twilio_send_request_origin(model, *args, **kwargs)
             self._sms += [{
                 'body': body,
@@ -143,7 +193,7 @@ class MockSmsTwilioApi(SMSCase):
             yield
 
     @contextmanager
-    def mock_sms_twilio_gateway(self, ok=True):
+    def mock_sms_twilio_gateway(self, error_type=False, error_number_to_type=None):
         self._clear_sms_sent()
         sms_create_origin = SmsSms.create
 
@@ -154,7 +204,7 @@ class MockSmsTwilioApi(SMSCase):
 
         with (
             patch.object(SmsSms, 'create', autospec=True, wraps=SmsSms, side_effect=_sms_sms_create),
-            self.mock_sms_twilio_send(ok=ok),
+            self.mock_sms_twilio_send(error_type=error_type, error_number_to_type=error_number_to_type),
         ):
             yield
 

--- a/addons/sms_twilio/tests/test_sms_twilio.py
+++ b/addons/sms_twilio/tests/test_sms_twilio.py
@@ -16,12 +16,15 @@ class TestSmsTwilio(MockSmsTwilio):
 
     @users('employee')
     def test_send_sms_composer_number(self):
-        for number, expected_status, expected_failure_type, expected_to_delete in [
-            (self.twilio_valid_phone_number, "pending", False, True),
-            (self.twilio_invalid_phone_number, "error", "sms_number_format", False),
+        for number, twilio_error, expected_status, expected_failure_type, expected_to_delete in [
+            (self.twilio_valid_phone_number, False, "pending", False, True),
+            # check some error code support
+            (self.twilio_valid_phone_number, "twilio_callback", "error", "twilio_callback", False),
+            (self.twilio_invalid_phone_number, "wrong_number_format", "error", "sms_number_format", False),
+            (self.twilio_invalid_phone_number, "sms_number_missing", "error", "sms_number_missing", False),
         ]:
-            with self.subTest(number=number):
-                with self.mock_sms_twilio_gateway(ok=(number != self.twilio_invalid_phone_number)):
+            with self.subTest(number=number, twilio_error=twilio_error):
+                with self.mock_sms_twilio_gateway(error_type=twilio_error):
                     body = f"Send SMS to {number}"
                     composer = self.env['sms.composer'].create({
                         'body': body,
@@ -40,25 +43,36 @@ class TestSmsTwilio(MockSmsTwilio):
 
     @users('employee')
     def test_send_sms_composer_partner(self):
-        for partner, expected_status, expected_failure_type, expected_to_delete in [
-            (self.valid_partner, "pending", False, True),
-            (self.invalid_partner, "error", "sms_number_format", False),
+        for partner, twilio_error, exp_notif_status, exp_failure_type, exp_failure_reason, exp_to_delete in [
+            (self.valid_partner, False, "pending", False, False, True),
+            # check some error code support
+            (
+                self.invalid_partner, "wrong_number_format", "exception", "sms_number_format",
+                "The number you're trying to reach is not correctly formatted.", False
+            ), (
+                self.invalid_partner, "sms_number_missing", "exception", "sms_number_missing",
+                "A 'To' phone number is required.", False
+            ),
         ]:
-            with self.subTest(partner=partner, number=partner.phone):
-                with self.mock_sms_twilio_gateway(ok=(partner != self.invalid_partner)):
+            with self.subTest(partner=partner, number=partner.phone, twilio_error=twilio_error):
+                with self.mock_sms_twilio_gateway(error_type=twilio_error):
                     body = f"Send SMS to {partner.name}"
                     composer = self.env['sms.composer'].with_context(
                         active_model='res.partner',
-                        active_id=partner,
+                        active_id=partner.id,
                     ).create({'body': body})
-                    composer._action_send_sms()
-                    self.assertSMS(
-                        partner, partner.phone, expected_status,
-                        content=body,
-                        failure_type=expected_failure_type,
-                        fields_values={
-                            "to_delete": expected_to_delete,
-                        },
+                    message = composer._action_send_sms()
+                    self.assertEqual(len(message), 1)
+                    self.assertSMSNotification(
+                        [{
+                            'number': partner.phone, 'partner': partner,
+                            'failure_type': exp_failure_type, 'failure_reason': exp_failure_reason,
+                            'state': exp_notif_status,
+                            'sms_fields_values': {
+                                "to_delete": exp_to_delete,
+                            },
+                        }], body,
+                        messages=message,
                     )
 
     @users('employee')

--- a/addons/sms_twilio/tests/test_sms_twilio.py
+++ b/addons/sms_twilio/tests/test_sms_twilio.py
@@ -45,13 +45,21 @@ class TestSmsTwilio(MockSmsTwilio):
     def test_send_sms_composer_partner(self):
         for partner, twilio_error, exp_notif_status, exp_failure_type, exp_failure_reason, exp_to_delete in [
             (self.valid_partner, False, "pending", False, False, True),
+            # twilio specific issues
+            (
+                self.invalid_partner, "twilio_acc_unverified", "exception", "sms_acc",
+                "Unverified recipient on Trial Account", False
+            ), (
+                self.invalid_partner, "twilio_callback", "exception", "twilio_callback",
+                "Twilio StatusCallback URL is incorrect", False
+            ),
             # check some error code support
             (
                 self.invalid_partner, "wrong_number_format", "exception", "sms_number_format",
-                "The number you're trying to reach is not correctly formatted.", False
+                "The number you're trying to reach is not correctly formatted", False
             ), (
                 self.invalid_partner, "sms_number_missing", "exception", "sms_number_missing",
-                "A 'To' phone number is required.", False
+                "A 'To' phone number is required", False
             ),
         ]:
             with self.subTest(partner=partner, number=partner.phone, twilio_error=twilio_error):

--- a/addons/sms_twilio/tests/test_twilio_account_manage.py
+++ b/addons/sms_twilio/tests/test_twilio_account_manage.py
@@ -36,7 +36,7 @@ class TestSmsTwilio(MockSmsTwilio, TransactionCase):
         for twilio_error, notif_params in zip(
             (False, "wrong_number_format"),
             ({}, {
-                'message': 'sms_number_format: None',
+                'message': 'Wrong Number Format: Wrong Number Format',
                 'type': 'danger',
             }),
             strict=True,

--- a/addons/sms_twilio/tests/test_twilio_account_manage.py
+++ b/addons/sms_twilio/tests/test_twilio_account_manage.py
@@ -33,21 +33,20 @@ class TestSmsTwilio(MockSmsTwilio, TransactionCase):
         wizard = self.env["sms.twilio.account.manage"].create({
             'test_number': '+32455001122',
         })
-        for has_error, notif_params in zip(
-            (False, True),
+        for twilio_error, notif_params in zip(
+            (False, "wrong_number_format"),
             ({}, {
                 'message': 'sms_number_format: None',
                 'type': 'danger',
             }),
             strict=True,
         ):
-            with self.subTest(has_error=has_error):
-                with self.mock_sms_twilio_send(ok=not has_error):
+            with self.subTest(twilio_error=twilio_error):
+                with self.mock_sms_twilio_send(error_type=twilio_error):
                     notif = wizard.action_send_test()
                 params = {
                     'title': "Twilio SMS",
-                    # FIXME: check this
-                    'message': 'The SMS has been sent from False',
+                    'message': 'The SMS has been sent from +32455998877 (Belgium)',
                     'type': 'success',
                     'sticky': False,
                     **notif_params,

--- a/addons/sms_twilio/tools/sms_twilio.py
+++ b/addons/sms_twilio/tools/sms_twilio.py
@@ -4,7 +4,6 @@ import hmac
 
 from werkzeug.urls import url_join
 
-from odoo import fields
 from odoo.addons.phone_validation.tools import phone_validation
 
 
@@ -13,10 +12,13 @@ def get_twilio_from_number(company, to_number):
     :return: the Twilio number from which we'll send the SMS depending on the country of destination (to_number)
     """
     country_code = phone_validation.phone_get_country_code_for_number(to_number)
-    from_number = company.env['sms.twilio.number'].search([
-        ('company_id', '=', company.id),
-    ])
-    return fields.first(from_number.filtered(lambda n: n.country_code == country_code)) or fields.first(from_number)
+    from_number = company.sms_twilio_number_ids
+    if not from_number or not country_code:
+        return from_number[:1]
+    return from_number.sorted(
+        lambda rec: rec.country_code == country_code,
+        reverse=True,
+    )[0]
 
 
 def get_twilio_status_callback_url(company, uuid):

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage.py
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage.py
@@ -86,9 +86,10 @@ class SmsTwilioAccountManage(models.TransientModel):
             message = _("The SMS has been sent from %s", get_twilio_from_number(self.company_id.sudo(), self.test_number).display_name)
         elif sms_su.failure_type != "unknown":
             sms_api = self.company_id._get_sms_api_class()(self.env)
+            failure_type = dict(self.env['sms.sms']._fields['failure_type'].get_description(self.env)['selection']).get(sms_su.failure_type, sms_su.failure_type)
             message = _('%(failure_type)s: %(failure_reason)s',
-                         failure_type=sms_su.failure_type,
-                         failure_reason=sms_api._get_sms_api_error_messages().get(sms_su.failure_type),
+                         failure_type=failure_type,
+                         failure_reason=sms_api._get_sms_api_error_messages().get(sms_su.failure_type, failure_type),
             )
         else:
             message = _("Error: %s", sms_su.failure_type)

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage.py
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage.py
@@ -83,7 +83,7 @@ class SmsTwilioAccountManage(models.TransientModel):
 
         has_error = bool(sms_su.failure_type)
         if not has_error:
-            message = _("The SMS has been sent from %s", get_twilio_from_number(self.company_id, self.test_number).display_name)
+            message = _("The SMS has been sent from %s", get_twilio_from_number(self.company_id.sudo(), self.test_number).display_name)
         elif sms_su.failure_type != "unknown":
             sms_api = self.company_id._get_sms_api_class()(self.env)
             message = _('%(failure_type)s: %(failure_reason)s',

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage.py
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage.py
@@ -77,6 +77,7 @@ class SmsTwilioAccountManage(models.TransientModel):
         composer = self.env['sms.composer'].create({
             'body': _("This is a test SMS from Odoo"),
             'composition_mode': 'numbers',
+            'numbers': self.test_number,
         })
         sms_su = composer._action_send_sms()[0]
 

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -13,7 +13,7 @@ from odoo.tools import mute_logger
 
 
 @tagged('mass_mailing', 'mass_mailing_sms')
-class TestMassSMSInternals(TestMassSMSCommon, MockSmsTwilioApi):
+class TestMassSMSInternals(TestMassSMSCommon):
 
     @users('user_marketing')
     def test_mass_sms_domain(self):
@@ -283,32 +283,6 @@ class TestMassSMSInternals(TestMassSMSCommon, MockSmsTwilioApi):
         with self.with_user('user_marketing'):
             with self.mock_mail_gateway(), self.assertRaises(Exception):
                 mailing_test.action_send_sms()
-
-    def test_mass_sms_test_button_twilio(self):
-        """ Test the testing tool when twilio is activated on company """
-        self._setup_sms_twilio(self.user_marketing.company_id)
-
-        mailing = self.env['mailing.mailing'].create({
-            'name': 'TestButton',
-            'subject': 'Subject {{ object.name }}',
-            'preview': 'Preview {{ object.name }}',
-            'state': 'draft',
-            'mailing_type': 'sms',
-            'body_plaintext': 'Hello {{ object.name }}',
-            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
-        })
-        mailing_test = self.env['mailing.sms.test'].with_user(self.user_marketing).create({
-            'numbers': '+32456001122',
-            'mailing_id': mailing.id,
-        })
-
-        with self.with_user('user_marketing'):
-            with self.mock_sms_twilio_gateway():
-                mailing_test.action_send_sms()
-
-        self.assertSMS(
-            self.env["res.partner"], '+32456001122', 'outgoing',
-        )
 
 
 @tagged('mass_mailing', 'mass_mailing_sms')

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -435,26 +435,68 @@ class TestMassSMSTwilio(TestMassSMSCommon, MockSmsTwilioApi):
         super().setUpClass()
         cls._setup_sms_twilio(cls.user_admin.company_id)
 
-    @users('user_marketing')
-    def test_mass_sms(self):
-        mailing = self.env['mailing.mailing'].browse(self.mailing_sms.ids)
-        mailing.write({
+        cls.mailing_sms.write({
             'body_plaintext': 'This is a mass SMS',
             'sms_template_id': False,
             'sms_force_send': True,
             'sms_allow_unsubscribe': False,
         })
+        cls.records_fail = cls.env['mail.test.sms'].create([
+            {
+                'name': 'MassSMSTest- No Number',
+                'phone_nbr': False,
+            }, {
+                'name': 'MassSMSTest- Invalid Number',
+                'phone_nbr': '1234',
+            },
+        ])
+        cls.records += cls.records_fail
+        cls.records_numbers += [False, '1234']
+
+    @users('user_marketing')
+    def test_mass_sms(self):
+        """ Test SMS marketing using twilio """
+        mailing = self.env['mailing.mailing'].browse(self.mailing_sms.ids)
 
         with self.mock_sms_twilio_gateway():
             mailing.action_send_sms()
 
+        exp_failure_types = [False] * 10 + ['sms_number_missing', 'sms_number_format']
         self.assertSMSTraces(
             [{
+                'failure_type': exp_failure_types[i],
                 'partner': record.customer_id,
                 'number': self.records_numbers[i],
-                'trace_status': 'pending',
+                'trace_status': 'pending' if record not in self.records_fail else 'cancel',
                 'content': 'This is a mass SMS',
             } for i, record in enumerate(self.records)],
             mailing,
             self.records,
         )
+
+    @users('user_marketing')
+    def test_mass_sms_twilio_issue(self):
+        """ Test specific propagation / update to trace failure_type from twilio
+        errors """
+        for error_type, exp_failure_type in [
+            ("twilio_acc_unverified", "sms_acc"),
+            ("twilio_callback", "twilio_callback"),
+        ]:
+            with self.subTest(error_type=error_type):
+                mailing = self.env['mailing.mailing'].browse(self.mailing_sms.ids).copy()
+
+                with self.mock_sms_twilio_gateway(error_type=error_type):
+                    mailing.action_send_sms()
+
+                exp_failure_types = [exp_failure_type] * 10 + ['sms_number_missing', 'sms_number_format']
+                self.assertSMSTraces(
+                    [{
+                        'failure_type': exp_failure_types[i],
+                        'partner': record.customer_id,
+                        'number': self.records_numbers[i],
+                        'trace_status': 'error' if record not in self.records_fail else 'cancel',
+                        'content': 'This is a mass SMS',
+                    } for i, record in enumerate(self.records)],
+                    mailing,
+                    self.records,
+                )

--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -183,7 +183,7 @@ class TestMailingSMSTest(TestMassMailCommon, MockSmsTwilioApi):
             (False, 'outgoing', '<ul><li>Test SMS successfully sent to +32456001122</li></ul>'),
             (
                 'wrong_number_format', 'outgoing',  # not sure why outgoing but hey
-                "<ul><li>Test SMS could not be sent to +32456001122: The number you're trying to reach is not correctly formatted.</li></ul>"
+                "<ul><li>Test SMS could not be sent to +32456001122: The number you're trying to reach is not correctly formatted</li></ul>"
             ),
         ]:
             with self.subTest(error_type=error_type):

--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import lxml.html
 
+from odoo.addons.sms_twilio.tests.common import MockSmsTwilioApi
 from odoo.addons.test_mass_mailing.tests.common import TestMassMailCommon
 from odoo.fields import Command
 from odoo.tests.common import users, tagged
@@ -150,3 +151,48 @@ class TestMailingTest(TestMassMailCommon):
             subject=expected_subject,
             body_content=expected_body,
         )
+
+
+@tagged('mailing_manage', 'twilio')
+class TestMailingSMSTest(TestMassMailCommon, MockSmsTwilioApi):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_sms_twilio(cls.user_marketing.company_id)
+
+    def test_mass_sms_test_button_twilio(self):
+        """ Test the testing tool when twilio is activated on company """
+        self._setup_sms_twilio(self.user_marketing.company_id)
+
+        mailing = self.env['mailing.mailing'].create({
+            'name': 'TestButton',
+            'subject': 'Subject {{ object.name }}',
+            'preview': 'Preview {{ object.name }}',
+            'state': 'draft',
+            'mailing_type': 'sms',
+            'body_plaintext': 'Hello {{ object.name }}',
+            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+        })
+        mailing_test = self.env['mailing.sms.test'].with_user(self.user_marketing).create({
+            'numbers': '+32456001122',
+            'mailing_id': mailing.id,
+        })
+
+        for error_type, exp_state, exp_msg in [
+            (False, 'outgoing', '<ul><li>Test SMS successfully sent to +32456001122</li></ul>'),
+            (
+                'wrong_number_format', 'outgoing',  # not sure why outgoing but hey
+                "<ul><li>Test SMS could not be sent to +32456001122: The number you're trying to reach is not correctly formatted.</li></ul>"
+            ),
+        ]:
+            with self.subTest(error_type=error_type):
+                with self.with_user('user_marketing'):
+                    with self.mock_sms_twilio_gateway(error_type=error_type):
+                        mailing_test.action_send_sms()
+
+                notification = mailing.message_ids[0]
+                self.assertEqual(notification.body, exp_msg)
+                self.assertSMS(
+                    self.env["res.partner"], '+32456001122', exp_state,
+                )


### PR DESCRIPTION
Followup of odoo/odoo#206818 and odoo/enterprise#93495

Provide various improvements in testing tools, notably to better cover
twilio feedback and error type management.

Provide various fixes linked to error types, propagation, error messages.

Fix propagation to mail notification and mailing traces, which was missing
in original PR.

For more details see sub commits.

Task-5053537