### PR TITLE
[FIX] iot_drivers: replace DBFormatter by ColoredFormatter

### DIFF
--- a/addons/iot_drivers/server_logger.py
+++ b/addons/iot_drivers/server_logger.py
@@ -6,7 +6,7 @@ import time
 
 from odoo.addons.iot_drivers.tools import helpers
 from odoo.addons.iot_drivers.tools.system import IS_TEST
-from odoo.netsvc import DBFormatter
+from odoo.netsvc import ColoredFormatter
 
 _logger = logging.getLogger(__name__)
 
@@ -165,7 +165,7 @@ def _server_log_sender_handler_filter(log_record):
 # in this case we force close the log handler (as it does not make sense anymore)
 _server_log_sender_handler = AsyncHTTPHandler(helpers.get_odoo_server_url(), get_odoo_config_log_to_server_option())
 if not IS_TEST:
-    _server_log_sender_handler.setFormatter(DBFormatter('%(asctime)s %(pid)s %(levelname)s %(dbname)s %(name)s: %(message)s %(perf_info)s'))
+    _server_log_sender_handler.setFormatter(ColoredFormatter('%(asctime)s %(pid)s %(levelname)s %(dbname)s %(name)s: %(message)s %(perf_info)s'))
     _server_log_sender_handler.addFilter(_server_log_sender_handler_filter)
     # Set it in the 'root' logger, on which every logger (including odoo) is a child
     logging.getLogger().addHandler(_server_log_sender_handler)


### PR DESCRIPTION
As DBFormatter was removed (odoo/odoo#225303), we need to remove it in our iot server_logger.
