### PR TITLE
[FIX] html_builder: prevent crash when removing background image

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_image.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_image.xml
@@ -6,7 +6,7 @@
         <BuilderButton preview="false" title.translate="Edit image" type="'success'" action="'replaceBgImage'"> Replace </BuilderButton>
         <ImageSize />
     </BuilderRow>
-    <BuilderRow t-if="showMainColorPicker()" label.translate="Main Color" level="2">
+    <BuilderRow t-if="this.domState.show" label.translate="Main Color" level="2">
         <t t-foreach="getColorPickerColorNames()" t-as="colorName" t-key="colorName_index">
             <BuilderColorPicker action="'dynamicColor'" actionParam="colorName" enabledTabs="['solid', 'custom']"/>
         </t>

--- a/addons/html_builder/static/src/plugins/background_option/background_image_option.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option.js
@@ -1,4 +1,4 @@
-import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { getBgImageURLFromEl, normalizeColor } from "@html_builder/utils/utils_css";
 import { ImageSize } from "../image/image_size";
 import { getHtmlStyle } from "@html_editor/utils/formatting";
@@ -11,6 +11,9 @@ export class BackgroundImageOption extends BaseOptionComponent {
         // done here because we have direct access to the editing element
         // (which we don't have in the normalize of the current plugin)
         this.toggleBgImageClasses();
+        this.domState = useDomState((editingEl) => ({
+            show: this.showMainColorPicker(editingEl),
+        }));
         super.setup();
     }
     toggleBgImageClasses() {
@@ -23,8 +26,7 @@ export class BackgroundImageOption extends BaseOptionComponent {
             );
         });
     }
-    showMainColorPicker() {
-        const editingEl = this.env.getEditingElement();
+    showMainColorPicker(editingEl) {
         const src = new URL(getBgImageURLFromEl(editingEl), window.location.origin);
         return (
             src.origin === window.location.origin &&


### PR DESCRIPTION
Steps to reproduce:
- Open a website in edit mode
- Drag & drop the "Floating Blocks" eCommerce snippet
- Remove the background image of the second block
- A traceback is raised

Cause:
The `editingEl` was `undefined` when calling `showMainColorPicker`, leading to an error.

Solution:
Use `useDomState` to safely compute the value of `showMainColorPicker` based on the current `editingEl`.
