### PR TITLE
[FIX] html_builder: enable "On Hover" animation for images with shapes

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -1,13 +1,8 @@
-import {
-    cropperDataFieldsWithAspectRatio,
-    isGif,
-    loadImage,
-    loadImageInfo,
-} from "@html_editor/utils/image_processing";
+import { cropperDataFieldsWithAspectRatio, loadImage } from "@html_editor/utils/image_processing";
 import { registry } from "@web/core/registry";
 import { Plugin } from "@html_editor/plugin";
 import { ImageToolOption } from "./image_tool_option";
-import { isImageCorsProtected, getMimetype } from "@html_editor/utils/image";
+import { isImageCorsProtected } from "@html_editor/utils/image";
 import { withSequence } from "@html_editor/utils/resource";
 import {
     REPLACE_MEDIA,
@@ -119,35 +114,8 @@ class ImageToolOptionPlugin extends Plugin {
     setup() {
         this.htmlStyle = getHtmlStyle(this.document);
     }
-
-    async canHaveHoverEffect(img) {
-        const getDataset = async () => Object.assign({}, img.dataset, await loadImageInfo(img));
-        return img.tagName === "IMG"
-            ? !this.isDeviceShape(img) &&
-                  !this.isAnimatedShape(img) &&
-                  this.isImageSupportedForShapes(img, await getDataset()) &&
-                  !(await isImageCorsProtected(img))
-            : null;
-    }
-    isDeviceShape(img) {
-        const shapeName = img.dataset.shape;
-        if (!shapeName) {
-            return false;
-        }
-        const shapeCategory = shapeName.split("/")[1];
-        return shapeCategory === "devices";
-    }
-    isAnimatedShape(img) {
-        // todo: to implement while implementing the animated shapes
-        return false;
-    }
-    isImageSupportedForShapes(img, dataset = img.dataset) {
-        // todo: The hover effect code should probably be define somewhere else.
-        const isHoverEffect = !!dataset["hoverEffect"];
-        return (
-            isHoverEffect ||
-            (dataset.originalId && isImageSupportedForProcessing(getMimetype(img, dataset)))
-        );
+    async canHaveHoverEffect(imgEl) {
+        return imgEl.tagName === "IMG" && !(await isImageCorsProtected(imgEl));
     }
     // TODO Remove in master.
     migrateImages(rootEl) {
@@ -308,16 +276,3 @@ export class AltAction extends BuilderAction {
 }
 
 registry.category("builder-plugins").add(ImageToolOptionPlugin.id, ImageToolOptionPlugin);
-
-/**
- * @param {String} mimetype
- * @param {Boolean} [strict=false] if true, even partially supported images (GIFs)
- *     won't be accepted.
- * @returns {Boolean}
- */
-function isImageSupportedForProcessing(mimetype, strict = false) {
-    if (isGif(mimetype)) {
-        return !strict;
-    }
-    return ["image/jpeg", "image/png", "image/webp"].includes(mimetype);
-}

--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -21,8 +21,8 @@ export class AnimateOptionPlugin extends Plugin {
         getEffectsItems: this.getEffectsItems.bind(this),
         canHaveHoverEffect: async (el) => {
             const proms = this.getResource("hover_effect_allowed_predicates").map((p) => p(el));
-            const allowed = (await Promise.all(proms)).filter((allowed) => allowed != null);
-            return allowed.length && allowed.every(Boolean);
+            const settledProms = await Promise.all(proms);
+            return settledProms.length && settledProms.every(Boolean);
         },
     };
     resources = {


### PR DESCRIPTION
Applying a shape to an image unintentionally disabled the "On Hover" animation option. This commit restores the option with proper checks, ensuring it remains disabled only when the applied shape includes an animation.

The related code was also refactored slightly for improved readability.

Steps to reproduce:
1. Enter edit mode in Website.
2. Add an image and apply a shape.
3. Notice that the "On Hover" animation option is incorrectly hidden.