### PR TITLE
[FIX] website: edit correct menu with "Edit Menu" on link of submenu

### DIFF
--- a/addons/website/static/src/builder/plugins/menu_data_plugin.js
+++ b/addons/website/static/src/builder/plugins/menu_data_plugin.js
@@ -44,7 +44,12 @@ export class MenuDataPlugin extends Plugin {
                         });
                     },
                     onClickEditMenu: () => {
+                        const rootID = parseInt(
+                            props.linkElement.closest("[data-content_menu_id]")?.dataset
+                                .content_menu_id
+                        );
                         this.services.dialog.add(EditMenuDialog, {
+                            rootID: isNaN(rootID) ? null : rootID,
                             save: async () => {
                                 await this.dependencies.savePlugin.save();
                                 await this.config.reloadEditor();

--- a/addons/website/static/tests/builder/website_builder/menu_data.test.js
+++ b/addons/website/static/tests/builder/website_builder/menu_data.test.js
@@ -229,6 +229,8 @@ describe("EditMenuDialog", () => {
             expect(model).toBe("website.menu");
             expect(method).toBe("get_tree");
             expect(args[0]).toBe(1);
+            expect(args[1]).toBe(null);
+            expect.step("get_tree");
             return sampleMenuData;
         });
 
@@ -243,6 +245,36 @@ describe("EditMenuDialog", () => {
         await waitFor(".o_website_dialog");
         expect(".oe_menu_editor").toHaveCount(1);
         expect(".js_menu_label").toHaveText("Top Menu Item");
+        expect.verifySteps(["get_tree"]);
+    });
+
+    test("after clicking on edit menu button in a sub-menu, an EditMenuDialog should appear", async () => {
+        await setupEditor(
+            `<ul class="nav" data-content_menu_id="4">
+                <li>
+                    <a class="nav-link" href="exists">
+                        <span>[]Top Menu Item</span>
+                    </a>
+                </li>
+            </ul>`,
+            {
+                config: { Plugins: [...MAIN_PLUGINS, MenuDataPlugin, SavePlugin] },
+            }
+        );
+
+        onRpc(({ model, method, args }) => {
+            expect(model).toBe("website.menu");
+            expect(method).toBe("get_tree");
+            expect(args[0]).toBe(1);
+            expect(args[1]).toBe(4);
+            expect.step("get_tree");
+            return sampleMenuData;
+        });
+
+        await waitFor(".o-we-linkpopover");
+        await click(".js_edit_menu");
+        await waitFor(".o_website_dialog");
+        expect.verifySteps(["get_tree"]);
     });
 
     test("clicking save in the EditMenuDialog should not clear the editor changes", async () => {


### PR DESCRIPTION
With the initial [website builder refactor], when user wanted to edit sub-menu with "Edit Menu", it opened the dialog to edit the top-level menu.

This commit fixes that behavior by looking up the id of the containing menu (if any)

Steps to reproduce:
- On `/event/<some-event>`, open website builder
- Click on a link in the menu of the event (not the top menu)
- Click on "Edit Menu" button in the link popover
- Bug: the edit menu dialog opens for the top level menu

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
