### PR TITLE
[FIX] l10n_es_edi_tbai: prevent sequence length over max

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_move.py
+++ b/addons/l10n_es_edi_tbai/models/account_move.py
@@ -153,7 +153,7 @@ class AccountMove(models.Model):
             sequence = regex_sub(r"\s+", " ", sequence)  # no more than one consecutive whitespace allowed
             # NOTE (optional) not recommended to use chars out of ([0123456789ABCDEFGHJKLMNPQRSTUVXYZ.\_\-\/ ])
             sequence += "TEST" if self.company_id.l10n_es_edi_test_env else ""
-        return sequence, number
+        return sequence[-20:], number
 
     def _get_l10n_es_tbai_signature_and_date(self):
         """


### PR DESCRIPTION
Before this commit, records with sequences over 20 characters will present a cryptic error when uploaded to TicketBAI.

Steps to reproduce
-----
1. Create a point of sale with a name >20 characters
2. Validate an order on the POS
3. Go to Point of Sale > Orders > Your order, click "Send to TicketBAI"
4. Invalid Operation
```
002: Fichero no cumple el esquema XSD. Detalle del error: cvc-maxLength-valid: Value 'ThisisaveryveryveryveryverylongPOSnameTEST' with length = '42' is not facet-valid with respect to maxLength '20' for type 'TextMax20Type'.
```

Issue
-----
The schema for SerieFactura specifies a TextMax20Type, but the generated sequence can be over 20 characters.

Solution
-----
Truncate the sequence to 20 characters.

opw-4750372