### PR TITLE
[FIX] l10n_es_edi_verifactu: add translations

### DIFF
--- a/addons/l10n_es_edi_verifactu/i18n/es.po
+++ b/addons/l10n_es_edi_verifactu/i18n/es.po
@@ -23,6 +23,8 @@ msgid ""
 "%(existing_warning)sA Veri*Factu document is waiting to be sent as soon as "
 "possible."
 msgstr ""
+"%(existing_warning)sUn documento Veri*Factu está pendiente de ser enviado lo antes "
+"posible."
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_state
@@ -34,6 +36,10 @@ msgid ""
 "                - Accepted: Registered by the AEAT without errors\n"
 "                - Cancelled: Registered by the AEAT as cancelled"
 msgstr ""
+"- Rechazado: enviado correctamente a la AEAT, pero fue rechazado durante la validación\n"
+"                - Registrado con errores: registrado en la AEAT, pero la AEAT ha detectado algunos problemas con el documento enviado\n"
+"                - Aceptado: registrado por la AEAT sin errores\n"
+"                - Cancelado: registrado por la AEAT como cancelado"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__state
@@ -42,23 +48,26 @@ msgid ""
 "                - Registered with Errors: Registered at the AEAT, but the AEAT has some issues with the sent record\n"
 "                - Accepted: Registered by the AEAT without errors"
 msgstr ""
+"- Rechazado: enviado correctamente a la AEAT, pero fue rechazado durante la validación\n"
+"                - Registrado con errores: registrado en la AEAT, pero la AEAT ha detectado algunos problemas con el registro enviado\n"
+"                - Aceptado: Registrado por la AEAT sin errores"
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.report_invoice_document
 msgid "<strong class=\"text-center\">QR tributario:</strong>"
-msgstr ""
+msgstr "<strong class=\"text-center\">QR tributario:</strong>"
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.report_invoice_document
 msgid "<strong class=\"text-center\">VERI*FACTU</strong>"
-msgstr ""
+msgstr "<strong class=\"text-center\">VERI*FACTU</strong>"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "A non-simplified invoice needs a partner."
-msgstr ""
+msgstr "Es necesario establecer un contacto en las facturas no simplificadas."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -75,148 +84,151 @@ msgid ""
 "A refund with Refund Reason %(refund_reason)s is not simplified (it needs a "
 "partner)."
 msgstr ""
+"Un reembolso con el motivo de reembolso %(refund_reason)s no está simplificado (se necesita un "
+"contacto)"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "A tax with value '%(tax_type)s' as %(field)s is not supported."
-msgstr ""
+msgstr "Un impuesto con el valor '%(tax_type)s' como %(field)s no es compatible."
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move__l10n_es_edi_verifactu_state__accepted
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__l10n_es_edi_verifactu_document__state__accepted
 msgid "Accepted"
-msgstr ""
+msgstr "Aceptado"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_account_chart_template
 msgid "Account Chart Template"
-msgstr ""
+msgstr "Plantilla de plan contable"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_account_move_reversal
 msgid "Account Move Reversal"
-msgstr ""
+msgstr "Reversión de asiento contable"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_account_move_send
 msgid "Account Move Send"
-msgstr ""
+msgstr "Envío de asiento contable"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_tax__l10n_es_applicability
 msgid "Applicability (Spain)"
-msgstr ""
+msgstr "Aplicabilidad (España)"
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.res_config_settings_view_form
 msgid "Automatically generate and send Veri*Factu records to the AEAT."
-msgstr ""
+msgstr "Genere y envíe automáticamente los registros Veri*Factu a la AEAT."
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_available_clave_regimens
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move__l10n_es_edi_verifactu_available_clave_regimens
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_available_clave_regimens
 msgid "Available Veri*Factu Regime Key"
-msgstr ""
+msgstr "Clave del régimen de Veri*Factu disponible"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__l10n_es_edi_verifactu_document__document_type__cancellation
 msgid "Cancellation"
-msgstr ""
+msgstr "Cancelación"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move__l10n_es_edi_verifactu_state__cancelled
 msgid "Cancelled"
-msgstr ""
+msgstr "Cancelado"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.ui.menu,name:l10n_es_edi_verifactu.menu_l10n_es_edi_verifactu_certificates
 msgid "Certificates"
-msgstr ""
+msgstr "Certificados"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.actions.act_window,name:l10n_es_edi_verifactu.l10n_es_edi_verifactu_certificate_action
 msgid "Certificates for Veri*Factu"
-msgstr ""
+msgstr "Certificado para Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__chain_index
 msgid "Chain Index"
-msgstr ""
+msgstr "Índice de cadena"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_res_company
 msgid "Companies"
-msgstr ""
+msgstr "Compañías"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__company_id
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__company_id
 msgid "Company"
