### PR TITLE
[IMP] website_sale(,_stock): reintegrate GMC

### DIFF
--- a/addons/website_sale_gmc/__init__.py
+++ b/addons/website_sale_gmc/__init__.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers
+from . import models
+
+
+def _post_init_hook(env):
+    websites_enabled_gmc = env['website'].search([('enabled_gmc_src', '=', True)])
+
+    # Enable the feature group if already enabled on a website
+    if websites_enabled_gmc:
+        env.ref('base.group_user')._apply_group(env.ref('website_sale_gmc.group_product_feed'))
+
+    websites_enabled_gmc._populate_product_feeds()

--- a/addons/website_sale_gmc/__manifest__.py
+++ b/addons/website_sale_gmc/__manifest__.py
@@ -1,0 +1,24 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Google Merchant Center",
+    'category': 'Website/Website',
+    'sequence': 50,
+    'summary': "Synchronize your products with Google Merchant Center",
+    'depends': ['website_sale'],
+    'data': [
+        # Security
+        'security/ir.model.access.csv',
+        'security/res_groups.xml',
+
+        # Model views.
+        'views/gmc_templates.xml',
+        'views/product_feed_views.xml',
+        'views/website_sale_gmc_menus.xml',
+        'views/res_config_settings_views.xml',
+    ],
+    'installable': True,
+    'post_init_hook': '_post_init_hook',
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/website_sale_gmc/const.py
+++ b/addons/website_sale_gmc/const.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+
+
+PRODUCT_FEED_SOFT_LIMIT = 5000
+PRODUCT_FEED_HARD_LIMIT = 6000
+
+# Google Merchant Center
+GMC_SUPPORTED_UOM = {
+    'oz',
+    'lb',
+    'mg',
+    'g',
+    'kg',
+    'floz',
+    'pt',
+    'ct',
+    'qt',
+    'gal',
+    'ml',
+    'cl',
+    'l',
+    'cbm',
+    'in',
+    'ft',
+    'yd',
+    'cm',
+    'm',
+    'sqft',
+    'sqm',
+}
+GMC_BASE_MEASURE = re.compile(r'(?P<base_count>\d+)?\s*(?P<base_unit>[a-z]+)')

--- a/addons/website_sale_gmc/controllers/__init__.py
+++ b/addons/website_sale_gmc/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product_feed

--- a/addons/website_sale_gmc/controllers/product_feed.py
+++ b/addons/website_sale_gmc/controllers/product_feed.py
@@ -1,0 +1,81 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+
+from odoo.http import request
+from odoo.tools import consteq
+
+from odoo.addons.website_sale.controllers.gmc import GoogleMerchantCenter
+
+
+class ProductFeed(GoogleMerchantCenter):
+
+    def gmc_data_source(self, feed_id='', access_token='', **_kwargs):
+        """Serve a dynamic XML feed to synchronize the eCommerce products with Google Merchant
+        Center (GMC).
+
+        This method generates an XML feed containing information about eCommerce products.
+        The feed is configured via the `product.feed` model, allowing customization such as:
+        - Localization by specifying a language or pricelist (currency).
+        - Filtering products by category or categories.
+
+        Notes:
+        - The feed is only accessible through a valid `access_token`.
+        - A feed will contain at most 6000 products. If there are more than 6000 products,
+          only the first 6000 will be included in the feed. This is a technical limit, but a soft
+          limit of 5000 products is also enforced on the `product.feed` record.
+
+        See also https://support.google.com/merchants/answer/7052112 for the XML format.
+
+        :return: The XML feed compressed using GZIP.
+        :rtype: bytes
+        """
+        if not request.website.enabled_gmc_src:
+            raise NotFound()
+
+        feed_sudo = self._find_and_check_feed_access(feed_id, access_token)
+
+        if feed_sudo.website_id != request.website:
+            feed_sudo._notify_website_manager(
+                subject=request.env._("GMC: Domain Mismatch"),
+                body=request.env._(
+                    "The feed '%(feed_name)s' is configured for '%(feed_website)s', but was"
+                    " accessed from '%(request_website)s'. This may be due to a recent"
+                    " configuration change. Please ensure the URL is updated in Google Merchant"
+                    " Center as well.",
+                    feed_name=feed_sudo.display_name,
+                    request_website=request.website.display_name,
+                    feed_website=feed_sudo.website_id.display_name,
+                ),
+            )
+            raise BadRequest()
+
+        compressed_gmc_xml = feed_sudo._render_and_cache_compressed_gmc_feed()
+
+        return request.make_response(compressed_gmc_xml, [
+            ('Content-Type', 'application/xml; charset=utf-8'), ('Content-Encoding', 'gzip')
+        ])
+
+    def _find_and_check_feed_access(self, feed_id, access_token):
+        """Find the feed by its ID and validate its access token.
+
+        :param str feed_id: The ID of the feed to validate.
+        :param str access_token: The access token associated with the feed.
+        :raises BadRequest: If the feed ID cannot be converted to an integer.
+        :raises NotFound: If the feed ID does not match any existing feed.
+        :raises Forbidden: If the provided access token does not match the feed's access token.
+        :return: The feed record if access is successfully validated, in sudo mode.
+        :rtype: product.feed
+        """
+        try:
+            feed_id = int(feed_id)
+        except ValueError:
+            raise BadRequest()
+        feed_sudo = request.env['product.feed'].sudo().browse(feed_id).exists()
+        if not feed_sudo:
+            raise NotFound()
+
+        if not consteq(feed_sudo.access_token, access_token):
+            raise Forbidden()
+
+        return feed_sudo

