### PR TITLE
[FIX] base: prevent import of identical partner without company

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -885,6 +885,18 @@ class ResPartner(models.Model):
     def create(self, vals_list):
         if self.env.context.get('import_file'):
             self._check_import_consistency(vals_list)
+            vals_no_company = [val for val in vals_list if not val.get("company_id")]
+            for val in vals_no_company:
+                if "email" in val:
+                    partner = self.env['res.partner'].with_context(allowed_company_ids=[self.env.company.id]).search([
+                        ("name", "=", val["name"]),
+                        ("email", "=", val["email"]),
+                        ("parent_id", "!=", False),
+                        ("company_id", "!=", False),
+                    ])
+                    if partner:
+                        raise UserError(
+                            self.env._("This record requires a company ID"))
         for vals in vals_list:
             if vals.get('website'):
                 vals['website'] = self._clean_website(vals['website'])

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -332,6 +332,26 @@ class TestPartner(TransactionCaseWithUserDemo):
 
         self.assertEqual(child_contact.with_context(lang='fr_FR').display_name, 'Parent, Autre')
 
+    def test_import_identical_partner_false_company(self):
+        og_partner = self.env['res.partner'].create([{
+            "name": "partner",
+            "email": "mail@mail.mail",
+            "company_id": self.env.company.id,
+        }])
+        parent_company = self.env['res.partner'].create([{
+            "name": "parent_company",
+            "email": "mail@mail.mail",
+            "company_id": self.env.company.id,
+            "child_ids": [Command.set(og_partner.ids)],
+        }])
+        og_partner.parent_id = parent_company.id
+        with self.assertRaises(UserError):
+            self.env['res.partner'].with_context(import_file=True).create([{
+                "name": og_partner.name,
+                "email": og_partner.email,
+                "company_id": False,
+            }])
+
 
 @tagged('res_partner', 'res_partner_address')
 class TestPartnerAddressCompany(TransactionCase):


### PR DESCRIPTION
_______________________________________
## Short functional explanation of the error
Let's say that you have a contact of type Company and a child contact of type Individual. Both share the same company_id. But when exporting the individual, deleting its company in the downloaded .xlsx file and importing it again, it overrides the already existing individual, resulting in a single individual contact without company_id nor parent company. However, the contact of type company will still have the individual as its child, creating an inconsistency. This leads to errors in other modules as the rules aren't respected by these records anymore.

## Reproduction Steps
1. Go to the contact application and create a contact of type Company. Set an email and click on the Sales and Purchase tab and set a Company.
2. Go back to the Contacts tab and click on add contact. Click the radio button Contact, set an email and hit Save and Close.
3. Go back to the Contacts app. You should see 2 more contacts: one corresponding to the company and one corresponding to the individual.
4. Select the Individual contact and click Actions > export. Check 'I want to update data (import-compatible export)' and on the left panel, click on the + button next to Company. Then, click export.
5. Click on the file it generates and remove the company, then save.
6. Click on the cog next to Contacts on the top left and click Import Records. Then, click on Upload Data file and select the file you just exported. You should see that the field company_id has no value. Click Test then Import.

### Expected behavior
Either an error message should show up or the link between the Company contact and its child should be removed.

### Unexpected behavior
The individual contact containing the link to its parent Company contact is overridden by the contact we just imported, which doesn't have a link to the parent company contact. However, the company contact conserves a link to the child individual contact. This means that one way of the 2-ways link has been deleted, creating an inconsistency.

## Origin of the issue
We can override res.partners using the names and email addresses, which are primary keys, but the code doesn't check the consistency of parent/ children links.

_________________________________________
opw-4976400





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
