### PR TITLE
[FIX] web: x2many field: re-enable delete button after a while

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1051,7 +1051,8 @@ export class ListRenderer extends Component {
             return;
         }
         element.dataset.clicked = true;
-
+        // re-enable the button after a while (this is a manual debounce, but record by record)
+        setTimeout(() => delete element.dataset.clicked, 500);
         this.onDeleteRecord(record, ev);
     }
 


### PR DESCRIPTION
PR [1] aimed at fixing a double-click issue with the delete button in x2many lists. In standard views, it works fine. However, there are customizations (e.g. project sub tasks, product attributes...) that add a confirmation step before actually removing the row. If the user cancelled the deletion, clicking on the delete icon of that row afterwards had no effect at all.

This commit fixes the issue by re-enabling the button after 500ms, thus only preventing double clicks.

[1] https://github.com/odoo/odoo/pull/173481

opw~5019621

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
