### PR TITLE
[IMP] html_editor, html_builder: remove bottom margin from last element in table cells

### DIFF
--- a/addons/html_builder/static/tests/editor.test.js
+++ b/addons/html_builder/static/tests/editor.test.js
@@ -151,7 +151,7 @@ test("should apply default table classes on paste", async () => {
         anchorOffset: 0,
     });
     pasteHtml(editor, `<table><tr><td>1234</td></tr></table>`);
-    expect(editor.document.querySelector("table")).toHaveClass("table table-bordered");
+    expect(editor.document.querySelector("table")).toHaveClass("table table-bordered o_table");
 });
 
 describe("toolbar dropdowns", () => {

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -69,6 +69,8 @@ export const CLIPBOARD_WHITELISTS = {
         "img-thumbnail",
         "rounded",
         "rounded-circle",
+        // Odoo tables
+        "o_table",
         "table",
         "table-bordered",
         /^padding-/,

--- a/addons/html_editor/static/src/main/table/table.scss
+++ b/addons/html_editor/static/src/main/table/table.scss
@@ -2,3 +2,11 @@ th.o_table_header {
     background-color: #F7F7F7;
     font-weight: 900;
 }
+
+.o_table {
+    th, td {
+        > *:last-child {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -74,7 +74,7 @@ describe("Html Paste cleaning - whitelist", () => {
                 );
             },
             contentAfter:
-                '<p>123a</p><table class="table table-bordered"><tbody><tr><th>h</th></tr><tr><td>b</td></tr></tbody></table><p>d[]</p>',
+                '<p>123a</p><table class="table table-bordered o_table"><tbody><tr><th>h</th></tr><tr><td>b</td></tr></tbody></table><p>d[]</p>',
         });
     });
 
@@ -98,7 +98,7 @@ describe("Html Paste cleaning - whitelist", () => {
                 );
             },
             contentAfter: unformat(`
-                <table class="table table-bordered">
+                <table class="table table-bordered o_table">
                     <tbody>
                         <tr>
                             <td><p><br></p></td>
@@ -3853,7 +3853,7 @@ describe("Paste HTML tables", () => {
 </div>`
                 );
             },
-            contentAfter: `<table class="table table-bordered">
+            contentAfter: `<table class="table table-bordered o_table">
 ${"            "}
 ${"            "}
             <tbody><tr>
@@ -3952,7 +3952,7 @@ ${"            "}
 </google-sheets-html-origin>`
                 );
             },
-            contentAfter: `<table class="table table-bordered">
+            contentAfter: `<table class="table table-bordered o_table">
 ${"        "}
 ${"            "}
 ${"            "}
@@ -4087,7 +4087,7 @@ ${"        "}
 </html>`
                 );
             },
-            contentAfter: `<table class="table table-bordered">
+            contentAfter: `<table class="table table-bordered o_table">
 ${"        "}
 ${"        "}
         <tbody><tr>
@@ -4120,6 +4120,37 @@ ${"        "}
     </tbody></table><p>[]<br></p>`,
         });
     });
+    test("should apply default table classes (table, table-bordered, o_table) on paste", async () => {
+        await testEditor({
+            contentBefore: `
+                <p>[]<br></p>
+            `,
+            stepFunction: async (editor) => {
+                pasteHtml(
+                    editor,
+                    unformat(`
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    `)
+                );
+            },
+            contentAfter: unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>[]<br></p>
+            `),
+        });
+    });
     test("should move all rows from thead to tbody", async () => {
         await testEditor({
             contentBefore: "<p>[]<br></p>",
@@ -4149,7 +4180,7 @@ ${"        "}
                 );
             },
             contentAfter: unformat(`
-                        <table class="table table-bordered">
+                        <table class="table table-bordered o_table">
                             <tbody>
                                 <tr>
                                     <th>1</th>
@@ -4188,7 +4219,7 @@ ${"        "}
                 );
             },
             contentAfter: unformat(`
-                        <table class="table table-bordered">
+                        <table class="table table-bordered o_table">
                             <tbody>
                                 <tr>
                                     <th>1</th>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- Table cells had extra space because the last element (like p) kept its bottom margin. This made the content appear misaligned.

### Desired behavior after PR is merged:

- Ensure that pasted table elements get the standard classes: `table, table-bordered, and o_table.`
- The last element inside table cells (th, td) no longer has bottom margin.

task-5056199

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
