### PR TITLE
[FIX] website_sale_wishlist: restore list grid layout

### DIFF
--- a/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
+++ b/addons/website_sale_wishlist/static/src/scss/website_sale_wishlist.scss
@@ -51,3 +51,93 @@
         }
     }
 }
+
+.wishlist-section {
+    &:where(:has(.o_wsale_products_opt_design_grid)) {
+        .o_wsale_products_opt_design_grid {
+            border-left: 1px solid $border-color;
+        }
+
+        .o_wishlist_products_header {
+            padding: 0 $container-padding-x * 0.5;
+            border: $border-width solid $border-color;
+            border-top: 0;
+        }
+
+        &[style*="--o-wsale-products-grid-gap: 0px"] .oe_product_image_link,
+        &[style*="--o-wsale-products-grid-gap:0px"] .oe_product_image_link {
+            @include media-breakpoint-down(lg) {
+                height: 100%;
+                transform: translateX(-50%);
+                margin-left: 50%;
+            }
+        }
+
+        .oe_product_cart {
+            --o-wsale-card-flex-align-items: stretch;
+            --o-wsale-card-info-padding: #{map-get($spacers, 2) ($container-padding-x * 0.5) map-get($spacers, 2) map-get($spacers, 2)};
+            --o-wsale-card-info-marign: 0;
+            --o-wsale-card-sub-wrap: nowrap;
+            --o-wsale-card-sub-align-items: start;
+            --o-wsale-card-info-flex-align-items: auto;
+            --o-wsale-card-padding: 0;
+
+            @include media-breakpoint-up(md) {
+                --o-wsale-card-thumb-size: calc(126px * var(--o-wsale-card-thumb-aspect-ratio, 1));
+                --o-wsale-card-info-padding: 0 #{$container-padding-x * 0.5};
+                --o-wsale-card-sub-align-items: center;
+
+                .oe_product_image_link {
+                    height: 100%;
+                }
+
+                .o_wsale_product_information_text {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                    padding-right: inherit;
+                }
+
+                .o_wsale_product_sub {
+                    position: relative;
+                }
+
+                .o_wish_price {
+                    > span, > del {
+                        text-align: center;
+                    }
+                }
+
+                .o_wish_price, .o_wsale_product_btn {
+                    --_line-gap: #{map-get($spacers, 3)};
+
+                    padding-left: var(--_line-gap);
+
+                    &:before {
+                        @include o-position-absolute(0, auto, 0);
+                        transform: translateX(calc(var(--_line-gap) * -1));
+                        border-left: $border-width solid $border-color;
+                        content: "";
+                    }
+                }
+            }
+        }
+
+        .o_wish_rm {
+            @include media-breakpoint-down(md) {
+                margin-right: $container-padding-x * 0.5;
+            }
+        }
+    }
+
+    // Grid view only
+    :where(.o_wsale_products_opt_design_grid) .o_wsale_product_btn{
+        @include media-breakpoint-between(md, lg) {
+            @include hide-submit-button-label;
+
+            .btn {
+                --btn-padding-x: 0 !important;
+            }
+        }
+    }
+}

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -285,9 +285,11 @@
             <t t-set="additional_title">Shop Wishlist</t>
             <div id="wrap" class="js_sale">
                 <div class="oe_structure" id="oe_structure_website_sale_wishlist_product_wishlist_1"/>
-                <div class="container oe_website_sale pt-4">
+                <div class="container oe_website_sale">
                     <section class="container wishlist-section pb-5">
-                        <h1 class="h4-fs mb-3">My Wishlist</h1>
+                        <div class="o_wishlist_products_header pt-4 pb-3">
+                            <h1 class="h4-fs mb-0">My Wishlist</h1>
+                        </div>
                         <div
                             id="empty-wishlist-message"
                             t-attf-class="w-100 #{'d-none' if wishes else ''}"


### PR DESCRIPTION
This PR fixes the list grid layout within the `website_sale_wishlist` module by adding missing CSS rules coming from `website_sale`.

Prior to this PR, the CSS related to the list_grid layout was scoped within `website_sale`, and inside a selector specific to the `/shop`page, meaning the wishlist was not receiving that style at all.

With this PR, we add the missing style to the wishlist page, ensuring that both list_grid layout look the same, whether users are browsing the `/shop` or `/wishlist` page.

task-5059202

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
