### PR TITLE
[FIX] mail: ensure message Shadow DOM has access to CSS rules

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -8,6 +8,7 @@ import { MessageReactionMenu } from "@mail/core/common/message_reaction_menu";
 import { MessageReactions } from "@mail/core/common/message_reactions";
 import { RelativeTime } from "@mail/core/common/relative_time";
 import { htmlToTextContentInline } from "@mail/utils/common/format";
+import { getBundle } from "@web/core/assets";
 import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
 import { renderToElement } from "@web/core/utils/render";
 
@@ -136,9 +137,24 @@ export class Message extends Component {
             message: this.props.message,
             alignedRight: this.isAlignedRight,
         });
-        onMounted(() => {
+        onMounted(async () => {
             if (this.shadowBody.el) {
                 this.shadowRoot = this.shadowBody.el.attachShadow({ mode: "open" });
+
+                const res = await getBundle("web.assets_web");
+                const loadPromises = res.cssLibs.map((url) => {
+                    const link = document.createElement("link");
+                    link.rel = "stylesheet";
+                    link.href = url;
+                    this.shadowRoot.appendChild(link);
+
+                    return new Promise((resolve, reject) => {
+                        link.addEventListener("load", resolve);
+                        link.addEventListener("error", reject);
+                    });
+                });
+                await Promise.all(loadPromises);
+
                 const color = cookie.get("color_scheme") === "dark" ? "white" : "black";
                 const shadowStyle = document.createElement("style");
                 shadowStyle.textContent = `


### PR DESCRIPTION
Currently, in a chatter message, there's no way for a user to toggle on mail quotes.

### Steps to reproduce

* install `crm`
* in the settings, enable leads
* configure a mail alias for a sales team
* forward an email to that mail alias
* open lead that was created, look into the chatter to find the message of the email you sent

You should see that the body of the email you forwarded does not appear in the chatter.

### Cause

Email quotes are supposed to be hidden in the chatter, with an ellipsis button that allows the user to show them. In this case, all these elements are actually there in the DOM, but not visible/interactable by the user.

Both the forwarded email quote and the button are placed inside of a Shadow DOM. However, since Shadow DOMs ignore parent styles, the ellipsis button is lacking the necessary rules to be displayed at all. This leads to there not being any way for the user to unfold email quotes.

### Fix

Apply the CSS from the `web.assets_web` bundle into the Shadow DOM. That bundle should already be loaded in the containing document, so there's no cost or extra request by the browser.

opw-4863953