### PR TITLE
[FIX] website_event_track: allow public user to download track ics

### DIFF
--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -652,7 +652,7 @@ class EventTrack(models.Model):
             cal_track.add('summary').value = track.name
             cal_track.add('description').value = track._get_track_calendar_description()
             if track.event_id.address_inline or track.location_id:
-                cal_track.add('location').value = ', '.join([track.event_id.address_inline, track.location_id.name or ''])
+                cal_track.add('location').value = ', '.join([track.event_id.address_inline, track.location_id.sudo().name or ''])
 
             result[track.id] = cal.serialize().encode('utf-8')
         return result


### PR DESCRIPTION
[1] introduces email reminders for tracks which include an ics file url.

The ics file generation includes the location name, which is not accessible by public users.

It is safe to sudo the name by the point you already have access to the track (i.e. it is published and all ir rules were checked)

[1]: b7efd90f23833dee85c69434f84f859056650e66

task-5061885