### PR TITLE
[FIX] account: prevent error when zero balance invoice

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3247,6 +3247,7 @@ class AccountMoveLine(models.Model):
         for line in self:
             line.with_context(skip_analytic_sync=True).analytic_distribution = {
                 analytic_line._get_distribution_key(): -analytic_line.amount / line.balance * 100
+                if line.balance else 100
                 for analytic_line in line.analytic_line_ids
             }
 

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -765,6 +765,19 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon, AnalyticCommon):
             f"{self.analytic_account_2.id}": 60,
         })
 
+    def test_zero_balance_invoice_with_analytic_line(self):
+        """ Test that creating an analytic line on a 0-amount invoice does not crash and updates analytic_distribution safely. """
+        self.product_a.list_price = 0.0
+        invoice = self.create_invoice(self.partner_a, self.product_a)
+        invoice.action_post()
+        self.env['account.analytic.line'].create({
+            'name': 'Zero Balance Test',
+            'account_id': self.analytic_account_1.id,
+            'amount': 33.0,
+            'move_line_id': invoice.invoice_line_ids.id,
+        })
+        self.assertEqual(invoice.invoice_line_ids.analytic_distribution, {f"{self.analytic_account_1.id}": 100.0})
+
     def test_analytic_dynamic_update(self):
         plan1 = self.analytic_account_1.plan_id._column_name()
         plan2 = self.analytic_account_3.plan_id._column_name()


### PR DESCRIPTION
The system will crash with error when try to create a analytic item.

**Steps to Produce:-**
1. Install the `Accounting` module with demo data.
2. Go to `Settings > enable Analytic Accounting`.
3. Navigate to `Accounting > Customers > Invoices`.
4. Create a new invoice with total amount = 0 and confirm it.
5. Go to Accounting > Accounting > Transactions > Analytic Items.
6. Create a new Analytic Item and:
   - Set a value in the `Project` field.
   - Under the `Accounting` section, select the `Journal Item` linked to the last created 0-amount invoice and save.

**Error:-**
`ZeroDivisionError: float division by zero`

**Cause:-**
- At [1], when `line.balance` is 0.0 (for example, when a journal item is defined with a total of 0.0), the system raises an error.

**Solution:-**
- Added a condition to compute only when line.balance exists; otherwise,set the value to 100.

[1]: https://github.com/odoo/odoo/blob/dff2423ac320fdb97d6bf1f106dc84be1d71cac2/addons/account/models/account_move_line.py#L3248-L3251

**sentry-6844926153**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
