### PR TITLE
[FIX] hr_timesheet: include helpdesk ticket in timesheet report

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -35,7 +35,9 @@
                             <t t-set="timesheet_record_info" t-value="False"/>
                             <t t-if="show_project">
                                 <t t-set="timesheet_record_info" t-value="line.project_id.sudo().name"/>
-                                <t t-if="show_task and line.task_id" t-set="timesheet_record_info" t-value="'%s / %s' % (timesheet_record_info, line.task_id.sudo().name)"/>
+                                <t t-if="show_task and (line.task_id or line.helpdesk_ticket_id)"
+                                   t-set="timesheet_record_info"
+                                   t-value="'%s / %s' % (timesheet_record_info, (line.task_id.sudo().name if line.task_id else line.helpdesk_ticket_id.sudo().name))"/>
                             </t>
                             <t t-elif="show_task" t-set="timesheet_record_info" t-value="line.task_id.sudo().name"/>
                             <td t-if="show_task or show_project" class="align-middle">


### PR DESCRIPTION
to reproduce:
=============
1. make helpdesk team billable and records timesheets
2. create a helpdesk ticket and link it to a sale order
3. log timesheets on the ticket
4. print the timesheet report from the sale order -> the task column will contain only the helpdesk team name, while it should contain "helpdesk team / ticket name"

Problem:
========
on the report template, the task name is fetched from line.task_id only, but helpdesk timesheets are linked to a ticket through line.helpdesk_ticket_id

Solution:
=========
use conidtionally line.task_id or line.helpdesk_ticket_id to display the task name

opw-5002650


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
