### PR TITLE
[FIX] account_edi_ubl_cii: fix invoice address in ubl files

### DIFF
--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -110,7 +110,7 @@
                 xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <!-- Contact. -->
-                <ram:Name t-out="partner.display_name"/>
+                <ram:Name t-out="partner.display_name if partner.name else partner.commercial_partner_id.display_name"/>
                 <ram:SpecifiedLegalOrganization t-if="specified_legal_organization_val">
                     <ram:ID t-att-schemeID="str('0002')"
                             t-out="specified_legal_organization_val"/>

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -105,7 +105,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         return {
             'partner': partner,
             'party_identification_vals': self._get_partner_party_identification_vals_list(partner.commercial_partner_id),
-            'party_name_vals': [{'name': partner.display_name}],
+            'party_name_vals': [{'name': partner.display_name if partner.name else partner.commercial_partner_id.display_name}],
             'postal_address_vals': self._get_partner_address_vals(partner),
             'party_tax_scheme_vals': self._get_partner_party_tax_scheme_vals_list(partner.commercial_partner_id, role),
             'party_legal_entity_vals': self._get_partner_party_legal_entity_vals_list(partner.commercial_partner_id),


### PR DESCRIPTION
Before this commit:
- The invoice address for a customer without a specific name is displayed as `XXXX, Invoice address` in UBL files.

After this commit:
- The invoice address is correctly named using the partner's default name in the XML, instead of the placeholder `XXXX, Invoice address.`

Backport of https://github.com/odoo/odoo/pull/232819

task-4614564

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
