### PR TITLE
[FIX] point_of_sale: prevent error when creating invoice with QR code

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -177,7 +177,7 @@ class PosController(PortalAccount):
 
         # Set the proper context in case of unauthenticated user accessing
         # from the main company website
-        pos_order = pos_order.with_company(pos_order.company_id)
+        pos_order = pos_order.with_company(pos_order.company_id).with_context(allowed_company_ids=pos_order.company_id.ids)
 
         # If the order was already invoiced, return the invoice directly by forcing the access token so that the non-connected user can see it.
         if pos_order.account_move and pos_order.account_move.is_sale_document():


### PR DESCRIPTION
Before this commit, in a multi-company setup, an access error could occur when generating an invoice from a QR code.

Steps to reproduce:
1. Create a parent company and a branch company.
2. Create a PoS in the branch company and assign a sales journal from the parent company.
3. Create a product assigned to the branch company.
4. Enable Self Service invoicing in the PoS settings.
5. Create an order in the PoS and then try to create an invoice with the QR code.

Result: an access error was raised.

opw-5050536

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
