### PR TITLE
[IMP] iot_drivers: rename owner to session_id

### DIFF
--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -26,6 +26,7 @@ class Driver(Thread):
         self.data = {'value': '', 'result': ''}  # TODO: deprecate "value"?
         self._actions = {}
         self._stopped = Event()
+        self.session_id = None
 
     def __init_subclass__(cls):
         super().__init_subclass__()
@@ -48,9 +49,8 @@ class Driver(Thread):
         :return: the result of the action method
         """
         action = data.get('action', '')
-        session_id = data.get('session_id')
-        if session_id:
-            self.data["owner"] = session_id
+        self.session_id = data.get('session_id')
+
         try:
             response = {'status': 'success', 'result': self._actions[action](data), 'action_args': {**data}}
         except Exception as e:

--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -57,16 +57,13 @@ class EventManager:
         # Make notification available to longpolling event route
         event = {
             **device.data,
+            'iot_box_identifier': helpers.get_identifier(),
             'device_identifier': device.device_identifier,
+            'session_id': device.session_id,
             'time': time.time(),
             **data,
         }
-        send_to_controller({
-            **event,
-            'session_id': data.get('action_args', {}).get('session_id', ''),
-            'iot_box_identifier': helpers.get_identifier(),
-            **data,
-        })
+        send_to_controller(event)
         webrtc_client.send(event)
         self.events.append(event)
         for session in self.sessions:

--- a/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
@@ -26,7 +26,6 @@ class DisplayDriver(Driver):
         self.device_type = 'display'
         self.device_connection = 'hdmi'
         self.device_name = device['name']
-        self.owner = False
         self.customer_display_data = {}
         self.url, self.orientation = helpers.load_browser_state()
 

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -86,7 +86,7 @@ class PrinterDriverBase(Driver, ABC):
         """
         self.data['status'] = status
         self.data['message'] = message
-        event_manager.device_changed(self, {'session_id': self.data.get('owner')})
+        event_manager.device_changed(self)
 
     def print_receipt(self, data):
         _logger.debug("print_receipt called for printer %s", self.device_name)

--- a/addons/iot_drivers/iot_handlers/drivers/serial_base_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_base_driver.py
@@ -130,7 +130,7 @@ class SerialDriver(Driver):
         :param data: the `_actions` key mapped to the action method we want to call
         :type data: string
         """
-        self.data["owner"] = data.get('session_id')
+        self.session_id = data.get('session_id')
         self.data["action_args"] = {**data}
 
         if self._connection and self._connection.isOpen():

--- a/addons/iot_drivers/webrtc_client.py
+++ b/addons/iot_drivers/webrtc_client.py
@@ -66,7 +66,7 @@ class WebRtcClient(Thread):
                     else:
                         # Notify that the device is not connected
                         self.send({
-                            'owner': message['session_id'],
+                            'session_id': message['session_id'],
                             'device_identifier': device_identifier,
                             'time': time.time(),
                             'status': 'disconnected',


### PR DESCRIPTION
In order to standardize the session id (id to the request received), we renamed all occurrences of old "owner" key to "session_id".

Enterprise PR: odoo/enterprise#93739