### PR TITLE
[IMP] stock: improve forecast report usability and filtering

### DIFF
--- a/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
@@ -1,10 +1,12 @@
 import { ForecastedButtons } from "@stock/stock_forecasted/forecasted_buttons";
+import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { onWillStart } from "@odoo/owl";
 
 patch(ForecastedButtons.prototype, {
     setup() {
         super.setup();
+        this.orm = useService("orm");
         onWillStart(async () =>{
             const fields = this.resModel === "product.template" ? ['bom_ids'] : ['bom_ids', 'variant_bom_ids'];
             const res = (await this.orm.call(this.resModel, 'read', [this.productId], { fields }))[0];

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -70,6 +70,8 @@ class StockForecasted_Product_Product(models.AbstractModel):
         if 'product' not in res:
             res['product'] = dict()
         products = self._get_products(product_template_ids, product_ids)
+        if self.env.context.get('warehouse_id') == 0:
+            products = products.with_context(warehouse_id=self._get_warehouses().ids)
         for product in products:
             if product.id not in res['product']:
                 res['product'][product.id] = {
@@ -98,7 +100,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
     def _get_product_leadtime(self, res, product_template_ids, product_ids):
         """Return a dictionary with product lead times."""
         products = self._get_products(product_template_ids, product_ids)
-        location = self._get_warehouse().lot_stock_id
+        location = self._get_warehouses()[:1].lot_stock_id
         for product in products:
             rule = product._get_rules_from_location(location)
             leadtime = rule._get_lead_days(product)
@@ -150,24 +152,22 @@ class StockForecasted_Product_Product(models.AbstractModel):
             'id': move.picking_id.id
         }
 
-    def _get_warehouse(self):
-        return self.env['stock.warehouse'].browse(self.env.context.get('warehouse_id', False)) or self.env['stock.warehouse'].search([['active', '=', True]])[0]
+    def _get_warehouses(self):
+        if warehouse_id := self.env.context.get('warehouse_id'):
+            return self.env['stock.warehouse'].browse(warehouse_id)
+        else:
+            return self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)])
 
     def _get_report_data(self, product_template_ids=False, product_ids=False):
         assert product_template_ids or product_ids
         res = {}
 
-        warehouse = self._get_warehouse()
-        wh_location_ids = [loc['id'] for loc in self.env['stock.location'].search_read(
-            [('id', 'child_of', warehouse.view_location_id.id)],
-            ['id'],
-        )]
-        # any quantities in this location will be considered free stock, others are free stock in transit
-        wh_stock_location = warehouse.lot_stock_id
+        warehouses = self._get_warehouses()
+        wh_location_ids = self.env['stock.location'].search([('id', 'child_of', warehouses.view_location_id.ids)]).ids
 
         res.update(self._get_report_header(product_template_ids, product_ids, wh_location_ids))
 
-        res['lines'] = self._get_report_lines(product_template_ids, product_ids, wh_location_ids, wh_stock_location)
+        res['lines'] = self._get_report_lines(product_template_ids, product_ids, wh_location_ids, warehouses.lot_stock_id)
         res['user_can_edit_pickings'] = self.env.user.has_group('stock.group_stock_user')
         return res
 
@@ -236,8 +236,9 @@ class StockForecasted_Product_Product(models.AbstractModel):
     def _get_quant_domain(self, location_ids, products):
         return [('location_id', 'in', location_ids), ('quantity', '>', 0), ('product_id', 'in', products.ids)]
 
-    def _get_report_lines(self, product_template_ids, product_ids, wh_location_ids, wh_stock_location, read=True):
-        def _get_out_move_reserved_data(out, linked_moves, used_reserved_moves, currents, wh_stock_location, wh_stock_sub_location_ids):
+    def _get_report_lines(self, product_template_ids, product_ids, wh_location_ids, wh_stock_locations, read=True):
+
+        def _get_out_move_reserved_data(out, linked_moves, used_reserved_moves, currents, sub_location_to_stock):
             reserved_out = 0
             # the move to show when qty is reserved
             reserved_move = self.env['stock.move']
@@ -254,9 +255,10 @@ class StockForecasted_Product_Product(models.AbstractModel):
                 reserved_out += reserved
                 used_reserved_moves[move] += reserved
                 # any sublocation qties needs to be reserved to the main stock location qty as well
-                if move.location_id.id in wh_stock_sub_location_ids:
-                    currents[out.product_id.id, wh_stock_location.id] -= reserved
-                currents[(out.product_id.id, move.location_id.id)] -= reserved
+                parent_stock_id = sub_location_to_stock.get(move.location_id.id)
+                if parent_stock_id:
+                    currents[out.product_id.id, parent_stock_id] -= reserved
+                currents[out.product_id.id, move.location_id.id] -= reserved
                 if move.product_id.uom_id.compare(reserved_out, out.product_qty) >= 0:
                     break
 
@@ -266,7 +268,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
                 'linked_moves': linked_moves,
             }
 
-        def _get_out_move_taken_from_stock_data(out, currents, reserved_data, wh_stock_location, wh_stock_sub_location_ids):
+        def _get_out_move_taken_from_stock_data(out, currents, reserved_data, sub_location_to_stock):
             reserved_out = reserved_data['reserved']
             demand_out = out.product_qty - reserved_out
             linked_moves = reserved_data['linked_moves']
@@ -287,15 +289,16 @@ class StockForecasted_Product_Product(models.AbstractModel):
                     move_out_qty = sum(sibling_moves.filtered(lambda m: m.state == 'done').mapped('quantity'))
                     move_available_qty = move_in_qty - move_out_qty - reserved
                 else:
-                    move_available_qty = currents[(out.product_id.id, move.location_id.id)]
+                    move_available_qty = currents[out.product_id.id, move.location_id.id]
                 # count taken from stock, but avoid taking more than whats in stock in case of move origs,
                 # this can happen if stock adjustment is done after orig moves are done
-                taken_from_stock = min(demand, move_available_qty, currents[(out.product_id.id, move.location_id.id)])
+                taken_from_stock = min(demand, move_available_qty, currents[out.product_id.id, move.location_id.id])
                 if taken_from_stock > 0:
                     # any sublocation qties needs to be removed to the main stock location qty as well
-                    if move.location_id.id in wh_stock_sub_location_ids:
-                        currents[out.product_id.id, wh_stock_location.id] -= taken_from_stock
-                    currents[(out.product_id.id, move.location_id.id)] -= taken_from_stock
+                    parent_stock_id = sub_location_to_stock.get(move.location_id.id)
+                    if parent_stock_id:
+                        currents[out.product_id.id, parent_stock_id] -= taken_from_stock
+                    currents[out.product_id.id, move.location_id.id] -= taken_from_stock
                     taken_from_stock_out += taken_from_stock
                 demand_out -= taken_from_stock
             return {
@@ -308,6 +311,8 @@ class StockForecasted_Product_Product(models.AbstractModel):
                 in_data = in_id_to_in_data[in_id]
                 if product_uom.is_zero(in_data['qty']):
                     ins_to_remove.append(in_id)
+                    continue
+                if in_data['warehouse_id'] != out.location_id.warehouse_id.id:
                     continue
                 taken_from_in = min(demand, in_data['qty'])
                 demand -= taken_from_in
@@ -376,6 +381,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
                 'qty': in_.product_qty,
                 'move': in_,
                 'move_dests': in_._rollup_move_dests(),
+                'warehouse_id': in_.location_dest_id.warehouse_id.id,
             }
             product_id = in_.product_id.id
             ins_per_product[product_id].add(in_.id)
@@ -386,16 +392,29 @@ class StockForecasted_Product_Product(models.AbstractModel):
             self._get_quant_domain(wh_location_ids, outs.product_id | self._get_products(product_template_ids, product_ids)),
             ['product_id', 'location_id'], ['quantity:sum']
         )
