### PR TITLE
[FIX] l10n_in_ewaybill_stock: fix error-warning color display

### DIFF
--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -410,7 +410,7 @@ class Ewaybill(models.Model):
         self._handle_internal_warning_if_present(ewaybill_error.error_json)
         error_message = ewaybill_error.get_all_error_message()
         blocking_level = "error"
-        if "404" in ewaybill_error.error_codes:
+        if "access_error" in ewaybill_error.error_codes:
             blocking_level = "warning"
         self._write_error(error_message, blocking_level)
 

--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -15,12 +15,12 @@
                     <field name="state" widget="statusbar" statusbar_visible="pending,generated" invisible="state == 'challan'"/>
                 </header>
                 <field name="blocking_level" invisible="1"/>
-                <div class="alert alert-danger" role="alert" style="margin-bottom:0px;" invisible="not error_message or blocking_level == 'error'">
+                <div class="alert alert-danger" role="alert" style="margin-bottom:0px;" invisible="not error_message or blocking_level == 'warning'">
                     <div class="o_row">
                         <field name="error_message"/>
                     </div>
                 </div>
-                <div class="alert alert-warning" role="alert" style="margin-bottom:0px;" invisible="not error_message or blocking_level == 'warning'">
+                <div class="alert alert-warning" role="alert" style="margin-bottom:0px;" invisible="not error_message or blocking_level == 'error'">
                     <div class="o_row">
                         <field name="error_message"/>
                     </div>


### PR DESCRIPTION
Before:
---
Error and warning colors were mismatched in the e-waybill view.

In this commit:
---
Fixed the e-waybill view to correctly display error messages
- Errors now display in red (alert-danger) :red_square: 
- Warnings now display in yellow (alert-warning) :yellow_square: 

AccessError now handled correctly.

---
task-5050937
