### PR TITLE
[FIX] base: ensure partner belongs to the same company as the ticket

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -758,6 +758,7 @@ class Partner(models.Model):
                     if len(companies) > 1 or company not in companies:
                         raise UserError(
                             ("The selected company is not compatible with the companies of the related user(s)"))
+
                 if partner.child_ids:
                     partner.child_ids.write({'company_id': company_id})
         result = True


### PR DESCRIPTION
**Issue**:
It is possible to associate a partner that belongs to a different company than the ticket’s company. As a result, some users could see tickets in the list view that they should not have access to. When attempting to open those tickets, an error was raised. Even worse, in some cases (see the associated ticket), certain users were still able to access them.

**Steps to reproduce**:

- Create two companies (A and B)
- Switch to company A
- Open the Helpdesk application
- Create and open a ticket
- Select both companies A and B
- Assign a partner linked to company B to the ticket
- Save it

opw-4926497