-msgstr ""
+msgstr "Compañía"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Ajustes de configuración"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "Contacto"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_account_move_send__l10n_es_edi_verifactu_send_checkbox
 msgid ""
 "Create a Veri*Factu Document to register or update the record and send it to"
 " the AEAT."
-msgstr ""
+msgstr "Crear un documento Veri*Factu para registrar o actualizar el registro y"
+" envíelo a la AEAT."
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.actions.act_window,help:l10n_es_edi_verifactu.l10n_es_edi_verifactu_certificate_action
 msgid "Create the first certificate"
-msgstr ""
+msgstr "Crear el primer certificado"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__create_uid
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__create_uid
 msgid "Created by"
-msgstr ""
+msgstr "Creado por"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__create_date
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__create_date
 msgid "Created on"
-msgstr ""
+msgstr "Creado el"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__date_end
 msgid "Date End"
-msgstr ""
+msgstr "Fecha de finalización"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__date_start
 msgid "Date Start"
-msgstr ""
+msgstr "Fecha de inicio"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__display_name
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nombre para mostrar"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__document_type
 msgid "Document Type"
-msgstr ""
+msgstr "Tipo de documento"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_company__l10n_es_edi_verifactu_required
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_config_settings__l10n_es_edi_verifactu_required
 msgid "Enable Veri*Factu"
-msgstr ""
+msgstr "Activar Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -224,14 +236,14 @@ msgstr ""
 #: code:addons/l10n_es_edi_verifactu/tests/common.py:0
 #, python-format
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "Error while chaining the document: %s"
-msgstr ""
+msgstr "Error al encadenar el documento: %s"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -242,30 +254,32 @@ msgid ""
 "Error while sending the batch document:\n"
 "%s"
 msgstr ""
+"Error al enviar el documento por lote:\n"
+"%s"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__errors
 msgid "Errors"
-msgstr ""
+msgstr "Errores"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/account_move.py:0
 #, python-format
 msgid "Export"
-msgstr "Exportación"
+msgstr "Exportar"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__content
 msgid "File"
-msgstr ""
+msgstr "Archivo"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/account_move.py:0
 #, python-format
 msgid "General regime operation"
-msgstr "Operación de régimen general"
+msgstr "Operación del régimen general"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -274,23 +288,23 @@ msgstr "Operación de régimen general"
 #: code:addons/l10n_es_edi_verifactu/models/account_move.py:0
 #, python-format
 msgid "Go to the journal entry"
-msgstr ""
+msgstr "Ir al asiento contable"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__id
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_tax__l10n_es_applicability__03
 msgid "IGIC"
-msgstr ""
+msgstr "IGIC"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_tax__l10n_es_applicability__02
 msgid "IPSI"
-msgstr ""
+msgstr "IPSI"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__chain_index
@@ -298,27 +312,29 @@ msgid ""
 "Index in the chain of Veri*Factu Documents. It is only set if the generation"
 " was succesful."
 msgstr ""
+"Índice en la cadena de documentos Veri*Factu. Solo se establece si la generación"
+"fue exitosa."
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__json_attachment_base64
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__json_attachment_id
 msgid "JSON Attachment"
-msgstr ""
+msgstr "Archivo adjunto JSON"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__json_attachment_filename
 msgid "JSON Filename"
-msgstr ""
+msgstr "Nombre del archivo JSON"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_account_move
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__move_id
 msgid "Journal Entry"
-msgstr ""
+msgstr "Asiento contable"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move_send__l10n_es_edi_verifactu_send_enable
@@ -339,45 +355,45 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__write_uid
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__write_uid
 msgid "Last Updated by"
-msgstr ""
+msgstr "Última actualización por"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__write_date
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__write_date
 msgid "Last Updated on"
-msgstr ""
+msgstr "Última actualización el"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/account_move.py:0
 #, python-format
 msgid "Leasing of business premises"
-msgstr "Operaciones de arrendamiento de local de negocio"
+msgstr "Arrendamiento de locales comerciales"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_res_company__l10n_es_edi_verifactu_special_vat_regime
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_res_config_settings__l10n_es_edi_verifactu_special_vat_regime
 msgid "Leave empty for the normal regimen."
-msgstr ""
+msgstr "Déjelo vacío para el régimen normal."
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.res_config_settings_view_form
 msgid "Manage certificates"
-msgstr ""
+msgstr "Gestionar certificados"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "Missing Veri*Factu Regime Key (ClaveRegimen)."
-msgstr ""
+msgstr "Falta la clave del régimen de Veri*Factu (ClaveRegimen)."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "Missing Veri*Factu Tax Applicability (Impuesto)."
-msgstr ""
+msgstr "Falta la aplicabilidad fiscal de Veri*Factu (Impuesto)"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -388,6 +404,8 @@ msgid ""
 "Networking error while sending the document:\n"
 "%s"
 msgstr ""
