### PR TITLE
[REF] html_editor: rename setTag to setBlock

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -63,8 +63,8 @@ function getConnectedParents(nodes) {
  * @typedef {Object} DomShared
  * @property { DomPlugin['insert'] } insert
  * @property { DomPlugin['copyAttributes'] } copyAttributes
- * @property { DomPlugin['canSetTag'] } canSetTag
- * @property { DomPlugin['setTag'] } setTag
+ * @property { DomPlugin['canSetBlock'] } canSetBlock
+ * @property { DomPlugin['setBlock'] } setBlock
  * @property { DomPlugin['setTagName'] } setTagName
  * @property { DomPlugin['removeSystemProperties'] } removeSystemProperties
  */
@@ -75,8 +75,8 @@ export class DomPlugin extends Plugin {
     static shared = [
         "insert",
         "copyAttributes",
-        "canSetTag",
-        "setTag",
+        "canSetBlock",
+        "setBlock",
         "setTagName",
         "removeSystemProperties",
     ];
@@ -89,7 +89,7 @@ export class DomPlugin extends Plugin {
             },
             {
                 id: "setTag",
-                run: this.setTag.bind(this),
+                run: this.setBlock.bind(this),
                 isAvailable: isHtmlContentSupported,
             },
         ],
@@ -514,7 +514,7 @@ export class DomPlugin extends Plugin {
      * Basic method to change an element tagName.
      * It is a technical function which only modifies a tag and its attributes.
      * It does not modify descendants nor handle the cursor.
-     * @see setTag for the more thorough command.
+     * @see setBlock for the more thorough command.
      *
      * @param {HTMLElement} el
      * @param {string} newTagName
@@ -573,7 +573,7 @@ export class DomPlugin extends Plugin {
         this.dependencies.selection.setSelection({ anchorNode, anchorOffset });
     }
 
-    getBlocksToTag() {
+    getBlocksToSet() {
         const targetedBlocks = [...this.dependencies.selection.getTargetedBlocks()];
         return targetedBlocks.filter(
             (block) =>
@@ -582,8 +582,8 @@ export class DomPlugin extends Plugin {
         );
     }
 
-    canSetTag() {
-        return this.getBlocksToTag().length > 0;
+    canSetBlock() {
+        return this.getBlocksToSet().length > 0;
     }
 
     /**
@@ -591,7 +591,7 @@ export class DomPlugin extends Plugin {
      * @param {string} param0.tagName
      * @param {string} [param0.extraClass]
      */
-    setTag({ tagName, extraClass = "" }) {
+    setBlock({ tagName, extraClass = "" }) {
         let newCandidate = this.document.createElement(tagName.toUpperCase());
         if (extraClass) {
             newCandidate.classList.add(extraClass);
@@ -605,7 +605,7 @@ export class DomPlugin extends Plugin {
         }
         const cursors = this.dependencies.selection.preserveSelection();
         const newEls = [];
-        for (const block of this.getBlocksToTag()) {
+        for (const block of this.getBlocksToSet()) {
             if (
                 isParagraphRelatedElement(block) ||
                 isListItemElement(block) ||

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -136,7 +136,7 @@ export class BannerPlugin extends Plugin {
         const nextNode = this.dependencies.baseContainer.isCandidateForBaseContainer(blockEl)
             ? blockEl.nodeName
             : this.dependencies.baseContainer.getDefaultNodeName();
-        this.dependencies.dom.setTag({ tagName: nextNode });
+        this.dependencies.dom.setBlock({ tagName: nextNode });
         // If the first child of editable is contenteditable false element
         // a chromium bug prevents selecting the container.
         // Add a baseContainer above it so it's no longer the first child.

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -136,7 +136,7 @@ export class FontPlugin extends Plugin {
                 title: _t("Heading 1"),
                 description: _t("Big section heading"),
                 icon: "fa-header",
-                run: () => this.dependencies.dom.setTag({ tagName: "H1" }),
+                run: () => this.dependencies.dom.setBlock({ tagName: "H1" }),
                 isAvailable: this.blockFormatIsAvailable.bind(this),
             },
             {
@@ -144,7 +144,7 @@ export class FontPlugin extends Plugin {
                 title: _t("Heading 2"),
                 description: _t("Medium section heading"),
                 icon: "fa-header",
-                run: () => this.dependencies.dom.setTag({ tagName: "H2" }),
+                run: () => this.dependencies.dom.setBlock({ tagName: "H2" }),
                 isAvailable: this.blockFormatIsAvailable.bind(this),
             },
             {
@@ -152,7 +152,7 @@ export class FontPlugin extends Plugin {
                 title: _t("Heading 3"),
                 description: _t("Small section heading"),
                 icon: "fa-header",
-                run: () => this.dependencies.dom.setTag({ tagName: "H3" }),
+                run: () => this.dependencies.dom.setBlock({ tagName: "H3" }),
                 isAvailable: this.blockFormatIsAvailable.bind(this),
             },
             {
@@ -161,7 +161,7 @@ export class FontPlugin extends Plugin {
                 description: _t("Paragraph block"),
                 icon: "fa-paragraph",
                 run: () => {
-                    this.dependencies.dom.setTag({
+                    this.dependencies.dom.setBlock({
                         tagName: this.dependencies.baseContainer.getDefaultNodeName(),
                     });
                 },
@@ -172,7 +172,7 @@ export class FontPlugin extends Plugin {
                 title: _t("Quote"),
                 description: _t("Add a blockquote section"),
                 icon: "fa-quote-right",
-                run: () => this.dependencies.dom.setTag({ tagName: "blockquote" }),
+                run: () => this.dependencies.dom.setBlock({ tagName: "blockquote" }),
                 isAvailable: this.blockFormatIsAvailable.bind(this),
             },
             {
@@ -180,7 +180,7 @@ export class FontPlugin extends Plugin {
                 title: _t("Code"),
                 description: _t("Add a code section"),
                 icon: "fa-code",
-                run: () => this.dependencies.dom.setTag({ tagName: "pre" }),
+                run: () => this.dependencies.dom.setBlock({ tagName: "pre" }),
                 isAvailable: this.blockFormatIsAvailable.bind(this),
             },
         ],
@@ -200,7 +200,7 @@ export class FontPlugin extends Plugin {
                     getItems: () => this.availableFontItems,
                     getDisplay: () => this.font,
                     onSelected: (item) => {
-                        this.dependencies.dom.setTag({
+                        this.dependencies.dom.setBlock({
                             tagName: item.tagName,
                             extraClass: item.extraClass,
                         });
@@ -313,7 +313,7 @@ export class FontPlugin extends Plugin {
         this.fontSize = reactive({ displayName: "" });
         this.font = reactive({ displayName: "" });
         this.blockFormatIsAvailableMemoized = weakMemoize(
-            (selection) => isHtmlContentSupported(selection) && this.dependencies.dom.canSetTag()
+            (selection) => isHtmlContentSupported(selection) && this.dependencies.dom.canSetBlock()
         );
     }
 
@@ -490,7 +490,7 @@ export class FontPlugin extends Plugin {
                 targetOffset,
                 blockToSplit,
             });
-            this.dependencies.dom.setTag({
+            this.dependencies.dom.setBlock({
                 tagName: this.dependencies.baseContainer.getDefaultNodeName(),
             });
             return true;
@@ -590,7 +590,7 @@ export class FontPlugin extends Plugin {
                 this.dependencies.selection.getEditableSelection()
             );
             fillEmpty(blockEl);
-            this.dependencies.dom.setTag({ tagName: headingToBe });
+            this.dependencies.dom.setBlock({ tagName: headingToBe });
         }
     }
 

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -119,7 +119,7 @@ test("hint should only Be display for focused empty block element", async () => 
     expect(getContent(el)).toBe(
         `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
-    editor.shared.dom.setTag({ tagName: "H1" });
+    editor.shared.dom.setBlock({ tagName: "H1" });
     await animationFrame();
     // @todo @phoenix: getContent does not place the selection when anchor is BR
     expect(el.innerHTML).toBe(`<h1 o-we-hint-text="Heading 1" class="o-we-hint"><br></h1>`);

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -380,7 +380,7 @@ describe("system classes and attributes", () => {
 
     test("should not copy system classes when changing a tag name", async () => {
         const { el, editor } = await setupEditor(`<p class="x">a[]</p>`, { config: { Plugins } });
-        editor.shared.dom.setTag({
+        editor.shared.dom.setBlock({
             tagName: "h1",
         });
         expect(getContent(el)).toBe(`<h1>a[]</h1>`);

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -6,7 +6,7 @@ import { insertText, tripleClick, undo } from "./_helpers/user_actions";
 import { animationFrame } from "@odoo/hoot-mock";
 
 function setTag(tagName) {
-    return (editor) => editor.shared.dom.setTag({ tagName });
+    return (editor) => editor.shared.dom.setBlock({ tagName });
 }
 
 describe("to paragraph", () => {


### PR DESCRIPTION
This renames `setTag` to `setBlock` as it's more descriptive of what the function does. In doing so, related functions were also renamed (`canSetTag`, `getBlocksToTag`) following the same pattern.

task-4014389

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
