### PR TITLE
[FIX] project: prevent error on opening studio view

### DIFF
--- a/addons/project/models/project_update.py
+++ b/addons/project/models/project_update.py
@@ -77,7 +77,7 @@ class ProjectUpdate(models.Model):
     @api.depends('name')
     def _compute_name_cropped(self):
         for update in self:
-            update.name_cropped = (update.name[:57] + '...') if len(update.name) > 60 else update.name
+            update.name_cropped = (update.name[:57] + '...') if update.name and len(update.name) > 60 else update.name
 
     def _compute_closed_task_percentage(self):
         for update in self:


### PR DESCRIPTION
An error currently occurs when opening the studio view.

Steps to reproduce:
---
- Install `Project` and `web_studio`
- Project > Configuration > Projects > Create a New Project
- Click on the `Dashboard` button > Open studio view
- Error in terminal

Traceback:
---
`TypeError: object of type 'bool' has no len()`

This error occurs because `project.update` doesn’t have any records. When opening the studio view, at [1] it tries to compute the record’s name, which is `False`, and `False` has no length.

[1]- https://github.com/odoo/odoo/blob/e0322e2cbc16d2405e66f3b16cbabeac2ad265e7/addons/project/models/project_update.py#L80

sentry-6830573412

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
