### PR TITLE
[FIX] iot,hw_drivers: fix token/identifier bug

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -45,6 +45,7 @@ class Manager(Thread):
             iot_box = {
                 'name': helpers.get_hostname(),
                 'identifier': helpers.get_mac_address(),
+                'serial_number': helpers.get_serial_number(),
                 'ip': domain,
                 'token': helpers.get_token(),
                 'version': helpers.get_version(detailed_version=True),

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -280,6 +280,20 @@ def get_mac_address():
             if addr != '00:00:00:00:00:00':
                 return addr
 
+
+def get_serial_number():
+    if platform.system() == 'Linux':
+        return read_file_first_line('/sys/firmware/devicetree/base/serial-number').strip("\x00")
+
+    # On windows, get motherboard's uuid (serial number isn't reliable as it's not always present)
+    command = ['powershell', '-Command', "(Get-CimInstance Win32_ComputerSystemProduct).UUID"]
+    p = subprocess.run(command, stdout=subprocess.PIPE, check=False)
+    if p.returncode != 0:
+        _logger.error("Failed to get Windows IoT serial number")
+        return False
+
+    return p.stdout.decode().strip() or False
+
 def get_path_nginx():
     return str(list(Path().absolute().parent.glob('*nginx*'))[0])
 


### PR DESCRIPTION
We are currently experiencing a bug with the image 25_07 build on saas-18.4 In this version the "identifier" used in iot app is the iot box's serial number In versions < 18.4 the identifier used is the iot box's mac address

When connecting to a database in version 18.3 or less, the iot box: 1) Calls send_all_devices --> create a new iot box in the database with identifier = serial number 2) Runs git checkout to align itself to the database version 3) Calls send_all_devices again, this time with identifier = mac address 4) The database ignores the request because it considers it a new iot box with a different token

This PR fixes the issue by sending both mac address and serial number to the database If the database has an iot box with the corresponding serial number as an identifier, it updates it.

Enterprise PR: https://github.com/odoo/enterprise/pull/93657
