### PR TITLE
[FIX] stock{,_delivery,_picking_batch}: fixes for pack in pack

### DIFF
--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -116,8 +116,9 @@ class StockPackage(models.Model):
 
         display_uom = self.env.user.has_group('uom.group_uom')
         for package in self:
-            package_content = package.contained_quant_ids.mapped(lambda q: (q.quantity, q.product_uom_id.name, q.product_id.display_name))
-            package.content_description = format_list(self.env, [format_content(qty, uom_name, product_name, display_uom) for (qty, uom_name, product_name) in package_content])
+            package_content = package.contained_quant_ids.grouped(lambda q: (q.product_uom_id, q.product_id))
+            package_content = [(uom.name, product.display_name, sum(quants.mapped('quantity'))) for ((uom, product), quants) in package_content.items()]
+            package.content_description = format_list(self.env, [format_content(qty, uom_name, product_name, display_uom) for (uom_name, product_name, qty) in package_content])
 
     def _compute_json_popover(self):
         for package in self:

--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -485,14 +485,16 @@ class StockPackage(models.Model):
 
         return list(fetch_next_parents(self))
 
-    def _apply_package_dest_for_entire_packs(self):
+    def _apply_package_dest_for_entire_packs(self, allowed_package_ids=None):
         """ When a package is assigned to a picking, if all of its container is added,
             then we consider the container to be added itself, unless the container
             is a reusable package itself.
         """
         for container, packages in self.grouped('parent_package_id').items():
             if container.child_package_ids == packages and container.package_type_id.package_use != 'reusable':
+                if allowed_package_ids and container.id not in allowed_package_ids:
+                    continue
                 packages.package_dest_id = container
         if self.package_dest_id:
             # If one level was added, need to check if the upper container is fully contained as well.
-            self.package_dest_id._apply_package_dest_for_entire_packs()
+            self.package_dest_id._apply_package_dest_for_entire_packs(allowed_package_ids)

--- a/addons/stock/models/stock_package_history.py
+++ b/addons/stock/models/stock_package_history.py
@@ -21,3 +21,13 @@ class StockPackageHistory(models.Model):
     parent_dest_name = fields.Char('Destination Container Name')
     outermost_dest_id = fields.Many2one('stock.package', 'Outermost Destination Container')
     picking_ids = fields.Many2many('stock.picking', string='Transfers')
+
+    def _get_complete_dest_name_except_outermost(self):
+        self.ensure_one()
+        if not self.parent_dest_id:
+            return ''
+        elif self.parent_dest_id == self.outermost_dest_id:
+            return self.package_id.name
+
+        # Complete name without the first (outermost) package name
+        return ' > '.join(self.package_name.split(' > ')[1:])

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1263,7 +1263,9 @@ class StockPicking(models.Model):
             )
 
     def _check_move_lines_map_quant_package(self, package):
-        return package._check_move_lines_map_quant(self.move_line_ids.filtered(lambda ml: ml.package_id == package and ml.product_id.is_storable))
+        return package._check_move_lines_map_quant(self.move_line_ids.filtered(lambda ml:
+            ml.product_id.is_storable
+            and (ml.package_id == package or ml.package_id in package.all_children_package_ids)))
 
     def _get_entire_pack_location_dest(self, move_line_ids):
         location_dest_ids = move_line_ids.mapped('location_dest_id')

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1904,7 +1904,6 @@ class StockPicking(models.Model):
             'domain': [('picking_ids', 'in', self.ids)],
             'context': {
                 'picking_id': self.id,
-                'show_entire_packs': self.picking_type_id.show_entire_packs,
                 'search_default_main_packages': True,
             },
         }

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1873,7 +1873,7 @@ class StockPicking(models.Model):
             pack_move_lines = self.env['stock.move.line'].create(move_line_vals)
             pack_move_lines._apply_putaway_strategy()
             # Need to set the right package dest for now fully contained packages
-            self.move_line_ids.result_package_id._apply_package_dest_for_entire_packs()
+            self.move_line_ids.result_package_id._apply_package_dest_for_entire_packs(allowed_package_ids=all_package_ids)
             return True
         return False
 

--- a/addons/stock/report/package_templates.xml
+++ b/addons/stock/report/package_templates.xml
@@ -29,5 +29,10 @@
                 </t>
             </t>
         </template>
+
+        <template id="label_package_history_template_view">
+            <t t-set="docs" t-value="docs.package_id"/>
+            <t t-call="stock.label_package_template_view"/>
+        </template>
     </data>
 </odoo>

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -106,18 +106,20 @@
                         </tbody>
                     </table>
                     <table class="table table-sm table-borderless" t-elif="o.move_line_ids and o.state=='done'" name="stock_move_line_table">
+                        <t t-set="has_multi_level_packages" t-value="len(o.package_history_ids.filtered(lambda ph: ph.parent_dest_id)) > 0"/>
                         <t t-set="has_serial_number" t-value="False"/>
                         <t t-set="has_serial_number" t-value="o.move_line_ids.mapped('lot_id')" groups="stock.group_lot_on_delivery_slip"/>
                         <thead>
                             <tr>
-                                <th name="th_sml_product"><strong>Product</strong></th>
+                                <th name="th_sml_product">Product</th>
+                                <th name="th_sml_package" t-if="has_multi_level_packages">Package</th>
                                 <th name="th_sml_qty_ordered" class="text-end" t-if="not has_serial_number">
-                                    <strong>Ordered</strong>
+                                    Ordered
                                 </th>
                                 <th name="lot_serial" class="text-end" t-else="">
                                     Lot/Serial Number
                                 </th>
