### PR TITLE
[FIX] core: can compute translated non-callable


### DIFF
--- a/odoo/addons/test_new_api/tests/test_related_translation.py
+++ b/odoo/addons/test_new_api/tests/test_related_translation.py
@@ -348,3 +348,8 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
         # inconsistent behavior but usually users don't care or may even be happy about it
         self.assertEqual(record_en.html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
         self.assertEqual(record_fr.html, '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
+    def test_edit_translations_related_compute(self):
+        self.patch(self.env['test_new_api.related_translation_2']._fields['name'], 'readonly', True)
+        self.patch(self.env['test_new_api.related_translation_2']._fields['name'], 'inverse', None)
+        self.assertEqual(self.test2.with_context(lang='fr_FR', edit_translations=True).name, 'Couteau')

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -1219,7 +1219,7 @@ class Cache:
         """
         if field.translate:
             # only for model translated fields
-            lang = (records.env.lang or 'en_US') if dirty else records.env._lang
+            lang = (records.env.lang or 'en_US') if dirty or field.translate is True else records.env._lang
             field_cache = self._get_field_cache(records, field)
             cache_values = []
             for record, value in zip(records, values):


### PR DESCRIPTION
Scenario:

- activate another lang on website
- go to a product page (eg. /shop/1)
- swith to secondary language and edit translations

Result: a 500 error page is shown with error:

  Error while render the template
  ValueError: Compute method failed to assign
              product.template.attribute.value(378,).name
  Template: website_sale.product

Cause:

From 18.0 40d79d6c869e2fdd0e85c372aa589373e6607975 used an underscore
prefixed lang in cache, when it should have only done so if the field
had a callable translate.

note: to have the issue, the field needs to also be readonly or we use
update_raw with the non underscore prefixed language.

opw-5039727
opw-5040036
opw-5043034
opw-5043718
opw-5045525
opw-5049079
opw-5049139
opw-5045575
opw-5049531
opw-5049811
opw-5052090
opw-5052930
opw-5053949
opw-5057485
opw-5058659
opw-5059343
opw-5059987
opw-5060138

closes #[225192](https://github.com/odoo/odoo/pull//225192)