### PR TITLE
[FIX] website_slides: add highlighting to fullscreen slide

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -655,6 +655,10 @@
                     this.websiteAnimateWidget.destroy()
                     this.websiteAnimateWidget = null;
                 }
+                if (this.textHighlightWidget) {
+                    this.textHighlightWidget.destroy()
+                    this.textHighlightWidget = null;
+                }
 
                 // display quiz slide, or quiz attached to a slide
                 if (slide.category === 'quiz' || slide.isQuiz) {
@@ -683,6 +687,8 @@
                         $target: $content,
                     });
                     this.websiteAnimateWidget.attachTo($wpContainer);
+                    this.textHighlightWidget = new publicWidget.registry.TextHighlight();
+                    this.textHighlightWidget.attachTo($wpContainer);
                 }
                 unhideConditionalElements();
             } finally {

--- a/addons/website_slides/static/tests/tours/slides_text_highlights.js
+++ b/addons/website_slides/static/tests/tours/slides_text_highlights.js
@@ -1,0 +1,52 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+import wTourUtils from "@website/js/tours/tour_utils";
+
+const selectText = (selector) => {
+    return {
+        content: "Select some text content",
+        trigger: `iframe ${selector}`,
+        run() {
+            const iframeDOC = document.querySelector(".o_iframe").contentDocument;
+            const range = iframeDOC.createRange();
+            const selection = iframeDOC.getSelection();
+            range.selectNodeContents(this.$anchor[0]);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            this.$anchor[0].click();
+        },
+    };
+};
+
+registry.category("web_tour.tours").add("fullscreen_slide_text_highlights", {
+    test: true,
+    edition: true,
+    steps: () => [
+// registerWebsitePreviewTour step to wait for the edit mode
+{
+    content: "Wait for the edit mode to be started",
+    trigger: ".o_website_preview.editor_enable.editor_has_snippets",
+    timeout: 30000,
+    auto: true,
+    run: () => {}, // It's a check
+},
+selectText("#wrapwrap #wrap .s_text_block > p"),
+{
+    content: "Click on the 'Highlight Effects' button to activate the option",
+    trigger: "div.o_we_text_highlight",
+}, {
+    content: "Check that the highlight was applied",
+    trigger: "iframe .s_text_block p span.o_text_highlight > .o_text_highlight_item > svg:has(.o_text_highlight_path_underline)",
+    isCheck: true,
+},
+...wTourUtils.clickOnSave(),
+{
+    content: "Click on the fullscreen button",
+    trigger: 'iframe #wrapwrap a[aria-label="Fullscreen"]',
+}, {
+    content: "Check that the highlight was applied",
+    trigger: "iframe .s_text_block p span.o_text_highlight > .o_text_highlight_item > svg:has(.o_text_highlight_path_underline)",
+    isCheck: true,
+},
+]});

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -193,6 +193,18 @@ class TestUi(TestUICommon):
 
         self.start_tour('/slides', 'course_reviews', login=user_demo.login)
 
+    def test_fullscreen_slide_text_highlights(self):
+        slide = self.env['slide.slide'].create({
+            'name': 'Article test',
+            'channel_id': self.channel.id,
+            'slide_type': 'article',
+            'slide_category': 'article',
+            'is_published': True,
+            'html_content': "<section class=\"s_text_block\" data-snippet=\"s_text_block\"><p>Hello World!</p></section>"
+        })
+
+        self.start_tour(slide.website_url + '?enable_editor=1', 'fullscreen_slide_text_highlights', login='admin')
+
 
 @tests.common.tagged('post_install', '-at_install')
 class TestUiPublisher(HttpCaseGamification):


### PR DESCRIPTION
**Steps to reproduce:**
- Go to eLearning course on the website
- Edit an article
- Add the highlighting effect on the text
- Save the changes
- The text is properly displayed in normal article
- Go to the fullscreen version
- The highlighting is not present in this version

**Issue:**
This is an ordering issue caused by the dynamic rendering of fullscreen slides.
When in normal mode, the content is initialized and then the `TextHighlight` widget is started.
But the rendering of the slides in fullscreen mode is delayed and occurs after the widget is applied.

**Fix:**
Recreate and restart the widget on `_renderSlide` in the `slides_course_fullscreen_player``

opw-4978798

related: https://github.com/odoo/odoo/commit/f64c9f27f1a9106bc009ad2f696845f2c5c58066

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
