### PR TITLE
[FIX] hr: alignment for address fields

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -249,11 +249,13 @@
                                         <div class="o_address_format">
                                             <field name="private_street" placeholder="Street..." class="o_address_street"/>
                                             <field name="private_street2" placeholder="Street 2..." class="o_address_street"/>
-                                            <field name="private_city" placeholder="City" class="o_address_city"/>
-                                            <field name="private_state_id" class="o_address_state" placeholder="State" 
-                                                options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}"
-                                                domain="[('country_id', '=', private_country_id)]"/>
-                                            <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
+                                            <div class="o_row">
+                                                <field name="private_city" placeholder="City" class="o_address_city"/>
+                                                <field name="private_state_id" class="o_address_state" placeholder="State" 
+                                                    options="{'no_open': True, 'no_quick_create': True}" context="{'default_country_id': private_country_id}"
+                                                    domain="[('country_id', '=', private_country_id)]"/>
+                                                <field name="private_zip" placeholder="ZIP" class="o_address_zip"/>
+                                            </div>
                                             <field name="private_country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'/>
                                         </div>
                                         <label for="distance_home_work"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Align state, city, and zip fields horizontally on employee form (in Employee profile > Personal > Location)

Current behavior before PR: Not alignment in tab Employee > Work address as per fields state, city, and zip

Desired behavior after PR is merged: Fields aligned

Task ID: 5002920

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
