### PR TITLE
[FIX] point_of_sale: only show alert dialog once when loading all orders

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -657,9 +657,11 @@ odoo.define('point_of_sale.TicketScreen', function (require) {
                 await this.env.pos._loadMissingPartners(fetchedOrders);
                 // Cache these fetched orders so that next time, no need to fetch
                 // them again, unless invalidated. See `_onInvoiceOrder`.
+                this.env.pos.restrictAlertDialog = false;
                 fetchedOrders.forEach((order) => {
                     this._state.syncedOrders.cache[order.id] = Order.create({}, { pos: this.env.pos, json: order });
                 });
+                delete this.env.pos.restrictAlertDialog;
             }
             this._state.syncedOrders.totalCount = totalCount;
             this._state.syncedOrders.toShow = ids.map((id) => this._state.syncedOrders.cache[id]);

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1623,11 +1623,14 @@ class Product extends PosModel {
 
         // In case of nested pricelists, it is necessary that all pricelists are made available in
         // the POS. Display a basic alert to the user in this case.
-        if (!pricelist) {
+        if (!pricelist && !this.pos.restrictAlertDialog) {
             alert(_t(
                 'An error occurred when loading product prices. ' +
                 'Make sure all pricelists are available in the POS.'
             ));
+            if (this.pos.restrictAlertDialog === false){
+                this.pos.restrictAlertDialog = true;
+            }
         }
 
         var pricelist_items = _.filter(


### PR DESCRIPTION
When pricelist are removed from the pos config and you try to access paid orders in the pos, an alert message appears to warn the user that some pricelists are missing. However this message appears once for every pos order line that was affected by a missing pricelist. This can lead to the pos being unusable because there would be many notifications to close.

Steps to reproduce:
-------------------
* Create a pricelist, min qty=1, price = 10 $
* Make that pricelist available in the shop
* Open shop and make many orders for which the pricelist can apply
* Close shop
* Remove pricelsit from configuration
* Open shop
* Go to "Orders"
* Filter on paid orders
> You have to close the notification multiple times before being able
to use the pos

Why the fix:
------------
When loading orders we'll only show the notification once. There is no need to show it multiple times since it does not provide information about which pricelist is specifially missing.

opw-4982283