### PR TITLE
[FIX] web: use up to date context to execute cog menu actions

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -329,7 +329,7 @@ export class FormController extends Component {
     get cogMenuProps() {
         return {
             getActiveIds: () => (this.model.root.isNew ? [] : [this.model.root.resId]),
-            context: this.props.context,
+            context: this.model.root.context,
             items: this.props.info.actionMenus ? this.actionMenuItems : {},
             isDomainSelected: this.model.root.isDomainSelected,
             resModel: this.model.root.resModel,

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -253,7 +253,7 @@ export class KanbanController extends Component {
     get actionMenuProps() {
         return {
             getActiveIds: () => this.model.root.selection.map((r) => r.resId),
-            context: this.props.context,
+            context: this.model.root.context,
             domain: this.props.domain,
             items: this.actionMenuItems,
             isDomainSelected: this.model.root.isDomainSelected,

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -246,7 +246,7 @@ export class ListController extends Component {
     get actionMenuProps() {
         return {
             getActiveIds: () => this.model.root.selection.map((r) => r.resId),
-            context: this.props.context,
+            context: this.model.root.context,
             domain: this.props.domain,
             items: this.actionMenuItems,
             isDomainSelected: this.model.root.isDomainSelected,

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -12741,6 +12741,54 @@ test(`CogMenu dropdown's open/close state shouldn't be modified after 'onchange'
     });
 });
 
+test(`cog menu action is executed with up to date context`, async () => {
+    // this test simulates a case where the context of a form view evolves, which can happen with
+    // js customizations (js_class, custom widgets...) and the user then executes a cog menu action.
+    mockService("action", {
+        doAction(id, { additionalContext }) {
+            expect.step(`doAction ${additionalContext.x}`);
+        },
+    });
+
+    class MyField extends CharField {
+        static template = xml`<button class="my_btn" t-on-click="onClick">Reload</button>`;
+        onClick() {
+            this.props.record.model.load({ context: { x: "z" } });
+        }
+    }
+    fieldsRegistry.add("my_widget", {
+        component: MyField,
+    });
+
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        resId: 1,
+        arch: `<form><field name="bar" widget="my_widget"/></form>`,
+        context: {
+            x: "y",
+        },
+        info: {
+            actionMenus: {
+                action: [
+                    {
+                        id: 29,
+                        name: "Action partner",
+                    },
+                ],
+            },
+        },
+    });
+    expect(`.o_cp_action_menus .dropdown-toggle`).toHaveCount(1);
+    await toggleActionMenu();
+    await toggleMenuItem("Action Partner");
+
+    await contains(".my_btn").click();
+    await toggleActionMenu();
+    await toggleMenuItem("Action Partner");
+    expect.verifySteps(["doAction y", "doAction z"]);
+});
+
 test.tags("mobile");
 test(`preserve current scroll position on form view while closing dialog`, async () => {
     Partner._views = {


### PR DESCRIPTION
In form, list and kanban views, cog menu actions were executed with the context received in props. However, that context may change afterwards, especially with js customizations (js_class, widgets...). As a matter of fact, it is the case in the employee form view, as clicking on the status bar, which represents the versions, adds a key in the context to encode the current version. Before this commit, executing a cog menu action after changing the version of an employee was still executing it on the last version of that employee. With this commit, the correct (up to date) context is correctly given to the action.

Needed for task~4997195
