### PR TITLE
[FIX] website_slides: prevent error if slide not found

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1512,10 +1512,16 @@ class WebsiteSlides(WebsiteProfile):
             slide = request.env['slide.slide'].browse(slide_id)
             if not slide.exists() or not slide.sudo().active:
                 raise werkzeug.exceptions.NotFound()
+            # redirection to channel's homepage for category slides
+            if slide.sudo().is_category:
+                return request.redirect(slide.channel_id.website_url)
 
             referer_url = request.httprequest.headers.get('Referer', '')
             if is_external_embed:
                 slide.sudo()._embed_increment(referer_url)
+
+            if not slide.has_access('read'):
+                return request.render('website_slides.embed_slide_forbidden', {})
 
             values = self._get_slide_detail(slide)
             values['page'] = page

--- a/addons/website_slides/tests/test_embed_detection.py
+++ b/addons/website_slides/tests/test_embed_detection.py
@@ -50,3 +50,19 @@ class TestEmbedDetection(HttpCase, common.SlidesCase):
         self.assertFalse(bool(self.env['slide.embed'].search([
             ('slide_id', '=', self.slide.id)
         ])))
+
+    def test_embed_category_slide(self):
+        self.slide.channel_id.website_id = False
+        res = self.url_open(f'/slides/embed/{self.category.id}')
+        res.raise_for_status()
+        self.assertFalse(bool(self.env['slide.embed'].search([
+            ('slide_id', '=', self.category.id)
+        ])))
+
+    def test_embed_if_no_website_id(self):
+        self.slide.channel_id.website_id = False
+        res = self.url_open(f'/slides/embed/{self.slide.id}')
+        res.raise_for_status()
+        self.assertFalse(bool(self.env['slide.embed'].search([
+            ('slide_id', '=', self.slide.id)
+        ])))


### PR DESCRIPTION
When users try to access a `slide ID` that is not included in `channel_slides_ids`, a traceback occurs.

Steps to reproduce:
---
- Install `website_slides` module
- Go to the Website and click on the `Courses` menu.
- Then go to `/slides/embed/<int:slide_id>` route. (http://localhost:8069/slides/embed/7)
- The error will occur.

Traceback:
---
`ValueError: 7 is not in list`

At [1], `slide_content_ids` contains the IDs of `channel content`. However, we are trying to access a slide from the `channel category` in URL. As a result, at [2], when attempting to find the index of the slide in `slide_content_ids`, an error occurs because the slide ID actually belongs to `slide_category_ids` and is not present in `slide_content_ids`.

Solution:
---
Added a special case for category slides — if the slide is a category, redirect to the channel homepage.

[1]- https://github.com/odoo/odoo/blob/482bb19e103de9ddbe1b1942b94b33d3da38889b/addons/website_slides/controllers/main.py#L120 [2]- https://github.com/odoo/odoo/blob/482bb19e103de9ddbe1b1942b94b33d3da38889b/addons/website_slides/controllers/main.py#L121

sentry-6572999628

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
