### PR TITLE
[IMP] mail: rename 'Mark as Todo' message action to 'Add/Remove Star'

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -238,7 +238,7 @@
 </t>
 
 <t t-name="mail.Message.sidebarStarred">
-    <small class="text-center lh-1 o-opacity-35" t-att-class="{ 'align-self-start ms-1': isAlignedRight, 'align-self-end me-1': !isAlignedRight, 'mt-2': props.squashed, 'mt-1': !props.squashed }">
+    <small class="text-center lh-1 o-opacity-35" t-att-class="{ 'align-self-start ms-1': isAlignedRight, 'align-self-end me-1': !isAlignedRight, 'mt-2': props.squashed, 'mt-1': !props.squashed }" title="Starred message">
         <i class="fa fa-star o-mail-Message-starred"/>
     </small>
 </t>

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -94,7 +94,7 @@ registerMessageAction("toggle-star", {
         component.props.message.starred
             ? "fa fa-lg fa-star o-mail-Message-starred"
             : "fa fa-lg fa-star-o",
-    name: _t("Mark as Todo"),
+    name: (component) => (component.props.message.starred ? _t("Remove Star") : _t("Add Star")),
     onSelected: (component) => component.props.message.toggleStar(),
     sequence: 30,
 });

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -53,8 +53,8 @@ registry.category("web_tour.tours").add("discuss_channel_tour", {
             run: "press Enter",
         },
         {
-            trigger: ".o-mail-Message[data-persistent] [title='Mark as Todo']:not(:visible)",
-            content: _t("Hover on your message and mark as todo"),
+            trigger: ".o-mail-Message[data-persistent] [title='Add Star']:not(:visible)",
+            content: _t("Hover on your message and add a star"),
             tooltipPosition: "top",
             async run(helpers) {
                 await delay(1000);

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -181,7 +181,7 @@ test("Message (hard) delete notification", async () => {
     });
     await start();
     await openDiscuss("mail.box_inbox");
-    await click("[title='Mark as Todo']");
+    await click("[title='Add Star']");
     await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     await contains("button", { text: "Starred messages", contains: [".badge", { text: "1" }] });
     const [partner] = pyEnv["res.partner"].read(serverState.partnerId);

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -597,7 +597,7 @@ test("last discuss conversation is remembered", async () => {
     browser.localStorage.setItem(LAST_DISCUSS_ACTIVE_ID_LS, "discuss.channel_" + channelId);
     await start();
     await openDiscuss();
-    await contains("[role=\"heading\"]", { text: "Welcome to #General!" });
+    await contains('[role="heading"]', { text: "Welcome to #General!" });
 });
 
 test("sidebar: default no conversation selected", async () => {
@@ -762,7 +762,7 @@ test("rendering of inbox message", async () => {
     await contains(".o-mail-Message-header small", { text: "on Refactoring" });
     await contains(".o-mail-Message-actions i", { count: 4 });
     await contains("[title='Add a Reaction']");
-    await contains("[title='Mark as Todo']");
+    await contains("[title='Add Star']");
     await contains("[title='Mark as Read']");
     await contains("[title='Reply']");
 });

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -1295,7 +1295,7 @@ test("Redirect to the thread containing the starred message and highlight the me
     await start();
     await openDiscuss("mail.box_inbox");
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
-    await click(".o-mail-Message [title='Mark as Todo']");
+    await click(".o-mail-Message [title='Add Star']");
     await click("button", { text: "Starred messages", contains: [".badge", { count: 1 }] });
     await click(".o-mail-Message-header a", { text: "#General" });
     await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "General" });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1029,19 +1029,19 @@ test("toggle_star message", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message [title='Mark as Todo']");
-    await contains(".o-mail-Message [title='Mark as Todo']" + " i.fa-star-o");
+    await contains(".o-mail-Message [title='Add Star']");
+    await contains(".o-mail-Message [title='Add Star']" + " i.fa-star-o");
     await contains("button", { text: "Starred messages", contains: [".badge", { count: 0 }] });
-    await click(".o-mail-Message [title='Mark as Todo']");
+    await click(".o-mail-Message [title='Add Star']");
     await contains("button", { text: "Starred messages", contains: [".badge", { text: "1" }] });
     await waitForSteps(["rpc:toggle_message_starred"]);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message [title='Mark as Todo']" + " i.fa-star");
-    await click(".o-mail-Message [title='Mark as Todo']");
+    await contains(".o-mail-Message [title='Remove Star']" + " i.fa-star");
+    await click(".o-mail-Message [title='Remove Star']");
     await contains("button", { text: "Starred messages", contains: [".badge", { count: 0 }] });
     await waitForSteps(["rpc:toggle_message_starred"]);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message [title='Mark as Todo']" + " i.fa-star-o");
+    await contains(".o-mail-Message [title='Add Star']" + " i.fa-star-o");
 });
 
 test("Name of message author is only displayed in chat window for partners others than the current user", async () => {
@@ -1357,7 +1357,7 @@ test("Toggle star should update starred counter on all tabs", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
-    await click(`${env1.selector} .o-mail-Message [title='Mark as Todo']`);
+    await click(`${env1.selector} .o-mail-Message [title='Add Star']`);
     await contains(`${env2.selector} button`, {
         text: "Starred messages",
         contains: [".badge", { text: "1" }],
@@ -2067,7 +2067,7 @@ test("deleted message should not have translate feature", async () => {
     await click(".modal button:contains('Delete')");
     await contains(".o-mail-Message:contains('This message has been removed')");
     await contains(".o-mail-Message [title='Add a Reaction']");
-    await contains(".o-mail-Message [title='Mark as Todo']");
+    await contains(".o-mail-Message [title='Add Star']");
     await contains(".o-mail-Message [title*='Translate']", { count: 0 });
     await animationFrame(); // in case some extra rendering for expand
     if (queryFirst(".o-mail-Message [title='Expand']")) {

--- a/addons/test_mail_full/static/tests/tours/message_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/message_actions_tour.js
@@ -6,7 +6,7 @@ registry.category("web_tour.tours").add("star_message_tour", {
         {
             trigger:
                 "#chatterRoot:shadow .o-mail-Message:not([data-starred]):contains(Test Message)",
-            run: "hover && click #chatterRoot:shadow [title='Mark as Todo']",
+            run: "hover && click #chatterRoot:shadow [title='Add Star']",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message[data-starred]:contains(Test Message)",


### PR DESCRIPTION
This change of wording makes it consistent with "Starred messages" and gives a better understanding on what this does. The old label "Mark as Todo" was too opinionated and also could be confusing with "Inbox" / "Unread" that are kind of considered as screens with "todo" messages.

Task-5059478

Before
<img width="1162" height="454" alt="Screenshot 2025-09-02 at 13 19 44" src="https://github.com/user-attachments/assets/3475a8e7-3d5e-4110-90f4-84392014bb64" />

After
<img width="1142" height="451" alt="Screenshot 2025-09-02 at 13 19 13" src="https://github.com/user-attachments/assets/96a67ef9-5d7f-4555-ae4a-c98cb0ce7b93" />
