### PR TITLE
[FIX] website: reCaptcha line alignment issues

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/001.scss
+++ b/addons/website/static/src/snippets/s_website_form/001.scss
@@ -36,7 +36,7 @@
         display: none;
     }
 
-    .s_website_form_submit, .s_website_form_recaptcha {
+    .s_website_form_submit {
         .s_website_form_label {
             float: left;
             height: 1px;

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -16,11 +16,8 @@
     </t>
 
     <t t-name="website.s_website_form_recaptcha_legal">
-        <div class="col-12 s_website_form_recaptcha" data-name="Recaptcha Legal">
-            <div t-attf-style="width: #{labelWidth or '200px'}" class="s_website_form_label"/>
-            <div class="col-sm">
-                <t t-call="google_recaptcha.recaptcha_legal_terms"/>
-            </div>
+        <div class="col-12 s_website_form_recaptcha" data-name="Recaptcha Legal" style="text-align: right;">
+            <t t-call="google_recaptcha.recaptcha_legal_terms"/>
         </div>
     </t>
 


### PR DESCRIPTION
Steps to Reproduce:
1. Go to _Settings_ and search for reCAPTCHA.
2. Add the required keys.
3. Go to _Website_ and enter edit mode.
4. Drop any _Contact Form_ snippet.
5. Make the labels to top.
6. Enable the _Show reCAPTCHA_ option.
7. Notice an unnecessary blank space before the privacy policy line.

Issue:
The reCAPTCHA line created unnecessary blank space when aligned to the left.

Reason:
The line was placed inside the form block, which reserves space for a label. Since reCAPTCHA has no label, an empty placeholder space appeared.

Fix:
Removed the `.s_website_form_recaptcha` class responsible for reserving space for labels in the reCAPTCHA line, preventing the creation of an unnecessary blank space. Additionally, the reCAPTCHA line is now right-aligned by default.

Before:
<img width="1464" height="406" alt="image" src="https://github.com/user-attachments/assets/b5fc0fc2-104d-4a3e-a6c9-fab34992ee0d" />

After:
<img width="725" height="741" alt="image" src="https://github.com/user-attachments/assets/957e133d-817f-4af9-9435-c6b139564438" />


task-4756289