### PR TITLE
[FIX] web: setting header without label

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings/setting_header.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/setting_header.js
@@ -4,7 +4,7 @@ import { Setting } from "@web/views/form/setting/setting";
 
 export class SettingHeader extends Setting {
     get labelString() {
-        return this.props.string || this.props.record.fields[this.props.name].string;
+        return this.props.string || this.props.record.fields[this.props.name]?.string || "";
     }
 }
 SettingHeader.template = "web.HeaderSetting";

--- a/addons/web/static/src/webclient/settings_form_view/settings/setting_header.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings/setting_header.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="web.HeaderSetting">
         <div class="app_settings_header d-flex flex-column flex-md-row align-items-baseline gap-1 gap-md-5 py-3 bg-warning bg-opacity-25">
-            <label class="o_form_label" t-att-for="props.fieldId">
+            <label t-if="labelString" class="o_form_label" t-att-for="props.fieldId">
                 <t t-esc="labelString"/>
             </label>
             <div class="input-group align-items-baseline w-auto o_field_highlight">

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
@@ -1053,6 +1053,45 @@ QUnit.module("SettingsFormView", (hooks) => {
         assert.containsOnce(target, ".o_list_view", "should be open list view");
     });
 
+    QUnit.test("header without string or field", async (assert) => {
+        serverData.actions = {
+            1: {
+                id: 1,
+                name: "Settings view",
+                res_model: "res.config.settings",
+                type: "ir.actions.act_window",
+                views: [[1, "form"]],
+            },
+            4: {
+                id: 4,
+                name: "Other action",
+                res_model: "task",
+                type: "ir.actions.act_window",
+                views: [[2, "list"]],
+            },
+        };
+
+        serverData.views = {
+            "res.config.settings,1,form": `
+                <form string="Settings" js_class="base_settings">
+                    <app string="CRM" name="crm">
+                        <setting type="header">
+                            <div><span>Personalize setting</span></div>
+                        </setting>
+                    </app>
+                </form>`,
+            "task,2,list": '<tree><field name="display_name"/></tree>',
+            "res.config.settings,false,search": "<search></search>",
+            "task,false,search": "<search></search>",
+        };
+        const webClient = await createWebClient({ serverData });
+
+        await doAction(webClient, 1);
+
+        assert.containsOnce(target, ".app_settings_block:not(.d-none) .app_settings_header");
+        assert.containsNone(target, ".app_settings_header label");
+    });
+
     QUnit.test("clicking a button with dirty settings -- save", async (assert) => {
         registry.category("services").add(
             "action",


### PR DESCRIPTION
Before this commit, an error would occur if a header setting did not contain an attribute string or field. This was because the code tried to infer the label. However, the label should be optional.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
