### PR TITLE
[FIX] html_editor: correct overlay position after QWeb branching

### DIFF
--- a/addons/html_editor/static/src/core/overlay_plugin.js
+++ b/addons/html_editor/static/src/core/overlay_plugin.js
@@ -57,8 +57,8 @@ export class OverlayPlugin extends Plugin {
 
     getScrollContainer() {
         return (
-            closestScrollableY(this.editable) ||
             closestScrollableY(this.iframe) ||
+            closestScrollableY(this.editable) ||
             this.topDocument.documentElement
         );
     }


### PR DESCRIPTION
Problem:
Open "PDF Quote" report in Studio and observe when hovering on the
first table cell: the table menu button is always on top of the
first cell (with a small offset difference).

Cause:
In `OverlayPlugin` we get the container on which we later calculate
the overlay position during setup.
`QWebPlugin` may show/hide elements in reports (CSS `display`
controlled by attributes like `data-oe-t-group-active`).

The issue:
Before commit
https://github.com/odoo/odoo/commit/27a85d650dee8345a4ec701bf7456eec07851718
we used to find the scrollable starting from the `iframe`. This
always returned the same scrollable outside the `iframe`, even when
its content was scrollable. Now, since
`QWebPlugin.applyGroupQwebBranching` can change the `iframe`
content, the scrollable may differ.

Solution:
`getScrollContainer` should check the scrollable starting from the
`iframe` before `this.editable`.

Steps to reproduce:
1. Open "PDF Quote" report in Studio.
2. Hover on the table headers.
3. Observe the menu button is always positioned on top of the
   first cell.

opw-5046779

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
