### PR TITLE
[IMP] mail, crm: add rotting demo data

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -63,6 +63,7 @@
     ],
     'demo': [
         'data/crm_team_demo.xml',
+        'data/crm_stage_demo.xml',
         'data/mail_template_demo.xml',
         'data/crm_team_member_demo.xml',
         'data/crm_lead_demo.xml',

--- a/addons/crm/data/crm_lead_demo.xml
+++ b/addons/crm/data/crm_lead_demo.xml
@@ -662,6 +662,7 @@ Andrew</p>]]></field>
             <field name="create_date" eval="datetime.now() - timedelta(days=8)"/>
             <field name="type">opportunity</field>
             <field name="name">5 VP Chairs</field>
+            <field name="date_last_stage_update" eval="datetime.now() - timedelta(days=6)"/>
             <field name="expected_revenue">5600</field>
             <field name="probability">30.0</field>
             <field name="contact_name">Benjamin Flores</field>

--- a/addons/crm/data/crm_stage_demo.xml
+++ b/addons/crm/data/crm_stage_demo.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <data noupdate="1">
+        <record id="stage_lead3" model="crm.stage">
+            <field name="rotting_threshold_days">5</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/mail/static/src/js/rotting_mixin/rotting_column_progress.xml
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_column_progress.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.RottingColumnProgress" t-inherit="web.ColumnProgress" t-inherit-mode="primary">
         <AnimatedNumber position="before">
             <t t-set="rottingAggregate" t-value="getRottingGroupCount(props.group)"/>
-            <div t-if="rottingAggregate.value > 0" t-on-click="() => onRotIconClick()"
+            <div t-if="rottingAggregate.value > 0" t-on-click="onRottingIconClick"
                 t-attf-class="badge rounded-pill o_mail_resource_rotting_bg ms-3 {{ this.rottingFilterAvailable ? 'cursor-pointer' : 'cursor-default' }}"
                 t-att-title="rottingAggregate.title">
                 <div class="text-900 text-nowrap">


### PR DESCRIPTION
To provide better visibility on the rotting feature, demo data is added to CRM.
By default, the Proposition stage will be rotting, with the "5 VP Chairs" lead rotten.

--

This PR fixes a traceback in the rotting logic: using the
is_rotting filters would cause a traceback due to a query substring
with %()s placeholders being added to another string witout its own
placeholders being processed.

The substring is now added to the main query string as an f-string,
before placeholder processing.

--

This PR also fixes an issue where clicking on the rotting icons in
rotting column header bars would fail to filter on the column's rotten
items, instead resulting in a traceback.

task-5064952
