### PR TITLE
[IMP] point_of_sale: pre-fill partner form with search query

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -183,6 +183,7 @@
             ('remove', 'web/static/src/webclient/actions/reports/layout_assets/**/*'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
             'web/static/src/webclient/company_service.js',
+            'point_of_sale/static/src/backend/pos_res_partner_view/*',
         ],
         'point_of_sale.base_tests': [
             "web/static/lib/hoot-dom/**/*",

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -34,9 +34,16 @@ export class PartnerList extends Component {
         useHotkey("enter", () => this.onEnter());
     }
     async editPartner(p = false) {
-        const partner = await this.pos.editPartner(p);
-        if (partner) {
-            this.clickPartner(partner);
+        if (this.state.query) {
+            this.pos.partnerSearchContext = this.state.query;
+        }
+        try {
+            const partner = await this.pos.editPartner(p);
+            if (partner) {
+                this.clickPartner(partner);
+            }
+        } finally {
+            delete this.pos.partnerSearchContext;
         }
     }
     async onEnter() {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1898,7 +1898,20 @@ export class PosStore extends Reactive {
         });
     }
     editPartnerContext(partner) {
-        return {};
+        const context = {};
+        if (this.partnerSearchContext) {
+            const isPhoneNumber = /^[0-9]+$/.test(
+                this.partnerSearchContext.replace(/[+\s().-]/g, "")
+            );
+            if (isPhoneNumber) {
+                context.default_phone = this.partnerSearchContext;
+                context.default_focus = "phone";
+            } else {
+                context.default_name = this.partnerSearchContext;
+                context.default_focus = "name";
+            }
+        }
+        return context;
     }
     /**
      * @param {import("@point_of_sale/app/models/res_partner").ResPartner?} partner leave undefined to create a new partner

--- a/addons/point_of_sale/static/src/backend/pos_res_partner_view/res_partner_form_focus.js
+++ b/addons/point_of_sale/static/src/backend/pos_res_partner_view/res_partner_form_focus.js
@@ -1,0 +1,21 @@
+import { FormRenderer } from "@web/views/form/form_renderer";
+import { patch } from "@web/core/utils/patch";
+import { onMounted } from "@odoo/owl";
+
+patch(FormRenderer.prototype, {
+    setup() {
+        super.setup();
+
+        onMounted(() => {
+            const context = this.props.record.context || {};
+            const focusFieldName = context.default_focus;
+
+            if (focusFieldName) {
+                const input = document.querySelector(`[name=${focusFieldName}] input`);
+                if (input) {
+                    input.focus();
+                }
+            }
+        });
+    },
+});

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -803,3 +803,31 @@ registry.category("web_tour.tours").add("test_orderline_merge_with_higher_price_
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_customer_search_prefilled_on_create", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.searchCustomer("test customer"),
+            {
+                content: "Wait",
+                trigger: ".modal-dialog",
+                timeout: 100,
+            },
+            PartnerList.clickPartnerCreateBtn(),
+            PartnerList.checkInputForm("name", "test customer"),
+            PartnerList.selectFormDiscard(),
+
+            PartnerList.searchCustomer("+(123) 45.67-89"),
+            {
+                content: "Wait",
+                trigger: ".modal-dialog",
+                timeout: 100,
+            },
+            PartnerList.clickPartnerCreateBtn(),
+            PartnerList.checkInputForm("phone", "+(123) 45.67-89"),
+            PartnerList.selectFormDiscard(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/partner_list_util.js
@@ -1,3 +1,5 @@
+import * as Utils from "@point_of_sale/../tests/tours/utils/common";
+
 export function clickPartner(name = "", { expectUnloadPage = false } = {}) {
     return {
         content: `click partner '${name}' from partner list screen`,
@@ -64,8 +66,7 @@ export function checkContactValues(name, address = "", phone = "", mobile = "", 
 
     return steps;
 }
-
-export function searchCustomerValue(val) {
+export function searchCustomer(val) {
     return [
         {
             isActive: ["mobile"],
@@ -78,6 +79,11 @@ export function searchCustomerValue(val) {
             trigger: `.modal-dialog .input-group input`,
             run: `edit ${val}`,
         },
+    ];
+}
+export function searchCustomerValue(val) {
+    return [
+        ...searchCustomer(val),
         {
             content: `Click on search more if present`,
             trigger: `.search-more-button > button, .partner-list .partner-info:nth-child(1):contains("${val}")`,
@@ -89,5 +95,42 @@ export function searchCustomerValue(val) {
             content: `Check "${val}" is shown`,
             trigger: `.partner-list .partner-info:nth-child(1):contains("${val}")`,
         },
+    ];
+}
+export function selectFormDiscard() {
+    return [
+        {
+            trigger: "button.o_form_button_cancel",
+            content: "Click on discard the customer form",
+            run: "click",
+        },
+    ];
+}
+
+export function checkInputForm(fieldName, expectedValue) {
+    return [
+        {
+            trigger: `div[name="${fieldName}"] .o_input`,
+            content: `Check if "${expectedValue}" in form div "${fieldName}"`,
+            run: function () {
+                const input = document.querySelector(`div[name="${fieldName}"] .o_input`);
+                if (!input) {
+                    console.error(`Element div[name="${fieldName}"] .o_input not found`);
+                    return;
+                }
+                if (input.value !== expectedValue) {
+                    console.error(
+                        `Validation failed: expected "${expectedValue}", got "${input.value}"`
+                    );
+                }
+            },
+        },
+    ];
+}
+
+export function clickPartnerCreateBtn() {
+    return [
+        { ...Utils.selectButton("Create"), isActive: ["desktop"] },
+        { ...Utils.selectButton("New"), isActive: ["mobile"] },
     ];
 }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -82,6 +82,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
                 (4, cls.env.ref('base.group_user').id),
                 (4, cls.env.ref('point_of_sale.group_pos_user').id),
                 (4, cls.env.ref('stock.group_stock_user').id),
+                (4, cls.env.ref('base.group_partner_manager').id),
             ],
             'tz': 'America/New_York',
         })
@@ -2299,6 +2300,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
 
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_orderline_merge_with_higher_price_precision', login="pos_user")
+
+    def test_customer_search_prefilled_on_create(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        with self.assertLogs(level='WARNING') as log_catcher:
+            self.start_pos_tour('test_customer_search_prefilled_on_create')
+        self.assertTrue(all("Missing widget" in output for output in log_catcher.output))
 
 
 # This class just runs the same tests as above but with mobile emulation


### PR DESCRIPTION
If a user searches for a partner and no match is found, clicking "Create" will now automatically transfer the search term into the appropriate field (name or phone) in the creation form. The matched input is also auto-focused.

Task-4991076

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
