### PR TITLE
[FIX] mail: no crash on blocking mic after meeting end

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -352,7 +352,9 @@ export class Store extends BaseStore {
         await this.store.chatHub.initPromise;
         this.ChatWindow.get(thread)?.update({ autofocus: 0 });
         await this.env.services["discuss.rtc"].toggleCall(thread, { camera: true });
-        this.rtc.enterFullscreen({ initialSidePanel: "invite" });
+        if (this.rtc.selfSession) {
+            this.rtc.enterFullscreen({ initialSidePanel: "invite" });
+        }
     }
 
     /**


### PR DESCRIPTION
Before this commit, selecting "block" when prompted for microphone/camera permissions after quitting a meeting call, would result in a traceback.

Steps to reproduce:
1. Open Discuss and click "New Meeting"
2. Observe being prompted for permissions
3. Quit call
4. Block or allow microphone/camera permission

This happens because starting a meeting attempts to enter fullscreen, which is triggered once a call is joined.
Hoever joining the call is an async function that resolves only after permissions are granted/refused.
If the user quits the call first, we attempt to enter fullscreen on a non-existent session, leading to a crash.

task-5055378