+"Error de red al enviar el documento:\n"
+"%s"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -397,27 +415,29 @@ msgid ""
 "Networking error:\n"
 "%s"
 msgstr ""
+"Error de red:\n"
+"%s"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "Networking error: %s"
-msgstr ""
+msgstr "Error de red: %s"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "No Sujeto VAT taxes must have 0 amount."
-msgstr ""
+msgstr "Los importes no sujetos a IVA deben ser igual a 0."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "Only a single recargo tax may be used per \"main\" tax."
-msgstr ""
+msgstr "Solo se puede aplicar un único recargo por cada impuesto \"principal\"."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -442,110 +462,110 @@ msgstr "Operaciones de actividades incluidas en el Régimen Especial de Agicultu
 #: code:addons/l10n_es_edi_verifactu/models/account_tax.py:0
 #, python-format
 msgid "Other"
-msgstr ""
+msgstr "Otro"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__content
 msgid "PFX Certificate"
-msgstr ""
+msgstr "Certificado PFX"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__password
 msgid "Passphrase for the PFX certificate"
-msgstr ""
+msgstr "Frase de contraseña para el certificado PFX"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__password
 msgid "Password"
-msgstr ""
+msgstr "Contraseña"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_l10n_es_edi_verifactu_certificate
 msgid "Personal Digital Certificate"
-msgstr ""
+msgstr "Certificado digital personal"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move__l10n_es_edi_verifactu_refund_reason__r1
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move_reversal__l10n_es_edi_verifactu_refund_reason__r1
 msgid "R1: Art 80.1 and 80.2 and error of law"
-msgstr ""
+msgstr "R1: Art. 80.1 y 80.2 y error fundado en derecho"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move__l10n_es_edi_verifactu_refund_reason__r2
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move_reversal__l10n_es_edi_verifactu_refund_reason__r2
 msgid "R2: Art. 80.3"
-msgstr ""
+msgstr "R2: Art. 80.3"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move__l10n_es_edi_verifactu_refund_reason__r3
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move_reversal__l10n_es_edi_verifactu_refund_reason__r3
 msgid "R3: Art. 80.4"
-msgstr ""
+msgstr "R3: Art. 80.4"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move__l10n_es_edi_verifactu_refund_reason__r4
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move_reversal__l10n_es_edi_verifactu_refund_reason__r4
 msgid "R4: Rest"
-msgstr ""
+msgstr "R4: Resto"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move__l10n_es_edi_verifactu_refund_reason__r5
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move_reversal__l10n_es_edi_verifactu_refund_reason__r5
 msgid "R5: Corrective invoices concerning simplified invoices"
-msgstr ""
+msgstr "R5: Facturas rectificativas en facturas simplificadas"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__res_company__l10n_es_edi_verifactu_special_vat_regime__reagyp
 msgid "REAGYP (Special Regime for Agriculture, Livestock and Fisheries)"
-msgstr ""
+msgstr "REAGP (Régimen Especial de Agricultura, Ganadería y Pesca)"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__res_company__l10n_es_edi_verifactu_special_vat_regime__recargo
 msgid "Recargo de Equivalencia"
-msgstr ""
+msgstr "Recargo de Equivalencia"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/account_move.py:0
 #, python-format
 msgid "Recargo de equivalencia"
-msgstr ""
+msgstr "Recargo de equivalencia"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move__l10n_es_edi_verifactu_state__registered_with_errors
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__l10n_es_edi_verifactu_document__state__registered_with_errors
 msgid "Registered with Errors"
-msgstr ""
+msgstr "Registrado con errores"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_move__l10n_es_edi_verifactu_state__rejected
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__l10n_es_edi_verifactu_document__state__rejected
 msgid "Rejected"
-msgstr ""
+msgstr "Rechazado"
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.view_move_form_inherit_l10n_es_edi_verifactu
 msgid "Request Veri*Factu Cancellation"
-msgstr ""
+msgstr "Solicitar cancelación de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__response_csv
 msgid "Response CSV"
-msgstr ""
+msgstr "Respuesta CSV"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/wizard/account_move_send.py:0
 #, python-format
 msgid "See the 'Veri*Factu' tab for more information."
-msgstr ""
+msgstr "Consulte la pestaña Veri*Factu para obtener más información."
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_show_cancel_button
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move__l10n_es_edi_verifactu_show_cancel_button
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_show_cancel_button
 msgid "Show Veri*Factu Cancel Button"
