### PR TITLE
[FIX] hr_holidays: multiple requests wizard not clickable

### DIFF
--- a/addons/hr_holidays/static/src/views/list/holidays_list_controller.js
+++ b/addons/hr_holidays/static/src/views/list/holidays_list_controller.js
@@ -47,6 +47,8 @@ export class HolidaysListController extends ListController {
             } else {
                 this.onClickViewButton(params);
             }
+        } else {
+            this.onClickViewButton(params);
         }
     }
 


### PR DESCRIPTION
**Issue**
When clicking header buttons other than approve/refuse in Time Off list view, the actions are not processed correctly.

**Steps to Reproduce**
1. Navigate to Time Off > Management > Time Off or Allocations
2. Switch to List view
3. Click on New Group button
4. Action is not executed properly

**Root Cause**
Previously, handleViewButtonClick only processed approve/refuse actions and ignored other header button actions. Now, non-leave actions are correctly forwarded to the default handler.

Task ID: 5062846

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
