### PR TITLE
[FIX] html_editor: fix selection in iOS

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1046,9 +1046,7 @@ export class HistoryPlugin extends Plugin {
             return false;
         }
         const stepCommonAncestor = this.getMutationsRoot(currentStep.mutations) || this.editable;
-        const restoreFocus = this.dependencies.selection.preserveFocus();
         this.dispatchTo("normalize_handlers", stepCommonAncestor, type);
-        restoreFocus();
         this.handleObserverRecords(false);
         if (currentMutationsCount === currentStep.mutations.length) {
             // If there was no registered mutation during the normalization step,

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -167,7 +167,6 @@ function scrollToSelection(selection) {
  * @property { SelectionPlugin['getTargetedBlocks'] } getTargetedBlocks
  * @property { SelectionPlugin['getTargetedNodes'] } getTargetedNodes
  * @property { SelectionPlugin['modifySelection'] } modifySelection
- * @property { SelectionPlugin['preserveFocus'] } preserveFocus
  * @property { SelectionPlugin['preserveSelection'] } preserveSelection
  * @property { SelectionPlugin['rectifySelection'] } rectifySelection
  * @property { SelectionPlugin['areNodeContentsFullySelected'] } areNodeContentsFullySelected
@@ -189,7 +188,6 @@ export class SelectionPlugin extends Plugin {
         "setCursorStart",
         "setCursorEnd",
         "extractContent",
-        "preserveFocus",
         "preserveSelection",
         "resetSelection",
         "getTargetedNodes",
@@ -655,25 +653,6 @@ export class SelectionPlugin extends Plugin {
             }
             for (const { textarea, start, end, direction } of selections) {
                 textarea.setSelectionRange(start, end, direction);
-            }
-        };
-    }
-
-    /**
-     * Take the current active element and return a function that restores the
-     * focus in it if its content is editable.
-     *
-     * @returns {() => void}
-     */
-    preserveFocus() {
-        const activeElement = this.document.activeElement;
-        return () => {
-            if (
-                activeElement &&
-                activeElement !== this.document.activeElement &&
-                this.isNodeEditable(activeElement)
-            ) {
-                activeElement.focus();
             }
         };
     }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -529,6 +529,7 @@ export class ToggleBlockPlugin extends Plugin {
 
     normalize(element) {
         const cursors = this.dependencies.selection.preserveSelection();
+        let shouldRestoreCursor = false;
         for (const titleChild of selectElements(
             element,
             `${toggleSelector} ${titleSelector} > *:first-child`
@@ -539,12 +540,16 @@ export class ToggleBlockPlugin extends Plugin {
                 const nodes = children(titleChild.parentElement);
                 title.replaceChildren(nodes.shift());
                 toggle.after(...nodes);
+                shouldRestoreCursor = true;
             }
             if (!isParagraphRelatedElement(titleChild)) {
                 toggle.after(titleChild);
+                shouldRestoreCursor = true;
             }
         }
-        cursors.restore();
+        if (shouldRestoreCursor) {
+            cursors.restore();
+        }
         for (const emptyToggleNode of selectElements(
             element,
             `${toggleSelector} [data-embedded-editable]:empty`

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -351,8 +351,9 @@ test("can't use the toolbar in a caption", async () => {
             // inserting text.
             editor.document.execCommand("insertText", false, "a");
             expect(input.value).toBe("a");
-            await click("h1");
-            await animationFrame(); // Wait for the selection to change.
+            await click("h1"); // Blur the input.
+            await animationFrame(); // Wait for the focus event to trigger a step.
+            editor.shared.selection.setCursorStart(queryOne("h1"));
         },
         contentAfter: unformat(
             `<p><br></p>
@@ -702,13 +703,14 @@ test("add a link then a caption to an image surrounded by text", async () => {
     await testEditor({
         config: configWithEmbeddedCaption,
         contentBefore: `<p>ab<img class="img-fluid test-image" src="${base64Img}">cd</p>`,
-        stepFunction: async () => {
+        stepFunction: async (editor) => {
             await addLinkToImage("odoo.com");
             await animationFrame();
             await toggleCaption("Hello");
             // Blur the input to commit the caption.
-            await click("p");
-            await animationFrame(); // Wait for the selection to change.
+            await click("p"); // Blur the input.
+            await animationFrame(); // Wait for the focus event to trigger a step.
+            editor.shared.selection.setCursorStart(editor.document.querySelectorAll("p")[1]);
         },
         contentAfter: unformat(
             `<p>ab</p>


### PR DESCRIPTION
`setSelection` restores any lost textarea selection. But since a plugin was calling `setSelection` at every call to `normalize`, this was done at every single action in the editor. As it turns out, iOS struggles a lot with the focus in textareas, and restoring these textarea selections made it move the focus in there, making it impossible to type in peace.

task-4585835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