-msgstr ""
+msgstr "Mostrar el botón de cancelación para Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -563,11 +583,13 @@ msgid ""
 "Some of the documents can not be sent. They were sent already or could not "
 "be generated correctly."
 msgstr ""
+"Algunos de los documentos no se pueden enviar. Ya fueron enviados o no se pudieron "
+"generar correctamente."
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.res_config_settings_view_form
 msgid "Special VAT Regime"
-msgstr ""
+msgstr "Régimen especial en el IVA"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -579,31 +601,31 @@ msgstr "Régimen especial de comerciante minorista"
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__state
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__l10n_es_edi_verifactu_document__document_type__submission
 msgid "Submission"
-msgstr ""
+msgstr "Envío"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_substitution_move_ids
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move__l10n_es_edi_verifactu_substitution_move_ids
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_substitution_move_ids
 msgid "Substituted by"
-msgstr ""
+msgstr "Sustituido por"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_substituted_entry_id
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move__l10n_es_edi_verifactu_substituted_entry_id
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_substituted_entry_id
 msgid "Substitution of"
-msgstr ""
+msgstr "Sustitución de"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_account_tax
 msgid "Tax"
-msgstr ""
+msgstr "Impuesto"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_available_clave_regimens
@@ -613,11 +635,13 @@ msgid ""
 "Technical field to enable a dynamic selection of the field \"Veri*Factu "
 "Regime Key\""
 msgstr ""
+"Campo técnico para habilitar una selección dinámica del campo \"Clave del "
+"régimen de Veri*Factu\""
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.res_config_settings_view_form
 msgid "Test Environment"
-msgstr ""
+msgstr "Entorno de pruebas"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_document__response_csv
@@ -625,11 +649,13 @@ msgid ""
 "The CSV of the response from the tax agency. There may not be one in case "
 "all documents of the batch were rejected."
 msgstr ""
+"El CSV de la respuesta de la agencia tributaria. Puede que no exista uno si "
+"todos los documentos del lote fueron rechazados."
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_res_company__l10n_es_edi_verifactu_next_batch_time
 msgid "The Datetime at which the next submission to the AEAT can be made."
-msgstr ""
+msgstr "La fecha y hora en la que se puede realizar la siguiente presentación a la AEAT."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -639,13 +665,14 @@ msgstr ""
 msgid ""
 "The NIF '%(company_NIF)s' of the company is not exactly 9 characters long."
 msgstr ""
+"El NIF %(company_NIF)s de la empresa no tiene exactamente 9 caracteres."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "The SSL certificate could not be validated."
-msgstr ""
+msgstr "No se pudo validar el certificado SSL."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -655,6 +682,8 @@ msgid ""
 "The Veri*Factu Regime Key is not compatible with the Veri*Factu Tax "
 "Applicability."
 msgstr ""
+"La clave del régimen de Veri*Factu no es compatible con la aplicabilidad fiscal de "
+"Veri*Factu."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -664,6 +693,7 @@ msgstr ""
 msgid ""
 "The Veri*Factu document contains the following errors according to the AEAT"
 msgstr ""
+"El documento Veri*Factu contiene los siguientes errores según la AEAT."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -671,7 +701,7 @@ msgstr ""
 #: code:addons/l10n_es_edi_verifactu/tests/common.py:0
 #, python-format
 msgid "The Veri*Factu document could not be created"
-msgstr ""
+msgstr "No se pudo crear el documento Veri*Factu."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -685,48 +715,48 @@ msgstr ""
 #: code:addons/l10n_es_edi_verifactu/wizard/account_move_send.py:0
 #, python-format
 msgid "The Veri*Factu document could not be created for all invoices."
-msgstr ""
+msgstr "No se pudo crear el documento Veri*Factu para todas las facturas."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "The batch document could not be created"
-msgstr ""
+msgstr "No se pudo crear el documento por lote"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "The cancelled record is not Veri*Factu registered (inside Odoo)."
-msgstr ""
+msgstr "El registro cancelado no está registrado en Veri*Factu (dentro de Odoo)."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_certificate.py:0
 #, python-format
 msgid "The certificate is expired since %s"
-msgstr ""
+msgstr "El certificado ha caducado desde %s"
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.res_config_settings_view_form
 msgid "The data is sent to test servers and is not considered official."
-msgstr ""
+msgstr "Los datos se envían a servidores de prueba y no se consideran oficiales."
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.res_config_settings_view_form
 msgid "The data is sent to the tax agency."
-msgstr ""
+msgstr "Los datos se envían a la agencia tributaria."
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__date_end
 msgid "The date on which the certificate expires"
-msgstr ""
+msgstr "La fecha en la que el certificado caduca."
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,help:l10n_es_edi_verifactu.field_l10n_es_edi_verifactu_certificate__date_start
 msgid "The date on which the certificate starts to be valid"
