### PR TITLE
[FIX] l10n_it_edi: double discount when import xml bill

### DIFF
--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -135,7 +135,7 @@ class TestItEdiImport(TestItEdi):
                 'name': 'BILL/2023/09/0001',
                 'ref': '333333333333333',
                 'invoice_date': fields.Date.from_string('2023-09-08'),
-                'amount_untaxed': 57.54,
+                'amount_untaxed': 39.54,
                 'amount_tax': 3.95,
             }])
 
@@ -240,7 +240,7 @@ class TestItEdiImport(TestItEdi):
 
         self._assert_import_invoice('IT01234567890_FPR01.xml', [{
             'invoice_date': fields.Date.from_string('2014-12-18'),
-            'amount_untaxed': 3.0,
+            'amount_untaxed': 5.0,
             'amount_tax': 1.1,
             'invoice_line_ids': [
                 {
@@ -248,11 +248,6 @@ class TestItEdiImport(TestItEdi):
                     'name': 'DESCRIZIONE DELLA FORNITURA',
                     'price_unit': 1.0,
                 },
-                {
-                    'quantity': 1.0,
-                    'name': 'SCONTO',
-                    'price_unit': -2,
-                }
             ],
         }], applied_xml)
 


### PR DESCRIPTION
When importing a bill in an IT company the system will automatically parse the xml and populate the record. In case of discount, an element <ScontoMaggiorazione> will be present, either for the whole document or for a single line. However, an extra negative line may be present in the xml representation of the bill, creating a double discount

**Steps to reproduce**

- With an IT Company setup
- Import an xml bill having <ScontoMaggiorazione> element and a negative line representing the same discount

**Issue**

Double discount line will be created in the bill

**Analysis**

This occurs because, when parsing the bill, the system will import also negative lines, even if a discount has been already applied

opw-4913335
[Ticket link](https://www.odoo.com/odoo/project/49/tasks/4913335)