### PR TITLE
[FIX] orm: prevent error on invalid operator in domain

### DIFF
--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1532,7 +1532,7 @@ def _optimize_type_binary_attachment(condition, model):
             condition._raise('Binary field stored in attachment, accepts only existence check; skipping domain')
         except ValueError:
             # log with stacktrace
-            _logger.exception("Invalid operator for a binary field")
+            _logger.warning("Invalid operator for a binary field", exc_info=True)
         return _TRUE_DOMAIN
     if operator.endswith('like'):
         condition._raise('Cannot use like operators with binary fields', error=NotImplementedError)


### PR DESCRIPTION
Currently, an error occurs when user tries to apply an invalid filter on any binary field.

Steps to replicate:
- Add a filter like [('image_1024', 'in', [])] in the custom filter where the image exists(eg, Products) and save.
- Error triggered.

Error:
`ValueError: Binary field stored in attachment, accepts only existence check; skipping domain in condition ('image_1024', 'in', OrderedSet(['']))`

Cause:
- The system encountered an error when users attempted to apply invalid filters on binary fields (e.g., image_1024). The error occurs when operators like 'is in' with empty string values ('') are used, as binary fields are stored as attachments only support existence checks.

Solution:
- Changed the `_logger.exception` to `_logger.warning`.

sentry-6236134077
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