-msgstr ""
+msgstr "La fecha en la que el certificado comienza a ser válido"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -736,6 +766,8 @@ msgid ""
 "The document could not be sent; the access was denied due to a problem with "
 "the certificate."
 msgstr ""
+"No se pudo enviar el documento. El acceso fue rech debido a un problema con el "
+"certificado."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -745,6 +777,8 @@ msgid ""
 "The following entries will be skipped. They are already registered with the "
 "AEAT: %s"
 msgstr ""
+"Las siguientes entradas serán omitidas. Ya están registradas en la "
+"AEAT: %s"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -754,20 +788,22 @@ msgid ""
 "The following entries will be skipped. They are already waiting to send "
 "Veri*Factu records to the AEAT: %s"
 msgstr ""
+"Las siguientes entradas serán omitidas. Ya están pendientes de enviar registros de "
+"Veri*Factu a la AEAT: %s"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "The invoice date is missing."
-msgstr ""
+msgstr "Falta la fecha de facturación."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/account_move.py:0
 #, python-format
 msgid "The journal entry has to be posted."
-msgstr ""
+msgstr "Se debe publicar el asiento contable."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -776,20 +812,21 @@ msgstr ""
 msgid ""
 "The name of the record is not between 1 and 60 characters long: %(name)s."
 msgstr ""
+"El nombre del registro debe tener entre 1 y 60 caracteres: %(name)s."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "The record is Veri*Factu registered already."
-msgstr ""
+msgstr "El registro ya está registrado en el sistema Veri*Factu."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "The refund reason is not specified."
-msgstr ""
+msgstr "No se ha especificado el motivo del reembolso."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -799,13 +836,15 @@ msgid ""
 "The response of the server had the wrong format (HTML instead of XML). It is"
 " most likely a problem with the certificate."
 msgstr ""
+"La respuesta del servidor no tenía el formato correcto (HTML en lugar de XML). Es muy probable "
+"que sea un problema con el certificado."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "There are no taxes set on the invoice"
-msgstr ""
+msgstr "No se han establecido impuestos en la factura."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -817,6 +856,9 @@ msgid ""
 "- The password given or the certificate are not valid.\n"
 "- The certificate content is invalid."
 msgstr ""
+"Había un problema con el certificado, algunos problemas habituales pueden ser:\n"
+"La contraseña proporcionada o el certificado no son válidos.\n"
+"El contenido del certificado no es válido"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -824,7 +866,7 @@ msgstr ""
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "There is no Veri*Factu document for the refunded record."
-msgstr ""
+msgstr "No existe un documento Veri*Factu para el registro reembolsado."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -834,6 +876,7 @@ msgstr ""
 msgid ""
 "There is no Veri*Factu document for the reversal of the substituted record."
 msgstr ""
+"No existe un documento Veri*Factu para la reversión del registro sustituido."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -841,7 +884,7 @@ msgstr ""
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "There is no Veri*Factu document for the substituted record."
-msgstr ""
+msgstr "No existe un documento Veri*Factu para el registro sustituido."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -849,7 +892,7 @@ msgstr ""
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "There is no certificate configured for Veri*Factu on the company."
-msgstr ""
+msgstr "No hay un certificado configurado para Veri*Factu en la compañía."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -859,72 +902,74 @@ msgid ""
 "Timeout while waiting for the response from the server:\n"
 "%s"
 msgstr ""
+"Se ha agotado el tiempo de espera para recibir la respuesta del servidor:\n."
+"%s"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "Unsupported `operation` '%s'"
-msgstr ""
+msgstr "`Operación` no soportada '%s'"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu.selection__account_tax__l10n_es_applicability__01
 msgid "VAT"
-msgstr ""
+msgstr "IVA"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "Validation error: %s"
-msgstr ""
+msgstr "Error de validación: %s"
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.l10n_es_edi_verifactu_certificate_form
 msgid "Validity"
-msgstr ""
+msgstr "Validez"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move_send__l10n_es_edi_verifactu_send_checkbox
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.res_config_settings_view_form
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.view_move_form_inherit_l10n_es_edi_verifactu
 msgid "Veri*Factu"
-msgstr ""
+msgstr "Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.ui.menu,name:l10n_es_edi_verifactu.menu_l10n_es_edi_verifactu_root
 msgid "Veri*Factu (Spain)"
-msgstr ""
+msgstr "Veri*Factu (España)"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_company__l10n_es_edi_verifactu_certificate_ids
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_config_settings__l10n_es_edi_verifactu_certificate_ids
 msgid "Veri*Factu Certificates"
-msgstr ""
+msgstr "Certificados Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model,name:l10n_es_edi_verifactu.model_l10n_es_edi_verifactu_document
 msgid "Veri*Factu Document"
