### PR TITLE
[IMP] hr: group employees by birthday month instead of full date

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -72,7 +72,7 @@
                         <filter name="group_job" string="Job Position" domain="[]" context="{'group_by': 'job_id'}"/>
                         <filter name="group_employee_type" string="Employee Type" domain="[]" context="{'group_by': 'employee_type'}"/>
                         <separator name="main_groupby_separator"/>
-                        <filter name="group_birthday" domain="[]" context="{'group_by': 'birthday'}"/>
+                        <filter name="group_birthday" domain="[]" context="{'group_by': 'birthday_month'}"/>
                         <filter name="group_start" string="Start Date" domain="[]" context="{'group_by': 'contract_date_start'}" groups="hr.group_hr_manager"/>
                         <separator name="secondary_groupby_separator"/>
                         <separator name="managers_groupby_separator"/>
@@ -632,9 +632,9 @@
                                     <span t-if="record.contract_date_end.raw_value"> - </span>
                                     <field t-if="record.contract_date_end.raw_value" name="contract_date_end"/>
                                 </div>
-                                <div invisible="birthday_public_display_string == 'hidden'">
+                                <div invisible="not birthday" groups="hr.group_hr_user">
                                     <i class="fa fa-fw me-2 fa-birthday-cake text-primary" title="Birthday"/>
-                                    <field name="birthday_public_display_string"/>
+                                    <field name="birthday"/>
                                 </div>
                                 <field name="employee_properties" widget="properties"/>
                                 <field class="hr_tags" name="category_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" optional="hide"/>


### PR DESCRIPTION
#### Behavior before PR
When grouping employees by birthday, selecting "Month" from the
dropdown produced separate columns for the same month in different
years.
Employee birthdays on cards were only visible if "Show to all employees"
was checked, even for HR officers.

#### Behavior after PR
- A single grouping option "Birthday Month" is available in both
  `hr.employee` and `hr.employee.public` views.
- HR officers always see employee birthdays on cards if set,
  regardless of the "Show to all employees" checkbox.
- Non-HR users see employees only if their birthday is public.
- Grouping now produces one column per month, regardless of year.
- Month names still need translation in this context.

#### Solution
Added computed/stored fields `birthday_month` (for HR) and
`birthday_month_public` (for public), derived from `birthday`
and `birthday_public_display`. Updated search views to use
these fields for grouping.

task-5049427