### PR TITLE
[FIX] web: Cache: keep form view changes when the RPC returns.

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -95,18 +95,18 @@ export class Record extends DataPoint {
      * @param {RecordType<string, unknown>} data
      * @param {FieldSpecifications} [params]
      */
-    _setData(data, { orderBys } = {}) {
+    _setData(data, { orderBys, keepChanges } = {}) {
         this._isEvalContextReady = false;
         if (this.resId) {
             this._values = this._parseServerValues(data, { orderBys });
-            this._changes = markRaw({});
             Object.assign(this._textValues, this._getTextValues(data));
         } else {
-            this._values = markRaw({});
             const allVals = { ...this._getDefaultValues(), ...data };
-            this._initialChanges = markRaw(this._parseServerValues(allVals, { orderBys }));
-            this._changes = markRaw({ ...this._initialChanges });
+            this._values = markRaw(this._parseServerValues(allVals, { orderBys }));
             Object.assign(this._textValues, this._getTextValues(allVals));
+        }
+        if (!keepChanges) {
+            this._changes = markRaw({});
         }
         this.dirty = false;
         this.data = { ...this._values, ...this._changes };
@@ -198,10 +198,10 @@ export class Record extends DataPoint {
             } else {
                 this.model._updateConfig(this.config, { resId: false }, { reload: false });
                 this.dirty = false;
-                this._changes = markRaw(this._parseServerValues(this._getDefaultValues()));
-                this._values = markRaw({});
+                this._changes = markRaw({});
+                this._values = markRaw(this._parseServerValues(this._getDefaultValues()));
                 this._textValues = markRaw({});
-                this.data = { ...this._changes };
+                this.data = { ...this._values };
                 this._setEvalContext();
             }
         });
@@ -638,7 +638,7 @@ export class Record extends DataPoint {
             this._textValues = markRaw({ ...this._savePoint.textValues });
         } else {
             this.dirty = false;
-            this._changes = markRaw(this.isNew ? { ...this._initialChanges } : {});
+            this._changes = markRaw({});
             this._textValues = markRaw({ ...this._initialTextValues });
         }
         this.data = { ...this._values, ...this._changes };
@@ -699,6 +699,10 @@ export class Record extends DataPoint {
      * @param {FieldSpecifications} [params]
      */
     _getChanges(changes = this._changes, { withReadonly } = {}) {
+        if (!this.resId) {
+            // Apply the initial changes when the record is new
+            changes = { ...this._values, ...changes };
+        }
         const result = {};
         for (const [fieldName, value] of Object.entries(changes)) {
             const field = this.fields[fieldName];

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -312,14 +312,14 @@ export class RelationalModel extends Model {
                     if (root.config.isMonoRecord) {
                         if (!root.config.resId) {
                             // result is the response of the onchange rpc
-                            return root._setData(result.value);
+                            return root._setData(result.value, { keepChanges: true });
                         }
                         // result is the response of a web_read rpc
                         if (!result.length) {
                             // we read a record that no longer exists
                             throw new FetchRecordError([root.config.resId]);
                         }
-                        return root._setData(result[0]);
+                        return root._setData(result[0], { keepChanges: true });
                     }
 
                     // multi record case: either grouped or ungrouped

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -13136,3 +13136,131 @@ test(`cached web_read: don't cache if action have cache:false`, async () => {
     expect(`.o_last_breadcrumb_item`).toHaveText("new first record");
     expect.verifySteps(["web_read", "web_read", "web_read"]);
 });
+
+test(`cached web_read - don't loose changes`, async () => {
+    let def = null;
+    onRpc("web_read", async () => {
+        expect.step("web_read");
+        return def;
+    });
+
+    Partner._views = {
+        form: `<form><field name="foo"/></form>`,
+    };
+
+    defineActions([
+        {
+            id: 1,
+            name: "Partner",
+            res_model: "partner",
+            res_id: 1,
+            views: [[false, "form"]],
+            cache: true, // true is the default !
+        },
+        {
+            id: 2,
+            name: "Partner",
+            res_model: "partner",
+            res_id: 2,
+            views: [[false, "form"]],
+        },
+    ]);
+
+    await mountWithCleanup(WebClient);
+    // Open and Cache the first action
+    await getService("action").doAction(1);
+    expect(`.o_field_char input`).toHaveValue("yop");
+    expect(`.o_last_breadcrumb_item`).toHaveText("first record");
+
+    // Open and Cache the second action
+    await getService("action").doAction(2);
+    expect(`.o_field_char input`).toHaveValue("blip");
+    expect(`.o_last_breadcrumb_item`).toHaveText("second record");
+
+    def = new Deferred();
+
+    // Come back to the first action
+    getService("action").doAction(1);
+    await animationFrame();
+    // The record is shown even if the rpc is not finish (cached values)
+    expect(`.o_field_char input`).toHaveValue("yop");
+    expect(`.o_last_breadcrumb_item`).toHaveText("first record");
+
+    // Edit the field while the rpc is pending
+    await contains(`.o_field_widget[name=foo] input`).edit("This is yop");
+
+    // The rpc returns differnt values.
+    def.resolve([{ id: 1, foo: "new yop", display_name: "new first record" }]);
+    await animationFrame();
+
+    // The record is updated with the new values and the edition is kept
+    expect(`.o_field_char input`).toHaveValue("This is yop");
+    expect(`.o_last_breadcrumb_item`).toHaveText("new first record");
+    expect.verifySteps(["web_read", "web_read", "web_read"]);
+});
+
+test(`cached onchange - don't loose changes`, async () => {
+    let def = null;
+    onRpc("onchange", async () => {
+        expect.step("onchange");
+        return def;
+    });
+
+    Partner._views = {
+        form: `<form><field name="foo"/></form>`,
+    };
+
+    defineActions([
+        {
+            id: 1,
+            name: "Partner",
+            res_model: "partner",
+            views: [[false, "form"]],
+            cache: true, // true is the default !
+        },
+        {
+            id: 2,
+            name: "Partner",
+            res_model: "partner",
+            res_id: 2,
+            views: [[false, "form"]],
+        },
+    ]);
+
+    await mountWithCleanup(WebClient);
+    // Open and Cache the first action
+    await getService("action").doAction(1);
+    expect(`.o_field_char input`).toHaveValue("My little Foo Value");
+    expect(`.o_last_breadcrumb_item`).toHaveText("New");
+
+    // Open and Cache the second action
+    await getService("action").doAction(2);
+    expect(`.o_field_char input`).toHaveValue("blip");
+    expect(`.o_last_breadcrumb_item`).toHaveText("second record");
+
+    def = new Deferred();
+
+    // Come back to the first action
+    getService("action").doAction(1);
+    await animationFrame();
+    // The record is shown even if the rpc is not finish (cached values)
+    expect(`.o_field_char input`).toHaveValue("My little Foo Value");
+    expect(`.o_last_breadcrumb_item`).toHaveText("New");
+
+    // Edit the field while the rpc is pending
+    await contains(`.o_field_widget[name=foo] input`).edit("This is yop");
+
+    // The rpc returns differnt values.
+    def.resolve({
+        value: {
+            foo: "My New little Foo Value",
+            display_name: "",
+        },
+    });
+    await animationFrame();
+
+    // The record is updated with the new values and the edition is kept
+    expect(`.o_field_char input`).toHaveValue("This is yop");
+    expect(`.o_last_breadcrumb_item`).toHaveText("New");
+    expect.verifySteps(["onchange", "onchange"]);
+});


### PR DESCRIPTION
Before this commit, when opening an already cached form view (i.e. creating or opening a record) would display the cached information. If a user changed a field before the RPC returned, these changes would be lost as the form view would update with the data from the RPC result.

Now, the changes made by the user are kept when the RPC returns and only the non-changed fields are updated.