-msgstr ""
+msgstr "Documento Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "Veri*Factu Document %s"
-msgstr ""
+msgstr "Documento Veri*Factu: %s"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_company__l10n_es_edi_verifactu_chain_sequence_id
 msgid "Veri*Factu Document Chain Sequence"
-msgstr ""
+msgstr "Secuencia de cadena del documento Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/res_company.py:0
 #, python-format
 msgid "Veri*Factu Document Sequence for company %(name)s (%(id)s)"
-msgstr ""
+msgstr "Secuencia del documento Veri*Factu para la compañía %(name)s (%(id)s)"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_document_ids
@@ -932,19 +977,19 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_document_ids
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.view_move_form_inherit_l10n_es_edi_verifactu
 msgid "Veri*Factu Documents"
-msgstr ""
+msgstr "Documentos Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_company__l10n_es_edi_verifactu_next_batch_time
 msgid "Veri*Factu Next Batch Time"
-msgstr ""
+msgstr "Hora del siguiente lote de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_qr_code
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move__l10n_es_edi_verifactu_qr_code
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_qr_code
 msgid "Veri*Factu QR Code"
-msgstr ""
+msgstr "Código QR de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_refund_reason
@@ -952,14 +997,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move_reversal__l10n_es_edi_verifactu_refund_reason
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_refund_reason
 msgid "Veri*Factu Refund Reason"
-msgstr ""
+msgstr "Motivo de reembolso de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_clave_regimen
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move__l10n_es_edi_verifactu_clave_regimen
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_clave_regimen
 msgid "Veri*Factu Regime Key"
-msgstr ""
+msgstr "Clave del régimen de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_required
@@ -967,58 +1012,58 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move_reversal__l10n_es_edi_verifactu_required
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_required
 msgid "Veri*Factu Required"
-msgstr ""
+msgstr "Se necesita utilizar Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.view_account_invoice_filter
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu.view_account_move_filter
 msgid "Veri*Factu State"
-msgstr ""
+msgstr "Estado de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_state
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move__l10n_es_edi_verifactu_state
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_state
 msgid "Veri*Factu Status"
-msgstr ""
+msgstr "Estado de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_company__l10n_es_edi_verifactu_test_environment
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_config_settings__l10n_es_edi_verifactu_test_environment
 msgid "Veri*Factu Test Environment"
-msgstr ""
+msgstr "Entorno de pruebas de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_company__l10n_es_edi_verifactu_special_vat_regime
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_res_config_settings__l10n_es_edi_verifactu_special_vat_regime
 msgid "Veri*Factu VAT Regime"
-msgstr ""
+msgstr "Régimen de IVA de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_warning
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move__l10n_es_edi_verifactu_warning
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_warning
 msgid "Veri*Factu Warning"
-msgstr ""
+msgstr "Advertencia de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_bank_statement_line__l10n_es_edi_verifactu_warning_level
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_move__l10n_es_edi_verifactu_warning_level
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu.field_account_payment__l10n_es_edi_verifactu_warning_level
 msgid "Veri*Factu Warning Level"
-msgstr ""
+msgstr "Nivel de advertencia de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu
 #: model:ir.actions.server,name:l10n_es_edi_verifactu.cron_verifactu_batch_ir_actions_server
 msgid "Veri*Factu: Submit / Cancel Records"
-msgstr ""
+msgstr "Veri*Factu: enviar o cancelar registros"
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "We are waiting to send a Veri*Factu record to the AEAT already."
-msgstr ""
+msgstr "Ya estamos esperando para enviar un registro de Veri*Factu a la AEAT."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -1028,14 +1073,15 @@ msgstr ""
 msgid ""
 "We could not find any information about the record in the linked batch "
 "document."
-msgstr ""
+msgstr "No se pudo encontrar información sobre el registro en el documento de lote "
+"vinculado."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu/models/verifactu_document.py:0
 #, python-format
 msgid "We only allow a single \"main\" tax per line."
-msgstr ""
+msgstr "Solo se permite un único impuesto \"principal\" por línea."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -1045,6 +1091,9 @@ msgid ""
 "We only allow a single Veri*Factu Tax Applicability (Impuesto) per document:"
 " %(applicabilities)s."
 msgstr ""
+"Solo se permite una única aplicabilidad fiscal de Veri*Factu (Impuesto) por documento:"
+
+" %(applicabilities)s."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -1054,6 +1103,8 @@ msgid ""
 "You are modifying a journal entry for which a Veri*Factu document has been "
 "sent to the AEAT already."
 msgstr ""
+"Está modificando un asiento contable para el cual ya se ha enviado un documento "
+"Veri*Factu a la AEAT."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -1063,6 +1114,8 @@ msgid ""
 "You are modifying a journal entry for which a Veri*Factu document is waiting"
 " to be sent."
 msgstr ""
