### PR TITLE
[FIX] barcodes: barcode reading in Firefox

### DIFF
--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { isBrowserChrome, isMobileOS } from "@web/core/browser/feature_detection";
+import { isBrowserChrome, isBrowserFirefox, isMobileOS } from "@web/core/browser/feature_detection";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 
@@ -107,7 +107,7 @@ export const barcodeService = {
             }
         }
 
-        function mobileChromeHandler(ev) {
+        function workaroundHandler(ev) {
             if (ev.key === "Unidentified") {
                 return;
             }
@@ -119,12 +119,12 @@ export const barcodeService = {
         }
 
         whenReady(() => {
-            const isMobileChrome = barcodeService.isMobileChrome;
-            if (isMobileChrome) {
+            const isWorkaround = barcodeService.isMobileChrome || isBrowserFirefox;
+            if (isWorkaround) {
                 barcodeInput = makeBarcodeInput();
                 document.body.appendChild(barcodeInput);
             }
-            const handler = isMobileChrome ? mobileChromeHandler : keydownHandler;
+            const handler = isWorkaround ? workaroundHandler : keydownHandler;
             document.body.addEventListener('keydown', handler);
         });
 

--- a/addons/barcodes/static/tests/mobile/barcode_mobile_tests.js
+++ b/addons/barcodes/static/tests/mobile/barcode_mobile_tests.js
@@ -8,7 +8,7 @@ odoo.define('barcodes.barcode_mobile_tests', function (require) {
     var testUtils = require('web.test_utils');
 
     const maxTimeBetweenKeysInMs = barcodeService.maxTimeBetweenKeysInMs;
-    const isMobileChrome = barcodeService.isMobileChrome;
+    const isWorkaround = barcodeService.isMobileChrome || isBrowserFirefox;
     var triggerEvent = testUtils.dom.triggerEvent;
 
     function triggerKeyDown(char, target = document.body) {
@@ -37,7 +37,7 @@ odoo.define('barcodes.barcode_mobile_tests', function (require) {
         },
         after() {
             barcodeService.maxTimeBetweenKeysInMs = maxTimeBetweenKeysInMs;
-            barcodeService.isMobileChrome = isMobileChrome;
+            barcodeService.isMobileChrome = isWorkaround;
         },
     }, function () {
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If barcode contains '/' (https:// in GS1 digital link or lot number in GS1-128 for examples) focus is lost in Fixefox ('/' character is a shortcut) and reading stops.

Current behavior before PR:
1. Read in Firefox : `https:/`
<img width="132" height="132" alt="Sans titre" src="https://github.com/user-attachments/assets/22e12ccd-514a-450f-a159-fec6d4404eee" />

2. Read in Firefox : `01095060001343521722122510ABC/`
![Sans titre](https://github.com/user-attachments/assets/8d6a12ab-e401-4aba-a9ea-5c7962b92f00)

Desired behavior after PR is merged:
1. Read in Firefox: `https://id.gs1.org/01/09506000134352/10/ABC%252FDEF?17=221225`
2. Read in Firefox: `01095060001343521722122510ABC/DEF`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr