### PR TITLE
[ADD] base_setup,account: add model kpi.provider

### DIFF
--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -31,6 +31,7 @@ from . import account_cash_rounding
 from . import account_incoterms
 from . import decimal_precision
 from . import digest
+from . import kpi_provider
 from . import res_users
 from . import ir_actions_report
 from . import ir_attachment

--- a/addons/account/models/kpi_provider.py
+++ b/addons/account/models/kpi_provider.py
@@ -1,0 +1,29 @@
+from odoo import api, models
+
+
+class KpiProvider(models.AbstractModel):
+    _inherit = 'kpi.provider'
+
+    @api.model
+    def get_account_kpi_summary(self):
+        AccountMove = self.env['account.move']
+        grouped_draft_moves = AccountMove._read_group([('state', '=', 'draft')], ['move_type'], ['move_type'])
+
+        FieldsSelection = self.env['ir.model.fields.selection'].with_context(lang=self.env.user.lang)
+        move_type_names = {x.value: x.name for x in FieldsSelection.search([
+            ('field_id.model', '=', 'account.move'),
+            ('field_id.name', '=', 'move_type'),
+        ])}
+
+        return [{
+            'id': f'account_move_type.{group["move_type"]}',
+            'name': move_type_names[group['move_type']],
+            'type': 'integer',
+            'value': group['move_type_count'],
+        } for group in grouped_draft_moves]
+
+    @api.model
+    def get_kpi_summary(self):
+        result = super().get_kpi_summary()
+        result.extend(self.get_account_kpi_summary())
+        return result

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -23,6 +23,7 @@ from . import test_account_move_line_tax_details
 from . import test_account_journal_dashboard
 from . import test_chart_template
 from . import test_fiscal_position
+from . import test_kpi_provider
 from . import test_sequence_mixin
 from . import test_settings
 from . import test_tax

--- a/addons/account/tests/test_kpi_provider.py
+++ b/addons/account/tests/test_kpi_provider.py
@@ -1,0 +1,63 @@
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestKpiProvider(TransactionCase):
+
+    def test_kpi_summary(self):
+        """
+        - Ensure that nothing is reported when there is nothing to report
+        - All <account.move> in draft should be reported
+        - Posting one <account.move> should reduce the number reported
+        - Posting all <account.move> of a move_type should remove that move_type from the reporting
+        """
+        # Clean things for the test
+        self.env['account.move'].search([('state', '=', 'draft')]).unlink()
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [])
+
+        company_id = self.ref('base.main_company')
+        account_id = self.env['account.account'].search([('company_id', '=', company_id)], limit=1)
+        base_move = {
+            'company_id': company_id,
+            'line_ids': [Command.create({'account_id': account_id.id, 'quantity': 15, 'price_unit': 10})],
+        }
+        all_moves = self.env['account.move'].create(
+            [{**base_move, 'move_type': 'entry'}] * 2 +
+            [{**base_move, 'move_type': 'out_invoice'}] * 3 +
+            [{**base_move, 'move_type': 'out_refund'}] * 4 +
+            [{**base_move, 'move_type': 'in_invoice'}] * 5 +
+            [{**base_move, 'move_type': 'in_refund'}] * 6 +
+            [{**base_move, 'move_type': 'out_receipt'}] * 7 +
+            [{**base_move, 'move_type': 'in_receipt'}] * 8
+        )
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
+            {'id': 'account_move_type.entry', 'name': 'Journal Entry', 'type': 'integer', 'value': 2},
+            {'id': 'account_move_type.out_invoice', 'name': 'Customer Invoice', 'type': 'integer', 'value': 3},
+            {'id': 'account_move_type.out_refund', 'name': 'Customer Credit Note', 'type': 'integer', 'value': 4},
+            {'id': 'account_move_type.in_invoice', 'name': 'Vendor Bill', 'type': 'integer', 'value': 5},
+            {'id': 'account_move_type.in_refund', 'name': 'Vendor Credit Note', 'type': 'integer', 'value': 6},
+            {'id': 'account_move_type.out_receipt', 'name': 'Sales Receipt', 'type': 'integer', 'value': 7},
+            {'id': 'account_move_type.in_receipt', 'name': 'Purchase Receipt', 'type': 'integer', 'value': 8},
+        ])
+
+        all_moves[0].action_post()
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
+            {'id': 'account_move_type.entry', 'name': 'Journal Entry', 'type': 'integer', 'value': 1},
+            {'id': 'account_move_type.out_invoice', 'name': 'Customer Invoice', 'type': 'integer', 'value': 3},
+            {'id': 'account_move_type.out_refund', 'name': 'Customer Credit Note', 'type': 'integer', 'value': 4},
+            {'id': 'account_move_type.in_invoice', 'name': 'Vendor Bill', 'type': 'integer', 'value': 5},
+            {'id': 'account_move_type.in_refund', 'name': 'Vendor Credit Note', 'type': 'integer', 'value': 6},
+            {'id': 'account_move_type.out_receipt', 'name': 'Sales Receipt', 'type': 'integer', 'value': 7},
+            {'id': 'account_move_type.in_receipt', 'name': 'Purchase Receipt', 'type': 'integer', 'value': 8},
+        ])
+
+        all_moves[1].action_post()
+        self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [
+            {'id': 'account_move_type.out_invoice', 'name': 'Customer Invoice', 'type': 'integer', 'value': 3},
+            {'id': 'account_move_type.out_refund', 'name': 'Customer Credit Note', 'type': 'integer', 'value': 4},
+            {'id': 'account_move_type.in_invoice', 'name': 'Vendor Bill', 'type': 'integer', 'value': 5},
+            {'id': 'account_move_type.in_refund', 'name': 'Vendor Credit Note', 'type': 'integer', 'value': 6},
+            {'id': 'account_move_type.out_receipt', 'name': 'Sales Receipt', 'type': 'integer', 'value': 7},
+            {'id': 'account_move_type.in_receipt', 'name': 'Purchase Receipt', 'type': 'integer', 'value': 8},
+        ])

