### PR TITLE
[FIX] html_editor: infinite loop traceback on remove format

### DIFF
--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -239,6 +239,10 @@ export function hasColor(element, mode) {
     const style = element.style;
     const parent = element.parentNode;
     const classRegex = mode === "color" ? TEXT_CLASSES_REGEX : BG_CLASSES_REGEX;
+    if (element.classList.contains("btn")) {
+        // Ignore style applied on buttons from color detection
+        return false;
+    }
     if (isColorGradient(style["background-image"])) {
         if (element.classList.contains("text-gradient")) {
             if (mode === "color") {

--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -223,7 +223,8 @@ export function isColorGradient(value) {
     return value && value.includes("-gradient(");
 }
 
-export const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/;
+export const TEXT_CLASSES_REGEX =
+    /\btext-(primary|secondary|success|danger|warning|info|light|dark|body|muted|white|black|reset|gradient|opacity-\d{1,3}|o-[^\s]+|\d+)\b/;
 export const BG_CLASSES_REGEX = /\bbg-[^\s]*\b/;
 
 /**

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -778,6 +778,26 @@ test("should remove gradient color from span element", async () => {
     });
 });
 
+test("Remove format not remove background color if applied on .btn element", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><a href="#" class="btn btn-custom bg-o-color-5" style="font-weight: 400;">T[es]t</a></p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter:
+            '<p><a href="#" class="btn btn-custom bg-o-color-5" style="font-weight: 400;">T[es]t</a></p>',
+    });
+});
+
+test("Remove format not remove text color if applied on .btn element", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><a href="#" class="btn btn-custom text-o-color-5" style="font-weight: 400;">T[es]t</a></p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter:
+            '<p><a href="#" class="btn btn-custom text-o-color-5" style="font-weight: 400;">T[es]t</a></p>',
+    });
+});
+
 describe("Toolbar", () => {
     async function removeFormatClick() {
         await expectElementCount(".o-we-toolbar", 1);

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -894,3 +894,47 @@ describe("Toolbar", () => {
         );
     });
 });
+
+describe("removeFormat must not remove non-style classes", () => {
+    test("does not remove non-color classes", async () => {
+        await testEditor({
+            contentBefore: '<p><font class="text-wrap">[test]</font></p>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: '<p><font class="text-wrap">[test]</font></p>',
+        });
+        await testEditor({
+            contentBefore: '<p><font class="text-center">[test]</font></p>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: '<p><font class="text-center">[test]</font></p>',
+        });
+        await testEditor({
+            contentBefore: '<p><font class="text-align">[test]</font></p>',
+            stepFunction: (editor) => execCommand(editor, "removeFormat"),
+            contentAfter: '<p><font class="text-align">[test]</font></p>',
+        });
+    });
+
+    test("removes all supported color classes", async () => {
+        const classes = [
+            "text-primary",
+            "text-secondary",
+            "text-success",
+            "text-danger",
+            "text-warning",
+            "text-info",
+            "text-light",
+            "text-muted",
+            "text-white",
+            "text-black",
+            "text-o-color-1",
+            "text-100",
+        ];
+        for (const cls of classes) {
+            await testEditor({
+                contentBefore: `<p><font class="${cls}">[test]</font></p>`,
+                stepFunction: (editor) => execCommand(editor, "removeFormat"),
+                contentAfter: "<p>[test]</p>",
+            });
+        }
+    });
+});

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -168,6 +168,19 @@ describe("popover should edit,copy,remove the link", () => {
             '<p>this is a <a href="http://test.com/">linknew[]</a></p>'
         );
     });
+    test("after edit the label, the text of the link should be updated (2)", async () => {
+        const { el } = await setupEditor(
+            '<p>this is a <a class="text-wrap" href="http://test.com/">li[]nk</a></p>'
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+
+        await contains(".o-we-linkpopover input.o_we_label_link").fill("new");
+        await click(".o_we_apply_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a class="text-wrap o_link_in_selection" href="http://test.com/">linknew[]</a></p>'
+        );
+    });
     test("when the label is empty, it should be set as the URL", async () => {
         const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
         await waitFor(".o-we-linkpopover");


### PR DESCRIPTION
Description of the issue this PR addresses:

Issue 1:

Steps to Reproduce:

- Open the website.
- Create a mega menu.
- Enter edit mode.
- Change the mega menu template to “Cards”.
- Click on any option available in the mega menu.
- A link popover will open.
- Click the Edit link button in the popover.
- Click the Apply button to save the link.
- A traceback occurs.

The error occurs because the text-wrap class is applied to the link. When the
hasColor method is triggered, it checks whether a.nav-link has a text color
class. However, TEXT_CLASSES_REGEX incorrectly matches text-wrap as a color
class. As a result, the removeColor method attempts to remove it and triggers
_applyColor to remove the color, but in _applyColor method it does not find any
color to remove on selected text. As a result, the removeColor process enters an
infinite loop, which eventually leads to a traceback.

Solution:

Update TEXT_CLASSES_REGEX so that it only matches valid text color classes and
excludes formatting classes such as text-wrap, text-center, etc.

Issue 2:

This commit ensures that the remove format action is disabled when a button
(.btn element) has custom color or background color applied.

Because buttons include padding, there is no proper way to remove a background
color from a partially selected button, so the action must be ignored in this
case.

task-5062715


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
