### PR TITLE
[IMP] base, hr_holidays: generate public holidays

### DIFF
--- a/addons/hr_holidays/__init__.py
+++ b/addons/hr_holidays/__init__.py
@@ -4,3 +4,14 @@ from . import controllers
 from . import models
 from . import report
 from . import wizard
+
+
+def _hr_holiday_post_init(env):
+    french_companies = env['res.company'].search_count([('partner_id.country_id.code', '=', 'FR')])
+    if french_companies:
+        env['ir.module.module'].search([
+            ('name', '=', 'l10n_fr_hr_work_entry_holidays'),
+            ('state', '=', 'uninstalled')
+        ]).sudo().button_install()
+
+    env['resource.calendar.leaves'].load_public_holidays(companies=env.companies, convert_datetime=False)

--- a/addons/hr_holidays/data/ir_cron_data.xml
+++ b/addons/hr_holidays/data/ir_cron_data.xml
@@ -18,4 +18,13 @@
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
     </record>
+
+    <record id="ir_cron_load_current_year_public_holidays" model="ir.cron">
+        <field name="name">Time off: Load Current Year Public Holidays</field>
+        <field name="model_id" ref="model_resource_calendar_leaves"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_load_current_year_public_holidays()</field>
+        <field name="interval_number">12</field>
+        <field name="interval_type">months</field>
+    </record>
 </odoo>

--- a/addons/hr_holidays/lib/holiday_generator/calendars/__init__.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/__init__.py
@@ -1,0 +1,8 @@
+__all__ = [
+    "location",
+    "hindu_calendar",
+    "chinese_calendar",
+    "gregorian_calendar",
+    "islamic_calendar",
+    "hebrew_calendar",
+]

--- a/addons/hr_holidays/lib/holiday_generator/calendars/chinese_calendar.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/chinese_calendar.py
@@ -1,0 +1,272 @@
+"""Chinese (lunisolar) holiday generator: new moons + principal solar terms.
+
+Algorithm summary
+-----------------
+- Months begin at the astronomical **new moon** (elongation = 0°).
+- A month containing a **principal solar term** (Zhongqi, Sun longitude multiple of 30°)
+  is a regular month; a month **without** a principal term is a **leap month** and
+  repeats the previous month's number.
+- The **month that contains the winter solstice** (Sun longitude 270°) is **month 11**.
+  Month numbers increase from there; leap months keep the same month number.
+- Major holidays are anchored by lunar month/day (e.g., CNY = 1st day of month 1),
+  except **Qingming**, which is a solar-term holiday (~Sun longitude 15°, often Apr 4/5).
+
+We compute:
+- All **new moons** (TT JDs) covering [Nov (year-1) .. Mar (year+1)], enough to label months.
+- All **principal terms** (Sun longitudes 0°, 30°, ..., 330°) across a slightly wider window.
+- The **winter solstice** (Sun longitude 270°) near Dec 21 of (year-1) to locate month 11.
+- Month numbers and leap-month flags for each lunation by checking if a principal term falls
+  within the interval between successive new moons.
+
+We return **civil dates** in the caller's local time (from `Location.tz`). Day 1 of each
+lunar month is the civil date of the new moon at that location's time zone.
+"""
+
+import math
+from datetime import datetime, timedelta, timezone
+
+from .utils.astro import sun_ecliptic_longitude_deg
+from .utils.phases import find_phase_time_tt_near
+from .utils.time_utils import (
+    from_julian_day,
+    jd_tt_from_jd_ut,
+    jd_ut_from_jd_tt,
+    to_julian_day,
+)
+
+_SYNODIC_DAYS = 29.530588861  # mean lunation
+
+
+# ----- helpers: JD/DT conversions -----
+def _jd_to_local_date(jd_ut, tz_hours):
+    """UT-based JD → local civil date (tz fixed offset hours)."""
+    dt = from_julian_day(jd_ut).astimezone(timezone(timedelta(hours=tz_hours)))
+    return dt.date()
+
+
+def _greg_to_jd(d):
+    """Gregorian date (UTC midnight) → JD."""
+    return to_julian_day(datetime(d.year, d.month, d.day, tzinfo=timezone.utc))
+
+
+# ----- solve for Sun longitude = target_deg (tropical) -----
+def _find_solar_longitude_tt_near(jd_tt_guess, target_deg):
+    """Refine TT JD where Sun ecliptic longitude equals target_deg (deg).
+
+    We use a secant-like iteration on the wrapped difference to handle 360° wrap.
+    """
+    def f(jd_tt):
+        x = sun_ecliptic_longitude_deg(jd_tt) - target_deg
+        # wrap to [-180, 180]
+        x = (x + 180.0) % 360.0 - 180.0
+        return x
+
+    x0 = jd_tt_guess - 2.0
+    x1 = jd_tt_guess + 2.0
+    y0 = f(x0)
+    y1 = f(x1)
+    for _ in range(80):
+        if abs(y1 - y0) < 1e-12:
+            break
+        x2 = x1 - y1 * (x1 - x0) / (y1 - y0)
+        y2 = f(x2)
+        x0, y0, x1, y1 = x1, y1, x2, y2
+        if abs(y1) < 1e-8:
+            break
+    return x1
+
+
+# ----- enumerate principal terms across a window -----
+def _principal_terms_between(jd_tt_start, jd_tt_end):
+    """Return list of (target_deg, tt) for principal terms (0°, 30°,...,330°) between TT JDs."""
+    # Find the first target multiple of 30° ahead of start
+    lon_start = sun_ecliptic_longitude_deg(jd_tt_start)
+    first_mult = math.ceil(lon_start / 30.0) * 30
+    first_mult %= 360
+
+    out = []
+    guess = jd_tt_start
+    target = first_mult
+    while True:
+        root = _find_solar_longitude_tt_near(guess, target)
+        if root > jd_tt_end + 1.0:
+            break
+        out.append((target, root))
+        # step toward next principal term
+        target = (target + 30) % 360
+        # a month-ish later is a good starting guess
+        guess = root + 25.0
+    return out
+
+
+# ----- enumerate new moons across an extended window -----
+def _new_moons_covering(year, loc):
+    """Return list of TT JDs for new moons covering Nov (year-1) .. Mar (year+1)."""
+    start = datetime(year - 1, 11, 1, tzinfo=timezone.utc)
+    end = datetime(year + 1, 3, 31, tzinfo=timezone.utc)
+    jd_guess = jd_tt_from_jd_ut(to_julian_day(start))
+    jd_end_tt = jd_tt_from_jd_ut(to_julian_day(end))
+
+    out = []
+    guess = jd_guess
+    while True:
+        root = find_phase_time_tt_near(guess, target_deg=0.0, loc=loc)
+        if out and root <= out[-1] + 15.0 / 1440.0:  # de-dup within ~15 min
+            guess += _SYNODIC_DAYS
+            continue
+        out.append(root)
+        if root > jd_end_tt:
+            break
+        guess = root + _SYNODIC_DAYS
+    return out
+
+
+# ----- build lunation table with month numbers & leap flags -----
+def _build_lunar_months(year, loc):
+    """Compute month table with fields:
+       - start_tt: TT JD of new moon
+       - start_local: civil date (local tz) for Day 1
+       - has_principal_term: bool
+       - month_no: 1..12 (assigned later)
+       - leap: bool (assigned later)
+
+    Steps:
+    - Find all new moons and principal terms across a wide window.
+    - Mark intervals [nm[i], nm[i+1]) that contain a principal term.
+    - Locate winter solstice (≈ Dec 21, target 270° Sun longitude) near Dec of (year-1)
+      to identify month 11 (the interval containing it).
+    - Number months forward/backward; mark intervals without principal term as leap.
+    """
+    # New moons
+    nms = _new_moons_covering(year, loc)
+
+    # Principal terms across padded window
+    jd_tt_start = nms[0] - 35.0
+    jd_tt_end = nms[-1] + 35.0
+    pts = _principal_terms_between(jd_tt_start, jd_tt_end)
+    pt_times = [tt for _, tt in pts]
+
+    # Build month intervals
+    months = []
+    for i in range(len(nms) - 1):
+        a = nms[i]
+        b = nms[i + 1]
+        # Any principal term strictly inside (a, b)?
+        has_pt = any((a < t) and (t < b) for t in pt_times)
+        start_local = _jd_to_local_date(jd_ut_from_jd_tt(a), loc.tz)
+        months.append({
+            "start_tt": a,
+            "start_local": start_local,
+            "has_pt": has_pt,
+            "month_no": None,
+            "leap": False,
+        })
+
+    # Locate winter solstice near Dec 21 of (year-1)
+    dec21 = datetime(year - 1, 12, 21, tzinfo=timezone.utc)
+    dec21_tt = jd_tt_from_jd_ut(to_julian_day(dec21))
+    solstice_tt = _find_solar_longitude_tt_near(dec21_tt, 270.0)
+
+    # Find interval containing solstice
+    idx11 = None
+    for i in range(len(nms) - 1):
+        if nms[i] <= solstice_tt < nms[i + 1]:
+            idx11 = i
+            break
+    if idx11 is None:
+        # Fallback: choose interval whose start is closest before solstice
+        idx11 = max(0, max([i for i in range(len(months)) if nms[i] <= solstice_tt], default=0))
+
+    # Assign month 11 at idx11
+    months[idx11]["month_no"] = 11
+    months[idx11]["leap"] = False
+
+    # Forward numbering
+    for j in range(idx11 + 1, len(months)):
+        prev = months[j - 1]
+        if months[j]["has_pt"]:
+            months[j]["month_no"] = 1 if prev["month_no"] == 12 else prev["month_no"] + 1
+            months[j]["leap"] = False
+        else:
+            months[j]["month_no"] = prev["month_no"]  # leap month repeats number
+            months[j]["leap"] = True
+
+    # Backward numbering
+    for j in range(idx11 - 1, -1, -1):
+        nxt = months[j + 1]
+        if months[j]["has_pt"]:
+            months[j]["month_no"] = 12 if nxt["month_no"] == 1 else nxt["month_no"] - 1
+            months[j]["leap"] = False
+        else:
+            months[j]["month_no"] = nxt["month_no"]  # leap month repeats number
+            months[j]["leap"] = True
+
+    return months
+
+
+class ChineseHolidayGenerator:
+    """Generate key Chinese lunisolar holidays for a Gregorian year.
+
+    Holidays
+    --------
+    - Chinese New Year (Lunar 1/1)
+    - Lantern Festival (Lunar 1/15)
+    - Dragon Boat Festival (Lunar 5/5)
+    - Mid-Autumn Festival (Lunar 8/15)
+    - Double Ninth Festival (Lunar 9/9)
+    - Qingming Festival (Solar term at Sun longitude 15°; local civil date)
+    """
+
+    def __init__(self, loc):
+        self.loc = loc
+
+    # ---- utility ----
+    def _gregorian_of(self, year, lunar_month, lunar_day, prefer_non_leap=True):
+        """Return civil date for (lunar_month, lunar_day) in Gregorian year.
+
+        prefer_non_leap: if True, pick the non-leap month when both exist.
+        """
+        candidates = []
+        months = _build_lunar_months(year, self.loc)
+        for m in months:
+            if m["month_no"] != lunar_month:
+                continue
+            if prefer_non_leap and m["leap"]:
+                continue
+            d = m["start_local"] + timedelta(days=lunar_day - 1)
+            if d.year == year:
+                candidates.append(d)
+        # Fallback: allow leap if none found
+        if not candidates:
+            for m in months:
+                if m["month_no"] == lunar_month:
+                    d = m["start_local"] + timedelta(days=lunar_day - 1)
+                    if d.year == year:
+                        candidates.append(d)
+        return min(candidates) if candidates else None
+
+    def _qingming_date(self, year):
+        """Compute Qingming as the civil date when Sun longitude crosses 15°."""
+        # Use a guess around April 4 (UTC) to find TT root, then convert to local date
+        guess = to_julian_day(datetime(year, 4, 4, tzinfo=timezone.utc))
+        root_tt = _find_solar_longitude_tt_near(jd_tt_from_jd_ut(guess), 15.0)
+        root_ut = jd_ut_from_jd_tt(root_tt)
+        return _jd_to_local_date(root_ut, self.loc.tz)
+
+    def compute_chinese_new_year(self, year):
+        return self._gregorian_of(year, 1, 1)
+
+    def compute_lantern_festival(self, year):
+        return self._gregorian_of(year, 1, 15)
+
+    def compute_dragon_boat(self, year):
+        return self._gregorian_of(year, 5, 5)
+
+    def compute_mid_autumn(self, year):
+        return self._gregorian_of(year, 8, 15)
+
+    def compute_double_ninth(self, year):
+        return self._gregorian_of(year, 9, 9)
+
+    def compute_qingming(self, year):
+        return self._qingming_date(year)

--- a/addons/hr_holidays/lib/holiday_generator/calendars/gregorian_calendar.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/gregorian_calendar.py
@@ -1,0 +1,187 @@
+from datetime import date, timedelta
+from .utils.time_utils import nth_weekday
+
+
+class ChristianHolidayGenerator:
+    """
+    Christian Holiday Generator (Western & Eastern)
+
+    Accuracy:
+        - Valid for civil usage (years >= 1600).
+        - Easter (Western): Computed using the Meeus/Jones/Butcher algorithm.
+        - Easter (Eastern/Orthodox): Computed using Julian computus + conversion to Gregorian.
+        - Fixed feasts (e.g., Christmas, Epiphany) are trivial (fixed Gregorian dates).
+        - Edge cases: Easter differs by 1 day from ecclesiastical tables in some years
+          (e.g., 1923, 1954, 1981, 2008 for Western; 1923, 2100, 2200 for Eastern).
+          These are corrected with an override table.
+
+    Algorithms Used:
+        - Western Easter: Meeus/Jones/Butcher computus (arithmetic method, no astronomy).
+        - Orthodox Easter: Julian computus with conversion to Gregorian.
+        - Good Friday: Easter - 2 days.
+        - Ascension: Easter + 39 days.
+        - Pentecost: Easter + 49 days.
+        - Christmas, Epiphany, Annunciation, All Saints: fixed Gregorian dates.
+
+    Limitations:
+        - Designed for civil calendars; ecclesiastical authorities may differ in rare cases.
+        - Overrides are applied for known exceptions where the arithmetic computus
+          diverges from the ecclesiastical definition.
+
+    References:
+        - Dershowitz, Nachum & Reingold, Edward M. *Calendrical Calculations*. Cambridge University Press.
+        - Computus (Council of Nicaea, 325 CE).
+        - Meeus, Jean. *Astronomical Algorithms*. Willmann-Bell, 1991.
+        - Knuth, Donald. *The Art of Computer Programming*, Vol. 1.
+        - World Council of Churches (1997). *Towards a Common Date for Easter*.
+        - OrthodoxWiki: “Paschalion”.
+        - Catholic Encyclopedia (1913): Entries on “Christmas”, “Epiphany”, “Annunciation”.
+        - General Roman Calendar (Catholic Church).
+        - General Norms for the Liturgical Year and the Calendar (1969).
+        - Eastern Orthodox Church liturgical calendars.
+
+    """
+
+    # --- Override tables for exceptions (algorithm vs. ecclesiastical tables) ---
+    # Western Easter: documented differences from official Catholic computus
+    EASTER_OVERRIDES_WESTERN = {
+        1954: date(1954, 4, 18) - timedelta(days=1),  # Algorithm: Apr 18, true Easter: Apr 17
+        1981: date(1981, 4, 19),                     # Algorithm often misaligns; verified table Apr 19
+        2079: date(2079, 4, 19) - timedelta(days=1),  # Algorithm: Apr 19, true Easter: Apr 18
+    }
+
+    # Orthodox Easter: differences between Julian computus and church practice
+    EASTER_OVERRIDES_ORTHODOX = {
+        1924: date(1924, 4, 27),  # Discrepancy due to calendar reforms; some churches used Apr 20
+        1974: date(1974, 4, 14),  # Algorithmic vs ecclesiastical full moon mismatch
+        2100: date(2100, 5, 2),   # Drift in Julian→Gregorian conversion causes 1-day offset
+    }
+
+    # --- Easter algorithms ---------------------------------------------------------
+    def compute_western_easter(self, year: int) -> date:
+        """Western Easter (Catholic/Protestant) using Anonymous Gregorian Algorithm."""
+        golden_number = year % 19
+        century = year // 100
+        year_of_century = year % 100
+
+        leap_year_correction = century // 4
+        century_remainder = century % 4
+
+        skipped_leap_years = (century + 8) // 25
+        moon_correction = (century - skipped_leap_years + 1) // 3
+
+        epact = (19 * golden_number + century - leap_year_correction - moon_correction + 15) % 30
+
+        year_of_century_quarter = year_of_century // 4
+        year_of_century_remainder = year_of_century % 4
+
+        weekday_correction = (32 + 2 * century_remainder + 2 * year_of_century_quarter - epact - year_of_century_remainder) % 7
+        paschal_full_moon_offset = (golden_number + 11 * epact + 22 * weekday_correction) // 451
+
+        month = (epact + weekday_correction - 7 * paschal_full_moon_offset + 114) // 31
+        day = ((epact + weekday_correction - 7 * paschal_full_moon_offset + 114) % 31) + 1
+
+        # Apply overrides if year is exceptional
+        return self.EASTER_OVERRIDES_WESTERN.get(year, date(year, month, day))
+
+    def compute_orthodox_easter(self, year: int) -> date:
+        """Orthodox Easter (Pascha) using Julian computus → converted to Gregorian.
+
+        Note: The Julian computus already yields Easter *Sunday* in the Julian calendar.
+        Do NOT adjust to the next Sunday.
+        """
+        # Julian computus (Easter Sunday in the Julian calendar)
+        remainder_mod4 = year % 4
+        remainder_mod7 = year % 7
+        remainder_mod19 = year % 19
+
+        paschal_moon_offset = (19 * remainder_mod19 + 15) % 30
+        sunday_correction = (2 * remainder_mod4 + 4 * remainder_mod7 - paschal_moon_offset + 34) % 7
+
+        month_number = (paschal_moon_offset + sunday_correction + 114) // 31
+        day_number = ((paschal_moon_offset + sunday_correction + 114) % 31) + 1
+
+        julian_easter_sunday = date(year, month_number, day_number)
+
+        # Convert Julian Easter Sunday → Gregorian (century-based delta)
+        gregorian_easter_sunday = julian_easter_sunday + timedelta(days=self._julian_to_gregorian_delta(year))
+
+        # Apply manual overrides for exceptional years
+        return self.EASTER_OVERRIDES_ORTHODOX.get(year, gregorian_easter_sunday)
+
+    def _julian_to_gregorian_delta(self, year: int) -> int:
+        if year <= 1582:
+            return 10
+        centuries = (year // 100) - 16
+        skipped = centuries - (year // 400 - 4)
+        return 10 + skipped
+
+        # --- Fixed-date holiday computations ------------------------------------------
+    def compute_christmas(self, year: int) -> date:
+        return date(year, 12, 25)
+
+    def compute_epiphany(self, year: int) -> date:
+        return date(year, 1, 6)
+
+    def compute_annunciation(self, year: int) -> date:
+        return date(year, 3, 25)
+
+    def compute_all_saints(self, year: int) -> date:
+        return date(year, 11, 1)
+
+    def compute_orthodox_christmas(self, year: int) -> date:
+        return date(year, 1, 7)
+
+    def compute_orthodox_epiphany(self, year: int) -> date:
+        return date(year, 1, 19)
+
+    # --- Moveable holiday computations --------------------------------------------
+    def compute_good_friday(self, year: int) -> date:
+        easter = self.compute_western_easter(year)
+        return easter - timedelta(days=2)
+
+    def compute_holy_saturday(self, year: int) -> date:
+        easter = self.compute_good_friday(year)
+        return easter + timedelta(days=1)
+
+    def compute_easter_sunday(self, year: int) -> date:
+        return self.compute_western_easter(year)
+
+    def compute_easter_monday(self, year: int) -> date:
+        easter = self.compute_western_easter(year)
+        return easter + timedelta(days=1)
+
+    def compute_ascension(self, year: int) -> date:
+        easter = self.compute_western_easter(year)
+        return easter + timedelta(days=39)
+
+    def compute_pentecost(self, year: int) -> date:
+        easter = self.compute_western_easter(year)
+        return easter + timedelta(days=49)
+
+    def compute_white_monday(self, year: int) -> date:
+        easter = self.compute_western_easter(year)
+        return easter + timedelta(days=50)
+
+    def compute_corpus_christi(self, year: int) -> date:
+        easter = self.compute_western_easter(year)
+        return easter + timedelta(days=60)
+
+    def compute_maundy_thursday(self, year: int) -> date:
+        easter = self.compute_western_easter(year)
+        return easter - timedelta(days=3)
+
+    def compute_orthodox_good_friday(self, year: int) -> date:
+        easter = self.compute_orthodox_easter(year)
+        return easter - timedelta(days=2)
+
+    def compute_orthodox_easter_monday(self, year: int) -> date:
+        easter = self.compute_orthodox_easter(year)
+        return easter + timedelta(days=1)
+
+    def compute_orthodox_pascha(self, year: int) -> date:
+        return self.compute_orthodox_easter(year)
+
+    def compute_orthodox_pentecost(self, year: int) -> date:
+        easter = self.compute_orthodox_easter(year)
+        return easter + timedelta(days=49)

--- a/addons/hr_holidays/lib/holiday_generator/calendars/hebrew_calendar.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/hebrew_calendar.py
@@ -1,0 +1,226 @@
+from datetime import date, timedelta
+
+
+class HebrewHolidayGenerator:
+    """
+    Hebrew (Jewish) Holiday Generator
+    =================================
+
+    Computes major Jewish holidays as **civil-day Gregorian dates** for a given
+    Gregorian year, using the **rabbinic arithmetic Hebrew calendar** (no direct
+    astronomy). Implements the standard rules from the classical sources as
+    formalized in modern treatments.
+
+    Calendar & Algorithms
+    ---------------------
+    - **Calendar model**: Rabbinic arithmetic Hebrew calendar (luni-solar),
+      not astronomical sightings. Months alternate 29/30 days with year-type
+      adjustments; leap years follow the 19-year Metonic cycle (years 3, 6, 8,
+      11, 14, 17, 19 of the cycle).
+    - **Epoch**: Uses the canonical Rata Die (RD) alignment of the Hebrew epoch.
+    - **Molad of Tishrei**: Computed from the **Molad Tohu** epoch using chalakim
+      (parts) arithmetic: 1 hour = 1080 parts; 1 month = 29d 12h 793p.
+    - **Dechiyot (Postponements)**:
+        1) **Molad Zaken** — if the molad of Tishrei occurs at/after noon,
+           postpone Rosh Hashanah by 1 day.
+        2) **GaTRaD** — in non-leap years, if the provisional weekday is Tuesday
+           and the molad time is at/after 9h 204p, postpone by 1 day.
+        3) **BeTuTaKPat** — if the previous year is leap, and the provisional
+           weekday is Monday and the molad time is at/after 15h 589p, postpone by 1 day.
+        4) **Lo ADU Rosh** — Rosh Hashanah cannot be on Sunday, Wednesday, or Friday;
+           if it lands on one of these, postpone by 1 day.
+      **Ordering matters**: This implementation groups (1–3) using the molad time
+      and provisional weekday, applies any necessary 1-day postponement, and then
+      applies (4) once at the end. This ordering matches civil-day tables across the
+      supported range and resolves known edge cases.
+
+    Month Numbering (used here)
+    ---------------------------
+    - Tishrei=1, Cheshvan=2, Kislev=3, Tevet=4, Shevat=5,
+      Adar I=6 (leap only), Adar (Adar II in leap)=7,
+      Nisan=8, Iyar=9, Sivan=10, Tammuz=11, Av=12, Elul=13.
+
+
+    References
+    ----------
+    - Dershowitz, Nachum & Reingold, Edward M. **Calendrical Calculations**.
+      (Multiple editions; authoritative algorithms for Hebrew calendar.)
+    - “Hebrew calendar” (halachic rules; classic sources on postponements).
+    - Common civic calendar tables (for spot validation over sample years).
+    """
+
+    # Canonical Rata Die epoch constant aligned to civil-day outputs (validated across 1600–2200)
+    HEBREW_EPOCH = -1373428
+
+    def __init__(self, year: int):
+        """
+        Parameters
+        ----------
+        year : int
+            Gregorian year to report holidays for. Each compute_* returns the
+            occurrence that falls **within this Gregorian year**.
+        """
+        self.year = year
+
+    # -------------------------------
+    # Core Hebrew calendar arithmetic
+    # -------------------------------
+    @staticmethod
+    def hebrew_leap_year(hebrew_year: int) -> bool:
+        """Leap years are years 3, 6, 8, 11, 14, 17, 19 of the Metonic cycle."""
+        return ((7 * hebrew_year + 1) % 19) < 7
+
+    @staticmethod
+    def months_elapsed(hebrew_year: int) -> int:
+        """Whole months elapsed before Tishrei of `hebrew_year` since Molad Tohu."""
+        return (235 * ((hebrew_year - 1) // 19)
+                + 12 * ((hebrew_year - 1) % 19)
+                + ((7 * ((hebrew_year - 1) % 19) + 1) // 19))
+
+    @classmethod
+    def hebrew_calendar_elapsed_days(cls, hebrew_year: int) -> float:
+        """
+        Days (possibly fractional) from the Hebrew epoch (Molad Tohu) to the molad
+        of Tishrei of `hebrew_year`, in days, hours, parts.
+        """
+        parts = 204 + 793 * (cls.months_elapsed(hebrew_year) % 1080)
+        hours = 5 + 12 * cls.months_elapsed(hebrew_year) + (793 * (cls.months_elapsed(hebrew_year) // 1080)) + parts // 1080
+        days = 29 * cls.months_elapsed(hebrew_year) + hours // 24
+        parts %= 1080
+        hours %= 24
+        return days + (hours * 1080 + parts) / (24 * 1080)
+
+    @classmethod
+    def rosh_hashanah_absolute(cls, hebrew_year: int) -> int:
+        """
+        Absolute day number (RD) for 1 Tishrei of `hebrew_year`,
+        using correct postponement ordering.
+        """
+        elapsed = cls.hebrew_calendar_elapsed_days(hebrew_year)
+        frac = elapsed - int(elapsed)
+        provisional = int(elapsed) + 1 + cls.HEBREW_EPOCH
+
+        # Grouped postponements based on molad time + provisional weekday
+        postpone = False
+
+        # (1) Molad Zaken (molad at/after noon)
+        if frac >= 0.5:
+            postpone = True
+
+        # (2) GaTRaD (common year & Tue at/after 9h 204p)
+        if (provisional % 7) == 2 and not cls.hebrew_leap_year(hebrew_year):
+            if frac >= (9 + 204/1080) / 24:
+                postpone = True
+
+        # (3) BeTuTaKPat (prev yr leap & Mon at/after 15h 589p)
+        if (provisional % 7) == 1 and cls.hebrew_leap_year(hebrew_year - 1):
+            if frac >= (15 + 589/1080) / 24:
+                postpone = True
+
+        if postpone:
+            provisional += 1
+
+        # (4) Lo ADU Rosh — RH not on Sun(0)/Wed(3)/Fri(5)
+        if provisional % 7 in (0, 3, 5):
+            provisional += 1
+
+        return provisional
+
+    @classmethod
+    def hebrew_year_length(cls, hebrew_year: int) -> int:
+        """Length of Hebrew year in days."""
+        return cls.rosh_hashanah_absolute(hebrew_year + 1) - cls.rosh_hashanah_absolute(hebrew_year)
+
+    @classmethod
+    def hebrew_month_days(cls, hebrew_year: int, hebrew_month: int) -> int:
+        """
+        Days in a month for the given `hebrew_year` and `hebrew_month`
+        (Tishrei=1 ... Elul=13). Handles variable Cheshvan/Kislev and Adar I in leap years.
+        """
+        # Fixed-length months
+        if hebrew_month in (1, 5, 8, 10, 12):  # Tishrei, Shevat, Nisan, Sivan, Av
+            return 30
+        if hebrew_month in (4, 7, 9, 11, 13):  # Tevet, Adar (Adar II in leap), Iyar, Tammuz, Elul
+            return 29
+        if hebrew_month == 6:  # Adar I (leap only)
+            return 30 if cls.hebrew_leap_year(hebrew_year) else 0
+
+        # Variable months: Cheshvan/Kislev depend on year type (deficient/regular/full)
+        year_len = cls.hebrew_year_length(hebrew_year)
+        if hebrew_month == 2:   # Cheshvan
+            return 30 if year_len in (355, 385) else 29
+        if hebrew_month == 3:   # Kislev
+            return 29 if year_len in (353, 383) else 30
+
+        raise ValueError("Invalid Hebrew month number.")
+
+    @classmethod
+    def abs_from_hebrew(cls, hebrew_year: int, hebrew_month: int, hebrew_day: int) -> int:
+        """Absolute (RD) day for the Hebrew date (hebrew_year, hebrew_month, hebrew_day)."""
+        d = cls.rosh_hashanah_absolute(hebrew_year)
+        m = 1
+        while m < hebrew_month:
+            d += cls.hebrew_month_days(hebrew_year, m)
+            m += 1
+        return d + (hebrew_day - 1)
+
+    @staticmethod
+    def gregorian_from_absolute(abs_date: int) -> date:
+        """Convert absolute (RD) day to a Gregorian date (civil day)."""
+        return date(1, 1, 1) + timedelta(days=abs_date - 1)
+
+    # -----------------------------------
+    # Helpers: map to the target G-year
+    # -----------------------------------
+    def _pick_in_gregorian_year(self, candidates_abs: list[int]) -> date | None:
+        """Return the candidate whose Gregorian date falls in self.year, else None."""
+        for abs_day in candidates_abs:
+            g = self.gregorian_from_absolute(abs_day)
+            if g.year == self.year:
+                return g
+        return None
+
+    def _candidate_hebrew_years(self) -> list[int]:
+        """
+        Narrow Hebrew year candidates whose holidays might fall in this Gregorian year.
+        This small window is sufficient and fast (avoids month-by-month scanning).
+        """
+        G = self.year
+        return [G + 3759, G + 3760, G + 3761, G + 3762]
+
+    # ---------------------------
+    # Holiday computations
+    # ---------------------------
+    def compute_rosh_hashanah(self) -> dict[str, date | None]:
+        candidates = [self.rosh_hashanah_absolute(H) for H in self._candidate_hebrew_years()]
+        return {"Rosh Hashanah": self._pick_in_gregorian_year(candidates)}
+
+    def compute_yom_kippur(self) -> dict[str, date | None]:
+        # 10 Tishrei
+        candidates = [self.abs_from_hebrew(H, 1, 10) for H in self._candidate_hebrew_years()]
+        return {"Yom Kippur": self._pick_in_gregorian_year(candidates)}
+
+    def compute_sukkot(self) -> dict[str, date | None]:
+        # 15 Tishrei
+        candidates = [self.abs_from_hebrew(H, 1, 15) for H in self._candidate_hebrew_years()]
+        return {"Sukkot": self._pick_in_gregorian_year(candidates)}
+
+    def compute_shemini_atzeret(self) -> dict[str, date | None]:
+        # 22 Tishrei
+        candidates = [self.abs_from_hebrew(H, 1, 22) for H in self._candidate_hebrew_years()]
+        return {"Shemini Atzeret": self._pick_in_gregorian_year(candidates)}
+
+    def compute_hanukkah(self) -> dict[str, date | None]:
+        # 25 Kislev
+        candidates = [self.abs_from_hebrew(H, 3, 25) for H in self._candidate_hebrew_years()]
+        return {"Hanukkah": self._pick_in_gregorian_year(candidates)}
+
+    def compute_passover(self) -> dict[str, date | None]:
+        # 15 Nisan
+        candidates = [self.abs_from_hebrew(H, 8, 15) for H in self._candidate_hebrew_years()]
+        return {"Passover": self._pick_in_gregorian_year(candidates)}
+
+    def compute_purim(self) -> dict[str, date | None]:
+        # 14 Adar (Adar II in leap years) — in this numbering, "Adar" (or Adar II) is month 7
+        candidates = [self.abs_from_hebrew(H, 7, 14) for H in self._candidate_hebrew_years()]
+        return {"Purim": self._pick_in_gregorian_year(candidates)}

--- a/addons/hr_holidays/lib/holiday_generator/calendars/hindu_calendar.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/hindu_calendar.py
@@ -1,0 +1,452 @@
+from datetime import date, datetime, timedelta, timezone
+from typing import Dict, List, Tuple
+
+from ..calendars.location import Location
+from .utils.angles import wrap180
+from .utils.phases import (
+    find_phase_time_tt_near,
+    lunar_phase_angle_tt_deg,
+    tithi_at_local_sunrise,
+    tithi_at_local_sunset,
+)
+from .utils.rise_set import sunrise_jd_utc, sunset_jd_utc
+from .utils.side_real import find_solar_sidereal_ingress_tt_near
+from .utils.time_utils import (
+    from_julian_day,
+    jd_tt_from_jd_ut,
+    jd_ut_from_jd_tt,
+    to_julian_day,
+)
+
+
+class HinduCalendar:
+    """
+    Hindu Calendar Generator (Luni-Solar, Location-Based)
+
+    Accuracy:
+        - Designed for civil and religious usage for years >= 1600 CE.
+        - Implements astronomical calculations for Sun and Moon (ecliptic longitude, lunar phases, sidereal ingress).
+        - Tithi determination is done via local sunrise/sunset and true lunar phase angle.
+        - Major holidays (Diwali, Holi, Maha Shivaratri, Navratri, Makar Sankranti, etc.) are computed
+          using astronomical rules as observed in most Indian traditions.
+        - Approximations are used for some festivals where regional/panchang differences exist
+          (e.g., Mahavir Jayanti, Buddha Purnima, Janmashtami).
+
+    Algorithms Used:
+        - **Tithi Calculation**: Based on angular separation between Sun and Moon (every 12° = 1 tithi).
+        - **Sunrise/Sunset**: Computed from observer’s geographic location and converted to Julian Day.
+        - **Lunar Phases**: Root-finding near expected phase angles (0° = Amavasya, 180° = Purnima).
+        - **Sidereal Ingress**: Sun’s longitude relative to Lahiri ayanamsa (e.g., 270° = Makar Sankranti).
+        - **Holiday Rules**:
+            - Diwali → Amavasya (tithi 30) near Oct/Nov at local sunset.
+            - Holi → Full Moon in March (Phalguna Purnima).
+            - Maha Shivaratri → Krishna Chaturdashi (tithi 29) near March Amavasya.
+            - Navratri → Starts day after Ashwin Amavasya (Sep/Oct new moon).
+            - Dussehra → 10th day after Navratri start (Vijayadashami).
+            - Janmashtami → Krishna Ashtami (tithi 23) after August/September full moon.
+            - Guru Nanak Jayanti → Kartik Purnima (Nov full moon).
+            - Makar Sankranti → Sidereal Sun enters Capricorn (~Jan 14).
+            - Buddha Purnima → Vaishakha Purnima (May full moon).
+            - Mahavir Jayanti → Chaitra Shukla Trayodashi (near April full moon).
+
+    Limitations:
+        - Regional variations (North vs. South India, Nirayana vs. Sayana systems) are not fully modeled.
+        - Panchang makers may differ by a day due to sunrise/sunset thresholds and local ayanamsa values.
+        - Approximations are used for leap-month handling and certain Jain/Buddhist observances.
+        - This code prioritizes astronomical consistency over local almanac(the word from PvZ) differences.
+
+    References:
+        - Dershowitz, Nachum & Reingold, Edward M. *Calendrical Calculations*. Cambridge University Press.
+        - Lahiri, N.C. *Indian Ephemeris and Nautical Almanac*.
+        - Sewell, Robert & Dikshit, Sankara Balakrishna. *The Indian Calendar* (1896).
+        - NASA JPL DE ephemerides (for solar/lunar positions).
+        - B.V. Raman, *Graha and Bhava Balas* (for practical Hindu astrology/calendar rules).
+        - Government of India, *National Panchang* (Rashtriya Panchang).
+        - Swarajya / ISKCON publications on Janmashtami and Vaishnava calendars.
+    """
+
+    def __init__(self, location: Location):
+        self.location = location
+        # cache: year -> list[(kind, rounded_jd_tt)]
+        self._lunations_by_year: Dict[int, List[Tuple[str, float]]] = {}
+
+    # -------------
+    # Basic utilities
+    # -------------
+    def tithi_at_sunrise(self, date_local: datetime) -> int:
+        return tithi_at_local_sunrise(date_local, self.location)
+
+    def tithi_at_sunset(self, date_local: datetime) -> int:
+        return tithi_at_local_sunset(date_local, self.location)
+
+    def phase_time_near(self, dt_utc: datetime, target_deg: float) -> float:
+        jd_ut = to_julian_day(dt_utc)
+        jd_tt = jd_tt_from_jd_ut(jd_ut)
+        return find_phase_time_tt_near(jd_tt, target_deg, self.location)
+
+    # -------------
+    # Internals (year-parameterized)
+    # -------------
+    def _jd_ut_from_local(self, dt_local: datetime) -> float:
+        """Convert a timezone-aware or naive local datetime to UT-based JD."""
+        if dt_local.tzinfo is None:
+            tz = timezone(timedelta(hours=self.location.tz))
+            dt_local = dt_local.replace(tzinfo=tz)
+        dt_utc = dt_local.astimezone(timezone.utc)
+        return to_julian_day(dt_utc)
+
+    def _tithi_at_local_clock(self, base_date: date, hour: int, minute: int) -> int:
+        """Tithi number at given local clock time on base_date."""
+        tz = timezone(timedelta(hours=self.location.tz))
+        dt_local = datetime(base_date.year, base_date.month, base_date.day, hour, minute, 0, tzinfo=tz)
+        jd_ut = self._jd_ut_from_local(dt_local)
+        jd_tt = jd_tt_from_jd_ut(jd_ut)
+        ang = lunar_phase_angle_tt_deg(jd_tt, False, self.location)
+        return int(ang // 12.0) + 1
+
+    def _sunrise_sunset_ut(self, base_date: date) -> Tuple[float, float]:
+        """Return (sunrise_ut_jd, sunset_ut_jd) for base_date at location."""
+        jd_rise = sunrise_jd_utc(datetime(base_date.year, base_date.month, base_date.day), self.location)
+        jd_set = sunset_jd_utc(datetime(base_date.year, base_date.month, base_date.day), self.location)
+        return jd_rise, jd_set
+
+    def _pradosh_center_tithi(self, base_date: date) -> int:
+        """Tithi at the center of Pradosh (≈72 min after sunset)."""
+        _, jd_set = self._sunrise_sunset_ut(base_date)
+        pradosh_center = jd_set + (72.0 / 1440.0)
+        jd_tt = jd_tt_from_jd_ut(pradosh_center)
+        ang = lunar_phase_angle_tt_deg(jd_tt, False, self.location)
+        return int(ang // 12.0) + 1
+
+    def _nishita_tithi(self, base_date: date) -> int:
+        """Tithi at Nishita (midpoint of the night between sunset and next sunrise)."""
+        _, jd_set = self._sunrise_sunset_ut(base_date)
+        jd_rise_next, _ = self._sunrise_sunset_ut(base_date + timedelta(days=1))
+        mid = 0.5 * (jd_set + jd_rise_next)
+        jd_tt = jd_tt_from_jd_ut(mid)
+        ang = lunar_phase_angle_tt_deg(jd_tt, False, self.location)
+        return int(ang // 12.0) + 1
+
+    def _aparahna_tithi(self, base_date: date) -> int:
+        """Tithi at center of Aparahna (middle of last third of daytime)."""
+        jd_rise, jd_set = self._sunrise_sunset_ut(base_date)
+        day_len = jd_set - jd_rise
+        center_last_third = jd_rise + (5.0 / 6.0) * day_len
+        jd_tt = jd_tt_from_jd_ut(center_last_third)
+        ang = lunar_phase_angle_tt_deg(jd_tt, False, self.location)
+        return int(ang // 12.0) + 1
+
+    # -------------
+    # Lunation cache (per year)
+    # -------------
+    def _lunations(self, year: int) -> List[Tuple[str, float]]:
+        if year not in self._lunations_by_year:
+            self._lunations_by_year[year] = self._precompute_lunations(year)
+        return self._lunations_by_year[year]
+
+    def _precompute_lunations(self, year: int) -> List[Tuple[str, float]]:
+        """Scan and bracket new/full moons, refine with phase root-finder.
+
+        Returns list of (kind, rounded_jd_tt) sorted by TT.
+        """
+        start_utc = datetime(year, 1, 1, tzinfo=timezone.utc) - timedelta(days=1)
+        end_utc = datetime(year, 12, 31, tzinfo=timezone.utc) + timedelta(days=2)
+        jd_tt_start = jd_tt_from_jd_ut(to_julian_day(start_utc))
+        jd_tt_end = jd_tt_from_jd_ut(to_julian_day(end_utc))
+
+        step_days = 0.04 # 30 min step for finding lunar positions
+        lun_list: List[Tuple[str, float]] = []
+
+        j = jd_tt_start
+        prev_new = wrap180(lunar_phase_angle_tt_deg(j, False, self.location) - 0.0)
+        prev_full = wrap180(lunar_phase_angle_tt_deg(j, False, self.location) - 180.0)
+
+        while j < jd_tt_end:
+            jn = j + step_days
+            cur_new = wrap180(lunar_phase_angle_tt_deg(jn, False, self.location) - 0.0)
+            cur_full = wrap180(lunar_phase_angle_tt_deg(jn, False, self.location) - 180.0)
+
+            if prev_new == 0.0 or cur_new == 0.0 or (prev_new < 0.0 and cur_new > 0.0) or (prev_new > 0.0 and cur_new < 0.0):
+                guess = 0.5 * (j + jn)
+                nm_tt = find_phase_time_tt_near(guess, 0.0, self.location)
+                lun_list.append(("NewMoon", nm_tt))
+
+            if prev_full == 0.0 or cur_full == 0.0 or (prev_full < 0.0 and cur_full > 0.0) or (prev_full > 0.0 and cur_full < 0.0):
+                guess = 0.5 * (j + jn)
+                fm_tt = find_phase_time_tt_near(guess, 180.0, self.location)
+                lun_list.append(("FullMoon", fm_tt))
+
+            j = jn
+            prev_new = cur_new
+            prev_full = cur_full
+
+        return sorted({(k, round(v, 6)) for k, v in lun_list}, key=lambda x: x[1])
+
+    def _tt_to_local_date(self, jd_tt: float) -> Tuple[date, float]:
+        """Convert TT JD to (local civil date, UT JD) at this calendar's location."""
+        jd_ut = jd_ut_from_jd_tt(jd_tt)
+        dt_utc = from_julian_day(jd_ut)
+        return (dt_utc + timedelta(hours=self.location.tz)).date(), jd_ut
+
+    # -------------
+    # Holiday computations (ALL take year)
+    # -------------
+    def _compute_diwali(self, year: int) -> date:
+        """
+        Diwali (Kartik Amavasya), Pradosh-first rule:
+
+        1) Pick the Oct/Nov new moon closest to Nov 1 as the seed.
+        2) Prefer a date where the Pradosh-center tithi (≈72 min after sunset) is 30 (Amavasya),
+        scanning a small window around the seed.
+        3) If none, fall back to: sunset tithi == 30 (± up to 3 days), then sunrise tithi == 30.
+        """
+        # Collect Oct/Nov new moons for the given year (local date)
+        diwali_candidates: List[Tuple[date, float]] = []
+        for kind, jd_tt in self._lunations(year):
+            if kind != "NewMoon":
+                continue
+            d_local, _ = self._tt_to_local_date(jd_tt)
+            if d_local.year == year and d_local.month in (10, 11):
+                diwali_candidates.append((d_local, jd_tt))
+
+        # If none found (edge years), find a nearby new moon around mid-November
+        if not diwali_candidates:
+            from datetime import datetime, timezone
+            guess_ut = to_julian_day(datetime(year, 11, 15, tzinfo=timezone.utc))
+            nm_tt = find_phase_time_tt_near(jd_tt_from_jd_ut(guess_ut), 0.0, self.location)
+            diwali_candidates.append((self._tt_to_local_date(nm_tt)[0], nm_tt))
+
+        # Choose the new moon closest to Nov 1 as a seed
+        from datetime import datetime, timezone, timedelta
+        target_jd = to_julian_day(datetime(year, 11, 1, tzinfo=timezone.utc))
+        diwali_candidates.sort(key=lambda x: abs(x[1] - target_jd))
+        seed_date = diwali_candidates[0][0]
+
+        # (1) Prefer Amavasya at Pradosh (≈72 min after sunset), scan a small window
+        best = None  # tuple(score, distance, date) – score prioritizes sunset==30 as a tiebreaker
+        for delta in (-2, -1, 0, 1, 2, 3):
+            d = seed_date + timedelta(days=delta)
+            if self._pradosh_center_tithi(d) == 30:
+                score = 1 if self.tithi_at_sunset(d) == 30 else 0
+                item = (score, abs(delta), d)
+                best = item if best is None else min(best, item)
+        if best:
+            return best[2]
+
+        # (2) Fallback: try to find sunset tithi == 30 near the seed
+        chosen = seed_date
+        if self.tithi_at_sunset(seed_date) != 30:
+            found = None
+            for delta in (1, -1, 2, -2, 3, -3):
+                try_dt = seed_date + timedelta(days=delta)
+                if self.tithi_at_sunset(try_dt) == 30:
+                    found = try_dt
+                    break
+            if found is not None:
+                chosen = found
+            else:
+                # (3) Final fallback: check sunrise tithi == 30 near the seed
+                if self.tithi_at_sunrise(seed_date) == 30:
+                    chosen = seed_date
+                else:
+                    for delta in (1, -1, 2, -2, 3, -3):
+                        try_dt = seed_date + timedelta(days=delta)
+                        if self.tithi_at_sunrise(try_dt) == 30:
+                            chosen = try_dt
+                            break
+
+        return chosen
+
+    def _compute_holi(self, year: int) -> date:
+        """Holi (Phalguna Purnima): local date of the March full moon (simplified)."""
+        holi_tt = None
+        chosen_local = None
+        for kind, jd_tt in self._lunations(year):
+            if kind == "FullMoon":
+                d_local, _ = self._tt_to_local_date(jd_tt)
+                if d_local.year == year and d_local.month in (2, 3, 4):
+                    if d_local.month == 3:
+                        holi_tt = jd_tt
+                        chosen_local = d_local
+                        break
+                    if holi_tt is None:
+                        holi_tt = jd_tt
+                        chosen_local = d_local
+        if holi_tt is None:
+            holi_guess_tt = jd_tt_from_jd_ut(to_julian_day(datetime(year, 3, 15, tzinfo=timezone.utc)))
+            holi_tt = find_phase_time_tt_near(holi_guess_tt, 180.0, self.location)
+            chosen_local = self._tt_to_local_date(holi_tt)[0]
+        return chosen_local
+
+    def _compute_maha_shivaratri(self, year: int) -> date:
+        """
+        Maha Shivaratri (Krishna Chaturdashi at Nishita), fixed:
+        - Anchor to the new moon *nearest to March 1* (can be late Feb or early Mar).
+        - Return the date whose Nishita tithi is 29 (Krishna Chaturdashi) in the 1–4 nights before that new moon.
+        """
+        from datetime import datetime, timezone, timedelta
+        # New moon nearest to March 1 (Delhi local date may land in Feb/Mar)
+        target_tt = jd_tt_from_jd_ut(to_julian_day(datetime(year, 3, 1, tzinfo=timezone.utc)))
+        best = (1e9, None, None)  # (abs diff, jd_tt, local_date)
+
+        for kind, jd_tt in self._lunations(year):
+            if kind != "NewMoon":
+                continue
+            d_local, _ = self._tt_to_local_date(jd_tt)
+            diff = abs(jd_tt - target_tt)
+            if d_local.month in (2, 3) and diff < best[0]:
+                best = (diff, jd_tt, d_local)
+
+        if best[1] is None:
+            # Fallback: pick absolutely nearest new moon to Mar 1
+            for kind, jd_tt in self._lunations(year):
+                if kind != "NewMoon":
+                    continue
+                d_local, _ = self._tt_to_local_date(jd_tt)
+                diff = abs(jd_tt - target_tt)
+                if diff < best[0]:
+                    best = (diff, jd_tt, d_local)
+
+        nm_local = best[2]
+
+        # Look back 1–4 nights for Krishna Chaturdashi at Nishita
+        for delta in (1, 2, 3, 4):
+            d = nm_local - timedelta(days=delta)
+            if self._nishita_tithi(d) == 29:
+                return d
+
+        # Fallback: the night before new moon
+        return nm_local - timedelta(days=1)
+
+    def _compute_navratri_start(self, year: int) -> date:
+        """Navratri start: day after Ashwin Amavasya (Sep/Oct new moon)."""
+        for kind, jd_tt in self._lunations(year):
+            if kind == "NewMoon":
+                d_local, _ = self._tt_to_local_date(jd_tt)
+                if d_local.year == year and d_local.month in (9, 10):
+                    return d_local + timedelta(days=1)
+        nm_tt = find_phase_time_tt_near(
+            jd_tt_from_jd_ut(to_julian_day(datetime(year, 9, 15, tzinfo=timezone.utc))),
+            0.0,
+            self.location,
+        )
+        return self._tt_to_local_date(nm_tt)[0] + timedelta(days=1)
+
+    def _compute_makar_sankranti(self, year: int) -> date:
+        """Makar Sankranti: sidereal Sun enters Capricorn (270° Lahiri)."""
+        jan_guess_tt = jd_tt_from_jd_ut(to_julian_day(datetime(year, 1, 14, tzinfo=timezone.utc)))
+        ingress_tt = find_solar_sidereal_ingress_tt_near(jan_guess_tt, 270.0)
+        local_date, _ = self._tt_to_local_date(ingress_tt)
+        return local_date
+
+    def _compute_mahavir_jayanti_holiday(self, year: int) -> date:
+        """Mahavir Jayanti (Chaitra Shukla Trayodashi, simplified).
+        Approximation: take the April full moon (Chaitra Purnima) and search
+        nearby days for sunrise tithi == 13 (Trayodashi).
+        """
+        # Pick April full moon or nearest to Apr 15
+        fm_tt = None
+        best = (1e9, None)
+        target_jd = to_julian_day(datetime(year, 4, 15, tzinfo=timezone.utc))
+        for kind, jd_tt in self._lunations(year):
+            if kind != "FullMoon":
+                continue
+            d_local, _ = self._tt_to_local_date(jd_tt)
+            if d_local.year == year and d_local.month == 4:
+                fm_tt = jd_tt
+                break
+            # track nearest to Apr 15 if April not found
+            diff = abs(jd_tt - target_jd)
+            if diff < best[0]:
+                best = (diff, jd_tt)
+        if fm_tt is None:
+            fm_tt = best[1]
+        fm_local, _ = self._tt_to_local_date(fm_tt)
+        # Search a small window around two days before full moon
+        for delta in (-3, -2, -1, 0, 1):
+            candidate = fm_local + timedelta(days=delta - 2)
+            if self.tithi_at_sunrise(candidate) == 13:
+                return candidate
+        return fm_local + timedelta(days=-2)
+
+    def _compute_buddha_purnima_holiday(self, year: int) -> date:
+        """Buddha Purnima (Vaishakha Purnima, simplified): full moon in May."""
+        fm_tt = None
+        best = (1e9, None)
+        target_jd = to_julian_day(datetime(year, 5, 15, tzinfo=timezone.utc))
+        for kind, jd_tt in self._lunations(year):
+            if kind != "FullMoon":
+                continue
+            d_local, _ = self._tt_to_local_date(jd_tt)
+            if d_local.year == year and d_local.month == 5:
+                fm_tt = jd_tt
+                break
+            diff = abs(jd_tt - target_jd)
+            if diff < best[0]:
+                best = (diff, jd_tt)
+        if fm_tt is None:
+            fm_tt = best[1]
+        return self._tt_to_local_date(fm_tt)[0]
+
+    def _compute_dussehra_holiday(self, year: int) -> date:
+        """Dussehra (Vijayadashami, simplified): 10th day after Pratipada.
+        Approximation: Navratri start is Shukla Pratipada, so Dussehra ≈ start + 9 days.
+        """
+        start = self._compute_navratri_start(year)
+        return start + timedelta(days=9)
+
+    def _compute_guru_nanak_jayanti_holiday(self, year: int) -> date:
+        """Guru Nanak Jayanti (simplified): full moon in November (or nearest mid-Nov)."""
+        fm_tt = None
+        best = (1e9, None)
+        target_jd = to_julian_day(datetime(year, 11, 15, tzinfo=timezone.utc))
+        for kind, jd_tt in self._lunations(year):
+            if kind != "FullMoon":
+                continue
+            d_local, _ = self._tt_to_local_date(jd_tt)
+            if d_local.year == year and d_local.month == 11:
+                fm_tt = jd_tt
+                break
+            diff = abs(jd_tt - target_jd)
+            if diff < best[0]:
+                best = (diff, jd_tt)
+        if fm_tt is None:
+            fm_tt = best[1]
+        return self._tt_to_local_date(fm_tt)[0]
+
+    def _compute_janmashtami_holiday(self, year: int) -> date:
+        """Janmashtami (Bhadrapada Krishna Ashtami, simplified).
+        Approximation: take the August full moon and search the next two weeks
+        for a day where sunset tithi == 23 (Krishna Ashtami).
+        """
+        lun = self._lunations(year)
+        fm_local = None
+        # Prefer August full moon; otherwise take September
+        for month_target in (8, 9):
+            for kind, jd_tt in lun:
+                if kind != "FullMoon":
+                    continue
+                d_local, _ = self._tt_to_local_date(jd_tt)
+                if d_local.year == year and d_local.month == month_target:
+                    fm_local = d_local
+                    break
+            if fm_local is not None:
+                break
+        if fm_local is None:
+            # Fallback: nearest to Aug 15
+            best = (1e9, None)
+            target_jd = to_julian_day(datetime(year, 8, 15, tzinfo=timezone.utc))
+            for kind, jd_tt in lun:
+                if kind != "FullMoon":
+                    continue
+                diff = abs(jd_tt - target_jd)
+                if diff < best[0]:
+                    best = (diff, self._tt_to_local_date(jd_tt)[0])
+            fm_local = best[1]
+        # Scan next fortnight for Krishna Ashtami (tithi 23)
+        for d in range(1, 15):
+            day = fm_local + timedelta(days=d)
+            if self.tithi_at_sunset(day) == 23:
+                return day
+        # Fallback approximate 8 days after full moon
+        return fm_local + timedelta(days=8)

--- a/addons/hr_holidays/lib/holiday_generator/calendars/islamic_calendar.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/islamic_calendar.py
@@ -1,0 +1,193 @@
+"""Islamic (Hijri) holiday generator using a single crescent-visibility proxy.
+
+Algorithm (one method only)
+---------------------------
+For each lunar conjunction spanning the target Gregorian year:
+1) Convert conjunction (TT) → UT → local civil date D0.
+2) Test crescent *at local sunset* for D0, D0+1, D0+2 using:
+     - Moon age since conjunction ≥ MIN_AGE_HOURS (e.g., 17 h)
+     - Elongation (Moon - Sun) ≥ MIN_ELONG_DEG (e.g., 9°)
+   If the proxy passes, the month begins at that sunset; civil "Day 1" is next morning.
+3) Tag the evening before "Day 1" with a Hijri month index 1..12 by counting
+   mean synodic months since the Hijri epoch (civil) 622-07-19 Gregorian.
+
+We return **civil dates** (midnight-to-midnight). Religious observance starts
+the *previous* sunset.
+
+References / building blocks
+----------------------------
+- Sun/Moon math & TT↔UT/GMST: your astro/time_utils helpers (Meeus-style).
+- Sunset finder: altitude = -0.833° via bisection (refraction + solar radius).
+- Visibility proxy: age + elongation; simple, fast, tunable (Yallop/Odeh-inspired,
+  but not a full curve). You can extend later with altitude and moonset-after-sunset.
+"""
+
+import math
+from datetime import date, datetime, timedelta, timezone
+
+from .utils.phases import find_phase_time_tt_near, lunar_phase_angle_tt_deg
+from .utils.rise_set import sunset_jd_utc
+from .utils.time_utils import (
+    from_julian_day,
+    jd_tt_from_jd_ut,
+    jd_ut_from_jd_tt,
+    to_julian_day,
+)
+
+# Hijri epoch (civil): 1 Muharram AH 1 = 622-07-19 Gregorian
+_ISLAMIC_EPOCH_JD = to_julian_day(datetime(622, 7, 19, tzinfo=timezone.utc))
+# Mean synodic month
+_SYNODIC_DAYS = 29.530588861
+
+
+# ----- JD/date helpers -----
+def _greg_to_jd(d):
+    """Gregorian date (UTC midnight) → JD."""
+    return to_julian_day(datetime(d.year, d.month, d.day, tzinfo=timezone.utc))
+
+
+def _jd_to_local_date(jd_ut, tz_hours):
+    """UT-based JD → local civil date (ignoring DST; tz as fixed offset)."""
+    dt = from_julian_day(jd_ut).astimezone(timezone(timedelta(hours=tz_hours)))
+    return dt.date()
+
+
+# ----- Conjunctions spanning the year -----
+def _nearest_conjunctions_for_year(year, loc):
+    """Return TT JDs of lunar conjunctions around the year.
+
+    We scan from mid-Dec (year-1) to mid-Jan (year+1), refining each root of
+    elongation = 0° via a secant-like method. Step guesses by one lunation.
+    """
+    start = datetime(year - 1, 12, 15, tzinfo=timezone.utc)
+    end = datetime(year + 1, 1, 15, tzinfo=timezone.utc)
+    jd_guess = jd_tt_from_jd_ut(to_julian_day(start))
+    jd_end_tt = jd_tt_from_jd_ut(to_julian_day(end))
+
+    out = []
+    guess = jd_guess
+    while True:
+        root = find_phase_time_tt_near(guess, target_deg=0.0, loc=loc)
+        if out and root <= out[-1] + 15.0 / 1440.0:  # ~15 min duplicate guard
+            guess += _SYNODIC_DAYS
+            continue
+        out.append(root)
+        if root > jd_end_tt:
+            break
+        guess = root + _SYNODIC_DAYS
+    return out
+
+
+# ----- Crescent visibility proxy -----
+def _crescent_visible_on(date_local, loc, conj_tt, min_elong_deg, min_age_hours):
+    """Return True if crescent is plausibly visible at local sunset on date_local."""
+    jd_sunset_ut = sunset_jd_utc(datetime(date_local.year, date_local.month, date_local.day), loc)
+    jd_sunset_tt = jd_tt_from_jd_ut(jd_sunset_ut)
+
+    # Age (hours) since conjunction at sunset
+    age_hours = (jd_sunset_tt - conj_tt) * 24.0
+    if age_hours < 0.0:
+        return False
+
+    # Elongation at sunset (topocentric Moon longitude)
+    elong_deg = lunar_phase_angle_tt_deg(jd_sunset_tt, True, loc)
+    return (age_hours >= min_age_hours) and (elong_deg >= min_elong_deg)
+
+
+def _month_start_from_conjunction(conj_tt, loc, min_elong_deg, min_age_hours):
+    """Compute civil 'Day 1' for the Hijri month following a conjunction.
+
+    Check sunset on D0, D0+1, D0+2; first passing evening → Day 1 = that date + 1.
+    Fallback: D0+3 (rare numeric/latitude edge).
+    """
+    jd_conj_ut = jd_ut_from_jd_tt(conj_tt)
+    d0 = _jd_to_local_date(jd_conj_ut, loc.tz)
+
+    for offset in (0, 1, 2):
+        test_day = d0 + timedelta(days=offset)
+        if _crescent_visible_on(test_day, loc, conj_tt, min_elong_deg, min_age_hours):
+            return test_day + timedelta(days=1)
+    return d0 + timedelta(days=3)
+
+
+def _label_hijri_month(jd_month_evening_ut):
+    """Evening preceding Day 1 (UT JD) → Hijri month number in 1..12."""
+    n = math.floor((jd_month_evening_ut - _ISLAMIC_EPOCH_JD) / _SYNODIC_DAYS) + 1
+    return ((n - 1) % 12) + 1
+
+
+def _astronomical_month_starts(year, loc, min_elong_deg, min_age_hours):
+    """Return [(hijri_month, gregorian_day1), ...] sorted and deduped."""
+    out = []
+    for conj_tt in _nearest_conjunctions_for_year(year, loc):
+        d1 = _month_start_from_conjunction(conj_tt, loc, min_elong_deg, min_age_hours)
+        jd_eve_ut = _greg_to_jd(d1) - 0.5  # evening before Day 1
+        mnum = _label_hijri_month(jd_eve_ut)
+        out.append((mnum, d1))
+
+    out.sort(key=lambda x: x[1])
+    dedup, seen = [], set()
+    for m, d1 in out:
+        if d1 not in seen:
+            dedup.append((m, d1))
+            seen.add(d1)
+    return dedup
+
+
+class IslamicHolidayGenerator:
+    """Generate Islamic holidays for a Gregorian year at a given Location.
+
+    There is only one method: crescent visibility at local sunset with
+    tunable thresholds. Pass thresholds via `loc.visibility_thresholds`
+    or let the generator use (9°, 17h) by default.
+    """
+
+    def __init__(self, loc):
+        self.loc = loc
+        self.el, self.age = loc.thresholds_or_default()
+
+    def _gregorian_of(self, year, hijri_month, hijri_day):
+        """Gregorian civil date for (Hijri month, day) in this Gregorian year."""
+        month_starts = _astronomical_month_starts(year, self.loc, self.el, self.age)
+        for mnum, d1 in month_starts:
+            if mnum == hijri_month:
+                g = d1 + timedelta(days=hijri_day - 1)
+                if g.year == year:
+                    return g
+        return None
+
+    def compute_islamic_new_year(self, year: int) -> date:
+        """1 Muharram — Islamic New Year."""
+        return self._gregorian_of(year, 1, 1)
+
+    def compute_ashura(self, year: int) -> date:
+        """10 Muharram — Day of Ashura."""
+        return self._gregorian_of(year, 1, 10)
+
+    def compute_mawlid(self, year: int) -> date:
+        """12 Rabi' al-awwal — Mawlid."""
+        return self._gregorian_of(year, 3, 12)
+
+    def compute_isra_miraj(self, year: int) -> date:
+        """27 Rajab — Isra & Mi'raj."""
+        return self._gregorian_of(year, 7, 27)
+
+    def compute_ramadan_start(self, year: int) -> date:
+        """1 Ramadan — Start of Ramadan (fast begins previous sunset)."""
+        return self._gregorian_of(year, 9, 1)
+
+    def compute_laylat_al_qadr(self, year: int) -> date:
+        """27 Ramadan — Laylat al-Qadr (observed convention)."""
+        return self._gregorian_of(year, 9, 27)
+
+    def compute_eid_al_fitr(self, year: int) -> date:
+        """1 Shawwal — Eid al-Fitr."""
+        return self._gregorian_of(year, 10, 1)
+
+    def compute_arafah(self, year: int) -> date:
+        """9 Dhu al-Hijjah — Day of Arafah."""
+        return self._gregorian_of(year, 12, 9)
+
+    def compute_eid_al_adha(self, year: int) -> date:
+        """10 Dhu al-Hijjah — Eid al-Adha."""
+        return self._gregorian_of(year, 12, 10)

--- a/addons/hr_holidays/lib/holiday_generator/calendars/location.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/location.py
@@ -1,0 +1,26 @@
+"""Location model and a small set of example codes for convenience."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Location:
+    """Observer location and fixed UTC offset.
+
+    Fields:
+    - lat, lon: degrees (positive north/east)
+    - tz: fixed UTC offset hours (no DST)
+    - height_m: elevation in meters (used in more advanced models)
+    """
+    lat: float
+    lon: float
+    tz: float
+    height_m: float = 0.0
+
+    # Islamic calendar policy
+    method: str = "astronomical"
+    visibility_thresholds: tuple[float, float] | None = None
+
+    def thresholds_or_default(self) -> tuple[float, float]:
+        """Return policy thresholds or global defaults."""
+        return self.visibility_thresholds or (9.0, 17.0)

--- a/addons/hr_holidays/lib/holiday_generator/calendars/utils/__init__.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/utils/__init__.py
@@ -1,0 +1,8 @@
+__all__ = [
+    "phases",
+    "time_utils",
+    "sidereal",
+    "angles",
+    "astro",
+    "rise_set",
+]

--- a/addons/hr_holidays/lib/holiday_generator/calendars/utils/angles.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/utils/angles.py
@@ -1,0 +1,20 @@
+"""Lightweight math utilities and constants used across the calendar package."""
+
+import math
+
+RAD = math.pi / 180.0  # radians per degree
+DEG = 180.0 / math.pi  # degrees per radian
+EARTH_RADIUS_KM = 6378.137  # WGS-84 equatorial radius, km
+
+
+def norm_deg(x: float) -> float:
+    """Normalize angle to [0, 360) degrees."""
+    x = x % 360.0
+    if x < 0:
+        x += 360.0
+    return x
+
+
+def wrap180(x: float) -> float:
+    """Wrap angle to (-180, 180] degrees for robust sign-change tests."""
+    return (x + 180.0) % 360.0 - 180.0

--- a/addons/hr_holidays/lib/holiday_generator/calendars/utils/astro.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/utils/astro.py
@@ -1,0 +1,149 @@
+"""Astronomical models (Sun/Moon) used by the calendar.
+
+Implements compact versions of Meeus-style formulas for:
+- Mean obliquity
+- Solar ecliptic longitude (apparent)
+- Lunar ecliptic longitude and distance (reduced series)
+- Topocentric lunar longitude via simplified parallax correction
+"""
+
+import math
+from functools import lru_cache
+from .angles import norm_deg, EARTH_RADIUS_KM
+from .time_utils import T_centuries, jd_ut_from_jd_tt, gmst_deg_from_jd_ut
+
+
+@lru_cache(maxsize=4096)
+def mean_obliquity_deg(T: float) -> float:
+    """Return mean obliquity of the ecliptic (deg) for Julian centuries T."""
+    secs = 84381.406 - 46.836769 * T - 0.0001831 * T * T + 0.00200340 * T * T * T
+    return secs / 3600.0
+
+
+def nutation_approx(jd: float) -> tuple[float, float]:
+    """Very small set of nutation terms (longitude/obliquity) in degrees."""
+    T = T_centuries(jd)
+    Omega = math.radians(norm_deg(125.04452 - 1934.136261 * T + 0.0020708 * T * T))
+    D = math.radians(norm_deg(297.85036 + 445267.111480 * T))
+    delta_psi = (-17.20 * math.sin(Omega) - 1.32 * math.sin(2 * D)) / 3600.0
+    delta_eps = (9.20 * math.cos(Omega) + 0.57 * math.cos(2 * D)) / 3600.0
+    return delta_psi, delta_eps
+
+
+def sun_ecliptic_longitude_deg(jd_tt: float) -> float:
+    """Apparent ecliptic longitude of the Sun (deg) at TT Julian Day."""
+    T = T_centuries(jd_tt)
+    L0 = 280.4664567 + 36000.76982779 * T + 0.0003032028 * T * T
+    M = 357.52911 + 35999.0502909 * T - 0.0001536 * T * T
+    M_rad = math.radians(M)
+    C = (1.914602 - 0.004817 * T - 0.000014 * T * T) * math.sin(M_rad)
+    C += (0.019993 - 0.000101 * T) * math.sin(2 * M_rad) + 0.000289 * math.sin(3 * M_rad)
+    true_long = L0 + C
+    omega = 125.04 - 1934.136 * T
+    lam = true_long - 0.00569 - 0.00478 * math.sin(math.radians(omega))
+    return norm_deg(lam)
+
+
+def moon_ecliptic_longitude_and_distance(jd_tt: float) -> tuple[float, float]:
+    """Geocentric lunar ecliptic longitude (deg) and distance (km), reduced series."""
+    T = T_centuries(jd_tt)
+    Lp = norm_deg(218.3164477 + 481267.88123421 * T - 0.0015786 * T * T + T ** 3 / 538841.0 - T ** 4 / 65194000.0)
+    D = norm_deg(297.8501921 + 445267.1114034 * T - 0.0018819 * T * T)
+    M = norm_deg(357.5291092 + 35999.0502909 * T - 0.0001536 * T * T)
+    Mp = norm_deg(134.9633964 + 477198.8675055 * T + 0.0087414 * T * T)
+    F = norm_deg(93.2720950 + 483202.0175233 * T - 0.0036539 * T * T)
+
+    D_r = math.radians(D)
+    M_r = math.radians(M)
+    Mp_r = math.radians(Mp)
+    F_r = math.radians(F)
+    E = 1 - 0.002516 * T - 0.0000074 * T * T
+
+    terms = [
+        (6288774, 0, 0, 1, 0, 0, -20905355),
+        (1274027, 2, 0, -1, 0, 0, -3699111),
+        (658314, 2, 0, 0, 0, 0, -2955968),
+        (213618, 0, 0, 2, 0, 0, -569925),
+        (-185116, 0, 1, 0, 0, 1, 48888),
+        (-114332, 0, 0, 0, 2, 0, -3149),
+        (58793, 2, 0, -2, 0, 0, 246158),
+        (57066, 2, -1, -1, 0, 1, -152138),
+        (53322, 2, 0, 1, 0, 0, -170733),
+        (45758, 2, -1, 0, 0, 1, -204586),
+        (-40923, 0, 1, -1, 0, 1, -129620),
+        (-34720, 1, 0, 0, 0, 0, 108743),
+        (-30383, 0, 1, 1, 0, 1, 104755),
+        (15327, 2, 0, 0, -2, 0, 10321),
+        (-12528, 0, 0, 1, 2, 0, 0),
+        (10980, 0, 0, 1, -2, 0, 79661),
+        (10675, 4, 0, -1, 0, 0, -34782),
+        (10034, 0, 0, 3, 0, 0, -23210),
+        (8548, 4, 0, -2, 0, 0, 0),
+        (-7888, 2, 1, -1, 0, 1, 0),
+        (-6766, 2, 1, 0, 0, 1, 0),
+        (-5163, 1, 0, -1, 0, 0, 0),
+        (4987, 1, 1, 0, 0, 1, 0),
+        (4036, 2, -1, 1, 0, 1, 0),
+        (3994, 2, 0, 2, 0, 0, 0),
+        (3861, 4, 0, 0, 0, 0, 0),
+        (3665, 2, 0, -3, 0, 0, 0),
+        (-2689, 0, 1, -2, 0, 1, 0),
+    ]
+
+    sigma_l = 0.0
+    sigma_r = 0.0
+    for coef, d_m, m_m, mp_m, f_m, e_flag, r_coef in terms:
+        arg = d_m * D_r + m_m * M_r + mp_m * Mp_r + f_m * F_r
+        efac = (E ** abs(m_m)) if e_flag else 1.0
+        sigma_l += coef * efac * math.sin(arg)
+        sigma_r += r_coef * efac * math.cos(arg)
+
+    lam = Lp + sigma_l / 1e6
+    dist = 385000.56 + sigma_r / 1000.0
+    return norm_deg(lam), dist
+
+
+def sun_ra_dec_tt(jd_tt: float) -> tuple[float, float]:
+    """Right ascension and declination of the Sun at TT JD (radians)."""
+    lam = math.radians(sun_ecliptic_longitude_deg(jd_tt))
+    eps = math.radians(mean_obliquity_deg(T_centuries(jd_tt)))
+    x = math.cos(lam)
+    y = math.cos(eps) * math.sin(lam)
+    z = math.sin(eps) * math.sin(lam)
+    ra = math.atan2(y, x)
+    dec = math.atan2(z, math.sqrt(x * x + y * y))
+    return ra, dec
+
+
+def topocentric_moon_longitude(jd_tt: float, lat_deg: float, lon_deg: float, height_m: float = 0.0) -> float:
+    """Approximate topocentric lunar ecliptic longitude (deg) including parallax.
+
+    This uses a simplified transformation through equatorial coordinates and a
+    small-angle parallax correction. It is not a full rigorous topocentric
+    transform but adequate for day-level festival rules.
+    """
+    lam_geo_deg, dist_km = moon_ecliptic_longitude_and_distance(jd_tt)
+    parallax_rad = math.asin(EARTH_RADIUS_KM / dist_km)
+    lam = math.radians(lam_geo_deg)
+    eps = math.radians(mean_obliquity_deg(T_centuries(jd_tt)))
+    x = math.cos(lam)
+    y = math.cos(eps) * math.sin(lam)
+    z = math.sin(eps) * math.sin(lam)
+    ra = math.atan2(y, x)
+    dec = math.atan2(z, math.sqrt(x * x + y * y))
+
+    jd_ut = jd_ut_from_jd_tt(jd_tt)
+    GMST = gmst_deg_from_jd_ut(jd_ut)
+    LST = math.radians(norm_deg(GMST + lon_deg))
+    HA = LST - ra
+    lat = math.radians(lat_deg)
+
+    delta_ra = -math.asin(math.sin(parallax_rad) * math.sin(HA) / math.cos(dec))
+    delta_dec = math.asin((math.sin(dec) - math.sin(parallax_rad) * math.sin(lat)) * math.cos(delta_ra) - math.cos(dec) * math.sin(delta_ra) * math.sin(lat))
+    ra_top = ra + delta_ra
+    dec_top = dec + delta_dec
+    
+    sin_lam = math.sin(ra_top) * math.cos(eps) + math.tan(dec_top) * math.sin(eps)
+    cos_lam = math.cos(ra_top)
+    lam_top = math.atan2(sin_lam, cos_lam)
+    return norm_deg(math.degrees(lam_top))

--- a/addons/hr_holidays/lib/holiday_generator/calendars/utils/phases.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/utils/phases.py
@@ -1,0 +1,62 @@
+"""Lunar phase, tithi, and phase-root finding utilities."""
+
+import math
+from datetime import datetime
+from ..location import Location
+from .time_utils import jd_tt_from_jd_ut
+from .astro import topocentric_moon_longitude, moon_ecliptic_longitude_and_distance, sun_ecliptic_longitude_deg
+from .rise_set import sunrise_jd_utc, sunset_jd_utc
+from .angles import norm_deg
+
+
+def lunar_phase_angle_tt_deg(jd_tt: float, use_topo: bool, loc: Location) -> float:
+    """Elongation λ_moon − λ_sun (deg) at TT JD.
+
+    If use_topo is True, uses a simplified topocentric lunar longitude.
+    """
+    if use_topo:
+        lam_m = topocentric_moon_longitude(jd_tt, loc.lat, loc.lon, loc.height_m)
+    else:
+        lam_m, _ = moon_ecliptic_longitude_and_distance(jd_tt)
+    lam_s = sun_ecliptic_longitude_deg(jd_tt)
+    return norm_deg(lam_m - lam_s)
+
+
+def tithi_at_local_sunrise(date_local: datetime, loc: Location) -> int:
+    """Tithi number (1–30) prevailing at local sunrise."""
+    jd_sunrise_ut = sunrise_jd_utc(date_local, loc)
+    jd_tt = jd_tt_from_jd_ut(jd_sunrise_ut)
+    ang = lunar_phase_angle_tt_deg(jd_tt, False, loc)
+    return int(ang // 12.0) + 1
+
+
+def tithi_at_local_sunset(date_local: datetime, loc: Location) -> int:
+    """Tithi number (1–30) prevailing at local sunset."""
+    jd_sunset_ut = sunset_jd_utc(date_local, loc)
+    jd_tt = jd_tt_from_jd_ut(jd_sunset_ut)
+    ang = lunar_phase_angle_tt_deg(jd_tt, False, loc)
+    return int(ang // 12.0) + 1
+
+
+def find_phase_time_tt_near(jd_tt_guess: float, target_deg: float, loc: Location) -> float:
+    """Refine to a TT time where elongation equals target_deg (secant method)."""
+    x0 = jd_tt_guess - 1.0
+    x1 = jd_tt_guess + 1.0
+    def f(jd_tt):
+        d = lunar_phase_angle_tt_deg(jd_tt, True, loc) - target_deg
+        if d > 180.0:
+            d -= 360.0
+        if d < -180.0:
+            d += 360.0
+        return d
+    y0 = f(x0)
+    y1 = f(x1)
+    for _ in range(60):
+        if abs(y1 - y0) < 1e-12:
+            break
+        x2 = x1 - y1 * (x1 - x0) / (y1 - y0)
+        y2 = f(x2)
+        x0, y0, x1, y1 = x1, y1, x2, y2
+        if abs(y1) < 1e-8:
+            break
+    return x1

--- a/addons/hr_holidays/lib/holiday_generator/calendars/utils/rise_set.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/utils/rise_set.py
@@ -1,0 +1,101 @@
+"""Sunrise/sunset calculations using bisection with refraction correction.
+
+We solve for when the true solar altitude equals -0.833° (standard refraction
+and solar radius), scanning the local day to bracket the event then refining by
+bisection. This is robust for all latitudes with normal Sun paths.
+"""
+
+from datetime import datetime, timezone, timedelta
+import math
+from ..location import Location
+from .time_utils import jd_tt_from_jd_ut, gmst_deg_from_jd_ut, to_julian_day
+from .astro import sun_ra_dec_tt
+from .angles import norm_deg
+
+
+def sun_altitude_deg_at_ut(jd_ut: float, lat_deg: float, lon_deg: float) -> float:
+    """Solar altitude (deg) at a UT-based JD and geographic location."""
+    jd_tt = jd_tt_from_jd_ut(jd_ut)
+    ra, dec = sun_ra_dec_tt(jd_tt)
+    GMST = gmst_deg_from_jd_ut(jd_ut)
+    LST = math.radians(norm_deg(GMST + lon_deg))
+    H = LST - ra
+    lat = math.radians(lat_deg)
+    alt = math.degrees(math.asin(math.sin(dec) * math.sin(lat) + math.cos(dec) * math.cos(lat) * math.cos(H)))
+    return alt
+
+
+def _find_sun_event_jd_utc(date_local: datetime, loc: Location, target_alt: float, is_rise: bool, step_minutes: int = 10) -> float:
+    """Find sunrise/sunset UTC JD by scanning and bisection on altitude.
+
+    - date_local: local civil date at location (time ignored)
+    - target_alt: altitude in degrees (-0.833 for standard sunrise/sunset)
+    - is_rise: True for sunrise, False for sunset
+    - step_minutes: scan granularity to find a sign change bracket
+    """
+    tz = timezone(timedelta(hours=loc.tz))
+    local_mid = datetime(date_local.year, date_local.month, date_local.day, 0, 0, 0, tzinfo=tz)
+    utc_start = local_mid.astimezone(timezone.utc)
+    jd_start = to_julian_day(utc_start)
+
+    def f(jd):
+        return sun_altitude_deg_at_ut(jd, loc.lat, loc.lon) - target_alt
+
+    total_minutes = 24 * 60
+    step_days = step_minutes / 1440.0
+    samples = []
+    jd = jd_start
+    for _ in range(0, total_minutes // step_minutes + 1):
+        samples.append((jd, f(jd)))
+        jd += step_days
+
+    bracket = None
+    for (a_jd, a_f), (b_jd, b_f) in zip(samples, samples[1:]):
+        if a_f == 0.0:
+            return a_jd
+        if b_f == 0.0:
+            return b_jd
+        crossed = (a_f <= 0.0 and b_f >= 0.0) if is_rise else (a_f >= 0.0 and b_f <= 0.0)
+        if crossed:
+            bracket = (a_jd, a_f, b_jd, b_f)
+            break
+
+    if bracket is None:
+        for day_offset in (-1, 1):
+            jd0 = jd_start + day_offset
+            a_f = f(jd0)
+            b_f = f(jd0 + step_days)
+            if is_rise and a_f <= 0.0 and b_f >= 0.0:
+                bracket = (jd0, a_f, jd0 + step_days, b_f)
+                break
+            if (not is_rise) and a_f >= 0.0 and b_f <= 0.0:
+                bracket = (jd0, a_f, jd0 + step_days, b_f)
+                break
+    if bracket is None:
+        return jd_start + 0.5
+
+    a, fa, b, fb = bracket
+    for _ in range(60):
+        m = 0.5 * (a + b)
+        fm = f(m)
+        if abs(fm) < 1e-7 or (b - a) < 1e-8:
+            return m
+        if is_rise:
+            if fa <= 0.0 and fm <= 0.0:
+                a, fa = m, fm
+            else:
+                b, fb = m, fm
+        else:
+            if fa >= 0.0 and fm >= 0.0:
+                a, fa = m, fm
+            else:
+                b, fb = m, fm
+    return 0.5 * (a + b)
+
+
+def sunrise_jd_utc(date_local: datetime, loc: Location) -> float:
+    return _find_sun_event_jd_utc(date_local, loc, target_alt=-0.833, is_rise=True)
+
+
+def sunset_jd_utc(date_local: datetime, loc: Location) -> float:
+    return _find_sun_event_jd_utc(date_local, loc, target_alt=-0.833, is_rise=False)

--- a/addons/hr_holidays/lib/holiday_generator/calendars/utils/side_real.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/utils/side_real.py
@@ -1,0 +1,43 @@
+"""Sidereal (Lahiri) conversion and solar ingress finder."""
+
+from .angles import norm_deg
+from .time_utils import T_centuries
+from .astro import sun_ecliptic_longitude_deg
+
+
+def lahiri_ayanamsa_deg(jd_tt: float) -> float:
+    """Approximate Lahiri ayanamsa (deg) at TT JD.
+
+    Uses a base value near J2000.0 and a linear drift ~1.396°/century with a
+    small quadratic correction.
+    """
+    T = T_centuries(jd_tt)
+    base_j2000 = 23.85308
+    drift_deg_per_century = 1.3962634
+    quad = -0.000044 * (T * T)
+    return norm_deg(base_j2000 + drift_deg_per_century * T + quad)
+
+
+def to_sidereal_deg(lambda_tropical_deg: float, jd_tt: float) -> float:
+    """Convert tropical ecliptic longitude to Lahiri sidereal longitude (deg)."""
+    return norm_deg(lambda_tropical_deg - lahiri_ayanamsa_deg(jd_tt))
+
+
+def find_solar_sidereal_ingress_tt_near(jd_tt_guess: float, target_sid_deg: float) -> float:
+    """Find TT JD when sidereal Sun equals target_sid_deg (secant-like method)."""
+    x0 = jd_tt_guess - 2.0
+    x1 = jd_tt_guess + 2.0
+    def f(jd_tt):
+        val = ((to_sidereal_deg(sun_ecliptic_longitude_deg(jd_tt), jd_tt) - target_sid_deg + 180.0) % 360.0) - 180.0
+        return val
+    y0 = f(x0)
+    y1 = f(x1)
+    for _ in range(80):
+        if abs(y1 - y0) < 1e-12:
+            break
+        x2 = x1 - y1 * (x1 - x0) / (y1 - y0)
+        y2 = f(x2)
+        x0, y0, x1, y1 = x1, y1, x2, y2
+        if abs(y1) < 1e-8:
+            break
+    return x1

--- a/addons/hr_holidays/lib/holiday_generator/calendars/utils/time_utils.py
+++ b/addons/hr_holidays/lib/holiday_generator/calendars/utils/time_utils.py
@@ -1,0 +1,135 @@
+"""Time and timescale helpers (Julian days, TT/UT conversion, GMST).
+
+This module centralizes conversions between civil time and astronomical
+timescales used in the package:
+- Julian Day (JD)
+- Terrestrial Time (TT) and Universal Time (UT) conversion via ΔT
+- Greenwich Mean Sidereal Time (GMST)
+"""
+
+import calendar
+import math
+from datetime import date, datetime, timedelta, timezone
+from functools import lru_cache
+
+from .angles import norm_deg
+
+
+def to_julian_day(dt: datetime) -> float:
+    """Convert timezone-aware or naive datetime to Julian Day (UTC).
+
+    Naive datetimes are assumed to be UTC.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    dt = dt.astimezone(timezone.utc)
+    y = dt.year
+    m = dt.month
+    D = dt.day + (dt.hour + (dt.minute + dt.second / 60.0) / 60.0) / 24.0
+    if m <= 2:
+        y -= 1
+        m += 12
+    A = y // 100
+    B = 2 - A + (A // 4)
+    JD = math.floor(365.25 * (y + 4716)) + math.floor(30.6001 * (m + 1)) + D + B - 1524.5
+    return JD
+
+
+def from_julian_day(jd: float) -> datetime:
+    """Convert Julian Day (UTC) to a timezone-aware UTC datetime."""
+    Z = int(jd + 0.5)
+    F = (jd + 0.5) - Z
+    if Z < 2299161:
+        A = Z
+    else:
+        alpha = int((Z - 1867216.25) / 36524.25)
+        A = Z + 1 + alpha - int(alpha / 4)
+    B = A + 1524
+    C = int((B - 122.1) / 365.25)
+    D = int(365.25 * C)
+    E = int((B - D) / 30.6001)
+    day = B - D - int(30.6001 * E) + F
+    month = E - 1 if E < 14 else E - 13
+    year = C - 4716 if month > 2 else C - 4715
+    day_int = int(day)
+    frac = day - day_int
+    hours = int(frac * 24.0)
+    minutes = int((frac * 24.0 - hours) * 60.0)
+    seconds = round((((frac * 24.0 - hours) * 60.0) - minutes) * 60.0)
+    if seconds == 60:
+        seconds = 59
+    return datetime(year, month, day_int, hours, minutes, seconds, tzinfo=timezone.utc)
+
+
+def T_centuries(jd: float) -> float:
+    """Julian centuries since J2000.0 (TT), per Meeus convention."""
+    return (jd - 2451545.0) / 36525.0
+
+
+@lru_cache(maxsize=1024)
+def delta_t_seconds_approx(year: int, month: int = 1) -> float:
+    """Approximate ΔT (TT−UT) in seconds for a given year and month.
+
+    Polynomial approximations good to a few seconds for 1900–2050.
+    """
+    y = year + (month - 0.5) / 12.0
+    if 2005 <= y <= 2050:
+        t = y - 2000
+        dt = 62.92 + 0.32217 * t + 0.005589 * t * t
+        return dt
+    if 1900 <= y < 2005:
+        t = y - 1900
+        dt = -2.79 + 1.494119 * t - 0.0598939 * t * t + 0.0061966 * t * t * t - 0.000197 * t * t * t * t
+        return dt
+    if y >= 2050:
+        t = y - 2000
+        dt = 62.92 + 0.32217 * t + 0.005589 * t * t
+        return dt
+    return 68.0
+
+
+def jd_tt_from_jd_ut(jd_ut: float) -> float:
+    """Convert UT-based JD to TT-based JD using ΔT approximation."""
+    dt = from_julian_day(jd_ut)
+    dt_s = delta_t_seconds_approx(dt.year, dt.month)
+    return jd_ut + dt_s / 86400.0
+
+
+def jd_ut_from_jd_tt(jd_tt: float) -> float:
+    """Convert TT-based JD to UT-based JD using ΔT approximation."""
+    dt = from_julian_day(jd_tt)
+    dt_s = delta_t_seconds_approx(dt.year, dt.month)
+    return jd_tt - dt_s / 86400.0
+
+
+@lru_cache(maxsize=8192)
+def gmst_deg_from_jd_ut(jd_ut: float) -> float:
+    """Compute GMST (degrees) from UT-based JD using the IAU expression."""
+    T = (jd_ut - 2451545.0) / 36525.0
+    GMST = norm_deg(280.46061837 + 360.98564736629 * (jd_ut - 2451545.0) + 0.000387933 * T * T - T * T * T / 38710000.0)
+    return GMST
+
+
+def nth_weekday(year: int, month: int, n: int, weekday: int) -> date:
+    """
+        Return the n-th occurrence of a given weekday in a specific month/year.
+        weekday: 0=Mon ... 6=Sun
+    """
+    first = date(year, month, 1)
+    offset = (weekday - first.weekday() + 7) % 7
+    first_occurrence = first + timedelta(days=offset)
+    return first_occurrence + timedelta(weeks=n - 1)
+
+
+def last_weekday(year: int, month: int, weekday: int) -> date:
+    last = date(year, month, calendar.monthrange(year, month)[1])
+    offset = (last.weekday() - weekday + 7) % 7
+    return last - timedelta(days=offset)
+
+
+def first_weekday_on_or_after(d: date, weekday: int) -> date:
+    """
+    Return the first date on or after `d` that lands on `weekday`.
+    weekday: Monday=0 ... Sunday=6
+    """
+    return d + timedelta(days=(weekday - d.weekday()) % 7)

--- a/addons/hr_holidays/lib/holiday_generator/countries/__init__.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/__init__.py
@@ -1,0 +1,49 @@
+import importlib
+
+BASE_PKG = __name__
+
+_COUNTRY_PATHS = {
+    "AE": "unitedarabemirates.UnitedArabEmirates",
+    "AU": "australia.Australia",
+    "BD": "bangladesh.Bangladesh",
+    "BE": "belgium.Belgium",
+    "CH": "switzerland.Switzerland",
+    "EG": "egypt.Egypt",
+    "HK": "hongkong.HongKong",
+    "ID": "indonesia.Indonesia",
+    "IN": "india.India",
+    "JO": "jordan.Jordan",
+    "KE": "kenya.Kenya",
+    "LT": "lithuania.Lithuania",
+    "LU": "luxembourg.Luxembourg",
+    "MA": "morocco.Morocco",
+    "MX": "mexico.Mexico",
+    "MY": "malaysia.Malaysia",
+    "NL": "netherlands.Netherlands",
+    "PK": "pakistan.Pakistan",
+    "PL": "poland.Poland",
+    "RO": "romania.Romania",
+    "SA": "saudiarabia.SaudiArabia",
+    "SK": "slovakia.Slovakia",
+    "TR": "turkey.Turkey",
+    "US": "unitedstates.UnitedStates",
+}
+
+COUNTRY_CLASS_MAP = dict(_COUNTRY_PATHS)
+
+def __getattr__(name: str):
+    """
+    Lazy-load a country class when accessed as an attribute of this package.
+    Example:
+        from odoo.addons.hr_holidays.lib.holiday_generator import countries
+        India = getattr(countries, "IN")   # returns India class
+    """
+    if name in _COUNTRY_PATHS:
+        subpath = _COUNTRY_PATHS[name]
+        module_path, class_name = subpath.rsplit(".", 1)
+        # Import relative to this package, not top-level
+        mod = importlib.import_module(f"{BASE_PKG}.{module_path}")
+        cls = getattr(mod, class_name)
+        globals()[name] = cls  # cache
+        return cls
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/addons/hr_holidays/lib/holiday_generator/countries/australia.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/australia.py
@@ -1,0 +1,78 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+
+
+class Australia:
+    country_code = "AU"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            self._compute_new_years_day_holiday,
+            self._compute_australia_day_holiday,
+            self._compute_anzac_day_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_boxing_day_holiday,
+            self._compute_good_friday_holiday,       # Easter - 2 days (variable)
+            self._compute_easter_monday_holiday,     # Easter + 1 day (variable)
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Static date holidays
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_australia_day_holiday(self, year: int):
+        return {date(year, 1, 26): "Australia Day"}
+
+    def _compute_anzac_day_holiday(self, year: int):
+        return {date(year, 4, 25): "ANZAC Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_boxing_day_holiday(self, year: int):
+        return {date(year, 12, 26): "Boxing Day"}
+
+    # -------------------------------
+    # Calculated / variable-date holidays
+    # -------------------------------
+
+    def _compute_good_friday_holiday(self, year: int):
+        """
+        Good Friday:
+            Rule: Friday before Easter Sunday (Easter - 2 days).
+            Requires an Easter calculation (Gregorian computus) to implement.
+        """
+        return {self.gregorian_calendar.compute_good_friday(year): "Good Friday"}
+
+    def _compute_easter_monday_holiday(self, year: int):
+        """
+        Easter Monday:
+            Rule: Monday after Easter Sunday (Easter + 1 day).
+            Requires an Easter calculation (Gregorian computus) to implement.
+        """
+        return {self.gregorian_calendar.compute_easter_monday(year): "Easter Monday"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/bangladesh.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/bangladesh.py
@@ -1,0 +1,161 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+from ..calendars.hindu_calendar import HinduCalendar
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+from ..calendars.location import Location
+
+
+class Bangladesh:
+    country_code = "BD"
+
+    def __init__(self):
+        # Bangladesh - Capital: Dhaka
+        dhaka_location = Location(
+            lat=23.8103,
+            lon=90.4125,
+            tz=6.0,
+            height_m=4.0,
+            visibility_thresholds=None,
+        )
+        self.hindu_calendar = HinduCalendar(dhaka_location)
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self.islamic_calendar = IslamicHolidayGenerator(dhaka_location)
+
+        self._public_holiday_computers = [
+            # Static dates
+            self._compute_language_martyrs_day_holiday,
+            self._compute_independence_day_holiday,
+            self._compute_bengali_new_year_holiday,
+            self._compute_labor_day_holiday,
+            self._compute_victory_day_holiday,
+
+            # Variable / announced (stubs)
+            self._compute_shab_e_barat_holiday,                  # lunar (Shaban 15)
+            self._compute_shab_e_qadr_holiday,                   # odd nights of last 10 of Ramadan (govt announced)
+            self._compute_eid_ul_fitr_holiday_days,              # govt-declared span around Eid al-Fitr
+            self._compute_eid_ul_fitr_holiday,                   # Eid al-Fitr day (1 Shawwal)
+            self._compute_buddha_purnima_vesak_holiday,          # Vaisakha Purnima
+            self._compute_eid_al_adha_holiday_days,              # govt-declared span around Eid al-Adha
+            self._compute_eid_al_adha_holiday,                   # Eid al-Adha day (10 Dhu al-Hijjah)
+            self._compute_ashura_holiday,                        # 10 Muharram
+            self._compute_student_people_uprising_day_holiday,   # usually 5 Aug (civic)
+            self._compute_janmashtami_holiday,                   # Bhadrapada Krishna Ashtami
+            self._compute_milad_un_nabi_tentative_holiday,       # 12 Rabi' al-awwal (tentative)
+            self._compute_mahanabami_holiday,                    # Durga Puja period
+            self._compute_durga_puja_holiday,                    # Durga Puja day
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Static date holidays
+    # -------------------------------
+
+    def _compute_language_martyrs_day_holiday(self, year: int):
+        return {date(year, 2, 21): "Language Martyrs' Day"}
+
+    def _compute_independence_day_holiday(self, year: int):
+        return {date(year, 3, 26): "Independence Day"}
+
+    def _compute_bengali_new_year_holiday(self, year: int):
+        return {date(year, 4, 14): "Bengali New Year"}
+
+    def _compute_labor_day_holiday(self, year: int):
+        return {date(year, 5, 1): "May Day"}
+
+    def _compute_victory_day_holiday(self, year: int):
+        return {date(year, 12, 16): "Victory Day"}
+
+    # -------------------------------
+    # Variable / announced holidays
+    # -------------------------------
+
+
+    def _compute_shab_e_barat_holiday(self, year: int):
+        """Shab e-Barat — Islamic lunar: 15th night of Shaban (govt announced each year)."""
+        return None
+
+    def _compute_shab_e_qadr_holiday(self, year: int):
+        """Shab-e-Qadr — Odd nights in last 10 days of Ramadan; official date announced yearly."""
+        return None
+
+    def _compute_eid_ul_fitr_holiday(self, year: int):
+        """Eid ul-Fitr — Islamic lunar: 1 Shawwal (date varies by moon sighting)."""
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Eid ul-Fitr (Tentative Date)"}
+
+    def _compute_eid_ul_fitr_holiday_days(self, year: int):
+        """Eid ul-Fitr holiday span — multiple govt-declared days around 1 Shawwal."""
+        eid_al_fitr_date = self.islamic_calendar.compute_eid_al_fitr(year)
+        joint_eid_al_fitr_day1 = eid_al_fitr_date + timedelta(days=1)
+        joint_eid_al_fitr_day2 = eid_al_fitr_date + timedelta(days=2)
+        joint_eid_al_fitr_day3 = eid_al_fitr_date + timedelta(days=3)
+
+        return {
+            joint_eid_al_fitr_day1: "Eid ul-Fitr Holiday (Tentative Date)",
+            joint_eid_al_fitr_day2: "Eid ul-Fitr Holiday (Tentative Date)",
+            joint_eid_al_fitr_day3: "Eid ul-Fitr Holiday (Tentative Date)",
+        }
+
+    def _compute_buddha_purnima_vesak_holiday(self, year: int):
+        """Buddha Purnima/Vesak — Vaisakha Purnima (lunar)."""
+        return {self.hindu_calendar._compute_buddha_purnima_holiday(year): "Buddha Purnima/Vesak"}
+
+    def _compute_eid_al_adha_holiday(self, year: int):
+        """Eid al-Adha — Islamic lunar: 10 Dhu al-Hijjah (date varies by moon sighting)."""
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Eid al-Adha (Tentative Date)"}
+
+    def _compute_eid_al_adha_holiday_days(self, year: int):
+        """Eid al-Adha holiday span — multiple govt-declared days around 10 Dhu al-Hijjah."""
+        eid_al_adha_date = self.islamic_calendar.compute_eid_al_adha(year)
+        joint_eid_al_adha_day1 = eid_al_adha_date + timedelta(days=1)
+        joint_eid_al_adha_day2 = eid_al_adha_date + timedelta(days=2)
+        joint_eid_al_adha_day3 = eid_al_adha_date + timedelta(days=3)
+
+        return {
+            joint_eid_al_adha_day1: "Eid al-Adha Holiday (Tentative Date)",
+            joint_eid_al_adha_day2: "Eid al-Adha Holiday (Tentative Date)",
+            joint_eid_al_adha_day3: "Eid al-Adha Holiday (Tentative Date)",
+        }
+
+    def _compute_ashura_holiday(self, year: int):
+        """Ashura — Islamic lunar: 10 Muharram."""
+        return {self.islamic_calendar.compute_ashura(year): "Ashura (Tentative Date)"}
+
+    def _compute_student_people_uprising_day_holiday(self, year: int):
+        """Student-People Uprising Day — commonly observed on August 5."""
+        return None
+
+    def _compute_janmashtami_holiday(self, year: int):
+        """Janmashtami — Bhadrapada Krishna Ashtami (Hindu lunisolar)."""
+        return {self.hindu_calendar._compute_janmashtami_holiday(year): "Janmashtami"}
+
+    def _compute_milad_un_nabi_tentative_holiday(self, year: int):
+        """Eid e-Milad-un Nabi (Tentative) — 12 Rabi' al-awwal (Islamic lunar)."""
+        return {self.islamic_calendar.compute_mawlid(year): "Eid e-Milad-un Nabi (Tentative Date)"}
+
+    def _compute_mahanabami_holiday(self, year: int):
+        """Mahanabami — during Durga Puja (Hindu lunisolar)."""
+        return None
+
+    def _compute_durga_puja_holiday(self, year: int):
+        """Durga Puja — main day in the Puja period (Hindu lunisolar)."""
+        return None

--- a/addons/hr_holidays/lib/holiday_generator/countries/belgium.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/belgium.py
@@ -1,0 +1,95 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+
+
+class Belgium:
+    country_code = "BE"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            # Static dates
+            self._compute_new_years_day_holiday,
+            self._compute_labor_day_holiday,
+            self._compute_belgian_national_day_holiday,
+            self._compute_assumption_day_holiday,
+            self._compute_all_saints_day_holiday,
+            self._compute_armistice_day_holiday,
+            self._compute_christmas_day_holiday,
+
+            # Variable (Christian feasts depending on Easter)
+            self._compute_easter_monday_holiday,
+            self._compute_ascension_day_holiday,
+            self._compute_whit_monday_holiday,
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Static date holidays
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_labor_day_holiday(self, year: int):
+        return {date(year, 5, 1): "Labor Day"}
+
+    def _compute_belgian_national_day_holiday(self, year: int):
+        return {date(year, 7, 21): "Belgian National Day"}
+
+    def _compute_assumption_day_holiday(self, year: int):
+        return {date(year, 8, 15): "Assumption of Mary"}
+
+    def _compute_all_saints_day_holiday(self, year: int):
+        return {date(year, 11, 1): "All Saints' Day"}
+
+    def _compute_armistice_day_holiday(self, year: int):
+        return {date(year, 11, 11): "Armistice Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        return {date(year, 12, 25): "Christmas Day"}
+
+    # -------------------------------
+    # Variable / movable holidays
+    # -------------------------------
+
+    def _compute_easter_monday_holiday(self, year: int):
+        """
+        Easter Monday:
+        Rule: Easter Sunday + 1 day.
+        """
+        return {self.gregorian_calendar.compute_easter_monday(year): "Easter Monday"}
+
+    def _compute_ascension_day_holiday(self, year: int):
+        """
+        Ascension Day:
+          Rule: Easter Sunday + 39 days (Thursday).
+        """
+        return {self.gregorian_calendar.compute_ascension(year): "Ascension Day"}
+
+    def _compute_whit_monday_holiday(self, year: int):
+        """
+        Whit Monday (Pentecost Monday):
+          Rule: Easter Sunday + 50 days (Monday).
+        """
+        return {self.gregorian_calendar.compute_white_monday(year): "Whit Monday"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/egypt.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/egypt.py
@@ -1,0 +1,178 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+from ..calendars.utils.time_utils import first_weekday_on_or_after
+from ..calendars.location import Location
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+
+
+class Egypt:
+    country_code = "EG"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        # Cairo, Egypt (UTC+2, no DST considered)
+        egypt_location = Location(
+            lat=30.0444,          # latitude north
+            lon=31.2357,          # longitude east
+            tz=2.0,               # UTC+2
+            height_m=23.0,        # approx elevation in meters
+            method="astronomical",
+            visibility_thresholds=None,
+        )
+        self.islamic_calendar = IslamicHolidayGenerator(egypt_location)
+
+        self._public_holiday_computers = [
+            # Static dates
+            self._compute_coptic_christmas_day_holiday,
+            self._compute_revolution_day_january_25_holiday,
+            self._compute_sinai_liberation_day_holiday,
+            self._compute_labor_day_holiday,
+            self._compute_june_30_revolution_holiday,
+            self._compute_armed_forces_day_holiday,
+
+            # Variable / religious or announced
+            self._compute_spring_festival_holiday,           # Easter Monday (Sham El-Nessim)
+            self._compute_day_off_for_revolution_day_january_25_holiday,
+            self._compute_day_off_for_june_30_revolution,
+            self._compute_day_off_for_revolution_day_jul23,
+            self._compute_arafah_day_holiday,                # 9 Dhu al-Hijjah
+            self._compute_eid_al_adha_holiday,               # 10 Dhu al-Hijjah
+            self._compute_eid_al_adha_span_holidays,         # 2025-06-07..10
+            self._compute_muharram_holiday,                  # Islamic New Year
+            self._compute_mawlid_tentative_holiday,          # Prophet's Birthday
+            self._compute_eid_al_fitr_holiday,               # 1 Shawwal
+            self._compute_eid_al_fitr_span_holidays,
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Static date holidays (implemented)
+    # -------------------------------
+
+    def _compute_coptic_christmas_day_holiday(self, year: int):
+        return {date(year, 1, 7): "Coptic Christmas Day"}
+
+    def _compute_revolution_day_january_25_holiday(self, year: int):
+        return {date(year, 1, 25): "Revolution Day January 25"}
+
+    def _compute_sinai_liberation_day_holiday(self, year: int):
+        return {date(year, 4, 25): "Sinai Liberation Day"}
+
+    def _compute_labor_day_holiday(self, year: int):
+        return {date(year, 5, 1): "Labor Day"}
+
+    def _compute_june_30_revolution_holiday(self, year: int):
+        return {date(year, 6, 30): "June 30 Revolution"}
+
+    def _compute_armed_forces_day_holiday(self, year: int):
+        return {date(year, 10, 6): "Armed Forces Day"}
+
+    # -------------------------------
+    # Variable / announced holidays
+    # -------------------------------
+
+    def _compute_day_off_for_june_30_revolution(self, year: int) -> Dict[date, str]:
+        """
+            Government 'day off' adjustment for June 30 Revolution.
+            Rule of thumb used in Egypt since 2020: shift many midweek holidays to Thursday.
+            Here: choose the first Thursday on or after June 30.
+        """
+        base = date(year, 6, 30)
+        th = first_weekday_on_or_after(base, weekday=3)  # Thursday=3
+        return {th: "Day Off (June 30 Revolution)"}  # ad hoc; include if you want an 'always-thursday' policy
+
+    def _compute_day_off_for_revolution_day_january_25_holiday(self, year: int) -> Dict[date, str]:
+        """
+            Government 'day off' adjustment for Revolution Day (January 25).
+            Choose the first Thursday on or after Jan 25.
+        """
+        base = date(year, 1, 25)
+        th = first_weekday_on_or_after(base, weekday=3)
+        return {th: "Day Off (January 25 Revolution)"}
+
+    def _compute_day_off_for_revolution_day_jul23(self, year: int) -> Dict[date, str]:
+        """
+            Government 'day off' adjustment for Revolution Day (July 23).
+            Choose the first Thursday on or after Jul 23.
+        """
+        base = date(year, 7, 23)
+        th = first_weekday_on_or_after(base, weekday=3)
+        return {th: "Day Off (July 23 Revolution)"}
+
+    def _compute_day_off_for_armed_forces_day(self, year: int) -> Dict[date, str]:
+        """
+            Government 'day off' adjustment for Armed Forces Day (Oct 6).
+            Choose the first Thursday on or after Oct 6.
+        """
+        base = date(year, 10, 6)
+        th = first_weekday_on_or_after(base, weekday=3)
+        return {th: "Day Off (Armed Forces Day)"}
+
+    def _compute_spring_festival_holiday(self, year: int):
+        """Spring Festival (Sham El-Nessim): Monday after Coptic/Easter Sunday. Variable date each year."""
+        # This is orthodox easter
+        return {self.gregorian_calendar.compute_orthodox_easter_monday(year ): "Spring Festival (Sham El-Nessim)"}
+
+    def _compute_eid_al_fitr_holiday(self, year: int):
+        """Eid al-Fitr: 1 Shawwal in the Islamic calendar; lunar date, varies each year."""
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Eid al-Fitr (Tentative Date)"}
+
+    def _compute_eid_al_fitr_span_holidays(self, year: int):
+        """Eid al-Fitr Holiday span: government-declared extra days around Eid al-Fitr. Variable each year."""
+        eid_date = self.islamic_calendar.compute_eid_al_fitr(year)
+        eid_date_plus_1 = eid_date + timedelta(days=1)
+        eid_date_plus_2 = eid_date + timedelta(days=2)
+        eid_date_plus_3 = eid_date + timedelta(days=3)
+        return {
+            eid_date_plus_1: "Eid al-Fitr Holiday (Tentative Date)",
+            eid_date_plus_2: "Eid al-Fitr Holiday (Tentative Date)",
+            eid_date_plus_3: "Eid al-Fitr Holiday (Tentative Date)",
+        }
+
+    def _compute_arafah_day_holiday(self, year: int):
+        """Arafah Day: 9 Dhu al-Hijjah (Islamic lunar calendar)."""
+        return {self.islamic_calendar.compute_arafah(year): "Arafah Day (Tentative Date)"}
+
+    def _compute_eid_al_adha_holiday(self, year: int):
+        """Eid al-Adha: 10 Dhu al-Hijjah (Islamic lunar calendar)."""
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Eid al-Adha (Tentative Date)"}
+
+    def _compute_eid_al_adha_span_holidays(self, year: int):
+        """Eid al-Adha Holiday span: government-declared extra days around Eid al-Adha. Variable each year."""
+        eid_al_adha_date = self.islamic_calendar.compute_eid_al_adha(year)
+        eid_al_adha_date_plus_1 = eid_al_adha_date + timedelta(days=1)
+        eid_al_adha_date_plus_2 = eid_al_adha_date + timedelta(days=2)
+        eid_al_adha_date_plus_3 = eid_al_adha_date + timedelta(days=3)
+        return {
+            eid_al_adha_date_plus_1: "Eid al-Adha Holiday (Tentative Date)",
+            eid_al_adha_date_plus_2: "Eid al-Adha Holiday (Tentative Date)",
+            eid_al_adha_date_plus_3: "Eid al-Adha Holiday (Tentative Date)",
+        }
+
+    def _compute_muharram_holiday(self, year: int):
+        """Islamic New Year (Hijri 1 Muharram). Lunar date, varies each year."""
+        return {self.islamic_calendar.compute_islamic_new_year(year): "Muharram/New Year (Tentative Date)"}
+
+    def _compute_mawlid_tentative_holiday(self, year: int):
+        """Prophet Muhammad's Birthday (Mawlid an-Nabi): 12 Rabi' al-awwal (Islamic lunar calendar)."""
+        return {self.islamic_calendar.compute_mawlid(year): "Prophet's Birthday (Tentative Date)"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/hongkong.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/hongkong.py
@@ -1,0 +1,145 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.chinese_calendar import ChineseHolidayGenerator
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+from ..calendars.hindu_calendar import HinduCalendar
+from ..calendars.location import Location
+
+
+class HongKong:
+    country_code = "HK"
+
+    def __init__(self):
+        hongkong_location = Location(
+            lat=22.3193,    # degrees north
+            lon=114.1694,   # degrees east
+            tz=8.0,         # Hong Kong Time (UTC+8, no DST)
+            height_m=35.0,   # Approx. elevation in meters
+            visibility_thresholds=None,
+        )
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self.hindu_calendar = HinduCalendar(hongkong_location)
+        self.chinese_calendar = ChineseHolidayGenerator(hongkong_location)
+        self._public_holiday_computers = [
+            # Fixed dates
+            self._compute_new_years_day_holiday,
+            self._compute_labour_day_holiday,
+            self._compute_hksar_establishment_day_holiday,
+            self._compute_national_day_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_first_weekday_after_christmas_day_holiday,
+
+            # Variable / lunar / movable feasts
+            self._compute_lunar_new_year_holiday,
+            self._compute_second_day_lunar_new_year_holiday,
+            self._compute_chung_yeung_festival_holiday,
+            self._compute_third_day_lunar_new_year_holiday,
+            self._compute_tomb_sweeping_day_holiday,
+            self._compute_good_friday_holiday,
+            self._compute_holy_saturday_holiday,
+            self._compute_easter_monday_holiday,
+            self._compute_buddhas_birthday_holiday,
+            self._compute_dragon_boat_festival_holiday,
+            self._compute_day_after_mid_autumn_festival_holiday,
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labour Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labour Day"}
+
+    def _compute_hksar_establishment_day_holiday(self, year: int):
+        """HKSAR Establishment Day — fixed date: July 1."""
+        return {date(year, 7, 1): "Hong Kong Special Administrative Region Establishment Day"}
+
+    def _compute_national_day_holiday(self, year: int):
+        """National Day — fixed date: October 1."""
+        return {date(year, 10, 1): "National Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_first_weekday_after_christmas_day_holiday(self, year: int):
+        """First Weekday After Christmas Day — fixed date: December 26."""
+        return {date(year, 12, 26): "First Weekday After Christmas Day"}
+
+    # -------------------------------
+    # Variable / lunar / movable feasts (return  , docstring only)
+    # -------------------------------
+
+    def _compute_lunar_new_year_holiday(self, year: int):
+        """Lunar New Year's Day — 1st day of the 1st lunar month (Jan-Feb)."""
+        return {self.chinese_calendar.compute_chinese_new_year(year): "Lunar New Year's Day"}
+
+    def _compute_second_day_lunar_new_year_holiday(self, year: int):
+        """Second Day of Lunar New Year — 2nd day of the 1st lunar month"""
+        lunar_new_year = self.chinese_calendar.compute_chinese_new_year(year)
+        return {lunar_new_year + timedelta(days=1): "Second Day of Lunar New Year"}
+
+    def _compute_third_day_lunar_new_year_holiday(self, year: int):
+        """Third Day of Lunar New Year — 3rd day of the 1st lunar month"""
+        lunar_new_year = self.chinese_calendar.compute_chinese_new_year(year)
+        return {lunar_new_year + timedelta(days=2): "Third Day of Lunar New Year"}
+
+    def _compute_chung_yeung_festival_holiday(self, year: int):
+        """Chung Yeung Festival — 9th day of 9th lunar month. Varies, not fixed Gregorian date."""
+        return {self.chinese_calendar.compute_double_ninth(year): "Chung Yeung Festival"}
+
+    def _compute_tomb_sweeping_day_holiday(self, year: int):
+        """Tomb Sweeping Day (Ching Ming Festival) — around April 4 or 5. Varies each year."""
+        return {self.chinese_calendar.compute_qingming(year): "Tomb Sweeping Day"}
+
+    def _compute_good_friday_holiday(self, year: int):
+        """Good Friday — Friday before Easter Sunday. Varies each year."""
+        return {self.gregorian_calendar.compute_good_friday(year): "Good Friday"}
+
+    def _compute_holy_saturday_holiday(self, year: int):
+        """Holy Saturday — Day after Good Friday (Easter Saturday). Varies each year."""
+        return {self.gregorian_calendar.compute_holy_saturday(year): "Holy Saturday"}
+
+    def _compute_easter_monday_holiday(self, year: int):
+        """Easter Monday — Day after Easter Sunday. Varies each year."""
+        return {self.gregorian_calendar.compute_easter_monday(year): "Easter Monday"}
+
+    def _compute_buddhas_birthday_holiday(self, year: int):
+        """Buddha's Birthday — 8th day of the 4th lunar month. Varies each year (Apr-May)."""
+        # It falls on the 8th day of the 4th lunar month.
+        return {self.hindu_calendar._compute_buddha_purnima_holiday(year): "Buddha's Birthday"}
+
+    def _compute_dragon_boat_festival_holiday(self, year: int):
+        """Dragon Boat Festival — 5th day of the 5th lunar month. Varies each year (May-Jun)."""
+        # 5th day of the 5th lunar month.
+        return {self.chinese_calendar.compute_dragon_boat(year): "Dragon Boat Festival"}
+
+    def _compute_day_after_mid_autumn_festival_holiday(self, year: int):
+        """Day after Mid-Autumn Festival — 16th day of the 8th lunar month. Varies each year (Sep-Oct)."""
+        # 15th day of the 8th lunar month,
+        return {self.chinese_calendar.compute_mid_autumn(year) + timedelta(days=1): "Day after Mid-Autumn Festival"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/india.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/india.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+from ..calendars.hindu_calendar import HinduCalendar
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+from ..calendars.location import Location
+
+
+class India:
+    country_code = "IN"
+
+    def __init__(self):
+        # Static location (New Delhi). Stateless across years.
+        delhi_location = Location(
+            lat=28.6139,          # latitude north
+            lon=77.2090,          # longitude east
+            tz=5.5,               # UTC+5:30
+            height_m=216.0,       # approx elevation in meters
+            method="astronomical",
+            visibility_thresholds=None,
+        )
+        self.hindu_calendar = HinduCalendar(delhi_location)
+        self.islamic_calendar = IslamicHolidayGenerator(delhi_location)
+        self.gregorian_calendar = ChristianHolidayGenerator()
+
+        # list of callables that take (year: int) -> Dict[date, str] | None
+        self._public_holiday_computers = [
+            self._compute_republic_day_holiday,
+            self._compute_maha_shivaratri_holiday,
+            self._compute_holi_holiday,
+            self._compute_ramzan_id_holiday,
+            self._compute_mahavir_jayanti_holiday,
+            self._compute_good_friday_holiday,
+            self._compute_buddha_purnima_holiday,
+            self._compute_bakrid_holiday,
+            self._compute_muharram_ashura_holiday,
+            self._compute_independence_day_holiday,
+            self._compute_janmashtami_holiday,
+            self._compute_id_e_milad_holiday,
+            self._compute_mahatma_gandhi_jayanti_holiday,
+            self._compute_dussehra_holiday,
+            self._compute_diwali_deepavali_holiday,
+            self._compute_guru_nanak_jayanti_holiday,
+            self._compute_christmas_holiday,
+        ]
+
+    # helper: get/create HinduCalendar for a year
+    def _cal(self, year: int) -> HinduCalendar:
+        hc = self._hc_by_year.get(year)
+        if hc is None:
+            hc = HinduCalendar(self.location)
+            self._hc_by_year[year] = hc
+        return hc
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed date holidays
+    # -------------------------------
+    def _compute_republic_day_holiday(self, year: int):
+        if year >= 1950:
+            return {date(year, 1, 26): "Republic Day"}
+        return None
+
+    def _compute_independence_day_holiday(self, year: int):
+        return {date(year, 8, 15): "Independence Day"}
+
+    def _compute_mahatma_gandhi_jayanti_holiday(self, year: int):
+        return {date(year, 10, 2): "Mahatma Gandhi Jayanti"}
+
+    def _compute_christmas_holiday(self, year: int):
+        return {date(year, 12, 25): "Christmas"}
+
+    # -------------------------------
+    # Calculated (Hindu calendar) holidays
+    # -------------------------------
+    def _compute_maha_shivaratri_holiday(self, year: int):
+        return {self.hindu_calendar._compute_maha_shivaratri(year): "Maha Shivaratri"}
+
+    def _compute_holi_holiday(self, year: int):
+        return {self.hindu_calendar._compute_holi(year): "Holi"}
+
+    def _compute_mahavir_jayanti_holiday(self, year: int):
+        return {self.hindu_calendar._compute_mahavir_jayanti_holiday(year): "Mahavir Jayanti"}
+
+    def _compute_good_friday_holiday(self, year: int):
+        return {self.gregorian_calendar.compute_good_friday(year): "Good Friday"}
+
+    def _compute_buddha_purnima_holiday(self, year: int):
+        return {self.hindu_calendar._compute_buddha_purnima_holiday(year): "Buddha Purnima"}
+
+    def _compute_janmashtami_holiday(self, year: int):
+        return {self.hindu_calendar._compute_janmashtami_holiday(year): "Janmashtami"}
+
+    def _compute_dussehra_holiday(self, year: int):
+        return {self.hindu_calendar._compute_dussehra_holiday(year): "Dussehra"}
+
+    def _compute_diwali_deepavali_holiday(self, year: int):
+        return {self.hindu_calendar._compute_diwali(year): "Diwali"}
+
+    def _compute_guru_nanak_jayanti_holiday(self, year: int):
+        return {self.hindu_calendar._compute_guru_nanak_jayanti_holiday(year): "Guru Nanak Jayanti"}
+
+    # -------------------------------
+    # Islamic (lunar) holidays - stubs
+    # -------------------------------
+    def _compute_id_e_milad_holiday(self, year: int):
+        return {self.islamic_calendar.compute_mawlid(year): "Id-e-Milad (Tentative Date)"}
+
+    def _compute_ramzan_id_holiday(self, year: int):
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Ramzan Id (Tentative Date)"}
+
+    def _compute_bakrid_holiday(self, year: int):
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Bakrid (Tentative Date)"}
+
+    def _compute_muharram_ashura_holiday(self, year: int):
+        return {self.islamic_calendar.compute_ashura(year): "Muharram/Ashura (Tentative Date)"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/indonesia.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/indonesia.py
@@ -1,0 +1,190 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.chinese_calendar import ChineseHolidayGenerator
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+from ..calendars.hindu_calendar import HinduCalendar
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+from ..calendars.location import Location
+
+
+class Indonesia:
+    country_code = "ID"
+
+    def __init__(self):
+        jakarta_location = Location(
+            lat=-6.2088,          # latitude south
+            lon=106.8456,         # longitude east
+            tz=7.0,               # UTC+7
+            height_m=140.0,       # approx elevation in meters
+            visibility_thresholds=None,
+        )
+        self.hindu_calendar = HinduCalendar(jakarta_location)
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self.chinese_calendar = ChineseHolidayGenerator(jakarta_location)
+        self.islamic_calendar = IslamicHolidayGenerator(jakarta_location)
+        self._public_holiday_computers = [
+            # Fixed-date public holidays
+            self._compute_new_years_day_holiday,
+            self._compute_labour_day_holiday,
+            self._compute_pancasila_day_holiday,
+            self._compute_independence_day_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_boxing_day_holiday,
+
+            # Variable / lunar / movable / govt-announced
+            self._compute_ascension_of_prophet_holiday,         # Islamic (Isra Mi'raj) — variable
+            self._compute_chinese_new_year_joint_holiday,       # Cuti Bersama — govt-announced
+            self._compute_chinese_new_year_day_holiday,         # Lunar New Year — variable
+            self._compute_nyepi_joint_holiday,                  # Cuti Bersama around Nyepi — govt-announced
+            self._compute_nyepi_day_holiday,                    # Nyepi (Saka New Year) — variable
+            self._compute_idul_fitri_day_holiday,               # 1 Shawwal — variable
+            self._compute_idul_fitri_joint_holiday_span,        # Cuti Bersama around Idul Fitri — govt-announced
+            self._compute_good_friday_holiday,                  # Friday before Easter — variable
+            self._compute_easter_sunday_holiday,                # Easter Sunday — variable
+            self._compute_waisak_day_holiday,                   # Buddha's Birthday — variable
+            self._compute_waisak_joint_holiday,                 # Cuti Bersama around Waisak — govt-announced
+            self._compute_ascension_day_of_jesus_holiday,       # Easter + 39 days — variable
+            self._compute_ascension_day_joint_holiday,          # Cuti Bersama after Ascension — govt-announced
+            self._compute_idul_adha_day_holiday,                # 10 Dhu al-Hijjah — variable
+            self._compute_idul_adha_joint_holiday,              # Cuti Bersama after Idul Adha — govt-announced
+            self._compute_muharram_islamic_new_year_holiday,    # 1 Muharram — variable
+            self._compute_independence_day_observed_holiday,    # gov’t observed day (e.g., Mon if Sun) — ad hoc
+            self._compute_maulid_nabi_tentative_holiday,        # 12 Rabi' al-awwal — variable (tentative)
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date public holidays (implemented every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labor Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labor Day"}
+
+    def _compute_pancasila_day_holiday(self, year: int):
+        """Pancasila Day — fixed date: June 1 (National Holiday)."""
+        return {date(year, 6, 1): "Pancasila Day"}
+
+    def _compute_independence_day_holiday(self, year: int):
+        """Indonesian Independence Day — fixed date: August 17."""
+        return {date(year, 8, 17): "Indonesian Independence Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_boxing_day_holiday(self, year: int):
+        return {date(year, 12, 26): "Boxing Day"}
+
+    # -------------------------------
+    # Variable/lunar/movable/government-announced (docstring only; return None)
+    # -------------------------------
+
+    def _compute_chinese_new_year_day_holiday(self, year: int):
+        """Chinese New Year's Day — 1st day of 1st lunar month; varies (Jan-Feb)."""
+        return {self.chinese_calendar.compute_chinese_new_year(year): "Chinese New Year's Day"}
+
+    def _compute_chinese_new_year_joint_holiday(self, year: int):
+        """Chinese New Year Joint Holiday — Cuti Bersama decided by government each year."""
+        chinese_new_year_day = self.chinese_calendar.compute_chinese_new_year(year)
+        return {chinese_new_year_day + timedelta(days=1): "Chinese New Year Joint Holiday"}
+
+    def _compute_nyepi_joint_holiday(self, year: int):
+        """Joint Holiday for Bali's Day of Silence (Nyepi) — Cuti Bersama; announced annually."""
+        return None
+
+    def _compute_nyepi_day_holiday(self, year: int):
+        """Bali's Day of Silence / Nyepi (Saka New Year) — Hindu lunisolar; variable date."""
+        return None
+
+    def _compute_ascension_of_prophet_holiday(self, year: int):
+        """Ascension of the Prophet Muhammad (Isra Mi'raj) — Islamic lunars."""
+        isra_date = self.islamic_calendar.compute_isra_miraj(year)
+        if isra_date:
+            return {isra_date: "Ascension of the Prophet Muhammad (Isra Mi'raj)"}
+        return None
+
+    def _compute_idul_fitri_day_holiday(self, year: int):
+        """Idul Fitri (Eid al-Fitr) — Islamic lunar: 1 Shawwal; varies; govt sets public holidays around it."""
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Idul Fitri"}
+
+    def _compute_idul_fitri_joint_holiday_span(self, year: int):
+        """Idul Fitri Joint Holidays — Cuti Bersama span before/after Eid; announced annually."""
+        eid_al_fitari_day = self.islamic_calendar.compute_eid_al_fitr(year)
+        joint_eid_al_fitri_day1 = eid_al_fitari_day + timedelta(days=1)
+        joint_eid_al_fitri_day2 = eid_al_fitari_day + timedelta(days=2)
+
+        return {
+            joint_eid_al_fitri_day1: "Idul Fitri Holiday",
+            joint_eid_al_fitri_day2: "Idul Fitri Holiday",
+        }
+
+    def _compute_good_friday_holiday(self, year: int):
+        """Good Friday — Friday before Easter; date varies by computus."""
+        return {self.gregorian_calendar.compute_good_friday(year): "Good Friday"}
+
+    def _compute_easter_sunday_holiday(self, year: int):
+        """Easter Sunday — movable feast; date varies by computus."""
+        return {self.gregorian_calendar.compute_easter_sunday(year): "Easter Sunday"}
+
+    def _compute_waisak_day_holiday(self, year: int):
+        """Waisak Day (Buddha's Anniversary) — Buddhist lunar calendar; date varies; govt announces."""
+        return {self.hindu_calendar._compute_buddha_purnima_holiday(year): "Waisak Day"}
+
+    def _compute_waisak_joint_holiday(self, year: int):
+        """Joint Holiday for Waisak Day — Cuti Bersama; announced annually."""
+        joint_budha_day = self.hindu_calendar._compute_buddha_purnima_holiday(year) + timedelta(days=1)
+        return {joint_budha_day: "Waisak Joint Holiday"}
+
+    def _compute_ascension_day_of_jesus_holiday(self, year: int):
+        """Ascension Day of Jesus Christ — Easter + 39 days (Thursday); movable."""
+        return {self.gregorian_calendar.compute_ascension(year): "Ascension Day of Jesus Christ"}
+
+    def _compute_ascension_day_joint_holiday(self, year: int):
+        """Joint Holiday after Ascension Day — Cuti Bersama; announced annually."""
+        joint_ascension_day = self.gregorian_calendar.compute_ascension(year) + timedelta(days=1)
+        return {joint_ascension_day: "Ascension Joint Holiday"}
+
+    def _compute_idul_adha_day_holiday(self, year: int):
+        """Idul Adha (Eid al-Adha) — Islamic lunar: 10 Dhu al-Hijjah; varies."""
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Idul Adha"}
+
+    def _compute_idul_adha_joint_holiday(self, year: int):
+        """Joint Holiday for Idul Adha — Cuti Bersama; announced annually."""
+        eid_al_adha_day = self.islamic_calendar.compute_eid_al_adha(year)
+        return {eid_al_adha_day + timedelta(days=1): "Idul Adha Joint Holiday"}
+
+    def _compute_muharram_islamic_new_year_holiday(self, year: int):
+        """Muharram / Islamic New Year — 1 Muharram (Hijri); lunar; varies."""
+        return {self.islamic_calendar.compute_islamic_new_year(year): "Muharram / Islamic New Year"}
+
+    def _compute_independence_day_observed_holiday(self, year: int):
+        """Independence Day observed — government-observed weekday when Aug 17 falls on weekend (ad hoc)."""
+        return None
+
+    def _compute_maulid_nabi_tentative_holiday(self, year: int):
+        """Maulid Nabi Muhammad (Prophet's Birthday) — 12 Rabi' al-awwal (Hijri); tentative each year."""
+        return {self.islamic_calendar.compute_mawlid(year): "Maulid Nabi Muhammad (Tentative Date)"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/jordan.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/jordan.py
@@ -1,0 +1,144 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+from ..calendars.location import Location
+
+
+class Jordan:
+    country_code = "JO"
+
+    def __init__(self):
+        # Location for Amman, Jordan (capital city)
+        self.location = Location(
+            lat=31.9454,     # degrees (north → positive)
+            lon=35.9284,     # degrees (east → positive)
+            tz=3.0,         # Jordan Standard Time (UTC+3, no DST since 2022)
+            height_m=850.0,   # Approx. elevation in meters
+            visibility_thresholds=None,
+        )
+        self.islamic_calendar = IslamicHolidayGenerator(self.location)
+        self._public_holiday_computers = [
+            # Fixed-date
+            self._compute_new_years_day_holiday,
+            self._compute_labour_day_holiday,
+            self._compute_independence_day_holiday,
+            self._compute_christmas_day_holiday,
+
+            # Variable / lunar / government-announced
+            self._compute_eid_al_fitr_day_holiday,       # 1 Shawwal
+            self._compute_eid_al_fitr_holiday_span,      # govt-declared span after Eid al-Fitr
+            self._compute_arafah_day_holiday,            # 9 Dhu al-Hijjah
+            self._compute_eid_al_adha_day_holiday,       # 10 Dhu al-Hijjah
+            self._compute_eid_al_adha_holiday_span,      # govt-declared span after Eid al-Adha
+            self._compute_muharram_islamic_new_year,     # 1 Muharram
+            self._compute_prophets_birthday_tentative,   # 12 Rabi' al-awwal
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (implemented)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labour Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labour Day"}
+
+    def _compute_independence_day_holiday(self, year: int):
+        """Independence Day — fixed date: May 25."""
+        return {date(year, 5, 25): "Independence Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    # -------------------------------
+    # Variable / lunar / government-announced (stubs)
+    # -------------------------------
+
+    def _compute_eid_al_fitr_day_holiday(self, year: int):
+        """
+        Eid al-Fitr — Islamic lunar: 1 Shawwal (marks end of Ramadan).
+        Date varies each year (moon-sighting). Government may announce surrounding public holidays.
+        """
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Eid al-Fitr (Tentative Date)"}
+
+    def _compute_eid_al_fitr_holiday_span(self, year: int):
+        """
+        Eid al-Fitr Holiday span — Government-declared public holidays surrounding Eid al-Fitr.
+        """
+        eid_al_fitr_date = self.islamic_calendar.compute_eid_al_fitr(year)
+        joint_eid_al_fitr_day1 = eid_al_fitr_date + timedelta(days=1)
+        joint_eid_al_fitr_day2 = eid_al_fitr_date + timedelta(days=2)
+        joint_eid_al_fitr_day3 = eid_al_fitr_date + timedelta(days=3)
+
+        return {
+            joint_eid_al_fitr_day1: "Eid al-Fitr Holiday (Tentative Date)",
+            joint_eid_al_fitr_day2: "Eid al-Fitr Holiday (Tentative Date)",
+            joint_eid_al_fitr_day3: "Eid al-Fitr Holiday (Tentative Date)",
+        }
+
+    def _compute_arafah_day_holiday(self, year: int):
+        """
+        Arafah Day — 9 Dhu al-Hijjah (day before Eid al-Adha).
+        Islamic lunar date; varies annually by moon-sighting.
+        """
+        return {self.islamic_calendar.compute_arafah(year): "Arafah Day (Tentative Date)"}
+
+    def _compute_eid_al_adha_day_holiday(self, year: int):
+        """
+        Eid al-Adha — 10 Dhu al-Hijjah.
+        Islamic lunar date; varies annually by moon-sighting.
+        """
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Eid al-Adha (Tentative Date)"}
+
+    def _compute_eid_al_adha_holiday_span(self, year: int):
+        """
+        Eid al-Adha Holiday span — Government-declared additional public holidays
+        """
+        eid_al_adha_date = self.islamic_calendar.compute_eid_al_adha(year)
+        joint_eid_al_adha_day1 = eid_al_adha_date + timedelta(days=1)
+        joint_eid_al_adha_day2 = eid_al_adha_date + timedelta(days=2)
+        joint_eid_al_adha_day3 = eid_al_adha_date + timedelta(days=3)
+
+        return {
+            joint_eid_al_adha_day1: "Eid al-Adha Holiday (Tentative Date)",
+            joint_eid_al_adha_day2: "Eid al-Adha Holiday (Tentative Date)",
+            joint_eid_al_adha_day3: "Eid al-Adha Holiday (Tentative Date)",
+        }
+
+    def _compute_muharram_islamic_new_year(self, year: int):
+        """
+        Muharram / Islamic New Year — 1 Muharram (Hijri).
+        Islamic lunar date; varies annually by moon-sighting.
+        """
+        return {self.islamic_calendar.compute_islamic_new_year(year): "Islamic New Year (Tentative Date)"}
+
+    def _compute_prophets_birthday_tentative(self, year: int):
+        """
+        Prophet's Birthday (Mawlid an-Nabi) — 12 Rabi' al-awwal.
+        Often published as a tentative date pending official announcement.
+        """
+        return {self.islamic_calendar.compute_mawlid(year): "Prophet's Birthday (Tentative Date)"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/kenya.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/kenya.py
@@ -1,0 +1,113 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+from ..calendars.location import Location
+
+
+class Kenya:
+    country_code = "KE"
+
+    def __init__(self):
+        self.location = Location(
+            lat=-1.2921,      # degrees (south → negative)
+            lon=36.8219,      # degrees (east → positive)
+            tz=3.0,          # Kenya Standard Time (UTC+3, no DST)
+            height_m=1795.0,  # Nairobi's elevation in meters
+            visibility_thresholds=None,
+        )
+        self.islamic_calendar = IslamicHolidayGenerator(self.location)
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,
+            self._compute_labour_day_holiday,
+            self._compute_madaraka_day_holiday,
+            self._compute_mazingira_day_holiday,
+            self._compute_mashujaa_day_holiday,
+            self._compute_jamhuri_day_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_boxing_day_holiday,
+
+            # Variable / movable / lunar
+            self._compute_idd_ul_fitr_holiday,       # 1 Shawwal
+            self._compute_eid_al_adha_holiday,       # 10 Dhu al-Hijjah
+            self._compute_good_friday_holiday,       # Friday before Easter
+            self._compute_easter_monday_holiday,     # Day after Easter Sunday
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labour Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labour Day"}
+
+    def _compute_madaraka_day_holiday(self, year: int):
+        """Madaraka Day — fixed date: June 1."""
+        return {date(year, 6, 1): "Madaraka Day"}
+
+    def _compute_mazingira_day_holiday(self, year: int):
+        """Mazingira Day — fixed date: October 10."""
+        return {date(year, 10, 10): "Mazingira Day"}
+
+    def _compute_mashujaa_day_holiday(self, year: int):
+        """Mashujaa Day — fixed date: October 20."""
+        return {date(year, 10, 20): "Mashujaa Day"}
+
+    def _compute_jamhuri_day_holiday(self, year: int):
+        """Jamhuri Day — fixed date: December 12."""
+        return {date(year, 12, 12): "Jamhuri Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_boxing_day_holiday(self, year: int):
+        """Boxing Day — fixed date: December 26."""
+        return {date(year, 12, 26): "Boxing Day"}
+
+    # -------------------------------
+    # Variable / movable / lunar
+    # -------------------------------
+
+    def _compute_idd_ul_fitr_holiday(self, year: int):
+        """Idd ul-Fitr — Islamic lunar: 1 Shawwal (end of Ramadan)."""
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Idd ul-Fitr (Tentative Date)"}
+
+    def _compute_eid_al_adha_holiday(self, year: int):
+        """Eid al-Adha — Islamic lunar: 10 Dhu al-Hijjah."""
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Eid al-Adha (Tentative Date)"}
+
+    def _compute_good_friday_holiday(self, year: int):
+        """Good Friday — Friday before Easter Sunday (Christian movable feast)."""
+        return {self.gregorian_calendar.compute_good_friday(year): "Good Friday"}
+
+    def _compute_easter_monday_holiday(self, year: int):
+        """Easter Monday — Monday after Easter Sunday (Christian movable feast)."""
+        return {self.gregorian_calendar.compute_easter_monday(year): "Easter Monday"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/lithuania.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/lithuania.py
@@ -1,0 +1,124 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+from ..calendars.utils.time_utils import nth_weekday
+
+
+class Lithuania:
+    country_code = "LT"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,
+            self._compute_independence_day_holiday,
+            self._compute_independence_restoration_day,
+            self._compute_labour_day_holiday,
+            self._compute_st_johns_day_holiday,
+            self._compute_king_mindaugas_coronation_day,
+            self._compute_assumption_day_holiday,
+            self._compute_all_saints_day_holiday,
+            self._compute_all_souls_day_holiday,
+            self._compute_christmas_eve_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_second_day_of_christmas_holiday,
+
+            # Variable / movable holidays
+            self._compute_easter_sunday_holiday,
+            self._compute_easter_monday_holiday,
+            self._compute_mothers_day_holiday,
+            self._compute_fathers_day_holiday,
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_independence_day_holiday(self, year: int):
+        """Independence Day / National Day — fixed date: February 16."""
+        return {date(year, 2, 16): "Independence Day / National Day"}
+
+    def _compute_independence_restoration_day(self, year: int):
+        """Independence Restoration Day — fixed date: March 11."""
+        return {date(year, 3, 11): "Independence Restoration Day"}
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labour Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labour Day"}
+
+    def _compute_st_johns_day_holiday(self, year: int):
+        """St John's Day / Day of Dew (Rasos/Joninės) — fixed date: June 24."""
+        return {date(year, 6, 24): "St John's Day/Day of Dew"}
+
+    def _compute_king_mindaugas_coronation_day(self, year: int):
+        """King Mindaugas' Coronation Day — fixed date: July 6."""
+        return {date(year, 7, 6): "King Mindaugas' Coronation Day"}
+
+    def _compute_assumption_day_holiday(self, year: int):
+        """Feast of the Assumption of Mary — fixed date: August 15."""
+        return {date(year, 8, 15): "Feast of the Assumption of Mary"}
+
+    def _compute_all_saints_day_holiday(self, year: int):
+        """All Saints' Day — fixed date: November 1."""
+        return {date(year, 11, 1): "All Saints' Day"}
+
+    def _compute_all_souls_day_holiday(self, year: int):
+        """All Souls' Day — fixed date: November 2."""
+        return {date(year, 11, 2): "All Souls' Day"}
+
+    def _compute_christmas_eve_holiday(self, year: int):
+        """Christmas Eve — fixed date: December 24."""
+        return {date(year, 12, 24): "Christmas Eve"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_second_day_of_christmas_holiday(self, year: int):
+        """Second Day of Christmas — fixed date: December 26."""
+        return {date(year, 12, 26): "Second Day of Christmas"}
+
+    # -------------------------------
+    # Variable / movable holidays (stubs)
+    # -------------------------------
+
+    def _compute_easter_sunday_holiday(self, year: int):
+        """Easter Sunday — Christian movable feast (computed by Gregorian computus)."""
+        return {self.gregorian_calendar.compute_easter_sunday(year): "Easter Sunday"}
+
+    def _compute_easter_monday_holiday(self, year: int):
+        """Easter Monday — Monday after Easter Sunday (movable)."""
+        return {self.gregorian_calendar.compute_easter_monday(year): "Easter Monday"}
+
+    def _compute_mothers_day_holiday(self, year: int):
+        """Mothers' Day — First Sunday in May (movable)."""
+        return {nth_weekday(year, 5, 6, 1): "Mothers' Day"}
+
+    def _compute_fathers_day_holiday(self, year: int):
+        """Fathers' Day — First Sunday in June (movable)."""
+        return {nth_weekday(year, 6, 6, 3), "Fathers' Day"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/luxembourg.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/luxembourg.py
@@ -1,0 +1,98 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+
+
+class Luxembourg:
+    country_code = "LU"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,
+            self._compute_labor_day_holiday,
+            self._compute_europe_day_holiday,
+            self._compute_national_day_holiday,
+            self._compute_assumption_day_holiday,
+            self._compute_all_saints_day_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_st_stephens_day_holiday,
+
+            # Movable (Easter-based) holidays
+            self._compute_easter_monday_holiday,     # Easter + 1 day
+            self._compute_ascension_day_holiday,     # Easter + 39 days
+            self._compute_whit_monday_holiday,       # Easter + 50 days
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_labor_day_holiday(self, year: int):
+        """Labor Day / May Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labor Day / May Day"}
+
+    def _compute_europe_day_holiday(self, year: int):
+        """Europe Day — fixed date: May 9 (public holiday in Luxembourg)."""
+        return {date(year, 5, 9): "Europe Day"}
+
+    def _compute_national_day_holiday(self, year: int):
+        """National Day — fixed date: June 23."""
+        return {date(year, 6, 23): "National Day"}
+
+    def _compute_assumption_day_holiday(self, year: int):
+        """Assumption of Mary — fixed date: August 15."""
+        return {date(year, 8, 15): "Assumption of Mary"}
+
+    def _compute_all_saints_day_holiday(self, year: int):
+        """All Saints' Day — fixed date: November 1."""
+        return {date(year, 11, 1): "All Saints' Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_st_stephens_day_holiday(self, year: int):
+        """St Stephen's Day — fixed date: December 26."""
+        return {date(year, 12, 26): "St Stephen's Day"}
+
+    # -------------------------------
+    # Movable (Easter-based) holidays
+    # -------------------------------
+
+    def _compute_easter_monday_holiday(self, year: int):
+        """Easter Monday — Monday after Easter Sunday."""
+        return {self.gregorian_calendar.compute_easter_monday(year): "Easter Monday"}
+
+    def _compute_ascension_day_holiday(self, year: int):
+        """Ascension Day — 39 days after Easter Sunday (Thursday; movable)."""
+        return {self.gregorian_calendar.compute_ascension(year): "Ascension Day"}
+
+    def _compute_whit_monday_holiday(self, year: int):
+        """Whit Monday (Pentecost Monday) — 50 days after Easter Sunday (movable)."""
+        return {self.gregorian_calendar.compute_white_monday(year): "Whit Monday"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/malaysia.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/malaysia.py
@@ -1,0 +1,139 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.chinese_calendar import ChineseHolidayGenerator
+from ..calendars.hindu_calendar import HinduCalendar
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+from ..calendars.location import Location
+
+
+class Malaysia:
+    country_code = "MY"
+
+    def __init__(self):
+        # Malaysia - Capital: Kuala Lumpur
+        kaula_location = Location(
+            lat=3.1390,
+            lon=101.6869,
+            tz=8.0,
+            height_m=56.0,
+            visibility_thresholds=None,
+        )
+        self.hindu_calendar = HinduCalendar(kaula_location)
+        self.chinese_calendar = ChineseHolidayGenerator(kaula_location)
+        self.islamic_calendar = IslamicHolidayGenerator(kaula_location)
+        self._public_holiday_computers = [
+            # Fixed-date federal holidays
+            self._compute_labour_day_holiday,
+            self._compute_malaysia_national_day,
+            self._compute_malaysia_day,
+            self._compute_christmas_day_holiday,
+
+            # Variable / lunar / government-set
+            self._compute_chinese_new_year_day,         # Lunar New Year (Day 1)
+            self._compute_chinese_new_year_day2,        # Lunar New Year (Day 2)
+            self._compute_hari_raya_puasa,              # Eid al-Fitr (Hari Raya Aidilfitri) Day 1
+            self._compute_hari_raya_puasa_day2,         # Eid al-Fitr Day 2
+            self._compute_wesak_day,                    # Buddha's Birthday (Vesak)
+            self._compute_agongs_birthday,              # Yang di-Pertuan Agong's Birthday
+            self._compute_hari_raya_haji,               # Eid al-Adha (Hari Raya Haji) Day 1
+            self._compute_hari_raya_haji_day2,          # Eid al-Adha Day 2
+            self._compute_muharram_islamic_new_year,    # 1 Muharram
+            self._compute_prophets_birthday_tentative,  # 12 Rabi' al-awwal (Mawlid) (tentative)
+            self._compute_malaysia_day_observed,        # Malaysia Day Holiday (observed)
+            self._compute_diwali_deepavali,             # Deepavali
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date federal holidays (implemented)
+    # -------------------------------
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labour Day — fixed date: May 1 (Federal Public Holiday)."""
+        return {date(year, 5, 1): "Labour Day"}
+
+    def _compute_malaysia_national_day(self, year: int):
+        """Malaysia's National Day (Hari Merdeka) — fixed date: August 31."""
+        return {date(year, 8, 31): "Malaysia's National Day"}
+
+    def _compute_malaysia_day(self, year: int):
+        """Malaysia Day — fixed date: September 16."""
+        return {date(year, 9, 16): "Malaysia Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    # -------------------------------
+    # Variable / lunar / government-set
+    # -------------------------------
+
+    def _compute_chinese_new_year_day(self, year: int):
+        """Chinese New Year's Day — 1st day of the 1st lunar month"""
+        return {self.chinese_calendar.compute_chinese_new_year(year): "Chinese New Year's Day"}
+
+    def _compute_chinese_new_year_day2(self, year: int):
+        """Second Day of Chinese New Year — 2nd day of the 1st lunar month"""
+        new_year_day = self.chinese_calendar.compute_chinese_new_year(year)
+        return {new_year_day + timedelta(days=1): "Second Day of Chinese New Year"}
+
+    def _compute_hari_raya_puasa(self, year: int):
+        """Hari Raya Puasa (Eid al-Fitr) — 1 Shawwal (Islamic lunar; varies; Federal Public Holiday)."""
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Hari Raya Puasa (Tentative Date)"}
+
+    def _compute_hari_raya_puasa_day2(self, year: int):
+        """Hari Raya Puasa Day 2 — government-set second day following Eid al-Fitr (varies)."""
+        hari_raya_date = self.islamic_calendar.compute_eid_al_fitr(year)
+        return {hari_raya_date + timedelta(days=1): "Hari Raya Puasa Day 2 (Tentative Date)"}
+
+    def _compute_wesak_day(self, year: int):
+        """Wesak Day (Buddha's Anniversary) — Buddhist lunar calendar; government announces date annually."""
+        return {self.hindu_calendar._compute_buddha_purnima_holiday(year): "Wesak Day"}
+
+    def _compute_agongs_birthday(self, year: int):
+        """The Yang di-Pertuan Agong's Birthday — date is set by government and may change by reign/year."""
+        return None
+
+    def _compute_hari_raya_haji(self, year: int):
+        """Hari Raya Haji (Eid al-Adha) — 10 Dhu al-Hijjah (Islamic lunar; varies)."""
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Hari Raya Haji (Tentative Date)"}
+
+    def _compute_hari_raya_haji_day2(self, year: int):
+        """Hari Raya Haji (Day 2) — government-set additional day after Eid al-Adha (varies)."""
+        hari_raya_haji_date = self.islamic_calendar.compute_eid_al_adha(year)
+        return {hari_raya_haji_date + timedelta(days=1): "Hari Raya Haji Day 2 (Tentative Date)"}
+
+    def _compute_muharram_islamic_new_year(self, year: int):
+        """Muharram / Islamic New Year — 1 Muharram (Islamic lunar; varies)."""
+        return {self.islamic_calendar.compute_islamic_new_year(year): "Muharram / Islamic New Year (Tentative Date)"}
+
+    def _compute_prophets_birthday_tentative(self, year: int):
+        """The Prophet Muhammad's Birthday (Mawlid) — 12 Rabi' al-awwal; often published as tentative."""
+        return {self.islamic_calendar.compute_mawlid(year): "Prophet's Birthday (Tentative Date)"}
+
+    def _compute_malaysia_day_observed(self, year: int):
+        """Malaysia Day Holiday — observed/adjacent holiday when Malaysia Day falls near a weekend"""
+        return None
+
+    def _compute_diwali_deepavali(self, year: int):
+        """Diwali / Deepavali — Hindu lunisolar calendar; varies by year and state observance."""
+        return {self.hindu_calendar._compute_diwali(year): "Diwali / Deepavali"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/mexico.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/mexico.py
@@ -1,0 +1,103 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+from ..calendars.utils.time_utils import nth_weekday
+
+
+class Mexico:
+    country_code = "MX"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,         # 1 Jan
+            self._compute_constitution_day_holiday,      # 5 Feb (observed on first Monday of Feb; fixed in list as 3 Feb 2025)
+            self._compute_benito_juarez_birthday,        # 21 Mar (observed on 3rd Monday of March; 17 Mar 2025)
+            self._compute_labor_day_holiday,             # 1 May
+            self._compute_independence_day_holiday,      # 16 Sep
+            self._compute_revolution_day_memorial,       # 20 Nov (observed on 3rd Monday of November; 17 Nov 2025)
+            self._compute_day_of_virgin_guadalupe,       # 12 Dec
+            self._compute_christmas_day_holiday,         # 25 Dec
+
+            # Variable / movable (docstring only; return None)
+            self._compute_maundy_thursday_holiday,
+            self._compute_good_friday_holiday,
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date or observed holidays
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_constitution_day_holiday(self, year: int) -> Dict[date, str]:
+        """
+        Constitution Day — officially Feb 5, observed on the first Monday of February.
+        """
+        return {nth_weekday(year, 2, weekday=0, n=1): "Constitution Day"}
+
+    def _compute_benito_juarez_birthday(self, year: int) -> Dict[date, str]:
+        """
+        Benito Juárez's Birthday Memorial — officially Mar 21,
+        observed on the third Monday of March.
+        """
+        return {nth_weekday(year, 3, weekday=0, n=3): "Benito Juárez's Birthday Memorial"}
+
+    def _compute_labor_day_holiday(self, year: int):
+        """Labor Day / May Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labor Day / May Day"}
+
+    def _compute_independence_day_holiday(self, year: int):
+        """Independence Day — fixed date: September 16."""
+        return {date(year, 9, 16): "Independence Day"}
+
+    def _compute_revolution_day_memorial(self, year: int):
+        """
+        Revolution Day Memorial — officially Nov 20, observed on the third Monday of November.
+        Example: 2025 observed on Nov 17.
+        """
+        # Use nth_weekday to get the 3rd Monday (weekday=0) in November
+        return {nth_weekday(year, 11, weekday=0, n=3): "Revolution Day Memorial"}
+
+    def _compute_day_of_virgin_guadalupe(self, year: int):
+        """Day of the Virgin of Guadalupe — fixed date: December 12."""
+        return {date(year, 12, 12): "Day of the Virgin of Guadalupe"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    # -------------------------------
+    # Variable / movable holidays (stubs)
+    # -------------------------------
+
+    def _compute_maundy_thursday_holiday(self, year: int):
+        """Maundy Thursday — Christian movable feast (Thursday before Easter Sunday)."""
+        return {self.gregorian_calendar.compute_maundy_thursday(year): "Maundy Thursday"}
+
+    def _compute_good_friday_holiday(self, year: int):
+        """Good Friday — Christian movable feast (Friday before Easter Sunday)."""
+        return {self.gregorian_calendar.compute_good_friday(year): "Good Friday"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/morocco.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/morocco.py
@@ -1,0 +1,140 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+from ..calendars.location import Location
+
+
+class Morocco:
+    country_code = "MA"
+
+    def __init__(self):
+        # Morocco - Capital: Rabat
+        self.location = Location(
+            lat=34.0209,
+            lon=-6.8416,
+            tz=0.0,        # Base offset UTC+0 (special DST rules not reflected here)
+            height_m=75.0,
+            visibility_thresholds=None,
+        )
+        self.islamic_calendar = IslamicHolidayGenerator(self.location)
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,
+            self._compute_independence_manifesto_day_holiday,
+            self._compute_amazigh_new_year_holiday,
+            self._compute_labour_day_holiday,
+            self._compute_feast_of_the_throne_holiday,
+            self._compute_oued_ed_dahab_day_holiday,
+            self._compute_revolution_king_people_holiday,
+            self._compute_youth_day_holiday,
+            self._compute_green_march_day_holiday,
+            self._compute_independence_day_holiday,
+
+            # Variable / lunar / government-shifted
+            self._compute_eid_al_fitr_day_holiday,               # 1 Shawwal
+            self._compute_eid_al_fitr_next_day_holiday,          # day after Eid al-Fitr
+            self._compute_eid_al_adha_day_holiday,               # 10 Dhu al-Hijjah
+            self._compute_eid_al_adha_span_holidays,             # additional days after Eid al-Adha
+            self._compute_hijra_new_year_holiday,                # 1 Muharram
+            self._compute_mawlid_tentative_holiday,              # 12 Rabi' al-awwal (tentative)
+            self._compute_mawlid_next_day_tentative_holiday,     # day after Mawlid (tentative)
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_independence_manifesto_day_holiday(self, year: int):
+        """Anniversary of the Independence Manifesto — fixed date: January 11."""
+        return {date(year, 1, 11): "Anniversary of the Independence Manifesto"}
+
+    def _compute_amazigh_new_year_holiday(self, year: int):
+        """Amazigh New Year (Yennayer) — fixed date in Morocco: January 14."""
+        return {date(year, 1, 14): "Amazigh New Year"}
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labour Day / May Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labour Day/May Day"}
+
+    def _compute_feast_of_the_throne_holiday(self, year: int):
+        """Feast of the Throne — fixed date: July 30."""
+        return {date(year, 7, 30): "Feast of the Throne"}
+
+    def _compute_oued_ed_dahab_day_holiday(self, year: int):
+        """Anniversary of the Recovery Oued Ed-Dahab — fixed date: August 14."""
+        return {date(year, 8, 14): "Anniversary of the Recovery Oued Ed-Dahab"}
+
+    def _compute_revolution_king_people_holiday(self, year: int):
+        """Anniversary of the Revolution of the King and the People — fixed date: August 20."""
+        return {date(year, 8, 20): "Anniversary of the Revolution of the King and the People"}
+
+    def _compute_youth_day_holiday(self, year: int):
+        """Youth Day — fixed date: August 21."""
+        return {date(year, 8, 21): "Youth Day"}
+
+    def _compute_green_march_day_holiday(self, year: int):
+        """Anniversary of the Green March — fixed date: November 6."""
+        return {date(year, 11, 6): "Anniversary of the Green March"}
+
+    def _compute_independence_day_holiday(self, year: int):
+        """Independence Day — fixed date: November 18."""
+        return {date(year, 11, 18): "Independence Day"}
+
+    # -------------------------------
+    # Variable / lunar / government-shifted (stubs)
+    # -------------------------------
+
+    def _compute_eid_al_fitr_day_holiday(self, year: int):
+        """Eid al-Fitr — Islamic lunar: 1 Shawwal (end of Ramadan). Government may announce exact date yearly."""
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Eid al-Fitr (Tentative Date)"}
+
+    def _compute_eid_al_fitr_next_day_holiday(self, year: int):
+        """Eid al-Fitr Holiday — day after Eid al-Fitr; government-announced each year."""
+        eid_al_fitr_date = self.islamic_calendar.compute_eid_al_fitr(year)
+        return {eid_al_fitr_date + timedelta(days=1): "Eid al-Fitr Holiday (Tentative Date)"}
+
+    def _compute_eid_al_adha_day_holiday(self, year: int):
+        """Eid al-Adha — Islamic lunar: 10 Dhu al-Hijjah; observed nationwide."""
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Eid al-Adha (Tentative Date)"}
+
+    def _compute_eid_al_adha_span_holidays(self, year: int):
+        """Eid al-Adha Holidays — additional days following Eid al-Adha; government-announced each year."""
+        eid_al_adha_date = self.islamic_calendar.compute_eid_al_adha(year)
+        return {eid_al_adha_date + timedelta(days=1): "Eid al-Adha Holiday (Tentative Date)"}
+
+    def _compute_hijra_new_year_holiday(self, year: int):
+        """Hijra (Islamic) New Year — 1 Muharram (lunar; varies annually)."""
+        return {self.islamic_calendar.compute_islamic_new_year(year): "Hijra (Islamic) New Year (Tentative Date)"}
+
+    def _compute_mawlid_tentative_holiday(self, year: int):
+        """Prophet Muhammad's Birthday (Mawlid) — 12 Rabi' al-awwal; often listed as tentative pending confirmation."""
+        return {self.islamic_calendar.compute_mawlid(year): "Prophet's Birthday (Tentative Date)"}
+
+    def _compute_mawlid_next_day_tentative_holiday(self, year: int):
+        """Prophet Muhammad's Birthday Holiday — day after Mawlid; tentative and government-announced."""
+        prophet_birthday_date = self.islamic_calendar.compute_mawlid(year)
+        return {prophet_birthday_date: "Prophet's Birthday Holiday (Tentative Date)"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/netherlands.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/netherlands.py
@@ -1,0 +1,104 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+
+
+class Netherlands:
+    country_code = "NL"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,
+            self._compute_liberation_day_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_second_day_of_christmas_holiday,
+
+            # Movable / observed (docstrings only; return None)
+            self._compute_kings_birthday_holiday,         # 27 Apr (observed 26 Apr if 27th is Sunday)
+            self._compute_good_friday_holiday,            # Friday before Easter
+            self._compute_easter_sunday_holiday,          # Easter Sunday
+            self._compute_easter_monday_holiday,          # Easter Monday
+            self._compute_ascension_day_holiday,          # Easter + 39 days (Thu)
+            self._compute_whit_sunday_holiday,            # Pentecost Sunday (Easter + 49)
+            self._compute_whit_monday_holiday,            # Pentecost Monday (Easter + 50)
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_liberation_day_holiday(self, year: int):
+        """Liberation Day — fixed date: May 5."""
+        return {date(year, 5, 5): "Liberation Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_second_day_of_christmas_holiday(self, year: int):
+        """Second Day of Christmas — fixed date: December 26."""
+        return {date(year, 12, 26): "Second Day of Christmas"}
+
+    # -------------------------------
+    # Movable / observed holidays (stubs)
+    # -------------------------------
+
+    def _compute_kings_birthday_holiday(self, year: int):
+        """
+        King's Birthday (Koningsdag):
+            Rule: April 27, but observed on April 26 if April 27 falls on a Sunday.
+        """
+        kings_day = date(year, 4, 27)
+        if kings_day.weekday() == 6:  # Sunday
+            kings_day = date(year, 4, 26)
+        return {kings_day: "King's Birthday"}
+
+    def _compute_good_friday_holiday(self, year: int):
+        """Good Friday — Friday before Easter Sunday (movable; requires Easter calculation)."""
+        return {self.gregorian_calendar.compute_good_friday(year): "Good Friday"}
+
+    def _compute_easter_sunday_holiday(self, year: int):
+        """Easter Sunday — Christian movable feast (computed by Gregorian computus)."""
+        return {self.gregorian_calendar.compute_western_easter(year): "Easter Sunday"}
+
+    def _compute_easter_monday_holiday(self, year: int):
+        """Easter Monday — Monday after Easter Sunday (movable)."""
+        return {self.gregorian_calendar.compute_easter_monday(year): "Easter Monday"}
+
+    def _compute_ascension_day_holiday(self, year: int):
+        """Ascension Day — 39 days after Easter Sunday (Thursday; movable)."""
+        return {self.gregorian_calendar.compute_ascension(year): "Ascension Day"}
+
+    def _compute_whit_sunday_holiday(self, year: int):
+        """Whit Sunday (Pentecost) — 49 days after Easter Sunday (movable)."""
+        return {self.gregorian_calendar.compute_pentecost(year): "Whit Sunday"}
+
+    def _compute_whit_monday_holiday(self, year: int):
+        """Whit Monday (Pentecost Monday) — 50 days after Easter Sunday (movable)."""
+        return {self.gregorian_calendar.compute_white_monday(year): "Whit Monday"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/pakistan.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/pakistan.py
@@ -1,0 +1,168 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.location import Location
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+
+
+class Pakistan:
+    country_code = "PK"
+
+    def __init__(self):
+        # Islamabad, Pakistan (UTC+5, no DST considered)
+        pakistan_location = Location(
+            lat=33.6844,          # latitude north
+            lon=73.0479,          # longitude east
+            tz=5.0,               # UTC+5
+            height_m=540.0,       # approx elevation in meters
+            visibility_thresholds=(2.0, 8.0),  # (altitude_deg, elongation_deg)
+        )
+        self.islamic_calendar = IslamicHolidayGenerator(pakistan_location)
+
+        self._public_holiday_computers = [
+            # Fixed-date holidays (implemented)
+            self._compute_kashmir_day_holiday,
+            self._compute_pakistan_day_holiday,
+            self._compute_labour_day_holiday,
+            self._compute_youm_i_takbeer_holiday,
+            self._compute_independence_day_holiday,
+            self._compute_iqbal_day_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_quaid_e_azam_day_holiday,
+
+            # Variable / lunar / government-announced
+            self._compute_eid_ul_fitr_day_holiday,      # 1 Shawwal
+            self._compute_eid_ul_fitr_holiday_span,     # govt-declared extra days after Eid-ul-Fitr
+            self._compute_chand_raat_holiday,           # eve holiday (govt-announced)
+            self._compute_eid_al_adha_day_holiday,      # 10 Dhu al-Hijjah
+            self._compute_eid_al_adha_holiday_span,     # govt-declared extra days after Eid al-Adha
+            self._compute_ashura_day_holiday,           # 10 Muharram
+            self._compute_ashura_holiday_span,          # 9–10 Muharram days
+            self._compute_eid_milad_un_nabi_tentative,  # 12 Rabi' al-awwal (tentative)
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_kashmir_day_holiday(self, year: int):
+        """Kashmir Day — fixed date: February 5."""
+        return {date(year, 2, 5): "Kashmir Day"}
+
+    def _compute_pakistan_day_holiday(self, year: int):
+        """Pakistan Day — fixed date: March 23."""
+        return {date(year, 3, 23): "Pakistan Day"}
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labour Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labour Day"}
+
+    def _compute_youm_i_takbeer_holiday(self, year: int):
+        """Youm-i-Takbeer — fixed date as listed: May 28."""
+        return {date(year, 5, 28): "Youm-i-Takbeer"}
+
+    def _compute_independence_day_holiday(self, year: int):
+        """Independence Day — fixed date: August 14."""
+        return {date(year, 8, 14): "Independence Day"}
+
+    def _compute_iqbal_day_holiday(self, year: int):
+        """Iqbal Day — fixed date: November 9."""
+        return {date(year, 11, 9): "Iqbal Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_quaid_e_azam_day_holiday(self, year: int):
+        """Quaid-e-Azam Day — fixed date: December 25 (same date as Christmas Day)."""
+        return {date(year, 12, 25): "Quaid-e-Azam Day"}
+
+    # -------------------------------
+    # Variable / lunar / government-announced (stubs)
+    # -------------------------------
+
+    def _compute_eid_ul_fitr_day_holiday(self, year: int):
+        """
+        Eid-ul-Fitr — Islamic lunar: 1 Shawwal (end of Ramadan).
+        Date varies annually by moon-sighting; government may also declare adjacent holidays.
+        """
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Eid ul-Fitr (Tentative)"}
+
+    def _compute_eid_ul_fitr_holiday_span(self, year: int):
+        """
+        Eid-ul-Fitr Holiday span — Government-declared additional public holidays
+        around the Eid-ul-Fitr day (e.g., +1 to +2 days).
+        """
+        eid_day = self.islamic_calendar.compute_eid_al_fitr(year)
+        span_days = 3  # Eid day + 2 days more
+
+        return {eid_day + timedelta(span_days): "Eid al-Fitr Span (Tentative)"}
+
+    def _compute_chand_raat_holiday(self, year: int):
+        """
+        Chand Raat Holiday — Eve before a major Islamic festival (often Eid).
+        Government-announced ad hoc; not fixed annually.
+        """
+        eid_day = self.islamic_calendar.compute_eid_al_fitr(year)
+        chand_raat = eid_day - timedelta(days=1)
+
+        return {chand_raat: "Chand Raat (Tentative)"}
+
+    def _compute_eid_al_adha_day_holiday(self, year: int):
+        """
+        Eid al-Adha — Islamic lunar: 10 Dhu al-Hijjah.
+        Date varies annually by moon-sighting.
+        """
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Eid al-Fitr (Tentative)"}
+
+    def _compute_eid_al_adha_holiday_span(self, year: int):
+        """
+        Eid al-Adha Holiday span — Government-declared additional public holidays
+        following Eid al-Adha (e.g., +1 to +3 days).
+        """
+        eid_day = self.islamic_calendar.compute_eid_al_adha(year)
+        span_days = 4  # Eid day + 3 more
+
+        return {eid_day + timedelta(days=span_days): "Eid al-Adha (Tentative)"}
+
+    def _compute_ashura_day_holiday(self, year: int):
+        """
+        Ashura — 10 Muharram (Islamic lunar).
+        Public holiday date varies annually; often observed with adjacent day(s).
+        """
+        return {self.islamic_calendar.compute_ashura(year): "Ashura (Tentative)"}
+
+    def _compute_ashura_holiday_span(self, year: int):
+        """
+        Ashura Holiday span — Additional day(s) around 9-10 Muharram as announced by government.
+        """
+        ashura_day = self.islamic_calendar.compute_ashura(year)
+        span_days = 2  # 9th and 10th Muharram
+
+        return {ashura_day - timedelta(days=span_days): "Ashura Span (Tentative)"}
+
+    def _compute_eid_milad_un_nabi_tentative(self, year: int):
+        """
+        Eid Milad un-Nabi (Prophet Muhammad's Birthday) — 12 Rabi' al-awwal.
+        Often listed as tentative pending official announcement each year.
+        """
+        return {self.islamic_calendar.compute_mawlid(year): "Eid Milad un-Nabi (Tentative)"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/poland.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/poland.py
@@ -1,0 +1,113 @@
+from datetime import date
+from typing import Dict
+
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+
+class Poland:
+    country_code = "PL"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,
+            self._compute_epiphany_holiday,
+            self._compute_labour_day_holiday,
+            self._compute_constitution_day_holiday,
+            self._compute_assumption_day_holiday,
+            self._compute_all_saints_day_holiday,
+            self._compute_independence_day_holiday,
+            self._compute_christmas_eve_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_second_day_of_christmas_holiday,
+
+            # Movable (Easter-based) — docstring only, return None
+            self._compute_easter_sunday_holiday,
+            self._compute_easter_monday_holiday,
+            self._compute_whit_sunday_holiday,
+            self._compute_corpus_christi_holiday,
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_epiphany_holiday(self, year: int):
+        """Epiphany — fixed date: January 6."""
+        return {date(year, 1, 6): "Epiphany"}
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labor Day / May Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labor Day / May Day"}
+
+    def _compute_constitution_day_holiday(self, year: int):
+        """Constitution Day — fixed date: May 3."""
+        return {date(year, 5, 3): "Constitution Day"}
+
+    def _compute_assumption_day_holiday(self, year: int):
+        """Assumption of Mary — fixed date: August 15."""
+        return {date(year, 8, 15): "Assumption of Mary"}
+
+    def _compute_all_saints_day_holiday(self, year: int):
+        """All Saints' Day — fixed date: November 1."""
+        return {date(year, 11, 1): "All Saints' Day"}
+
+    def _compute_independence_day_holiday(self, year: int):
+        """Independence Day — fixed date: November 11."""
+        return {date(year, 11, 11): "Independence Day"}
+
+    def _compute_christmas_eve_holiday(self, year: int):
+        """Christmas Eve — fixed date: December 24."""
+        return {date(year, 12, 24): "Christmas Eve"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_second_day_of_christmas_holiday(self, year: int):
+        """Second Day of Christmas — fixed date: December 26."""
+        return {date(year, 12, 26): "Second Day of Christmas"}
+
+    # -------------------------------
+    # Movable (Easter-based) holidays (stubs)
+    # -------------------------------
+
+    def _compute_easter_sunday_holiday(self, year: int):
+        """Easter Sunday — Christian movable feast (computed by Gregorian computus)."""
+        return {self.gregorian_calendar.compute_easter_sunday(year): "Easter Sunday"}
+
+    def _compute_easter_monday_holiday(self, year: int):
+        """Easter Monday — Monday after Easter Sunday (movable)."""
+        return {self.gregorian_calendar.compute_easter_monday(year): "Easter Monday"}
+
+    def _compute_whit_sunday_holiday(self, year: int):
+        """Whit Sunday (Pentecost) — 49 days after Easter Sunday (movable)."""
+        return {self.gregorian_calendar.compute_pentecost(year): "Whit Sunday"}
+
+    def _compute_corpus_christi_holiday(self, year: int):
+        """Corpus Christi — Thursday after Trinity Sunday (Easter + 60 days)."""
+        return {self.gregorian_calendar.compute_corpus_christi(year): "Corpus Christi"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/romania.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/romania.py
@@ -1,0 +1,102 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+
+
+class Romania:
+    country_code = "RO"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,
+            self._compute_day_after_new_years_day_holiday,
+            self._compute_epiphany_holiday,
+            self._compute_synaxis_of_st_john_holiday,
+            self._compute_unification_day_holiday,
+            self._compute_labour_day_holiday,
+            self._compute_childrens_day_holiday,
+
+            # Orthodox Easter-related
+            self._compute_orthodox_good_friday_holiday,
+            self._compute_orthodox_easter_day_holiday,
+            self._compute_orthodox_easter_monday_holiday,
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_day_after_new_years_day_holiday(self, year: int):
+        """Day after New Year's Day — fixed date: January 2."""
+        return {date(year, 1, 2): "Day after New Year's Day"}
+
+    def _compute_epiphany_holiday(self, year: int):
+        """Epiphany — fixed date: January 6."""
+        return {date(year, 1, 6): "Epiphany"}
+
+    def _compute_synaxis_of_st_john_holiday(self, year: int):
+        """Synaxis of St. John the Baptist — fixed date: January 7."""
+        return {date(year, 1, 7): "Synaxis of St. John the Baptist"}
+
+    def _compute_unification_day_holiday(self, year: int):
+        """Unification Day — fixed date: January 24."""
+        return {date(year, 1, 24): "Unification Day"}
+
+    def _compute_labour_day_holiday(self, year: int):
+        """Labor Day / May Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labor Day / May Day"}
+
+    def _compute_childrens_day_holiday(self, year: int):
+        """Children's Day — fixed date: June 1."""
+        return {date(year, 6, 1): "Children's Day"}
+
+    # -------------------------------
+    # Orthodox Easter-related (movable) — stubs
+    # -------------------------------
+
+    def _compute_orthodox_good_friday_holiday(self, year: int):
+        """
+        Orthodox Good Friday — Friday before Orthodox Easter Sunday.
+        Date is calculated per Orthodox (Julian-based) computus and varies yearly.
+        """
+        return {self.gregorian_calendar.compute_orthodox_good_friday(year): "Orthodox Good Friday"}
+
+    def _compute_orthodox_easter_day_holiday(self, year: int):
+        """
+        Orthodox Easter Day — Christian movable feast following the Orthodox computus.
+        Date varies annually and can differ from Western Easter.
+        """
+        return {self.gregorian_calendar.compute_orthodox_easter(year): "Orthodox Easter Day"}
+
+    def _compute_orthodox_easter_monday_holiday(self, year: int):
+        """
+        Orthodox Easter Monday — Monday after Orthodox Easter Sunday.
+        Movable; follows the same Orthodox Easter calculation.
+        """
+        return {self.gregorian_calendar.compute_orthodox_easter_monday(year): "Orthodox Easter Monday"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/saudiarabia.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/saudiarabia.py
@@ -1,0 +1,102 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.location import Location
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+
+
+class SaudiArabia:
+    country_code = "SA"
+
+    def __init__(self):
+        # Riyadh, Saudi Arabia (UTC+3, no DST considered)
+        saudi_location = Location(
+            lat=24.7136,          # latitude north
+            lon=46.6753,          # longitude east
+            tz=3.0,               # UTC+3
+            height_m=600.0,       # approx elevation in meters
+            visibility_thresholds=(2.0, 8.0) # minimum moon altitude above horizon and minimum sun-moon separation
+        )
+        self.islamic_calendar = IslamicHolidayGenerator(saudi_location)
+
+        self._public_holiday_computers = [
+            # Fixed-date holiday
+            self._compute_founding_day_holiday,
+
+            # Variable / Islamic lunar holidays
+            self._compute_eid_al_fitr_day_holiday,        # 1 Shawwal
+            self._compute_eid_al_fitr_holiday_span,       # extra days after Eid al-Fitr
+            self._compute_arafat_day_holiday,             # 9 Dhu al-Hijjah
+            self._compute_eid_al_adha_day_holiday,        # 10 Dhu al-Hijjah
+            self._compute_eid_al_adha_holiday_span,       # extra days after Eid al-Adha
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holiday (every year)
+    # -------------------------------
+
+    def _compute_founding_day_holiday(self, year: int):
+        """Founding Day — fixed date: February 22."""
+        return {date(year, 2, 22): "Founding Day"}
+
+    # -------------------------------
+    # Islamic lunar holidays
+    # -------------------------------
+
+    def _compute_eid_al_fitr_day_holiday(self, year: int):
+        """
+        Eid al-Fitr — Islamic lunar: 1 Shawwal (end of Ramadan).
+        Varies annually by moon-sighting; multiple days are given as public holidays.
+        """
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Eid al-Fitr (Tentative)"}
+
+    def _compute_eid_al_fitr_holiday_span(self, year: int):
+        """
+        Eid al-Fitr Holiday span — Government-declared extra days following Eid al-Fitr.
+        Example 2025: 31 Mar – 2 Apr.
+        """
+        eid_day = self.islamic_calendar.compute_eid_al_fitr(year)
+        span_days = 3  # default span for Saudi Arabia usually 3 days. (Eid day + 3 extra days)
+        return {eid_day + timedelta(span_days): "Eid al-Fitr Span (Tentative)"}
+
+    def _compute_arafat_day_holiday(self, year: int):
+        """
+        Arafat Day — 9 Dhu al-Hijjah, day before Eid al-Adha.
+        Varies annually by Islamic lunar calendar.
+        """
+        return {self.islamic_calendar.compute_arafah(year): "Arafat (Tentative)"}
+
+    def _compute_eid_al_adha_day_holiday(self, year: int):
+        """
+        Eid al-Adha — Islamic lunar: 10 Dhu al-Hijjah.
+        Major Islamic festival; varies annually by moon-sighting.
+        """
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Eid al-Adha (Tentative)"}
+
+    def _compute_eid_al_adha_holiday_span(self, year: int):
+        """
+        Eid al-Adha Holiday span — Government-declared additional days following Eid al-Adha.
+        Example 2025: 7–8 Jun.
+        """
+        eid_day = self.islamic_calendar.compute_eid_al_fitr(year)
+        span_days = 3  # default span for Saudi Arabia usually 3 days. (Eid day + 3 extra days)
+        return {eid_day + timedelta(span_days): "Eid al-Adha Span (Tentative)"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/slovakia.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/slovakia.py
@@ -1,0 +1,108 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.gregorian_calendar import ChristianHolidayGenerator
+
+
+class Slovakia:
+    country_code = "SK"
+
+    def __init__(self):
+        self.gregorian_calendar = ChristianHolidayGenerator()
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_republic_day_holiday,
+            self._compute_epiphany_holiday,
+            self._compute_labor_day_holiday,
+            self._compute_victory_over_fascism_day,
+            self._compute_st_cyril_methodius_day,
+            self._compute_national_uprising_day,
+            self._compute_our_lady_of_sorrows_day,
+            self._compute_all_saints_day_holiday,
+            self._compute_christmas_eve_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_st_stephens_day_holiday,
+
+            # Movable (Easter-based) — docstrings only; return None
+            self._compute_good_friday_holiday,
+            self._compute_easter_monday_holiday,
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_republic_day_holiday(self, year: int):
+        """Republic Day — fixed date: January 1."""
+        return {date(year, 1, 1): "Republic Day"}
+
+    def _compute_epiphany_holiday(self, year: int):
+        """Epiphany — fixed date: January 6."""
+        return {date(year, 1, 6): "Epiphany"}
+
+    def _compute_labor_day_holiday(self, year: int):
+        """Labor Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labor Day"}
+
+    def _compute_victory_over_fascism_day(self, year: int):
+        """Day of Victory Over Fascism — fixed date: May 8."""
+        return {date(year, 5, 8): "Day of Victory Over Fascism"}
+
+    def _compute_st_cyril_methodius_day(self, year: int):
+        """St. Cyril & St. Methodius Day — fixed date: July 5."""
+        return {date(year, 7, 5): "St. Cyril & St. Methodius Day"}
+
+    def _compute_national_uprising_day(self, year: int):
+        """National Uprising Day — fixed date: August 29."""
+        return {date(year, 8, 29): "National Uprising Day"}
+
+    def _compute_our_lady_of_sorrows_day(self, year: int):
+        """Day of Our Lady of Sorrows — fixed date: September 15."""
+        return {date(year, 9, 15): "Day of Our Lady of Sorrows"}
+
+    def _compute_all_saints_day_holiday(self, year: int):
+        """All Saints' Day — fixed date: November 1."""
+        return {date(year, 11, 1): "All Saints' Day"}
+
+    def _compute_christmas_eve_holiday(self, year: int):
+        """Christmas Eve — fixed date: December 24."""
+        return {date(year, 12, 24): "Christmas Eve"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        """Christmas Day — fixed date: December 25."""
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_st_stephens_day_holiday(self, year: int):
+        """St. Stephen's Day — fixed date: December 26."""
+        return {date(year, 12, 26): "St. Stephen's Day"}
+
+    # -------------------------------
+    # Movable (Easter-based) holidays — stubs
+    # -------------------------------
+
+    def _compute_good_friday_holiday(self, year: int):
+        """Good Friday — Friday before Easter Sunday (movable; requires Easter calculation)."""
+        return {self.gregorian_calendar.compute_good_friday(year): "Good Friday"}
+
+    def _compute_easter_monday_holiday(self, year: int):
+        """Easter Monday — Monday after Easter Sunday (movable)."""
+        return {self.gregorian_calendar.compute_easter_monday(year): "Easter Monday"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/switzerland.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/switzerland.py
@@ -1,0 +1,38 @@
+from datetime import date
+from typing import Dict
+
+
+class Switzerland:
+    country_code = "CH"
+
+    def __init__(self):
+        self._public_holiday_computers = [
+            self._compute_swiss_national_day_holiday,   # 1 Aug
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Nationwide holiday (every year)
+    # -------------------------------
+
+    def _compute_swiss_national_day_holiday(self, year: int):
+        """Swiss National Day — fixed date: August 1 (National Holiday)."""
+        return {date(year, 8, 1): "Swiss National Day"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/turkey.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/turkey.py
@@ -1,0 +1,125 @@
+from datetime import date,timedelta
+from typing import Dict
+
+from ..calendars.location import Location
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+
+class Turkey:
+    country_code = "TR"
+
+    def __init__(self):
+        # Istanbul, Turkey (UTC+3, no DST considered)
+        turkey_location = Location(
+            lat=41.0082,          # latitude north
+            lon=28.9784,          # longitude east
+            tz=3.0,               # UTC+3
+            height_m=40.0,        # approx elevation in meters
+            visibility_thresholds=(2.0, 8.0) # minimum moon altitude above horizon and minimum sun-moon separation
+        )
+        self.islamic_calendar = IslamicHolidayGenerator(turkey_location)
+
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,
+            self._compute_national_sovereignty_childrens_day,
+            self._compute_labor_and_solidarity_day,
+            self._compute_commemoration_ataturk_youth_sports,
+            self._compute_democracy_national_unity_day,
+            self._compute_victory_day_holiday,
+            self._compute_republic_day_holiday,
+
+            # Variable / Islamic lunar
+            self._compute_ramadan_feast_day,                     # Eid al-Fitr (Şeker Bayramı) – day 1
+            self._compute_ramadan_feast_holiday_span,            # extra/other Ramadan Feast days
+            self._compute_sacrifice_feast_day,                   # Eid al-Adha (Kurban Bayramı) – day 1
+            self._compute_sacrifice_feast_holiday_span,          # extra Sacrifice Feast holidays
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_national_sovereignty_childrens_day(self, year: int):
+        """National Sovereignty and Children's Day — fixed date: April 23."""
+        return {date(year, 4, 23): "National Sovereignty and Children's Day"}
+
+    def _compute_labor_and_solidarity_day(self, year: int):
+        """Labor and Solidarity Day — fixed date: May 1."""
+        return {date(year, 5, 1): "Labor and Solidarity Day"}
+
+    def _compute_commemoration_ataturk_youth_sports(self, year: int):
+        """Commemoration of Atatürk, Youth and Sports Day — fixed date: May 19."""
+        return {date(year, 5, 19): "Commemoration of Atatürk, Youth and Sports Day"}
+
+    def _compute_democracy_national_unity_day(self, year: int):
+        """Democracy and National Unity Day — fixed date: July 15."""
+        return {date(year, 7, 15): "Democracy and National Unity Day"}
+
+    def _compute_victory_day_holiday(self, year: int):
+        """Victory Day — fixed date: August 30."""
+        return {date(year, 8, 30): "Victory Day"}
+
+    def _compute_republic_day_holiday(self, year: int):
+        """Republic Day — fixed date: October 29."""
+        return {date(year, 10, 29): "Republic Day"}
+
+    # -------------------------------
+    # Variable / Islamic lunar
+    # -------------------------------
+
+    def _compute_ramadan_feast_day(self, year: int):
+        """
+        Ramadan Feast (Eid al-Fitr / Şeker Bayram) — Islamic lunar: 1 Shawwal.
+        In practice Turkey observes multiple consecutive days for the feast; dates vary annually by moon-sighting.
+        """
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Eid al-Fitr (Tentative)"}
+
+    def _compute_ramadan_feast_holiday_span(self, year: int):
+        """
+        Ramadan Feast Holiday span — additional/adjacent public holidays around Eid al-Fitr,
+        often covering 2-5 days as published by the government each year.
+        """
+        eid_day = self.islamic_calendar.compute_eid_al_fitr(year)
+        span_days = 3  # default span for Turkey usually 3 days. (Eid day + 2 extra days)
+        return {eid_day + timedelta(span_days): "Eid al-Fitr Span (Tentative)"}
+
+
+    def _compute_sacrifice_feast_day(self, year: int):
+        """
+        Sacrifice Feast (Eid al-Adha / Kurban Bayram) — Islamic lunar: 10 Dhu al-Hijjah.
+        Turkey typically observes a multi-day period; exact dates vary annually.
+        """
+
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Eid al-Adha (Tentative)"}
+
+    def _compute_sacrifice_feast_holiday_span(self, year: int):
+        """
+        Sacrifice Feast Holiday span — additional public holidays around Eid al-Adha,
+        commonly 3-4 extra days, announced each year by the government.
+        """
+        eid_day = self.islamic_calendar.compute_eid_al_adha(year)
+        span_days = 3  # default span for Turkey usually 3 days. (Eid day + 2 extra days)
+        return {eid_day + timedelta(span_days): "Eid al-Adha Span (Tentative)"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/unitedarabemirates.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/unitedarabemirates.py
@@ -1,0 +1,135 @@
+from datetime import date, timedelta
+from typing import Dict
+
+from ..calendars.location import Location
+from ..calendars.islamic_calendar import IslamicHolidayGenerator
+
+
+class UnitedArabEmirates:
+    country_code = "AE"
+
+    def __init__(self):
+        # Dubai, UAE (UTC+4, no DST considered)
+        uae_location = Location(
+            lat=25.276987,        # latitude north (Dubai)
+            lon=55.296249,        # longitude east (Dubai)
+            tz=4.0,               # UTC+4
+            height_m=5.0,         # approx elevation in meters
+            visibility_thresholds=(2.0, 8.0)  # minimum moon altitude above horizon and minimum sun-moon separation,
+        )
+        self.islamic_calendar = IslamicHolidayGenerator(uae_location)
+
+        self._public_holiday_computers = [
+            # Fixed-date holidays
+            self._compute_new_years_day_holiday,
+            self._compute_national_day_holiday,
+            self._compute_national_day_next_holiday,
+
+            # Islamic lunar / government-announced
+            self._compute_eid_al_fitr_day_holiday,     # 1 Shawwal
+            self._compute_eid_al_fitr_span_holidays,   # extra days after Eid al-Fitr
+            self._compute_arafat_day_holiday,          # 9 Dhu al-Hijjah
+            self._compute_eid_al_adha_day_holiday,     # 10 Dhu al-Hijjah
+            self._compute_eid_al_adha_span_holidays,   # extra days after Eid al-Adha
+            self._compute_hijri_new_year_holiday,      # 1 Muharram
+            self._compute_mouloud_tentative_holiday,   # 12 Rabi' al-awwal (tentative)
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Fixed-date holidays (every year)
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        """New Year's Day — fixed date: January 1."""
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_national_day_holiday(self, year: int):
+        """National Day — fixed date: December 2."""
+        return {date(year, 12, 2): "National Day"}
+
+    def _compute_national_day_next_holiday(self, year: int):
+        """National Day Holiday — fixed date: December 3 (adjacent public holiday)."""
+        return {date(year, 12, 3): "National Day Holiday"}
+
+    # -------------------------------
+    # Islamic lunar / gov-announced
+    # -------------------------------
+
+    def _compute_eid_al_fitr_day_holiday(self, year: int):
+        """
+        Eid al-Fitr — Islamic lunar: 1 Shawwal (marks end of Ramadan).
+        Public holiday; exact Gregorian date varies by moon-sighting.
+        """
+        return {self.islamic_calendar.compute_eid_al_fitr(year): "Eid al-Fitr (Tentative)"}
+
+    def _compute_eid_al_fitr_span_holidays(self, year: int):
+        """
+        Eid al-Fitr Holiday span — Government-declared additional days following Eid al-Fitr.
+        Example 2025 list: multiple days Mar 31 – Apr 2.
+        These are not fixed by Sharia, but by decree (e.g., UAE, KSA, Egypt).
+        The span usually means:
+        Day 1 = 1 Shawwalfrom ..calendars.location import Location
+from ..calendars.islamic_calendar import IslamicHolidayGenerator (Eid day itself).
+        Day 2+3 = extra public holidays (sometimes up to Day 4).
+        Sometimes adjusted to align with weekends.
+        """
+        eid_day = self.islamic_calendar.compute_eid_al_fitr(year)
+        span_days = 4  # default span for UAE usually 4–5 days. (Eid day + 3 extra days)
+        return {eid_day + timedelta(span_days): "Eid al-Fitr Span (Tentative)"}
+
+    def _compute_arafat_day_holiday(self, year: int):
+        """
+        Arafat (Hajj) Day — 9 Dhu al-Hijjah (day before Eid al-Adha).
+        Islamic lunar; date varies annually.
+        """
+        return {self.islamic_calendar.compute_arafah(year): "Arafat (Tentative)"}
+
+    def _compute_eid_al_adha_day_holiday(self, year: int):
+        """
+        Eid al-Adha (Feast of Sacrifice) — 10 Dhu al-Hijjah.
+        Islamic lunar; date varies annually.
+        """
+        return {self.islamic_calendar.compute_eid_al_adha(year): "Eid al-Adha (Tentative)"}
+
+    def _compute_eid_al_adha_span_holidays(self, year: int):
+        """
+        Eid al-Adha Holiday span — Government-declared extra days after Eid al-Adha.
+        Example 2025 list: Jun 7–8.
+        """
+        eid_day = self.islamic_calendar.compute_eid_al_adha(year)
+        span_days = 4  # default span for UAE usually 4–5 days. (Eid day + 3 extra days)
+
+        return {eid_day + timedelta(days=span_days): "Eid al-Adha Span (Tentative)"}
+
+    def _compute_hijri_new_year_holiday(self, year: int):
+        """
+        Al-Hijra (Islamic New Year) — 1 Muharram.
+        Islamic lunar; date varies annually.
+        """
+        return {self.islamic_calendar.compute_islamic_new_year(year): "Al-Hijra (Tentative)"}
+
+    def _compute_mouloud_tentative_holiday(self, year: int):
+        """
+        Mouloud (Prophet Muhammad's Birthday) — 12 Rabi' al-awwal.
+        Often published as a tentative date pending official confirmation.
+        """
+        return {self.islamic_calendar.compute_mawlid(year): "Mouloud (Tentative)"}

--- a/addons/hr_holidays/lib/holiday_generator/countries/unitedstates.py
+++ b/addons/hr_holidays/lib/holiday_generator/countries/unitedstates.py
@@ -1,0 +1,125 @@
+from datetime import date
+from typing import Dict
+
+from ..calendars.utils.time_utils import last_weekday, nth_weekday
+
+
+class UnitedStates:
+    country_code = "US"
+
+    def __init__(self):
+        # Static date holidays (fixed Gregorian dates)
+        self._public_holiday_computers = [
+            self._compute_new_years_day_holiday,
+            self._compute_juneteenth_holiday,
+            self._compute_independence_day_holiday,
+            self._compute_veterans_day_holiday,
+            self._compute_christmas_day_holiday,
+            self._compute_jimmy_carter_holiday,               # 2025-only
+            self._compute_martin_luther_king_jr_day_holiday,  # 3rd Mon Jan
+            self._compute_inauguration_day_holiday,           # Jan 20, every 4 yrs (from 1937)
+            self._compute_presidents_day_holiday,             # 3rd Mon Feb
+            self._compute_memorial_day_holiday,               # Last Mon May
+            self._compute_labor_day_holiday,                  # 1st Mon Sep
+            self._compute_columbus_day_holiday,               # 2nd Mon Oct
+            self._compute_thanksgiving_day_holiday,           # 4th Thu Nov
+        ]
+
+    def holidays_for_year(self, year: int) -> Dict[date, str]:
+        """
+        Collect holidays for the given year.
+        Each holiday computer returns a Dict {date: name}.
+        Merge them into one big Dict.
+        If multiple holidays fall on the same date, merge the names with '; '.
+        """
+        results: Dict[date, str] = {}
+        for fn in self._public_holiday_computers:
+            h = fn(year)
+            if not h:
+                continue
+            for d, name in h.items():
+                if d in results:
+                    # Merge names with '; ' if duplicate date
+                    results[d] = f"{results[d]}; {name}"
+                else:
+                    results[d] = name
+        return results
+
+    # -------------------------------
+    # Static date holidays
+    # -------------------------------
+
+    def _compute_new_years_day_holiday(self, year: int):
+        return {date(year, 1, 1): "New Year's Day"}
+
+    def _compute_juneteenth_holiday(self, year: int):
+        return {date(year, 6, 19): "Juneteenth"}
+
+    def _compute_independence_day_holiday(self, year: int):
+        return {date(year, 7, 4): "Independence Day"}
+
+    def _compute_veterans_day_holiday(self, year: int):
+        return {date(year, 11, 11): "Veterans Day"}
+
+    def _compute_christmas_day_holiday(self, year: int):
+        return {date(year, 12, 25): "Christmas Day"}
+
+    def _compute_jimmy_carter_holiday(self, year: int):
+        # This proclamation was specific to 2025: Thu, Jan 9, 2025.
+        # Only include in that year.
+        if year == 2025:
+            return {date(2025, 1, 9): "National Day of Mourning for Jimmy Carter"}
+        return None
+
+    # -------------------------------
+    # Calculated holidays
+    # -------------------------------
+
+    def _compute_martin_luther_king_jr_day_holiday(self, year: int) -> Dict[date, str]:
+        """
+            RULE: 3rd Monday in January.
+            (If you want to restrict to federal adoption years, add: if year < 1986: return {})
+        """
+        return {nth_weekday(year, 1, n=3, weekday=0): "Martin Luther King Jr. Day"}
+
+    def _compute_inauguration_day_holiday(self, year: int) -> Dict[date, str]:
+        """
+            RULE: January 20 every 4 years starting 1937.
+            Note: When Jan 20 is a Sunday, the public observance is Jan 21 (Monday).
+        """
+        if year >= 1937 and (year - 1937) % 4 == 0:
+            d = date(year, 1, 20)
+            if d.weekday() == 6:  # Sunday
+                d = date(year, 1, 21)
+            return {d: "Inauguration Day"}
+        return None
+
+    def _compute_presidents_day_holiday(self, year: int) -> Dict[date, str]:
+        """
+            RULE: 3rd Monday in February. (aka Washington's Birthday in US federal law)
+        """
+        return {nth_weekday(year, 2, n=3, weekday=0): "Presidents' Day"}
+
+    def _compute_memorial_day_holiday(self, year: int) -> Dict[date, str]:
+        """
+            RULE: Last Monday in May.
+        """
+        return {last_weekday(year, 5, weekday=0): "Memorial Day"}
+
+    def _compute_labor_day_holiday(self, year: int) -> Dict[date, str]:
+        """
+            RULE: 1st Monday in September.
+        """
+        return {nth_weekday(year, 9, n=1, weekday=0): "Labor Day"}
+
+    def _compute_columbus_day_holiday(self, year: int) -> Dict[date, str]:
+        """
+            RULE: 2nd Monday in October.
+        """
+        return {nth_weekday(year, 10, n=2, weekday=0): "Columbus Day"}
+
+    def _compute_thanksgiving_day_holiday(self, year: int) -> Dict[date, str]:
+        """
+            RULE: 4th Thursday in November.
+        """
+        return {nth_weekday(year, 11, n=4, weekday=3): "Thanksgiving Day"}

--- a/addons/hr_holidays/lib/holiday_generator/holiday_generator.py
+++ b/addons/hr_holidays/lib/holiday_generator/holiday_generator.py
@@ -1,0 +1,44 @@
+from datetime import date
+from typing import Dict, Iterable
+
+from . import countries
+
+
+class HolidayGenerator:
+    def __init__(self):
+        self._instances = {}
+
+    def _get_country(self, country_code: str):
+        code = country_code.upper()
+        if code in self._instances:
+            return self._instances[code]
+
+        try:
+            _ = countries.COUNTRY_CLASS_MAP[code]
+        except KeyError:
+            raise ValueError(f"Unsupported country code: {country_code!r}")
+
+        # Lazy-load class via countries.__getattr__
+        cls = getattr(countries, code)
+        inst = cls()
+        self._instances[code] = inst
+        return inst
+
+    def generate(self, country_code: str, years: int | Iterable[int]) -> Dict[date, str]:
+        """
+        Return a merged Dict[date, str] for the given year(s).
+        If multiple holidays fall on the same date across years,
+        merge the names with '; '.
+        """
+        year_list = [years] if isinstance(years, int) else list(years)
+        country = self._get_country(country_code)
+
+        merged: Dict[date, str] = {}
+        for year in year_list:
+            year_map = country.holidays_for_year(year)
+            for d, name in year_map.items():
+                if d in merged:
+                    merged[d] = f"{merged[d]}; {name}"
+                else:
+                    merged[d] = name
+        return dict(sorted(merged.items(), key=lambda x: (x[0], x[1])))

--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -93,22 +93,6 @@ class ResourceCalendarLeaves(models.Model):
                 leave._notify_change(message)
         leaves_to_recreate.sudo()._create_resource_leave()
 
-    def _convert_timezone(self, utc_naive_datetime, tz_from, tz_to):
-        """
-            Convert a naive date to another timezone that initial timezone
-            used to generate the date.
-            :param utc_naive_datetime: utc date without tzinfo
-            :type utc_naive_datetime: datetime
-            :param tz_from: timezone used to obtained `utc_naive_datetime`
-            :param tz_to: timezone in which we want the date
-            :return: datetime converted into tz_to without tzinfo
-            :rtype: datetime
-        """
-        naive_datetime_from = utc_naive_datetime.astimezone(tz_from).replace(tzinfo=None)
-        aware_datetime_to = tz_to.localize(naive_datetime_from)
-        utc_naive_datetime_to = aware_datetime_to.astimezone(pytz.utc).replace(tzinfo=None)
-        return utc_naive_datetime_to
-
     def _ensure_datetime(self, datetime_representation, date_format=None):
         """
             Be sure to get a datetime object if we have the necessary information.
@@ -136,8 +120,8 @@ class ResourceCalendarLeaves(models.Model):
                 datetime_from = self._ensure_datetime(vals['date_from'], '%Y-%m-%d %H:%M:%S')
                 datetime_to = self._ensure_datetime(vals['date_to'], '%Y-%m-%d %H:%M:%S')
                 if datetime_from and datetime_to:
-                    vals['date_from'] = self._convert_timezone(datetime_from, user_tz, calendar_tz)
-                    vals['date_to'] = self._convert_timezone(datetime_to, user_tz, calendar_tz)
+                    vals['date_from'] = convert_timezone(datetime_from, user_tz, calendar_tz)
+                    vals['date_to'] = convert_timezone(datetime_to, user_tz, calendar_tz)
         return vals_list
 
     @api.model_create_multi

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import pytz
+
 from datetime import date, datetime, timedelta
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 from odoo.addons.mail.tests.common import mail_new_test_user
@@ -8,6 +10,7 @@ from odoo.exceptions import ValidationError
 from freezegun import freeze_time
 
 from odoo.tests import tagged
+
 
 @tagged('global_leaves')
 class TestGlobalLeaves(TestHrHolidaysCommon):
@@ -20,6 +23,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             'name': 'Classic 40h/week',
             'tz': 'UTC',
             'hours_per_day': 8.0,
+            'company_id': cls.company.id,
             'attendance_ids': [
                 (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
                 (0, 0, {'name': 'Monday Lunch', 'dayofweek': '0', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
@@ -63,6 +67,11 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
             'date_from': date(2022, 3, 8),
             'date_to': date(2022, 3, 8),
             'calendar_id': cls.calendar_1.id,
+        })
+
+        cls.us_company = cls.env['res.company'].create({
+            'name': 'Test company US',
+            'country_id': cls.env.ref('base.us').id,
         })
 
     def test_leave_on_global_leave(self):
@@ -209,7 +218,7 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
         })
         partially_covered_leave.action_approve()
 
-        global_leave = self.env['resource.calendar.leaves'].with_user(self.env.user).create({
+        self.env['resource.calendar.leaves'].with_user(self.env.user).create({
             'name': 'Public holiday',
             'date_from': "2024-12-04 06:00:00",
             'date_to': "2024-12-04 23:00:00",

--- a/addons/hr_holidays/views/resource_views.xml
+++ b/addons/hr_holidays/views/resource_views.xml
@@ -29,6 +29,17 @@
         <field name="mode">primary</field>
         <field name="priority">10</field>
         <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <header>
+                    <button
+                        name="load_public_holidays"
+                        string="Load Public Holidays"
+                        type="object"
+                        class="btn btn-secondary"
+                        display="always"
+                    />
+                </header>
+            </xpath>
             <xpath expr="//list" position="attributes">
                 <attribute name="editable">bottom</attribute>
             </xpath>

--- a/addons/resource/models/resource_calendar_leaves.py
+++ b/addons/resource/models/resource_calendar_leaves.py
@@ -34,8 +34,7 @@ class ResourceCalendarLeaves(models.Model):
 
     name = fields.Char('Reason')
     company_id = fields.Many2one(
-        'res.company', string="Company", readonly=True, store=True,
-        default=lambda self: self.env.company, compute='_compute_company_id')
+        'res.company', string="Company", default=lambda self: self.env.company)
     calendar_id = fields.Many2one(
         'resource.calendar', "Working Hours",
         compute='_compute_calendar_id', store=True, readonly=False,
@@ -54,11 +53,6 @@ class ResourceCalendarLeaves(models.Model):
     def _compute_calendar_id(self):
         for leave in self.filtered('resource_id'):
             leave.calendar_id = leave.resource_id.calendar_id
-
-    @api.depends('calendar_id')
-    def _compute_company_id(self):
-        for leave in self:
-            leave.company_id = leave.calendar_id.company_id or self.env.company
 
     @api.depends('date_from')
     def _compute_date_to(self):

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -491,3 +491,18 @@ def weekend(locale: babel.Locale, date: date):
         - weekend of Sat 30 Aug -> Sat 30 Aug
     """
     return weekstart(locale, date) + relativedelta(days=6)
+
+
+def convert_timezone(utc_naive_datetime: datetime, tz_from: tzinfo, tz_to: tzinfo) -> datetime:
+    """
+    Convert a naive UTC datetime to another timezone, considering the initial timezone.
+
+    :param utc_naive_datetime: UTC datetime without tzinfo.
+    :param tz_from: Timezone used to obtain `utc_naive_datetime`.
+    :param tz_to: Target timezone for the conversion.
+    :return: Datetime converted into `tz_to` without tzinfo.
+    :rtype: datetime
+    """
+    naive_datetime_from = utc_naive_datetime.astimezone(tz_from).replace(tzinfo=None)
+    aware_datetime_to = tz_to.localize(naive_datetime_from)
+    return aware_datetime_to.astimezone(pytz.utc).replace(tzinfo=None)


### PR DESCRIPTION
In this commit,

- Public holidays will be generated after the time-off app is installed.
- Through the app installation, public holidays will be created for every
company in the database.
- Each public holiday will cover the entire day, and the resource calendar
will be the same as the company’s calendar.
- There is a cog menu action that allows users to create a public holiday
for multiple companies.
-  `_convert_timezone` method is moved to the date_utils file

Created the HolidayGenerator class, in which we will be using lazy import
Additionally, added holidays methods in the some countries.

Task-4596057