### PR TITLE
[FIX] account_edi_ubl_cii: map CII PaymentReference to bill payment_reference

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -304,7 +304,7 @@ class AccountEdiXmlCII(models.AbstractModel):
 
         # ==== payment_reference ====
 
-        payment_reference_node = tree.find('.//{*}BuyerOrderReferencedDocument/{*}IssuerAssignedID')
+        payment_reference_node = tree.find('.//{*}ApplicableHeaderTradeSettlement/{*}PaymentReference')
         if payment_reference_node is not None:
             invoice.payment_reference = payment_reference_node.text
 

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -732,6 +732,21 @@ class TestUBLBE(TestUBLCommon):
             move_type='out_invoice',
         )
 
+    def test_import_header_fields_min_cii(self):
+        invoice = self._create_empty_vendor_bill()
+        self.update_invoice_from_file(
+            'l10n_account_edi_ubl_cii_tests',
+            'tests/test_files/from_factur-x_doc',
+            'facturx_invoice_basis_quantity.xml',
+            invoice,
+        )
+
+        self.assertEqual(invoice.ref, 'F20220024')
+        self.assertIn('FOURNISSEUR F', invoice.narration or '')
+        self.assertEqual(invoice.payment_reference, 'F20180023BUYER')
+        self.assertEqual(str(invoice.invoice_date), '2022-01-31')
+        self.assertEqual(str(invoice.invoice_date_due), '2022-03-02')
+
     def test_inverting_negative_price_unit(self):
         """ We can not have negative unit prices, so we try to invert the unit price and quantity.
         """


### PR DESCRIPTION
When importing a vendor bill from a Factur-X/CII PDF, we were filling `account.move.payment_reference` from `BuyerOrderReferencedDocument/IssuerAssignedID`. The payment reference lives at: `ApplicableHeaderTradeSettlement/PaymentReference`.

The fix is to read
`.//ram:ApplicableHeaderTradeSettlement/ram:PaymentReference` instead of:
`.//ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID`

Steps to reproduce
------------------
1. In Company A (ES), install `l10n_es` and `l10n_es_edi_tbai`.
2. Create a customer invoice to Company B (BE) and set a “Customer reference” under Other Info
3. send and print it.
4. Switch to Company B and upload that PDF under Vendor Bills.
5. see the payment reference

[opw-4936320](https://www.odoo.com/odoo/project/49/tasks/4936320)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
