### PR TITLE
[FIX] stock: fix spanish translation of Delivery Slip

### DIFF
--- a/addons/stock/i18n/es_419.po
+++ b/addons/stock/i18n/es_419.po
@@ -186,7 +186,7 @@ msgstr "'Hoja de conteos'"
 msgid ""
 "'Delivery Slip - %s - %s' % (object.partner_id.name or '', object.name)"
 msgstr ""
-"'Recibo de entrega - %s - %s' % (object.partner_id.name or '', object.name)"
+"'Remito - %s - %s' % (object.partner_id.name or '', object.name)"
 
 #. module: stock
 #: model:ir.actions.report,print_report_name:stock.action_report_location_barcode
@@ -1298,7 +1298,7 @@ msgstr "Auto"
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__auto_print_delivery_slip
 msgid "Auto Print Delivery Slip"
-msgstr "Imprimir el recibo de entrega de forma automática"
+msgstr "Imprimir el remito de forma automática"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__auto_print_lot_labels
@@ -2737,7 +2737,7 @@ msgstr "Ruta de entrega"
 #: model:ir.actions.report,name:stock.action_report_delivery
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_type_form
 msgid "Delivery Slip"
-msgstr "Recibo de entrega"
+msgstr "Remito"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_procurement_group__move_type


### PR DESCRIPTION
Steps to reproduce:
1. Add language Spanish(AR) 
2. Go to Inventory (Inventario) > Operations (Operaciones)
3. Deliveries (Entregas) > Open any record.
4. Click ⚙ > Print (Imprimir) > Delivery Slip (Recibo de entrega)


Issue:
- The translation of "Delivery Slip" in Spanish (es_419) shows as "Recibo de entrega", 
 which is incorrect for Argentina.

Cause:
- Odoo currently labels document as “Recibo de entrega”, but legally it must be “Remito de entrega”. 
  According to AFIP General Resolution 1415/2003(Arts. 28–30) a REMITO “R” or “X” must explicitly 
  include “DOCUMENTO NO VÁLIDO COMO FACTURA” and follow the mandatory structure and 
  data placement defined by law.
  Go through : https://www.odoo.com/mail/message/848099710

Solution:
- Updated the translation from "Recibo de entrega" to "Remito de entrega"

opw-5004345