+"Está modificando un asiento contable para el que hay un documento Veri*Factu "
+"pendiente de envío."
 
 #. module: l10n_es_edi_verifactu
 #. odoo-python
@@ -1072,3 +1125,5 @@ msgid ""
 "You cannot delete Veri*Factu Documents that are part of the chain of all "
 "Veri*Factu Documents."
 msgstr ""
+"No se pueden eliminar los documentos Veri*Factu que forman parte de la cadena de "
+"documentos Veri*Factu."

--- a/addons/l10n_es_edi_verifactu_pos/i18n/es.po
+++ b/addons/l10n_es_edi_verifactu_pos/i18n/es.po
@@ -23,6 +23,8 @@ msgid ""
 "%(existing_warning)sA Veri*Factu document is waiting to be sent as soon as "
 "possible."
 msgstr ""
+"%(existing_warning)sUn documento Veri*Factu está listo para ser enviado lo antes "
+"posible."
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,help:l10n_es_edi_verifactu_pos.field_pos_order__l10n_es_edi_verifactu_state
@@ -32,6 +34,10 @@ msgid ""
 "                - Accepted: Registered by the AEAT without errors\n"
 "                - Cancelled: Registered by the AEAT as cancelled"
 msgstr ""
+"- Rechazado: enviado correctamente a la AEAT, pero fue rechazado durante la validación\n"
+"                - Registrado con errores: registrado en la AEAT, pero la AEAT ha detectado algunos problemas con el documento enviado\n"
+"                - Aceptado: registrado por la AEAT sin errores\n"
+"                - Cancelado: registrado por la AEAT como cancelado"
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-python
@@ -40,102 +46,103 @@ msgstr ""
 msgid ""
 "A partner has to be specified for the selected Veri*Factu Refund Reason."
 msgstr ""
+"Se debe especificar un contacto para el motivo de reembolso de Veri*Factu seleccionado."
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu_pos.selection__pos_order__l10n_es_edi_verifactu_state__accepted
 msgid "Accepted"
-msgstr ""
+msgstr "Aceptado"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu_pos.selection__pos_order__l10n_es_edi_verifactu_state__cancelled
 msgid "Cancelled"
-msgstr ""
+msgstr "Cancelado"
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-javascript
 #: code:addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
 #, python-format
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_l10n_es_edi_verifactu_document__pos_order_id
 msgid "PoS Order"
-msgstr ""
+msgstr "Pedido de TPV"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model,name:l10n_es_edi_verifactu_pos.model_pos_config
 msgid "Point of Sale Configuration"
-msgstr ""
+msgstr "Configuración del TPV"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model,name:l10n_es_edi_verifactu_pos.model_pos_order
 msgid "Point of Sale Orders"
-msgstr ""
+msgstr "Pedidos de TPV"
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-javascript
 #: code:addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/order_receipt/order_receipt.xml:0
 #, python-format
 msgid "QR tributario:"
-msgstr ""
+msgstr "QR tributario:"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu_pos.selection__pos_order__l10n_es_edi_verifactu_refund_reason__r1
 msgid "R1: Art 80.1 and 80.2 and error of law"
-msgstr ""
+msgstr "R1: Art. 80.1 y 80.2 y error fundado en derecho"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu_pos.selection__pos_order__l10n_es_edi_verifactu_refund_reason__r2
 msgid "R2: Art. 80.3"
-msgstr ""
+msgstr "R2: Art. 80.3"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu_pos.selection__pos_order__l10n_es_edi_verifactu_refund_reason__r3
 msgid "R3: Art. 80.4"
-msgstr ""
+msgstr "R3: Art. 80.4"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu_pos.selection__pos_order__l10n_es_edi_verifactu_refund_reason__r4
 msgid "R4: Rest"
-msgstr ""
+msgstr "R4: Resto"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu_pos.selection__pos_order__l10n_es_edi_verifactu_refund_reason__r5
 msgid "R5: Corrective invoices concerning simplified invoices"
-msgstr ""
+msgstr "R5: Facturas rectificativas en facturas simplificadas"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu_pos.selection__pos_order__l10n_es_edi_verifactu_state__registered_with_errors
 msgid "Registered with Errors"
-msgstr ""
+msgstr "Registrado con errores"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields.selection,name:l10n_es_edi_verifactu_pos.selection__pos_order__l10n_es_edi_verifactu_state__rejected
 msgid "Rejected"
-msgstr ""
+msgstr "Rechazado"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu_pos.view_pos_order_form_inherit_l10n_es_pos_verifactu
 msgid "Request Veri*Factu Cancellation"
