### PR TITLE
[FIX] website{,_sale}: fix snippet's button translation and theme related issues

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -528,6 +528,12 @@ class Website(models.Model):
             if template_class not in snippet_classes:
                 snippet_classes.append(template_class)
 
+        # Add 'o_colored_level' to maintain correct color configuration.
+        snippet_classes.append('o_colored_level')
+
+        # Apply class modifications (add/remove) to the snippet or its children.
+        # - If dict is found, apply to the first child matching the selector.
+        # - Otherwise, treated as direct modification on the snippet element.
         class_modifications = [
             ('remove', customizations.get('remove_classes', []) or default_settings.get('remove_classes', [])),
             ('add', customizations.get('add_classes', []) or default_settings.get('add_classes', [])),

--- a/addons/website_sale/const.py
+++ b/addons/website_sale/const.py
@@ -320,7 +320,6 @@ SNIPPET_DEFAULTS = {
         },
         'add_classes': [
             'o_wsale_products_opt_design_cards',
-            'o_wsale_products_opt_rounded_2',
             'o_wsale_products_opt_has_comparison',
             {
                 's_dynamic_snippet_title': 's_dynamic_snippet_title_aside col-lg-3 flex-lg-column justify-content-lg-start',

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_categories/dynamic_snippet_category.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_categories/dynamic_snippet_category.js
@@ -22,13 +22,14 @@ export class DynamicSnippetCategory extends DynamicSnippet {
         super.setup();
         this.templateKey = 'website_sale.s_dynamic_snippet_category.grid';
         const nodeData = this.el.dataset;
+        nodeData.button = nodeData.button || _t("Explore Now");
         const colsCount = uiUtils.isSmall() ? 1 : parseInt(nodeData.columns);
         const colSpanTwo = colsCount !== 1 && (nodeData.size !== 'small' || colsCount === 5);
         // Pass custom data to the template.
         nodeData.customTemplateData = JSON.stringify({
             size: SIZE_CONFIG[nodeData.size].span,
             alignmentClass: ALIGNMENT_CLASSES_MAPPING[nodeData.alignment],
-            buttonText: _t(nodeData.button),
+            buttonText: nodeData.button,
             colSpanTwo: colSpanTwo,
             includeParent: nodeData.parentCategoryId && nodeData.showParent,
             parentCategoryId: parseInt(nodeData.parentCategoryId),

--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_category_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_category_option_plugin.js
@@ -41,7 +41,6 @@ export class DynamicSnippetCategoryOptionPlugin extends Plugin {
                 ['rounded', 2],
                 ['gap', 2],
                 ['size', 'medium'],
-                ['button', 'Explore Now'],
                 ['alignment', 'center'],
             ]) {
                 setDatasetIfUndefined(snippetEl, optionName, value);


### PR DESCRIPTION
The Category List snippet assigns the default `data-button` value from the plugin and try to translate it in the interaction. Since `_t` doesn’t work with expressions, this fails. A fix is introduced in task-5039210 to translate the button value directly in the plugin, but this also required handling in the configurator flow (using `_`)

Fix:
- Assign and translate the default value in the interaction.
- Use the user’s value if provided, otherwise fallback to 'Explore Now'.
- Translation now works correctly when switching between languages, it can be seen [here](https://www.awesomescreenshot.com/video/43758508?key=51e16443bc6364a93b39c9d4f532e0b4)

This PR https://github.com/odoo/odoo/pull/203436 also introduced support for non-website snippets from the configurator with theme customizations but some color configuration issues were found because a required class was missing.

Fix:
- Added the missing class to ensure snippets work properly with customizations.