### PR TITLE
[FIX] base_import: fix import error caused by field matching

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -835,7 +835,7 @@ class Import(models.TransientModel):
                     min_dist_field = field['name']
                     min_dist = current_field_dist
 
-            if min_dist < self.FUZZY_MATCH_DISTANCE:
+            if round(min_dist, 1) < self.FUZZY_MATCH_DISTANCE:
                 return {
                     'field_path': [min_dist_field],
                     'distance': min_dist

--- a/addons/test_base_import/models/test_base_import.py
+++ b/addons/test_base_import/models/test_base_import.py
@@ -100,3 +100,11 @@ class ComplexModel(models.Model):
     currency_id = fields.Many2one('res.currency')
     d = fields.Date()
     dt = fields.Datetime()
+
+
+class CharSameString(models.Model):
+    _name = model('char.string')
+    _description = 'Tests: Base Import Model Char String'
+
+    test = fields.Char(string='Test 1', readonly=True)
+    test2 = fields.Char(string='Test 2')

--- a/addons/test_base_import/security/ir.model.access.csv
+++ b/addons/test_base_import/security/ir.model.access.csv
@@ -13,3 +13,4 @@ access_test_base_import_o2m_child,base.import.tests.models.o2m.child,model_base_
 access_test_base_import_float,base.import.tests.models.float,model_base_import_float,base.group_user,1,1,1,1
 access_test_base_import_preview,base.import.tests.models.preview,model_base_import_preview,base.group_user,1,1,1,1
 access_test_base_import_complex,access_test_base_import_complex,model_base_import_complex,base.group_user,1,0,0,0
+access_test_base_import_char_string,access_test_base_import_char_string,model_base_import_char_string,base.group_user,1,1,1,1

--- a/addons/test_base_import/tests/test_base_import.py
+++ b/addons/test_base_import/tests/test_base_import.py
@@ -103,6 +103,12 @@ class TestBasicFields(BaseImportCase):
                 {'id': 'value', 'name': '.id', 'string': 'Database ID', 'required': True, 'fields': [], 'type': 'id', 'model_name': base_import_model('m2o.required')},
         ]))
 
+    def test_field_with_similar_string(self):
+        fields_tree = self.get_fields('char.string')
+        match = self.env['base_import.import']._get_mapping_suggestion("Test 1", fields_tree, ['char'], {})
+
+        self.assertFalse(bool(match), "Match should not be empty")
+
 
 class TestO2M(BaseImportCase):
 
@@ -289,7 +295,7 @@ class TestColumnMapping(TransactionCase):
             match = self.env['base_import.import']._get_mapping_suggestion(value[1], model_fields_info, ['char'], {})
 
             self.assertEqual(
-                bool(match), distance < max_distance
+                bool(match), round(distance, 1) < max_distance
             )
 
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install `hr_holidays`
- Go to Time Off → Management → Allocations
- Create a new allocation and fill in all required fields
- Export the record with the "Allocation Type" field
- Try to import the same record again
- Click on `Test` button during import

**Issue:**
- Error: `Value 'Regular Allocation' not found in selection field 'Allocation Mode'`.

**Cause:**
- Field names "Allocation Type" (`allocation_type`) and "Allocation Mode" (`holiday_type`) They are very similar.
- Mapping suggestions method finds a matching field, the distance between the above fields is computed as 0.19999999999996, which is considered less than the FUZZY_MATCH_DISTANCE (0.2).
https://github.com/odoo/odoo/blob/c483f59b370bffe4a412ad7cc40f538399b7aadb/addons/base_import/models/base_import.py#L193
- This caused the importer to incorrectly map "Allocation Type" values to "Allocation Mode".
- https://github.com/odoo/odoo/blob/c483f59b370bffe4a412ad7cc40f538399b7aadb/addons/base_import/models/base_import.py#L752-L772

**Solution:**
- Round the computed distance to one decimal place before comparing with the fuzzy match distance, preventing false positives.

opw-5049420


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
