### PR TITLE
[FIX] bus: worker started only when needed

### DIFF
--- a/addons/bus/static/src/multi_tab_shared_worker_service.js
+++ b/addons/bus/static/src/multi_tab_shared_worker_service.js
@@ -49,6 +49,7 @@ export const multiTabSharedWorkerService = {
         }
 
         async function startWorker() {
+            await workerService.ensureWorkerStarted();
             await workerService.registerHandler(messageHandler);
             workerService.send("ELECTION:REGISTER");
             state = STATE.REGISTERED;


### PR DESCRIPTION
In [1], the `worker_service` was introduced. It encapsulates the worker handling logic that was previously in the bus service.

However, there is a small difference: previously, the `send` method would be ignored if the worker had not yet started. We don’t want to fetch the worker script unnecessarily. This is especially important on websites, where most users do not interact with the live chat.

After this PR, the worker is started when `send` is called. We don’t want each caller to implement its own "worker is started" logic. This PR fixes the issue by adding a parameter to the `send` method: `ensureWorker`.

There are actually only two places where we want the worker to start if it hasn’t already. This keeps most call sites intact while controlling when the worker starts. This ensures that future calls won’t start the worker by mistake.

task-5046441

[1]: https://github.com/odoo/odoo/pull/218332

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
