### PR TITLE
[FIX] html_builder, website: fix parallax in nested elements

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_image_option.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option.js
@@ -8,6 +8,7 @@ export class BackgroundImageOption extends BaseOptionComponent {
     static props = {};
     static components = { ImageSize };
     setup() {
+        this.editingElement = this.env.getEditingElement();
         // done here because we have direct access to the editing element
         // (which we don't have in the normalize of the current plugin)
         this.toggleBgImageClasses();
@@ -15,17 +16,15 @@ export class BackgroundImageOption extends BaseOptionComponent {
     }
     toggleBgImageClasses() {
         this.env.editor.shared.history.ignoreDOMMutations(() => {
-            const editingEl = this.env.getEditingElement();
-            const backgroundURL = getBgImageURLFromEl(editingEl);
+            const backgroundURL = getBgImageURLFromEl(this.editingElement);
             this.env.editor.shared.backgroundImageOption.setImageBackground(
-                editingEl,
+                this.editingElement,
                 backgroundURL
             );
         });
     }
     showMainColorPicker() {
-        const editingEl = this.env.getEditingElement();
-        const src = new URL(getBgImageURLFromEl(editingEl), window.location.origin);
+        const src = new URL(getBgImageURLFromEl(this.editingElement), window.location.origin);
         return (
             src.origin === window.location.origin &&
             (src.pathname.startsWith("/html_editor/shape/") ||
@@ -34,10 +33,9 @@ export class BackgroundImageOption extends BaseOptionComponent {
     }
     getColorPickerColorNames() {
         const colorNames = [];
-        const editingEl = this.env.getEditingElement();
         for (let nbr = 1; nbr <= 5; nbr++) {
             const colorName = `c${nbr}`;
-            if (getBackgroundImageColor(editingEl, colorName)) {
+            if (getBackgroundImageColor(this.editingElement, colorName)) {
                 colorNames.push(colorName);
             }
         }

--- a/addons/website/static/tests/builder/website_builder/background.test.js
+++ b/addons/website/static/tests/builder/website_builder/background.test.js
@@ -58,6 +58,34 @@ test("remove parallax from block containing an inner block with parallax", async
     expect(":iframe section#section_a > .s_parallax_bg").not.toHaveCount();
     expect(":iframe section#section_b > .s_parallax_bg").toHaveCount();
 });
+
+test("remove parallax from inner block", async () => {
+    const backgroundImageUrl = "url('/web/image/123/transparent.png')";
+    await setupWebsiteBuilder(`
+            <section
+                class="s_parallax_no_overflow_hidden"
+                style="background-image: ${backgroundImageUrl}">
+                AAAA
+                        <section data-name="SectionB" id="section_b" class="s_parallax_no_overflow_hidden"
+                        style="background-image: ${backgroundImageUrl}">
+                            BBBB
+                        </section>
+            </section>`);
+    await contains(":iframe section#section_b").click();
+    await contains(
+        "[data-container-title='SectionB'] [data-label='Scroll Effect'] button.o-dropdown"
+    ).click();
+    await contains("[data-action-value='top']").click();
+    expect(":iframe section#section_b").toHaveClass("parallax");
+    expect(":iframe section#section_b > .s_parallax_bg").toHaveCount();
+
+    await contains(
+        "[data-container-title='SectionB'] [data-label='Scroll Effect'] button.o-dropdown"
+    ).click();
+    await contains("[data-action-value='none']").click();
+    expect(":iframe section#section_b > .s_parallax_bg").not.toHaveCount();
+});
+
 test("parallax scroll effect 'none' doesn't remove the color filter", async () => {
     const backgroundImageUrl = "url('/web/image/123/transparent.png')";
     await setupWebsiteBuilder(`


### PR DESCRIPTION
Before this commit, setting parallax to "none" for elements nested inside other elements with a background image caused an error. The issue occurred because the function `showMainColorPicker` was called after the `.parallax` span element was removed. Since the `.parallax` element is the editingElement of this option, the function should not have been invoked in the first place.

This commit fixes the issue by querying the editing element only once during the setup of `BackgroundImageOption`. This ensures that even if `showMainColorPicker` is called after the `.parallax` element is removed, no error occurs.

How to reproduce
The problem can be reproduced with many combinations of nested elements. For example:
1. Place the `s_three_columns` snippet
2. Set a background image for the whole snippet
3. Set a background image for a single card
4. Set a parallax effect for the card background image (e.g.: "Scroll Effect" -> "Fixed")
5. Set the same parallax effect back to "none" (Scroll Effect -> "None")
6. Traceback pops up

task-4367641