### PR TITLE
[IMP] l10n_id_efaktur_coretax: no default tku

### DIFF
--- a/addons/l10n_id_efaktur_coretax/models/account_move.py
+++ b/addons/l10n_id_efaktur_coretax/models/account_move.py
@@ -315,7 +315,7 @@ class AccountMove(models.Model):
             "CustomDocMonthYear": self.l10n_id_coretax_custom_doc_month_year and self.l10n_id_coretax_custom_doc_month_year.strftime("%m%Y") or "",
             "FacilityStamp": "",
             "RefDesc": self.name,
-            "SellerIDTKU": self.company_id.vat + self.company_id.partner_id.l10n_id_tku,
+            "SellerIDTKU": self.company_id.vat + (self.company_id.partner_id.l10n_id_tku or '000000'),
             "BuyerDocument": partner.l10n_id_buyer_document_type,
             "BuyerTin": partner.vat if partner.l10n_id_buyer_document_type == "TIN" else "0000000000000000",
             "BuyerCountry": COUNTRY_CODE_MAP.get(partner.country_id.code),
@@ -323,7 +323,7 @@ class AccountMove(models.Model):
             "BuyerName": self.partner_id.name,
             "BuyerAdress": self.partner_id.contact_address.replace('\n', ' ').strip(),
             "BuyerEmail": partner.email or "",
-            "BuyerIDTKU": partner.vat + partner.l10n_id_tku,
+            "BuyerIDTKU": partner.vat + (partner.l10n_id_tku or '000000'),
         })
 
         if trx_code == '07':

--- a/addons/l10n_id_efaktur_coretax/models/res_partner.py
+++ b/addons/l10n_id_efaktur_coretax/models/res_partner.py
@@ -7,9 +7,8 @@ class Partner(models.Model):
     _inherit = "res.partner"
 
     l10n_id_tku = fields.Char(
-        default="000000",
         string="TKU",
-        help="Branch Number of your company, 000000 is the default for headquarters"
+        help="Branch Number of your company, leave empty for headquarters"
     )
 
     # document selection

--- a/addons/l10n_id_efaktur_coretax/views/res_partner.xml
+++ b/addons/l10n_id_efaktur_coretax/views/res_partner.xml
@@ -13,7 +13,7 @@
                 <group string="Indonesian Taxes"  invisible="not l10n_id_pkp">
                     <group>
                         <field name="l10n_id_nik"/>
-                        <field name="l10n_id_tku"/>
+                        <field name="l10n_id_tku" placeholder="000000"/>
                         <label for="l10n_id_buyer_document_type" string="Document Type"/>
                         <div class="d-flex gap-2">
                             <field name="l10n_id_buyer_document_type" />


### PR DESCRIPTION
Avoid setting a default TKU on all partner records, and instead leave empty with a fallback when used in the code.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
