### PR TITLE
[IMP] pos_self_order: scroll up to requireds attributes

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.AttributeSelection">
          <t t-foreach="props.productTemplate.attribute_line_ids" t-as="attribute" t-key="attribute.id">
-             <h2 class="text-start py-3 m-0" t-out="attribute.attribute_id.name"/>
+             <h2 class="text-start py-3 m-0" t-out="attribute.attribute_id.name" t-att-id="attribute.attribute_id.id"/>
              <div class="self_order_attribute_selection row pb-3">
                 <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">
                     <t t-set="valueSelected" t-value="isValueSelected(attribute,value)"/>

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection_helper.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection_helper.js
@@ -52,8 +52,8 @@ export class AttributeSelectionHelper {
         }
     }
 
-    hasMissingAttributeValues(attributes) {
-        return attributes.some(
+    getMissingAttributeValue(attributes) {
+        return attributes.find(
             (attr) => attr.attribute_id.display_type !== "multi" && !this.hasValueSelected(attr)
         );
     }

--- a/addons/pos_self_order/static/src/app/components/missing_required_details/missing_required_details.scss
+++ b/addons/pos_self_order/static/src/app/components/missing_required_details/missing_required_details.scss
@@ -1,0 +1,12 @@
+.missing_required_details button {
+  animation: jump 0.8s infinite ease-in-out;
+}
+
+@keyframes jump {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}

--- a/addons/pos_self_order/static/src/app/components/missing_required_details/missing_required_details.xml
+++ b/addons/pos_self_order/static/src/app/components/missing_required_details/missing_required_details.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_self_order.MissingRequiredDetails">
+        <div class="missing_required_details d-flex flex-column align-items-center p-3 text-center">
+            <button class="btn btn-primary mb-2 rounded-circle" t-on-click="scrollUpToRequired" style="width:60px; height: 60px;">
+                <i class="fa fa-fw fa-arrow-up" aria-hidden="true"/>
+            </button>
+            <h2 class="mb-3">See what you missed</h2>
+            <p>Make sure you choose all your options for this item. You're alomost there.</p>
+        </div>
+    </t>
+</templates>

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -211,7 +211,7 @@ export class ComboPage extends Component {
         if (!selection) {
             return true;
         }
-        return selection.hasMissingAttributeValues(product.attribute_line_ids);
+        return Boolean(selection.getMissingAttributeValue(product.attribute_line_ids));
     }
 
     changeQuantity(increase) {
@@ -438,6 +438,17 @@ export class ComboPage extends Component {
 
     goBack() {
         this.router.navigate("product_list");
+    }
+
+    scrollUpToRequired() {
+        const selectedItem = this.currentChoiceState.displayAttributesOfItem.product_id;
+        const selection = this.state.selectedValues[selectedItem.id];
+        const missingAttribute = selection?.getMissingAttributeValue(
+            selectedItem.attribute_line_ids
+        );
+        document
+            .getElementById(missingAttribute?.attribute_id?.id)
+            ?.scrollIntoView({ behavior: "smooth" });
     }
 
     /*

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -111,6 +111,7 @@
                         <div class="">
                             <AttributeSelection t-if="product.attribute_line_ids.length" productTemplate="product" onSelection="onAttributeSelection" />
                         </div>
+                        <t t-if="hasMissingAttributeValues(currentChoiceState.displayAttributesOfItem)" t-call="pos_self_order.MissingRequiredDetails" />
                     </div>
 
                     <!-- Confirmation -->

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -86,7 +86,7 @@ export class ProductPage extends Component {
         if (!selection) {
             return true;
         }
-        return selection.hasMissingAttributeValues(this.productTemplate.attribute_line_ids);
+        return Boolean(selection.getMissingAttributeValue(this.productTemplate.attribute_line_ids));
     }
 
     isAddToCartEnabled() {
@@ -145,6 +145,16 @@ export class ProductPage extends Component {
 
     goBack() {
         this.router.navigate("product_list");
+    }
+
+    scrollUpToRequired() {
+        const selection = this.state.selectedValues[this.productTemplate.id];
+        const missingAttribute = selection?.getMissingAttributeValue(
+            this.productTemplate.attribute_line_ids
+        );
+        document
+            .getElementById(missingAttribute?.attribute_id?.id)
+            ?.scrollIntoView({ behavior: "smooth" });
     }
 
     /*

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -41,6 +41,7 @@
                  <div  t-if="showQtyButtons and selfOrder.ordering" class="d-flex container o_self_container justify-content-end pt-0 py-3">
                      <t t-call="pos_self_order.QuantityWidget" />
                  </div>
+                 <t t-if="hasMissingAttributeValues()" t-call="pos_self_order.MissingRequiredDetails" />
             </div>
 
             <!-- Footer -->

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -3,6 +3,7 @@ import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
+import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("self_attribute_selector", {
     steps: () => [
@@ -101,13 +102,20 @@ registry.category("web_tour.tours").add("test_self_order_multi_check_attribute_w
             ProductPage.setupAttribute(
                 [
                     { name: "Fabric", value: "Leather" },
-                    { name: "Size", value: "M" },
                     { name: "Add-ons", value: "Pen Holder" },
                     { name: "Add-ons", value: "Mini Drawer" },
                     { name: "Colour", value: "Blue" },
                 ],
                 false
             ),
+            Utils.checkMissingRequiredsExists(),
+            Utils.clickMissingRequireds(),
+            {
+                content: "Size attribute selection is visible",
+                trigger: "h2:contains('Size'):visible",
+            },
+            ProductPage.setupAttribute([{ name: "Size", value: "M" }], false),
+            negateStep(Utils.checkMissingRequiredsExists()),
             Utils.clickBtn("Add to Cart"),
             Utils.clickBtn("Checkout"),
             CartPage.checkProduct("Desk Organizer", "11.62", "1"),

--- a/addons/pos_self_order/static/tests/tours/utils/common.js
+++ b/addons/pos_self_order/static/tests/tours/utils/common.js
@@ -108,3 +108,18 @@ export function setProductAvailability(productName, value) {
         },
     };
 }
+
+export function checkMissingRequiredsExists() {
+    return {
+        content: "Redirecting component is available for handling missing details",
+        trigger: "div.missing_required_details",
+    };
+}
+
+export function clickMissingRequireds() {
+    return {
+        content: "Click on missing required details button",
+        trigger: "div.missing_required_details button",
+        run: "click",
+    };
+}

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -1,3 +1,6 @@
+import * as Utils from "@pos_self_order/../tests/tours/utils/common";
+import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
+
 export function clickProduct(productName) {
     return {
         content: `Click on product '${productName}'`,
@@ -137,7 +140,9 @@ export function setupCombo(products, addToCart = true) {
         steps.push(clickComboProduct(product.product));
 
         if (product.attributes.length > 0) {
+            Utils.checkMissingRequiredsExists();
             steps.push(...setupAttribute(product.attributes));
+            negateStep(Utils.checkMissingRequiredsExists());
         }
     }
 


### PR DESCRIPTION
In this commit:
----------
- We are introducing a feature where the user will be redirected to the missing required attribute on the click of the arrow button at last of the product page/combo page.

task-4886023
