### PR TITLE
[FIX] base_automation: clean active_test in action

### DIFF
--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -294,7 +294,7 @@
                     <field name="name"/>
                     <field name="model_id"/>
                     <separator/>
-                    <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+                    <filter string="Include Archived" name="inactive" domain="[('active', 'in', [False, True])]"/>
                 </search>
             </field>
         </record>
@@ -306,7 +306,7 @@
             <field name="path">automations</field>
             <field name="view_mode">kanban,list,form</field>
             <field name="view_id" ref="view_base_automation_kanban"/>
-            <field name="context">{'active_test': False}</field>
+            <field name="context">{'search_default_inactive': 1}</field>
             <field name="help" type="html">
                 <img class="w-100 w-md-75"
                 src="/base_automation/static/img/automation.svg" />

--- a/addons/test_base_automation/tests/test_tour.py
+++ b/addons/test_base_automation/tests/test_tour.py
@@ -17,7 +17,7 @@ class BaseAutomationTestUi(HttpCase):
         self.env["base.automation"].with_context(active_test=False).search([]).write({"active": False})
         if neutralize_action:
             context = ast.literal_eval(self.env.ref("base_automation.base_automation_act").context)
-            del context["active_test"]
+            del context["search_default_inactive"]
             self.env.ref("base_automation.base_automation_act").context = str(context)
 
     def test_01_base_automation_tour(self):


### PR DESCRIPTION
**Before**
- the active_test context key is part of the main base_automation
  action (base_automation_act), but this context key stays in the
  context further, leading to unwanted filtering in i.e. the
  action_server_ids.resource_ref search view dialog.
- Steps to reproduce:
  - have base_automation installed
  - create an automation rule targeting the res.users model
  - add an Update server action targeting the Partner field
  - in the resource_ref autocomplete, click on Search More...
  - the search view dialogs displays archived records

**After**
- we chose to instead have a default filter in the base_automation_act
  action to include archived records by default. As the context key
  to activate the default filter starts with 'search_default_', it
  is already cleared from the context when opening the form view
  (standard behavior).
- when you reproduce the same steps as before, the archived records
  are no longer displayed in the search view dialog.

**Additional Note**
This fix requires to upgrade the base_automation module.

opw-4886487