### PR TITLE
[FIX] website: partial search dropdown shown on biggest side


### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/search_bar_results.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar_results.js
@@ -79,16 +79,16 @@ export class SearchBarResults extends Interaction {
 
         // Adjust the menu's position based on the scroll height.
         this.isDropup = false;
-        this.dropdownSticksOut = false;
         if (this.el.getBoundingClientRect().bottom > document.documentElement.offsetHeight) {
-            this.dropdownSticksOut = true;
             // If the menu overflows below the page, we reduce its height.
             this.el.style.overflowY = "auto";
             // We then recheck if the menu still overflows below the page.
             if (this.el.getBoundingClientRect().bottom > document.documentElement.offsetHeight) {
-                // If the menu still overflows below the page after its height
-                // has been reduced, we position it above the input.
-                this.isDropup = true;
+                // If the menu still overflows below the viewport after its
+                // height has been reduced, we position it where most space is
+                // available
+                const searchPosition = this.searchBarEl.getBoundingClientRect();
+                this.isDropup = searchPosition.top > document.documentElement.offsetHeight - searchPosition.bottom;
             }
         }
     }


### PR DESCRIPTION

Scenario:
- go to /shop
- increase zoom to 175% (or decrease height of window)
- search "a" and let the suggestions dropdown open

Result: the dropdwon menu is shown on top of the search bar, where there
is the less space available.

Cause:

When the dropdown doesn't fit fully in the viewport below the searchbar
it is always added on top even if there is less space available.

The code was added in 15.0 62c265ee7d7cf36db01bf6a95b2c5ea9843ba2d3 with
the intent of putting the dropdown on the top if it increased the page
height when putting it below (eg. when we put a search bar in the
footer).

But in saas-18.2 refactoring (b9b3a605e0f4c5da3a258c980107d6162da7f44f),
the code was rewritten and now:

- the dropdown has a scroll bar if it is too big to fit on viewport

- if the dropdown doesn't fit fully below the searchbar in the viewport,
  it is placed above the searchbar even if there is less space

Fix: place the dropdown below the searchbar if there is more space below
than above.

opw-5019685
