### PR TITLE
[PERF] pos_loyalty: load required loyalty cards in indexedDb

### DIFF
--- a/addons/pos_loyalty/models/loyalty_card.py
+++ b/addons/pos_loyalty/models/loyalty_card.py
@@ -12,7 +12,10 @@ class LoyaltyCard(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data):
-        return [('program_id', 'in', [program["id"] for program in data["loyalty.program"]['data']])]
+        return [
+            ('partner_id', 'in', [partner["id"] for partner in data["res.partner"]['data']]),
+            ('program_id', 'in', [program["id"] for program in data["loyalty.program"]['data']]),
+        ]
 
     @api.model
     def _load_pos_data_fields(self, config_id):


### PR DESCRIPTION
Before this commit:
-------------------------------------------------------------------
- All loyalty cards of a program were loaded into IndexedDB when opening the POS.
- For large datasets (e.g., 100k+ cards), this caused performance issues and slowed down the system.

After this commit:
-------------------------------------------------------------------
- Only loyalty cards matching the following criteria are loaded:
   - The related partner is loaded.
   - The related active program is loaded.
   - Card points > 0. This optimization significantly reduces unnecessary data loading and improves POS performance.

task - 4966308


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
