### PR TITLE
[REF] mail: activities use user_id rather than persona

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -636,9 +636,9 @@ class MailActivity(models.Model):
             "res_model",
             "state",
             "summary",
+            Store.One("user_id", Store.One("partner_id")),
             Store.Many("attachment_ids", ["name"]),
             Store.Many("mail_template_ids", ["name"]),
-            Store.One("persona", value=lambda activity: activity.user_id.partner_id),
         ]
 
     @api.readonly

--- a/addons/mail/static/src/core/common/activity_model.js
+++ b/addons/mail/static/src/core/common/activity_model.js
@@ -52,7 +52,6 @@ export class Activity extends Record {
     icon = "fa-tasks";
     mail_template_ids = fields.Many("mail.template");
     note = fields.Html("");
-    persona = fields.One("res.partner");
     /** @type {string} */
     res_model;
     /** @type {[number, string]} */
@@ -65,15 +64,14 @@ export class Activity extends Record {
     state;
     /** @type {string} */
     summary;
-    /** @type {[number, string]} */
-    user_id;
+    user_id = fields.One("res.users");
     /** @type {string} */
     write_date;
     /** @type {[number, string]} */
     write_uid;
 
     serialize() {
-        return JSON.parse(JSON.stringify(this.toData(["persona"])));
+        return JSON.parse(JSON.stringify(this.toData(["user_id"])));
     }
 }
 

--- a/addons/mail/static/src/core/web/activity.js
+++ b/addons/mail/static/src/core/web/activity.js
@@ -83,13 +83,13 @@ export class Activity extends Component {
     }
 
     onClickAvatar(ev) {
-        if (!this.props.activity.persona) {
+        if (!this.props.activity.user_id) {
             return;
         }
         const target = ev.currentTarget;
         if (!this.avatarCard.isOpen) {
             this.avatarCard.open(target, {
-                id: this.props.activity.persona.main_user_id?.id,
+                id: this.props.activity.user_id.id,
             });
         }
     }

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -4,19 +4,19 @@
 <t t-name="mail.Activity">
     <div class="o-mail-Activity d-flex py-1 mb-2" t-on-click="onClick">
         <div class="o-mail-Activity-sidebar d-flex flex-shrink-0 position-relative align-items-start justify-content-center">
-            <div class="o-mail-Activity-avatarContainer position-relative d-flex align-items-center justify-content-center" t-att-role="props.activity.persona ? 'button' : 'img'" t-on-click="onClickAvatar">
-                <img t-if="props.activity.persona" class="w-100 h-100 rounded object-fit-cover" t-att-src="props.activity.persona.avatarUrl" />
+            <div class="o-mail-Activity-avatarContainer position-relative d-flex align-items-center justify-content-center" t-att-role="props.activity.user_id ? 'button' : 'img'" t-on-click="onClickAvatar">
+                <img t-if="props.activity.user_id?.partner_id" class="w-100 h-100 rounded object-fit-cover" t-att-src="props.activity.user_id.partner_id.avatarUrl" />
                 <div
                     class="o-mail-Activity-iconContainer rounded-circle d-flex align-items-center justify-content-center"
                     t-att-class="{
-                        'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 w-50 h-50': props.activity.persona,
+                        'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 w-50 h-50': props.activity.user_id,
                         'text-bg-success': props.activity.state === 'planned',
                         'text-bg-warning': props.activity.state === 'today',
                         'text-bg-danger': props.activity.state === 'overdue',
                         }"
-                    t-attf-style="{{!props.activity.persona ? 'height:80%; width:80%;' : ''}}"
+                    t-attf-style="{{!props.activity.user_id ? 'height:80%; width:80%;' : ''}}"
                 >
-                    <i class="fa small" t-attf-class="{{ props.activity.icon }} {{props.activity.persona ? 'small' : 'fs-2'}}"/>
+                    <i class="fa small" t-attf-class="{{ props.activity.icon }} {{props.activity.user_id ? 'small' : 'fs-2'}}"/>
                 </div>
             </div>
         </div>
@@ -28,7 +28,7 @@
                 <span class="fw-bolder text-danger" t-elif="delay lt 0"><t t-esc="-delay"/> days overdue:</span>
                 <span class="fw-bolder text-warning" t-else="">Today:</span>
                 <span class="fw-bolder px-2 text-break"><t t-esc="displayName"/></span>
-                <span class="o-mail-Activity-user px-1" t-if="props.activity.persona" >for <t t-esc="props.activity.persona.displayName"/></span>
+                <span class="o-mail-Activity-user px-1" t-if="props.activity.user_id?.partner_id" >for <t t-esc="props.activity.user_id.partner_id.displayName"/></span>
                 <button class="btn btn-link btn-primary p-0 lh-1 border-0">
                     <i class="fa fa-info-circle" role="img" title="Info" aria-label="Info" t-on-click="toggleDetails"/>
                 </button>
@@ -38,7 +38,7 @@
                     <tbody>
                         <tr><td class="text-end fw-bolder">Activity type</td><td><t t-esc="props.activity.activity_type_id?.name"/></td></tr>
                         <tr><td class="text-end fw-bolder">Created</td><td><t t-esc="props.activity.dateCreateFormatted"/> by <t t-esc="props.activity.create_uid?.name"/></td></tr>
-                        <tr t-if="props.activity.persona"><td class="text-end fw-bolder">Assigned to</td><td><t t-esc="props.activity.persona.displayName"/></td></tr>
+                        <tr t-if="props.activity.user_id"><td class="text-end fw-bolder">Assigned to</td><td><t t-esc="props.activity.user_id.name"/></td></tr>
                         <tr><td class="text-end fw-bolder">Due on</td><td><t t-esc="props.activity.dateDeadlineFormatted"/></td></tr>
                     </tbody>
                 </table>

--- a/addons/mail/static/src/core/web/activity_list_popover_item.xml
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.xml
@@ -29,9 +29,9 @@
                 </button>
             </div>
             <div class="d-flex align-items-center flex-wrap mx-3">
-                <img class="me-2 rounded object-fit-cover" t-if="props.activity.persona" t-att-src="props.activity.persona.avatarUrl" style="max-width: 1.5rem; max-height: 1.5rem;"/>
+                <img class="me-2 rounded object-fit-cover" t-if="props.activity.user_id?.partner_id" t-att-src="props.activity.user_id.partner_id.avatarUrl" style="max-width: 1.5rem; max-height: 1.5rem;"/>
                 <div class="mt-1">
-                    <small t-if="props.activity.persona" class="text-truncate" t-esc="props.activity.persona.displayName"/>
+                    <small t-if="props.activity.user_id" class="text-truncate" t-esc="props.activity.user_id.name"/>
                     <small t-if="props.activity.state !== 'today'" class="mx-1">-</small>
                     <small t-if="['overdue', 'planned'].includes(props.activity.state)" class="fw-bold" t-att-title="props.activity.dateDeadlineFormatted" t-esc="delayLabel"/>
                     <small t-if="props.activity.state === 'done'" class="fw-bold" t-att-title="dateDoneFormatted" t-esc="props.activity.dateDoneFormatted"/>

--- a/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
@@ -49,10 +49,6 @@ export class MailActivity extends models.ServerModel {
         const MailActivityType = this.env["mail.activity.type"];
         /** @type {import("mock_models").MailTemplate} */
         const MailTemplate = this.env["mail.template"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
-        /** @type {import("mock_models").ResUsers} */
-        const ResUsers = this.env["res.users"];
         store._add_record_fields(
             this,
             fields.filter((f) => !["activity_type_id"].includes(f))
@@ -81,8 +77,6 @@ export class MailActivity extends models.ServerModel {
             if (data.summary) {
                 data.display_name = data.summary;
             }
-            const [user] = ResUsers.browse(activity.user_id);
-            data.persona = mailDataHelpers.Store.one(ResPartner.browse(user.partner_id));
             store._add_record_fields(this.browse(activity.id), data);
         }
     }
@@ -108,6 +102,12 @@ export class MailActivity extends models.ServerModel {
             "res_model",
             "state",
             "summary",
+            mailDataHelpers.Store.one(
+                "user_id",
+                makeKwArgs({
+                    fields: [mailDataHelpers.Store.one("partner_id")],
+                })
+            ),
         ];
     }
 


### PR DESCRIPTION
enterprise: https://github.com/odoo/enterprise/pull/93988

This commit refactors the activity model and component to use the `user_id` field rather than the deprecated `persona` (res.partner).

task-4675954