### PR TITLE
[FIX] l10n_sa: company logo missing on invoice pdf

### DIFF
--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -20,7 +20,7 @@
             </div>
         </xpath>
         <xpath expr="//t[@t-set='address']" position="after">
-            <t t-if="o.company_id.country_id.code == 'SA' and o.is_sale_document() and not o._l10n_sa_is_legal() " t-set="custom_header">
+            <t t-if="o.company_id.country_id.code == 'SA' and o.is_sale_document() and not o._l10n_sa_is_legal()" t-set="custom_header_sa">
                 <div class="fw-bold text-center mt-2">
                     <h5>THIS IS NOT A LEGAL DOCUMENT</h5>
                     <h5>هذا المستند ليس مستنداً قانونياً</h5>

--- a/addons/l10n_sa/views/report_templates_views.xml
+++ b/addons/l10n_sa/views/report_templates_views.xml
@@ -6,7 +6,7 @@
     <template id="l10n_sa_external_layout_standard" inherit_id="web.external_layout_standard">
         <!-- support for custom header -->
         <xpath expr="//img" position="after">
-            <t t-if="custom_header" t-out="custom_header"/>
+            <t t-if="custom_header_sa" t-out="custom_header_sa"/>
         </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
@@ -15,7 +15,7 @@
     <template id="l10n_sa_external_layout_boxed" inherit_id="web.external_layout_boxed">
         <!-- support for custom header -->
         <xpath expr="//img" position="after">
-            <t t-if="custom_header" t-out="custom_header"/>
+            <t t-if="custom_header_sa" t-out="custom_header_sa"/>
         </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
@@ -24,7 +24,7 @@
     <template id="l10n_sa_external_layout_bold" inherit_id="web.external_layout_bold">
         <!-- support for custom header -->
         <xpath expr="//img" position="after">
-            <t t-if="custom_header" t-out="custom_header"/>
+            <t t-if="custom_header_sa" t-out="custom_header_sa"/>
         </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
@@ -33,7 +33,7 @@
     <template id="l10n_sa_external_layout_striped" inherit_id="web.external_layout_striped">
         <!-- support for custom header -->
         <xpath expr="//img" position="after">
-            <t t-if="custom_header" t-out="custom_header"/>
+            <t t-if="custom_header_sa" t-out="custom_header_sa"/>
         </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
@@ -42,7 +42,7 @@
     <template id="l10n_sa_external_layout_folder" inherit_id="web.external_layout_folder">
         <!-- support for custom header -->
         <xpath expr="//img" position="after">
-            <t t-if="custom_header" t-out="custom_header"/>
+            <t t-if="custom_header_sa" t-out="custom_header_sa"/>
         </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
@@ -51,7 +51,7 @@
     <template id="l10n_sa_external_layout_wave" inherit_id="web.external_layout_wave">
         <!-- support for custom header -->
         <xpath expr="//img" position="after">
-            <t t-if="custom_header" t-out="custom_header"/>
+            <t t-if="custom_header_sa" t-out="custom_header_sa"/>
         </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
@@ -60,7 +60,7 @@
     <template id="l10n_sa_external_layout_bubble" inherit_id="web.external_layout_bubble">
         <!-- support for custom header -->
         <xpath expr="//img" position="after">
-            <t t-if="custom_header" t-out="custom_header"/>
+            <t t-if="custom_header_sa" t-out="custom_header_sa"/>
         </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>


### PR DESCRIPTION
steps to reproduce:
-------------------
1. Install `l10n_sa_edi` and `l10n_latam_invoice_document`
2. Create and confirm an invoice.
3. Print the invoice PDF

issue:
------
The company logo is not printed on the invoice PDF.

cause of the issue:
-------------------
The `l10n_latam_invoice_document` hides the standard company logo if
`company_header` is set to true:
https://github.com/odoo/odoo/blob/0f6cb037e05db86e808682659a12442464b2cdd2/addons/l10n_latam_invoice_document/views/report_templates.xml#L6-L8

In the case of `l10n_sa`, the custom_header value is set because of this condition:
https://github.com/odoo/odoo/blob/0f6cb037e05db86e808682659a12442464b2cdd2/addons/l10n_sa/views/report_invoice.xml#L23

However, the condition in `l10n_latam_invoice_documnet` expects
a callable record instead of static XML data, which is incorrect:
https://github.com/odoo/odoo/blob/022fcbcf40a28afa56010f6130c26bb0503d5467/addons/l10n_latam_invoice_document/views/report_templates.xml#L9-L14

solution:
---------
Renaming the variable to `custom_header_sa` resolves the issue.

<details>
    <summary>Click here to see:</summary>
    Before:
    <img src="https://github.com/user-attachments/assets/f4606a44-10ce-4038-92a3-2c8ec2a69edf"/>

    After:
   <img src="https://github.com/user-attachments/assets/70055155-63f2-4fec-aaf6-3bf5587f5591"/>
</details>


opw-4977422
