### PR TITLE
[FIX] mail: no guest auto join in non fullscreen channels

### DIFF
--- a/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
@@ -24,6 +24,8 @@ patch(DiscussClientAction.prototype, {
     },
     closeWelcomePage() {
         super.closeWelcomePage(...arguments);
-        this.joinCallWithDefaultSettings();
+        if (this.store.discuss.thread.default_display_mode === "video_full_screen") {
+            this.joinCallWithDefaultSettings();
+        }
     },
 });

--- a/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
@@ -18,6 +18,10 @@ registry.category("web_tour.tours").add("discuss_channel_as_guest_tour.js", {
             run: "click",
         },
         {
+            content: "Check that we are on not in a call",
+            trigger: "button[name='call']",
+        },
+        {
             content: "Check that we are on channel page",
             trigger: ".o-mail-Thread",
             run: "press ctrl+k",


### PR DESCRIPTION
Before this commit, when joining a channel as a guest via invitation link, the guest would automatically start a call after closing the welcome page.

This commit fixes the issue by checking that we are joining a fullscreen (meeting) channel before automatically joining the call.

Introduced by: https://github.com/odoo/odoo/pull/223356

task-5042923