### PR TITLE
[FIX] hr_holidays : Count public leaves when reevaluating

### DIFF
--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -200,7 +200,7 @@ class HrEmployeeBase(models.AbstractModel):
 
                 leave_type_data = allocations_leaves_consumed[employee][leave_type]
                 for leave in leaves_per_employee_type[employee][leave_type].sorted('date_from'):
-                    leave_duration = leave[leave_duration_field]
+                    leave_duration = leave._get_durations()[leave.id][0 if leave_unit == 'days' else 1]
                     skip_excess = False
 
                     if sorted_leave_allocations.filtered(lambda alloc: alloc.allocation_type == 'accrual') and leave.date_from.date() > target_date:

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -254,3 +254,52 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
         }
         for day, value in expected.items():
             self.assertEqual(flex_days.get(day), value, f"Day {day} should be {'unusual' if value else 'normal'}")
+
+    def test_public_holidays_for_consecutive_allocations(self):
+        employee = self.employee_emp
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Paid Time Off',
+            'time_type': 'leave',
+            'requires_allocation': 'yes',
+        })
+        self.env['hr.leave.allocation'].create([
+            {
+                'name': '2025 allocation',
+                'holiday_status_id': leave_type.id,
+                'number_of_days': 20,
+                'employee_id': employee.id,
+                'state': 'confirm',
+                'date_from': date(2025, 1, 1),
+                'date_to': date(2025, 12, 31),
+            },
+            {
+                'name': '2026 allocation',
+                'holiday_status_id': leave_type.id,
+                'number_of_days': 20,
+                'employee_id': employee.id,
+                'state': 'confirm',
+                'date_from': date(2026, 1, 1),
+                'date_to': date(2026, 12, 31),
+            }
+        ]).action_validate()
+
+        leave = self.env['hr.leave'].create({
+            'name': 'Holiday 1 week',
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': datetime(2025, 12, 8, 7, 0),
+            'request_date_to': datetime(2026, 1, 3, 18, 0),
+        })
+        leave.action_validate()
+
+        self.assertEqual(leave.number_of_days, 20, "Number of days should be 20")
+
+        public_holiday = self.env['resource.calendar.leaves'].create({
+            'name': 'Global Time Off',
+            'date_from': datetime(2025, 12, 31, 23, 0, 0),
+            'date_to': datetime(2026, 1, 1, 22, 59, 59),
+        })
+
+        self.assertTrue(public_holiday)
+        self.assertEqual(leave.number_of_days, 19, "Number of days should be 19 as one day has been granted back to the"
+                                                   "the employee for the public holiday")


### PR DESCRIPTION
### Steps to reproduce:
	- Install Time off apps
	- Create two consecutive allocations (e.g. one for 2025 and one for 2026)
	- Create a leave that overlap with the two allocation (e.g. from 8th Dec to 3rd Jan)
	- Create a public holiday at the beginning of the second allocation (e.g. on 1st Jan 2026)

### Cause:
When we are checking the leave duration after having a public holiday the  will return the attendance without
the public holidays duration so when subtracting the attendance duration from the leave duration we will have a remaining amout equals to the public holiday duration and it will be considered as excess days.

https://github.com/odoo/odoo/blob/06e47d8601ba56b1650eeaeef71ebd7a4af39b8b/addons/hr_holidays/models/hr_employee_base.py#L228-L230

https://github.com/odoo/odoo/blob/06e47d8601ba56b1650eeaeef71ebd7a4af39b8b/addons/hr_holidays/models/hr_employee_base.py#L246-L254

### Fix:
We check for public holidays in the interval we are fetching its attendance to avoid assuming it is an excess days in the leave

opw-5006119