### PR TITLE
[FIX] hr:fixed test payroll field access error

### DIFF
--- a/addons/hr/tests/test_payroll_fields_access.py
+++ b/addons/hr/tests/test_payroll_fields_access.py
@@ -79,6 +79,7 @@ class TestPayrollFieldsAccess(TransactionCase):
             'new_bike',
             'new_bike_model_id',
             'originated_offer_id',
+            'is_non_resident',
         ]
         missing_group_field_names = [
             f_name


### PR DESCRIPTION
**Issue:**
The payroll access test test_payroll_fields_are_hidden_to_non_payroll_users_in_employee_form_view failed because the field 'is_non_resident' was reported as missing the payroll group restriction.

**Reason:**
The 'is_non_resident' field is not strictly payroll-related — it is also present in the Personal Information tab. Applying payroll group restrictions would hide it from HR users who still need access.

**Fix:**
Added 'is_non_resident' to the whitelist_field_names list in _test_payroll_fields_are_hidden_to_non_payroll_users. This ensures the test passes without incorrectly enforcing payroll-only restrictions on this field.

build_error-231304

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
