### PR TITLE
[FIX] website, *: remove duplicate id="connect" from footer snippet

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1617,7 +1617,7 @@
                             <p>We are a team of passionate people whose goal is to improve everyone's life through disruptive products. We build great products to solve your business problems.
                             <br/><br/>Our products are designed for small to medium size companies willing to optimize their performance.</p>
                         </div>
-                        <div id="connect" class="col-lg-4 offset-lg-1 pt24 pb24">
+                        <div class="col-lg-4 offset-lg-1 pt24 pb24">
                             <h5 class="mb-3">Connect with us</h5>
                             <ul class="list-unstyled">
                                 <li><i class="fa fa-comment fa-fw me-2"/><span><a href="/contactus">Contact us</a></span></li>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -1082,7 +1082,7 @@
                             <div class="s_hr pt16 pb16" data-snippet="s_hr" data-name="Separator">
                                 <hr class="w-100 mx-auto" style="border-top-color: var(--400)  !important;"/>
                             </div>
-                            <div id="connect">
+                            <div>
                                 <ul class="list-unstyled text-nowrap">
                                     <li><i class="fa fa-comment fa-fw me-2"></i><span><a href="/contactus">Contact us</a></span></li>
                                     <li><i class="fa fa-envelope fa-fw me-2"></i><span><a href="mailto:info@yourcompany.example.com">info@yourcompany.example.com</a></span></li>


### PR DESCRIPTION
*:website_hr_recruitment

Using `id="connect"` in the footer block could result in duplicate IDs when the snippet was added multiple times, leading to invalid HTML and unreliable CSS/JS selectors. This commit removes the hard-coded ID to ensure valid markup and predictable behavior.
