### PR TITLE
[FIX] im_livechat: selection of least active agent

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -249,10 +249,8 @@ class ImLivechatChannel(models.Model):
             LEFT OUTER JOIN mail_message m ON c.id = m.res_id AND m.model = 'discuss.channel'
             LEFT OUTER JOIN operator_rtc_session rtc ON rtc.partner_id = c.livechat_operator_id
             WHERE c.channel_type = 'livechat' AND c.create_date > ((now() at time zone 'UTC') - interval '24 hours')
-            AND (
-                c.livechat_active IS TRUE
-                OR m.create_date > ((now() at time zone 'UTC') - interval '30 minutes')
-            )
+            AND c.livechat_active IS TRUE
+            AND m.create_date > ((now() at time zone 'UTC') - interval '30 minutes')
             AND c.livechat_operator_id in %s
             GROUP BY c.livechat_operator_id, rtc.nbr
             ORDER BY COUNT(DISTINCT c.id) < 2 OR rtc.nbr IS NULL DESC, COUNT(DISTINCT c.id) ASC, rtc.nbr IS NULL DESC""",


### PR DESCRIPTION
Live chat agents are assigned based on their expertise, language, country, and other criteria. When several agents match these criteria, the system chooses the least active one.

There was an issue with the SQL query that retrieves agent occupation: an agent was still considered buisy if a message was received within the last 30 minutes, even if the live chat was ended.

This commit fixes the issue: the query now excludes ended live chats as well as live chats without any activity  for at least 30 minutes.

task-5065567