### PR TITLE
[FIX] project: simplify embedded actions UI in mobile combined dropdown

### DIFF
--- a/addons/project/static/src/views/project_task_control_panel/project_task_control_panel.xml
+++ b/addons/project/static/src/views/project_task_control_panel/project_task_control_panel.xml
@@ -3,7 +3,7 @@
 
     <t t-name="project.ProjectTaskControlPanel" t-inherit="web.ControlPanel">
         <xpath expr="//button[@name='embedded_actions']" position="replace">
-            <t t-if="showTaskOptions">
+            <t t-if="showTaskOptions and !env.isSmall or env.isSmall and !state.embeddedInfos.embeddedActions?.length">
                 <Dropdown>
                     <button class="btn btn-secondary" t-att-title="taskOptionsTitle">
                         <i class="fa fa-sliders"/>
@@ -22,6 +22,38 @@
                 </Dropdown>
             </t>
         </xpath>
+         <xpath expr="//t[@t-if='state.embeddedInfos.embeddedActions?.length and env.isSmall']" position="replace">
+            <t t-call="project.MobileCombinedActionsDropdown"/>
+        </xpath>
+    </t>
+
+   <t t-name="project.MobileCombinedActionsDropdown">
+        <t t-if="env.isSmall and state.embeddedInfos.embeddedActions?.length">
+            <Dropdown menuClass="'o_combined_mobile_dropdown'">
+                <button class="btn btn-secondary">
+                    <i class="fa fa-sliders" />
+                </button>
+                <t t-set-slot="content">
+                    <DropdownItem
+                        onSelected="() => this.onClickShowSubtasks()"
+                        class="state.showSubtasks ? 'selected' : ''"
+                    >
+                        Show Sub-Tasks
+                    </DropdownItem>
+                    <div role="separator" class="dropdown-divider"/>
+                    <t t-if="state.embeddedInfos.embeddedActions?.length">
+                        <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
+                            <DropdownItem
+                                class="this.getDropdownClass(action)"
+                                onSelected="() => this.onEmbeddedActionClick(action)"
+                            >
+                                <span t-out="action.name" />
+                            </DropdownItem>
+                        </t>
+                    </t>
+                </t>
+            </Dropdown>
+        </t>
     </t>
 
 </templates>


### PR DESCRIPTION
After this commit:

- A single combined dropdown is used in mobile view to avoid overlapping sliders.
- The "Show Sub-Tasks" button is placed at the top of this dropdown.
- Embedded action menu items are displayed directly below, as flat list items.
- This improves mobile usability and ensures a cleaner, unified UI experience.

task-4971617

