### PR TITLE
[FIX] iot_box_image: windows iot decorator requirement

### DIFF
--- a/addons/iot_box_image/configuration/requirements.txt
+++ b/addons/iot_box_image/configuration/requirements.txt
@@ -5,6 +5,7 @@ gatt; sys_platform == "linux" and "rpi" in platform_release
 # The following requirements are needed only on Windows Virtual IoT:
 aiortc==1.4.0; sys_platform == "win32"
 ghostscript==0.7; sys_platform == "win32"
+decorator; sys_platform == "win32"
 
 # The following requirements are needed on every platforms, but are installed
 # via apt-get on the Raspberry Pi:


### PR DESCRIPTION
Commit ef1f76c removed the lib "decorator" from Odoo dependencies. As the windows installer is build on runbot in master env but then is using 18.4 version when installed, there is a crash when trying to run the virtual IoT due to decorator not being installed.

Should be a temporary fix as the best approach would be to build the installer on runbot using the same dependencies as the version we use in the virtual IoT.

opw-5055928

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
