### PR TITLE
[FIX] portal_rating: improve rating display by hiding empty 'by on' fragments

### DIFF
--- a/addons/portal_rating/views/rating_rating_views.xml
+++ b/addons/portal_rating/views/rating_rating_views.xml
@@ -9,11 +9,12 @@
                 <label for="publisher_comment" string="Comment"/>
                 <div>
                     <field name="publisher_comment"/>
-                    <br />
-                    <span class="oe_inline">by </span>
-                    <field name="publisher_id" class="oe_inline"/>
-                    <span class="oe_inline"> on </span>
-                    <field name="publisher_datetime" class="oe_inline"/>
+                    <div invisible="not publisher_comment">
+                        <span>by </span>
+                        <field name="publisher_id" class="oe_inline"/>
+                        <span> on </span>
+                        <field name="publisher_datetime" class="oe_inline"/>
+                    </div>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Steps to Reproduce:
1. Navigate to a rating record form view
2. View ratings without publisher comments
3. Notice confusing 'by on' text fragments appearing

Current Behavior:
- 'by on' text shows even when there's no comment or publisher information
- Text fragments remain visible after comments are removed

Expected Behavior:
- 'by' and 'on' text should only appear when there's actual content to display
- Proper conditional visibility based on comment presence

Changes Made:
- Added conditional visibility to rating form view text elements
- Improved XML structure for better maintainability
- Fixed persistent text display issues when comments are removed

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
