### PR TITLE
[FIX] stock_{account,dropshipping}: exchange diff under stock valo account

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -324,7 +324,7 @@ class AccountMoveLine(models.Model):
 
     def _get_exchange_journal(self, company):
         if (
-            self and self.move_id.sudo().stock_valuation_layer_ids and
+            self and self.account_id == self.product_id._get_product_accounts()['stock_input'] and
             self.product_id.categ_id.property_valuation == 'real_time'
         ):
             return self.product_id.categ_id.property_stock_journal
@@ -332,7 +332,7 @@ class AccountMoveLine(models.Model):
 
     def _get_exchange_account(self, company, amount):
         if (
-            self and self.move_id.sudo().stock_valuation_layer_ids and
+            self and self.account_id == self.product_id._get_product_accounts()['stock_input'] and
             self.product_id.categ_id.property_valuation == 'real_time'
         ):
             return self.product_id.categ_id.property_stock_valuation_account_id


### PR DESCRIPTION
Issue
-----
When receiving product after having billed it already, if:
- the product is valuated,
- the purchase is in a foreign currency,
- there is an underlying exchange diff between time of bill and reception
- the diff exchange rate is negative

then the exchange difference account move will occur in the regular exchange account.

Steps to reproduce
-----
- Enable automatic (anglo-saxon) accounting & dropshipping
- Enable the EUR currency and add 2 exchange rates
    - today with 2:1 (EUR:USD)
    - yesterday with 1:2 (EUR:USD)
- Create a new AVCO product category
    - costing method: AVCO
    - valuation: automatic
- Create a new product
    - type: storable
    - category: AVCO
    - purchase: 5€
    - set dropship route
- Create and confirm a SO
- Confirm PO and validate delivery
- Create bill for the PO
    - change bill date to before yesterday & confirm

> Journal entry created in "Exchange Difference" journal

Cause
-----
Thanks to commit 80ff2d2 the flow is well behaved if the new rate is higher (company currency worth more comparatively) because we use the credit aml

https://github.com/odoo/odoo/blob/b57bb1decd46dcbb1fe602bb72b6f8e5382e9b28/addons/account/models/account_move_line.py#L2214-L2215

whose move has a svl

https://github.com/odoo/odoo/blob/b57bb1decd46dcbb1fe602bb72b6f8e5382e9b28/addons/stock_account/models/account_move.py#L335

This is not the case for the debit aml, so we end up using the default currency exchange account.

-----
Ticket:
opw-4797287