-msgstr ""
+msgstr "Solicitar cancelación de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-javascript
 #: code:addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/ticket_screen/ticket_screen.js:0
 #, python-format
 msgid "Select the refund reason (Veri*Factu)"
-msgstr ""
+msgstr "Seleccione el motivo de reembolso (Veri*Factu)."
 
 #. module: l10n_es_edi_verifactu_pos
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu_pos.view_pos_order_form_inherit_l10n_es_pos_verifactu
 msgid "Send Veri*Factu"
-msgstr ""
+msgstr "Enviar documentos Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_pos_order__l10n_es_edi_verifactu_show_cancel_button
 msgid "Show Veri*Factu Cancel Button"
-msgstr ""
+msgstr "Mostrar el botón de cancelación para Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-python
@@ -145,6 +152,8 @@ msgid ""
 "The order can not be invoiced. It is waiting to send a Veri*Factu record to "
 "the AEAT already."
 msgstr ""
+"No se puede facturar el pedido. Ya está pendiente el envío de un registro de Veri*Factu "
+"a la AEAT."
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-javascript
@@ -153,66 +162,66 @@ msgstr ""
 #: code:addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
 #, python-format
 msgid "The order needs to be invoiced since its total amount is above 400€."
-msgstr ""
+msgstr "El pedido debe ser facturado, ya que su importe total supera los 400 €."
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-javascript
 #: code:addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/order_receipt/order_receipt.xml:0
 #, python-format
 msgid "VERI*FACTU"
-msgstr ""
+msgstr "VERI*FACTU"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu_pos.view_pos_order_form_inherit_l10n_es_pos_verifactu
 msgid "Veri*Factu"
-msgstr ""
+msgstr "Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model,name:l10n_es_edi_verifactu_pos.model_l10n_es_edi_verifactu_document
 msgid "Veri*Factu Document"
-msgstr ""
+msgstr "Documento Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_pos_order__l10n_es_edi_verifactu_document_ids
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu_pos.view_pos_order_form_inherit_l10n_es_pos_verifactu
 msgid "Veri*Factu Documents"
-msgstr ""
+msgstr "Documentos Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_pos_order__l10n_es_edi_verifactu_qr_code
 msgid "Veri*Factu QR Code"
-msgstr ""
+msgstr "Código QR de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_pos_order__l10n_es_edi_verifactu_refund_reason
 msgid "Veri*Factu Refund Reason"
-msgstr ""
+msgstr "Motivo de reembolso de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_pos_config__l10n_es_edi_verifactu_required
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_pos_order__l10n_es_edi_verifactu_required
 msgid "Veri*Factu Required"
-msgstr ""
+msgstr "Se necesita utilizar Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_verifactu_pos.view_pos_order_filter
 msgid "Veri*Factu State"
-msgstr ""
+msgstr "Estado de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_pos_order__l10n_es_edi_verifactu_state
 msgid "Veri*Factu Status"
-msgstr ""
+msgstr "Estado de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_pos_order__l10n_es_edi_verifactu_warning
 msgid "Veri*Factu Warning"
-msgstr ""
+msgstr "Advertencia de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #: model:ir.model.fields,field_description:l10n_es_edi_verifactu_pos.field_pos_order__l10n_es_edi_verifactu_warning_level
 msgid "Veri*Factu Warning Level"
-msgstr ""
+msgstr "Nivel de advertencia de Veri*Factu"
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-python
@@ -221,6 +230,7 @@ msgstr ""
 msgid ""
 "Veri*Factu documents can only be generated for paid Point of Sale Orders."
 msgstr ""
+"Los documentos Veri*Factu solo se pueden generar para pedidos de TPV pagados."
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-python
@@ -229,6 +239,7 @@ msgstr ""
 msgid ""
 "Veri*Factu documents can only be generated for paid or posted Point of Sale Orders."
 msgstr ""
+"Los documentos Veri*Factu solo se pueden generar para pedidos de TPV pagados o publicados."
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-python
@@ -236,11 +247,11 @@ msgstr ""
 #: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
 #, python-format
 msgid "You can only refund products from the same order."
-msgstr ""
+msgstr "Solo se pueden reembolsar productos del mismo pedido."
 
 #. module: l10n_es_edi_verifactu_pos
 #. odoo-python
 #: code:addons/l10n_es_edi_verifactu_pos/models/pos_order.py:0
 #, python-format
 msgid "You have to specify a refund reason."
-msgstr ""
+msgstr "Debe especificar un motivo de reembolso."


### PR DESCRIPTION
Due to time constraints the translations were not added in the commit adding the modules (72ac059edfcc35ad44c5faa9daf971123377af24). This commit adds the translations / fills the `.po` files.

The translations were created by LMAN based on the 18.0 po files.

Veri*Factu task:
task-3745982
