### PR TITLE
[FIX] stock: avoid AccessError when confirming SO with Buy replenishm…

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2352,7 +2352,7 @@ Please change the quantity done or the rounding precision of your unit of measur
                 orderpoints_context_by_company[orderpoint.company_id].setdefault(orderpoint.id, [])
                 orderpoints_context_by_company[orderpoint.company_id][orderpoint.id].append(move.origin)
         for company, orderpoints in orderpoints_by_company.items():
-            orderpoints.with_context(origins=orderpoints_context_by_company[company])._procure_orderpoint_confirm(
+            orderpoints.sudo().with_context(origins=orderpoints_context_by_company[company])._procure_orderpoint_confirm(
                 company_id=company, raise_user_error=False)
 
     def _trigger_assign(self):


### PR DESCRIPTION
…ent to a cross-company vendor

Confirming a Sales Order for a product that has a *Buy* replenishment rule pointing to a vendor in another company fails with `AccessError` in `_get_filtered_supplier` / `_get_fiscal_position` because the salesman cannot read that vendor. Run `_procure_orderpoint_confirm()` with `sudo()` on the orderpoints so the replenishment can run and the SO be confirmed.

Description of the issue/feature this PR addresses:

When confirming a Sales Order, if the salesman belongs to Company A and the product has no company set but has a Buy replenishment rule pointing to a vendor in Company B, the confirmation fails.
Odoo tries to read the vendor data during replenishment and raises an AccessError because the salesman from Company A has no rights on Company B’s vendor.

Current behavior before PR:

Confirming the SO raises an AccessError in _get_filtered_supplier / _get_fiscal_position.
The replenishment cannot be created and the SO cannot be confirmed.

Desired behavior after PR is merged:

_procure_orderpoint_confirm() is executed with sudo() on the orderpoints.
The replenishment is correctly created and the SO is confirmed.
Security rules are still respected: the salesman does not gain access to vendors or POs from other companies.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
