### PR TITLE
[IMP] mail: show private placeholder for empty group_ids using falsy_value_label

### DIFF
--- a/addons/mail/models/mail_canned_response.py
+++ b/addons/mail/models/mail_canned_response.py
@@ -1,7 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api
+from odoo.tools import LazyTranslate
 from odoo.addons.mail.tools.discuss import Store
+
+_lt = LazyTranslate(__name__)
 
 
 class MailCannedResponse(models.Model):
@@ -27,6 +30,7 @@ class MailCannedResponse(models.Model):
         "res.groups",
         string="Authorized Groups",
         domain=lambda self: [("id", "in", self.env.user.all_group_ids.ids)],
+        falsy_value_label=_lt("🔒 Private"),
     )
     is_shared = fields.Boolean(
         string="Determines if the canned_response is currently shared with other users",

--- a/addons/mail/static/src/views/web/fields/many2many_falsy_value_label/many2many_falsy_value_label_field.js
+++ b/addons/mail/static/src/views/web/fields/many2many_falsy_value_label/many2many_falsy_value_label_field.js
@@ -1,0 +1,31 @@
+import { Component } from "@odoo/owl";
+
+import { registry } from "@web/core/registry";
+import {
+    many2ManyTagsField,
+    Many2ManyTagsField,
+} from "@web/views/fields/many2many_tags/many2many_tags_field";
+
+export class Many2ManyFalsyValueLabelField extends Component {
+    static template = "mail.Many2ManyFalsyValueLabelField";
+    static components = { Many2ManyTagsField };
+    static props = {
+        ...Many2ManyTagsField.props,
+    };
+
+    get m2mProps() {
+        return {
+            ...this.props,
+            placeholder: this.falsyValueLabel,
+        };
+    }
+
+    get falsyValueLabel() {
+        return this.props.record.fields[this.props.name].falsy_value_label;
+    }
+}
+
+registry.category("fields").add("many2many_falsy_value_label", {
+    ...many2ManyTagsField,
+    component: Many2ManyFalsyValueLabelField,
+});

--- a/addons/mail/static/src/views/web/fields/many2many_falsy_value_label/many2many_falsy_value_label_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2many_falsy_value_label/many2many_falsy_value_label_field.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="mail.Many2ManyFalsyValueLabelField">
+        <div class="o-mail-Many2ManyFalsyValueLabelField d-flex align-items-center gap-1">
+            <span t-if="props.readonly and !props.record.data[props.name].records.length" t-out="falsyValueLabel" class="text-muted"/>
+            <Many2ManyTagsField t-else="" t-props="m2mProps"/>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/tests/mock_server/mock_models/mail_canned_response.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_canned_response.js
@@ -1,19 +1,26 @@
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
-import { getKwArgs, makeKwArgs, models } from "@web/../tests/web_test_helpers";
+import { fields, getKwArgs, makeKwArgs, models } from "@web/../tests/web_test_helpers";
 
 export class MailCannedResponse extends models.ServerModel {
     _name = "mail.canned.response";
+
+    group_ids = fields.Many2many({
+        relation: "res.groups",
+        falsy_value_label: "🔒 Private",
+    });
 
     _views = {
         list: `
             <list>
                 <field name="source" widget="shortcut"/>
+                <field name="group_ids" widget="many2many_falsy_value_label"/>
             </list>
         `,
         form: `
             <form>
                 <field name="source" widget="shortcut"/>
+                <field name="group_ids" widget="many2many_falsy_value_label"/>
             </form>
         `,
         kanban: `
@@ -21,6 +28,7 @@ export class MailCannedResponse extends models.ServerModel {
                 <templates>
                     <t t-name="card">
                         <field name="source" widget="shortcut"/>
+                        <field name="group_ids" widget="many2many_falsy_value_label"/>
                     </t>
                 </templates>
             </kanban>

--- a/addons/mail/static/tests/web/fields/many2many_falsy_value_label_field.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_falsy_value_label_field.test.js
@@ -1,0 +1,38 @@
+import {
+    click,
+    contains,
+    defineMailModels,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { describe, test } from "@odoo/hoot";
+import { waitFor } from "@odoo/hoot-dom";
+import { getService, switchView } from "@web/../tests/web_test_helpers";
+
+defineMailModels();
+describe.current.tags("desktop");
+
+test("many2many_falsy_value_label widget displays `🔒 private` label across views", async () => {
+    const pyenv = await startServer();
+    pyenv["mail.canned.response"].create([{ source: "hello" }]);
+    await start();
+    await getService("action").doAction({
+        res_model: "mail.canned.response",
+        type: "ir.actions.act_window",
+        views: [
+            [false, "list"],
+            [false, "kanban"],
+            [false, "form"],
+        ],
+    });
+    await contains(".o_control_panel_navigation .o_cp_switch_buttons");
+    await waitFor(".o_switch_view:count(2)");
+    await contains(".o_list_view .o_content");
+    await contains(".o-mail-Many2ManyFalsyValueLabelField:text('🔒 Private')");
+    await switchView("kanban");
+    await contains(".o_kanban_view .o_content");
+    await contains(".o-mail-Many2ManyFalsyValueLabelField:text('🔒 Private')");
+    await click(".o_control_panel_main_buttons .o-kanban-button-new");
+    await contains(".o_form_view .o_content");
+    await contains(".o-mail-Many2ManyFalsyValueLabelField input[placeholder='🔒 Private']");
+});

--- a/addons/mail/views/mail_canned_response_views.xml
+++ b/addons/mail/views/mail_canned_response_views.xml
@@ -26,7 +26,7 @@
                     <field name="source" placeholder="e.g. hello" widget="shortcut" readonly="not is_editable"/>
                     <field name="substitution" placeholder="e.g. Hello, how may I help you?" readonly="not is_editable"/>
                     <field name="create_uid" widget="many2one_avatar_user" optional="hide"/>
-                    <field name="group_ids" widget="many2many_tags" readonly="not is_editable" optional="hide"/>
+                    <field name="group_ids" widget="many2many_falsy_value_label" readonly="not is_editable" optional="hide"/>
                     <field name="last_used" readonly="1" optional="hide"/>
                     <field name="is_editable" column_invisible="True"/>
                     <field name="is_shared" column_invisible="True"/>
@@ -43,7 +43,7 @@
                         <group>
                             <field name="source" widget="shortcut" readonly="not is_editable"/>
                             <field name="substitution" placeholder="e.g. Hello, how may I help you?" readonly="not is_editable"/>
-                            <field name="group_ids" widget="many2many_tags" readonly="not is_editable"/>
+                            <field name="group_ids" widget="many2many_falsy_value_label" readonly="not is_editable"/>
                             <field name="is_editable" invisible="True"/>
                         </group>
                     </sheet>
@@ -66,7 +66,7 @@
                                     <field name="substitution"/>
                                 </div>
                                 <div class="pt-1">
-                                    <field name="group_ids" widget="many2many_tags"/>
+                                    <field name="group_ids" widget="many2many_falsy_value_label"/>
                                 </div>
                             </div>
                         </t>


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Previously, when the `group_ids` field was left empty on canned responses,
there was no indication that the response was private.

**Desired behaviour after PR is merged:**
- Uses the python field attribute `falsy_value_label` to provide a meaningful,
translatable label for the falsy state of relational fields.
- Adds a lightweight UI widget that:
- Displays the field’s falsy_value_label  `🔒 Private` when the field is
read-only and not set.
- Falls back to the standard many2many_tags behavior when the field has values
or is editable.
- The widget is applied to `group_ids` on `mail.canned.response`, ensuring a
consistent label across list, form, and kanban views.

Related Documentation PR: https://github.com/odoo/documentation/pull/14601

Before / After:
<img width="150" height="48" alt="image" src="https://github.com/user-attachments/assets/59d9fff8-fd9c-4359-ab28-91ad6463d3d6" /> <img width="158" height="40" alt="image" src="https://github.com/user-attachments/assets/bfc768ef-a7d6-4da0-8537-b9d2d6825bcb" />

task-[5071026](https://www.odoo.com/odoo/project/1519/tasks/5071026)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
