### PR TITLE
[FIX] account: no cash basis move from bank entry

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2478,6 +2478,10 @@ class AccountMove(models.Model):
         '''
         self.ensure_one()
 
+        # No cash basis journal entry should be created for an account move in a bank or cash journal
+        if self.journal_id.type in ('bank', 'cash'):
+            return None
+
         values = {
             'move': self,
             'to_process_lines': [],


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting

- In Accounting settings, activate "Cash Basis"
- Create/modify a tax with "Tax Exigibility" set to "Based on Payment"
- Set an account as "Cash Basis Transition Account"

- Create an invoice:
  * Customer: [any]
  * Invoice Lines:
    - [Price] 200.0
    - [Taxes] The cash basis tax (e.g. 15%)
- Confirm the invoice

- Go to "Bank" journal
- Create a bank statement for a lower amount than the invoice (e.g. $200)
- Match the statement with the invoice from the "Match Existing Entries" tab
- Select the added line and click on "fully paid" link
=> A new line with the amount difference should be added
- On the new line, select an expense account and the cash basis tax 
=> A new tax line should be added (e.g. $3.91)
- Validate
- Go to "Accounting / Reporting / Statement Reports / Tax Report"

**Issue:**
The amount of the Tax is equal to:
[Tax amount of the invoice] - 2 * [Tax amount of the difference line] = $30 - 2 * $3.91 = $22.18
which is not correct.
The tax amount of the difference line (coming from the bank reconciliation widget) is taken twice into account.

**Cause:**
A cash basis move is created for the tax line created in the bank reconciliation widget.
This move is using the same tax account as debit and credit account and is directly reversed using the same account.
No cash basis move should be created for that line because the tax line is added while reconciling a bank statement, which means the tax should have been received.

**Solution:**
Do not create a cash basis move for journal entries made in a bank or cash journal.

opw-4663059




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