-                                <th name="th_sml_quantity" class="text-end"><strong>Delivered</strong></th>
+                                <th name="th_sml_quantity" class="text-end">Delivered</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -127,10 +129,10 @@
                                 2. If any packages are assigned => split products up by package (or non-package) and then apply use case 1 -->
                             <!-- If has destination packages => create sections of corresponding products -->
                             <t t-if="o.packages_count" name="has_packages">
-                                <t t-set="packages" t-value="o.move_line_ids.mapped('result_package_id')"/>
+                                <t t-set="packages" t-value="o.package_history_ids.filtered(lambda ph: not ph.parent_dest_id).package_id"/>
                                 <t t-foreach="packages" t-as="package">
                                     <t t-call="stock.stock_report_delivery_package_section_line"/>
-                                    <t t-set="package_move_lines" t-value="o.move_line_ids.filtered(lambda l: l.result_package_id == package)"/>
+                                    <t t-set="package_move_lines" t-value="o.move_line_ids.filtered(lambda l: l.result_package_id == package or l.package_history_id.outermost_dest_id == package).sorted('product_id')"/>
                                     <!-- If printing lots/serial numbers => keep products in original lines -->
                                     <t t-if="has_serial_number">
                                         <tr t-foreach="package_move_lines" t-as="move_line">
@@ -242,8 +244,14 @@
                 <span t-out="description" t-options="{'widget': 'text'}"/>
             </p>
         </td>
+        <td t-if="has_multi_level_packages">
+            <t t-if="move_line.result_package_id != package">
+                <span t-if="move_line.package_history_id" t-out="move_line.package_history_id._get_complete_dest_name_except_outermost()"/>
+                <span t-else="" t-field="move_line.result_package_id"/>
+            </t>
+        </td>
         <t t-if="has_serial_number" name="move_line_lot">
-            <td class="text-center"><span t-field="move_line.lot_id.name"/></td>
+            <td class="text-end"><span t-field="move_line.lot_id.name"/></td>
         </t>
         <td class="text-end" name="move_line_lot_quantity">
             <span t-out="format_number(move_line.quantity)"/>
@@ -257,6 +265,12 @@
                 <p t-if="aggregated_lines[line]['description']">
                     <span t-esc="aggregated_lines[line]['description']"  t-options="{'widget': 'text'}"/>
                 </p>
+            </td>
+            <td t-if="has_multi_level_packages">
+                <t t-if="aggregated_lines[line].get('package') and aggregated_lines[line]['package'] != package">
+                    <span t-if="aggregated_lines[line]['package_history']" t-out="aggregated_lines[line]['package_history']._get_complete_dest_name_except_outermost()"/>
+                    <span t-else="" t-out="aggregated_lines[line]['package'].name"/>
+                </t>
             </td>
             <td class="text-end" name="move_line_aggregated_qty_ordered">
                 <span t-out="format_number(aggregated_lines[line]['qty_ordered'])"/>
@@ -283,16 +297,16 @@
 
     <!-- package related "section lines" -->
     <template id="stock_report_delivery_package_section_line">
-        <tr t-att-class="'fw-bold o_line_section'">
-            <td colspan="99" name="package_info">
-                <span t-field="package.name"/>
+        <tr class="o_line_section">
+            <td colspan="99" class="bg-secondary" name="package_info">
+                <span class="ms-1" t-field="package.name"/>
             </td>
         </tr>
     </template>
     <template id="stock_report_delivery_no_package_section_line">
-        <tr t-att-class="'fw-bold o_line_section'">
-            <td colspan="99" name="no_package_info">
-                <span>Products with no package assigned</span>
+        <tr class="o_line_section">
+            <td colspan="99" class="bg-secondary" name="no_package_info">
+                <span class="ms-1">Products with no package assigned</span>
             </td>
         </tr>
     </template>

--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -7,9 +7,7 @@
         <t t-set="uom_unit_id" t-value="env.ref('uom.product_uom_unit').id"/>
         <t t-set="gs1_uom_patterns" t-value="{rule.associated_uom_id.id: rule.pattern[1:4] + str(len(str('{:.10f}'.format(rule.associated_uom_id.rounding).rstrip('0')).split('.')[1])) for rule in env['barcode.rule'].search([('associated_uom_id', '!=', False), ('associated_uom_id.id', '!=', uom_unit_id), ('is_gs1_nomenclature', '=', True)])}"/>
         <t t-foreach="docs" t-as="o">
-        <!-- Filters out package's quants with no quantity. -->
-        <t t-set="package_quants" t-value="o.contained_quant_ids.filtered('quantity')"/>
-            <div class="page">
+            <div class="page mt-4">
                 <div class="oe_structure"/>
                 <!-- HEADER: Package's information -->
                 <div class="row mb-5">
@@ -35,7 +33,7 @@
                     </div>
                 </div>
                 <div class="oe_structure"/>
-                <div class="row mt32 mb32">
+                <div class="row">
                     <div t-if="o.pack_date" class="col">
                         <strong>Pack Date:</strong>
                         <span t-field="o.pack_date">2021-09-01</span>
@@ -46,108 +44,162 @@
                     </div>
                 </div>
                 <div class="oe_structure"/>
