### PR TITLE
[FIX] base_vat: prevent error when country not defined

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -760,7 +760,7 @@ class ResPartner(models.Model):
         # are in the same country as the partner), then skip.
         vat_required_valid = super()._get_vat_required_valid(company=company)
         if (
-            company and self.with_company(company).perform_vies_validation
+            company and company.country_id and self.with_company(company).perform_vies_validation
             and ('EU' in company.country_id.country_group_codes or self.country_id and self.country_id.has_foreign_fiscal_position)
         ):
             vat_required_valid = vat_required_valid and self.vies_valid

--- a/addons/base_vat/tests/test_vat_numbers.py
+++ b/addons/base_vat/tests/test_vat_numbers.py
@@ -39,6 +39,24 @@ class TestStructure(TransactionCase):
         })
         self.assertEqual(partner.vat, 'RORO790707I47', "Partner VAT should not be altered")
 
+    def test_missing_company_country(self):
+        company = self.env['res.company'].create({
+            'name': 'Test Company',
+            'country_id': False,
+            'vat_check_vies': True,
+        })
+        partner = self.env['res.partner'].create({
+            'name': 'Customer BE',
+            'country_id': self.env.ref('base.be').id,
+            'vat': 'DE123456788',
+            'company_id': company.id,
+        })
+        valid = partner._get_vat_required_valid(company=company)
+        self.assertEqual(valid, True)
+        partner.vat = False
+        invalid = partner._get_vat_required_valid(company=company)
+        self.assertEqual(invalid, False)
+
     def test_parent_validation(self):
         """Test the validation with company and contact"""
 


### PR DESCRIPTION
The system crashes with an error when a user tries to create an invoice.

**Steps to produce:-**
- Install `Accounting` module and switch to `BE Company`.
- Go to `Settings > Users & Companies > Companies` and remove the country from the BE company.
- Create a new customer with:-
    - Country as `Belgium`. 
    - Tax ID as `DE123456788`.
- `Accounting > configuration > settings > enable Verify VAT Numbers`.
- Now try to make `invoice` with customer as previously created customer.

**Error:-**
`TypeError : argument of type 'bool' is not iterable`

**Root cause:-**
- At [1], the code attempts to access `company.country_id`, but since the country was manually removed from the company, it evaluates to null record, leading to the error.

**Solution:-**
- Add a safeguard to ensure `company.country_id` also exist before accessing `country_group_codes`.

[1] -https://github.com/odoo/odoo/blob/4c2330f3cc0d1a0046e28d351f894763aeea57d2/addons/base_vat/models/res_partner.py#L764

**sentry-6851141424**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
