### PR TITLE
[FIX] pos_glory_cash: underterministic test

### DIFF
--- a/addons/pos_glory_cash/static/tests/socket_io.test.js
+++ b/addons/pos_glory_cash/static/tests/socket_io.test.js
@@ -52,7 +52,7 @@ describe("when open message is received", () => {
         await waitUntil(() => websocketState.instance.readyState);
 
         websocketState.instance.send(OPEN_MESSAGE);
-        await advanceTime(10000);
+        await advanceTime(11000);
 
         expect(websocketState.received).toHaveLength(2);
         expect(websocketState.received[0]).toBe(PING_MESSAGE);


### PR DESCRIPTION
Before this commit, the socket.io test to check if a ping was sent every 5 seconds was failing about 1/10 times.

After this commit, we increase the `advanceTime` amount from 10 seconds to 11 seconds, which fixes the inconsistency and guarantees that 2x5 second periods have elapsed.

runbot-231444

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
