### PR TITLE
[FIX] sale: pre-fill contact preferred address on so

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -722,8 +722,13 @@ class SaleOrder(models.Model):
 
     def onchange(self, values, field_names, fields_spec):
         self_with_context = self
-        if not field_names: # Some warnings should not be displayed for the first onchange
-            self_with_context = self.with_context(sale_onchange_first_call=True)
+        if not field_names:
+            self_with_context = self.with_context(
+                # Some warnings should not be displayed for the first onchange
+                sale_onchange_first_call=True,
+                # invoice & delivery address with higher `customer_rank` should take priority
+                res_partner_search_mode='customer',
+            )
         return super(SaleOrder, self_with_context).onchange(values, field_names, fields_spec)
 
     @api.onchange('commitment_date', 'expected_date')


### PR DESCRIPTION
## Versions
17.0+

## Issue
When creating a SO from the Contacts app, the first delivery address is used, ignoring the preferred one. In contrast, the Sales app correctly uses the preferred delivery address. This fix ensures consistent behavior across both.

## Steps to reproduce
*Ensure Contacts app is installed*
*Activate "Customer Addresses" in the settings*

- Go to the Contacts app:
  - Create a new contact:
    - Name: C1;
    - Contacts & Addresses:
      - Delivery Address (Add 2 new addresses):
        - D1;
        - D2.
  - Click the "Sales" action button:
    - Create a new SO for C1 (pre-filled):
      - Invoice Address: C1, D2;
      - Delivery Address: C1, D2;
      - Add any product with:
        - Quantity: 1;
        - Delivered: 1.
      - Create the invoice and confirm it.
- Go back to Contacts and look for C1:
  - Click the the "Sales" action button:
    - Create a new SO and see the Delivery Address set to "C1, D1".
- Go to Sales app:
  - Create a new SO and select C1 as customer;
  - Delivery Address retrieves "C1, D2" as it is the preferred address.

## Cause
Each time an invoice is validated, the corresponding address gets a higher score.
This score is then used in the SQL ordering of customers/suppliers:
https://github.com/odoo/odoo/blob/b523f5c6d8e235a6cedb029f701a0ebd89a5f74a/addons/account/models/partner.py#L347-L354

## Fix
Apply context search mode if first call. This mimics the base behavior: https://github.com/odoo/odoo/blob/b57bb1decd46dcbb1fe602bb72b6f8e5382e9b28/odoo/addons/base/views/res_partner_views.xml#L534

opw-4916381