### PR TITLE
[FIX] html_editor: table cell vertical alignment not applied

### DIFF
--- a/addons/html_editor/static/src/main/table/table_align_selector.xml
+++ b/addons/html_editor/static/src/main/table/table_align_selector.xml
@@ -6,16 +6,18 @@
                 <t t-call="{{ selectedItem ? selectedItem.template : 'html_editor.VerticalAlignTop' }}" />
             </button>
             <t t-set-slot="content">
-                <t t-foreach="items" t-as="item" t-key="item.mode">
-                    <button
-                        t-attf-class="btn btn-light"
-                        t-att-class="{ active: item.mode === state.displayName }"
-                        t-on-pointerdown.prevent="() => {}"
-                        t-on-click="() => this.onSelected(item)"
-                    >
-                        <t t-call="{{item.template}}" />
-                    </button>
-                </t>
+                <div data-prevent-closing-overlay="true">
+                    <t t-foreach="items" t-as="item" t-key="item.mode">
+                        <button
+                            t-attf-class="btn btn-light"
+                            t-att-class="{ active: item.mode === state.displayName }"
+                            t-on-pointerdown.prevent="() => {}"
+                            t-on-click="() => this.onSelected(item)"
+                        >
+                            <t t-call="{{item.template}}" />
+                        </button>
+                    </t>
+                </div>
             </t>
         </Dropdown>
     </t>


### PR DESCRIPTION
### Steps to reproduce:

- Navigate to the Website module.
- Drag and drop a Text Snippet.
- Create a Table (e.g., /table) and select a table cell.
- Click on Vertical Align button in toolbar and apply alignment option.

### Description of the issue/feature this PR addresses:

- When clicking on a vertical align option inside the dropdown, overlay was immediately closed. Because of this, the click event handler was not triggered, and the selected vertical alignment was not applied to the table cell.

### Desired behavior after PR is merged:

- Prevent overlay from closing by using `data-prevent-closing-overlay`.

task-5062814

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
