### PR TITLE
[FIX] website_sale: Product tags visibility issue

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2335,10 +2335,7 @@
     </template>
 
     <template id="product_tags" name="Product Tags" active="True">
-        <div
-            class="o_product_tags o_field_tags d-flex flex-wrap align-items-center gap-2 mb-2 mt-1"
-            t-if="any(tag.visible_to_customers for tag in all_product_tags)"
-        >
+        <div class="o_product_tags o_field_tags d-flex flex-wrap align-items-center gap-2 mb-2 mt-1">
             <t t-foreach="all_product_tags" t-as="tag">
                 <t t-if="tag.visible_to_customers">
                     <span t-if="tag.image"


### PR DESCRIPTION
### Steps to Reproduce:

1. Create a database of version 18.0 to 18.3 with the website and website_sale modules installed.
2. Create a product and add some variants for that product.
3. Assign product tags to all variants.
4. In the default variant of the product, add tags where visible_to_customer = False.
5. Migrate that database to version 18.4.

### Issue:

After migration, product tags are not shown for any variant If the default product variant has no visible tags.

This happens because of the condition:
`t-if="any(tag.visible_to_customers for tag in all_product_tags)"` defined in website_sale.product_tags
[view](https://github.com/odoo/odoo/blob/saas-18.4/addons/website_sale/views/templates.xml#L2337-L2361)

Here, the template is always rendered with all_product_tags from the [default variant](https://github.com/odoo/odoo/blob/saas18.4/addons/website_sale/views/templates.xml#L1979-L1987). So, if the default variant has no visible_to_customer tags, the condition fails, and as a result, tags from other variants are never displayed—even if they are visible.

### Fix:
Remove the redundant outer condition:
`t-if="any(tag.visible_to_customers for tag in all_product_tags)"` Since inside the loop we already have:
`<t t-if="tag.visible_to_customers">`
which checks visibility for each tag individually across variants, There’s no need for the extra wrapper condition.

This ensures product tags are displayed correctly for all variants that have visible_to_customers = True, regardless of the default variant’s tags.

OPW - [5031068](https://www.odoo.com/odoo/project/70/tasks/5031068)
UPG - [3114696](https://upgrade.odoo.com/odoo/upgrade.request/3114696)

Description of the issue/feature this PR addresses:

#### Current behavior before PR:
The product tag is not visible on the website, even though the tag is visible to customer
<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/64bea4b4-314a-4595-8b46-b93b745086b0" />



#### behavior after PR is merged:
The product tag is visible now
<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/694cc0c8-fc92-441c-b7be-e835298fbec2" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
