### PR TITLE
[FIX] website_sale_comparison: restore bottom bar visibility

### DIFF
--- a/addons/website_sale_comparison/static/src/interactions/product_comparison.js
+++ b/addons/website_sale_comparison/static/src/interactions/product_comparison.js
@@ -11,7 +11,7 @@ import {
 } from '@website_sale_comparison/js/product_comparison_bottom_bar/product_comparison_bottom_bar';
 
 export class ProductComparison extends Interaction {
-    static selector = 'main:has(.o_add_compare, .o_add_compare_dyn, .o_add_to_compare)';
+    static selector = '.js_sale:not(.o_wsale_comparison_page)';
 
     dynamicContent = {
         '.o_add_compare, .o_add_compare_dyn': { 't-on-click': this.addProduct },

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -215,7 +215,7 @@
     <template id="product_compare" name="Comparator Page">
         <t t-call="website.layout">
             <t t-set="additional_title">Shop Comparator</t>
-            <div id="wrap" class="js_sale">
+            <div id="wrap" class="js_sale o_wsale_comparison_page">
                 <div class="oe_structure oe_empty" id="oe_structure_website_sale_comparison_product_compare_1"/>
                 <div t-attf-class="oe_website_sale o_wsale_comparison_page pb-5 #{is_view_active('website_sale.shop_fullwidth') and 'container-fluid' or 'container'}">
                     <h1 class="h4 mt-4 mb-3">Compare Products</h1>


### PR DESCRIPTION
With Commit[1],the `ProductComparison` interaction selector was changed from `.js_sale` to
`main:has(.o_add_compare, .o_add_compare_dyn, .o_add_to_compare)`, but this  breaks the comparison functionality because these buttons are not visible on all the pages.

The original `.js_sale` selector is more reliable because:

1. It targets the main container element that's consistently present on `website_sale_*` pages

2. The comparison buttons (`.o_add_compare`, etc.) are dynamically added through template inheritance, so relying on their presence for mounting the interaction can be unreliable

By restoring the `.js_sale` selector, the ProductComparisonBottomBar will be properly mounted on all `website_sale_*
pages where comparison functionality  should be available.

[1]: 524c968

task-5059327
follow-up of task-4911142

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
