### PR TITLE
[FIX] account: retrieve default sending method from parent contact

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -21,7 +21,7 @@ class AccountMoveSend(models.AbstractModel):
     @api.model
     def _get_default_sending_method(self, move) -> str:
         """ By default, we use the sending method set on the partner or email. """
-        return move.partner_id.with_company(move.company_id).invoice_sending_method or 'email'
+        return move.commercial_partner_id.with_company(move.company_id).invoice_sending_method or 'email'
 
     @api.model
     def _get_all_extra_edis(self) -> dict:
@@ -39,11 +39,11 @@ class AccountMoveSend(models.AbstractModel):
     @api.model
     def _get_default_invoice_edi_format(self, move, **kwargs) -> str:
         """ By default, we generate the EDI format set on partner. """
-        return move.partner_id.with_company(move.company_id).invoice_edi_format
+        return move.commercial_partner_id.with_company(move.company_id).invoice_edi_format
 
     @api.model
     def _get_default_pdf_report_id(self, move):
-        return move.partner_id.with_company(move.company_id).invoice_template_pdf_report_id or self.env.ref('account.account_invoices')
+        return move.commercial_partner_id.with_company(move.company_id).invoice_template_pdf_report_id or self.env.ref('account.account_invoices')
 
     @api.model
     def _get_default_mail_template_id(self, move):

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -723,6 +723,21 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
                 'email': {'count': 1, 'label': 'by Email'},
             })
 
+    def test_invoice_multi_child_contact(self):
+        """ Test bulk invoice sending will retrieve info from the main partner. """
+        self.partner_a.write({'invoice_sending_method': 'manual'})
+        partner = self.env['res.partner'].create({
+            'type': 'invoice',
+            'email': 'child@example.com',
+            'parent_id': self.partner_a.id
+        })
+        invoice1 = self.init_invoice("out_invoice", amounts=[1000], partner=partner, post=True)
+        invoice2 = self.init_invoice("out_invoice", amounts=[1000], partner=partner, post=True)
+        wizard = self.create_send_and_print(invoice1 + invoice2)
+        self.assertEqual(wizard.summary_data, {
+            'manual': {'count': 2, 'label': 'Manually'}
+        })
+
     def test_invoice_mail_attachments_widget(self):
         invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
 


### PR DESCRIPTION
**Steps to reproduce**

- Have a partner with Invoice Sending configured 'by Peppol'
- Create a child contact for that partner
- Make 2 invoices for the child contact
- Select both and click 'Send'

**Issue**
The system will try to send invoice by mail, even if Peppol is correctly setup

This occurs because when retrieving the default sending method we only look at the partner of the move, that, being a child contact, does not have invoicing info

opw-4925876