### PR TITLE
[FIX] website, *: restore (odoo.com) custo of `_check_user_can_modify`

### DIFF
--- a/addons/test_website/tests/test_restricted_editor.py
+++ b/addons/test_website/tests/test_restricted_editor.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import unittest
+
 import odoo.tests
 
 from odoo.tests.common import new_test_user
@@ -54,6 +56,11 @@ class TestRestrictedEditor(odoo.tests.HttpCase):
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_restricted_editor_test_admin', login='restricted')
 
+    # FIXME the logic of the commit that introduced the fix at 8c41c147a4c6a415e
+    # was reverted, so this test is disabled for now. Branding *on views* as
+    # a restricted editor is something we want in some custo (e.g. odoo.com).
+    # See commit messages for details.
+    @unittest.skip
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_03_restricted_editor_tester(self):
         """

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -44,7 +44,7 @@ class IrQWeb(models.AbstractModel):
         irQweb = super()._prepare_frontend_environment(values)
 
         current_website = request.website
-        editable = has_group_designer = irQweb.env.user.has_group('website.group_website_designer')
+        editable = irQweb.env.user.has_group('website.group_website_designer')
         has_group_restricted_editor = irQweb.env.user.has_group('website.group_website_restricted_editor')
         if not editable and has_group_restricted_editor and 'main_object' in values:
             try:
@@ -90,7 +90,7 @@ class IrQWeb(models.AbstractModel):
 
         irQweb = irQweb.with_context(website_id=current_website.id)
         if 'inherit_branding' not in irQweb.env.context and not self.env.context.get('rendering_bundle'):
-            if has_group_designer and editable:
+            if editable:
                 # in edit mode add branding on ir.ui.view tag nodes
                 irQweb = irQweb.with_context(inherit_branding=True)
             elif has_group_restricted_editor:


### PR DESCRIPTION
*: test_website

This reverts commit [1]. Indeed, while it fixed the bug as intended while keeping the `_check_user_can_modify` feature, it apparently did not keep that one working in all cases: having partial view edition rights for some website.page (see uses in our Odoo.com customizations).

While searching for a solution allowing to keep the fix of [1] and the whole purpose of `_check_user_can_modify`, the logic part of [1] is reverted, keeping the test but disabled.

[1]: https://github.com/odoo/odoo/commit/8c41c147a4c6a415e7c5bfdde9297edbf40b4239
