### PR TITLE
[FIX] point_of_sale: limitedProductPricelistLoading tour

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -350,9 +350,11 @@ registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
                 ...ProductScreen.orderLineHas("Test Product 1", "1"),
                 ...ProductScreen.clickLine("Test Product 1"),
                 Numpad.click("2"),
+                {
+                    trigger:
+                        ".orderline:is(.selected):contains(test product 1):has(.qty:contains(2)):has(.price:contains(140.00))",
+                },
             ]),
-            ProductScreen.selectedOrderlineHas("Test Product 1", "2", "140.0"),
-
             scan_barcode("0100300"),
             Chrome.endTour(),
         ].flat(),


### PR DESCRIPTION
In this commit, we just change the place of step that ensure the content of the product 1 is correct because inleftside function in common.js add a rollback step in mobile view and then the tour failed. If the check step is before the rollback ... then it works.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
