### PR TITLE
[FIX] l10n_my_edi: correct EDI placeholder

### DIFF
--- a/addons/l10n_my_edi/models/res_company.py
+++ b/addons/l10n_my_edi/models/res_company.py
@@ -67,13 +67,13 @@ class ResCompany(models.Model):
         for company in self:
             placeholder = 'N/A'
             if company.l10n_my_identification_type == 'NRIC':
-                placeholder = '830503-11-4923'
+                placeholder = '830503114923'
             elif company.l10n_my_identification_type == 'BRN':
                 placeholder = '202201234565'
             elif company.l10n_my_identification_type == 'PASSPORT':
                 placeholder = 'A00000000'
             elif company.l10n_my_identification_type == 'ARMY':
-                placeholder = '830805-13-4983'
+                placeholder = '830805134983'
             company.l10n_my_identification_number_placeholder = placeholder
 
     # ----------------

--- a/addons/l10n_my_edi/models/res_partner.py
+++ b/addons/l10n_my_edi/models/res_partner.py
@@ -69,13 +69,13 @@ class ResPartner(models.Model):
         for partner in self:
             placeholder = 'N/A'
             if partner.l10n_my_identification_type == 'NRIC':
-                placeholder = '830503-11-4923'
+                placeholder = '830503114923'
             elif partner.l10n_my_identification_type == 'BRN':
                 placeholder = '202201234565'
             elif partner.l10n_my_identification_type == 'PASSPORT':
                 placeholder = 'A00000000'
             elif partner.l10n_my_identification_type == 'ARMY':
-                placeholder = '830805-13-4983'
+                placeholder = '830805134983'
             partner.l10n_my_identification_number_placeholder = placeholder
 
     # --------------


### PR DESCRIPTION
Hyphens are generally omitted in ERPs, and just shown on the Identity card.
Putting hyphens in the placeholder is actually misleading for users, and prevents validation through the IAP server and MyInvois
Ref: https://en.wikipedia.org/wiki/Malaysian_identity_card#Structure_of_the_National_Registration_Identity_Card_Number_(NRIC)

Task [link](https://www.odoo.com/odoo/project/967/tasks/5054821)
task-5054821