### PR TITLE
[FIX] base_install_request: conditional ai module installation

### DIFF
--- a/addons/base_install_request/__init__.py
+++ b/addons/base_install_request/__init__.py
@@ -1,21 +1,38 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import wizard
+import psycopg2
 
 from odoo import tools
 
+from . import models
+from . import wizard
+
+
+def pgvector_is_available(env):
+    try:
+        with tools.mute_logger('odoo.sql_db'), env.cr.savepoint():
+            env.cr.execute(tools.SQL("CREATE EXTENSION IF NOT EXISTS vector"))
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
 
 def _auto_install_apps(env):
-    if not tools.config.get('default_productivity_apps', False):
-        return
-    env['ir.module.module'].sudo().search([
-        ('name', 'in', [
+    modules_to_install = []
+    if tools.config.get('default_productivity_apps', False):
+        modules_to_install.extend([
             # Community
             'hr', 'mass_mailing', 'project', 'survey',
             # Enterprise
             'appointment', 'knowledge', 'planning', 'sign',
-        ]),
-        ('state', '=', 'uninstalled')
-    ]).button_install()
+        ])
+
+    if pgvector_is_available(env):
+        modules_to_install.append('ai')
+
+    if modules_to_install:
+        env['ir.module.module'].sudo().search([
+            ('name', 'in', modules_to_install),
+            ('state', '=', 'uninstalled')
+        ]).button_install()


### PR DESCRIPTION
Since https://github.com/odoo/enterprise/pull/93271, the ai module is auto_install. This however introduce problems because most computers running odoo doesn't have pgvector installed.

In this PR, we're now conditionally auto installing the ai module. base_install_request is also a good place to write the condition because its odoo module dependency is similar to ai's.

Related: https://github.com/odoo/enterprise/pull/93903