### PR TITLE
[FIX] mail: fix rotting field crashing in gantt kanban popover

### DIFF
--- a/addons/mail/static/src/js/rotting_mixin/rotting_widget.js
+++ b/addons/mail/static/src/js/rotting_mixin/rotting_widget.js
@@ -40,7 +40,7 @@ export class KanbanRottingField extends Component {
         });
 
         this.title = getRottingDaysTitle(
-            this.env.model.config.resModel,
+            this.props.record.model.config.resModel,
             this.props.record.data.rotting_days
         );
     }


### PR DESCRIPTION
Steps to reproduce:

- Click on any pill in gantt view of project

Issue:

- A traceback.

Reason:

- Kanban popover is a feature through which we open the pill's kanban card in gantt pill popover.
- In this way we wont any environment from parent component this env is empty. As it is rendered seperately.

Fix:

- Change the way we get Model required of rotting text generation in rotting widget.
- Get the model name from record as `env` might not available in some cases.

task-5065730