### PR TITLE
[FIX] hr_timesheet_attendance: qualify undefined sql query variable

### DIFF
--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report.py
@@ -44,7 +44,7 @@ class TimesheetAttendance(models.Model):
                             at time zone 'utc'
                             at time zone
                                 (SELECT calendar.tz FROM resource_calendar as calendar
-                                INNER JOIN hr_employee as employee ON employee.id = employee_id
+                                INNER JOIN hr_employee as employee ON employee.id = hr_attendance.employee_id
                                 WHERE calendar.id = employee.resource_calendar_id)
                     as DATE) as date,
                     resource_resource.company_id as company_id


### PR DESCRIPTION
In the affected query, the variable "employee_id" is undefined in the scope where it is used. This leads postgres to interpret it as a variable with default type VARCHAR and to the impossibility to compare it against an integer. We just qualify the variable name so it now works as expected.

Failing upgrade requests:
[3103245](https://upgrade.odoo.com/odoo/request/3103245)
[3121291](https://upgrade.odoo.com/odoo/request/3121291)

Fixes https://github.com/odoo/odoo/pull/192434/commits/c97ecfa7fc091f763329af589b69db2292931163
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
