### PR TITLE
[FIX] account: add refresh_out_einvoices_status to fetch_einvoices_cog

### DIFF
--- a/addons/account/static/src/components/fetch_einvoices/fetch_einvoices_cog.js
+++ b/addons/account/static/src/components/fetch_einvoices/fetch_einvoices_cog.js
@@ -17,6 +17,12 @@ export class FetchEInvoices extends Component {
         this.action = useService("action");
     }
 
+    get buttonAction() {
+        return this.env.searchModel.globalContext.show_fetch_in_einvoices_button
+            ? "button_fetch_in_einvoices"
+            : "button_refresh_out_einvoices_status";
+    }
+
     get buttonLabel() {
         return this.env.searchModel.globalContext.show_fetch_in_einvoices_button
             ? _t("Fetch e-Invoices")
@@ -32,7 +38,7 @@ export class FetchEInvoices extends Component {
         this.action.doActionButton({
             type: "object",
             resId: journalId,
-            name: "button_fetch_in_einvoices",
+            name: this.buttonAction,
             resModel: "account.journal",
             onClose: () => window.location.reload(),
         });


### PR DESCRIPTION
[FIX] account: add refresh_out_einvoices_status to fetch_einvoices_cog

The fetch_einvoices_cog OWL component was missing the trigger for button_refresh_out_einvoices_status, as it always called button_fetch_in_einvoices. Now the function will call a getter to allow easier customization by overriding buttonAction, and it now supports the missing flow for button_refresh_out_einvoices_status.

task-4714467
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
