### PR TITLE
[IMP] orm: translation hint

### DIFF
--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -106,6 +106,7 @@ class BaseString(Field[str | typing.Literal[False]]):
         if isinstance(value, bytes):
             s = value.decode()
         else:
+            context = {'lang': record.env.lang or 'en_US'}
             s = str(value)
         value = s[:self.size]
         if validate and callable(self.translate):


### PR DESCRIPTION
Add a local variable context in `convert_to_cache` so we give a hint to the translation mechanism about the language. This is useful when we use _lt on any field inside a create dict.

