### PR TITLE
[FIX] mrp: prevent component consumption when only quants are changed

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -406,9 +406,10 @@ class StockMove(models.Model):
                 updated_product_move._action_confirm()
                 move_to_unlink.unlink()
                 self = other_move + updated_product_move
-        if self.env.context.get('force_manual_consumption'):
-            vals['manual_consumption'] = True
-            vals['picked'] = True
+        if self.env.context.get('force_manual_consumption') and 'quantity' in vals:
+            moves_to_update = self.filtered(lambda move: move.product_uom_qty != vals['quantity'])
+            if moves_to_update:
+                moves_to_update.write({'manual_consumption': True, 'picked': True})
         if 'product_uom_qty' in vals and 'move_line_ids' in vals:
             # first update lines then product_uom_qty as the later will unreserve
             # so possibly unlink lines

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -244,3 +244,62 @@ class TestManualConsumption(TestMrpCommon):
         self.assertEqual(mo.reservation_state, "assigned")
         mo.move_raw_ids.filtered(lambda m: m.product_id == components[0]).picked = True
         self.assertEqual(mo.reservation_state, "assigned")
+
+    def test_no_consumption_when_quant_changed(self):
+        """
+        Test to ensure that from 'Details' wizard, changing only the lot or location
+        of a component move line/quant (without changing the quantity) does not mark it as consumed.
+
+        The wizard (opened via 'action_show_details' on move) should only set
+        'manual_consumption' and 'picked' to True when the done quantity(quantity)
+        differs from the demanded quantity(product_uom_qty).
+        """
+        bom = self.bom_4
+        component = bom.bom_line_ids.product_id
+        component.write({
+            "is_storable": True,
+            "tracking": "lot",
+        })
+
+        # Create two lots with quants.
+        lots = self.env["stock.lot"].create([
+            {"name": f"lot_{i}", "product_id": component.id} for i in range(2)
+        ])
+        for lot in lots:
+            self.env["stock.quant"]._update_available_quantity(
+                component, self.stock_location, 5, lot_id=lot
+            )
+
+        # Create and confirm a Manufacturing Order.
+        mo_form = Form(self.env["mrp.production"])
+        mo_form.bom_id = bom
+        mo_form.product_qty = 1
+        mo = mo_form.save()
+        mo.action_confirm()
+
+        # Initially: not consumed.
+        self.assertRecordValues(mo.move_raw_ids, [
+            {"manual_consumption": False, "picked": False, "lot_ids": lots[0].ids},
+        ])
+
+        # Change only the lot in the 'Details' wizard, keep quantity unchanged.
+        with Form.from_action(self.env, mo.move_raw_ids[0].action_show_details()) as wiz_form:
+            with wiz_form.move_line_ids.edit(0) as move_line:
+                move_line.lot_id = lots[1]
+            wiz_form.save()
+
+        # Still it should not consumed.
+        self.assertRecordValues(mo.move_raw_ids, [
+            {"manual_consumption": False, "picked": False, "lot_ids": lots[1].ids},
+        ])
+
+        # Change the quantity in the 'Details' wizard.
+        with Form.from_action(self.env, mo.move_raw_ids[0].action_show_details()) as wiz_form:
+            with wiz_form.move_line_ids.edit(0) as move_line:
+                move_line.quantity = 2
+            wiz_form.save()
+
+        # Now it should be marked as consumed, since the done quantity differs from the demand.
+        self.assertRecordValues(mo.move_raw_ids, [
+            {"manual_consumption": True, "picked": True, "lot_ids": lots[1].ids},
+        ])


### PR DESCRIPTION
Issue Before This Commit:
============================
When only the quants/move line were changed without modifying the quantity,
the system automatically marked components as consumed (manual consumption
and picked boolean were set). This created confusion for the user since
no actual consumption took place.

Steps to Reproduce:
============================
- Install the `mrp` module.
- Create a tracked product (lot/serial) with quants.
- Create and confirm an MO having that product as a component.
- Change only the quants (e.g., location of the quant, not quantity);
  notice that manual consumption and picked boolean are set.

Cause of the Issue:
===========================
This issue occurs when clicking the 'Details' button (`action_show_details` 
method) on a stock move. That action passes the context `force_manual_consumption`, 
based on that which directly sets the `manual_consumption` and `picked` booleans in the 
`write` and `create` methods. [see](https://github.com/odoo/odoo/blob/master/addons/mrp/models/stock_move.py#L276).

With This Commit:
============================
Manual consumption and picked boolean are no longer set when only quants
(not quantity) are changed. Component consumption is now triggered only if
the quantity differs from the demand, ensuring consistency and avoiding
confusion for the user.

This fix avoids unintended behaviour by ensuring that the picked and manual
consumption booleans change only when the quantity differs from the demand.

TaskID:- 5062365