### PR TITLE
[FIX] website: s_company_team allow different image size


### DIFF
--- a/addons/website/static/src/snippets/s_company_team/000.scss
+++ b/addons/website/static/src/snippets/s_company_team/000.scss
@@ -1,7 +1,8 @@
 
 .s_company_team {
     @include media-breakpoint-down(lg) {
-        img {
+        // Avatar dimensions
+        .row.s_col_no_resize > .o_not_editable img.o_editable_media {
             max-width: 50%;
         }
     }


### PR DESCRIPTION
Scenario:

- Add s_company_team snippet ("Meet our team" with avatar side by side
  with description)
- Add an image in the description (small or big)
- See the page with mobile

Result: all images in the description get a fixed 50% max-width (from
18.0 a 8rem height) which was only meant for the avatar image.

Fix: be more specific with the selector to target only the avatar. The
selector .row.s_col_no_resize > .o_not_editable img.o_editable_media
should only target the intended avatar.

opw-4997932