--- a/addons/website_sale_gmc/models/__init__.py
+++ b/addons/website_sale_gmc/models/__init__.py
@@ -1,0 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product_feed
+from . import res_config_settings
+from . import website

--- a/addons/website_sale_gmc/models/product_feed.py
+++ b/addons/website_sale_gmc/models/product_feed.py
@@ -1,0 +1,382 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import base64
+from dateutil.relativedelta import relativedelta
+import gzip
+from urllib.parse import urlparse
+import uuid
+
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.fields import Domain
+from odoo.http import request
+from odoo.tools import float_is_zero, float_round, urls
+
+from odoo.addons.website_sale import utils
+from odoo.addons.website_sale_gmc import const
+
+
+class ProductFeed(models.Model):
+    _name = 'product.feed'
+    _inherit = ['mail.thread']
+    _description = "Product Feed"
+
+    name = fields.Char(required=True)
+    website_id = fields.Many2one('website', required=True)
+    pricelist_id = fields.Many2one(
+        'product.pricelist',
+        help="Specify a pricelist to localize the feed with a specific currency."
+             " If not set, the default website pricelist will be used.\n"
+             "Note that the pricelist must be selectable on the website.",
+        domain="[('website_id', 'in', (False, website_id)), ('selectable', '=', True)]",
+    )
+    lang_id = fields.Many2one(
+        'res.lang',
+        string="Language",
+        help="Select the language to translate product names, descriptions,"
+             " and other text in the feed.",
+        required=True,
+        domain="[('id', 'in', website_lang_ids)]",
+    )
+    website_lang_ids = fields.Many2many(related='website_id.language_ids')
+    product_category_ids = fields.Many2many('product.public.category', string="Categories")
+    format = fields.Selection(
+        selection=[
+            ('gmc', "Google Merchant Center"),
+        ],
+        default='gmc',
+        required=True,
+    )
+    access_token = fields.Char(
+        default=lambda _: uuid.uuid4().hex,
+        required=True,
+        copy=False,
+        readonly=True,
+    )
+    url = fields.Char(compute='_compute_url')
+
+    # Caching mechanism (technical fields)
+    feed_cache = fields.Binary(compute='_compute_feed_cache', store=True, readonly=True)
+    cache_expiry = fields.Datetime(default=fields.Datetime.now, required=True, readonly=True)
+
+    @api.depends('format')
+    def _compute_url(self):
+        """Compute the full feed url."""
+        for feed in self:
+            match feed.format:
+                case 'gmc':
+                    path = '/gmc.xml'
+                case _:
+                    raise NotImplementedError()
+
+            feed.url = urls.urljoin(
+                feed.website_id.get_base_url(),
+                f'{path}?feed_id={feed.id}&access_token={feed.access_token}',
+            )
+
+    @api.depends(
+        'website_id', 'pricelist_id', 'lang_id', 'product_category_ids'
+    )
+    def _compute_feed_cache(self):
+        """Invalidate cache on feed parameter changes."""
+        self.action_invalidate_cache()
+
+    @api.constrains('product_category_ids', 'website_id')
+    def _check_product_limit(self):
+        """Add a soft limit on the number of products a feed can contain. A strong limit of 6000 is
+        applied during the feed rendering phase."""
+        for feed in self:
+            product_count = feed.env['product.product'].search_count(
+                feed._get_feed_product_domain(), limit=const.PRODUCT_FEED_SOFT_LIMIT + 1
+            )
+            if product_count > const.PRODUCT_FEED_SOFT_LIMIT:
+                raise ValidationError(feed.env._(
+                    "A single feed cannot contain more than %(limit)s products."
+                    " Please separate products with Categories.",
+                    limit=f"{const.PRODUCT_FEED_SOFT_LIMIT:,}",  # Format to 5,000
+                ))
+
+    def action_invalidate_cache(self):
+        self.feed_cache = False
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'success',
+                'message': self.env._("Feed cache successfully reset."),
+            },
+        }
+
+    def _render_and_cache_compressed_gmc_feed(self):
+        """Render and cache the Google Merchant Center feed. This method ensures that the feed is
+        rendered only once per day and caches the result. If the feed parameters change, the cache
+        is invalidated, and the feed is re-rendered.
+
+        :raises LockError: If the feed is already being rendered by another request.
+        :return: The rendered feed compressed using gzip.
+        :rtype: bytes
+        """
+        self.ensure_one()
+
+        if not self.feed_cache or self.cache_expiry < fields.Datetime.now():
+            # Lock the record to prevent concurrent rendering
+            self.lock_for_update()
+            gmc_xml = self._render_gmc_feed()
+            # The binary field stores the data in the `datas` field of an `ir.attachment` which is a
+            # base64 view of its `raw` data, therefore we encode the gzip content before saving it.
+            self.feed_cache = base64.b64encode(gzip.compress(gmc_xml.encode()))
+            self.cache_expiry = fields.Datetime.today() + relativedelta(days=1)
+
+        return base64.b64decode(self.feed_cache)
+
+    def _render_gmc_feed(self):
+        """Render the Google Merchant Center feed.
+
+        See also https://support.google.com/merchants/answer/7052112 for the XML format.
+
+        :return: The rendered XML feed.
+        :rtype: str
+        """
+        self.ensure_one()
+        # Set the language context for rendering.
+        # Ensures all links, product names, descriptions, etc., are localized.
+        self = self.with_context(lang=self.lang_id.code)  # noqa: PLW0642
+
+        # Override the pricelist of the request to localize the currency and prices, otherwise, uses
+        # the website default pricelist.
+        if self.pricelist_id:
+            request.pricelist = self.pricelist_id
+
+        homepage_url = self.website_id.homepage_url or '/'
+        website_homepage = self.website_id._get_website_pages(
+            Domain([('url', '=', homepage_url), ('website_id', '!=', False)]), limit=1
+        )
+
+        gmc_data = {
+            'title': website_homepage.website_meta_title or self.website_id.name,
+            'link': urls.urljoin(
+                self.website_id.get_base_url(),
+                self.env['ir.http']._url_lang(homepage_url, lang_code=self.lang_id.code),
+            ),
+            'description': website_homepage.website_meta_description or self.website_id,
+            'items': self._prepare_gmc_items(),
+        }
+
+        return self.env['ir.ui.view'].sudo()._render_template(
+            'website_sale.gmc_xml', gmc_data,
+        )
+
+    def _prepare_gmc_items(self):
+        """Prepare Google Merchant Center items' fields.
+
+        See Google's (https://support.google.com/merchants/answer/7052112) documentation for more
+        information about each field.
+
+        :return: a dictionary for each product in this recordset.
+        :rtype: list[dict]
+        """
+        products = self._get_feed_products()
+        base_url = self.website_id.get_base_url()
+
+        def format_product_link(url_):
+            if self.pricelist_id:
+                url_ = urlparse(url_)._replace(query=f'pricelist={self.pricelist_id.id}').geturl()
+            return urls.urljoin(
+                base_url, self.env['ir.http']._url_lang(url_, lang_code=self.lang_id.code)
+            )
+
+        return {
+            product: {
+                'id': product.default_code or product.id,
+                'title': product.with_context(display_default_code=False).display_name,
+                'description': product.website_meta_description or product.description_sale,
+                'link': format_product_link(product.website_url),
+                **self._prepare_gmc_identifier(product),
+                **self._prepare_gmc_image_links(product, base_url),
+                **price_info,
+                **self._prepare_gmc_stock_info(product),
+                **self._prepare_gmc_additional_info(product),
+            }
+            for product in products
+            if product._is_variant_possible()
+            and (price_info := self._prepare_gmc_price_info(product))
+        }
+
+    def _get_feed_product_domain(self):
+        product_domain = Domain.AND([
+            Domain('is_published', '=', True),
+            Domain('type', 'in', ('consu', 'combo')),
+            self.website_id.website_domain(),
+        ])
+        if self.product_category_ids:
+            product_domain &= Domain('public_categ_ids', 'child_of', self.product_category_ids.ids)
+
+        return product_domain
+
+    def _get_feed_products(self):
+        product_domain = self._get_feed_product_domain()
+
+        products = self.env['product.product'].search(
+            product_domain, limit=const.PRODUCT_FEED_HARD_LIMIT
+        )
+
+        # Send an early warning to the website manager if the number of products exceeds the
+        # midpoint between the soft and hard limit.
+        if len(products) > (const.PRODUCT_FEED_SOFT_LIMIT + const.PRODUCT_FEED_HARD_LIMIT) / 2:
+            self._notify_website_manager(
+                subject=self.env._("GMC: Product Limit Exceeded"),
+                body=self.env._(
+                    "The feed %(feed_name)s contains more than %(limit)s products,"
+                    " which may not be fully updated. Consider refining the feed by adjusting"
+                    " the product categories.",
+                    feed_name=self.display_name,
+                    limit=f"{const.PRODUCT_FEED_SOFT_LIMIT:,}",  # Format to 5,000
+                ),
+            )
+
+        return products
+
+    def _prepare_gmc_identifier(self, product):
+        """Prepare the product identifiers for Google Merchant Center.
+
+        :return: The barcode of the product as GTIN
+        :rtype: dict
+        """
+        if product.barcode:
+            return {'gtin': product.barcode, 'identifier_exists': 'yes'}
+        return {'identifier_exists': 'no'}
+
+    def _prepare_gmc_image_links(self, product, base_url):
+        """Prepare the product image links for Google Merchant Center.
+
+        :return: The main product image link, and the extra images. No videos.
+        :rtype: dict
+        """
+        return {
+            # Don't send any image link if there isn't. Google does not allow placeholder
+            'image_link': (
+                urls.urljoin(base_url, product._get_image_1920_url()) if product.image_128 else ''
+            ),
+            # Supports up to 10 extra images
+            'additional_image_link': [
+                urls.urljoin(base_url, url) for url in product._get_extra_image_1920_urls()[:10]
+            ],
+        }
+
+    def _prepare_gmc_price_info(self, product):
+        """Prepare price-related information for Google Merchant Center.
+
+        Note: If the product is flagged to prevent zero price sales, an empty dictionary is
+        returned.
+
+        :return: A dictionary containing nothing if the product is "prevent zero price sale", or:
+            - List price,
+            - Sale price (if applicable), and
+            - Comparison prices (e.g., $100 / ml) if "Product Reference Price" is enabled.
+        :rtype: dict
+        """
+        price_context = product._get_product_price_context(
+            product.product_template_attribute_value_ids
+        )
+        combination_info = product.with_context(
+            **price_context,
+        ).product_tmpl_id._get_additionnal_combination_info(
+            product,
+            quantity=1.0,
+            uom=product.uom_id,
+            date=fields.Date.context_today(self),
+            website=self.website_id,
+        )
+        if combination_info['prevent_zero_price_sale']:
+            return {}
+
+        price_info = {
+            'price': utils.gmc_format_price(
+                combination_info['list_price'], combination_info['currency'],
+            ),
+        }
+
+        if combination_info['has_discounted_price']:
+            price_info['sale_price'] = utils.gmc_format_price(
+                combination_info['price'], combination_info['currency'],
+            )
+            start_date = combination_info['discount_start_date']
+            end_date = combination_info['discount_end_date']
+            if start_date and end_date:
+                price_info['sale_price_effective_date'] = '/'.join(
+                    map(utils.gmc_format_date, (start_date, end_date)),
+                )
+
+        # Note: Google only supports a restricted set of unit and computes the comparison prices
+        # differently than Odoo.
+        # Ex: product="Pack of wine (6 bottles)", price=$65.00, uom_name="Pack".
+        #   - in odoo: base_unit_count=6.0, base_unit_name="750ml"
+        #       => displayed: "$10.83 / 750ml"
+        #   - in google: unit_pricing_measure="4500ml", unit_pricing_base_measure="750ml"
+        #       => displayed: "$10.83 / 750ml"
+        if (
+            combination_info.get('base_unit_name')
+            and product.base_unit_count
+            and (match := const.GMC_BASE_MEASURE.match(
+                combination_info['base_unit_name'].strip().lower()
+            ))
+        ):
+            base_count, base_unit = match['base_count'] or '1', match['base_unit']
+            count = product.base_unit_count * int(base_count)
+            if (
+                base_unit in const.GMC_SUPPORTED_UOM
+                and not float_is_zero(count, precision_digits=2)
+            ):
+                price_info['unit_pricing_measure'] = (
+                    f'{float_round(count, precision_digits=2)}{base_unit}'
+                )
+                price_info['unit_pricing_base_measure'] = f'{base_count}{base_unit}'
+
+        return price_info
+
+    def _prepare_gmc_stock_info(self, _product):
+        """Intended to be overridden in stock."""
+        return {'availability': 'in_stock'}
+
+    def _prepare_gmc_additional_info(self, product):
+        additional_info = {
+            'product_detail': [
+                (attr.attribute_id.name, attr.name)
+                for attr in product.product_template_attribute_value_ids
+            ],
+            'is_bundle': 'yes' if product.type == 'combo' else 'no',
+            'product_type': [
+                category.replace('/', '>')  # Google uses a different format
+                for category in (
+                    # Up to 5 categories
+                    product.public_categ_ids.sorted('sequence').mapped('display_name')[:5]
+                )
+            ],
+            'custom_label': [
+                (f'custom_label_{i}', tag_name)
+                for i, tag_name in enumerate(
+                    # Supports up to 5 custom labels
+                    product.all_product_tag_ids.sorted('sequence').mapped('name')[:5]
+                )
+            ],
+        }
+
+        # Link variants together
+        if len(product.product_tmpl_id.product_variant_ids) > 1:
+            additional_info['item_group_id'] = product.product_tmpl_id.id
+
+        return additional_info
+
+    def _notify_website_manager(self, **kwargs):
+        """Send a notification to the website manager using OdooBot.
+
+        This method wraps around `message_notify` to notify the manager of the feed's website.
+
+        :param dict kwargs: Additional arguments passed to `message_notify`.
+        :return: The created `mail.message` record.
+        :rtype: mail.message
+        """
+        return self.with_user(self.env.ref('base.user_root')).message_notify(
+            partner_ids=self.website_id.salesperson_id.partner_id.ids, **kwargs
+        )

