### PR TITLE
[FIX] l10n_es_edi_verifactu: fix the regime key dropdown

### DIFF
--- a/addons/l10n_es_edi_verifactu/views/account_move_views.xml
+++ b/addons/l10n_es_edi_verifactu/views/account_move_views.xml
@@ -98,6 +98,7 @@
                                    readonly="state != 'draft'"/>
                             <field name="l10n_es_edi_verifactu_substituted_entry_id" invisible="not l10n_es_edi_verifactu_substituted_entry_id"/>
                             <field name="reversed_entry_id" invisible="not reversed_entry_id"/>
+                            <field name="l10n_es_edi_verifactu_available_clave_regimens" invisible="1"/> <!--needed for the dynamic_selection widget-->
                             <field name="l10n_es_edi_verifactu_clave_regimen"
                                    readonly="state != 'draft'"
                                    widget="dynamic_selection"


### PR DESCRIPTION
### Issue:
The dropdown for the regime key doesn't show any value, even when it's supposed to.

### Steps to reproduce:
- Install "l10n_es_edi_verifactu" and switch to a Spanish company
- Create an invoice for a Spanish partner with the tax "21% G (Goods)" for example
- In the page "Veri*factu" the field "Veri*Factu Regime Key" has a dropdown but no values to choose from

### Cause:
This field uses the widget `dynamic_selection` which applies a filter on the possible values of the selection. This filter is simply the field `l10n_es_edi_verifactu_available_clave_regimens` which is computed from the list of possible values and the tax_ids on the invoice. As this field is computed and non stored but do not appear in the view, it is never recomputed, so the dropdown shows no values.

### Solution:
Add the field in the view, and make it invisible.

opw-5039271