### PR TITLE
[FIX] base_vat: handle Greek VAT numbers starting with 'EL'

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -123,11 +123,12 @@ class ResPartner(models.Model):
         '''
         if not country_code.encode().isalpha():
             return False
+
+        country_code = _eu_country_vat_inverse.get(country_code.upper(), country_code).lower()
         check_func_name = 'check_vat_' + country_code
         check_func = getattr(self, check_func_name, None) or getattr(stdnum.util.get_cc_module(country_code, 'vat'), 'is_valid', None)
         if not check_func:
             # No VAT validation available, default to check that the country code exists
-            country_code = _eu_country_vat_inverse.get(country_code, country_code)
             return bool(self.env['res.country'].search([('code', '=ilike', country_code)]))
         return check_func(vat_number)
 

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -158,6 +158,22 @@ class TestStructure(TransactionCase):
             with self.assertRaises(ValidationError):
                 test_partner.vat = ubn
 
+    def test_vat_with_el_prefix(self):
+        """Ensure VAT numbers starting with 'EL' are validated correctly as Greek VATs"""
+        partner = self.env['res.partner'].create({
+            'name': 'Greek Company EL',
+            'country_id': self.env.ref('base.gr').id,
+            'vat': 'EL033910442',
+        })
+        vat_country, vat_id_no = partner._split_vat(partner.vat)
+        vat_is_valid = partner.simple_vat_check(vat_country, vat_id_no)
+
+        self.assertTrue(
+            vat_is_valid,
+            f"Expected EL-prefixed VAT ({partner.vat}) to be recognized as valid Greek VAT, "
+            f"but simple_vat_check({vat_country}, {vat_id_no}) returned False."
+        )
+
 
 @tagged('-standard', 'external')
 class TestStructureVIES(TestStructure):


### PR DESCRIPTION
**Issue**
When a VAT number starts with EL, it is not recognised as a valid country code, and therefore Greece is not properly identified in exports.

**Steps to Reproduce**
1. Create a new customer from Greece with VAT number EL033910442
2. Create an invoice for that customer
3. Navigate to Accounting > Reporting > General Ledger
4. Download Datev Data through the gear icon
5. Open EXTF_Customer_accounts.csv
6. Notice that EL was not recognised as the country code

**Root Cause**
The VAT validation logic `simple_vat_check` first tries to find a country-specific check function `check_vat_EL`, but such a function does not exist. For Greece, the correct function is `check_vat_GR` (since the ISO country code is `GR`). When `EL` is passed directly, no check function is found, validation fails, and the VAT country is left empty.

**Fix**
Normalize the VAT prefix before validation by mapping EL → GR, ensuring Greek VAT numbers prefixed with EL are validated with the existing check_vat_GR logic.

Opw-4982164
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
