### PR TITLE
[FIX] purchase: prevent creation of UoM from order lines

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -260,7 +260,7 @@
                                     <field name="product_uom_id" groups="uom.group_uom"
                                         readonly="state in ('purchase', 'done', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
-                                        options="{'no_open': True, 'quantity_field': 'product_qty'}"
+                                        options="{'no_create': True, 'no_open': True, 'quantity_field': 'product_qty'}"
                                         widget="many2one_uom"
                                         force_save="1" optional="show"/>
                                     <field name="price_unit" readonly="qty_invoiced != 0"/>


### PR DESCRIPTION
When users create a new UoM from order lines, and after deleting the newly created UoM, they try to confirm the order.

Steps to reproduce:
---
- Install `purchase_stock` module
- Create a New PO
- Add an order line -> Remove its `Unit` and create a New one
- Delete newly created UoM from `Units & Packagings`
- Now Confirm Order

Traceback:
---
- `ValueError: Expected singleton: uom.uom()`
- `ZeroDivisionError: float division by zero`

This error occurs because, after deleting the newly created UoM, the `product_uom_id` becomes empty, which leads to errors in multiple lines.

Solution:
---
We are restricting users from creating a UoM from purchase order lines, as already done in other modules (e.g., stock, account, …).

sentry-6746792383, 6853969554

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