-                <!-- TABLE'S HEADER -->
-                <table class="w-100 table table-sm table-striped"><thead><tr>
-                    <th name="th_product_barcode" class="text-start" style="width: 30%;">Barcode</th>
-                    <th name="th_product" class="text-start" style="width: 30%;">Product</th>
-                    <th name="th_quantity" class="text-end" style="width: 20%;">Quantity</th>
-                    <th name="th_content_barcode" class="text-center" style="width: 20%;">Contents</th>
-                </tr></thead></table>
-                <!-- PACKAGE CONTENT -->
-                <t t-foreach="package_quants.product_id" t-as="product">
-                    <t t-set="product_quants" t-value="package_quants.filtered(lambda q: q.product_id.id == product.id)"/>
-                    <t t-set="product_qty" t-value="sum(product_quants.mapped('quantity'))"/>
-                    <!-- Display each individual LN/SN if there is less than 50. -->
-                    <t t-set="display_content_details" t-value="0 &lt; len(product_quants.lot_id) &lt; 50"/>
-                    <t t-set="aggregate_barcodes" t-value="product_quants.get_aggregate_barcodes()"/>
-                    <table class="w-100 table table-sm table-striped">
-                        <!-- Quant's summary: product's barcode, product, qty and content's barcode.  -->
-                        <thead><tr>
-                            <th name="th_product_barcode" class="text-center" style="width: 30%;">
-                                <div t-field="product.barcode"
-                                    class="w-100 text-center pt-2 pb-1"
-                                    t-options="{
-                                        'widget': 'barcode',
-                                        'width': 600,
-                                        'height': 100,
-                                        'img_style': 'width:100%;height:50px;'
-                                    }"/>
-                                <div t-if="product.barcode" t-field="product.barcode" class="pb-2">Product barcode</div>
-                            </th>
-                            <th name="th_product" class="text-start" style="width: 30%;">
-                                <span t-field="product.display_name"/>
-                            </th>
-                            <th name="th_quantity" class="text-end" style="width: 20%;">
-                                <span t-out="product_qty">12.0</span>
-                                <span t-field="product.uom_id.name" groups="uom.group_uom">Units</span>
-                            </th>
-                            <th name="th_content_barcode" class="text-center" style="width: 20%;">
-                                <div t-if="len(aggregate_barcodes) == 1"
-                                    t-out="aggregate_barcodes[0]"
-                                    class="my-3"
-                                    t-options="{
-                                        'widget': 'barcode',
-                                        'symbology': 'QR',
-                                        'img_style': 'width: 24mm; height: 24mm',
-                                    }"/>
-                            </th>
-                        </tr></thead>
-                        <!-- Quant's details.  -->
-                        <tbody t-if="display_content_details or len(aggregate_barcodes) &gt; 1">
-                            <!-- Lot/Serial numbers, displayed 4 by 4.  -->
-                            <tr t-if="display_content_details" style="font-size: 0.8em;"
-                                t-foreach="product_quants[i:i+4] for i in range(0, len(product_quants), 4)"
-                                t-as="quants">
-                                <td colspan="4">
-                                    <div t-foreach="quants" t-as="quant"
-                                        class="d-inline-block w-25 text-end"
-                                        style="height: 18mm;">
-                                        <div class="d-inline-block p-2 text-end align-top">
-                                            <div t-field="quant.lot_id.name" class="mt-2">54326786758</div>
-                                            <div class="mt-1">
-                                                <span t-field="quant.quantity">3.00</span>
-                                                <span t-field="quant.product_id.uom_id.name" groups="uom.group_uom">Units</span>
-                                            </div>
-                                        </div>
-                                        <div class="d-inline-block py-2 text-center">
-                                            <t t-set="quant_barcode" t-value="quant.lot_id.name"/>
-                                            <t groups="stock.group_stock_lot_print_gs1"
-                                                t-set="quant_barcode"
-                                                t-value="quant._get_gs1_barcode(gs1_uom_patterns) or quant_barcode"/>
-                                            <span t-out="quant_barcode" t-options="{
-                                                    'widget': 'barcode',
-                                                    'symbology': 'QR',
-                                                    'img_style': 'width: 14mm; height: 14mm',
-                                                }"/>
-                                        </div>
+                <!-- CONTAINED PACKAGES CONTENT -->
+                <t t-foreach="o.child_package_ids" t-as="child_package">
+                    <div class="border border-dark p-3 mt-2">
+                        <div class="row mb-5">
+                            <h2 class="col-6">
+                                <span t-field="child_package.name" class="mt0 float-start">Package Reference</span>
+                            </h2>
+                            <div t-if="child_package.valid_sscc" class="col-6 text-center">
+                                <t t-set="barcode" t-value="'00' + child_package.name"/>
+                                <t t-if="child_package.pack_date" t-set="barcode" t-value="barcode + '13' + child_package.pack_date.strftime('%y%m%d')"/>
+                                <div name="datamatrix_barcode" t-out="barcode" t-options="{'widget': 'barcode', 'symbology': 'QR', 'width': 100, 'height': 100}">
+                                    <div class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center px-1 py-2 opacity-75 text-muted text-center">
+                                        (package barcode)
                                     </div>
