### PR TITLE
[FIX] hr_recruitment_ai: fix the traceback on refuse ai button

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -41,6 +41,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
         compute='_compute_from_template_id', readonly=False, store=True,
         help="send emails after that date. This date is considered as being in UTC timezone."
     )
+    model = fields.Char('Related Document Model', compute='_compute_model')
 
     @api.depends('applicant_ids')
     def _compute_applicant_without_email(self):
@@ -71,6 +72,9 @@ class ApplicantGetRefuseReason(models.TransientModel):
             self.duplicate_applicant_ids = self.env['hr.applicant'].search(self.duplicate_applicant_ids_domain)
         else:
             self.duplicate_applicant_ids = self.env['hr.applicant']
+
+    def _compute_model(self):
+        self.model = 'hr.applicant'
 
     # Overrides of mail.composer.mixin
     @api.depends('refuse_reason_id')  # fake trigger otherwise not computed in new mode


### PR DESCRIPTION
Step to reproduce:
- install hr_recruitment.
- go to any applicant in any job position.
- click on refuse button.
- click on AI button

Issue:
- traceback occurs

Reason:
- required field for using this widget is not defined.
- so it tries to slice the res_ids field which is still not defined

Solution
- add the necessary fields required for the widget.

task-5058510