### PR TITLE
[IMP] core: support lazy translation as legal write value

### DIFF
--- a/odoo/addons/test_orm/i18n/fr.po
+++ b/odoo/addons/test_orm/i18n/fr.po
@@ -20,3 +20,15 @@ msgstr ""
 #: model:ir.model.constraint,message:test_orm.constraint_test_orm_category_positive_color
 msgid "The color code must be positive !"
 msgstr "La couleur doit être une valeur positive !"
+
+#. module: test_orm
+#. odoo-python
+#: code:addons/test_orm/tests/test_fields.py:0
+msgid "lazy_translation_1_en"
+msgstr "lazy_translation_1_fr"
+
+#. module: test_orm
+#. odoo-python
+#: code:addons/test_orm/tests/test_fields.py:0
+msgid "lazy_translation_2_en"
+msgstr "lazy_translation_2_fr"

--- a/odoo/addons/test_orm/i18n/test_orm.pot
+++ b/odoo/addons/test_orm/i18n/test_orm.pot
@@ -19,3 +19,15 @@ msgstr ""
 #: model:ir.model.constraint,message:test_orm.constraint_test_orm_category_positive_color
 msgid "The color code must be positive !"
 msgstr ""
+
+#. module: test_orm
+#. odoo-python
+#: code:addons/test_orm/tests/test_fields.py:0
+msgid "lazy_translation_1_en"
+msgstr ""
+
+#. module: test_orm
+#. odoo-python
+#: code:addons/test_orm/tests/test_fields.py:0
+msgid "lazy_translation_2_en"
+msgstr ""

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -14,9 +14,12 @@ from odoo.fields import Domain
 from odoo.tests import Form, TransactionCase, tagged, users
 from odoo.tools import float_repr, mute_logger
 from odoo.tools.image import image_data_uri
+from odoo.tools.translate import LazyTranslate
 
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.addons.base.tests.test_expression import TransactionExpressionCase
+
+_lt = LazyTranslate(__name__)
 
 
 class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
@@ -3251,6 +3254,23 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         self.assertEqual(record.comment0, record_value)
         record.invalidate_recordset()
         self.assertEqual(record.comment0, record_value)
+
+    def test_write_value_lazy_translation(self):
+        self.env['res.lang']._activate_lang('fr_FR')
+        Container_en = self.env['test_orm.compute.container']
+        container_en = Container_en.create({'name': 'test', 'name_translated': _lt('lazy_translation_1_en')})
+        container_fr = container_en.with_context(lang='fr_FR')
+
+        self.assertEqual(container_en.name_translated, 'lazy_translation_1_en')
+        self.assertEqual(container_fr.name_translated, 'lazy_translation_1_en')
+
+        container_en.name_translated = _lt('lazy_translation_2_en')
+        self.assertEqual(container_en.name_translated, 'lazy_translation_2_en')
+        self.assertEqual(container_fr.name_translated, 'lazy_translation_2_en')
+
+        container_fr.name_translated = _lt('lazy_translation_1_en')
+        self.assertEqual(container_en.name_translated, 'lazy_translation_2_en')
+        self.assertEqual(container_fr.name_translated, 'lazy_translation_1_fr')
 
 
 class TestX2many(TransactionExpressionCase):

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -106,6 +106,8 @@ class BaseString(Field[str | typing.Literal[False]]):
         if isinstance(value, bytes):
             s = value.decode()
         else:
+            # provide ``context`` in case the ``value`` is a lazy translation object
+            context = record.env.context  # noqa: F841
             s = str(value)
         value = s[:self.size]
         if validate and callable(self.translate):

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -107,7 +107,7 @@ class BaseString(Field[str | typing.Literal[False]]):
             s = value.decode()
         else:
             # provide ``context`` in case the ``value`` is a lazy translation object
-            context = record.env.context  # noqa: F841
+            context = {'lang': record.env.context.get('lang')}  # noqa: F841
             s = str(value)
         value = s[:self.size]
         if validate and callable(self.translate):

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -505,13 +505,13 @@ def _get_uid(frame) -> int | None:
 
 
 def _get_lang(frame, default_lang='') -> str:
-    # get from: context.get('lang')
-    if 'context' in frame.f_locals and isinstance((local_context := frame.f_locals['context']), dict):
-        return local_context.get('lang') or 'en_US'
-    # get from: kwargs['context'].get('lang'),
+    # get from: context['lang']
+    if 'context' in frame.f_locals and isinstance((local_context := frame.f_locals['context']), dict) and 'lang' in local_context:
+        return local_context['lang'] or 'en_US'
+    # get from: kwargs['context']['lang'],
     if (kwargs := frame.f_locals.get('kwargs')) and isinstance(kwargs, dict) \
-        and 'context' in kwargs and isinstance((local_context := kwargs['context']), dict):
-        return local_context.get('lang') or 'en_US'
+        and 'context' in kwargs and isinstance((local_context := kwargs['context']), dict) and 'lang' in local_context:
+        return local_context['lang'] or 'en_US'
     # get from: self.env.context.get('lang')
     if isinstance((local_env := getattr((frame.f_locals.get('self')), 'env', None)), odoo.api.Environment):
         return local_env.context.get('lang') or 'en_US'


### PR DESCRIPTION
before this commit,
1. lang=None in context or env is not equivalent to lang='en_US'
2. record is not considered which causes lazy translation object cannot be correctly stringified in field.convert_to_cache

after this commit,
1. for valid context, env, lang=None is equivalent to lang='en_US'
2. lazy translation objects can be correctly stringified in field.convert_to_cache with lang in record.env

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
