### PR TITLE
[FIX] discuss: prevent undeterministic state in welcome view

### DIFF
--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -98,7 +98,7 @@ class PublicPageController(http.Controller):
                 timezone=request.env["mail.guest"]._get_timezone_from_request(request),
             )
         if guest and not guest_already_known:
-            store.add_global_values(shouldDisplayWelcomeViewInitially=True)
+            store.add_global_values(is_welcome_page_displayed=True)
             channel = channel.with_context(guest=guest)
         return self._response_discuss_public_template(store, channel)
 

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -75,7 +75,7 @@ patch(Thread.prototype, {
         if (
             this.store.env.services.ui.isSmall &&
             this.model !== "mail.box" &&
-            !this.store.shouldDisplayWelcomeViewInitially
+            !this.store.is_welcome_page_displayed
         ) {
             this.open({ focus: true });
         }

--- a/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/call/public/discuss_client_action_patch.js
@@ -15,7 +15,7 @@ patch(DiscussClientAction.prototype, {
             return;
         }
         if (
-            this.publicState.welcome ||
+            this.store.is_welcome_page_displayed ||
             this.store.discuss.thread.default_display_mode !== "video_full_screen"
         ) {
             return;

--- a/addons/mail/static/src/discuss/core/public/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public/@types/models.d.ts
@@ -4,7 +4,7 @@ declare module "models" {
         discuss_public_thread: Thread;
         inPublicPage: boolean|undefined;
         isChannelTokenSecret: boolean|undefined;
-        shouldDisplayWelcomeViewInitially: boolean|undefined;
+        is_welcome_page_displayed: boolean|undefined;
     }
     export interface Thread {
         setActiveURL: () => void;

--- a/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.js
@@ -1,6 +1,5 @@
 import { DiscussClientAction } from "@mail/core/public_web/discuss_client_action";
 import { WelcomePage } from "@mail/discuss/core/public/welcome_page";
-import { useState } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { patch } from "@web/core/utils/patch";
 
@@ -8,9 +7,6 @@ DiscussClientAction.components = { ...DiscussClientAction.components, WelcomePag
 patch(DiscussClientAction.prototype, {
     setup() {
         super.setup(...arguments);
-        this.publicState = useState({
-            welcome: this.store.shouldDisplayWelcomeViewInitially,
-        });
         if (this.store.isChannelTokenSecret) {
             // Change the URL to avoid leaking the invitation link.
             browser.history.replaceState(
@@ -30,10 +26,10 @@ patch(DiscussClientAction.prototype, {
     },
     async restoreDiscussThread() {
         await super.restoreDiscussThread(...arguments);
-        this.publicState.welcome ||=
+        this.store.is_welcome_page_displayed &&=
             this.store.discuss.thread?.default_display_mode === "video_full_screen";
     },
     closeWelcomePage() {
-        this.publicState.welcome = false;
+        this.store.is_welcome_page_displayed = false;
     },
 });

--- a/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.xml
+++ b/addons/mail/static/src/discuss/core/public/discuss_client_action_patch.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussClientAction" t-inherit-mode="extension">
         <xpath expr="//Discuss" position="attributes">
-            <attribute name="t-if">!publicState.welcome and store.discuss.hasRestoredThread </attribute>
+            <attribute name="t-if">!store.is_welcome_page_displayed and store.discuss.hasRestoredThread </attribute>
         </xpath>
         <xpath expr="//Discuss" position="after">
-            <WelcomePage t-if="publicState.welcome" proceed.bind="closeWelcomePage"/>
+            <WelcomePage t-if="store.is_welcome_page_displayed" proceed.bind="closeWelcomePage"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/public/store_service_patch.js
@@ -13,7 +13,7 @@ const storeServicePatch = {
         /** @type {boolean|undefined} */
         this.isChannelTokenSecret;
         /** @type {boolean|undefined} */
-        this.shouldDisplayWelcomeViewInitially;
+        this.is_welcome_page_displayed;
     },
 };
 


### PR DESCRIPTION
Before this commit, whether to display the welcome view was based on a component state, so it was dependent on the lifecycle of components

This commit makes the welcome page display condition a single store variable, which should prevent any lifecycle related inconsistency.

https://runbot.odoo.com/odoo/error/111051

related to: https://github.com/odoo/odoo/pull/225325
