### PR TITLE
[IMP] sale: Multi creation of invoice lines per sale line

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1535,9 +1535,9 @@ class SaleOrder(models.Model):
                     optional_values['extra_tax_data'] = self.env['account.tax']\
                         ._reverse_quantity_base_line_extra_tax_data(line.extra_tax_data)
 
-                invoice_line_vals.append(
-                    Command.create(line._prepare_invoice_line(**optional_values))
-                )
+                for vals in line._prepare_invoice_lines_vals_list(**optional_values):
+                    invoice_line_vals.append(Command.create(vals))
+
                 invoice_item_sequence += 1
 
             invoice_vals['invoice_line_ids'] += invoice_line_vals

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1423,6 +1423,9 @@ class SaleOrderLine(models.Model):
         """
         return new or old
 
+    def _prepare_invoice_lines_vals_list(self, **optional_values):
+        return [self._prepare_invoice_line(**optional_values)]
+
     def _prepare_invoice_line(self, **optional_values):
         """Prepare the values to create the new invoice line for a sales order line.
 


### PR DESCRIPTION
Previous this commit, it was not possible to create multiple invoice lines from a sale line when creating an invoice from the Sale order

This commit modifies implementation adds a new method to allow creating multiple invoice lines if necessary for a sale line

target: master
task: 3731106

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
