### PR TITLE
[FIX] iot_drivers: missing brackets overwriting data in event

### DIFF
--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -52,7 +52,7 @@ class EventManager:
         :param Driver device: actual device class
         :param dict data: data returned by the device (optional)
         """
-        data = data or request.params.get('data', {}) if request else {}
+        data = data or (request.params.get('data', {}) if request else {})
 
         # Make notification available to longpolling event route
         event = {


### PR DESCRIPTION
A simplification in the code introduced an error overwriting the param containing the data returned by the action.

This commit ensures the data is correctly provided to the event.
