### PR TITLE
[IMP] mail: use composerHtml for restore

### DIFF
--- a/addons/base_automation/tests/test_mail_composer.py
+++ b/addons/base_automation/tests/test_mail_composer.py
@@ -48,3 +48,35 @@ class TestMailFullComposer(MailCommon, HttpCase):
         messages = self._new_msgs.filtered(lambda message: message.author_id == self.user_employee.partner_id)
         self.assertEqual(len(messages), 3)
         self.assertIn(user.partner_id, messages[0].partner_ids)
+
+    def test_mail_html_composer_test_tour(self):
+        self.env['mail.template'].create({
+            'auto_delete': True,
+            'lang': '{{ object.lang }}',
+            'model_id': self.env['ir.model']._get_id('res.partner'),
+            'name': 'Test template',
+            'partner_to': '{{ object.id }}',
+        })
+
+        automation = self.env['base.automation'].create({
+            'name': 'Test',
+            'active': True,
+            'trigger': 'on_change',
+            'on_change_field_ids': (4, self.ref('mail.field_mail_compose_message__template_id')),
+            'model_id': self.env.ref('mail.model_mail_compose_message').id,
+        })
+        server_action = self.env['ir.actions.server'].create({
+            'name': 'Test',
+            'base_automation_id': automation.id,
+            'state': 'code',
+            'model_id': self.env.ref('mail.model_mail_compose_message').id,
+        })
+        automation.write({'action_server_ids': [(4, server_action.id)]})
+        partner = self.env["res.partner"].create({"name": "Jane", "email": "jane@example.com"})
+        partner.message_subscribe(partner_ids=[self.user_admin.partner_id.id])
+        with self.mock_mail_app():
+            self.start_tour(
+                f"/odoo/res.partner/{partner.id}",
+                "mail/static/tests/tours/mail_html_composer_test_tour.js",
+                login=self.user_employee.login,
+            )

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -9,7 +9,7 @@ export class Composer extends Record {
     clear() {
         this.attachments.length = 0;
         this.replyToMessage = undefined;
-        this.composerHtml = markup("<p><br></p>");
+        this.composerHtml = markup("<div class='o-paragraph'><br></div>");
         Object.assign(this.selection, {
             start: 0,
             end: 0,
@@ -44,10 +44,10 @@ export class Composer extends Record {
             }
         },
     });
-    composerHtml = fields.Html(markup("<p><br></p>"), {
+    composerHtml = fields.Html(markup("<div class='o-paragraph'><br></div>"), {
         compute() {
             if (this.syncHtmlWithMessage) {
-                return this.message.body || markup("<p><br></p>");
+                return this.message.body || markup("<div class='o-paragraph'><br></div>");
             }
             return this.composerHtml;
         },

--- a/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_composer_plugin.js
@@ -6,7 +6,7 @@ import { withSequence } from "@html_editor/utils/resource";
 
 export class MailComposerPlugin extends Plugin {
     static id = "mail.composer";
-    static dependencies = ["hint"];
+    static dependencies = ["hint", "selection"];
     resources = {
         hints: [
             withSequence(1, {

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -6,6 +6,7 @@ import { HtmlMailField, htmlMailField } from "../html_mail_field/html_mail_field
 import { MentionPlugin } from "./mention_plugin";
 import { ContentExpandablePlugin } from "./content_expandable_plugin";
 import { fillEmpty } from "@html_editor/utils/dom";
+import { markup } from "@odoo/owl";
 
 export class HtmlComposerMessageField extends HtmlMailField {
     setup() {
@@ -19,14 +20,8 @@ export class HtmlComposerMessageField extends HtmlMailField {
                 const emailAddSignature = Boolean(
                     this.editor.editable.querySelector(".o-signature-container")
                 );
-                const elContent = this.getNoSignatureElContent();
-                // Temporarily Put the content in the DOM to be able to extract innerText newLines.
-                this.editor.editable.after(elContent);
-                // TODO: the following legacy regex may not have the desired effect as it
-                // agglomerates multiple newLines together.
-                const composerText = elContent.innerText.replace(/(\t|\n)+/g, "\n");
-                elContent.remove();
-                ev.detail.onSaveContent({ composerText, emailAddSignature });
+                const composerHtml = markup(this.getNoSignatureElContent().innerHTML);
+                ev.detail.onSaveContent({ composerHtml, emailAddSignature });
             });
             useBus(this.env.fullComposerBus, "ATTACHMENT_REMOVED", (ev) => {
                 const attachmentElements = this.editor.editable.querySelectorAll(

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1337,7 +1337,9 @@ test("composer reply-to message is restored on thread change", async () => {
         browser.localStorage.getItem(
             store.Thread.get({ model: "discuss.channel", id: channelId }).composer.localId
         )
-    ).toBe('{"emailAddSignature":true,"replyToMessageId":1,"composerText":""}');
+    ).toBe(
+        '{"emailAddSignature":true,"replyToMessageId":1,"composerHtml":["markup","<div class=\'o-paragraph\'><br></div>"]}'
+    );
 });
 
 test("composer reply-to message is restored page reload", async () => {
@@ -1436,7 +1438,7 @@ test("html composer: send a message with styling", async () => {
         editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
     };
     await htmlInsertText(editor, "Hello");
-    await tripleClick(editor.editable.querySelector("p"));
+    await tripleClick(editor.editable.querySelector("div.o-paragraph"));
     await press("Control+b");
     await click(".o-mail-Composer-send:enabled");
     await click(".o-mail-Message[data-persistent] strong:contains(Hello)");

--- a/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
@@ -1,0 +1,99 @@
+import { registry } from "@web/core/registry";
+import { contains } from "@web/../tests/utils";
+
+/**
+ * This tour depends on data created by python test in charge of launching it.
+ * It is not intended to work when launched from interface. It is needed to test
+ * an action (action manager) which is not possible to test with QUnit.
+ * @see mail/tests/test_mail_composer.py
+ */
+registry.category("web_tour.tours").add("mail/static/tests/tours/mail_html_composer_test_tour.js", {
+    steps: () => [
+        {
+            content: "Wait for the chatter to be fully loaded",
+            trigger: ".o-mail-Chatter",
+            async run() {
+                const composerService = odoo.__WOWL_DEBUG__.root.env.services["mail.composer"];
+                composerService.setHtmlComposer();
+                await contains(".o-mail-Message", { count: 1 });
+            },
+        },
+        {
+            content: "Click on Send Message",
+            trigger: "button:contains(Send message)",
+            run: "click",
+        },
+        {
+            content: "Write something in composer",
+            trigger: ".o-mail-Composer-html.odoo-editor-editable",
+            run: "editor Hello",
+        },
+        {
+            content: "Select the text",
+            trigger: ".o-mail-Composer-html.odoo-editor-editable",
+            run: "dblclick",
+        },
+        {
+            trigger: ".o-we-toolbar",
+        },
+        {
+            content: "Bold the text",
+            trigger: ".o-we-toolbar button[title='Toggle bold']",
+            run: "click",
+        },
+        {
+            content: "The bolded text is in the composer",
+            trigger: ".o-mail-Composer-html.odoo-editor-editable strong:contains(Hello)",
+        },
+        {
+            content: "Open full composer",
+            trigger: "button[title='Open Full Composer']",
+            run: "click",
+        },
+        {
+            content: "Check composer keeps the formatted content",
+            trigger: ".o_mail_composer_message strong:contains(Hello)",
+        },
+        {
+            content: "Focus the text in full composer",
+            trigger: ".o_mail_composer_message .odoo-editor-editable",
+            run: "click",
+        },
+        {
+            content: "Select the text in full composer",
+            trigger: ".o_mail_composer_message .odoo-editor-editable",
+            run: "dblclick",
+        },
+        {
+            trigger: ".o-we-toolbar",
+        },
+        {
+            content: "Remove the Bold",
+            trigger: ".o-we-toolbar button[title='Toggle bold']",
+            run: "click",
+        },
+        {
+            content: "Italicize the text",
+            trigger: ".o-we-toolbar button[title='Toggle italic']",
+            run: "click",
+        },
+        {
+            content: "The italicized text is in the full composer",
+            trigger: ".o_mail_composer_message em:contains(Hello)",
+        },
+        {
+            content: "Close full composer",
+            trigger: ".btn-close",
+            run: "click",
+        },
+        {
+            content: "Click on Send Message",
+            trigger: "button:contains(Send message)",
+            run: "click",
+        },
+        {
+            content: "The italicized text is in the composer",
+            trigger: ".o-mail-Composer-html.odoo-editor-editable em:contains(Hello)",
+        },
+    ],
+});

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -332,6 +332,35 @@ class TestMailComposerUI(MailCommon, HttpCase):
         self.assertEqual(len(re.findall(signature_pattern, message_3.body)), 0)
         self.assertTrue(message_3.email_add_signature)
 
+    def test_mail_html_composer_test_tour(self):
+        template_data = [
+            {
+                'name': 'Test template',
+                'partner_to': '{{ object.id }}',
+            },
+            {
+                'name': 'Test template for admin',
+                'user_id': self.env.ref('base.user_admin').id,
+            },
+        ]
+        self.env['mail.template'].create([
+            {
+                **data,
+                'auto_delete': True,
+                'lang': '{{ object.lang }}',
+                'model_id': self.env['ir.model']._get_id('res.partner'),
+            }
+            for data in template_data
+        ])
+        partner = self.env["res.partner"].create({"name": "Jane", "email": "jane@example.com"})
+        partner.message_subscribe(partner_ids=[self.user_admin.partner_id.id])
+        with self.mock_mail_app():
+            self.start_tour(
+                f"/odoo/res.partner/{partner.id}",
+                "mail/static/tests/tours/mail_html_composer_test_tour.js",
+                login=self.user_employee.login,
+            )
+
     def test_send_attachment_without_body(self):
         self.start_tour("/odoo/discuss", "create_thread_for_attachment_without_body",login="admin")
 

--- a/addons/web/static/src/core/utils/html.js
+++ b/addons/web/static/src/core/utils/html.js
@@ -286,3 +286,7 @@ export function setElementContent(element, content) {
         element.textContent = content;
     }
 }
+
+export function isMarkup(content) {
+    return content instanceof Markup;
+}

--- a/addons/web_tour/static/src/js/tour_automatic/tour_step_automatic.js
+++ b/addons/web_tour/static/src/js/tour_automatic/tour_step_automatic.js
@@ -162,7 +162,9 @@ export class TourStepAutomatic extends TourStep {
 
     get elementIsInModal() {
         if (this.hasAction) {
-            const overlays = hoot.queryFirst(".popover, .o-we-command, .o_notification");
+            const overlays = hoot.queryFirst(
+                ".popover, .o-we-command, .o-we-toolbar, .o_notification"
+            );
             const modal = hoot.queryFirst(".modal:visible:not(.o_inactive_modal):last");
             if (modal && !overlays && !this.trigger.startsWith("body")) {
                 return (


### PR DESCRIPTION
This commit updates the mail composer to use the composerHtml for restoring content, ensuring that HTML content is preserved and properly rendered.

This commit also includes synchronization of the content between the small composer and the full composer.

task-5022243

https://github.com/odoo/enterprise/pull/93740

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
