### PR TITLE
[FIX] website_sale: "showcase" design, disable onHover buttons option

### DIFF
--- a/addons/website_sale/static/src/website_builder/products_design_panel.xml
+++ b/addons/website_sale/static/src/website_builder/products_design_panel.xml
@@ -480,7 +480,7 @@
             <div class="o_wsale_design_panel_section_title ps-2 pt-3 pb-1 fw-bold">Actions</div>
             <hr class="mx-2 mt-0 mb-2"/>
 
-            <t t-set="isOnHoverAvailable" t-value="anyCatalog || this.isActiveItem('wsale_design_showcase_list')"/>
+            <t t-set="isOnHoverAvailable" t-value="anyCatalog"/>
 
             <BuilderRow
                 label.translate="Buttons"


### PR DESCRIPTION
This PR disallow the "onHover buttons" option for the "Showcase" card design.
It was initially considered a "nice to have", but after further testing it's now clear that the option provides sub-optimal results both functionally and design-wise.

task-5065733



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
