### PR TITLE
[FIX] hr_skills: fix one2many_tags_skills' button color

### DIFF
--- a/addons/hr_skills/models/hr_individual_skill_mixin.py
+++ b/addons/hr_skills/models/hr_individual_skill_mixin.py
@@ -219,7 +219,7 @@ class HrIndividualSkillMixin(models.AbstractModel):
 
     def _compute_certification_skill_type_count(self):
         certification_skill_type_count = self.env['hr.skill.type'].search_count(domain=[('is_certification', '=', True)])
-        self.write({'certification_skill_type_count': certification_skill_type_count})
+        self.certification_skill_type_count = certification_skill_type_count
 
     #  To reset the validity period if the skill become certified or uncertified
     @api.onchange('is_certification')

--- a/addons/hr_skills/static/src/fields/one2many_tags_skills/one2many_tags_skills.xml
+++ b/addons/hr_skills/static/src/fields/one2many_tags_skills/one2many_tags_skills.xml
@@ -11,7 +11,7 @@
                 class="btn btn-link text-action"
                 role="button"
                 style="padding: 0; line-height: 0; height: min-content;">
-                <i class="fa fa-plus" />
+                <i class="fa fa-plus text-info" />
             </button>
         </div>
     </t>


### PR DESCRIPTION
With this commit, the "+" button is always blue.

task-4680306

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