--- a/addons/website_sale_gmc/models/res_config_settings.py
+++ b/addons/website_sale_gmc/models/res_config_settings.py
@@ -1,0 +1,44 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.Model):
+    _inherit = 'res.config.settings'
+
+    group_gmc_feed = fields.Boolean(
+        string="Google Merchant Center Data Source",
+        implied_group='website_sale_gmc.group_product_feed',
+        group='base.group_user',
+        related='website_id.enabled_gmc_src',
+        readonly=False,
+    )
+
+    _check_gmc_ecommerce_access = models.Constraint('CHECK (TRUE)', "Disable the constraint")
+
+    def set_values(self):
+        """Override to pre-populate the website feeds if none already exists."""
+        super().set_values()
+
+        if self.group_gmc_feed and not self.env['product.feed'].search_count(
+            [('website_id', '=', self.website_id.id)], limit=1
+        ):
+            self.website_id._populate_product_feeds()
+
+    @api.readonly
+    def action_open_product_feeds(self):
+        """Open the list view to manage the feed specific to the current website."""
+        self.ensure_one()
+        return {
+            'name': self.env._("Product Feeds"),
+            'type': 'ir.actions.act_window',
+            'res_model': 'product.feed',
+            'views': [(False, 'list')],
+            'target': 'new',
+            'context': {
+                'default_website_id': self.website_id.id,
+                'default_lang_id': self.website_id.default_lang_id.id,
+                'hide_website_column': True,
+            },
+            'domain': [('website_id', '=', self.website_id.id)],
+        }

