### PR TITLE
[FIX] html_editor, project: fix record id mismatch on tab switch

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_odoo_plugin.js
@@ -633,7 +633,7 @@ export class CollaborationOdooPlugin extends Plugin {
         // different history, we should not apply it.
         this.historyShareId = Math.floor(Math.random() * Math.pow(2, 52)).toString();
 
-        const lastStepId = content && this.getLastHistoryStepId(content);
+        const lastStepId = content && content.match(/data-last-history-steps="([\d,]+)"/)?.[1];
         if (lastStepId) {
             this.dependencies.collaboration.setInitialBranchStepId(lastStepId);
         }

--- a/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_plugin.js
@@ -95,7 +95,10 @@ export class CollaborationPlugin extends Plugin {
      */
     getBranchIds() {
         const steps = this.dependencies.history.getHistorySteps();
-        return [this.initialBranchStepId].concat(this.branchStepIds).concat(steps.map((s) => s.id));
+        return (this.initialBranchStepId || "")
+            .split(",")
+            .concat(this.branchStepIds)
+            .concat(steps.map((s) => s.id));
     }
     /**
      * Safely set an attribute on a node.

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -27,7 +27,7 @@ function changeDescriptionContentAndSave(newContent) {
     ];
 }
 
-function insertEditorContentAndSave(newContent) {
+function insertEditorContent(newContent) {
     return [
         {
             // force focus on editable so editor will create initial p (if not yet done)
@@ -45,9 +45,9 @@ function insertEditorContentAndSave(newContent) {
                 this.anchor.dispatchEvent(new Event("input", { bubbles: true }));
             },
         },
-        ...stepUtils.saveForm(),
     ];
 }
+
 
 registry.category("web_tour.tours").add("project_task_history_tour", {
     url: "/odoo",
@@ -221,7 +221,8 @@ registry.category("web_tour.tours").add("project_task_last_history_steps_tour", 
         trigger: ".o_kanban_view .o_kanban_record:contains(Test History Task)",
         run: "click",
     },
-    ...insertEditorContentAndSave("0"),
+        ...insertEditorContent("0"),
+        ...stepUtils.saveForm(),
     {
         content: "Open History Dialog",
         trigger: ".o_cp_action_menus i.fa-cog",
@@ -245,6 +246,18 @@ registry.category("web_tour.tours").add("project_task_last_history_steps_tour", 
         trigger: '.modal button.btn-primary:contains(/^Restore$/)',
         run: "click",
     },
-    ...insertEditorContentAndSave("2")
+        ...insertEditorContent("2"),
+        ...stepUtils.saveForm(),
+        ...insertEditorContent("4"),
+    {
+        trigger: ".o_notebook_headers li:nth-of-type(2) a",
+        run: "click",
+    },
+    {
+        trigger: ".o_notebook_headers li:nth-of-type(1) a",
+        run: "click",
+    },
+        ...insertEditorContent("5"),
+        ...stepUtils.saveForm(),
     ],
 });


### PR DESCRIPTION
Problem:
When editing a task description, if changes are made and then the tab is switched before returning to the description tab and making further edits, saving raises a record ID mismatch error.

Cause:
Switching tabs destroys the editor. On reset, the editor retrieves IDs locally from the record and strips them down to the last one. This causes the loss of the last ID known by the server.

Solution:
On reset, append all IDs from the content instead of only the last one, since the server ID might not be the most recent.

Steps to reproduce:
1. Open a task.
2. Change the description.
3. Switch to another tab and return to the description.
4. Make further changes.
5. Save.
- An error occurs due to record ID mismatch.

opw-5012949


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
