### PR TITLE
[REF] *: remove importing of hoot-dom in tour files

### DIFF
--- a/addons/calendar/static/tests/tours/calendar_tour.js
+++ b/addons/calendar/static/tests/tours/calendar_tour.js
@@ -1,4 +1,3 @@
-import { waitFor } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
@@ -91,7 +90,6 @@ const clickOnTheEvent = {
         const custom = document.querySelector(".o_cw_custom_highlight");
         if (custom) {
             custom.click();
-            await waitFor(".o_cw_popover", { timeout: 8000 });
         }
     },
 };
@@ -99,6 +97,9 @@ const clickOnTheEvent = {
 registry.category("web_tour.tours").add("test_calendar_delete_tour", {
     steps: () => [
         clickOnTheEvent,
+        {
+            trigger: ".o_cw_popover",
+        },
         {
             content: "Delete the event",
             trigger: ".o_cw_popover_delete",
@@ -115,6 +116,9 @@ registry.category("web_tour.tours").add("test_calendar_delete_tour", {
 registry.category("web_tour.tours").add("test_calendar_decline_tour", {
     steps: () => [
         clickOnTheEvent,
+        {
+            trigger: ".o_cw_popover",
+        },
         {
             content: "Delete the event",
             trigger: ".o_cw_popover_delete",

--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -1,4 +1,3 @@
-import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 const today = luxon.DateTime.now();
@@ -58,9 +57,9 @@ registry.category("web_tour.tours").add('crm_forecast', {
     }, {
         trigger: ".o_kanban_record:contains('Test Opportunity 1')",
         content: "move to the next month",
-        async run(helpers) {
+        async run({ queryAll, drag_and_drop }) {
             const undefined_groups = queryAll('.o_column_title:contains("None")').length;
-            await helpers.drag_and_drop(`.o_opportunity_kanban .o_kanban_group:eq(${1 + undefined_groups})`);
+            await drag_and_drop(`.o_opportunity_kanban .o_kanban_group:eq(${1 + undefined_groups})`);
         },
     }, {
         trigger: ".o_kanban_record:contains('Test Opportunity 1')",

--- a/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
@@ -27,10 +27,9 @@ function getMeetingViewTourSteps({ inWelcomePage = false } = {}) {
         {
             trigger:
                 ".o-mail-Meeting-sidePanel .o-mail-Thread:contains('john (base.group_user) and bob (base.group_user)')",
-            async run() {
+            async run({ waitFor }) {
                 const files = [new File(["hi there"], "file2.txt", { type: "text/plain" })];
                 await dragenterFiles(".o-mail-Meeting-sidePanel", files);
-                const { waitFor } = odoo.loader.modules.get("@odoo/hoot-dom");
                 // Ensure other dropzones such as discuss or chat window dropzones are not active in meeting view.
                 await waitFor(".o-Dropzone", { only: true });
             },

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -1,6 +1,4 @@
 import { reactive } from "@odoo/owl";
-import { waitFor } from "@odoo/hoot-dom";
-
 import { registry } from "@web/core/registry";
 import { getOrigin } from "@web/core/utils/urls";
 import { click, inputFiles } from "@web/../tests/utils";
@@ -78,7 +76,7 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         },
         {
             trigger: '.o-mail-AttachmentContainer:not(.o-isUploading)[title="image.png"]',
-            async run() {
+            async run({ waitFor }) {
                 /** @type {import("models").Store} */
                 const store = odoo.__WOWL_DEBUG__.root.env.services["mail.store"];
                 if (store.self_guest) {

--- a/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
+++ b/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
@@ -1,4 +1,3 @@
-import { waitFor } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("discuss.invite_by_email", {
@@ -13,12 +12,12 @@ registry.category("web_tour.tours").add("discuss.invite_by_email", {
         },
         {
             trigger: ".o-discuss-ChannelInvitation-selectable:contains('john (base.group_user)')",
-            async run() {
+            async run({ waitFor, click }) {
                 await waitFor(".o-discuss-ChannelInvitation-selectable", {
                     only: true,
                     timeout: 5000,
                 });
-                this.anchor.click();
+                await click();
             },
         },
         {

--- a/addons/point_of_sale/static/tests/pos/tours/pos_performance_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_performance_tour.js
@@ -1,5 +1,4 @@
 import { registry } from "@web/core/registry";
-import { waitFor } from "@odoo/hoot-dom";
 
 function logText(displayText) {
     console.log(
@@ -15,7 +14,7 @@ registry.category("web_tour.tours").add("tourSessionOpenProductPerformance", {
             {
                 trigger: "body",
                 timeout: 25000,
-                async run() {
+                async run({ waitFor }) {
                     await waitFor("body:not(:has(.pos-loader))", { timeout: 20000 });
                     const startTime = performance.timeOrigin;
                     const endTime = Date.now();

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -1,6 +1,5 @@
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
-import { waitFor } from "@odoo/hoot-dom";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 const { DateTime } = luxon;
 
@@ -183,7 +182,7 @@ export function waitRequest() {
             trigger: "body",
             content: "Wait loading is finished if it is shown",
             timeout: 15000,
-            async run() {
+            async run({ waitFor }) {
                 let isLoading = false;
                 try {
                     isLoading = await waitFor("body:has(.fa-circle-o-notch)", { timeout: 2000 });

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -1,4 +1,3 @@
-import { queryOne } from "@odoo/hoot-dom";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
@@ -13,7 +12,7 @@ export function table({ name, withClass = "", withoutClass, run = () => {}, numO
     return {
         content: `Check table with attributes: ${JSON.stringify(arguments[0])}`,
         trigger,
-        run: typeof run === "string" ? run : () => run(trigger),
+        run: typeof run === "string" ? run : (helpers) => run(helpers, trigger),
     };
 }
 export const clickTable = (name) => table({ name, run: "click" });
@@ -22,10 +21,10 @@ export const selectedTableIs = (name) => table({ name, withClass: ".selected" })
 export const ctrlClickTable = (name) =>
     table({
         name,
-        run: (trigger) => {
-            queryOne(trigger).dispatchEvent(
-                new MouseEvent("click", { bubbles: true, ctrlKey: true })
-            );
+        run: (helpers, trigger) => {
+            helpers
+                .queryOne(trigger)
+                .dispatchEvent(new MouseEvent("click", { bubbles: true, ctrlKey: true }));
         },
     });
 export function clickFloor(name) {
@@ -175,7 +174,6 @@ export function addFloor(floorName) {
 
 import { TourHelpers } from "@web_tour/js/tour_automatic/tour_helpers";
 import { patch } from "@web/core/utils/patch";
-import * as hoot from "@odoo/hoot-dom";
 
 patch(TourHelpers.prototype, {
     async drag_multiple_and_then_drop(...drags) {
@@ -185,9 +183,10 @@ patch(TourHelpers.prototype, {
             await new Promise((resolve) => setTimeout(resolve, this.delay));
         };
         const element = this.anchor;
-        const { drop, moveTo } = await hoot.drag(element);
+        const { drag } = odoo.loader.modules.get("@odoo/hoot-dom");
+        const { drop, moveTo } = await drag(element);
         await dragEffectDelay();
-        await hoot.hover(element, {
+        await this.hover(element, {
             position: {
                 top: 20,
                 left: 20,
@@ -197,7 +196,7 @@ patch(TourHelpers.prototype, {
         await dragEffectDelay();
         for (const [selector, options] of drags) {
             console.log("Selector", selector, options);
-            const target = await hoot.waitFor(selector, {
+            const target = await this.waitFor(selector, {
                 visible: true,
                 timeout: 500,
             });

--- a/addons/sale/static/src/js/tours/combo_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/combo_configurator_tour_utils.js
@@ -1,5 +1,3 @@
-import { queryAll } from '@odoo/hoot-dom';
-
 function comboSelector(comboName) {
     return `
         .sale-combo-configurator-dialog
@@ -21,7 +19,7 @@ function assertComboCount(count) {
         trigger: '.sale-combo-configurator-dialog',
         run() {
             const selector = `.sale-combo-configurator-dialog [name="sale_combo_configurator_title"]`;
-            if (queryAll(selector).length !== count) {
+            if (document.querySelectorAll(selector).length !== count) {
                 console.error(`Assertion failed`);
             }
         },
@@ -32,7 +30,7 @@ function assertComboItemCount(comboName, count) {
     return {
         content: `Assert that there are ${count} combo items in combo ${comboName}`,
         trigger: comboSelector(comboName),
-        run() {
+        run({ queryAll }) {
             const selector = `${comboSelector(comboName)} + .row .product-card`;
             if (queryAll(selector).length !== count) {
                 console.error(`Assertion failed`);
@@ -47,7 +45,7 @@ function assertSelectedComboItemCount(count) {
         trigger: '.sale-combo-configurator-dialog',
         run() {
             const selector = `.sale-combo-configurator-dialog .row .product-card.selected`;
-            if (queryAll(selector).length !== count) {
+            if (document.querySelectorAll(selector).length !== count) {
                 console.error(`Assertion failed`);
             }
         },
@@ -60,7 +58,7 @@ function assertPreselectedComboItemCount(count) {
         trigger: '.sale-combo-configurator-dialog',
         run() {
             const selector = '.sale-combo-configurator-dialog div[name="preselected_product_name"]';
-            if (queryAll(selector).length !== count) {
+            if (document.querySelectorAll(selector).length !== count) {
                 console.error(`Assertion failed`);
             }
         },

--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -1,5 +1,3 @@
-import { queryAttribute } from '@odoo/hoot-dom';
-
 function productSelector(productName) {
     return `
         table.o_sale_product_configurator_table
@@ -16,10 +14,10 @@ function optionalProductSelector(productName) {
     `;
 }
 
-function optionalProductImageSrc(productName) {
-    return queryAttribute(
-        `${optionalProductSelector(productName)} td.o_sale_product_configurator_img>img`, 'src'
-    );
+function optionalProductImageSrc(queryOne, productName) {
+    return queryOne(
+        `${optionalProductSelector(productName)} td.o_sale_product_configurator_img>img`
+    ).getAttribute("src");
 }
 
 function addOptionalProduct(productName) {

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -3,7 +3,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 import tourUtils from "@sale/js/tours/tour_utils";
 
 import { markup } from "@odoo/owl";
-import { queryText } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add('sale_timesheet_tour', {
     url: '/odoo',
@@ -118,7 +117,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
 }, {
     trigger: 'div[name="order_line"]',
     content: 'Check if the quantity delivered is equal to 1 hour.',
-    run: function () {
+    run({ queryFirst }) {
         const header = this.anchor.querySelectorAll("thead > tr");
         if (!header || header.length === 0)
             console.error('No Sales Order Item is found in the Sales Order.');
@@ -129,8 +128,8 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
             if (th.dataset && th.dataset.name === 'qty_delivered')
                 index = i;
         }
-        const qtyDelivered = queryText(`tbody > tr:first-child > td.o_data_cell:eq(${index})`, { root: this.anchor });
-        if (qtyDelivered !== "1.00")
+        const qtyDelivered = queryFirst(`tbody > tr:first-child > td.o_data_cell:eq(${index})`, { root: this.anchor });
+        if (qtyDelivered.textContent !== "1.00")
             console.error('The quantity delivered on this Sales Order Item should be equal to 1.00 hour. qtyDelivered = ' + qtyDelivered);
     },
 }, {

--- a/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
+++ b/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
@@ -1,4 +1,3 @@
-import { queryAll } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey_chained_conditional_questions', {
@@ -95,8 +94,10 @@ registry.category("web_tour.tours").add('test_survey_chained_conditional_questio
 
 ]});
 
-export function expectHiddenQuestion (questionTitle, msg){
-    if (queryAll(`div.js_question-wrapper.d-none:contains('${questionTitle}')`).length !== 1) {
+export function expectHiddenQuestion(questionTitle, msg) {
+    const divs = document.querySelectorAll("div.js_question-wrapper.d-none");
+    const matchingDivs = Array.from(divs).filter((div) => div.textContent.includes(questionTitle));
+    if (matchingDivs.length !== 1) {
         console.error(msg);
     }
 }

--- a/addons/survey/static/tests/tours/survey_prefill.js
+++ b/addons/survey/static/tests/tours/survey_prefill.js
@@ -1,4 +1,3 @@
-import { queryFirst, queryOne } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey_prefill', {
@@ -65,108 +64,65 @@ registry.category("web_tour.tours").add('test_survey_prefill', {
         content: 'Click on the previous page name in the breadcrumb',
         trigger: 'ol.breadcrumb a:first',
         run: "click",
-    }, {
-        trigger: 'div.js_question-wrapper:contains("How many times did you order products on our website?") input',
-        run: function () {
-            const inputQ3 = queryFirst(
-                'div.js_question-wrapper:contains("How many times did you order products on our website?") input'
-            );
-            if (inputQ3.value === "42.0") {
-                queryOne(".o_survey_title").classList.add("prefilled");
-            }
-        }
-    }, {
-        trigger: '.o_survey_title.prefilled',
-        run: function () {
-            // check that all the answers are prefilled in Page 1
-            var inputQ1 = queryOne('div.js_question-wrapper:contains("Where do you live?") input');
-            if (inputQ1.value !== 'Grand-Rosiere') {
-                return;
-            }
-
-            var inputQ2 = queryOne('div.js_question-wrapper:contains("When is your date of birth?") input');
-            if (inputQ2.value !== '05/05/1980') {
-                return;
-            }
-
-            var inputQ3 = queryOne('div.js_question-wrapper:contains("How frequently do you buy products online?") label:contains("Once a week") input');
-            if (!inputQ3.checked) {
-                return;
-            }
-
-            var inputQ4 = queryOne('div.js_question-wrapper:contains("How many times did you order products on our website?") input');
-            if (inputQ4.value !== '42.0') {
-                return;
-            }
-            document.querySelector(".o_survey_title").classList.add("tour_success");
-        }
-    }, {
-        trigger: '.o_survey_title.tour_success',
-        run: "click",
-    }, {
-        content: 'Click on Next Page',
-        trigger: 'button[value="next"]',
-        run: "click",
-    }, {
-        trigger: 'div.js_question-wrapper:contains("Do you have any other comments, questions, or concerns") textarea',
-        run: function () {
-            var inputQ3 = queryOne('div.js_question-wrapper:contains("Do you have any other comments, questions, or concerns") textarea');
-            if (inputQ3.value === "Is the prefill working?") {
-                document.querySelector('.o_survey_title').classList.add('prefilled2');
-            }
-        }
-    }, {
-        trigger: '.o_survey_title.prefilled2',
-        run: function () {
-            // check that all the answers are prefilled in Page 2
-            const input1Q1 = queryOne('div.js_question-wrapper:contains("Which of the following words would you use to describe our products") label:contains("High quality") input');
-            if (!input1Q1.checked) {
-                return;
-            }
-
-            const input2Q1 = queryOne('div.js_question-wrapper:contains("Which of the following words would you use to describe our products") label:contains("Good value for money") input');
-            if (!input2Q1.checked) {
-                return;
-            }
-
-            const input1Q2 = queryOne('div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("The new layout and design is fresh and up-to-date") input:first');
-            if (!input1Q2.checked) {
-                return;
-            }
-
-            const input2Q2 = queryOne('div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("It is easy to find the product that I want") input:eq(2)');
-            if (!input2Q2.checked) {
-                return;
-            }
-
-            const input3Q2 = queryOne('div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("The tool to compare the products is useful to make a choice") input:eq(3)');
-            if (!input3Q2.checked) {
-                return;
-            }
-
-            const input4Q2 = queryOne('div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("The checkout process is clear and secure") input:eq(2)');
-            if (!input4Q2.checked) {
-                return;
-            }
-
-            const input5Q2 = queryOne('div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("I have added products to my wishlist") input:last');
-            if (!input5Q2.checked) {
-                return;
-            }
-
-            const inputQ3 = queryOne('div.js_question-wrapper:contains("Do you have any other comments, questions, or concerns") textarea');
-            if (inputQ3.value !== "Is the prefill working?") {
-                return;
-            }
-
-            const inputQ4 = queryOne('div.js_question-wrapper:contains("How would you rate your experience on our website") label:contains("4") input');
-            if (!inputQ4.checked) {
-                return;
-            }
-
-            document.querySelector(".o_survey_title").classList.add("tour_success_2");
-        }
-    }, {
-        trigger: '.o_survey_title.tour_success_2',
-    }
-]});
+        },
+        {
+            content: "check survey is prefilled",
+            trigger:
+                'div.js_question-wrapper:contains("How many times did you order products on our website?") input:value(42)',
+        },
+        {
+            trigger: `div.js_question-wrapper:contains("Where do you live?") input:value(Grand-Rosiere)`,
+        },
+        {
+            trigger: `div.js_question-wrapper:contains("When is your date of birth?") input:value(05/05/1980)`,
+        },
+        {
+            trigger: `div.js_question-wrapper:contains("How frequently do you buy products online?) label:contains("Once a week") input:hidden:checked`,
+        },
+        {
+            trigger: ".o_survey_title",
+            run: "click",
+        },
+        {
+            content: "Click on Next Page",
+            trigger: 'button[value="next"]',
+            run: "click",
+        },
+        {
+            trigger:
+                'div.js_question-wrapper:contains("Do you have any other comments, questions, or concerns") textarea:value(Is the prefill working?)',
+        },
+        {
+            trigger:
+                'div.js_question-wrapper:contains("Which of the following words would you use to describe our products") label:contains("High quality") input:hidden:checked',
+        },
+        {
+            trigger:
+                'div.js_question-wrapper:contains("Which of the following words would you use to describe our products") label:contains("Good value for money") input:hidden:checked',
+        },
+        {
+            trigger:
+                'div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("The new layout and design is fresh and up-to-date") input:first:hidden:checked',
+        },
+        {
+            trigger:
+                'div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("It is easy to find the product that I want") input:eq(2):hidden:checked',
+        },
+        {
+            trigger:
+                'div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("The tool to compare the products is useful to make a choice") input:eq(3):hidden:checked',
+        },
+        {
+            trigger:
+                'div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("The checkout process is clear and secure") input:eq(2):hidden:checked',
+        },
+        {
+            trigger:
+                'div.js_question-wrapper:contains("What do your think about our new eCommerce") tr:contains("I have added products to my wishlist") input:last:hidden:checked',
+        },
+        {
+            trigger:
+                'div.js_question-wrapper:contains("How would you rate your experience on our website") label:contains("4") input:hidden:checked',
+        },
+    ],
+});

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -22,17 +22,21 @@ registry.category("web_tour.tours").add('sale_product_configurator_advanced_tour
         configuratorTourUtils.assertProductNameContains("Custom, White, PAV9, PAV5, PAV1"),
         {
             trigger: configuratorTourUtils.optionalProductSelector("Conference Chair (TEST) (Steel)"),
-            run: function () {
-                optionVariantImage =
-                    configuratorTourUtils.optionalProductImageSrc("Conference Chair (TEST) (Steel)")
+            run({ queryOne }) {
+                optionVariantImage = configuratorTourUtils.optionalProductImageSrc(
+                    queryOne,
+                    "Conference Chair (TEST) (Steel)"
+                );
             }
         },
         configuratorTourUtils.selectAttribute("Conference Chair", "Legs", "Aluminium"),
         {
             trigger: configuratorTourUtils.optionalProductSelector("Conference Chair (TEST) (Aluminium)"),
-            run: function () {
-                const newOptionVariantImage =
-                    configuratorTourUtils.optionalProductImageSrc("Conference Chair (TEST) (Aluminium)")
+            run({ queryOne }) {
+                const newOptionVariantImage = configuratorTourUtils.optionalProductImageSrc(
+                    queryOne,
+                    "Conference Chair (TEST) (Aluminium)"
+                );
                 if (newOptionVariantImage === optionVariantImage) {
                     console.error("The variant image wasn't updated");
                 }

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -1,4 +1,3 @@
-import { queryOne } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
@@ -16,7 +15,7 @@ registry.category("web_tour.tours").add('sale_product_configurator_single_custom
         tourUtils.editConfiguration(),
         {
             trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] *:contains("Customizable Desk (TEST)")) td>div[name="ptal"]:has(div>label:contains("product attribute")) input[type="text"]',
-            run: function () {
+            run({ queryOne }) {
                 // check custom value initialized
                 if (
                     queryOne(

--- a/addons/web_tour/static/src/js/tour_automatic/tour_helpers.js
+++ b/addons/web_tour/static/src/js/tour_automatic/tour_helpers.js
@@ -7,6 +7,15 @@ export class TourHelpers {
     constructor(anchor) {
         this.anchor = anchor;
         this.delay = 20;
+        return new Proxy(this, {
+            get(target, prop, receiver) {
+                const value = Reflect.get(target, prop, receiver);
+                if (typeof value === "function" && prop !== "constructor") {
+                    return value.bind(target);
+                }
+                return value;
+            },
+        });
     }
 
     /**
@@ -50,18 +59,19 @@ export class TourHelpers {
      * Performs a click sequence on the given **{@link Selector}**
      * @description Let's see more informations about click sequence here: {@link hoot.click}
      * @param {Selector} selector
+     * @param {import("@odoo/hoot-dom").PointerOptions} options
      * @example
      *  run: "click", // Click on the action element
      * @example
      *  run: "click .o_rows:first", // Click on the selector
      */
-    async click(selector) {
+    async click(selector, options = { interactive: false }) {
         const element = this._get_action_element(selector);
         // FIXME: should always target interactive element, but some tour steps are
         // targetting elements affected by 'pointer-events: none' for some reason.
         // This option should ultimately disappear, with all affected cased fixed
         // individually (no common cause found during a quick investigation).
-        await hoot.click(element, { interactive: false });
+        await hoot.click(element, options);
     }
 
     /**
@@ -76,20 +86,6 @@ export class TourHelpers {
     async dblclick(selector) {
         const element = this._get_action_element(selector);
         await hoot.dblclick(element);
-    }
-
-    /**
-     * Performs a pointerUp sequence on the given **{@link Selector}**
-     * @description Let's see more informations about pointerUp sequence here: {@link hoot.pointerUp}
-     * @param {Selector} selector
-     * @example
-     *  run: "pointerUp", // pointerUp on the action element
-     * @example
-     *  run: "pointerUp .o_rows:first", // pointerUp on the selector
-     */
-    async pointerup(selector) {
-        const element = this._get_action_element(selector);
-        await hoot.pointerUp(element);
     }
 
     /**
@@ -191,12 +187,13 @@ export class TourHelpers {
     /**
      * Performs a hover sequence on the given **{@link Selector}**.
      * @param {Selector} selector
+     * @param {import("@odoo/hoot-dom").PointerOptions} options
      * @example
      *  run: "hover",
      */
-    async hover(selector) {
+    async hover(selector, options) {
         const element = this._get_action_element(selector);
-        await hoot.hover(element);
+        await hoot.hover(element, options);
     }
 
     /**
@@ -361,5 +358,25 @@ export class TourHelpers {
         range.setStart(node, length);
         range.setEnd(node, length);
         selection.addRange(range);
+    }
+
+    queryAll(target, options) {
+        return hoot.queryAll(target, options);
+    }
+
+    queryFirst(target, options) {
+        return hoot.queryFirst(target, options);
+    }
+
+    queryOne(target, options) {
+        return hoot.queryOne(target, options);
+    }
+
+    waitFor(target, options) {
+        return hoot.waitFor(target, options);
+    }
+
+    waitUntil(predicate, options) {
+        return hoot.waitUntil(predicate, options);
     }
 }

--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -1,4 +1,3 @@
-import { queryFirst } from "@odoo/hoot-dom";
 import {
     changeOption,
     clickOnSnippet,
@@ -23,7 +22,7 @@ registerWebsitePreviewTour("default_shape_gets_palette_colors", {
     {
         content: "Check that shape does not have a background-image in its inline style",
         trigger: ':iframe #wrap .s_text_image .o_we_shape',
-        run() {
+        run({ queryFirst }) {
             const shape = queryFirst(":iframe :not(.o_ignore_in_tour) #wrap .s_text_image .o_we_shape");
             if (shape.style.backgroundImage) {
                 throw new Error("The default shape has a background-image in its inline style (should rely on the class)");

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-import { delay } from '@odoo/hoot-dom';
+import { delay } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 import {
     clickOnEditAndWaitEditMode,

--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -1,6 +1,5 @@
 /** @odoo-module */
 
-import { waitUntil } from "@odoo/hoot-dom";
 import {
     clickOnEditAndWaitEditMode,
     clickOnElement,
@@ -88,11 +87,12 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
         content: "Wait for the page to be scrolled to the top.",
         trigger: ":iframe .s_three_columns .row > .o_animating:last-child",
         isActive: [`:iframe .s_three_columns .row > .o_animating:last-child`],
-        run: (helpers) =>
-            waitUntil(
-                () => !helpers.anchor.classList.contains(`o_animating`),
+        async run({ waitUntil, anchor }) {
+            await waitUntil(
+                () => !anchor.classList.contains(`o_animating`),
                 { timeout: 10000 }
-            ),
+            );
+        }
     },
     {
         content: "Close the Cookies Bar.",
@@ -137,11 +137,12 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
         content: "Wait until the column is no longer animated/visible.",
         trigger: ":iframe .s_three_columns .row > .o_animating:last-child",
         isActive: [`:iframe .s_three_columns .row > .o_animating:last-child`],
-        run: (helpers) =>
-            waitUntil(
-                () => !helpers.anchor.classList.contains(`o_animating`),
+        async run({ anchor, waitUntil }) {
+            await waitUntil(
+                () => !anchor.classList.contains(`o_animating`),
                 { timeout: 10000 }
-            ),
+            );
+        }
     },
     {
         content: "Close the Popup",

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -1,4 +1,3 @@
-import { isVisible } from '@odoo/hoot-dom';
 import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
@@ -87,11 +86,10 @@ registerWebsitePreviewTour('snippet_table_of_content', {
     {
         content: "Check that we have the good TOC on desktop",
         trigger: ':iframe .s_table_of_content.o_snippet_mobile_invisible',
-        run: () => {
-            if (isVisible(':iframe .s_table_of_content.o_snippet_desktop_invisible')) {
-                console.error('The mobile TOC should not be visible on desktop');
-            }
-        },
+    },
+    {
+        content: "The mobile TOC should not be visible on desktop",
+        trigger: ':iframe .s_table_of_content.o_snippet_desktop_invisible:not(:visible)',
     },
     {
         content: "Toggle the mobile view",
@@ -101,10 +99,10 @@ registerWebsitePreviewTour('snippet_table_of_content', {
     {
         content: "Check that we have the good TOC on mobile",
         trigger: ':iframe .s_table_of_content.o_snippet_desktop_invisible',
-        run: () => {
-            if (isVisible(':iframe .s_table_of_content.o_snippet_mobile_invisible')) {
-                console.error('The desktop TOC should not be visible on mobile');
-            }
-        },
     },
+    {
+        content: "The desktop TOC should not be visible on mobile",
+        trigger: ":iframe .s_table_of_content.o_snippet_mobile_invisible:not(:visible)",
+
+    }
 ]);

--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -1,5 +1,3 @@
-import { waitFor } from "@odoo/hoot-dom";
-
 /*******************************
  *         Common Steps
  *******************************/
@@ -28,7 +26,7 @@ export const start = [
         content: "Verify the message has been sent",
         trigger:
             ".o-livechat-root:shadow .o-mail-ChatWindow:contains(El Deboulonnator) .o-mail-Thread:not([data-transient])",
-        async run() {
+        async run({ waitFor }) {
             await waitFor(".o-mail-Message:contains('Hello Sir!')", {
                 root: this.anchor,
                 only: true,

--- a/addons/website_livechat/static/tests/tours/website_livechat_request.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_request.js
@@ -1,4 +1,3 @@
-import { queryAll } from "@odoo/hoot-dom";
 import {
     closeChat,
     okRating,
@@ -28,7 +27,7 @@ const chatRequest = [
     {
         content: "Verify there is no duplicates",
         trigger: ".o-livechat-root:shadow .o-mail-Thread",
-        run() {
+        run({ queryAll }) {
             if (
                 queryAll(
                     ".o-mail-Message:contains('Hi ! What a coincidence! I need your help indeed.')",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_cart_recovery.js
@@ -1,4 +1,3 @@
-import { queryOne } from "@odoo/hoot-dom";
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
@@ -78,7 +77,7 @@ registry.category("web_tour.tours").add('shop_cart_recovery', {
     {
         content: "check the mail is sent, grab the recovery link, and logout",
         trigger: ".o-mail-Message-body a:contains(/^Resume order$/)",
-        run: function () {
+        run({ queryOne }) {
             var link = queryOne('.o-mail-Message-body a:contains("Resume order")').getAttribute('href');
             browser.localStorage.setItem(recoveryLinkKey, link);
             window.location.href = "/web/session/logout?redirect=/";

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
@@ -22,17 +22,17 @@ registry.category("web_tour.tours").add("a_shop_custom_attribute_value", {
     run: 'click',
 }, {
     trigger: configuratorTourUtils.optionalProductSelector("Conference Chair (TEST) (Steel)"),
-    run: function () {
+    run({ queryOne }) {
         optionVariantImage =
-            configuratorTourUtils.optionalProductImageSrc("Conference Chair (TEST) (Steel)")
+            configuratorTourUtils.optionalProductImageSrc(queryOne, "Conference Chair (TEST) (Steel)")
     }
 },
 configuratorTourUtils.selectAttribute("Conference Chair", "Legs", "Aluminium"),
 {
     trigger: configuratorTourUtils.optionalProductSelector("Conference Chair (TEST) (Aluminium)"),
-    run: function () {
+    run({ queryOne }) {
         const newOptionVariantImage =
-            configuratorTourUtils.optionalProductImageSrc("Conference Chair (TEST) (Aluminium)")
+            configuratorTourUtils.optionalProductImageSrc(queryOne, "Conference Chair (TEST) (Aluminium)")
         if (newOptionVariantImage === optionVariantImage) {
             console.error("The variant image wasn't updated");
         }

--- a/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
+++ b/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
@@ -1,4 +1,3 @@
-import { queryFirst } from '@odoo/hoot-dom';
 import {
     changeOptionInPopover,
     clickOnSave,
@@ -39,7 +38,7 @@ registerWebsitePreviewTour('website_sale.products_snippet_recently_viewed', {
     {
         content: 'make delete icon appear',
         trigger: ':iframe .s_dynamic_snippet_products .o_carousel_product_card',
-        run() {
+        run({ queryFirst }) {
             queryFirst(
                 `:iframe .o_carousel_product_card[aria-label="Storage Box"] .js_remove`,
             ).style.display = "block";

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 import { markup } from "@odoo/owl";
-import { queryFirst } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add('main_flow_tour', {
     url: "/odoo",
@@ -94,7 +93,7 @@ registry.category("web_tour.tours").add('main_flow_tour', {
     content: _t("Focus on customer taxes field."),
     async run(actions) {
         await actions.click();
-        const e = queryFirst(".ui-menu-item:not(.o_m2o_dropdown_option) > a.ui-state-active");
+        const e = document.querySelector(".ui-menu-item:not(.o_m2o_dropdown_option) > a.ui-state-active");
         if (e) {
             await actions.click(e);
         } else {
@@ -545,7 +544,7 @@ stepUtils.autoExpandMoreButtons(),
     content: _t("Focus on customer taxes field."),
     async run(actions) {
         await actions.click();
-        const e = queryFirst(
+        const e = document.querySelector(
             ".o_field_widget[name=taxes_id] .o-autocomplete--dropdown-item:not(.o_m2o_dropdown_option) > a"
         );
         if (e) {


### PR DESCRIPTION
In this commit, we replace hoot-dom uses in tour files by native
javascript.
For legitimate uses of hoot in tours, we exported the "queryFirst,
queryAll, queryOne, waitFor, and waitUntil" hoot helpers into
tour_helpers.
These two actions are made in order to lazy load hoot-dom in web_tour
to reduce assets size.