### PR TITLE
[FIX] website_sale: assume `sudo` for extra ecom fields

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2701,13 +2701,13 @@
 
     <template id="ecom_show_extra_fields" inherit_id="website_sale.product" active="True" name="Show Extra Fields">
         <xpath expr="//div[@id='product_details']" position="inside">
-            <t t-if="any([product[field.name] for field in website.shop_extra_field_ids])">
+            <t t-if="any([product.sudo()[field.name] for field in website.shop_extra_field_ids])">
                 <hr/>
                 <p class="text-muted">
-                    <t t-foreach='website.shop_extra_field_ids' t-as='field' t-if='product[field.name]'>
+                    <t t-foreach='website.shop_extra_field_ids' t-as='field' t-if='product.sudo()[field.name]'>
                         <b><t t-esc='field.label'/>: </b>
                         <t t-if='field.field_id.ttype != "binary"'>
-                            <span t-esc='product[field.name]' t-options="{'widget': field.field_id.ttype}"/>
+                            <span t-esc='product.sudo()[field.name]' t-options="{'widget': field.field_id.ttype}"/>
                         </t>
                         <t t-else=''>
                             <a target='_blank' t-attf-href='/web/content/product.template/#{product.id}/#{field.name}?download=1'>


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Enable debug mode;
2. go to Website / Configuration / Websites;
3. open first website;
4. open Product Page Extra Fields tab;
5. add Icon (Product);
6. go to a product page as Public User.

Issue
-----
> **403: Forbidden**

> [!Note]
> For this issue to occur, the extra field cannot be loaded into cache yet, making it difficult to reproduce in versions before 18.3. As of 18.3, access rights are checked regardless of cache status.

Cause
-----
It's possible to add extra fields that don't allow access to public users by default.

Solution
--------
In the `ecom_show_extra_fields` template, retrieve the field values in `sudo` mode.

opw-5031708