### PR TITLE
[IMP] pos_loyalty: add log for selling gift card from PoS

### DIFF
--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -2,6 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
+from markupsafe import Markup
+
 from odoo import _, models
 from odoo.tools import float_compare
 import base64
@@ -107,6 +109,9 @@ class PosOrder(models.Model):
         # Pos users don't have the create permission
         new_coupons = self.env['loyalty.card'].with_context(action_no_send_mail=True).sudo().create(coupon_create_vals)
 
+        # Add log for updated and newly created gift cards
+        self._add_log_for_gift_cards(updated_gift_cards | new_coupons.filtered(lambda c: c.program_type == 'gift_card'))
+
         # Map the newly created coupons
         for old_id, new_id in zip(coupons_to_create.keys(), new_coupons):
             coupon_new_id_map[new_id.id] = old_id
@@ -189,11 +194,7 @@ class PosOrder(models.Model):
             program_id = self.env['loyalty.program'].browse(coupon_vals['program_id'])
             if program_id.program_type == 'gift_card':
                 updated = False
-                gift_card = self.env['loyalty.card'].search([
-                    ('|'),
-                    ('code', '=', coupon_vals.get('code', '')),
-                    ('id', '=', coupon_vals.get('coupon_id', False))
-                ])
+                gift_card = self.env['loyalty.card'].search([('code', '=', coupon_vals.get('code', ''))])
                 if not gift_card.exists():
                     continue
 
@@ -242,6 +243,17 @@ class PosOrder(models.Model):
             coupon_data.pop(key, None)
 
         return updated_gift_cards
+
+    def _add_log_for_gift_cards(self, gift_cards):
+        body = Markup(
+            """
+                <span class='o-mail-Message-trackingOld text-muted fw-bold'>{message}<span/>
+                <i class='o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-1 text-600'/>
+                <span class='o-mail-Message-trackingNew text-info fw-bold'>{order_name}</span>
+            """
+        ).format(message=_('Loyalty coupon sold'), order_name=self._get_html_link())
+        for gift_card in gift_cards:
+            gift_card.message_post(body=body)
 
     def _check_existing_loyalty_cards(self, coupon_data):
         coupon_key_to_modify = []


### PR DESCRIPTION
Before this commit:
----------
- Gift card sales from PoS were not logged, making it difficult to trace the originating order.
- Gift card PDF was being generated when using gift cards in PoS.

After this commit:
----------
- A log entry is now added in the gift card chatter when it is sold from a PoS order.
- The gift card PDF is now generated only when gift cards are sold from PoS, preventing duplicate generation.

task-4643992