--- a/addons/website_sale_gmc/models/website.py
+++ b/addons/website_sale_gmc/models/website.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    def _populate_product_feeds(self):
+        """Populate product feeds for the website with default values."""
+        for website in self:
+            website.env['product.feed'].create({
+                'name': website.env._("GMC 1"),
+                'website_id': website.id,
+                'lang_id': website.default_lang_id.id,
+            })

--- a/addons/website_sale_gmc/security/ir.model.access.csv
+++ b/addons/website_sale_gmc/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_feed_base_group,access_product_feed base_group,model_product_feed,base.group_user,1,1,1,1

--- a/addons/website_sale_gmc/security/res_groups.xml
+++ b/addons/website_sale_gmc/security/res_groups.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Feature groups -->
+    <record id="group_product_feed" model="res.groups">
+        <field name="name">Product Feed</field>
+    </record>
+
+</odoo>

--- a/addons/website_sale_gmc/views/gmc_templates.xml
+++ b/addons/website_sale_gmc/views/gmc_templates.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="gmc_xml" inherit_id="website_sale.gmc_xml">
+        <xpath expr="//g:gtin/following-sibling::*[1]" position="replace"/>
+        <t name="shippings" position="replace"/>
+    </template>
+</odoo>

--- a/addons/website_sale_gmc/views/product_feed_views.xml
+++ b/addons/website_sale_gmc/views/product_feed_views.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_feed_search_view" model="ir.ui.view">
+        <field name="name">product.feed.view.search</field>
+        <field name="model">product.feed</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="website_id" groups="website.group_multi_website"/>
+                <field name="pricelist_id" groups="product.group_product_pricelist"/>
+                <field name="lang_id"/>
+                <field name="product_category_ids"/>
+                <group>
+                    <filter
+                        name="groupby_website"
+                        string="Website"
+                        context="{'group_by': 'website_id'}"
+                        groups="website.group_multi_website"
+                    />
+                    <filter
+                        name="groupby_pricelist"
+                        string="Pricelist"
+                        context="{'group_by': 'pricelist_id'}"
+                        groups="product.group_product_pricelist"
+                    />
+                    <filter
+                        name="groupby_lang"
+                        string="Language"
+                        context="{'group_by': 'lang_id'}"
+                    />
+                    <filter
+                        name="groupby_product_category"
+                        string="eCommerce Category"
+                        context="{'group_by': 'product_category_ids'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="product_feed_list_view" model="ir.ui.view">
+        <field name="name">product.feed.view.list</field>
+        <field name="model">product.feed</field>
+        <field name="arch" type="xml">
+            <list string="Product Feeds" editable="top" multi_edit="True">
+                <field name="name"/>
+                <field
+                    name="website_id"
+                    column_invisible="context.get('hide_website_column')"
+                    groups="website.group_multi_website"
+                    options="{'no_create': True}"
+                />
+                <field name="pricelist_id" placeholder="Default" options="{'no_create': True}"/>
+                <field name="lang_id" options="{'no_create': True}"/>
+                <field
+                    name="product_category_ids"
+                    placeholder="All Categories"
+                    widget="many2many_tags"
+                    options="{'no_create': True}"
+                />
+                <!-- The `o_field_handle` class disables the o-text-overflow styling added by the
+                     list renderer, which, if not disabled, causes misalignment of the icon. -->
+                <field
+                    name="url"
+                    string="Copy URL"
+                    widget="CopyClipboardButton"
+                    class="o_field_handle"
+                    width="100px"
+                    nolabel="1"
+                    options="{'btn_class': 'primary btn-sm'}"
+                />
+            </list>
+        </field>
+    </record>
+
+    <record id="product_feed_form_view" model="ir.ui.view">
+        <field name="name">product.feed.view.form</field>
+        <field name="model">product.feed</field>
+        <field name="arch" type="xml">
+            <form string="Product Feed">
+                <sheet>
+                    <div class="oe_title">
+                        <h1><field name="name"/></h1>
+                    </div>
+                    <div name="button_box">
+                        <field name="url" string="Copy URL" widget="CopyClipboardButton"/>
+                    </div>
+                    <group>
+                        <field name="website_id"/>
+                        <field name="pricelist_id" placeholder="Default"/>
+                        <field name="lang_id" options="{'no_create': True}"/>
+                        <field
+                            name="product_category_ids"
+                            placeholder="All Categories"
+                            widget="many2many_tags"
+                        />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_product_feeds" model="ir.actions.act_window">
+        <field name="name">Product Feeds</field>
+        <field name="res_model">product.feed</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <record id="action_invalidate_cache" model="ir.actions.server">
+        <field name="name">Reset Cache</field>
+        <field name="model_id" ref="model_product_feed"/>
+        <field name="binding_model_id" ref="website_sale.model_product_feed"/>
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_invalidate_cache()</field>
+        <field name="group_ids" eval="[Command.link(ref('base.group_no_one'))]"/>
+    </record>
+
+</odoo>

