### PR TITLE
[FIX] account_payment: prevent removing active payment journal

### DIFF
--- a/addons/account_payment/views/account_journal_views.xml
+++ b/addons/account_payment/views/account_journal_views.xml
@@ -8,7 +8,11 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='inbound_payment_method_line_ids']//field[@name='payment_account_id']" position="after">
                 <field name="code" column_invisible="True"/>
-                <field name="payment_provider_id" options="{'no_open': True, 'no_create': True}" optional="hide" domain="[('code', '=', code)]"/>
+                <field name="payment_provider_id"
+                       options="{'no_open': True, 'no_create': True}"
+                       optional="hide"
+                       domain="[('code', '=', code)]"
+                       readonly="payment_provider_state in ('enabled', 'test')"/>
                 <field name="payment_provider_state" column_invisible="True"/>
                 <button name="action_open_provider_form"
                         type="object"


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Have an active payment provider;
2. create a branch company;
3. set payment provider's company to branch;
4. leave Payment Journal unchanged (parent company Bank);
5. go to Accounting / Configuration / Accounting / Journals;
6. open Bank journal;
7. open "Incoming Payments" tab;
8. enable the "Payment Provider" column;
9. unset the payment provider on the active provider's line & save;
10. attempt paying using the provider.

Issue
-----
> Error: psycopg2.errors.NotNullViolation:
> null value in column "journal_id" of relation "account_payment" violates not-null constraint

Cause
-----
We shouldn't be able to change the related journal of active providers.

Solution
--------
Make the field read-only if the payment method is active.

opw-5045000