--- a/addons/base_setup/models/__init__.py
+++ b/addons/base_setup/models/__init__.py
@@ -2,5 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import ir_http
+from . import kpi_provider
 from . import res_config_settings
 from . import res_users

--- a/addons/base_setup/models/kpi_provider.py
+++ b/addons/base_setup/models/kpi_provider.py
@@ -1,0 +1,25 @@
+from odoo import api, models
+
+
+class KpiProvider(models.AbstractModel):
+    _name = 'kpi.provider'
+    _description = 'KPI Provider'
+
+    @api.model
+    def get_kpi_summary(self):
+        """
+        Other modules can override this method to add their own KPIs to the list.
+        This method will be called by the databases module to retrieve the data displayed on the databases list.
+        The return value shall be a list of dictionaries with the following keys:
+
+        - id: a unique identifier for the KPI
+        - type: the type of data (`integer` or `return_status`)
+        - name: the translated name of the KPI, as displayable to the current user
+        - value: either the numeric value (for `type=integer`) or one of the statuses (for `type=return_status`):
+          - late       one return of this type should have been done already
+          - longterm   the deadline of the closest uncompleted return is in more than 3 months
+          - to_do      the deadline of the closest uncompleted return is in less than 3 months
+          - to_submit  the closest uncompleted return is ready, but still needs an action
+          - done       all of the forseeable returns are completed
+        """
+        return []


### PR DESCRIPTION
This commit introduces a new abstract model `kpi.provider` that allows different modules to contribute their Key Performance Indicators (KPIs) in a modular and extensible way.

The `kpi.provider` model defines a base structure for KPI reporting and includes a `get_kpis_summary` method that should be overridden in inheriting models. This method is responsible for returning a list of KPI data specific to the module.

KPI data are identified by a unique name and a type allowing for the caller to know how to present the corresponding value.

The `account` module inherits from `kpi.provider` to include the amount of draft `account.move` for each `move_type`.

Task-id: 5062431