--- a/addons/website_sale_gmc/views/res_config_settings_views.xml
+++ b/addons/website_sale_gmc/views/res_config_settings_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.website.sale</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <setting
+                    id="google_merchant_center_setting"
+                    position="replace"
+            >
+                <setting
+                    id="google_merchant_center_setting"
+                    help="Connect your eCommerce to Google Merchant Center via a product file."
+                    documentation="/applications/websites/ecommerce/google_merchant_center.html"
+                >
+                    <field name="group_gmc_feed"/>
+                    <div class="mt8" invisible="not group_gmc_feed">
+                        <button
+                            type="object"
+                            name="action_open_product_feeds"
+                            string="Manage feeds"
+                            class="btn-link"
+                            icon="oi-arrow-right"
+                        />
+                    </div>
+                </setting>
+            </setting>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_sale_gmc/views/website_sale_gmc_menus.xml
+++ b/addons/website_sale_gmc/views/website_sale_gmc_menus.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <menuitem id="menu_product_feeds"
+              parent="website_sale.menu_ecommerce_settings"
+              action="website_sale_gmc.action_product_feeds"
+              groups="website_sale_gmc.group_product_feed"
+              sequence="150"
+    />
+
+</odoo>

--- a/addons/website_sale_stock_gmc/__init__.py
+++ b/addons/website_sale_stock_gmc/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/website_sale_stock_gmc/__manifest__.py
+++ b/addons/website_sale_stock_gmc/__manifest__.py
@@ -1,0 +1,11 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Google Merchant Center Stock",
+    'category': 'Website/Website',
+    'summary': 'Synchronize your stock with Google Merchant Center',
+    'depends': ['website_sale_gmc', 'website_sale_stock'],
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/website_sale_stock_gmc/models/__init__.py
+++ b/addons/website_sale_stock_gmc/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import product_feed

