### PR TITLE
[FIX] hr_recruitment: fix error when selecting refuse reason

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -97,11 +97,11 @@ class ApplicantGetRefuseReason(models.TransientModel):
             'subject': 'subject',
         }
         for wizard in self:
-            if wizard.template_id:
-                for wizard_field_name, template_field_name in fields_to_copy_name_mapping.items():
+            for wizard_field_name, template_field_name in fields_to_copy_name_mapping.items():
+                if wizard.template_id:
                     wizard[wizard_field_name] = wizard.template_id[template_field_name]
-            else:
-                wizard[wizard_field_name] = False
+                else:
+                    wizard[wizard_field_name] = False
 
     def action_refuse_reason_apply(self):
         if self.send_mail:


### PR DESCRIPTION
When user tries to select a refuse reason without Email Template in Application,
A traceback will appear.

Steps to reproduce the error:
- Install ``hr_recruitment`` module
- Go to Recruitment > Configuration > Refuse Reasons > Create a new Reason without Email Template
- Create a Application > Refuse > Select refuse reason without email template

Traceback:
```
UnboundLocalError: cannot access local variable 'wizard_field_name'
where it is not associated with a value
```

https://github.com/odoo/odoo/blob/f6874befe64daf78dc59fa09a349cad305717bed/addons/hr_recruitment/wizard/applicant_refuse_reason.py#L99-L104
Here, the ``wizard_field_name`` variable is referenced before the assignment,
So, It will lead to the above traceback.

sentry-6844982581

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
