### PR TITLE
[IMP] account_edi_ubl_cii: group imported invoice lines by tax

### DIFF
--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -26,6 +26,7 @@ Pro rules and show the errors.
         'data/cii_22_templates.xml',
         'data/ubl_20_templates.xml',
         'data/ubl_21_templates.xml',
+        'views/account_move_views.xml',
         'views/res_partner_views.xml',
     ],
     'assets': {

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -835,6 +835,10 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         rounding_line_vals, rounding_logs = self._import_rounding_amount(invoice, tree, './{*}LegalMonetaryTotal/{*}PayableRoundingAmount', qty_factor)
         line_vals = allowance_charges_line_vals + invoice_line_vals + rounding_line_vals
 
+        if invoice.company_id.extract_single_line_per_tax:
+            # squash amls with same tax id into one aml, with the total amount
+            line_vals = invoice._get_lines_vals_group_by_tax(line_vals, invoice.partner_id, invoice_values['invoice_date'], invoice.currency_id)
+
         invoice_values = {
             **invoice_values,
             'invoice_line_ids': [Command.create(line_value) for line_value in line_vals],

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -108,6 +108,7 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             'partner_id': company.partner_id.id,
             'acc_holder_name': 'The Chosen One'
         })]
+        company.extract_single_line_per_tax = False
 
         for ubl_cii_format in ['facturx', 'ubl_bis3']:
             with self.subTest(sub_test_name=f"format: {ubl_cii_format}"):

--- a/addons/account_edi_ubl_cii/views/account_move_views.xml
+++ b/addons/account_edi_ubl_cii/views/account_move_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record model="ir.actions.server" id="action_group_lines_by_tax">
+            <field name="name">(Un)Group lines by tax</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
+            <field name="binding_model_id" ref="account.model_account_move" />
+            <field name="state">code</field>
+            <field name="binding_view_types">form</field>
+            <field name="code">
+if records:
+    records.action_group_ungroup_lines_by_tax()
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_attacheddocument.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_attacheddocument.py
@@ -52,6 +52,7 @@ class TestUBLAttachedDocument(TestUBLCommon):
         string in EmbeddedDocumentBinaryObject or as a CDATA[] value inside of an
         ExternalReference/Description tag. Importing such files should ignore the outside wrapper
         and return the correct original invoice takes from a_nz_out_invoice. """
+        self.env.company.extract_single_line_per_tax = False
         self._assert_imported_invoice_from_file(
             subfolder='tests/test_files/from_odoo',
             filename='a_nz_out_invoice_attacheddocument_b64.xml',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_au.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_au.py
@@ -170,6 +170,7 @@ class TestUBLAU(TestUBLCommon):
     ####################################################
 
     def test_import_invoice_xml(self):
+        self.env.company.extract_single_line_per_tax = False
         self._assert_imported_invoice_from_file(
             subfolder='tests/test_files/from_odoo',
             filename='a_nz_out_invoice.xml',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -292,6 +292,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
                 }
             },
         ]
+        self.env.company.extract_single_line_per_tax = False
         for test in test_data:
             cash_rounding_method = test['invoice_cash_rounding_id']
             with self.subTest(sub_test_name=f"cash rounding method: {cash_rounding_method.name if cash_rounding_method else 'None'}"):
@@ -1045,6 +1046,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
         self.assertTrue(created_bill)
 
     def test_import_invoice_xml(self):
+        self.env.company.extract_single_line_per_tax = False
         kwargs = {
             'subfolder': 'tests/test_files/from_odoo',
             'invoice_vals': {

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
@@ -252,6 +252,7 @@ class TestUBLDE(TestUBLCommon):
     ####################################################
 
     def test_import_invoice_xml(self):
+        self.env.company.extract_single_line_per_tax = False
         self._assert_imported_invoice_from_file(
             subfolder='tests/test_files/from_odoo',
             filename='xrechnung_ubl_out_invoice.xml',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_nl.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_nl.py
@@ -240,6 +240,7 @@ class TestUBLNL(TestUBLCommon):
 
     def test_import_invoice_xml(self):
         # test files https://github.com/peppolautoriteit-nl/validation ?
+        self.env.company.extract_single_line_per_tax = False
         self._assert_imported_invoice_from_file(
             subfolder='tests/test_files/from_odoo',
             filename='nlcius_out_invoice.xml',

--- a/addons/l10n_dk_oioubl/tests/test_xml_oioubl_dk.py
+++ b/addons/l10n_dk_oioubl/tests/test_xml_oioubl_dk.py
@@ -216,6 +216,7 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
 
     @freeze_time('2017-01-01')
     def test_oioubl_import_exemple_file_1(self):
+        self.env.company.extract_single_line_per_tax = False
         file_name = 'external/ADVORD_01_01_00_Invoice_v2p1.xml'
         bill = self.import_bill_xml_file_in_purchase_journal(file_name)
         self.assertRecordValues(bill, ({
@@ -234,6 +235,7 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
 
     @freeze_time('2017-01-01')
     def test_oioubl_import_exemple_file_2(self):
+        self.env.company.extract_single_line_per_tax = False
         file_name = 'external/ADVORD_02_02_00_Invoice_v2p1.xml'
         bill = self.import_bill_xml_file_in_purchase_journal(file_name)
         self.assertRecordValues(bill, ({
@@ -252,6 +254,7 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
 
     @freeze_time('2017-01-01')
     def test_oioubl_import_exemple_file_3(self):
+        self.env.company.extract_single_line_per_tax = False
         file_name = 'external/ADVORD_03_03_00_Invoice_v2p1.xml'
         bill = self.import_bill_xml_file_in_purchase_journal(file_name)
         self.assertRecordValues(bill, ({
@@ -270,6 +273,7 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
 
     @freeze_time('2017-01-01')
     def test_oioubl_import_exemple_file_4(self):
+        self.env.company.extract_single_line_per_tax = False
         file_name = 'external/BASPRO_01_01_00_Invoice_v2p1.xml'
         bill = self.import_bill_xml_file_in_purchase_journal(file_name)
         self.assertRecordValues(bill, ({

--- a/addons/purchase_edi_ubl_bis3/models/__init__.py
+++ b/addons/purchase_edi_ubl_bis3/models/__init__.py
@@ -1,2 +1,3 @@
+from . import account_move
 from . import purchase_edi_xml_ubl_bis3
 from . import purchase_order

--- a/addons/purchase_edi_ubl_bis3/models/account_move.py
+++ b/addons/purchase_edi_ubl_bis3/models/account_move.py
@@ -1,0 +1,13 @@
+from odoo.exceptions import UserError
+
+from odoo import _, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _check_move_for_group_ungroup_lines_by_tax(self):
+        # Extends account.move
+        super()._check_move_for_group_ungroup_lines_by_tax()
+        if any(line.purchase_order_id for line in self.line_ids):
+            raise UserError(_("You can only (un)group lines of an invoice not linked to a purchase order"))


### PR DESCRIPTION
[IMP] account_edi_ubl_cii: group imported invoice lines by tax

Most of the time, an accountant that imports a bill don't need to see every line. What's useful to him is to see what amount is linked to what tax.

task-5047859