### PR TITLE
[IMP] mail,*: use data-* attributes for test

### DIFF
--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -432,11 +432,11 @@ test("Local sidebar category state is shared between tabs", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(undefined, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
-    await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-down", { target: env1 });
-    await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-down", { target: env2 });
-    await click(".o-mail-DiscussSidebarCategory-livechat .btn", { target: env1 });
-    await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-right", { target: env1 });
-    await contains(".o-mail-DiscussSidebarCategory-livechat .oi-chevron-right", { target: env2 });
+    await contains(`${env1.selector} .o-mail-DiscussSidebarCategory-livechat .oi-chevron-down`);
+    await contains(`${env2.selector} .o-mail-DiscussSidebarCategory-livechat .oi-chevron-down`);
+    await click(`${env1.selector} .o-mail-DiscussSidebarCategory-livechat .btn`);
+    await contains(`${env1.selector} .o-mail-DiscussSidebarCategory-livechat .oi-chevron-right`);
+    await contains(`${env2.selector} .o-mail-DiscussSidebarCategory-livechat .oi-chevron-right`);
 });
 
 test("live chat is displayed below its category", async () => {

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -250,15 +250,15 @@ test("chat bubbles are synced between tabs", async () => {
     });
     const tab1 = await start({ asTab: true });
     const tab2 = await start({ asTab: true });
-    await contains(".o-mail-ChatBubble", { target: tab1 });
-    await contains(".o-mail-ChatBubble", { target: tab2 });
+    await contains(`${tab1.selector} .o-mail-ChatBubble`);
+    await contains(`${tab2.selector} .o-mail-ChatBubble`);
     await runAllTimers(); // Wait for bus service to fully load
-    await click(".o-mail-ChatBubble[name='Marc']", { target: tab1 });
-    await contains(".o-mail-ChatWindow", { target: tab2 }); // open sync
-    await click(".o-mail-ChatWindow-command[title='Fold']", { target: tab2 });
-    await contains(".o-mail-ChatWindow", { target: tab1, count: 0 }); // fold sync
-    await click(".o-mail-ChatBubble[name='Marc'] .o-mail-ChatBubble-close", { target: tab1 });
-    await contains(".o-mail-ChatBubble[name='Marc']", { target: tab2, count: 0 }); // close sync
+    await click(`${tab1.selector} .o-mail-ChatBubble[name='Marc']`);
+    await contains(`${tab2.selector} .o-mail-ChatWindow`); // open sync
+    await click(`${tab2.selector} .o-mail-ChatWindow-command[title='Fold']`);
+    await contains(`${tab1.selector} .o-mail-ChatWindow`, { count: 0 }); // fold sync
+    await click(`${tab1.selector} .o-mail-ChatBubble[name='Marc'] .o-mail-ChatBubble-close`);
+    await contains(`${tab2.selector} .o-mail-ChatBubble[name='Marc']`, { count: 0 }); // close sync
 });
 
 test("Chat bubbles do not fetch messages until becoming open", async () => {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -205,18 +205,18 @@ test.skip("Fold state of chat window is sync among browser tabs", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const env1 = await start({ asTab: true });
     const env2 = await start({ asTab: true });
-    await click(".o_menu_systray i[aria-label='Messages']", { target: env1 });
-    await click(".o-mail-NotificationItem", { target: env1 });
-    await contains(".o-mail-ChatWindow-header", { target: env2 });
-    await click(".o-mail-ChatWindow-header", { target: env1 }); // Fold
-    await contains(".o-mail-Thread", { count: 0, target: env1 });
-    await contains(".o-mail-Thread", { count: 0, target: env2 });
-    await click(".o-mail-ChatBubble", { target: env2 }); // Unfold
-    await contains(".o-mail-ChatWindow .o-mail-Thread", { target: env1 });
-    await contains(".o-mail-ChatWindow .o-mail-Thread", { target: env2 });
-    await click("[title*='Close Chat Window']", { target: env1 });
-    await contains(".o-mail-ChatWindow", { count: 0, target: env1 });
-    await contains(".o-mail-ChatWindow", { count: 0, target: env2 });
+    await click(`${env1.selector} .o_menu_systray i[aria-label='Messages']`);
+    await click(`${env1.selector} .o-mail-NotificationItem`);
+    await contains(`${env2.selector} .o-mail-ChatWindow-header`);
+    await click(`${env1.selector} .o-mail-ChatWindow-header`); // Fold
+    await contains(`${env1.selector} .o-mail-Thread`, { count: 0 });
+    await contains(`${env2.selector} .o-mail-Thread`, { count: 0 });
+    await click(`${env2.selector} .o-mail-ChatBubble`); // Unfold
+    await contains(`${env1.selector} .o-mail-ChatWindow .o-mail-Thread`);
+    await contains(`${env2.selector} .o-mail-ChatWindow .o-mail-Thread`);
+    await click(`${env1.selector} [title*='Close Chat Window']`);
+    await contains(`${env1.selector} .o-mail-ChatWindow`, { count: 0 });
+    await contains(`${env2.selector} .o-mail-ChatWindow`, { count: 0 });
 });
 
 test("Mobile: opening a chat window should not update channel state on the server", async () => {

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -26,10 +26,10 @@ test("Messages are received cross-tab", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
-    await insertText(".o-mail-Composer-input", "Hello World!", { target: env1 });
-    await click("button[aria-label='Send']:enabled", { target: env1 });
-    await contains(".o-mail-Message-content", { target: env1, text: "Hello World!" });
-    await contains(".o-mail-Message-content", { target: env2, text: "Hello World!" });
+    await insertText(`${env1.selector} .o-mail-Composer-input`, "Hello World!");
+    await click(`${env1.selector} button[aria-label='Send']:enabled`);
+    await contains(`${env1.selector} .o-mail-Message-content`, { text: "Hello World!" });
+    await contains(`${env2.selector} .o-mail-Message-content`, { text: "Hello World!" });
 });
 
 test("Delete starred message updates counter", async () => {
@@ -46,13 +46,13 @@ test("Delete starred message updates counter", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
-    await contains(".o-mail-Message", { target: env1, text: "Hello World!" });
-    await contains(".o-mail-Message", { target: env2, text: "Hello World!" });
-    await contains("button", { target: env2, text: "Starred1" });
-    await click(":nth-child(1 of .o-mail-Message) [title='Expand']", { target: env2 });
-    await click(".o-mail-Message-moreMenu [title='Delete']", { target: env2 });
-    await click("button", { text: "Confirm" }, { target: env2 });
-    await contains("button", { count: 0, target: env2, text: "Starred1" });
+    await contains(`${env1.selector} .o-mail-Message`, { text: "Hello World!" });
+    await contains(`${env2.selector} .o-mail-Message`, { text: "Hello World!" });
+    await contains(`${env2.selector} button`, { text: "Starred1" });
+    await click(`${env2.selector} :nth-child(1 of .o-mail-Message) [title='Expand']`);
+    await click(`${env2.selector} .o-mail-Message-moreMenu [title='Delete']`);
+    await click(`${env2.selector} button`, { text: "Confirm" });
+    await contains(`${env2.selector} button`, { count: 0, text: "Starred1" });
 });
 
 test.tags("focus required");
@@ -66,13 +66,12 @@ test("Thread rename", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
-    await insertText(".o-mail-Discuss-threadName:enabled", "Sales", {
+    await insertText(`${env1.selector} .o-mail-Discuss-threadName:enabled`, "Sales", {
         replace: true,
-        target: env1,
     });
     triggerHotkey("Enter");
-    await contains(".o-mail-Discuss-threadName[title='Sales']", { target: env2 });
-    await contains(".o-mail-DiscussSidebarChannel", { target: env2, text: "Sales" });
+    await contains(`${env2.selector} .o-mail-Discuss-threadName[title='Sales']`);
+    await contains(`${env2.selector} .o-mail-DiscussSidebarChannel`, { text: "Sales" });
 });
 
 test.tags("focus required");
@@ -86,14 +85,17 @@ test("Thread description update", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
-    await insertText(".o-mail-Discuss-threadDescription", "The very best channel", {
-        replace: true,
-        target: env1,
-    });
+    await insertText(
+        `${env1.selector} .o-mail-Discuss-threadDescription`,
+        "The very best channel",
+        {
+            replace: true,
+        }
+    );
     triggerHotkey("Enter");
-    await contains(".o-mail-Discuss-threadDescription[title='The very best channel']", {
-        target: env2,
-    });
+    await contains(
+        `${env2.selector} .o-mail-Discuss-threadDescription[title='The very best channel']`
+    );
 });
 
 test.skip("Channel subscription is renewed when channel is added from invite", async () => {
@@ -147,9 +149,9 @@ test("Adding attachments", async () => {
         attachment_ids: [attachmentId],
         message_id: messageId,
     });
-    await contains(".o-mail-AttachmentCard:not(.o-isUploading):contains(test.txt)", {
-        target: env2,
-    });
+    await contains(
+        `${env2.selector} .o-mail-AttachmentCard:not(.o-isUploading):contains(test.txt)`
+    );
 });
 
 test("Remove attachment from message", async () => {
@@ -170,10 +172,10 @@ test("Remove attachment from message", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
-    await contains(".o-mail-AttachmentCard", { target: env1, text: "test.txt" });
-    await click(".o-mail-AttachmentCard-unlink", { target: env2 });
-    await click(".modal-footer .btn", { text: "Ok", target: env2 });
-    await contains(".o-mail-AttachmentCard", { count: 0, target: env1, text: "test.txt" });
+    await contains(`${env1.selector} .o-mail-AttachmentCard`, { text: "test.txt" });
+    await click(`${env2.selector} .o-mail-AttachmentCard-unlink`);
+    await click(`${env2.selector} .modal-footer .btn`, { text: "Ok" });
+    await contains(`${env1.selector} .o-mail-AttachmentCard`, { count: 0, text: "test.txt" });
 });
 
 test("Message delete notification", async () => {

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -331,13 +331,13 @@ test("join/leave sounds are only played on main tab", async () => {
     });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
-    await click("[title='Start a Call']", { target: env1 });
-    await contains(".o-discuss-Call", { target: env1 });
-    await contains(".o-discuss-Call", { target: env2 });
+    await click(`${env1.selector} [title='Start a Call']`);
+    await contains(`${env1.selector} .o-discuss-Call`);
+    await contains(`${env2.selector} .o-discuss-Call`);
     await assertSteps(["tab1 - play - channel-join"]);
-    await click("[title='Disconnect']:not([disabled])", { target: env1 });
-    await contains(".o-discuss-Call", { target: env1, count: 0 });
-    await contains(".o-discuss-Call", { target: env2, count: 0 });
+    await click(`${env1.selector} [title='Disconnect']:not([disabled])`);
+    await contains(`${env1.selector} .o-discuss-Call`, { count: 0 });
+    await contains(`${env2.selector} .o-discuss-Call`, { count: 0 });
     await assertSteps(["tab1 - play - channel-leave"]);
 });
 

--- a/addons/mail/static/tests/discuss/core/attachment_panel.test.js
+++ b/addons/mail/static/tests/discuss/core/attachment_panel.test.js
@@ -59,20 +59,17 @@ test("Can toggle allow public upload", async () => {
     const env1 = await start({ asTab: true });
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
-    await click(".o-mail-Discuss-header button[title='Attachments']", { target: env1 });
-    await contains(".o-mail-ActionPanel", {
+    await click(`${env1.selector} .o-mail-Discuss-header button[title='Attachments']`);
+    await contains(`${env1.selector} .o-mail-ActionPanel`, {
         contains: ["label", { text: "File upload is disabled for external users" }],
-        target: env1,
     });
     await openDiscuss(channelId, { target: env2 });
-    await click(".o-mail-Discuss-header button[title='Attachments']", { target: env2 });
-    await contains(".o-mail-ActionPanel", {
+    await click(`${env2.selector} .o-mail-Discuss-header button[title='Attachments']`);
+    await contains(`${env2.selector} .o-mail-ActionPanel`, {
         contains: ["label", { text: "File upload is disabled for external users" }],
-        target: env2,
     });
-    await click(".o-mail-ActionPanel input[type='checkbox']", { target: env1 });
-    await contains(".o-mail-ActionPanel", {
+    await click(`${env1.selector} .o-mail-ActionPanel input[type='checkbox']`);
+    await contains(`${env2.selector} .o-mail-ActionPanel`, {
         contains: ["label", { text: "File upload is enabled for external users" }],
-        target: env2,
     });
 });

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -274,14 +274,14 @@ test("Chat is added to discuss on other tab that the one that joined", async () 
     const env2 = await start({ asTab: true });
     await openDiscuss(undefined, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
-    await click(".o-mail-DiscussSidebarCategory-chat .o-mail-DiscussSidebarCategory-add", {
-        target: env1,
-    });
-    await insertText(".o-discuss-ChannelSelector input", "Jer", { target: env1 });
-    await click(".o-discuss-ChannelSelector-suggestion", { target: env1 });
+    await click(
+        `${env1.selector} .o-mail-DiscussSidebarCategory-chat .o-mail-DiscussSidebarCategory-add`
+    );
+    await insertText(`${env1.selector} .o-discuss-ChannelSelector input`, "Jer");
+    await click(`${env1.selector} .o-discuss-ChannelSelector-suggestion`);
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel", { target: env1, text: "Jerry Golay" });
-    await contains(".o-mail-DiscussSidebarChannel", { target: env2, text: "Jerry Golay" });
+    await contains(`${env1.selector} .o-mail-DiscussSidebarChannel`, { text: "Jerry Golay" });
+    await contains(`${env2.selector} .o-mail-DiscussSidebarChannel`, { text: "Jerry Golay" });
 });
 
 test("no conversation selected when opening non-existing channel in discuss", async () => {

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -1276,10 +1276,10 @@ test("Update channel data via bus notification", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
-    await contains(".o-mail-DiscussSidebarChannel", { text: "Sales", target: env1 });
-    await insertText(".o-mail-Discuss-threadName", "test", { target: env1 });
+    await contains(`${env1.selector} .o-mail-DiscussSidebarChannel`, { text: "Sales" });
+    await insertText(`${env1.selector} .o-mail-Discuss-threadName`, "test");
     await triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel", { text: "Salestest", target: env2 });
+    await contains(`${env2.selector} .o-mail-DiscussSidebarChannel`, { text: "Salestest" });
 });
 
 test("sidebar: show loading on initial opening", async () => {

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -283,6 +283,8 @@ async function addSwitchTabDropdownItem(rootTarget, tabTarget) {
     dropdownDiv.querySelector(".dropdown-menu").appendChild(li);
 }
 
+let discussAsTabId = 0;
+
 /**
  * @param {{
  *  asTab?: boolean;
@@ -326,13 +328,16 @@ export async function start(options) {
     }
     let env;
     if (options?.asTab) {
+        discussAsTabId++;
         restoreRegistry(registry);
         const rootTarget = target;
         target = document.createElement("div");
         target.classList.add("o-mail-Discuss-asTabContainer");
+        target.dataset.asTabId = discussAsTabId;
         rootTarget.appendChild(target);
         addSwitchTabDropdownItem(rootTarget, target);
-        env = await makeMockEnv({}, { makeNew: true });
+        const selector = `.o-mail-Discuss-asTabContainer[data-as-tab-id="${target.dataset.asTabId}"]`;
+        env = await makeMockEnv({ discussAsTabId, selector }, { makeNew: true });
     } else {
         env = getMockEnv() || (await makeMockEnv({}));
     }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1244,9 +1244,8 @@ test("Toggle star should update starred counter on all tabs", async () => {
     const env2 = await start({ asTab: true });
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(undefined, { target: env2 });
-    await click(".o-mail-Message [title='Mark as Todo']", { target: env1 });
-    await contains("button", {
-        target: env2,
+    await click(`${env1.selector} .o-mail-Message [title='Mark as Todo']`);
+    await contains(`${env2.selector} button`, {
         text: "Starred",
         contains: [".badge", { text: "1" }],
     });


### PR DESCRIPTION
This commit updates the test selectors to use data-as-tab-id to avoid ambiguity. This change enhances the robustness of the tests by reducing their dependency on CSS classes.

Using data-as-tab-id attributes provides a more stable and reliable way to select elements in the DOM for testing purposes.

backport - https://github.com/odoo/odoo/pull/224974

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
