### PR TITLE
[FIX] mail: unpin threads on mobile by swiping

### DIFF
--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -165,7 +165,7 @@ export class MessagingMenu extends Component {
     }
 
     canUnpinItem(thread) {
-        return thread.canUnpin && thread.message_unread_counter === 0;
+        return thread.canUnpin && thread.selfMember?.message_unread_counter === 0;
     }
 }
 


### PR DESCRIPTION
Before this commit, swiping left to unpin threads in the messaging menu was not working.

This issue was introduced by [1] (which is a backport of [2]), and it stems from trying to acccess the message_unread_counter on the thread instead of the self channel member.

This commit fixes the issue by accessing the property correctly from the self channel member.

[1] https://github.com/odoo/odoo/pull/212793
[2] https://github.com/odoo/odoo/pull/212793

task-5058496