### PR TITLE
[FIX] tests: default value for test_tags is None

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -726,7 +726,7 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
         """Guess if the test_methods is a query_count and adds an `is_query_count` tag on the test
         """
         additional_tags = []
-        if 'is_query_count' in odoo.tools.config['test_tags']:
+        if odoo.tools.config['test_tags'] and 'is_query_count' in odoo.tools.config['test_tags']:
             method_source = inspect.getsource(test_method) if test_method else ''
             if 'self.assertQueryCount' in method_source:
                 additional_tags.append('is_query_count')
@@ -2064,7 +2064,7 @@ class HttpCase(TransactionCase):
         guess if the test_methods is a tour and adds an `is_tour` tag on the test
         """
         additional_tags = super().get_method_additional_tags(test_method)
-        if 'is_tour' in odoo.tools.config['test_tags']:
+        if odoo.tools.config['test_tags'] and 'is_tour' in odoo.tools.config['test_tags']:
             method_source = inspect.getsource(test_method)
             if 'self.start_tour' in method_source:
                 additional_tags.append('is_tour')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The issue arises when using pytest (to get junit xml for CI) with [pytest-odoo==1.0.1](https://github.com/camptocamp/pytest-odoo)

```
run_tests     def get_method_additional_tags(self, test_method):
run_tests         """Guess if the test_methods is a query_count and adds an `is_query_count` tag on the test
run_tests         """
run_tests         additional_tags = []
run_tests >       if 'is_query_count' in odoo.tools.config['test_tags']:
run_tests E       TypeError: argument of type 'NoneType' is not iterable
run_tests 
run_tests ../custom/src/odoo/odoo/tests/common.py:778: TypeError
```

Info @wt-io-it


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