-                                </td>
-                            </tr>
-                            <!-- Content's Barcodes -->
-                            <tr t-if="len(aggregate_barcodes) &gt; 1" style="border-bottom-color: black">
-                                <td colspan="4" name="quant_qr_codes" class="py-4">
-                                    <t t-foreach="aggregate_barcodes[i:i+3] for i in range(0, len(aggregate_barcodes), 3)"
-                                        t-as="batch_aggregate_barcodes">
-                                        <div class="w-100 p-0 py-5">
-                                            <div t-foreach="batch_aggregate_barcodes" t-as="barcode" t-out="barcode"
-                                                class="d-inline-block text-center"
-                                                style="width: 33%;"
-                                                t-options="{
-                                                    'widget': 'barcode',
-                                                    'symbology': 'QR',
-                                                    'img_style': 'width: 48mm; height: 48mm',
-                                                    'width': 800,
-                                                    'height': 800,
-                                                }"/>
-                                        </div>
-                                    </t>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                                </div>
+                            </div>
+                            <div t-else="" class="col-6 text-center">
+                                <div t-field="child_package.name" t-options="{'widget': 'barcode', 'width': 600, 'height': 100, 'img_style': 'width:300px;height:50px;'}">
+                                    <div class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center px-1 py-2 opacity-75 text-muted text-center">
+                                        (package barcode)
+                                    </div>
+                                </div>
+                                <div t-field="child_package.name">Package Reference</div>
+                            </div>
+                        </div>
+                        <t t-call="stock.report_package_barcode_content">
+                            <!-- Filters out package's quants with no quantity. -->
+                            <t t-set="package_quants" t-value="child_package.contained_quant_ids.filtered('quantity')"/>
+                        </t>
+                    </div>
+                    <div class="oe_structure"/>
+                </t>
+                <!-- DIRECTLY CONTAINED QUANTS -->
+                <t t-if="o.quant_ids">
+                    <div class="border border-dark p-3 mt-2" t-if="len(o.quant_ids) != len(o.contained_quant_ids)">
+                        <div class="row mb-5">
+                            <h2 class="col-6">
+                                <span class="mt0 float-start">No assigned package</span>
+                            </h2>
+                        </div>
+                        <t t-call="stock.report_package_barcode_content">
+                            <t t-set="package_quants" t-value="o.quant_ids.filtered('quantity')"/>
+                        </t>
+                    </div>
+                    <div class="mt-2" t-else="">
+                        <t t-call="stock.report_package_barcode_content">
+                            <t t-set="package_quants" t-value="o.quant_ids.filtered('quantity')"/>
+                        </t>
+                    </div>
                 </t>
             </div>
         </t>
+    </t>
+</template>
+
+<template id="report_package_barcode_content">
+    <table class="w-100 table table-sm table-borderless my-0 border border-dark">
+        <thead><tr>
+            <th name="th_product_barcode" class="text-center" style="width: 30%;">Barcode</th>
+            <th name="th_product" class="text-center" style="width: 30%;">Product</th>
+            <th name="th_quantity" class="text-end" style="width: 20%;">Quantity</th>
+            <th name="th_content_barcode" class="text-center" style="width: 20%;">Contents</th>
+        </tr></thead>
+    </table>
+    <t t-foreach="package_quants.product_id" t-as="product">
+        <t t-set="product_quants" t-value="package_quants.filtered(lambda q: q.product_id.id == product.id)"/>
+        <t t-set="product_qty" t-value="sum(product_quants.mapped('quantity'))"/>
+        <!-- Display each individual LN/SN if there is less than 50. -->
+        <t t-set="display_content_details" t-value="0 &lt; len(product_quants.lot_id) &lt; 50"/>
+        <t t-set="aggregate_barcodes" t-value="product_quants.get_aggregate_barcodes()"/>
+        <table class="w-100 table table-sm table-borderless border border-dark mb-0 mt-2">
+            <!-- Quant's summary: product's barcode, product, qty and content's barcode.  -->
+            <thead><tr>
+                <th name="th_product_barcode" class="text-center" style="width: 30%;">
+                    <div t-field="product.barcode"
+                        class="w-100 text-center pt-2 pb-1"
+                        t-options="{
+                            'widget': 'barcode',
+                            'width': 600,
+                            'height': 100,
+                            'img_style': 'width:100%;height:50px;'
+                        }"/>
+                    <div t-if="product.barcode" t-field="product.barcode" class="pb-2">Product barcode</div>
+                </th>
+                <th name="th_product" class="text-center" style="width: 30%;">
+                    <span t-field="product.display_name"/>
+                </th>
+                <th name="th_quantity" class="text-end" style="width: 20%;">
+                    <span t-out="product_qty">12.0</span>
+                    <span t-field="product.uom_id.name" groups="uom.group_uom">Units</span>
+                </th>
+                <th name="th_content_barcode" class="text-center" style="width: 20%;">
+                    <div t-if="len(aggregate_barcodes) == 1"
+                        t-out="aggregate_barcodes[0]"
+                        class="my-3"
+                        t-options="{
+                            'widget': 'barcode',
+                            'symbology': 'QR',
+                            'img_style': 'width: 24mm; height: 24mm',
+                        }"/>
+                    <div t-if="len(aggregate_barcodes) == 1" class="pb-2">Content</div>
+                </th>
+            </tr></thead>
+            <!-- Quant's details.  -->
+            <tbody t-if="display_content_details or len(aggregate_barcodes) &gt; 1">
+                <!-- Lot/Serial numbers, displayed 4 by 4.  -->
+                <tr t-if="display_content_details" style="font-size: 0.8em;"
+                    t-foreach="product_quants[i:i+4] for i in range(0, len(product_quants), 4)"
+                    t-as="quants">
+                    <td colspan="4">
+                        <div t-foreach="quants" t-as="quant"
+                            class="d-inline-block w-25 text-end"
+                            style="height: 18mm;">
+                            <div class="d-inline-block p-2 text-end align-top">
+                                <div t-field="quant.lot_id.name" class="mt-2">54326786758</div>
+                                <div class="mt-1">
+                                    <span t-field="quant.quantity">3.00</span>
+                                    <span t-field="quant.product_id.uom_id.name" groups="uom.group_uom">Units</span>
+                                </div>
+                            </div>
+                            <div class="d-inline-block py-2 text-center">
+                                <t t-set="quant_barcode" t-value="quant.lot_id.name"/>
+                                <t groups="stock.group_stock_lot_print_gs1"
+                                    t-set="quant_barcode"
+                                    t-value="quant._get_gs1_barcode(gs1_uom_patterns) or quant_barcode"/>
+                                <span t-out="quant_barcode" t-options="{
+                                        'widget': 'barcode',
+                                        'symbology': 'QR',
+                                        'img_style': 'width: 14mm; height: 14mm',
+                                    }"/>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                <!-- Content's Barcodes -->
+                <tr t-if="len(aggregate_barcodes) &gt; 1" style="border-bottom-color: black">
+                    <td colspan="4" name="quant_qr_codes" class="py-4">
+                        <t t-foreach="aggregate_barcodes[i:i+3] for i in range(0, len(aggregate_barcodes), 3)"
+                            t-as="batch_aggregate_barcodes">
+                            <div class="w-100 p-0 py-5">
+                                <div t-foreach="batch_aggregate_barcodes" t-as="barcode" t-out="barcode"
+                                    class="d-inline-block text-center"
+                                    style="width: 33%;"
+                                    t-options="{
+                                        'widget': 'barcode',
+                                        'symbology': 'QR',
+                                        'img_style': 'width: 48mm; height: 48mm',
+                                        'width': 800,
+                                        'height': 800,
+                                    }"/>
+                            </div>
+                        </t>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     </t>
 </template>
 
