### PR TITLE
[IMP] web: save separator property fold state

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/properties_field.xml
@@ -6,15 +6,14 @@
             <t t-set="_groupedPropertiesList" t-value="groupedPropertiesList"/>
             <t t-foreach="groupedPropertiesList" t-as="propertiesListGroup" t-key="propertiesListGroup_index">
                 <t t-set="foldable" t-value="propertiesListGroup.name and propertiesListGroup.title and propertiesListGroup.title.length"/>
-                <t t-set="isFolded" t-value="propertiesListGroup.name and !unfoldedSeparators.includes(propertiesListGroup.name)"/>
                 <div class="o_inner_group o_group col-lg-6 o_property_group"
                     t-att-property-name="propertiesListGroup.name || ''">
                     <div t-if="!propertiesListGroup.invisibleLabel"
                         class="o_field_property_label o_field_property_group_label d-flex flex-row w-100 mb-3 text-uppercase fw-bolder align-items-baseline pe-2"
-                        t-att-class="{'invisible': propertiesListGroup.columnSeparator, 'folded': isFolded}"
+                        t-att-class="{'invisible': propertiesListGroup.columnSeparator, 'folded': propertiesListGroup.isFolded}"
                         t-on-click="() => this.onSeparatorClick(propertiesListGroup.name)">
                         <div t-if="foldable" class="me-2">
-                            <i class="fa fa-fw" t-att-class="isFolded ? 'fa-caret-right' : 'fa-caret-down'"/>
+                            <i class="fa fa-fw" t-att-class="propertiesListGroup.isFolded ? 'fa-caret-right' : 'fa-caret-down'"/>
                         </div>
                         <span t-if="propertiesListGroup.title" t-out="propertiesListGroup.title"/>
                         <i
@@ -30,7 +29,7 @@
                         t-key="propertyConfiguration.name"
                         class="o_property_field o_wrap_label text-900"
                         t-att-class="{
-                            'd-flex flex-row': !env.isSmall and !isFolded, 'o_property_folded': isFolded,
+                            'd-flex flex-row': !env.isSmall and !propertiesListGroup.isFolded, 'o_property_folded': propertiesListGroup.isFolded,
                             'mb-4': renderedColumnsCount === 1, 'mb-3': renderedColumnsCount !== 1
                         }"
                         t-att-property-name="propertyConfiguration.name">
@@ -86,7 +85,7 @@
                             class="btn btn-light text-muted text-break m-0"
                             t-on-click="onPropertyCreate">
                             <i class="fa fa-plus"/>
-                            Add a Property
+                            Add Property
                         </button>
                     </div>
                 </div>

--- a/addons/web/static/src/views/fields/properties/property_definition.js
+++ b/addons/web/static/src/views/fields/properties/property_definition.js
@@ -244,6 +244,10 @@ export class PropertyDefinition extends Component {
             propertyDefinition.currency_field = this.defaultCurrencyField;
         }
 
+        if (newType === "separator") {
+            propertyDefinition.fold_by_default = true;
+        }
+
         PropertyDefinition._propertyParametersMap.forEach((types, param) => {
             if (!types.includes(propertyDefinition.type)) {
                 delete propertyDefinition[param];

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -203,15 +203,20 @@
                     />
                 </div>
                 <div t-else="" class="o_field_property_definition_kanban d-contents mb-3 mb-sm-0">
-                    <label t-att-for="getUniqueDomID('fold')" class="o_form_label align-self-center text-900">
-                        Fold by default
+                    <t t-set="separatorId" t-value="getUniqueDomID('separator')"/>
+                    <label t-att-for="separatorId" class="o_form_label align-self-center text-900">
+                        Default State
                     </label>
-                    <CheckBox
-                        id="getUniqueDomID('fold')"
-                        value="props.propertyDefinition.fold_by_default"
-                        disabled="props.readonly"
-                        onChange.bind="onFoldByDefaultChange"
-                    />
+                    <div class="o_field_property_definition_fold text-nowrap d-inline-flex w-100 align-items-baseline">
+                        <label class="form-check o_radio_item p-0">
+                            <input type="radio" class="form-check-input o_radio_input" t-att-checked="!state.propertyDefinition.fold_by_default" t-attf-name="{{separatorId}}_separator" t-attf-id="{{separatorId}}_open" t-on-change="() => this.onFoldByDefaultChange(false)"/>
+                            <label class="form-check-label o_form_label ms-1" t-attf-for="{{separatorId}}_open">Open</label>
+                        </label>
+                        <label class="form-check o_radio_item">
+                            <input type="radio" class="form-check-input o_radio_input" t-att-checked="!!state.propertyDefinition.fold_by_default" t-attf-name="{{separatorId}}_separator" t-attf-id="{{separatorId}}_fold" t-on-change="() => this.onFoldByDefaultChange(true)"/>
+                            <label class="form-check-label o_form_label ms-1" t-attf-for="{{separatorId}}_fold">Fold</label>
+                        </label>
+                    </div>
                 </div>
             </div>
         </div>

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -602,10 +602,6 @@ class Properties(Field):
                 # Do not store None key
                 continue
 
-            if property_type == 'separator':
-                # "separator" is used as a visual separator in the form view UI
-                # it does not have a value and does not need to be stored on children
-                continue
             if property_type not in ('integer', 'float') or property_value != 0:
                 property_value = property_value or False
             if property_type in ('many2one', 'many2many') and property_model and property_value:


### PR DESCRIPTION
Before this commit, it was only possible to set the default fold state in a separator property and this state was not saved when we toggled the group. Now, the state is always set to "folded" by default and is saved when we toggle the group. The fold state is per record.

task-5062284