### PR TITLE
[FIX] product: preserve aspect ratio in catalog

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -676,7 +676,14 @@ action = {
                                         groups="product.group_product_variant"
                                         options="{'color_field': 'color'}"/>
                             </div>
-                            <field name="image_128" widget="image" alt="Product" invisible="not image_128" class="ms-auto" options="{'size': [55, 55]}"/>
+                            <field
+                                name="image_128"
+                                class="ms-auto"
+                                invisible="not image_128"
+                                widget="image"
+                                options="{'size': [55, 55], 'img_class': 'object-fit-contain'}"
+                                alt="Product"
+                            />
                         </div>
                     </t>
                 </templates>


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have products with non-square images available for sale;
2. open a quotation;
3. open the product catalog.

Issue
-----
The product images appear stretched.

Cause
-----
Commit e8836b42200e3 replaced the `div.kanban_image` element with a `field` element using the `image` widget. It maintained the same size limit of 55x55 via the widget's options, but without additional input, this causes the widget to stretch the images to fill the area.

Solution
--------
Add the `object-fit-contain` as `img_class` to the options. This class contains the image to the area instead of stretching it.

opw-5007629
