### PR TITLE
[FIX] website_sale: adapts add_and_remove_main_product_image_no_variant

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
@@ -55,7 +55,7 @@ registerWebsitePreviewTour("add_and_remove_main_product_image_no_variant", {
     },
     {
         content: "Click on the new image",
-        trigger: ".o_select_media_dialog img[title='s_default_image.jpg']",
+        trigger: ".o_select_media_dialog .o_existing_attachment_cell .o_button_area",
         run: "click",
     },
     {


### PR DESCRIPTION
Fixes [1]: Since [2], a button covers the image for accessibility, so direct image clicks no longer work.

[1]: https://runbot.odoo.com/odoo/runbot.build.error/231160
[2]: https://github.com/odoo/odoo/commit/a0b630d