### PR TITLE
[FIX] membership: added context in invoice action

### DIFF
--- a/addons/membership/views/partner_views.xml
+++ b/addons/membership/views/partner_views.xml
@@ -140,7 +140,7 @@
                                     </group>
                                     <group>
                                         <field name="member_price"/>
-                                        <field name="account_invoice_id" context="{'form_view_ref': 'account.view_move_form'}"/>
+                                        <field name="account_invoice_id" context="{'form_view_ref': 'account.view_move_form', 'default_move_type': 'out_invoice'}"/>
                                     </group>
                                 </group>
                             </form>

--- a/addons/membership/wizard/membership_invoice.py
+++ b/addons/membership/wizard/membership_invoice.py
@@ -32,4 +32,5 @@ class MembershipInvoice(models.TransientModel):
             'type': 'ir.actions.act_window',
             'views': [(tree_view_ref.id, 'tree'), (form_view_ref.id, 'form')],
             'search_view_id': search_view_ref and [search_view_ref.id],
+            'context': {'default_move_type': 'out_invoice'},
         }


### PR DESCRIPTION
**Steps to Reproduce:**
1. Create a new membership product from the Membership module.
2. Open any partner and go to the Membership page.
3. Click on Buy Membership and select the created product.
4. Click on Invoice Membership.
5. Open the newly created draft invoice.
6. From the invoice line, open the product form (via the internal link).
7. Disable the Can be Purchased option and return to the invoice using breadcrumbs.
8. Add a new line in the invoice and search for the same product by its name.



**Observation:**
1. When Can be Purchased is enabled on the product, the product appears in the invoice line search.
2. When Can be Purchased is disabled, the product no longer appears in the search.



**Issue:**

In the product field domain defined in
https://github.com/odoo/odoo/blob/9ba5b41ef0252f4421ff6cdcd7c047b7c53706f4/addons/account/views/account_move_views.xml#L1022-L1029 the `default_move_type` context is `null`.
As a result, only the condition `[('purchase_ok', '=', True)]` is applied in the `name_search` domain.



**Solution:**

Pass the proper context value in the invoice action, ensuring the domain evaluates correctly and the product remains searchable.




**Note:**

The domain used in the following field
https://github.com/odoo/odoo/blob/9ba5b41ef0252f4421ff6cdcd7c047b7c53706f4/addons/account/views/account_move_views.xml#L1022-L1029

is evaluated by a following JavaScript function
https://github.com/odoo/odoo/blob/9ba5b41ef0252f4421ff6cdcd7c047b7c53706f4/addons/web/static/src/core/py_js/py_interpreter.js#L483-L489

rather than on the Python backend. Because the domain logic depends on dynamic
context evaluation performed client-side, there is no straightforward way to
retrieve or test the domain arguments dynamically within the `name_search`
method on the server. As a result, it is not feasible to write automated test
cases for this specific domain filtering scenario in the backend.



opw-5028789