### PR TITLE
[FIX] website: support params for custom Goal in Plausible

### DIFF
--- a/addons/website/static/src/interactions/plausible_push.js
+++ b/addons/website/static/src/interactions/plausible_push.js
@@ -8,7 +8,7 @@ export class PlausiblePush extends Interaction {
         const { eventName, eventParams } = this.el.dataset;
 
         window.plausible ||= function () { (window.plausible.q = window.plausible.q || []).push(arguments) };
-        window.plausible(eventName, { props: eventParams || {} });
+        window.plausible(eventName, { props: JSON.parse(eventParams) || {} });
     }
 }
 

--- a/addons/website/static/tests/interactions/plausible_push.test.js
+++ b/addons/website/static/tests/interactions/plausible_push.test.js
@@ -27,5 +27,5 @@ test("plausible_push interaction notifies plausible if .js_plausible_push", asyn
     `);
     expect(core.interactions).toHaveLength(1);
     expect(window.plausible.q[0][0]).toBe("Lead Generation");
-    expect(window.plausible.q[0][1]).toEqual({ props: '{"CTA": "Contact Us"}' });
+    expect(window.plausible.q[0][1]).toEqual({ props: {"CTA": "Contact Us"} });
 });


### PR DESCRIPTION
Since commit b9b3a60, conversion to owl, the props are sent as string instead of object.
This commit restores old behaviour of using a JSON object for props.

Before commit b9b3a60:
> $($0).data('event-params')
{Type1: 'cart'}

After commit b9b3a60:
> $0.dataset.eventParams
'{"Type1": "cart"}'

After this commit:
> JSON.parse($0.dataset.eventParams)
{Type1: 'cart'}

opw-oxpslide-stbu
