### PR TITLE
[IMP] hr: format private and emergency phone numbers on employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -391,6 +391,16 @@ class HrEmployee(models.Model):
                                              "Please select a date outside existing contracts",
                                              format_date_abbr(self.env, date)))
 
+    @api.onchange('private_phone')
+    def _onchange_private_phone_validation(self):
+        if self.private_phone:
+            self.private_phone = self._phone_format(fname="private_phone", force_format="INTERNATIONAL") or self.private_phone
+
+    @api.onchange('emergency_phone')
+    def _onchange_emergency_phone_validation(self):
+        if self.emergency_phone:
+            self.emergency_phone = self._phone_format(fname="emergency_phone", force_format="INTERNATIONAL") or self.emergency_phone
+
     @api.onchange('contract_template_id')
     def _onchange_contract_template_id(self):
         if self.contract_template_id:


### PR DESCRIPTION
Follow-up of: https://github.com/odoo/odoo/pull/224224

#### Behavior before PR
Employee private_phone and emergency_phone are saved as entered, without automatic formatting.

Only `work_phone` and `mobile_phone` benefit from automatic formatting (added in the previous PR).

#### Behavior after PR
`private_phone` and `emergency_phone` are now also formatted according to the employee’s private country (from the current version).

#### Solution
Add an onchange method to `hr.employee` to format `private_phone` and `emergency_phone` automatically when edited in the UI, using `_phone_format()` from phone_validation.

task-5063306