--- a/addons/website_sale_stock_gmc/models/product_feed.py
+++ b/addons/website_sale_stock_gmc/models/product_feed.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ProductFeed(models.Model):
+    _inherit = 'product.feed'
+
+    def _prepare_gmc_stock_info(self, product):
+        """Override of `website_sale_gmc` to check the stock level if the current product cannot be
+        out of stock."""
+        stock_info = super()._prepare_gmc_stock_info(product)
+        if product._is_sold_out():
+            stock_info['availability'] = 'out_of_stock'
+        return stock_info


### PR DESCRIPTION
In [^1], a new feature was introduced to allow users to synchronize their eCommerce with Google Merchant Center and increase their product visibility, keep stock status updated, and improve product listings.

However, the initial implementation attempted to include shipping information in the feed, which required computing rates for every product, carrier, and country. This quickly became infeasible due to performance constraints and third-party carrier rate limits, forcing us to disable the feature [^2].

This commit reintroduces the GMC feed without shipping details, making it lightweight and reliable. To ensure scalability, we also (i) enforce a limit of 5000 products per feed, and (ii) introduce a caching mechanism to avoid recomputing expensive product data (e.g., prices) for subsequent requests.

task-5049357

[^1]: https://github.com/odoo/odoo/pull/186976
[^2]: https://github.com/odoo/odoo/pull/224649
