### PR TITLE
[FIX] pos_online_payment: handle error when validating online payment

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -1036,6 +1036,10 @@ export class PosOrder extends Base {
         }
     }
 
+    canBeValidated() {
+        return this.is_paid() && this._isValidEmptyOrder();
+    }
+
     _generateTicketCode() {
         return random5Chars();
     }

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -71,7 +71,7 @@
             t-on-click="() => this.validateOrder()"
             t-attf-class="
                 {{ ui.isSmall ? 'btn-switchpane flex-fill' : 'button next w-50' }}
-                {{ currentOrder.is_paid() and currentOrder._isValidEmptyOrder() ? 'highlight' : 'disabled' }}
+                {{ currentOrder.canBeValidated() ? 'highlight' : 'disabled' }}
             "
         >
             <span>Validate</span>

--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/models/pos_order.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/models/pos_order.js
@@ -8,4 +8,13 @@ patch(PosOrder.prototype, {
             onlinePaymentData: { ...this.onlinePaymentData },
         };
     },
+    canBeValidated() {
+        const hasOnlinePayment = this.payment_ids?.some(
+            (p) => p?.payment_method_id?.is_online_payment
+        );
+        if (hasOnlinePayment && typeof this.id !== "number") {
+            return false;
+        }
+        return super.canBeValidated();
+    },
 });


### PR DESCRIPTION
Currently, an error occurs when validating an online payment if the network is slow.

**Steps to Reproduce:**
1) Install POS (with demo data) and the Demo Payment module. 
2) Go to Payment Methods and create a new online payment method for any shop (e.g., a clothing shop). Set the Payment Provider to `Demo`.
3) Open a POS session for the clothing shop, select any product, and proceed to payment.
4) Open Inspect → Network tab, create a custom slow network profile(e.g., `set both download and upload speed to 1 KB/s`), and switch to that network.
5) Select the online payment method you just created and continuously click on Validate.

Error:
ValueError: Expected singleton: pos.order('p', 'o', 's', '.', 'o', 'r', 'd', 'e', 'r', '_', '4')

**Root Cause:**
When an online payment is validated, the `_isOrderValid` and `addNewPaymentLine` methods are called.
- With a slow network, the order ID is still temporary(e.g., e74a3369-7dcd-4234-b35e-04daa149ffe6) as the order is not synced completely, when the code at [1] is executed.
- Due to multiple clicks, `_isOrderValid` forces a call to `update_online_payments_data_with_server` at [2] before order is synced.
- This eventually passes the temporary ID to `get_and_set_online_payments_data` at [3], causing the issue.

**Fix:**
Prevent multiple clicks on Validate until the order is successfully synced.

[1]- https://github.com/odoo/odoo/blob/eb88370e2fc1887e8c88dfd8dbeadce23bb7abe5/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js#L11-L17

[2]- https://github.com/odoo/odoo/blob/eb88370e2fc1887e8c88dfd8dbeadce23bb7abe5/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js#L87

[3]- https://github.com/odoo/odoo/blob/eb88370e2fc1887e8c88dfd8dbeadce23bb7abe5/addons/pos_online_payment/static/src/overrides/pos_overrides/models/pos_store.js#L18-L26

**sentry-6849786792**
