### PR TITLE
Fix add to cart button

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
@@ -42,11 +42,10 @@ export class BuilderMany2One extends Component {
             ({ actionId }) => getAction(actionId).getValue
         );
         const { actionId, actionParam } = actionWithGetValue;
+        const getValue = (el) =>
+            getAction(actionId).getValue({ editingElement: el, params: actionParam });
         this.domState = useDomState(async (el) => {
-            const selectedString = getAction(actionId).getValue({
-                editingElement: el,
-                params: actionParam,
-            });
+            const selectedString = getValue(el);
             const selected = selectedString && JSON.parse(selectedString);
             if (selected && !("display_name" in selected && "name" in selected)) {
                 Object.assign(
@@ -65,7 +64,7 @@ export class BuilderMany2One extends Component {
         });
         if (this.props.id) {
             useDependencyDefinition(this.props.id, {
-                getValue: () => this.domState.selected && JSON.stringify(this.domState.selected),
+                getValue: () => getValue(this.env.getEditingElement()),
             });
         }
 

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -221,7 +221,7 @@ export function useGetItemValue() {
     });
     return function getItemValue(itemId) {
         listenedKeys.add(itemId);
-        if (state[itemId] === undefined) {
+        if (!(itemId in state)) {
             return getValue(itemId);
         }
         return state[itemId];


### PR DESCRIPTION
### [FIX] html_builder: avoid recomputing item value equal to undefined

With initial [website builder refactor], state of `useGetItemValue` is
recomputed too often if it is equal to undefined. This commit fixes to
comparison to check if the key is in the map.

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641

### [FIX] html_builder: fix add to cart button options

With 4e25350bde07ca4267887aa612b538bac0b3c6eb, `useDomState` became
async, thus reading it in `getValue` in a dependency definition became
incorrect.

With this commit, `BuilderMany2One` uses only the synchronous part for
the dependency value computation

Steps to reproduce:
- Open website builder (with website_sale)
- Drop the inner snippet "Add to Cart Button"
- Choose a "Product" that has variants (for example "Conference Chair")
- Bug: the option for the variant is not shown
- Remove the choice
- Bug: the option for variant now appears

task-4367641

