### PR TITLE
[FIX] event: set communication status to cancelled on event cancellation

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -63,7 +63,7 @@ class EventMail(models.Model):
     mail_done = fields.Boolean("Sent", copy=False, readonly=True)
     mail_state = fields.Selection(
         [('running', 'Running'), ('scheduled', 'Scheduled'), ('sent', 'Sent'), ('error', 'Error'), ('cancelled', 'Cancelled')],
-        string='Global communication Status', compute='_compute_mail_state')
+        string='Scheduler Status', compute='_compute_mail_state')
     mail_count_done = fields.Integer('# Sent', copy=False, readonly=True)
     notification_type = fields.Selection([('mail', 'Mail')], string='Send', compute='_compute_notification_type')
     template_ref = fields.Reference(string='Template', ondelete={'mail.template': 'cascade'}, required=True, selection=[('mail.template', 'Mail')])
@@ -91,7 +91,7 @@ class EventMail(models.Model):
             if scheduler.error_datetime:
                 scheduler.mail_state = 'error'
             # event cancelled
-            elif not scheduler.mail_done and scheduler.event_id.kanban_state == 'cancel':
+            elif scheduler.event_id.kanban_state == 'cancel':
                 scheduler.mail_state = 'cancelled'
             # registrations based
             elif scheduler.interval_type == 'after_sub':

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -104,7 +104,7 @@
                                     <field name="interval_type"/>
                                     <field name="scheduled_date" groups="base.group_no_one"/>
                                     <field name="mail_count_done"/>
-                                    <field name="mail_state" widget="event_icon_selection" string=" " nolabel="1"
+                                    <field name="mail_state" widget="event_icon_selection" string="Scheduler"
                                         options="{
                                             'error': 'fa fa-exclamation-triangle',
                                             'sent': 'fa fa-check',

--- a/addons/event/views/event_mail_views.xml
+++ b/addons/event/views/event_mail_views.xml
@@ -49,7 +49,7 @@
                 <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}" widget="EventMailTemplateReferenceField"/>
                 <field name="scheduled_date"/>
                 <field name="mail_count_done"/>
-                <field name="mail_state" widget="event_icon_selection" string=" " nolabel="1"
+                <field name="mail_state" widget="event_icon_selection" string="Scheduler"
                     options="{'sent': 'fa fa-check', 'scheduled': 'fa fa-hourglass-half', 'running': 'fa fa-cogs', 'cancelled': 'fa fa-times-circle'}"/>
             </list>
         </field>


### PR DESCRIPTION
The condition for setting `mail_state` to cancelled was wrong, as `mail_done` is `True`
when there are no registrations or all mails are sent. So, the cancelled icon is still not
visible when we cancel an event.

This PR updates the `mail_state` value to cancelled immediately when an event is cancelled.

Ref: https://github.com/odoo/odoo/pull/198141

Task-5063079
