### PR TITLE
[IMP] account, *: group imported invoice lines by tax

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -304,6 +304,9 @@ class ResCompany(models.Model):
         help="During perpetual valuation, this account will hold the price difference between the standard price and the bill price.",
     )
 
+    # Group invoice lines per tax
+    extract_single_line_per_tax = fields.Boolean(string="Single Invoice Line Per Tax", default=True)
+
     def get_next_batch_payment_communication(self):
         '''
         When in need of a batch payment communication reference (several invoices paid at the same time)

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -207,6 +207,10 @@ class ResConfigSettings(models.TransientModel):
     income_account_id = fields.Many2one(related='company_id.income_account_id', readonly=False)
     expense_account_id = fields.Many2one(related='company_id.expense_account_id', readonly=False)
 
+    # Group invoice lines per tax
+    extract_single_line_per_tax = fields.Boolean(related='company_id.extract_single_line_per_tax',
+                                                 string="Single Invoice Line Per Tax", readonly=False)
+
     @api.depends('country_code')
     def _compute_is_account_peppol_eligible(self):
         # we want to show Peppol settings only to customers that are eligible for Peppol,

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -250,6 +250,9 @@
                                     </div>
                                 </div>
                             </setting>
+                            <setting company_dependent="1" help="Enable to get only one invoice line per tax">
+                                <field name="extract_single_line_per_tax"/>
+                            </setting>
                         </block>
 
                         <t groups="account.group_account_user">

--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -24,6 +24,7 @@ Pro rules and show the errors.
     'depends': ['account'],
     'data': [
         'data/cii_22_templates.xml',
+        'views/account_move_views.xml',
         'views/account_tax_views.xml',
         'views/res_partner_views.xml',
     ],

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1070,6 +1070,10 @@ class AccountEdiXmlUbl_20(models.AbstractModel):
         rounding_line_vals, rounding_logs = self._import_rounding_amount(invoice, tree, './{*}LegalMonetaryTotal/{*}PayableRoundingAmount', document_type=invoice.move_type, qty_factor=qty_factor)
         line_vals = allowance_charges_line_vals + invoice_line_vals + rounding_line_vals
 
+        if (invoice.company_id.extract_single_line_per_tax and not invoice.env.context.get('ungroup_invoice_lines')) or invoice.env.context.get('group_invoice_lines'):
+            # group amls with the same tax id into one aml, with the total amount
+            line_vals = invoice._get_lines_vals_group_by_tax(line_vals, invoice.partner_id, invoice_values['invoice_date'], invoice.currency_id)
+
         invoice_values = {
             **invoice_values,
             'invoice_line_ids': [Command.create(line_value) for line_value in line_vals],

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -129,6 +129,7 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon, HttpCase):
             'partner_id': company.partner_id.id,
             'acc_holder_name': 'The Chosen One'
         })]
+        company.extract_single_line_per_tax = False
 
         for ubl_cii_format in ['facturx', 'ubl_bis3']:
             with self.subTest(sub_test_name=f"format: {ubl_cii_format}"):

--- a/addons/account_edi_ubl_cii/views/account_move_views.xml
+++ b/addons/account_edi_ubl_cii/views/account_move_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record model="ir.actions.server" id="action_group_lines_by_tax">
+            <field name="name">(Un)Group lines by tax</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="group_ids" eval="[(4, ref('account.group_account_invoice'))]"/>
+            <field name="binding_model_id" ref="account.model_account_move"/>
+            <field name="state">code</field>
+            <field name="binding_view_types">form</field>
+            <field name="code">
+                if records:
+                    records.action_group_ungroup_lines_by_tax()
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/common.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/common.py
@@ -54,6 +54,7 @@ class TestUBLCommon(AccountTestInvoicingCommon):
             'include_base_amount': True,
             'sequence': 2,
         })
+        cls.company.extract_single_line_per_tax = False
 
     def assert_same_invoice(self, invoice1, invoice2, **invoice_kwargs):
         self.assertEqual(len(invoice1.invoice_line_ids), len(invoice2.invoice_line_ids))

--- a/addons/l10n_dk_oioubl/tests/test_xml_oioubl_dk.py
+++ b/addons/l10n_dk_oioubl/tests/test_xml_oioubl_dk.py
@@ -21,6 +21,7 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
             'vat': 'DK12345674',
             'phone': '+45 32 12 34 56',
             'street': 'Paradisæblevej, 10',
+            'extract_single_line_per_tax': False,
         })
         cls.env['res.partner.bank'].create({
             'acc_type': 'iban',

--- a/addons/purchase_edi_ubl_bis3/models/__init__.py
+++ b/addons/purchase_edi_ubl_bis3/models/__init__.py
@@ -1,2 +1,3 @@
+from . import account_move
 from . import purchase_edi_xml_ubl_bis3
 from . import purchase_order

--- a/addons/purchase_edi_ubl_bis3/models/account_move.py
+++ b/addons/purchase_edi_ubl_bis3/models/account_move.py
@@ -1,0 +1,12 @@
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _check_move_for_group_ungroup_lines_by_tax(self):
+        # Extends account.move
+        super()._check_move_for_group_ungroup_lines_by_tax(self)
+        if any(line.purchase_order_id for line in self.line_ids):
+            raise UserError(_("You can only (un)group lines of an invoice not linked to a purchase order"))


### PR DESCRIPTION
[IMP] account, *: group imported invoice lines by tax

modules: account, account_edi_ubl_cii, l10n_account_edi_ubl_cii_tests, l10n_dk_oioubl, purchase_edi_ubl_bis_3

Most of the time, an accountant that imports a bill don't need to see every line. What's useful to him is to see what amount is linked to what tax.

task-5047859
