### PR TITLE
[FIX] l10n_uy: correct website link in manifest

### DIFF
--- a/addons/l10n_uy/__manifest__.py
+++ b/addons/l10n_uy/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Uruguay - Accounting',
-    'website': 'https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/uruguay.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['uy'],
     'version': '0.1',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The website link in the `l10n_uy` manifest was pointing to a generic documentation page.

Current behavior before PR:
Link in manifest points to `https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations.html`

Desired behavior after PR is merged:
Link in manifest points to `https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations/uruguay.html`