-        wh_stock_sub_location_ids = set(
-            (wh_stock_location.search([('id', 'child_of', wh_stock_location.id)]) - wh_stock_location)._ids
+
+        # Prepare sub_location to stock mapping
+        stock_child_locations = self.env['stock.location'].search_read(
+            [('id', 'child_of', wh_stock_locations.ids), ('id', 'not in', wh_stock_locations.ids)],
+            ['id', 'parent_path']
         )
+
+        sub_location_to_stock = {}
+        wh_stock_sub_location_ids = set()
+        for loc in stock_child_locations:
+            loc_id = loc['id']
+            wh_stock_sub_location_ids.add(loc_id)
+            path_ids = [int(p) for p in loc['parent_path'].split('/') if p]
+            sub_location_to_stock[loc_id] = next(id for id in path_ids if id in wh_stock_locations.ids)
+
         currents = defaultdict(float)
         for product, location, quantity in qties:
             location_id = location.id
             # any sublocation qties will be added to the main stock location qty as well
-            if location_id in wh_stock_sub_location_ids:
-                currents[product.id, wh_stock_location.id] += quantity
-            currents[(product.id, location_id)] += quantity
+            currents[product.id, location_id] += quantity
+            parent_stock_id = sub_location_to_stock.get(location_id)
+            if parent_stock_id:
+                currents[product.id, parent_stock_id] += quantity
         moves_data = {}
         for out_moves in outs_per_product.values():
             # to handle multiple out wtih same in (ex: same pick/pack for 2 outs)
@@ -403,11 +422,11 @@ class StockForecasted_Product_Product(models.AbstractModel):
             # for all out moves, check for linked moves and count reserved quantity
             for out in out_moves:
                 moves_data[out] = _get_out_move_reserved_data(
-                    out, linked_moves_per_out[out], used_reserved_moves, currents, wh_stock_location, wh_stock_sub_location_ids
+                    out, linked_moves_per_out[out], used_reserved_moves, currents, sub_location_to_stock
                 )
             # another loop to remove qty from current stock after reserved is counted for
             for out in out_moves:
-                data = _get_out_move_taken_from_stock_data(out, currents, moves_data[out], wh_stock_location, wh_stock_sub_location_ids)
+                data = _get_out_move_taken_from_stock_data(out, currents, moves_data[out], sub_location_to_stock)
                 moves_data[out].update(data)
         product_sum = defaultdict(float)
         for product_loc, quantity in currents.items():
@@ -418,7 +437,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
             lines_init_count = len(lines)
             unreconciled_outs = []
             # remaining stock
-            free_stock = currents[product.id, wh_stock_location.id]
+            free_stock = sum(currents[product.id, stock_id] for stock_id in wh_stock_locations.ids)
             transit_stock = product_sum[product.id] - free_stock
             # add report lines and see if remaining demand can be reconciled by unreservable stock or ins
             for out in outs_per_product[product.id]:

--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { Component, markup } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 export class ForecastedButtons extends Component {
     static template = "stock.ForecastedButtons";
@@ -12,7 +12,6 @@ export class ForecastedButtons extends Component {
 
     setup() {
         this.actionService = useService("action");
-        this.orm = useService("orm");
         this.context = this.props.action.context;
         this.productId = this.context.variant_id ? this.context.variant_id : this.context.active_id;
         this.resModel = this.props.resModel || this.context.active_model || this.context.params?.active_model || 'product.template';
@@ -44,17 +43,6 @@ export class ForecastedButtons extends Component {
             target: 'new',
             context: context,
         };
-        return this.actionService.doAction(action, { onClose: this._onClose.bind(this) });
-    }
-
-    async _onClickUpdateQuantity() {
-        const action = await this.orm.call(this.resModel, "action_open_quants", [[this.productId]]);
-        if (action.res_model === "stock.quant") { // Quant view in inventory mode.
-            action.views = [[false, "list"]];
-        }
-        if (action.help) {
-            action.help = markup(action.help);
-        }
         return this.actionService.doAction(action, { onClose: this._onClose.bind(this) });
     }
 }

--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
@@ -14,7 +14,7 @@ export class ForecastedButtons extends Component {
         this.actionService = useService("action");
         this.orm = useService("orm");
         this.context = this.props.action.context;
-        this.productId = this.context.active_id;
+        this.productId = this.context.variant_id ? this.context.variant_id : this.context.active_id;
         this.resModel = this.props.resModel || this.context.active_model || this.context.params?.active_model || 'product.template';
     }
 

--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.xml
@@ -6,10 +6,6 @@
             class="o_forecasted_replenish_btn btn btn-primary">
             Replenish
         </button>
-        <button title="Update Quantity" t-on-click="this._onClickUpdateQuantity"
-            class="o_forecasted_update_qty_btn btn btn-secondary">
-            Update Quantity
-        </button>
     </t>
 
 </templates>

--- a/addons/stock/static/src/stock_forecasted/forecasted_graph.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_graph.xml
@@ -4,5 +4,8 @@
         <xpath expr="//canvas[@t-custom-ref='canvas']" position="attributes">
             <attribute name="height">300</attribute>
         </xpath>
+        <xpath expr="//t[@t-call='{{ this.props.buttonTemplate }}']" position="attributes">
+            <attribute name="t-if" add="!this.model.useSampleModel"/>
+        </xpath>
     </t>
 </templates>

--- a/addons/stock/static/src/stock_forecasted/forecasted_graph.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_graph.xml
@@ -4,5 +4,8 @@
         <xpath expr="//canvas[@t-custom-ref='canvas']" position="attributes">
             <attribute name="height">300</attribute>
         </xpath>
+        <xpath expr="//t[@t-call='{{ this.props.buttonTemplate }}']" position="attributes">
+            <attribute name="t-if" add="!model.useSampleModel"/>
+        </xpath>
     </t>
 </templates>

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.js
@@ -27,6 +27,22 @@ export class ForecastedHeader extends Component {
         return this.action.doAction(action);
     }
 
+    async _onClickTransfers(type) {
+        const action = await this.orm.call(
+            "stock.picking",
+            `get_action_picking_tree_${type === "incoming" ? "incoming" : "outgoing"}`
+        );
+        action.domain = [
+            ["product_id", "in", this.props.docs.product_variants_ids],
+            ["state", "not in", ["draft", "done", "cancel"]],
+            ["picking_type_id.warehouse_id", "in", this.props.selectedWarehouseIds],
+        ];
+        if (action.help) {
+            action.help = markup(action.help);
+        }
+        return this.action.doAction(action);
+    }
+
     get products() {
         return this.props.docs.product;
     }

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.js
@@ -4,7 +4,7 @@ import { Component, markup } from "@odoo/owl";
 
 export class ForecastedHeader extends Component {
     static template = "stock.ForecastedHeader";
-    static props = { docs: Object, openView: Function };
+    static props = { docs: Object, openView: Function, selectedWarehouseIds: Array };
 
     setup(){
         this.orm = useService("orm");
@@ -14,9 +14,13 @@ export class ForecastedHeader extends Component {
         this._formatFloat = (num) => formatFloat(num, { digits: [0, this.props.docs.precision] });
     }
 
-    async _onClickInventory(){
+    async _onClickInventory() {
         const productIds = this.props.docs.product_variants_ids;
         const action = await this.orm.call('product.product', 'action_open_quants', [productIds]);
+        action.domain = [
+            ...(action.domain || []),
+            ["warehouse_id", "in", this.props.selectedWarehouseIds],
+        ];
         if (action.help) {
             action.help = markup(action.help);
         }

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.js
@@ -27,6 +27,28 @@ export class ForecastedHeader extends Component {
         return this.action.doAction(action);
     }
 
+    async _onClickTransfers(type) {
+        const action = await this.orm.call("stock.picking", this._getPickingActionMethod(type));
+        action.domain = [
+            ...(action.domain || []),
+            ["product_id", "in", this.props.docs.product_variants_ids],
+            ["state", "not in", ["draft", "done", "cancel"]],
+            ["picking_type_id.warehouse_id", "in", this.props.selectedWarehouseIds],
+        ];
+        if (action.help) {
+            action.help = markup(action.help);
+        }
+        return this.action.doAction(action);
+    }
+
+    _getPickingActionMethod(type) {
+        const methodMap = {
+            incoming: "get_action_picking_tree_incoming",
+            outgoing: "get_action_picking_tree_outgoing",
+        };
+        return methodMap[type];
+    }
+
     get products() {
         return this.props.docs.product;
     }

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.xml
@@ -32,14 +32,16 @@
                 <div class="h3 col-md-auto text-center">+</div>
                 <div t-attf-class="col-md-auto text-center #{this.props.docs.incoming_qty}">
                     <div class="h3">
-                        <t t-out="this._formatFloat(this.incomingQty)"/>
+                        <a href="#" t-on-click.prevent="() => this._onClickTransfers('incoming')"
+                            t-out="this._formatFloat(this.incomingQty)"/>
                     </div>
                     <div>Incoming</div>
                 </div>
                 <div class="h3 col-md-auto text-center">-</div>
                 <div t-attf-class="col-md-auto text-center #{this.props.docs.outgoing_qty}">
                     <div class="h3">
-                        <t t-out="this._formatFloat(this.outgoingQty)"/>
+                        <a href="#" t-on-click.prevent="() => this._onClickTransfers('outgoing')"
+                            t-out="this._formatFloat(this.outgoingQty)"/>
                     </div>
                     <div>Outgoing</div>
                 </div>

--- a/addons/stock/static/src/stock_forecasted/forecasted_product_variant_filter.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_product_variant_filter.js
@@ -1,0 +1,32 @@
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { Component } from "@odoo/owl";
+
+export class ForecastedProductVariantFilter extends Component {
+    static template = "stock.ForecastedProductVariantFilter";
+    static components = { Dropdown, DropdownItem };
+    static props = { action: Object, setVariantInContext: Function, variants: Array };
+
+    setup() {
+        this.context = this.props.action.context;
+        this.variants = this.props.variants;
+    }
+
+    _onSelected(id) {
+        this.props.setVariantInContext(Number(id));
+    }
+
+    get activeVariant() {
+        return this.context.variant_id
+            ? this.variants.find((v) => v.id == this.context.variant_id)
+            : this.variants[0];
+    }
+
+    get variantItems() {
+        return this.variants.map((variant) => ({
+            id: variant.id,
+            label: variant.display_name,
+            onSelected: () => this._onSelected(variant.id),
+        }));
+    }
+}

--- a/addons/stock/static/src/stock_forecasted/forecasted_product_variant_filter.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_product_variant_filter.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="stock.ForecastedProductVariantFilter">
+        <Dropdown menuClass="o_filter_menu" items="this.variantItems">
+            <button class="btn btn-secondary">
+                <span class="fa fa-sitemap"/> Variant: <t t-out="this.activeVariant.display_name"/>
+            </button>
+        </Dropdown>
+    </t>
+</templates>

--- a/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
@@ -1,7 +1,6 @@
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { useService } from "@web/core/utils/hooks";
-import { Component, onWillStart } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 export class ForecastedWarehouseFilter extends Component {
     static template = "stock.ForecastedWarehouseFilter";
@@ -9,14 +8,8 @@ export class ForecastedWarehouseFilter extends Component {
     static props = { action: Object, setWarehouseInContext: Function, warehouses: Array };
 
     setup() {
-        this.orm = useService("orm");
         this.context = this.props.action.context;
         this.warehouses = this.props.warehouses;
-        onWillStart(this.onWillStart)
-    }
-
-    async onWillStart() {
-        this.displayWarehouseFilter = (this.warehouses.length > 1);
     }
 
     _onSelected(id){

--- a/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
-
     <t t-name="stock.ForecastedWarehouseFilter">
-        <div t-if="this.displayWarehouseFilter" class="btn-group">
-            <Dropdown items="this.warehousesItems">
-                <button class="btn btn-secondary">
-                    <span class="fa fa-home"/> Warehouse: <t t-out="this.activeWarehouse.name"/>
-                </button>
-            </Dropdown>
-        </div>
+        <Dropdown items="this.warehousesItems">
+            <button class="btn btn-secondary">
+                <span class="fa fa-home"/> Warehouse: <t t-out="this.activeWarehouse.name"/>
+            </button>
+        </Dropdown>
     </t>
-
 </templates>

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -9,7 +9,7 @@ import { ForecastedDetails } from "./forecasted_details";
 import { ForecastedHeader } from "./forecasted_header";
 import { ForecastedWarehouseFilter } from "./forecasted_warehouse_filter";
 import { ForecastedProductVariantFilter } from "./forecasted_product_variant_filter";
-import { Component, onWillStart, proxy } from "@odoo/owl";
+import { Component, markup, onWillStart, proxy } from "@odoo/owl";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
 
 export class StockForecasted extends Component {
@@ -172,7 +172,9 @@ export class StockForecasted extends Component {
     }
 
     get graphInfo() {
-        return { noContentHelp: _t("Try to add some incoming or outgoing transfers.") };
+        return {
+            noContentHelp: markup(`<span class="text-muted">${_t("No History Yet")}</span>`),
+        };
     }
 
     async openView(resModel, view, resId=false, domain = false) {

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -10,6 +10,7 @@ import { ForecastedButtons } from "./forecasted_buttons";
 import { ForecastedDetails } from "./forecasted_details";
 import { ForecastedHeader } from "./forecasted_header";
 import { ForecastedWarehouseFilter } from "./forecasted_warehouse_filter";
+import { ForecastedProductVariantFilter } from "./forecasted_product_variant_filter";
 import { Component, onWillStart } from "@odoo/owl";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
 
@@ -19,6 +20,7 @@ export class StockForecasted extends Component {
         ControlPanel,
         ForecastedButtons,
         ForecastedWarehouseFilter,
+        ForecastedProductVariantFilter,
         ForecastedHeader,
         View,
         ForecastedDetails,
@@ -37,6 +39,7 @@ export class StockForecasted extends Component {
             this.reloadReport();
         }
         this.warehouses = useState([]);
+        this.variants = useState([]);
 
         onWillStart(this._getReportValues);
     }
@@ -45,15 +48,21 @@ export class StockForecasted extends Component {
         return this.context.warehouse_id;
     }
 
+    get variantId() {
+        return this.context.variant_id;
+    }
+
     async _getReportValues() {
         await this._getResModel();
         const isTemplate = !this.resModel || this.resModel === 'product.template';
         this.reportModelName = `stock.forecasted_product_${isTemplate ? "template" : "product"}`;
         await this._loadWarehouses();
+        if (this.context.has_variants) {
+            await this._loadVariants();
         }
         const reportValues = await this.orm.call(this.reportModelName, "get_report_values", [], {
             context: this.context,
-            docids: [this.productId],
+            docids: [this.variantId || this.productId],
         });
         this.docs = {
             ...reportValues.docs,
@@ -64,7 +73,8 @@ export class StockForecasted extends Component {
     }
 
     async _getResModel(){
-        this.resModel = this.context.active_model || this.context.params?.active_model;
+        const active_model = this.context.active_model || this.context.params?.active_model;
+        this.resModel = this.variantId ? "product.product" : active_model;
         //Following is used as a fallback when the forecast is not called by an action but through browser's history
         if (!this.resModel) {
             let resModel = this.props.action.res_model;
@@ -104,9 +114,31 @@ export class StockForecasted extends Component {
         }
     }
 
+    async _loadVariants() {
+        const variants = await this.orm.searchRead(
+            "product.product",
+            [["product_tmpl_id", "=", this.productId]],
+            ["id", "display_name"]
+        );
+        this.variants = [{ id: 0, display_name: _t("All Variants") }, ...variants];
+
+        // If no variant is selected by the user, set a default.
+        if (this.variantId === undefined) {
+            this.updateVariant(this.variants[0].id);
+        }
+    }
+
     async updateWarehouse(id) {
         const hasPreviousValue = this.warehouseId !== undefined;
         this.context.warehouse_id = id;
+        if (hasPreviousValue) {
+            await this.reloadReport();
+        }
+    }
+
+    async updateVariant(id) {
+        const hasPreviousValue = this.variantId !== undefined;
+        this.context.variant_id = id;
         if (hasPreviousValue) {
             await this.reloadReport();
         }
@@ -141,7 +173,9 @@ export class StockForecasted extends Component {
         if (this.resModel === "product.template") {
             domain.push(["product_tmpl_id", "=", this.productId]);
         } else if (this.resModel === "product.product") {
-            domain.push(["product_id", "=", this.productId]);
+            const productId =
+                this.context.active_model === "product.template" ? this.variantId : this.productId;
+            domain.push(["product_id", "=", productId]);
         }
         return domain;
     }

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -11,7 +11,7 @@ import { ForecastedDetails } from "./forecasted_details";
 import { ForecastedHeader } from "./forecasted_header";
 import { ForecastedWarehouseFilter } from "./forecasted_warehouse_filter";
 import { ForecastedProductVariantFilter } from "./forecasted_product_variant_filter";
-import { Component, onWillStart } from "@odoo/owl";
+import { Component, markup, onWillStart } from "@odoo/owl";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
 
 export class StockForecasted extends Component {
@@ -181,7 +181,9 @@ export class StockForecasted extends Component {
     }
 
     get graphInfo() {
-        return { noContentHelp: _t("Try to add some incoming or outgoing transfers.") };
+        return {
+            noContentHelp: markup(`<span class="text-muted">${_t("No History Yet")}</span>`),
+        };
     }
 
     async openView(resModel, view, resId=false, domain = false) {

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { View } from "@web/views/view";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
+import { user } from "@web/core/user";
 
 import { ForecastedButtons } from "./forecasted_buttons";
 import { ForecastedDetails } from "./forecasted_details";
@@ -40,14 +41,15 @@ export class StockForecasted extends Component {
         onWillStart(this._getReportValues);
     }
 
+    get warehouseId() {
+        return this.context.warehouse_id;
+    }
+
     async _getReportValues() {
         await this._getResModel();
         const isTemplate = !this.resModel || this.resModel === 'product.template';
         this.reportModelName = `stock.forecasted_product_${isTemplate ? "template" : "product"}`;
-        this.warehouses.splice(0, this.warehouses.length);
-        this.warehouses.push(...await this.orm.searchRead('stock.warehouse', [],['id', 'name', 'code']));
-        if (!this.context.warehouse_id) {
-            this.updateWarehouse(this.warehouses[0].id);
+        await this._loadWarehouses();
         }
         const reportValues = await this.orm.call(this.reportModelName, "get_report_values", [], {
             context: this.context,
@@ -85,8 +87,25 @@ export class StockForecasted extends Component {
         }
     }
 
+    async _loadWarehouses() {
+        const warehouses = await this.orm.searchRead(
+            "stock.warehouse",
+            [["company_id", "=", user.activeCompany.id]],
+            ["id", "name", "code"]
+        );
+        this.warehouses =
+            warehouses.length > 1
+                ? [{ id: 0, name: _t("All Warehouses") }, ...warehouses]
+                : warehouses;
+
+        // If no warehouse is selected by the user, set a default.
+        if (this.warehouseId === undefined) {
+            this.updateWarehouse(this.warehouses[0].id);
+        }
+    }
+
     async updateWarehouse(id) {
-        const hasPreviousValue = this.context.warehouse_id !== undefined;
+        const hasPreviousValue = this.warehouseId !== undefined;
         this.context.warehouse_id = id;
         if (hasPreviousValue) {
             await this.reloadReport();
@@ -105,10 +124,19 @@ export class StockForecasted extends Component {
         return this.action.doAction(actionRequest, options);
     }
 
+    get selectedWarehouseIds() {
+        if (this.warehouseId === 0) {
+            return this.warehouses
+                .filter((warehouse) => warehouse.id > 0)
+                .map((warehouse) => warehouse.id);
+        }
+        return [this.warehouseId];
+    }
+
     get graphDomain() {
         const domain = [
             ["state", "=", "forecast"],
-            ["warehouse_id", "=", this.context.warehouse_id],
+            ["warehouse_id", "in", this.selectedWarehouseIds],
         ];
         if (this.resModel === "product.template") {
             domain.push(["product_tmpl_id", "=", this.productId]);

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
@@ -5,11 +5,11 @@
             <t t-set-slot="control-panel-buttons">
                 <ForecastedButtons action="this.props.action" reloadReport.bind="this.reloadReport" resModel="this.resModel"/>
             </t>
-            <t t-set-slot="control-panel-actions">
-                <div class="btn-group o_search_options position-static" role="search">
-                    <ForecastedWarehouseFilter t-if="this.warehouses.length > 1" action="this.props.action"
-                        warehouses="this.warehouses" setWarehouseInContext.bind="this.updateWarehouse"/>
-                </div>
+            <t t-set-slot="control-panel-navigation-additional">
+                <ForecastedProductVariantFilter t-if="this.context.has_variants" action="this.props.action"
+                    variants="this.variants" setVariantInContext.bind="this.updateVariant"/>
+                <ForecastedWarehouseFilter t-if="this.warehouses.length > 1" action="this.props.action"
+                    warehouses="this.warehouses" setWarehouseInContext.bind="this.updateWarehouse"/>
             </t>
         </ControlPanel>
         <div class="o-content pt-3 container-fluid overflow-auto o_stock_forecasted_page">

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
@@ -7,23 +7,22 @@
             </t>
             <t t-set-slot="control-panel-actions">
                 <div class="btn-group o_search_options position-static" role="search">
-                    <ForecastedWarehouseFilter action="this.props.action" warehouses="this.warehouses" setWarehouseInContext.bind="this.updateWarehouse"/>
+                    <ForecastedWarehouseFilter t-if="this.warehouses.length > 1" action="this.props.action"
+                        warehouses="this.warehouses" setWarehouseInContext.bind="this.updateWarehouse"/>
                 </div>
             </t>
         </ControlPanel>
         <div class="o-content pt-3 container-fluid overflow-auto o_stock_forecasted_page">
-            <ForecastedHeader docs="this.docs" openView.bind="this.openView"/>
-            <t t-if="this.context.warehouse_id">
-                <View type="'graph'"
+            <ForecastedHeader docs="this.docs" openView.bind="this.openView"
+                selectedWarehouseIds="selectedWarehouseIds"/>
+            <View type="'graph'"
                 viewId="this.stock_report_view_graph"
                 resModel="'report.stock.quantity'"
                 domain="this.graphDomain"
                 display="{controlPanel: false}"
                 context="{fill_temporal: false}"
                 info="this.graphInfo"
-                useSampleModel="true"
-                />
-            </t>
+                useSampleModel="true"/>
             <ForecastedDetails docs="this.docs" openView.bind="this.openView" reloadReport.bind="this.reloadReport"/>
         </div>
     </div>

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -750,6 +750,7 @@ class TestReports(TestReportsCommon):
         report display the good moves according to the selected warehouse.
         """
         # Warehouse config.
+        wh_1 = self.env['stock.warehouse'].search([], limit=1)
         wh_2 = self.wh_2
         picking_type_out_2 = self.env['stock.picking.type'].search([
             ('code', '=', 'outgoing'),
@@ -766,7 +767,10 @@ class TestReports(TestReportsCommon):
             move_line.product_uom_qty = 5
         delivery = delivery_form.save()
 
-        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse_id': wh_1.id},
+        )
         draft_picking_qty = self.sum_dicts(docs['product'], 'draft_picking_qty')
         self.assertEqual(len(lines), 1, "Must have 1 line.")
         self.assertEqual(draft_picking_qty['out'], 5)
@@ -781,7 +785,10 @@ class TestReports(TestReportsCommon):
 
         # Confirm the delivery -> The report still have 1 line.
         delivery.action_confirm()
-        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse_id': wh_1.id},
+        )
         draft_picking_qty = self.sum_dicts(docs['product'], 'draft_picking_qty')
         self.assertEqual(len(lines), 1)
         self.assertEqual(draft_picking_qty['out'], 0)
@@ -806,7 +813,10 @@ class TestReports(TestReportsCommon):
             move_line.product_uom_qty = 8
         delivery_2 = delivery_form.save()
 
-        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse_id': wh_1.id},
+        )
         draft_picking_qty = self.sum_dicts(docs['product'], 'draft_picking_qty')
         self.assertEqual(len(lines), 1)
         self.assertEqual(draft_picking_qty['out'], 0)
@@ -822,7 +832,10 @@ class TestReports(TestReportsCommon):
         self.assertEqual(draft_picking_qty['out'], 8)
         # Confirm the second delivery -> The report must now have 1 line.
         delivery_2.action_confirm()
-        report_values, docs, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        report_values, docs, lines = self.get_report_forecast(
+            product_template_ids=self.product_template.ids,
+            context={'warehouse_id': wh_1.id},
+        )
         draft_picking_qty = self.sum_dicts(docs['product'], 'draft_picking_qty')
         self.assertEqual(len(lines), 1)
         self.assertEqual(draft_picking_qty['out'], 0)

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -446,7 +446,7 @@
                             <button type="object"
                                 name="action_product_tmpl_forecast_report"
                                 invisible="not show_forecasted_qty_status_button"
-                                context="{'default_product_tmpl_id': id}"
+                                context="{'default_product_tmpl_id': id, 'has_variants': product_variant_count &gt; 1}"
                                 class="oe_stat_button" icon="fa-area-chart">
                                 <div class="d-flex flex-row gap-1 ms-1">
                                     <div class="o_field_widget o_stat_info flex-column align-items-end gap-1">

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -70,9 +70,8 @@ class ProductReplenish(models.TransientModel):
             res['uom_id'] = product_tmpl_id.uom_id.id
         if 'company_id' in fields:
             res['company_id'] = company.id
-        if 'warehouse_id' in fields and 'warehouse_id' not in res:
-            warehouse = self.env['stock.warehouse'].search([('company_id', '=', company.id)], limit=1)
-            res['warehouse_id'] = warehouse.id
+        if 'warehouse_id' in fields and not res.get('warehouse_id'):
+            res['warehouse_id'] = self.env['stock.warehouse'].search([('company_id', '=', company.id)], limit=1).id
         if 'route_id' in fields and 'route_id' not in res and product_tmpl_id:
             res['route_id'] = self.env['stock.route'].search(self._get_route_domain(product_tmpl_id), limit=1).id
             if not res['route_id'] and product_tmpl_id.route_ids:

--- a/addons/stock/wizard/product_replenish_views.xml
+++ b/addons/stock/wizard/product_replenish_views.xml
@@ -29,7 +29,8 @@
                                 options="{'no_open': 1, 'no_create': 1, 'quantity_field': 'quantity'}"/>
                         </div>
                         <field name="warehouse_id"
-                            groups="stock.group_stock_multi_warehouses"/>
+                            groups="stock.group_stock_multi_warehouses"
+                            readonly="context.get('default_warehouse_id')"/>
                         <field name="route_id" domain="[('id', 'in', allowed_route_ids)]"/>
                         <field name="date_planned"/>
                     </group>


### PR DESCRIPTION
The forecasted report has been refined to improve usability
and provide a more comprehensive view of stock. Previously,
users could only view data for a single warehouse and had to
navigate away to analyze product variants. Additionally, the
report’s interface had redundant actions and certain controls
were not fully interactive.

The forecasted report now provides a more intuitive and flexible
experience for users:

- Supports multi-warehouse environments for accurate stock analysis,
- Adds a variant filter, allowing users to focus on specific product variants,
- Makes incoming and outgoing quantities directly clickable, 
- Removes redundant "Update Quantity" action,
- Hides graph controls when no meaningful data is available,
- Tones down the no-content help message for a cleaner UI.

These improvements make the forecasted report more interactive,
user-friendly, and aligned with user workflows, improving efficiency
when working with stock data.


Task-4385275