### PR TITLE
[FIX] portal_rating, website_slides: comment edit and delete dropdown

### DIFF
--- a/addons/portal_rating/static/src/chatter/frontend/message_patch.js
+++ b/addons/portal_rating/static/src/chatter/frontend/message_patch.js
@@ -1,8 +1,11 @@
 import { Message } from "@mail/core/common/message";
 import { convertBrToLineBreak } from "@mail/utils/common/format";
 
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { rpc } from "@web/core/network/rpc";
 import { patch } from "@web/core/utils/patch";
+
+Message.components = { ...Message.components, DropdownItem };
 
 patch(Message.prototype, {
     setup() {

--- a/addons/website_slides/static/tests/tours/slides_course_reviews_comment.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews_comment.js
@@ -45,5 +45,41 @@ registry.category("web_tour.tours").add("course_reviews_comment", {
             trigger:
                 "#chatterRoot:shadow .o-mail-Message:contains('Putting a comment...') :not(:has(button:contains('comment')))",
         },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message:contains(Putting a comment...) .o_wrating_publisher_comment .o-dropdown",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-dropdown-item:contains(Edit)",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Composer-input",
+            run: "edit Editing the comment...",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message button:contains(save)",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Editing the comment...)",
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message:contains(Editing the comment...) .o_wrating_publisher_comment .o-dropdown",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-dropdown-item:contains(Delete)",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:not(:contains(Editing the comment...)",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message button:contains(comment)",
+            run: "click",
+        },
     ],
 });


### PR DESCRIPTION
Since #221105, `DropdownItem` has been removed from the `Message` component. `DropdownItem` is used in the comment feature of the messages in portal chatter. Trying to access this dropdown crashes when you follow the steps below:

- Go to an app like elearning that has the comment feature in the portal (as admin)
- On one of the messages in chatter click the `comment` button and save it
- Try to edit or delete the comment by clicking the three dots on the right of the comment
- Error: Cannot find the definition of component "DropdownItem"

This change adds the `DropdownItem` component to the components of the message in portal.

