### PR TITLE
[FIX] hr_holidays: holiday responsible access error on multi request

### DIFF
--- a/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_generate_multi_wizard.py
@@ -43,7 +43,7 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
     def _get_employees_from_allocation_mode(self):
         self.ensure_one()
         if self.allocation_mode == 'employee':
-            employees = self.employee_ids
+            employees = self.employee_ids or self.env['hr.employee'].search(self._get_employee_domain())
         elif self.allocation_mode == 'category':
             employees = self.category_id.employee_ids.filtered(lambda e: e.company_id in self.env.companies)
         elif self.allocation_mode == 'company':
@@ -54,7 +54,7 @@ class HrLeaveGenerateMultiWizard(models.TransientModel):
 
     def _prepare_employees_holiday_values(self, employees, date_from_tz, date_to_tz):
         self.ensure_one()
-        work_days_data = employees._get_work_days_data_batch(date_from_tz, date_to_tz)
+        work_days_data = employees.sudo()._get_work_days_data_batch(date_from_tz, date_to_tz)
         validated = self.env.user.has_group('hr_holidays.group_hr_holidays_user') or self.holiday_status_id.leave_validation_type == 'no_validation'
         return [{
             'name': self.name,


### PR DESCRIPTION
purpose: fix the issue when a user who is `hr_holiday_responsible` creates a multi timeoff request, where an access right error appears because they don't have access on Employee.

task-id : task-5051859
