### PR TITLE
[FIX] core: handle `_check_company` error message in case of sub-companies

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4118,15 +4118,16 @@ class BaseModel(metaclass=MetaModel):
             root_company_msg = _lt("- Only a root company can be set on %(record)r. Currently set to %(company)r")
             for record, name, corecords in inconsistencies[:5]:
                 if record._name == 'res.company':
-                    msg, company = company_msg, record
+                    msg, companies = company_msg, record
                 elif record == corecords and name == 'company_id':
-                    msg, company = root_company_msg, record.company_id
+                    msg, companies = root_company_msg, record.company_id
                 else:
-                    msg, company = record_msg, record.company_id
+                    msg = record_msg
+                    companies = record.company_id if 'company_id' in record else record.company_ids
                 field = self.env['ir.model.fields']._get(self._name, name)
                 lines.append(str(msg) % {
                     'record': record.display_name,
-                    'company': company.display_name,
+                    'company': ", ".join(company.display_name for company in companies),
                     'field': field.field_description,
                     'fname': field.name,
                     'values': ", ".join(repr(rec.display_name) for rec in corecords),


### PR DESCRIPTION
`_check_company` can be called on models that don't have a `company_id` field, but they might have a `company_ids` one. In this case the message logged as the user error should be able to handle that scenario.

Example on how to reproduce the error in accounting:

```py
company_a, company_b

tax_group self.env["account.tax.group"].create(
   {
        "name": "Tax Group",
         "company_id": company_a.id,
    }
)

tax = self.env["account.tax"].create(
    {
        "name": "30% - Loan Tax",
        "type_tax_use": "sale",
        "tax_exigibility": "on_payment",
        "amount": 30,
        "amount_type": "percent",
        "tax_group_id": tax_group.id,
        "company_id": company_a.id,
    }
)

account = self.env["account.account"].create({
    ...,
    "company_ids": [Command.link(company_b.id)]
})
account.tax_ids |= tax
```

Error raised
```
AttributeError: 'account.account' object has no attribute 'company_id'
```

After the PR the following message appears:
```
odoo.exceptions.UserError: Incompatible companies on records:
- “Loan Principal” belongs to company “BE Company Loan Tests” and “Default Taxes” (tax_ids: '30% - Loan Tax') belongs to another company.
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
