### PR TITLE
[FIX] project: recover ability to create task from portal user incoming mail

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1918,7 +1918,11 @@ class Task(models.Model):
 
         if defaults:
             vals = {
-                **{key[8:]: value for key, value in self.env.context.items() if key.startswith("default_")},
+                **{
+                    key[8:]: value
+                    for key, value in self.env.context.items()
+                    if key.startswith("default_") and key[8:] in self._fields
+                },
                 **vals
             }
 


### PR DESCRIPTION
The new safety belt introduced in 745f3accaf775550294d6f1bf562a0dcc15f7a08
made it impossible for portal users to create tasks by sending emails to
the project alias.

@moduon MT-11332
