### PR TITLE
[IMP] purchase: Add hook to line comparison when merging purchase orders

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -841,6 +841,7 @@ class PurchaseOrder(models.Model):
                                                                                 l.product_uom_id == rfq_line.product_uom_id and
                                                                                 l.analytic_distribution == rfq_line.analytic_distribution and
                                                                                 l.discount == rfq_line.discount and
+                                                                                l._ensure_merge_compatibility(rfq_line) and
                                                                                 abs(l.date_planned - rfq_line.date_planned).total_seconds() <= 86400  # 24 hours in seconds
                                                                         )
                     if len(existing_line) > 1:

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -628,3 +628,6 @@ class PurchaseOrderLine(models.Model):
             "order_id": self.order_id,
             "force_uom": True,
         }
+
+    def _ensure_merge_compatibility(self, rfq_line):
+        return False

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -630,4 +630,4 @@ class PurchaseOrderLine(models.Model):
         }
 
     def _ensure_merge_compatibility(self, rfq_line):
-        return False
+        return True

--- a/doc/cla/individual/LuvForAirplanes.md
+++ b/doc/cla/individual/LuvForAirplanes.md
@@ -1,0 +1,14 @@
+United States, 2025-09-02
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Micah Stauffer micahstauffer04@gmail.com https://github.com/LuvForAirplanes
+
+micah@crop-doc.com
+micah@stauffer.enterprises


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
_I need to do a manual comparison of purchase order lines before I allow Odoo to simply merge them together. I believe this would be a useful feature to a broader audience._

_My specific use case is situations where individual lines represent individual items with different prices. Price is not taken into account in this hook. I also have other situation where this would be useful._

Current behavior before PR:
_Purchase order lines would be merged together with no easy way to hook in and override the merge condition logic._

Desired behavior after PR is merged:
_I will be able to hook into the purchase order line merge logic and prevent merges of unequal lines._

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)