### PR TITLE
[FIX] hr_contract : allow _get_unusual_days to process multiple running contract

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -204,18 +204,18 @@ class Employee(models.Model):
         if not employee_contracts:
             return super()._get_unusual_days(date_from, date_to)
 
-        selected_contract = employee_contracts.filtered(lambda c: c.state == 'open')
+        selected_contracts = employee_contracts.filtered(lambda c: c.state == 'open')
 
-        if not selected_contract:
-            selected_contract = max(employee_contracts, key=lambda c: (c.create_date, c.id))
+        if not selected_contracts:
+            selected_contracts = max(employee_contracts, key=lambda c: (c.create_date, c.id))
 
         unusual_days = {}
         date_from_date = datetime.strptime(date_from, '%Y-%m-%d %H:%M:%S').date()
         date_to_date = datetime.strptime(date_to, '%Y-%m-%d %H:%M:%S').date() if date_to else None
-        if selected_contract:
-            tmp_date_from = max(date_from_date, selected_contract.date_start)
-            tmp_date_to = min(date_to_date, selected_contract.date_end) if selected_contract.date_end else date_to_date
-            unusual_days.update(selected_contract.resource_calendar_id.sudo(False)._get_unusual_days(
+        for contract in selected_contracts:
+            tmp_date_from = max(date_from_date, contract.date_start)
+            tmp_date_to = min(date_to_date, contract.date_end) if contract.date_end else date_to_date
+            unusual_days.update(contract.resource_calendar_id.sudo(False)._get_unusual_days(
                 datetime.combine(fields.Date.from_string(tmp_date_from), time.min).replace(tzinfo=UTC),
                 datetime.combine(fields.Date.from_string(tmp_date_to), time.max).replace(tzinfo=UTC),
                 self.company_id,


### PR DESCRIPTION
**Step to Reproduce**
- install hr_contract and hr_holidays module
- go to employee -> contracts
- Add 2-3 contract to a employee, which can be done by having contracts in different interval (but same year)
- set their stage to `running`
- open Time off App

**Observation:**
- we receive a traceback
```
File "/data/build/odoo/addons/hr_contract/models/hr_employee.py", line 229, in _get_unusual_days
tmp_date_from = max(date_from_date, selected_contract.date_start)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/data/build/odoo/odoo/orm/fields.py", line 1424, in __get__
record.ensure_one()
File "/data/build/odoo/odoo/orm/models.py", line 5635, in ensure_one
raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: hr.contract(1, 2)
```


**Cause:**
- `_get_unusual_days` assumes that there is only one running contract
- Hence with multiple contract, it raises traceback

Fix:
- Adjust the method to accept multiple contracts

opw-5045306

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
