### PR TITLE
[FIX] website_sale: ensure sudo on fiscal position

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -409,7 +409,7 @@ class Website(models.Model):
                 [('code', '=', request.geoip.country_code)],
                 limit=1,
             )
-            partner_geoip = self.env['res.partner'].new({'country_id': country.id})
+            partner_geoip = self.env['res.partner'].sudo().new({'country_id': country.id})
             fpos_sudo = AccountFiscalPositionSudo._get_fiscal_position(partner_geoip)
 
         if not fpos_sudo:


### PR DESCRIPTION
Ensure the fiscal position is always computed using sudo.

When computing the fiscal position based on geolocated country, the result may not be return without sudo.

Steps to reproduce:
- Set a default Fiscal Position on the contact model (property_account_position_id)
- Visit the website shop without logging in.
- You will get a Forbidden error because Odoo raises an access error when fetching the fiscal position.

This fix add a sudo() to the partner used to compute the fiscal position, so that when accessing the partner property, it will be returned with `env.su = True`.

opw-5058588