### PR TITLE
[FIX] account: avoid spurious product matches on very short names

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -291,7 +291,10 @@ class ProductProduct(models.Model):
         if default_code:
             domains.append([('default_code', '=', default_code)])
         if name:
-            domains += [[('name', '=', name)], [('name', 'ilike', name)]]
+            domains.append([('name', '=', name)])
+            # avoid matching unrelated products whose names merely contain that short string
+            if len(name) > 4:
+                domains.append([('name', 'ilike', name)])
 
         company = company or self.env.company
         for company_domain in (


### PR DESCRIPTION
 hen resolving a product in _retrieve_product, the code searched by barcode, default_code, and then by name using both exact and ilike domains. For very short item names coming from imports (e.g., “-”, “A-1”, “0001”), the ilike fallback could match unrelated products whose names merely contain that short string. this led to incorrect product linkage on created documents (e.g., EDI-imported invoices).

discussed with: Christophe (chkl)

Steps to reproudce:
Accounting -> Invoices
upload an XML with a product name liek `-` or `a`
See the product attched to the invoice line.

opw-5003482


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
