### PR TITLE
[FIX] core : use correct lang for cache update

### DIFF
--- a/odoo/addons/test_new_api/tests/test_related_translation.py
+++ b/odoo/addons/test_new_api/tests/test_related_translation.py
@@ -348,3 +348,8 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
         # inconsistent behavior but usually users don't care or may even be happy about it
         self.assertEqual(record_en.html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
         self.assertEqual(record_fr.html, '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
+    def test_edit_translations_related_compute(self):
+        self.patch(self.env['test_new_api.related_translation_2']._fields['name'], 'readonly', True)
+        self.patch(self.env['test_new_api.related_translation_2']._fields['name'], 'inverse', False)
+        self.test2.with_context(edit_translations=True).name

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -1219,7 +1219,7 @@ class Cache:
         """
         if field.translate:
             # only for model translated fields
-            lang = (records.env.lang or 'en_US') if dirty else records.env._lang
+            lang = records.env.lang or 'en_US'
             field_cache = self._get_field_cache(records, field)
             cache_values = []
             for record, value in zip(records, values):


### PR DESCRIPTION
**step to reproduce**
- install website_sale and install french language
- open a product page and change language to fr
- open editor, click on Edit -> translate

**Observation:**
- we get a traceback
```
  File "/home/odoo/odoo/codebase/odoo/18.0/addons/product/models/product_product.py", line 522, in _compute_display_name
    variant = product.product_template_attribute_value_ids._get_combination_name()
  File "/home/odoo/odoo/codebase/odoo/18.0/addons/product/models/product_template_attribute_value.py", line 173, in _get_combination_name
    return ", ".join([ptav.name for ptav in ptavs])
  File "/home/odoo/odoo/codebase/odoo/18.0/addons/product/models/product_template_attribute_value.py", line 173, in <listcomp>
    return ", ".join([ptav.name for ptav in ptavs])
  File "/home/odoo/odoo/codebase/odoo/18.0/odoo/fields.py", line 1312, in __get__
    raise ValueError(f"Compute method failed to assign {missing_recs}.{self.name}")
ValueError: Compute method failed to assign product.template.attribute.value(5,).name
```

**Simple way to reproduce a issue using shell**
```
pt = env['product.template']
y = pt.browse(12)
y.with_context(edit_translations="1").uom_name
```

Traceback

```
if self.readonly and not self.store:
-> raise ValueError(f"Compute method failed to assign {missing_recs}.{self.name}")
    # fallback to null value if compute gives nothing, do it for every unset record
    false_value = self.convert_to_cache(False, record, validate=False)

ValueError: Compute method failed to assign product.template(12,).uom_name

```

**Cause:**
- When the context includes `edit_translations` or `check_translations`,
env._lang returns `_{lang}` (e.g., _en_US).
- currently, `_{lang}` is used as a cache key for compute/related fields
as they are not dirty and translatable
- however, the Field.__getter__ fails for such fields, as `missing_recs_ids` looks for the
records for `lang` as cache key, Since the cache is updated with `_{lang}`,
the lookup fails and translated fields are not retrieved correctly

**Fix:**
do not use context dependant lang, when updating cache

opw-5043034

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
