### PR TITLE
[IMP] web: improve color picker styles and resolve popover layout issue

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -138,7 +138,6 @@ export class BuilderColorPicker extends Component {
                     this.props.getUsedCustomColors || this.getUsedCustomColors.bind(this),
                 colorPrefix: "color-prefix-",
                 themeColorPrefix: "hb-cp-",
-                showRgbaField: true,
                 noTransparency: this.props.noTransparency,
                 enabledTabs: this.props.enabledTabs,
                 grayscales: this.props.grayscales,

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
@@ -11,6 +11,10 @@
     background-color: $o-we-item-clickable-bg;
     color: $white;
 
+    &:has(.theme-tab){
+        width: 250px;
+    }
+
     & > div:first-child {
         background-color: $o-we-bg-darker;
         padding-block: 0.5em;
@@ -105,19 +109,8 @@
     .gradient-angle-thumb {
         background-color: $white;
     }
-    .gradient-angle-knob + input[name=angle],
-    input[name=positionX],
-    input[name=positionY] {
-        @extend %o-hb-input-base;
 
-        & + .input-group-text {
-            background-color: revert;
-            border: revert;
-            color: inherit;
-        }
-    }
-
-    .o_color_picker_inputs {
+    .o_color_picker_inputs, .o_color_gradient_input {
         color: $o-we-item-clickable-color;
 
         & input {

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -165,7 +165,6 @@ test("custom text-colors used in the editor are shown in the colorpicker", async
     await click(".btn:contains('Custom')");
     await animationFrame();
     expect(".o_hex_input").toHaveValue("#00FF00");
-    expect(".o_rgba_div input").toHaveCount(0);
     expect(queryAll("button[data-color='#ff0000']")).toHaveCount(1);
     expect(queryOne("button[data-color='#ff0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
     expect(queryAll("button[data-color='#00ff00']")).toHaveCount(1);
@@ -186,7 +185,6 @@ test("custom background colors used in the editor are shown in the colorpicker",
     await click(".btn:contains('Custom')");
     await animationFrame();
     expect(".o_hex_input").toHaveValue("#00FF00");
-    expect(".o_rgba_div input").toHaveCount(0);
     expect(queryAll("button[data-color='#ff0000']")).toHaveCount(1);
     expect(queryOne("button[data-color='#ff0000']").style.backgroundColor).toBe("rgb(255, 0, 0)");
     expect(queryAll("button[data-color='#00ff00']")).toHaveCount(1);
@@ -524,7 +522,6 @@ test("gradient picker correctly shows the current selected gradient", async () =
     await click("button[title='Define a custom gradient']");
     await animationFrame();
     expect("button.active:contains('Linear')").toHaveCount(1);
-    expect(".o_rgba_div input").toHaveCount(0);
     expect("input[name='angle']").toHaveValue(2);
     expect("input[name='custom gradient percentage color 1']").toHaveValue(10);
     expect("input[name='custom gradient percentage color 2']").toHaveValue(90);

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -65,7 +65,6 @@ export class ColorPicker extends Component {
         enabledTabs: { type: Array, optional: true },
         colorPrefix: { type: String },
         themeColorPrefix: { type: String, optional: true },
-        showRgbaField: { type: Boolean, optional: true },
         defaultOpacity: { type: Number, optional: true },
         grayscales: { type: Object, optional: true },
         noTransparency: { type: Boolean, optional: true },
@@ -76,7 +75,6 @@ export class ColorPicker extends Component {
         close: () => {},
         defaultOpacity: 100,
         enabledTabs: ["solid", "gradient", "custom"],
-        showRgbaField: false,
         themeColorPrefix: "",
         setOnCloseCallback: () => {},
     };

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -16,8 +16,15 @@
     --bg: #{$o-we-toolbar-bg};
     --text-rgb: #{red($o-we-toolbar-color-text)}, #{green($o-we-toolbar-color-text)}, #{blue($o-we-toolbar-color-text)};
     --border-rgb: var(--text-rgb);
-    width: 250px;
+    width: 208px;
+    max-height: inherit;
+    overflow-y: auto;
+    border-radius: inherit;
+    background-color: inherit;
     box-shadow: $box-shadow;
+    &::-webkit-scrollbar {
+        display: none;
+    }
 }
 
 .o_color_button {
@@ -51,8 +58,8 @@
 .o_color_button {
     @extend %o-preview-alpha-background;
 
-    &:focus,
-    &:hover {
+    &:not(.selected):focus,
+    &:not(.selected):hover {
         outline: solid $o-enterprise-action-color;
         z-index: 1;
         transition: transform 0.1s ease-out;
@@ -161,12 +168,17 @@
 }
 .o_font_color_selector .o_colorpicker_widget {
     width: 100%;
+    margin-top: 2px;
     .o_hex_input {
         border: 1px solid !important;
         padding: 0 2px !important;
         width: 10ch !important;
         opacity: 0.7;
     }
+}
+
+.custom-gradient-configurator + .o_colorpicker_widget {
+    padding-bottom: 8px;
 }
 
 :root {

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
 <t t-name="web.ColorPicker">
     <div t-attf-class="o_font_color_selector user-select-none {{this.props.className}}" t-on-pointerdown.stop="() => {}" data-prevent-closing-overlay="true" t-ref="root">
-        <div class="my-1 d-flex">
+        <div class="mb-1 pt-2 d-flex">
             <button t-attf-class="btn btn-sm ms-1 text-truncate btn-tab theme-tab #{ isDarkTheme ? 'btn-secondary' : 'btn-light'} #{state.activeTab === 'theme' ? 'active' : ''}"
                 t-if="this.props.enabledTabs.includes('theme')"
                 t-on-click="() => this.setTab('theme')">
@@ -33,7 +33,7 @@
         </div>
         <!-- TODO: move the theme tab to html_builder. It shouldn't be in web. -->
         <t t-if="state.activeTab==='theme'">
-            <div class="pt-2 px-2 pb-3 d-flex flex-column gap-1 o_cc_preview_wrapper"
+            <div class="p-2 d-flex flex-column gap-1 o_cc_preview_wrapper"
                 t-on-click="onColorApply"
                 t-on-mouseover="onColorHover"
                 t-on-mouseout="onColorHoverOut"
@@ -65,7 +65,7 @@
             </div>
         </t>
         <t t-if="state.activeTab==='solid'">
-            <div class="d-flex flex-column align-items-center p-1"
+            <div class="d-flex flex-column align-items-center p-2"
                 t-on-click="onColorApply"
                 t-on-mouseover="onColorHover"
                 t-on-mouseout="onColorHoverOut"
@@ -90,7 +90,7 @@
             </div>
         </t>
         <t t-if="state.activeTab==='custom'">
-            <div class="d-flex flex-column align-items-start p-1" t-on-keydown="colorPickerNavigation">
+            <div class="d-flex flex-column align-items-start p-2 pb-0" t-on-keydown="colorPickerNavigation">
                 <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                     <t t-foreach="this.usedCustomColors" t-as="color" t-key="color_index">
                         <button t-if="color !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn p-0" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
@@ -117,13 +117,14 @@
             </div>
         </t>
         <t t-if="state.activeTab==='gradient'">
+            <t t-set="selectedGradient" t-value="this.defaultColor" />
             <t t-set="currentGradient" t-value="getCurrentGradientColor()" />
             <div class="o_colorpicker_sections p-2 d-grid gap-1" style="grid-template-columns: 1fr 1fr;" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                 <t t-set="gradientsWithOpacity" t-value="
                     this.DEFAULT_GRADIENT_COLORS.map((gradient) => applyOpacityToGradient(gradient, this.props.defaultOpacity))" />
                 <t t-foreach="gradientsWithOpacity"
                     t-as="gradient" t-key="gradient">
-                    <button class="w-100 m-0 o_color_button o_gradient_color_button btn p-0" t-att-class="{'selected': currentGradient?.includes(gradient)}" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
+                    <button class="w-100 m-0 o_color_button o_gradient_color_button btn p-0" t-att-class="{'selected': selectedGradient?.includes(gradient)}" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
                 </t>
             </div>
             <div class="px-2">

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -111,7 +111,6 @@
                     setOperationCallbacks.bind="setOperationCallbacks"
                     onColorSelect.bind="(color) => this.applyColor(color.hex)"
                     onColorPreview.bind="onColorPreview"
-                    showRgbaField="props.showRgbaField"
                     noTransparency="props.noTransparency"
                     defaultOpacity="props.defaultOpacity" />
             </div>

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -28,7 +28,6 @@ export class CustomColorPicker extends Component {
         onColorSelect: { type: Function, optional: true },
         onColorPreview: { type: Function, optional: true },
         onInputEnter: { type: Function, optional: true },
-        showRgbaField: { type: Boolean, optional: true },
         defaultOpacity: { type: Number, optional: true },
         setOnCloseCallback: { type: Function, optional: true },
         setOperationCallbacks: { type: Function, optional: true },
@@ -42,7 +41,6 @@ export class CustomColorPicker extends Component {
         onColorSelect: () => {},
         onColorPreview: () => {},
         onInputEnter: () => {},
-        showRgbaField: true,
     };
 
     setup() {
@@ -660,22 +658,12 @@ export class CustomColorPicker extends Component {
             case "hex":
                 // Handled by the "input" event (see "onHexColorInput").
                 return;
-            case "rgb":
-                this._updateRgba(
-                    parseInt(this.el.querySelector(".o_red_input").value),
-                    parseInt(this.el.querySelector(".o_green_input").value),
-                    parseInt(this.el.querySelector(".o_blue_input").value)
-                );
-                break;
             case "hsl":
                 this._updateHsl(
                     parseInt(this.el.querySelector(".o_hue_input").value),
                     parseInt(this.el.querySelector(".o_saturation_input").value),
                     parseInt(this.el.querySelector(".o_lightness_input").value)
                 );
-                break;
-            case "opacity":
-                this._updateOpacity(parseInt(this.el.querySelector(".o_opacity_input").value));
                 break;
         }
         this._updateUI();

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.scss
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.scss
@@ -47,9 +47,5 @@
         .o_hex_div input {
             width: 9ch;
         }
-        .o_rgba_div input {
-            margin-right: 3px;
-            width: 3ch;
-        }
     }
 }

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
@@ -24,7 +24,7 @@
         <div class="o_color_picker_inputs d-flex justify-content-between mb-2" t-on-change="debouncedOnChangeInputs">
             <t t-set="input_classes" t-value="'p-0 border-0 text-center font-monospace bg-transparent'" />
 
-            <div class="o_hex_div px-1 d-flex align-items-baseline me-1">
+            <div class="o_hex_div d-flex align-items-baseline me-1">
                 <input type="text" t-attf-class="o_hex_input {{input_classes}}" data-color-method="hex" size="1"
                     t-on-input="onHexColorInput"/>
                 <label class="flex-grow-0 ms-1 mb-0">hex</label>

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
@@ -29,20 +29,6 @@
                     t-on-input="onHexColorInput"/>
                 <label class="flex-grow-0 ms-1 mb-0">hex</label>
             </div>
-            <div t-if="props.showRgbaField" class="o_rgba_div px-1 d-flex align-items-baseline">
-                <input type="text" t-attf-class="o_red_input {{input_classes}}" data-color-method="rgb" size="1"/>
-                <input type="text" t-attf-class="o_green_input {{input_classes}}" data-color-method="rgb" size="1"/>
-                <input type="text" t-attf-class="o_blue_input {{input_classes}}" data-color-method="rgb" size="1"/>
-                <t t-if="!props.noTransparency">
-                    <input type="text" t-attf-class="o_opacity_input {{input_classes}}" data-color-method="opacity" size="1"/>
-                    <label class="flex-grow-0 ms-1 mb-0">
-                        RGBA
-                    </label>
-                </t>
-                <label t-else="" class="flex-grow-0 ms-1 mb-0">
-                    RGB
-                </label>
-            </div>
         </div>
     </div>
 </t>

--- a/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.scss
+++ b/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.scss
@@ -22,3 +22,18 @@
     transform-origin: center center;
     pointer-events: none;
 }
+
+.o_color_gradient_input {
+    font-size: 11px;
+
+    input {
+        font-family: monospace !important;
+        font-size: 12px;
+        width: 5ch !important;
+        padding: 0 2px !important;
+        background-color: transparent;
+        border: 1px solid !important;
+        text-align: center;
+        opacity: 0.7;
+    }
+}

--- a/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.xml
+++ b/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.xml
@@ -12,30 +12,31 @@
 
             <div t-if="this.state.type === 'linear'" class="d-flex align-items-center justify-content-between mb-1">
                 Angle
-                <span class="d-flex justify-content-between">
+                <span class="d-flex justify-content-between align-items-center">
                     <div class="d-flex justify-content-center align-items-center my-auto me-2 position-relative gradient-angle-knob"
                         t-ref="gradientAngleKnob"
                         t-attf-style="--angle: #{this.state.angle}deg;"
                         t-on-mousedown="onKnobMouseDown">
                         <div class="position-absolute gradient-angle-thumb"></div>
                     </div>
-                    <input
-                        name="angle"
-                        type="number"
-                        min="0"
-                        max="360"
-                        t-att-value="this.state.angle"
-                        t-on-change="onAngleChange"
-                        style="width: 5ch"
-                    />
-                    <span class="input-group-text">deg</span>
+                    <div class="o_color_gradient_input d-flex align-items-center">
+                        <input
+                            name="angle"
+                            type="number"
+                            min="0"
+                            max="360"
+                            t-att-value="this.state.angle"
+                            t-on-change="onAngleChange"
+                        />
+                        <label class="flex-grow-0 ms-1 mb-0">deg</label>
+                    </div>
                 </span>
             </div>
             <div t-else="" class="d-flex flex-column gap-1 mb-1">
                 Size
                 <div class="d-flex align-items-center justify-content-between">
                     <button t-on-click="() => this.onSizeChange('closest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-side' ? `active` : ''}}" title="Extend to the closest side">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 16 20" fill="none">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
                             <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
                             <path d="M3 4H9V8C9 8.55228 8.55228 9 8 9H4C3.44772 9 3 8.55228 3 8V4Z" fill="#8C8C92"></path>
                             <path d="M6 11C7.65685 11 9 9.65685 9 8C9 6.34315 7.65685 5 6 5C4.34315 5 3 6.34315 3 8C3 9.65685 4.34315 11 6 11Z" fill="#74747B"></path>
@@ -44,7 +45,7 @@
                         </svg>
                     </button>
                     <button t-on-click="() => this.onSizeChange('closest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'closest-corner' ? `active` : ''}}" title="Extend to the closest corner">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 16 20" fill="none">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
                             <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
                             <path d="M2 4H9V7C9 9.20914 7.20914 11 5 11H2V4Z" fill="#8C8C92"></path>
                             <path d="M6 11C7.65685 11 9 9.65685 9 8C9 6.34315 7.65685 5 6 5C4.34315 5 3 6.34315 3 8C3 9.65685 4.34315 11 6 11Z" fill="#74747B"></path>
@@ -54,7 +55,7 @@
                         </svg>
                     </button>
                     <button t-on-click="() => this.onSizeChange('farthest-side')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-side' ? `active` : ''}}" title="Extend to the farthest side">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 16 20" fill="none">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
                             <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
                             <path d="M7 12C10.3137 12 14 10.2091 14 8C14 5.79086 10.3137 4 7 4C3.68629 4 2 5.79086 2 8C2 10.2091 3.68629 12 7 12Z" fill="#8C8C92"></path>
                             <path d="M6 11C7.65685 11 9 9.65685 9 8C9 6.34315 7.65685 5 6 5C4.34315 5 3 6.34315 3 8C3 9.65685 4.34315 11 6 11Z" fill="#74747B"></path>
@@ -63,7 +64,7 @@
                         </svg>
                     </button>
                     <button t-on-click="() => this.onSizeChange('farthest-corner')" t-attf-class="btn btn-light p-0 {{ this.state.size === 'farthest-corner' ? `active` : ''}}" title="Extend to the farthest corner">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 16 20" fill="none">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="45" height="45" viewBox="0 0 16 20" fill="none">
                             <rect x="1.5" y="3.5" width="13" height="13" stroke="#AAAAAD"></rect>
                             <path d="M2 4H14V10C14 13.3137 11.3137 16 8 16H2V4Z" fill="#8C8C92"></path>
                             <path d="M6 11C7.65685 11 9 9.65685 9 8C9 6.34315 7.65685 5 6 5C4.34315 5 3 6.34315 3 8C3 9.65685 4.34315 11 6 11Z" fill="#74747B"></path>
@@ -75,7 +76,7 @@
                 </div>
                 <div class="d-flex align-items-center justify-content-between">
                     Position X
-                    <span class="d-flex justify-content-between">
+                    <span class="o_color_gradient_input">
                         <input
                             name="positionX"
                             type="number"
@@ -83,14 +84,12 @@
                             max="100"
                             t-att-value="this.positions['x']"
                             t-on-change="(ev) => this.onPositionChange('x', ev)"
-                            class="input"
-                            style="width: 5ch"
                         />
                     </span>
                 </div>
                 <div class="d-flex align-items-center justify-content-between">
                     Position Y
-                    <span class="d-flex justify-content-between">
+                    <span class="o_color_gradient_input">
                         <input
                             name="positionY"
                             type="number"
@@ -98,8 +97,6 @@
                             max="100"
                             t-att-value="this.positions['y']"
                             t-on-change="(ev) => this.onPositionChange('y', ev)"
-                            class="input"
-                            style="width: 5ch"
                         />
                     </span>
                 </div>

--- a/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.xml
+++ b/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.xml
@@ -133,7 +133,6 @@
                 setOperationCallbacks.bind="props.setOperationCallbacks"
                 defaultColor="this.currentColorHex"
                 selectedColor="this.currentColorHex"
-                showRgbaField="false"
                 noTransparency="props.noTransparency"
             />
         </div>

--- a/addons/web/static/tests/core/color_picker.test.js
+++ b/addons/web/static/tests/core/color_picker.test.js
@@ -3,7 +3,6 @@ import { press, click, animationFrame, queryOne } from "@odoo/hoot-dom";
 import { defineStyle, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { ColorPicker, DEFAULT_COLORS } from "@web/core/color_picker/color_picker";
 import { CustomColorPicker } from "@web/core/color_picker/custom_color_picker/custom_color_picker";
-import { convertRgbToHsl } from "@web/core/utils/colors";
 
 test("basic rendering", async () => {
     await mountWithCleanup(ColorPicker, {
@@ -234,79 +233,6 @@ test("custom color picker change color on click in hue slider", async () => {
     expect("input.o_hex_input").toHaveValue("#FF0000");
     await click(".o_color_slider");
     expect("input.o_hex_input").not.toHaveValue("#FF0000");
-});
-
-function getRgbaInput() {
-    return [
-        parseInt(queryOne("input.o_red_input").value),
-        parseInt(queryOne("input.o_green_input").value),
-        parseInt(queryOne("input.o_blue_input").value),
-        parseInt(queryOne("input.o_opacity_input").value),
-    ];
-}
-
-test("custom color picker keeps transparent selected color", async () => {
-    await mountWithCleanup(CustomColorPicker, { props: { selectedColor: "#00000000" } });
-    expect(getRgbaInput()).toEqual([0, 0, 0, 0]);
-});
-
-test("custom color picker change from transparent and black to solid color on hue click", async () => {
-    await mountWithCleanup(CustomColorPicker, { props: { selectedColor: "#00000000" } });
-    {
-        const [r, g, b, a] = getRgbaInput();
-        const hsl = convertRgbToHsl(r, g, b);
-        expect(a).toBe(0);
-        expect(hsl).toEqual({ hue: 0, saturation: 0, lightness: 0 });
-    }
-    await click(".o_color_slider");
-    {
-        const [r, g, b, a] = getRgbaInput();
-        const hsl = convertRgbToHsl(r, g, b);
-        expect(a).toBe(100);
-        expect(hsl.hue).not.toBe(0);
-        expect(hsl.saturation).toBe(100);
-        expect(hsl.lightness).toBe(50);
-    }
-});
-
-test("custom color picker change from white to solid color on hue click", async () => {
-    await mountWithCleanup(CustomColorPicker, { props: { selectedColor: "#ffffff40" } });
-    {
-        const [r, g, b, a] = getRgbaInput();
-        const hsl = convertRgbToHsl(r, g, b);
-        expect(a).toBe(25);
-        expect(hsl).toEqual({ hue: 0, saturation: 0, lightness: 100 });
-    }
-    await click(".o_color_slider");
-    {
-        const [r, g, b, a] = getRgbaInput();
-        const hsl = convertRgbToHsl(r, g, b);
-        expect(a).toBe(25);
-        expect(hsl.hue).not.toBe(0);
-        expect(hsl.saturation).toBe(100);
-        expect(hsl.lightness).toBe(50);
-    }
-});
-
-test("custom color picker change from grey to solid color on hue click", async () => {
-    await mountWithCleanup(CustomColorPicker, { props: { selectedColor: "#40404040" } });
-    {
-        const [r, g, b, a] = getRgbaInput();
-        const hsl = convertRgbToHsl(r, g, b);
-        expect(a).toBe(25);
-        expect(hsl.hue).toBe(0);
-        expect(hsl.saturation).toBe(0);
-        expect(Math.round(hsl.lightness)).toBe(25);
-    }
-    await click(".o_color_slider");
-    {
-        const [r, g, b, a] = getRgbaInput();
-        const hsl = convertRgbToHsl(r, g, b);
-        expect(a).toBe(25);
-        expect(hsl.hue).not.toBe(0);
-        expect(hsl.saturation).toBe(100);
-        expect(Math.round(hsl.lightness)).toBe(25);
-    }
 });
 
 test("custom gradient must be defined", async () => {

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
@@ -326,7 +326,7 @@ describe("Custom colorpicker: preview and commit", () => {
         await waitFor(".o-overlay-item .o_color_pick_area");
         expect(":iframe .test-options-target").not.toHaveAttribute("data-color");
         // Press shift+tab until it gets to the colorpicker area.
-        for (let i = 0; i < 9; i++) {
+        for (let i = 0; i < 5; i++) {
             await press("Tab", { shiftKey: true });
         }
         expect(".o-overlay-item .o_color_pick_area .o_picker_pointer").toBeFocused();
@@ -368,7 +368,7 @@ describe("Custom colorpicker: preview and commit", () => {
         expect(":iframe .test-options-target").toHaveAttribute("data-color");
         await press("Enter"); // Validate
         await animationFrame();
-        expect.verifySteps(["apply"]) // Commit
+        expect.verifySteps(["apply"]); // Commit
         await press("escape");
         await animationFrame();
         expect(":iframe .test-options-target").toHaveAttribute("data-color");


### PR DESCRIPTION
Desired behavior after PR is merged:

- Applied same padding across `Solid`, `Custom`, and `Gradient` tabs.
- Applied same styles to input field (position, angle, hex).
- Fixed content overflow inside the popover, allowing excess content to scroll when it exceeds the maximum height.
- Removed RGBA inputs related code and tests.

task-5047830

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