@@ -191,8 +243,18 @@
 </template>
 
 <template id="report_picking_packages">
-    <t t-set="docs" t-value="docs.move_line_ids.mapped('result_package_id')"/>
+    <t t-set="docs" t-value="docs._get_packages_for_print()"/>
     <t t-call="stock.report_package_barcode"/>
+</template>
+
+<template id="report_package_history_barcode">
+    <t t-set="docs" t-value="docs.package_id"/>
+    <t t-call="stock.report_package_barcode"/>
+</template>
+
+<template id="report_package_history_barcode_small">
+    <t t-set="docs" t-value="docs.package_id"/>
+    <t t-call="stock.report_package_barcode_small"/>
 </template>
 </data>
 </odoo>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -130,7 +130,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <t t-foreach="o.move_ids.filtered(lambda x: x.quantity)" t-as="move">
+                                    <t t-foreach="o.move_ids.filtered(lambda m: m.quantity and any(not ml.is_entire_pack for ml in m.move_line_ids))" t-as="move">
                                         <t t-set="move_lines_without_entire_pack" t-value="move.move_line_ids.filtered(lambda ml: not ml.is_entire_pack)"/>
                                         <!-- This flag is true if there are multiple move lines in a move, or if there is at least one tracked move line -->
                                         <t t-set="move_has_multiple_lines" t-value="len(move.move_line_ids) > 1 or any(move_line.lot_id or move_line.lot_name for move_line in move_lines_without_entire_pack)"/>
@@ -221,23 +221,44 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr t-foreach="o.move_line_ids.filtered(lambda ml: ml.is_entire_pack).package_id.sorted(key=lambda p: p.name)" t-as="package">
-                                        <td name="td_pk_barcode">
-                                            <t t-set="package" t-value="package.with_context(picking_id=o.id)" />
-                                            <div t-field="package.name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 600, 'height': 100, 'img_style': 'width:300px;height:50px;margin-left: -50px;'}">
-                                                <div class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center px-1 py-2  opacity-75 text-muted text-center">
-                                                    (package barcode)
+                                    <t t-if="o.state != 'done'">
+                                        <tr t-foreach="o.move_line_ids.filtered(lambda ml: ml.is_entire_pack).package_id.outermost_package_id.sorted(key=lambda p: p.name)" t-as="package">
+                                            <td name="td_pk_barcode">
+                                                <t t-set="package" t-value="package.with_context(picking_id=o.id)" />
+                                                <div t-field="package.name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 600, 'height': 100, 'img_style': 'width:300px;height:50px;margin-left: -50px;'}">
+                                                    <div class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center px-1 py-2  opacity-75 text-muted text-center">
+                                                        (package barcode)
+                                                    </div>
                                                 </div>
-                                            </div>
+                                                    <br/>
+                                            </td>
+                                            <td t-if="o.picking_type_id.code != 'incoming'" groups="stock.group_stock_multi_locations">
+                                                <span t-field="package.location_id"/>
+                                            </td>
+                                            <td t-if="o.picking_type_id.code != 'outgoing'" groups="stock.group_stock_multi_locations">
+                                                <span t-field="package.location_dest_id"/>
+                                            </td>
+                                        </tr>
+                                    </t>
+                                    <t t-else="">
+                                        <tr t-foreach="o.package_history_ids.filtered(lambda ph: not ph.parent_dest_id and all(ml.is_entire_pack for ml in ph.move_line_ids)).sorted(key=lambda ph: ph.package_id.name)" t-as="package_history">
+                                            <td name="td_pk_barcode">
+                                                <t t-set="package" t-value="package_history.package_id.with_context(picking_id=o.id)" />
+                                                <div t-field="package.name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 600, 'height': 100, 'img_style': 'width:300px;height:50px;margin-left: -50px;'}">
+                                                    <div class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center px-1 py-2  opacity-75 text-muted text-center">
+                                                        (package barcode)
+                                                    </div>
+                                                </div>
                                                 <br/>
-                                        </td>
-                                        <td t-if="o.picking_type_id.code != 'incoming'" groups="stock.group_stock_multi_locations">
-                                            <span t-field="package.location_id"/>
-                                        </td>
-                                        <td t-if="o.picking_type_id.code != 'outgoing'" groups="stock.group_stock_multi_locations">
-                                            <span t-field="package.location_dest_id"/>
-                                        </td>
-                                    </tr>
+                                            </td>
+                                            <td t-if="o.picking_type_id.code != 'incoming'" groups="stock.group_stock_multi_locations">
+                                                <span t-field="package_history.location_id"/>
+                                            </td>
+                                            <td t-if="o.picking_type_id.code != 'outgoing'" groups="stock.group_stock_multi_locations">
+                                                <span t-field="package_history.location_dest_id"/>
+                                            </td>
+                                        </tr>
+                                    </t>
                                 </tbody>
                             </table>
 

