### PR TITLE
[FIX] spreadsheet_dashboard: enable chart click navigation on mobile

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.js
+++ b/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { useService } from "@web/core/utils/hooks";
-import { _t } from "@web/core/l10n/translation";
+import { navigateToOdooMenu } from "@spreadsheet/helpers/helpers";
 
 patch(spreadsheet.components.FigureComponent.prototype, {
     setup() {
@@ -12,28 +12,17 @@ patch(spreadsheet.components.FigureComponent.prototype, {
         this.actionService = useService("action");
         this.notificationService = useService("notification");
     },
-    async navigateToOdooMenu() {
-        const menu = this.env.model.getters.getChartOdooMenu(this.props.figure.id);
-        if (!menu) {
-            throw new Error(`Cannot find any menu associated with the chart`);
-        }
-        if (!menu.actionID) {
-            this.notificationService.add(
-                _t(
-                    "The menu linked to this chart doesn't have an corresponding action. Please link the chart to another menu."
-                ),
-                { type: "danger" }
-            );
-            return;
-        }
-        await this.actionService.doAction(menu.actionID);
-    },
     get hasOdooMenu() {
         return this.env.model.getters.getChartOdooMenu(this.props.figure.id) !== undefined;
     },
     async onClick() {
-        if (this.env.isDashboard() && this.hasOdooMenu) {
-            this.navigateToOdooMenu();
+        if (this.hasOdooMenu) {
+            await navigateToOdooMenu({
+                figureId: this.props.figure.id,
+                model: this.env.model,
+                notificationService: this.notificationService,
+                actionService: this.actionService,
+            });
         }
     },
 });

--- a/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.xml
+++ b/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.xml
@@ -4,12 +4,12 @@
             <div
                 t-if="hasOdooMenu and !env.isDashboard()"
                 class="o-figure-menu-item o-chart-external-link"
-                t-on-click="navigateToOdooMenu">
+                t-on-click="onClick">
                 <span class="fa fa-external-link" />
             </div>
         </xpath>
         <xpath expr="//div[hasclass('o-figure')]" position="attributes">
-            <attribute name="t-on-click">() => this.onClick()</attribute>
+            <attribute name="t-on-click">() => env.isDashboard() ? this.onClick() : ""</attribute>
             <attribute name="t-att-role">env.isDashboard() and hasOdooMenu ? "button" : ""</attribute>
         </xpath>
     </div>

--- a/addons/spreadsheet/static/src/helpers/helpers.js
+++ b/addons/spreadsheet/static/src/helpers/helpers.js
@@ -1,5 +1,7 @@
 /** @odoo-module */
 
+import { _t } from "@web/core/l10n/translation";
+
 /**
  * Get the intersection of two arrays
  *
@@ -95,4 +97,21 @@ export function containsReferences(cell) {
         return false;
     }
     return cell.compiledFormula.tokens.some((token) => token.type === "REFERENCE");
+}
+
+export async function navigateToOdooMenu({ figureId, model, notificationService, actionService }) {
+    const menu = model.getters.getChartOdooMenu(figureId);
+    if (!menu) {
+        throw new Error(`Cannot find any menu associated with the chart`);
+    }
+    if (!menu.actionID) {
+        notificationService.add(
+            _t(
+                "The menu linked to this chart doesn't have an corresponding action. Please link the chart to another menu."
+            ),
+            { type: "danger" }
+        );
+        return;
+    }
+    await actionService.doAction(menu.actionID);
 }

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.js
@@ -3,11 +3,15 @@
 import * as spreadsheet from "@odoo/o-spreadsheet";
 
 import { Component, useSubEnv } from "@odoo/owl";
+import { navigateToOdooMenu } from "@spreadsheet/helpers/helpers";
+import { useService } from "@web/core/utils/hooks";
 const { registries } = spreadsheet;
 const { figureRegistry } = registries;
 
 export class MobileFigureContainer extends Component {
     setup() {
+        this.actionService = useService("action");
+        this.notificationService = useService("notification");
         useSubEnv({
             model: this.props.spreadsheetModel,
             isDashboard: () => this.props.spreadsheetModel.getters.isDashboard(),
@@ -33,6 +37,21 @@ export class MobileFigureContainer extends Component {
     isBefore(f1, f2) {
         // TODO be smarter
         return f1.x < f2.x ? f1.y < f2.y : f1.y < f2.y;
+    }
+
+    hasOdooMenu(figureId) {
+        return this.props.spreadsheetModel.getters.getChartOdooMenu(figureId) !== undefined;
+    }
+
+    async onClick(figureId) {
+        if (this.hasOdooMenu(figureId)) {
+            await navigateToOdooMenu({
+                figureId,
+                model: this.props.spreadsheetModel,
+                notificationService: this.notificationService,
+                actionService: this.actionService,
+            });
+        }
     }
 }
 

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
@@ -7,6 +7,7 @@
         <div
             t-foreach="figures" t-as="figure"
             t-key="figure.id"
+            t-on-click="() => this.onClick(figure.id)"
             t-attf-style="min-height: #{figure.height}px; direction: ltr;"
         >
             <t t-component="getFigureComponent(figure)" figure="figure" onFigureDeleted="() => {}"/>


### PR DESCRIPTION
Current behavior before PR:
- Clicking on a chart in mobile did nothing,
unlike on desktop where it redirects to the linked Odoo menu.

Desired behavior after PR is merged:
- Clicking on a chart in mobile also redirects to the corresponding Odoo menu.
- The test has been refactored to remove duplication and improve readability.

Task: [4884509](https://www.odoo.com/odoo/2328/tasks/4884509)