### PR TITLE
[FIX] website: add title to the "new website" modal

### DIFF
--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -1623,6 +1623,13 @@ msgid "Add Text Highlight Effects"
 msgstr ""
 
 #. module: website
+#. odoo-python
+#: code:addons/website/models/res_config_settings.py:0
+#, python-format
+msgid "Add Website"
+msgstr ""
+
+#. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_timeline_options
 msgid "Add Year"
 msgstr ""

--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -208,6 +208,7 @@ class ResConfigSettings(models.TransientModel):
 
     def action_website_create_new(self):
         return {
+            'name': _('Add Website'),
             'view_mode': 'form',
             'view_id': self.env.ref('website.view_website_form_view_themes_modal').id,
             'res_model': 'website',


### PR DESCRIPTION
The modal used to create a new website was missing a title. This commit fixes the issue by setting its header to "Add Website".
