### PR TITLE
[IMP] web: recordSelector supports quickCreate and virtual record

### DIFF
--- a/addons/web/static/src/core/record_selectors/record_autocomplete.js
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.js
@@ -21,6 +21,7 @@ export class RecordAutocomplete extends Component {
         fieldString: { type: String, optional: true },
         placeholder: { type: String, optional: true },
         slots: { optional: true },
+        buildQuickCreate: { type: Function, optional: true },
     };
     static components = { AutoComplete };
     static template = "web.RecordAutocomplete";
@@ -72,9 +73,20 @@ export class RecordAutocomplete extends Component {
             });
         }
         if (options.length === 0) {
-            options.push({ label: _t("(no result)") });
+            const quickCreateOption = this.getQuickCreateOption({ request: name });
+            if (quickCreateOption) {
+                options.push(quickCreateOption);
+            } else {
+                options.push({ label: _t("(no result)") });
+            }
         }
         return options;
+    }
+
+    getQuickCreateOption({ request }) {
+        if (!!this.props.buildQuickCreate && request.length > 0) {
+            return this.props.buildQuickCreate({ request });
+        }
     }
 
     async onSearchMore(name) {

--- a/addons/web/static/src/core/record_selectors/record_selector.js
+++ b/addons/web/static/src/core/record_selectors/record_selector.js
@@ -7,12 +7,14 @@ import { RecordAutocomplete } from "./record_autocomplete";
 export class RecordSelector extends Component {
     static props = {
         resId: [Number, { value: false }],
+        virtualRecord: { type: Object, optional: true },
         resModel: String,
         update: Function,
         domain: { type: Array, optional: true },
         context: { type: Object, optional: true },
         fieldString: { type: String, optional: true },
         placeholder: { type: String, optional: true },
+        buildQuickCreate: { type: Function, optional: true },
     };
     static components = { RecordAutocomplete };
     static template = "web.RecordSelector";
@@ -41,15 +43,19 @@ export class RecordSelector extends Component {
 
     async getDisplayNames(props) {
         const ids = this.getIds(props);
-        return this.nameService.loadDisplayNames(props.resModel, ids);
+        const displayNames = await this.nameService.loadDisplayNames(props.resModel, ids);
+        if (props.virtualRecord?.display_name) {
+            displayNames[false] = props.virtualRecord.display_name;
+        }
+        return displayNames;
     }
 
     getDisplayName(props = this.props, displayNames) {
         const { resId } = props;
-        if (resId === false) {
+        if (resId === false && !props.virtualRecord?.display_name) {
             return "";
         }
-        return typeof displayNames[resId] === "string"
+        return typeof displayNames[resId || false] === "string"
             ? displayNames[resId]
             : _t("Inaccessible/missing record ID: %s", resId);
     }

--- a/addons/web/static/src/core/record_selectors/record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/record_selector.xml
@@ -17,6 +17,7 @@
                 multiSelect="false"
                 getIds="() => []"
                 update.bind="update"
+                buildQuickCreate="props.buildQuickCreate"
             >
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <span t-if="isAvatarModel" class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">


### PR DESCRIPTION
This commit adds support for two features in the RecordSelector:
- a props "buildQuickCreate" can be passed, in which case, when the name_search returns no records a quick create item is available for click.
- a props "virtualRecord" can be passed, it allows for lazy quick creating a record. Its value should be retrieved by the user of RecordSelector and deal with it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
