### PR TITLE
[IMP] website_forum,*: remove href=#

### DIFF
--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -63,7 +63,7 @@ registerBackendAndFrontendTour("question", {
     run: "click",
 },
 {
-    trigger: "a:contains(Reply).collapsed",
+    trigger: "button:contains(Reply).collapsed",
     content: _t("Click to reply."),
     tooltipPosition: "bottom",
     run: "click",

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -82,7 +82,7 @@ registry.category("web_tour.tours").add('forum_question', {
     },
     {
         content: "Open dropdown to edit the post",
-        trigger: '.o_wforum_question a#dropdownMenuLink',
+        trigger: '.o_wforum_question button#dropdownMenuLink',
         run: "click",
     },
     {
@@ -102,7 +102,7 @@ registry.category("web_tour.tours").add('forum_question', {
         expectUnloadPage: true,
     },
     {
-        trigger: "a:contains(\"Reply\").collapsed",
+        trigger: "button:contains(\"Reply\").collapsed",
         content: "Click to reply.",
         tooltipPosition: "bottom",
         run: "click",

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -108,7 +108,7 @@
                 </span>
                 <div t-if="question_count or tags" class="dropdown ms-lg-auto">
                     <t t-if="_page_name == 'tags'" t-set="tag_filter" t-value="keep_query('filters').split('=')[1] if keep_query('filters') else ''"/>
-                    <a href="#" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown">
+                    <button class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown">
                         <!-- Foreach tag_filter/ Foreach filters -->
                         <t t-if="filters == 'all' or tag_filter == 'all' or not tag_filter and not filters">All</t>
                         <t t-if="_page_name == 'tags'">
@@ -121,7 +121,7 @@
                             <t t-elif="filters == 'unsolved'">Unsolved</t>
                             <t t-elif="filters == 'unanswered'">Unanswered</t>
                         </t>
-                    </a>
+                    </button>
                     <div class="dropdown-menu" role="menu">
                         <a t-attf-href="?#{ keep_query('search', 'sorting', 'create_uid', filters='all') }"
                             class="dropdown-item">

--- a/addons/website_forum/views/forum_forum_templates_moderation.xml
+++ b/addons/website_forum/views/forum_forum_templates_moderation.xml
@@ -133,7 +133,7 @@
                     </div>
                     <div class="modal-footer justify-content-start">
                         <button type="button" class="btn btn-primary o_wforum_mark_spam">Mark as spam</button>
-                        <a class="btn btn-light o_wforum_select_all_spam" href="#" type="button">Select All</a>
+                        <button class="btn btn-light o_wforum_select_all_spam" type="button">Select All</button>
                     </div>
                 </div>
             </div>
@@ -227,7 +227,7 @@
                                 </button>
                             </form>
                             <a t-if="queue_type == 'flagged'" t-attf-href="#{ post_url }/ask_for_mark_as_offensive" aria-label="Mark as offensive" title="Mark as offensive" class="btn btn-outline-danger flex-grow-1"><i class="fa fa-times"/><span class="ms-2">Offensive</span></a>
-                            <a t-if="queue_type == 'offensive'" href="#" disabled="disabled" aria-label="Offensive" title="Offensive" class="btn btn-outline-danger flex-grow-1"><i class="fa fa-times"/><span class="ms-2">Offensive</span></a>
+                            <button t-if="queue_type == 'offensive'" disabled="disabled" aria-label="Offensive" title="Offensive" class="btn btn-outline-danger flex-grow-1"><i class="fa fa-times"/><span class="ms-2">Offensive</span></button>
                         </div>
                     </div>
                 </div>

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -152,11 +152,11 @@
             <button type="submit" t-attf-class="o_wforum_submit_post #{ 'oe_social_share_call ' if forum.allow_share else '' }btn btn-primary my-3 #{ 'karma_required' if not question.can_answer else ''}"
                     t-att-data-karma="question.forum_id.karma_answer"
                     data-social-target-type="answer" data-hashtags="#answer">Post Answer</button>
-            <a href="#"
+            <button
                class="o_wforum_discard_btn btn btn-link"
                data-bs-toggle="collapse"
                data-bs-target=".answer_collapse"
-               aria-expanded="false">Discard</a>
+               aria-expanded="false">Discard</button>
         </div>
     </form>
 </template>
@@ -261,13 +261,12 @@
                 </section>
                 <!-- Write Answer -->
                 <div t-if="uid and not question.uid_has_answered and question.can_answer and question.state == 'active' and question.active != False" class="d-flex mt-3">
-                    <a t-attf-class="btn btn-outline-primary collapsed #{ 'karma_required text-muted' if not question.can_answer else '' }#{ ' disabled' if forum.has_pending_post else ''} text-decoration-none"
+                    <button t-attf-class="btn btn-outline-primary collapsed #{ 'karma_required text-muted' if not question.can_answer else '' }#{ ' disabled' if forum.has_pending_post else ''} text-decoration-none"
                         t-att-data-karma="question.forum_id.karma_answer"
                         data-bs-toggle="collapse"
-                        data-bs-target=".answer_collapse"
-                        href="#">
+                        data-bs-target=".answer_collapse">
                         <i class="fa fa-reply me-1"/>Reply
-                    </a>
+                    </button>
                 </div>
                 <t t-if="question.state != 'close' and question.active != False and question.can_answer and forum">
                     <div id="post_reply" class="answer_collapse position-fixed d-flex flex-column start-0 end-0 bottom-0 w-100 w-lg-50 shadow mx-auto px-3 bg-body"
@@ -364,9 +363,8 @@
                             <t t-set="helper_own_post">You can't vote for your own post</t>
                             <t t-set="helper_no_karma">You don't have enough karma</t>
                             <t t-set="helper_decline">Unmark as Best Answer</t>
-                            <a t-if="question.can_answer and question.forum_id.mode == 'questions'"
+                            <button t-if="question.can_answer and question.forum_id.mode == 'questions'"
                                 t-attf-class="o_wforum_validate_toggler btn #{ 'opacity-50 opacity-100-hover' if not answer.is_correct and answer.create_uid.id != uid and post_id.can_accept else ''} #{ 'karma_required opacity-25 ' if not post_id.can_accept else ''}#{ 'opacity-25' if answer.create_uid.id == uid else ''}"
-                                href="#"
                                 t-attf-data-karma="#{post_id.karma_accept}"
                                 t-att-data-helper-accept="helper_accept"
                                 t-att-data-helper-own-post="helper_own_post"
@@ -377,20 +375,19 @@
                                 t-attf-data-target="#answer-#{post_id.id}"
                                 t-attf-data-href="/forum/#{ slug(question.forum_id) }/post/#{ slug(answer) }/toggle_correct">
                                 <i t-attf-class="fa fa-lg #{ 'fa-check-circle text-success' if answer.is_correct else 'fa-check-circle-o' }"/>
-                            </a>
+                            </button>
                         </t>
                     </t>
                     <div class="d-flex align-items-center ms-auto">
                         <t t-if="post_id == question">
                             <t t-set="user_answer" t-value="uid and post_id.child_ids.filtered(lambda a: a.create_uid.id == uid)"/>
                             <div t-if="not user_answer and uid and question.can_answer and question.state == 'active' and question.active != False" class="d-flex ms-auto">
-                                <a t-attf-class="btn opacity-50 opacity-100-hover collapsed #{ 'karma_required text-muted' if not question.can_answer else '' }#{ 'disabled' if forum.has_pending_post else '' } text-decoration-none"
+                                <button t-attf-class="btn opacity-50 opacity-100-hover collapsed #{ 'karma_required text-muted' if not question.can_answer else '' }#{ 'disabled' if forum.has_pending_post else '' } text-decoration-none"
                                     t-att-data-karma="question.forum_id.karma_answer"
                                     data-bs-toggle="collapse" data-bs-target=".answer_collapse"
-                                    href="#"
                                 >
                                     <i class="fa fa-reply me-1"/>Reply
-                                </a>
+                                </button>
                             </div>
                             <a t-if="user_answer" class="btn btn-sm btn-primary"
                                 t-attf-href="#answer-#{user_answer.id}"
@@ -450,9 +447,9 @@
 </template>
 
 <template id="post_dropdown">
-    <a class="btn opacity-50 opacity-100-hover px-2" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button class="btn opacity-50 opacity-100-hover px-2" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="oi oi-ellipsis-h"  data-bs-toggle="tooltip" data-bs-placement="top" title="More"/>
-    </a>
+    </button>
     <div class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuLink">
         <t t-if="post_id == question">
             <t t-if="post_id.state == 'close'" t-call="website_forum.link_button">

--- a/addons/website_forum/views/forum_forum_templates_tools.xml
+++ b/addons/website_forum/views/forum_forum_templates_tools.xml
@@ -6,12 +6,12 @@
 <!-- ============================================================ -->
 
 <template id="show_flag_validator">
-    <a href="#" t-att-data-post-id="object.id" t-attf-data-action="validate" t-attf-class="o_wforum_flag_validator flag_validator btn btn-success #{'' if object.state == 'flagged' else 'd-none'} my-2 me-2" title="Validate" data-bs-toggle="tooltip" data-bs-placement="top">
+    <button t-att-data-post-id="object.id" t-attf-data-action="validate" t-attf-class="o_wforum_flag_validator flag_validator btn btn-success #{'' if object.state == 'flagged' else 'd-none'} my-2 me-2" title="Validate" data-bs-toggle="tooltip" data-bs-placement="top">
         <i class="fa fa-check"/> Accept
-    </a>
-    <a href="#" t-attf-data-action="/forum/#{object.id}/ask_for_mark_as_offensive" t-attf-class="o_wforum_flag_mark_as_offensive flag_validator #{'' if object.state == 'flagged' else 'd-none'} btn btn-danger my-2 me-2" title="Mark as Offensive"  data-bs-toggle="tooltip" data-bs-placement="top">
+    </button>
+    <button t-attf-data-action="/forum/#{object.id}/ask_for_mark_as_offensive" t-attf-class="o_wforum_flag_mark_as_offensive flag_validator #{'' if object.state == 'flagged' else 'd-none'} btn btn-danger my-2 me-2" title="Mark as Offensive"  data-bs-toggle="tooltip" data-bs-placement="top">
         <i class="fa fa-times"/> Reject
-    </a>
+    </button>
 </template>
 
 <template id="link_button">

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -324,7 +324,7 @@
                                     <div class="col-12 s_website_form_submit mb64" data-name="Submit Button">
                                         <div class="alert alert-warning mt-2 d-none" id="warning-message"></div>
                                         <div style="width: 200px" class="s_website_form_label"/>
-                                        <a href="#" role="button" class="btn btn-primary btn-lg s_website_form_send" id="apply-btn">I'm feeling lucky</a>
+                                        <button class="btn btn-primary btn-lg s_website_form_send" id="apply-btn">I'm feeling lucky</button>
                                         <span id="s_website_form_result"></span>
                                     </div>
                                 </div>

--- a/addons/website_links/static/src/interactions/website_links.js
+++ b/addons/website_links/static/src/interactions/website_links.js
@@ -9,7 +9,7 @@ import { WebsiteLinksTagsWrapper } from "@website_links/components/website_links
 class WebsiteLinks extends Interaction {
     static selector = ".o_website_links_create_tracked_url";
     dynamicContent = {
-        "#recent_links_sort_by a": {
+        "#recent_links_sort_by button": {
             "t-on-click": this.onRecentLinksFilterChange,
         },
         ".o_website_links_new_link_tracker": {
@@ -227,7 +227,7 @@ class WebsiteLinks extends Interaction {
     }
 
     updateFilters(filter) {
-        const dropdownBtnEls = this.el.querySelectorAll("#recent_links_sort_by a");
+        const dropdownBtnEls = this.el.querySelectorAll("#recent_links_sort_by button");
         for (const buttonEl of dropdownBtnEls) {
             const isCurrentFilter = buttonEl.dataset.filter === filter;
             if (isCurrentFilter) {

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -98,7 +98,7 @@ registry.category("web_tour.tours").add('website_links_tour', {
         },
         {
             content: "Sort by last clicked links",
-            trigger: "#recent_links_sort_by a[data-filter='recently-used']",
+            trigger: "#recent_links_sort_by button[data-filter='recently-used']",
             run: "click",
         },
         {

--- a/addons/website_links/views/website_links_graphs.xml
+++ b/addons/website_links/views/website_links_graphs.xml
@@ -33,8 +33,8 @@
                                 <p>
                                     <span class="o_website_links_short_url" id="short_url"><span id="short-url-host"><t t-out="short_url_host"/></span><span id="o_website_links_code"><t t-out="code"/></span></span>
                                     <span class="o_website_links_edit_tools">
-                                        <a role="button" class="o_website_links_ok_edit btn btn-sm btn-primary o_translate_inline" href="#">ok</a> or
-                                        <a class="o_website_links_cancel_edit o_translate_inline" href="#">cancel</a>
+                                        <button class="o_website_links_ok_edit btn btn-sm btn-primary o_translate_inline">ok</button> or
+                                        <button class="o_website_links_cancel_edit o_translate_inline btn btn-link p-0">cancel</button>
                                     </span>
                                     <a t-attf-class="#{'' if can_create_link_tracker_code else 'd-none'} o_website_links_edit_code o_translate_inline" aria-label="Edit code" title="Edit code"><span class="fa fa-pencil gray"></span></a>
                                     <a class="copy-to-clipboard btn btn-sm btn-primary o_translate_inline" t-att-data-clipboard-text="short_url"><i class="fa fa-copy me-2"/>Copy</a>

--- a/addons/website_links/views/website_links_template.xml
+++ b/addons/website_links/views/website_links_template.xml
@@ -50,8 +50,8 @@
                                     <p class="o_website_links_edition col-md-9 d-flex flex-nowrap gap-2 align-items-center mb-0">
                                         <span class="o_website_links_short_url d-flex align-items-center text-nowrap text-truncate" id="short_url"><span id="short-url-host" class="text-truncate"/><span id="o_website_links_code"/></span>
                                         <span class="o_website_links_edit_tools text-nowrap" style="display:none;">
-                                            <a role="button" class="o_website_links_ok_edit btn btn-sm btn-primary o_translate_inline" href="#">ok</a> or
-                                            <a class="o_website_links_cancel_edit o_translate_inline" href="#">cancel</a>
+                                            <button class="o_website_links_ok_edit btn btn-sm btn-primary o_translate_inline">ok</button> or
+                                            <button class="o_website_links_cancel_edit o_translate_inline btn btn-link p-0">cancel</button>
                                         </span>
                                         <a t-attf-class="#{'' if can_create_link_tracker_code else 'd-none'} o_website_links_edit_code o_translate_inline" aria-label="Edit code" title="Edit code"><i class="fa fa-pencil gray"/></a>
                                         <a class="copy-to-clipboard btn btn-success text-nowrap o_translate_inline"><i class="fa fa-copy me-2"/>Copy</a>
@@ -81,9 +81,9 @@
                                     Newest
                                 </button>
                                 <div id="recent_links_sort_by" class="dropdown-menu dropdown-menu-end">
-                                    <a data-filter="newest" class="dropdown-item active" href="#">Newest</a>
-                                    <a data-filter="most-clicked" class="dropdown-item" href="#">Number of Clicks</a>
-                                    <a data-filter="recently-used" class="dropdown-item" href="#">Last Clicks</a>
+                                    <button data-filter="newest" class="dropdown-item active">Newest</button>
+                                    <button data-filter="most-clicked" class="dropdown-item">Number of Clicks</button>
+                                    <button data-filter="recently-used" class="dropdown-item">Last Clicks</button>
                                 </div>
                             </div>
                         </small>

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -54,7 +54,7 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
         <div class="js_subscribe_wrap">
             <div t-attf-class="{{_wrap_classes or 'input-group'}}">
                 <input type="email" name="email" t-attf-class="s_newsletter_subscribe_form_input js_subscribe_value form-control #{_input_classes}" placeholder="Email Address"/>
-                <a role="button" href="#" t-attf-class="js_subscribe_btn o_submit {{_btn_classes or 'btn btn-primary'}}">Subscribe</a>
+                <button t-attf-class="js_subscribe_btn o_submit {{_btn_classes or 'btn btn-primary'}}">Subscribe</button>
             </div>
         </div>
     </div>
@@ -241,7 +241,7 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
                     <div class="s_website_form_submit s_website_form_no_submit_label col-12 mb-0 py-2 text-end" data-name="Submit Button">
                         <div style="width: 250px;" class="s_website_form_label"/>
                         <span id="s_website_form_result"></span>
-                        <a href="#" role="button" class="btn btn-primary ms-auto ms-lg-0 s_website_form_send">Subscribe</a>
+                        <button class="btn btn-primary ms-auto ms-lg-0 s_website_form_send">Subscribe</button>
                     </div>
                 </div>
             </form>


### PR DESCRIPTION
*website_hr_recruitment,website_links

We use `href=#` to activate <a> elements, but the default behavior of clicking this link is prevented. However, this creates an inconsistency for middle-click and Ctrl+Click, as these events are not prevented by default.

This commit removes `href=#` and replaces it with the appropriate element or class to activate the <a> elements correctly.

task-4380519

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
