### PR TITLE
[FIX] resource: Incorrect computation of total hours duration

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -666,7 +666,7 @@ class ResourceCalendar(models.Model):
         self.ensure_one()
         hour_count = 0.0
         for attendance in self._get_global_attendances():
-            hour_count += attendance.hour_to - attendance.hour_from
+            hour_count += attendance.duration_hours
         return hour_count / 2 if self.two_weeks_calendar else hour_count
 
     def _get_hours_per_day(self):


### PR DESCRIPTION
previous behavior:
- total duration (hours/week) is computed as sum of `hour_to - hour_from` for each line

current behavior:
- made hours duration computed depending on the duration of each line instead of `hour_to - hour_from`
    (because the correct `hour_to` and `hour_from` get computed afterwards)

task-id: task-5059812