### PR TITLE
[IMP] html_(editor, builder): add font items

### DIFF
--- a/addons/html_builder/static/src/plugins/font/font_plugin.js
+++ b/addons/html_builder/static/src/plugins/font/font_plugin.js
@@ -5,6 +5,7 @@ import { _t } from "@web/core/l10n/translation";
 import { Cache } from "@web/core/utils/cache";
 import { loadCSS } from "@web/core/assets";
 import { BuilderFontSizeSelector } from "./font_size_selector";
+import { withSequence } from "@html_editor/utils/resource";
 
 export class BuilderFontPlugin extends Plugin {
     static id = "builderFont";
@@ -26,6 +27,15 @@ export class BuilderFontPlugin extends Plugin {
             "display-3-font",
             "display-4-font",
             "buttons-font",
+        ],
+        font_items: [
+            ...[
+                { name: _t("Header 1 Display 2"), tagName: "h1", extraClass: "display-2" },
+                { name: _t("Header 1 Display 3"), tagName: "h1", extraClass: "display-3" },
+                { name: _t("Header 1 Display 4"), tagName: "h1", extraClass: "display-4" },
+            ].map((item) => withSequence(15, item)),
+            withSequence(43, { name: _t("Light"), tagName: "p", extraClass: "lead" }),
+            withSequence(46, { name: _t("Small"), tagName: "p", extraClass: "small" }),
         ],
     };
     setup() {

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -37,63 +37,6 @@ import { FontSizeSelector } from "./font_size_selector";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { weakMemoize } from "@html_editor/utils/functions";
 
-export const fontItems = [
-    {
-        name: _t("Header 1 Display 1"),
-        tagName: "h1",
-        extraClass: "display-1",
-    },
-    // TODO @phoenix use them if showExtendedTextStylesOptions is true
-    // {
-    //     name: _t("Header 1 Display 2"),
-    //     tagName: "h1",
-    //     extraClass: "display-2",
-    // },
-    // {
-    //     name: _t("Header 1 Display 3"),
-    //     tagName: "h1",
-    //     extraClass: "display-3",
-    // },
-    // {
-    //     name: _t("Header 1 Display 4"),
-    //     tagName: "h1",
-    //     extraClass: "display-4",
-    // },
-    // ----
-
-    { name: _t("Header 1"), tagName: "h1" },
-    { name: _t("Header 2"), tagName: "h2" },
-    { name: _t("Header 3"), tagName: "h3" },
-    { name: _t("Header 4"), tagName: "h4" },
-    { name: _t("Header 5"), tagName: "h5" },
-    { name: _t("Header 6"), tagName: "h6" },
-
-    {
-        name: _t("Normal"),
-        tagName: "div",
-        // for the FontSelector component
-        selector: getBaseContainerSelector("DIV"),
-    },
-    { name: _t("Paragraph"), tagName: "p" },
-
-    // TODO @phoenix use them if showExtendedTextStylesOptions is true
-    // consider baseContainer if enabling them
-    // {
-    //     name: _t("Light"),
-    //     tagName: "p",
-    //     extraClass: "lead",
-    // },
-    // {
-    //     name: _t("Small"),
-    //     tagName: "p",
-    //     extraClass: "small",
-    // },
-    // ----
-
-    { name: _t("Code"), tagName: "pre" },
-    { name: _t("Quote"), tagName: "blockquote" },
-];
-
 export const fontSizeItems = [
     { variableName: "display-1-font-size", className: "display-1-fs" },
     { variableName: "display-2-font-size", className: "display-2-fs" },
@@ -130,6 +73,30 @@ export class FontPlugin extends Plugin {
         "lineBreak",
     ];
     resources = {
+        font_items: [
+            withSequence(10, {
+                name: _t("Header 1 Display 1"),
+                tagName: "h1",
+                extraClass: "display-1",
+            }),
+            ...[
+                { name: _t("Header 1"), tagName: "h1" },
+                { name: _t("Header 2"), tagName: "h2" },
+                { name: _t("Header 3"), tagName: "h3" },
+                { name: _t("Header 4"), tagName: "h4" },
+                { name: _t("Header 5"), tagName: "h5" },
+                { name: _t("Header 6"), tagName: "h6" },
+            ].map((item) => withSequence(20, item)),
+            withSequence(30, {
+                name: _t("Normal"),
+                tagName: "div",
+                // for the FontSelector component
+                selector: getBaseContainerSelector("DIV"),
+            }),
+            withSequence(40, { name: _t("Paragraph"), tagName: "p" }),
+            withSequence(50, { name: _t("Code"), tagName: "pre" }),
+            withSequence(60, { name: _t("Quote"), tagName: "blockquote" }),
+        ],
         user_commands: [
             {
                 id: "setTagHeading1",
@@ -315,6 +282,11 @@ export class FontPlugin extends Plugin {
         this.blockFormatIsAvailableMemoized = weakMemoize(
             (selection) => isHtmlContentSupported(selection) && this.dependencies.dom.canSetBlock()
         );
+        this.availableFontItems = this.getResource("font_items").filter(
+            ({ tagName }) =>
+                !SUPPORTED_BASE_CONTAINER_NAMES.includes(tagName.toUpperCase()) ||
+                this.config.baseContainers.includes(tagName.toUpperCase())
+        );
     }
 
     normalize(root) {
@@ -323,14 +295,6 @@ export class FontPlugin extends Plugin {
                 unwrapContents(el);
             }
         }
-    }
-
-    get availableFontItems() {
-        return fontItems.filter(
-            ({ tagName }) =>
-                !SUPPORTED_BASE_CONTAINER_NAMES.includes(tagName.toUpperCase()) ||
-                this.config.baseContainers.includes(tagName.toUpperCase())
-        );
     }
 
     get fontName() {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -27,7 +27,7 @@ import {
     models,
     mountView,
 } from "@web/../tests/web_test_helpers";
-import { fontItems, fontSizeItems } from "../src/main/font/font_plugin";
+import { fontSizeItems } from "../src/main/font/font_plugin";
 import { Plugin } from "../src/plugin";
 import { MAIN_PLUGINS } from "../src/plugin_sets";
 import { convertNumericToUnit, getCSSVariableValue, getHtmlStyle } from "../src/utils/formatting";
@@ -288,9 +288,9 @@ test("toolbar works: can select font", async () => {
 });
 
 test("toolbar works: show the right font name", async () => {
-    await setupEditor("<p>[test]</p>");
+    const { editor } = await setupEditor("<p>[test]</p>");
     await waitFor(".o-we-toolbar");
-    const items = fontItems;
+    const items = editor.getResource("font_items");
     for (const item of items) {
         await contains(".o-we-toolbar [name='font'] .dropdown-toggle").click();
         await animationFrame();

--- a/addons/website/static/tests/builder/editor.test.js
+++ b/addons/website/static/tests/builder/editor.test.js
@@ -3,7 +3,7 @@ import { expect, test, describe } from "@odoo/hoot";
 import { animationFrame } from "@odoo/hoot-mock";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
-import { click, manuallyDispatchProgrammaticEvent, waitFor, queryOne } from "@odoo/hoot-dom";
+import { click, manuallyDispatchProgrammaticEvent, waitFor, queryOne, waitForNone } from "@odoo/hoot-dom";
 import { isTextNode } from "@html_editor/utils/dom_info";
 import { parseHTML } from "@html_editor/utils/html";
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
@@ -207,5 +207,54 @@ describe("toolbar dropdowns", () => {
         click(".o-we-toolbar .btn[name='font']");
         await animationFrame();
         expect(".o_font_selector_menu .o-dropdown-item[name='div']").toHaveCount(0);
+    });
+});
+
+describe("font types", () => {
+    test("Header 1 Display 1 to 4 are available", async () => {
+        const { getEditor } = await setupWebsiteBuilder(`<p>abc</p>`);
+        const editor = getEditor();
+        const p = editor.editable.querySelector("p");
+        setSelection({ anchorNode: p, anchorOffset: 0, focusOffset: 1 });
+        await waitFor(".o-we-toolbar");
+        click(".o-we-toolbar .btn[name='font']");
+        await waitFor(".o_font_selector_menu");
+        const expectedButtons = [
+            "Header 1 Display 1",
+            "Header 1 Display 2",
+            "Header 1 Display 3",
+            "Header 1 Display 4",
+        ];
+        expectedButtons.forEach((button) => {
+            expect(`.o_font_selector_menu .o-dropdown-item:contains('${button}')`).toHaveCount(1);
+        });
+    });
+    test("'Light' is available", async () => {
+        const { getEditor } = await setupWebsiteBuilder(`<p>abc</p>`);
+        const editor = getEditor();
+        const p = editor.editable.querySelector("p");
+        setSelection({ anchorNode: p, anchorOffset: 0, focusOffset: 1 });
+        await waitFor(".o-we-toolbar");
+        click(".o-we-toolbar .btn[name='font']");
+        await waitFor(".o_font_selector_menu");
+        expect(`.o_font_selector_menu .o-dropdown-item:contains('Light')`).toHaveCount(1);
+        click(".o_font_selector_menu .o-dropdown-item:contains('Light')");
+        await waitForNone(".o_font_selector_menu");
+        expect(".o-we-toolbar .btn[name='font']").toHaveText("Light");
+        expect(editor.editable.querySelector("p")).toHaveClass("lead");
+    });
+    test("'Small' is available", async () => {
+        const { getEditor } = await setupWebsiteBuilder(`<p>abc</p>`);
+        const editor = getEditor();
+        const p = editor.editable.querySelector("p");
+        setSelection({ anchorNode: p, anchorOffset: 0, focusOffset: 1 });
+        await waitFor(".o-we-toolbar");
+        click(".o-we-toolbar .btn[name='font']");
+        await waitFor(".o_font_selector_menu");
+        expect(`.o_font_selector_menu .o-dropdown-item:contains('Small')`).toHaveCount(1);
+        click(".o_font_selector_menu .o-dropdown-item:contains('Small')");
+        await waitForNone(".o_font_selector_menu");
+        expect(".o-we-toolbar .btn[name='font']").toHaveText("Small");
+        expect(editor.editable.querySelector("p")).toHaveClass("small");
     });
 });

--- a/addons/website_forum/static/src/plugins/font_plugin.js
+++ b/addons/website_forum/static/src/plugins/font_plugin.js
@@ -13,9 +13,8 @@ export class ForumFontPlugin extends FontPlugin {
         toolbar_items: this.resources.toolbar_items.filter(
             (item) => item.object.id !== "font-size"
         ),
+        font_items: this.resources.font_items.filter(
+            (item) => !excludedFontItems.includes(item.object.tagName)
+        ),
     };
-
-    get availableFontItems() {
-        return super.availableFontItems.filter((item) => !excludedFontItems.includes(item.tagName));
-    }
 }


### PR DESCRIPTION
This commit reintroduces the following "font types" that were missing after the refactor of the editor (html_editor) and the website builder:

- Header 1 Display 2
- Header 1 Display 3
- Header 1 Display 4
- Light
- Small

task-5065292

