### PR TITLE
[FIX] website: code lang selector show just code


### DIFF
--- a/addons/website/static/src/builder/plugins/options/language_selector_option.xml
+++ b/addons/website/static/src/builder/plugins/options/language_selector_option.xml
@@ -39,7 +39,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 actionParam="{
-                    views: ['website.header_language_selector_code']
+                    views: ['website.header_language_selector_code', 'website.header_language_selector_no_text']
                 }">
                 Code
             </BuilderSelectItem>


### PR DESCRIPTION

Scenario:

- have more than one language on website
- edit website page
- select the lang selector
- change Language Selector > Label to Code

Result: the render is the same than "Text"

Cause: the view website.header_language_selector_no_text that should be
enabled for code label type is missing from the website builder
refactoring (9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2).

opw-5022850
