### PR TITLE
[FIX] mail: clear composer when send a message

### DIFF
--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -32,13 +32,16 @@ export class Composer extends Record {
                 this.updateFrom = undefined;
                 return;
             }
-            this.updateFrom = "text";
             const validMentions = this.store.getMentionsFromText(this.composerText, {
                 mentionedChannels: this.mentionedChannels,
                 mentionedPartners: this.mentionedPartners,
                 mentionedRoles: this.mentionedRoles,
             });
-            this.composerHtml = prettifyMessageText(this.composerText, { validMentions });
+            const prettifiedHtml = prettifyMessageText(this.composerText, { validMentions });
+            if (this.composerHtml.toString() !== prettifiedHtml.toString()) {
+                this.updateFrom = "text";
+                this.composerHtml = prettifiedHtml;
+            }
         },
     });
     composerHtml = fields.Html(markup("<p><br></p>"), {
@@ -53,10 +56,13 @@ export class Composer extends Record {
                 this.updateFrom = undefined;
                 return;
             }
-            this.updateFrom = "html";
-            this.composerText = isHtmlEmpty(this.composerHtml)
+            const prettifiedText = isHtmlEmpty(this.composerHtml)
                 ? ""
                 : convertBrToLineBreak(this.composerHtml);
+            if (this.composerText !== prettifiedText) {
+                this.updateFrom = "html";
+                this.composerText = prettifiedText;
+            }
         },
     });
     thread = fields.One("Thread");

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1441,3 +1441,39 @@ test("html composer: send a message with styling", async () => {
     await click(".o-mail-Composer-send:enabled");
     await click(".o-mail-Message[data-persistent] strong:contains(Hello)");
 });
+
+test("[text composer] send a message end with a space clears the composer", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "General",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await insertText("textarea.o-mail-Composer-input", "Hello ");
+    await contains("textarea.o-mail-Composer-input", { value: "Hello ", count: 1 });
+    await press("Enter");
+    await contains("textarea.o-mail-Composer-input", { value: "Hello ", count: 0 });
+});
+
+test.tags("html composer");
+test("send a message end with a space clears the composer", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "General",
+    });
+    await start();
+    await openDiscuss(channelId);
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await htmlInsertText(editor, "Hello ");
+    await contains(editor.editable, { text: "Hello", count: 1 });
+    await press("Enter");
+    await contains(editor.editable, { text: "Hello", count: 0 });
+});


### PR DESCRIPTION
Clear composer input after sending a message end with a space.

task-5062642




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