--- a/addons/stock/report/stock_report_views.xml
+++ b/addons/stock/report/stock_report_views.xml
@@ -51,6 +51,15 @@
             <field name="binding_model_id" ref="model_stock_package"/>
             <field name="binding_type">report</field>
         </record>
+        <record id="action_report_package_history_barcode" model="ir.actions.report">
+            <field name="name">Package Barcode with Contents</field>
+            <field name="model">stock.package.history</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">stock.report_package_history_barcode</field>
+            <field name="report_file">stock.report_package_barcode</field>
+            <field name="binding_model_id" ref="model_stock_package_history"/>
+            <field name="binding_type">report</field>
+        </record>
         <record id="action_report_package_barcode_small" model="ir.actions.report">
             <field name="name">Package Barcode (PDF)</field>
             <field name="model">stock.package</field>
@@ -58,6 +67,15 @@
             <field name="report_name">stock.report_package_barcode_small</field>
             <field name="report_file">stock.report_package_barcode</field>
             <field name="binding_model_id" ref="model_stock_package"/>
+            <field name="binding_type">report</field>
+        </record>
+        <record id="action_report_package_history_barcode_small" model="ir.actions.report">
+            <field name="name">Package Barcode (PDF)</field>
+            <field name="model">stock.package.history</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">stock.report_package_history_barcode_small</field>
+            <field name="report_file">stock.report_package_barcode</field>
+            <field name="binding_model_id" ref="model_stock_package_history"/>
             <field name="binding_type">report</field>
         </record>
         <record id="action_report_location_barcode" model="ir.actions.report">
@@ -125,6 +143,15 @@
             <field name="report_name">stock.label_package_template_view</field>
             <field name="report_file">stock.label_package_template_view</field>
             <field name="binding_model_id" ref="model_stock_package"/>
+            <field name="binding_type">report</field>
+        </record>
+        <record id="label_package_history_template" model="ir.actions.report">
+            <field name="name">Package Barcode (ZPL)</field>
+            <field name="model">stock.package.history</field>
+            <field name="report_type">qweb-text</field>
+            <field name="report_name">stock.label_package_history_template_view</field>
+            <field name="report_file">stock.label_package_template_view</field>
+            <field name="binding_model_id" ref="model_stock_package_history"/>
             <field name="binding_type">report</field>
         </record>
         <record id="label_packaging_barcode" model="ir.actions.report">

--- a/addons/stock/static/src/views/list/stock_add_package_list_view.js
+++ b/addons/stock/static/src/views/list/stock_add_package_list_view.js
@@ -9,36 +9,33 @@ export class AddPackageListRenderer extends ListRenderer {
         this.orm = useService("orm");
         this.actionService = useService("action");
         this.pickingId = this.props.list.context.picking_id || 0;
-        this.showEntirePacks = this.props.list.context?.show_entire_packs;
     }
 
     get displayRowCreates() {
-        return this.showEntirePacks;
+        // As this view is not a Many2Many, this would be false otherwise.
+        return true;
     }
 
     async add(params) {
-        if (this.displayRowCreates) {
-            await this.onClickAdd();
-        }
+        await this.onClickAdd();
     }
 
-    async onClickAdd(){
-        const action = await this.orm.call("stock.move", "action_add_packages",
-            [[]],
-            { context: { picking_id: this.pickingId } },
-        );
+    async onClickAdd() {
+        const action = await this.orm.call("stock.move", "action_add_packages", [[]], {
+            context: { picking_id: this.pickingId },
+        });
         this.actionService.doAction(action, {
             onClose: () => {
                 this.actionService.doAction({
-                    'type': 'ir.actions.client',
-                    'tag': 'soft_reload',
+                    type: "ir.actions.client",
+                    tag: "soft_reload",
                 });
             },
         });
     }
 }
 
