### PR TITLE
[IMP] l10n_xx: Add dependency to account_edi_ubl_cii in Peppol countries

### DIFF
--- a/addons/l10n_at/__manifest__.py
+++ b/addons/l10n_at/__manifest__.py
@@ -23,6 +23,7 @@ Austrian charts of accounts (Einheitskontenrahmen 2010).
     """,
     'depends': [
         'account',
+        'account_edi_ubl_cii',
         'base_iban',
         'base_vat',
         'l10n_din5008',

--- a/addons/l10n_be/__manifest__.py
+++ b/addons/l10n_be/__manifest__.py
@@ -38,6 +38,7 @@ Wizards provided by this module:
     'author': 'Noviat, Odoo S.A.',
     'depends': [
         'account',
+        'account_edi_ubl_cii',
         'base_iban',
         'base_vat',
     ],

--- a/addons/l10n_ch/__manifest__.py
+++ b/addons/l10n_ch/__manifest__.py
@@ -23,6 +23,7 @@ The generation of the QR-bill is automatic if you meet the previous criteria. Th
     'category': 'Accounting/Localizations/Account Charts',
     'depends': [
         'account',
+        'account_edi_ubl_cii',
         'base_iban',
         'l10n_din5008',
     ],

--- a/addons/l10n_cy/__manifest__.py
+++ b/addons/l10n_cy/__manifest__.py
@@ -11,6 +11,7 @@ Basic package for Cyprus that contains the chart of accounts, taxes, tax reports
     'category': 'Accounting/Localizations/Account Charts',
     'depends': [
         'account',
+        'account_edi_ubl_cii',
         'base_vat',
     ],
     'auto_install': ['account'],

--- a/addons/l10n_cz/__manifest__.py
+++ b/addons/l10n_cz/__manifest__.py
@@ -20,6 +20,7 @@ Tento modul definuje:
     """,
     'depends': [
         'account',
+        'account_edi_ubl_cii',
         'base_iban',
         'base_vat',
     ],

--- a/addons/l10n_de/__manifest__.py
+++ b/addons/l10n_de/__manifest__.py
@@ -21,6 +21,7 @@ By default, the audit trail is enabled for GoBD compliance.
         'base_vat',
         'l10n_din5008',
         'account',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_dk/__manifest__.py
+++ b/addons/l10n_dk/__manifest__.py
@@ -92,6 +92,7 @@ Produkt setup:
         'base_iban',
         'base_vat',
         'account',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_ee/__manifest__.py
+++ b/addons/l10n_ee/__manifest__.py
@@ -12,6 +12,7 @@ This is the base module to manage the accounting chart for Estonia in Odoo.
     'author': 'Odoo SA',
     'depends': [
         'account',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_es/__manifest__.py
+++ b/addons/l10n_es/__manifest__.py
@@ -26,6 +26,7 @@ Spanish charts of accounts (PGCE 2008).
         'account',
         'base_iban',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_fi/__manifest__.py
+++ b/addons/l10n_fi/__manifest__.py
@@ -23,6 +23,7 @@ Set the payment reference type from the Sales Journal.
         'base_iban',
         'base_vat',
         'account',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_fr_account/__manifest__.py
+++ b/addons/l10n_fr_account/__manifest__.py
@@ -32,6 +32,7 @@ configuration of their taxes and fiscal positions manually.
         'base_iban',
         'base_vat',
         'account',
+        'account_edi_ubl_cii',
         'l10n_fr',
     ],
     'auto_install': ['account'],

--- a/addons/l10n_gr/__manifest__.py
+++ b/addons/l10n_gr/__manifest__.py
@@ -17,6 +17,7 @@ Greek accounting chart and localization.
         'account',
         'base_iban',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_ie/__manifest__.py
+++ b/addons/l10n_ie/__manifest__.py
@@ -13,6 +13,7 @@ This is the base module to manage the accounting chart for Republic of Ireland i
         "account",
         "base_iban",
         "base_vat",
+        "account_edi_ubl_cii",
     ],
     'auto_install': ['account'],
     "data": [

--- a/addons/l10n_it/__manifest__.py
+++ b/addons/l10n_it/__manifest__.py
@@ -6,6 +6,7 @@
         'account',
         'base_iban',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'author': 'OpenERP Italian Community',

--- a/addons/l10n_lt/__manifest__.py
+++ b/addons/l10n_lt/__manifest__.py
@@ -21,6 +21,7 @@ This module also includes:
     'category': 'Accounting/Localizations/Account Charts',
     'depends': [
         'account',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_lu/__manifest__.py
+++ b/addons/l10n_lu/__manifest__.py
@@ -25,6 +25,7 @@ Notes:
         'account',
         'base_iban',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_lv/__manifest__.py
+++ b/addons/l10n_lv/__manifest__.py
@@ -21,6 +21,7 @@ co-author is Chick.Farm (visit for more information https://www.myacc.cloud)
     'depends': [
         'account',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_mt/__manifest__.py
+++ b/addons/l10n_mt/__manifest__.py
@@ -12,6 +12,7 @@ Malta basic package that contains the chart of accounts, the taxes, tax reports,
     'depends': [
         'account',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_nl/__manifest__.py
+++ b/addons/l10n_nl/__manifest__.py
@@ -11,6 +11,7 @@
         'base_iban',
         'base_vat',
         'account',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_no/__manifest__.py
+++ b/addons/l10n_no/__manifest__.py
@@ -15,6 +15,7 @@ Updated for Odoo 9 by Bringsvor Consulting AS <www.bringsvor.com>
         'base_iban',
         'base_vat',
         'account',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_pl/__manifest__.py
+++ b/addons/l10n_pl/__manifest__.py
@@ -22,6 +22,7 @@ Wewnętrzny numer wersji OpenGLOBE 1.02
         'base_iban',
         'base_vat',
         'account',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_pt/__manifest__.py
+++ b/addons/l10n_pt/__manifest__.py
@@ -12,6 +12,7 @@
         'base',
         'account',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_ro/__manifest__.py
+++ b/addons/l10n_ro/__manifest__.py
@@ -10,6 +10,7 @@
     'depends': [
         'account',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'description': """

--- a/addons/l10n_se/__manifest__.py
+++ b/addons/l10n_se/__manifest__.py
@@ -17,6 +17,7 @@ It also includes the invoice OCR payment reference handling.
     'depends': [
         'account',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [

--- a/addons/l10n_si/__manifest__.py
+++ b/addons/l10n_si/__manifest__.py
@@ -12,6 +12,7 @@ Chart of accounts and taxes for Slovenia.
     'depends': [
         'account',
         'base_vat',
+        'account_edi_ubl_cii',
     ],
     'auto_install': ['account'],
     'data': [


### PR DESCRIPTION
Peppol countries need to be able to define data for the `ubl_cii_tax_category_code` and `ubl_cii_tax_exemption_reason_code` fields defined in `account_edi_ubl_cii`.

These countries don't have specific `l10n_xx_edi` modules, they all use `account_peppol` for sending invoices.

Also, `account_edi_ubl_cii` is already auto-installed.

So, to define data for those fields, instead of making useless bridge modules, we make `account_edi_ubl_cii` a dependency of those locs.

task-none