### PR TITLE
[FIX] purchase_stock: prevent access error for portal users in subcontracting

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -47,10 +47,10 @@ class StockMove(models.Model):
         super()._compute_description_picking()
         for move in self:
             if move.purchase_line_id:
-                seller = move.purchase_line_id.selected_seller_id
+                seller = move.purchase_line_id.sudo().selected_seller_id
                 vendor_reference = f'[{seller.product_code}]' if seller.product_code else ''
                 vendor_reference += f' {seller.product_name}' if seller.product_name else ''
-                no_variant_attributes = '\n'.join(f'{attribute.attribute_id.name}: {attribute.name}' for attribute in move.purchase_line_id.product_no_variant_attribute_value_ids)
+                no_variant_attributes = '\n'.join(f'{attribute.attribute_id.name}: {attribute.name}' for attribute in move.purchase_line_id.sudo().product_no_variant_attribute_value_ids)
                 move.description_picking = (no_variant_attributes + '\n' + vendor_reference + '\n' + move.description_picking).strip()
 
     def _get_description(self):


### PR DESCRIPTION
Issue Before This Commit:
=======================
When a subcontractor (portal user) tries to open a picking from the Manufacturing orders section in the portal view, the page appears blank with no data loaded on the frontend, while in the the backend logs show read Access Error is raised on the `product.supplierinfo` and on `product.template.attribute.value` models.

Steps to Reproduce:
=======================
-Install  `MRP` and `Purchase` modules, and enable Subcontracting.
-Create a product attribute with values and `variant creation` set to `Never`.
-Create a product and Assign the created attribute to the product’s attributes.
-Create a portal user and grant portal access.
-Create a BOM for the product, set it for subcontracting, and assign the portal
 user as a subcontractor.
-Create a Purchase Order for a subcontracted product linked to that vendor.
-Log in to the portal view as the portal user and open Manufacturing Orders.
-Try to open the related picking and the page fails to load and appears blank.

Cause of the issue:
=======================
In this [PR](https://github.com/odoo/odoo/pull/177390), The `_compute_description_picking` method was extended to include vendor product code and product name using the `selected_seller_id` field, and  the product attribute values using  the `product_no_variant_attribute_value_ids` field. Since `selected_seller_id` points to `product.supplierinfo` model and `product_no_variant_attribute_value_ids` points to `product.template.attribute.value` model, `group_portal` do not have read access to these models causing access errors when the picking description is computed, so the page appears blank while opening the picking.

After This Commit:
=======================
The `_compute_description_picking` method now uses `sudo()` to safely access `selected_seller_id` and `product_no_variant_attribute_value_ids` fields, allowing portal users to compute stock move descriptions without encountering access errors. This prevents the page from appearing blank when opening picking in the portal without granting direct model access.

Task-4958070