-registry.category('views').add('stock_add_package_list_view', {
+registry.category("views").add("stock_add_package_list_view", {
     ...listView,
     Renderer: AddPackageListRenderer,
 });

--- a/addons/stock/static/src/widgets/stock_package_m2o.js
+++ b/addons/stock/static/src/widgets/stock_package_m2o.js
@@ -8,7 +8,6 @@ import {
     Many2OneField,
 } from "@web/views/fields/many2one/many2one_field";
 
-
 class PackageMany2One extends Many2One {
     static template = "stock.PackageMany2One";
 }
@@ -24,7 +23,7 @@ export class StockPackageMany2One extends Component {
 
     setup() {
         this.orm = useService("orm");
-        this.isDone = ['done', 'cancel'].includes(this.props.record?.data?.state)
+        this.isDone = ["done", "cancel"].includes(this.props.record?.data?.state);
 
         onWillStart(async () => {
             if (!this.props.record.data[this.props.name]?.id) {
@@ -39,7 +38,7 @@ export class StockPackageMany2One extends Component {
                         display_name: {},
                     },
                     context: { ...this.displayNameContext },
-                },
+                }
             );
             if (res.length) {
                 this.packageName = res[0].display_name;
@@ -61,7 +60,7 @@ export class StockPackageMany2One extends Component {
 
     get displayValue() {
         const displayVal = this.props.record.data[this.props.name];
-        if (this.isDone && this.packageName) {
+        if (this.packageName) {
             displayVal["display_name"] = this.packageName;
             // Should only be used at load. Context is correctly applied in further searches.
             this.packageName = false;
@@ -74,7 +73,7 @@ export class StockPackageMany2One extends Component {
             show_src_package: this.props.displaySource,
             show_dest_package: this.props.displayDestination,
             is_done: this.isDone,
-        }
+        };
     }
 }
 

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5725,11 +5725,11 @@ class TestStockMove(TestStockCommon):
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.productA, self.customer_location), 15)
 
         aggregate_values1 = picking.move_line_ids[0]._get_aggregated_product_quantities(strict=True)
-        aggregated_val = aggregate_values1[f'{self.productA.id}_{self.productA.name}__{self.productA.uom_id.id}']
+        aggregated_val = aggregate_values1[f'{self.productA.id}_{self.productA.name}__{self.productA.uom_id.id}_{picking.move_line_ids[0].result_package_id.id}']
         self.assertEqual(aggregated_val['qty_ordered'], 5)
 
         aggregate_values2 = picking.move_line_ids[1]._get_aggregated_product_quantities(strict=True)
-        aggregated_val = aggregate_values2[f'{self.productA.id}_{self.productA.name}__{self.productA.uom_id.id}']
+        aggregated_val = aggregate_values2[f'{self.productA.id}_{self.productA.name}__{self.productA.uom_id.id}_{picking.move_line_ids[1].result_package_id.id}']
         self.assertEqual(aggregated_val['qty_ordered'], 10)
 
     def test_move_line_aggregated_product_quantities_incomplete_package(self):
@@ -5755,6 +5755,7 @@ class TestStockMove(TestStockCommon):
         move1.quantity = 5
         move1.picked = True
         picking.action_put_in_pack()  # Create a package
+        package = picking.move_line_ids.result_package_id
 
         delivery_form = Form(picking)
         delivery = delivery_form.save()
@@ -5766,12 +5767,12 @@ class TestStockMove(TestStockCommon):
         picking.backorder_ids.action_cancel()
 
         aggregate_values = picking.move_line_ids._get_aggregated_product_quantities()
-        aggregated_val = aggregate_values[f'{self.productA.id}_{self.productA.name}__{self.productA.uom_id.id}']
+        aggregated_val = aggregate_values[f'{self.productA.id}_{self.productA.name}__{self.productA.uom_id.id}_{package.id}']
         self.assertEqual(aggregated_val['qty_ordered'], 15)
         self.assertEqual(aggregated_val['quantity'], 5)
 
         aggregate_values = picking.move_line_ids._get_aggregated_product_quantities(strict=True)
-        aggregated_val = aggregate_values[f'{self.productA.id}_{self.productA.name}__{self.productA.uom_id.id}']
+        aggregated_val = aggregate_values[f'{self.productA.id}_{self.productA.name}__{self.productA.uom_id.id}_{package.id}']
         self.assertEqual(aggregated_val['qty_ordered'], 5)
         self.assertEqual(aggregated_val['quantity'], 5)
 

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -184,11 +184,9 @@
                         context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': True}"
                         widget="pick_from"
                         column_invisible="not parent.show_quant"
-                        options="{'no_create': True, 'no_open': True}"
-                        readonly="is_entire_pack"/>
+                        options="{'no_create': True, 'no_open': True}"/>
                     <field name="lot_id" groups="stock.group_production_lot"
                         column_invisible="parent.show_quant or parent.has_tracking == 'none' or not parent.show_lots_m2o"
-                        readonly="is_entire_pack"
                         domain="[('product_id', '=', parent.product_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
                         context="{
                             'active_picking_id': picking_id,
@@ -196,22 +194,21 @@
                         }"/>
                     <field name="lot_name" string="Lot/Serial Number" groups="stock.group_production_lot"
                         placeholder="e.g. SN000001"
-                        column_invisible="parent.has_tracking == 'none' or not parent.show_lots_text"
-                        readonly="is_entire_pack"/>
+                        column_invisible="parent.has_tracking == 'none' or not parent.show_lots_text"/>
                     <field name="location_dest_id" string="Store To"
                         column_invisible="parent.show_quant and parent.picking_code != 'internal'"
                         domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"
                         groups="stock.group_stock_multi_locations"/>
-                    <field name="package_id" column_invisible="1" readonly="(state == 'done' and is_locked) or is_entire_pack" groups="stock.group_tracking_lot"/>
-                    <field name="result_package_id" readonly="(state == 'done' and is_locked) or is_entire_pack" widget="package_m2o" groups="stock.group_tracking_lot" context="{'picking_id': picking_id, 'show_dest_package': 1}"/>
-                    <field name="owner_id" column_invisible="parent.show_quant" readonly="is_entire_pack" groups="stock.group_tracking_owner"/>
+                    <field name="package_id" column_invisible="1" readonly="state == 'done' and is_locked" groups="stock.group_tracking_lot"/>
+                    <field name="result_package_id" readonly="state == 'done' and is_locked" widget="package_m2o" groups="stock.group_tracking_lot" context="{'picking_id': picking_id, 'show_dest_package': 1}"/>
+                    <field name="owner_id" column_invisible="parent.show_quant" groups="stock.group_tracking_owner"/>
                     <field name="state" column_invisible="True"/>
                     <field name="is_locked" column_invisible="True"/>
                     <field name="picking_code" column_invisible="True"/>
                     <field name="picked" column_invisible="True"/>
-                    <field name="quantity" string="Quantity" readonly="(state == 'done' and is_locked) or is_entire_pack" sum="Quantity"/>
+                    <field name="quantity" string="Quantity" readonly="state == 'done' and is_locked" sum="Quantity"/>
                     <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" widget="many2one_uom"
-                        readonly="is_entire_pack or (state == 'done' and id)"/>
+                        readonly="state == 'done' and id"/>
                 </list>
             </field>
         </record>
@@ -249,7 +246,7 @@
                     <field name="owner_id" groups="stock.group_tracking_owner" column_invisible="context.get('picking_code') == 'incoming'" readonly="state in ('done', 'cancel') and is_locked" />
                     <field name="state" column_invisible="True"/>
                     <field name="is_locked" column_invisible="True"/>
-                    <field name="quantity" readonly="(state in ('done', 'cancel') and is_locked) or is_entire_pack" force_save="1"/>
+                    <field name="quantity" readonly="state in ('done', 'cancel') and is_locked" force_save="1"/>
                     <field name="product_uom_id" force_save="1" readonly="state != 'draft' and id" groups="uom.group_uom" widget="many2one_uom"/>
                 </list>
             </field>

--- a/addons/stock/views/stock_package_views.xml
+++ b/addons/stock/views/stock_package_views.xml
@@ -96,7 +96,7 @@
         <field name="name">stock.package.list.editable</field>
         <field name="model">stock.package</field>
         <field name="arch" type="xml">
-            <list editable="bottom" create="0" js_class="stock_add_package_list_view" open_form_view="1">
+            <list editable="bottom" js_class="stock_add_package_list_view" open_form_view="1">
                 <header>
                     <button class="btn-primary" name="action_put_in_pack" type="object" string="Put in Pack"/>
                     <button class="btn-secondary" name="action_remove_package" type="object" string="Remove"/>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -113,7 +113,6 @@
                                     <field name="use_existing_lots" string="Use Existing ones"/>
                                 </group>
                                 <group invisible="code not in ['incoming', 'outgoing', 'internal']" string="Packages" groups="stock.group_tracking_lot">
-                                    <field name="show_entire_packs"/>
                                     <field name="set_package_type"/>
                                 </group>
                                 <!-- As this group will be hidden without multi_loccation, you will not be able to create a

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -269,7 +269,7 @@
                                 <list decoration-muted="scrapped == True or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="bottom">
                                     <control>
                                         <create string="Add a Product"/>
-                                        <button name="action_add_packages" invisible="not parent.picking_type_entire_packs" context="{'picking_id': parent.id, 'show_src_package': 1}" string="Move a Pack" type="object" class="px-4 btn-link" groups="stock.group_tracking_lot"/>
+                                        <button name="action_add_packages" context="{'picking_id': parent.id, 'show_src_package': 1}" string="Move a Pack" type="object" class="px-4 btn-link" groups="stock.group_tracking_lot"/>
                                     </control>
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="state" readonly="0" column_invisible="True"/>

--- a/addons/stock_delivery/models/stock_package.py
+++ b/addons/stock_delivery/models/stock_package.py
@@ -43,3 +43,10 @@ class StockPackage(models.Model):
             context['default_package_carrier_type'] = move_lines._get_package_carrier_type_for_pack()
             res['context'] = context
         return res
+
+    def _post_put_in_pack_hook(self):
+        res = super()._post_put_in_pack_hook()
+        weight = self.env.context.get('weight')
+        if weight:
+            res.shipping_weight = weight
+        return res

--- a/addons/stock_delivery/models/stock_package.py
+++ b/addons/stock_delivery/models/stock_package.py
@@ -30,6 +30,7 @@ class StockPackage(models.Model):
     weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name', readonly=True, default=_get_default_weight_uom)
     weight_is_kg = fields.Boolean("Technical field indicating whether weight uom is kg or not (i.e. lb)", compute="_compute_weight_is_kg")
     weight_uom_rounding = fields.Float("Technical field indicating weight's number of decimal places", compute="_compute_weight_is_kg")
+    package_carrier_type = fields.Selection(related='package_type_id.package_carrier_type')
 
     def _pre_put_in_pack_hook(self, package_id=False, package_type_id=False, package_name=False, from_package_wizard=False):
         res = super()._pre_put_in_pack_hook(package_id, package_type_id, package_name, from_package_wizard)

--- a/addons/stock_delivery/wizard/stock_put_in_pack_views.xml
+++ b/addons/stock_delivery/wizard/stock_put_in_pack_views.xml
@@ -22,7 +22,7 @@
             </field>
             <field name="result_package_id" position="attributes">
                 <attribute name="domain">
-                    [('package_type_id.package_carrier_type', '=?', package_carrier_type), ('package_type_id', '=?', package_type_id), '|', '|', ('location_id', '=', False), ('location_id', '=', location_dest_id), ('id', 'in', origin_package_ids)]
+                    [('package_carrier_type', '=?', package_carrier_type), ('package_type_id', '=?', package_type_id), '|', '|', ('location_id', '=', False), ('location_id', '=', location_dest_id), ('id', 'in', origin_package_ids)]
                 </attribute>
             </field>
         </field>

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -388,7 +388,6 @@ class StockPickingBatch(models.Model):
             'domain': [('picking_ids', 'in', self.picking_ids.ids)],
             'context': {
                 'picking_id': self.picking_ids[:1].id,
-                'show_entire_packs': self.picking_type_id.show_entire_packs,
                 'search_default_main_packages': True,
             },
         }


### PR DESCRIPTION
Various fixes following the pack in pack introduced in #203987

Summary of the changes:
- Adapt the following PDF reports to consider package inside packages:
  - Packages with Content
  - Delivery Slip
  - Picking Operations
- Fix the display of the contents of a package containing serial numbers when adding entire packs
- Fix an issue preventing to select packages without Package Type in the 'Put in Pack' wizard as soon as `stock_delivery` was installed
- Fix an issue where packages containing both products and other packages weren't correctly re-assigned once a picking was done
- When adding an entire pack to a picking, only add the pack itself and not its container, even though the container's content is fully added.
- Allow to write on move lines belonging to an entire pack, and remove that flag if necessary after the update.
- Fix computation and saving of the `shipping_weight` of a package containing packages
- Always allow to add entire packages and change `Show entire packs` to only affect the display in the `stock_barcode` app.

Task-4314600

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
