### PR TITLE
[FIX] website_sale: prevent multiple calls to the `/shop/update_address` route

### DIFF
--- a/addons/website_sale/static/src/js/checkout.js
+++ b/addons/website_sale/static/src/js/checkout.js
@@ -49,7 +49,7 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
         // Highlight the newly selected address card.
         this._highlightAddressCard(newAddress);
         const selectedPartnerId = newAddress.dataset.partnerId;
-        await this.updateAddress(addressType, selectedPartnerId);
+
         // A delivery address is changed.
         if (addressType === 'delivery' || this.billingContainer.dataset.deliveryAddressDisabled) {
             if (this.billingContainer.dataset.deliveryAddressDisabled) {
@@ -65,6 +65,8 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
                 '/shop/delivery_methods'
             );
             await this._prepareDeliveryMethods();
+        } else {
+            await this.updateAddress(addressType, selectedPartnerId);
         }
         this._enableMainButton();  // Try to enable the main button.
     },


### PR DESCRIPTION
## Issue

When the shipping and billing addresses are the same during checkout,  
the `/shop/update_address` route is called multiple times unnecessarily.

## Current Behavior

- `updateAddress` is always invoked before checking whether the address  
  is a delivery address or if `this.billingContainer.dataset.deliveryAddressDisabled` is set.  
- If the condition is met, the method is called again, resulting in duplicate requests.

## Steps to Reproduce

1. Add a product to the cart.  
2. Start the checkout process.  
3. In the address step, select the same address for both shipping and billing.  
4. Submit the form.  
5. Multiple calls to `/shop/update_address` are triggered.

## Expected Behavior

- `updateAddress` should only be called once after verifying the condition.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
