### PR TITLE
[FIX] purchase_stock: correct on-time rate calculation in purchase stock

### DIFF
--- a/addons/purchase_stock/tests/test_purchase_order_process.py
+++ b/addons/purchase_stock/tests/test_purchase_order_process.py
@@ -77,6 +77,7 @@ class TestPurchaseOrderProcess(PurchaseTestCommon):
                 })],
         })
         purchase_order.button_confirm()
+        purchase_order.order_line.flush_recordset()
         purchase_order.picking_ids.move_ids.flush_recordset()
         delay_reports = self.env['vendor.delay.report']._read_group([('partner_id', '=', partner.id)], ['product_id'], ['on_time_rate:sum'])
         self.assertEqual([rec[1] for rec in delay_reports], [0.0, 0.0])

--- a/addons/purchase_stock/tests/test_purchase_stock_report.py
+++ b/addons/purchase_stock/tests/test_purchase_stock_report.py
@@ -370,3 +370,36 @@ class TestPurchaseStockReports(TestReportsCommon):
         self.assertEqual(data['qty_on_time'], 6)
         self.assertEqual(data['qty_total'], 10)
         self.assertEqual(data['on_time_rate'], 60)
+
+    def test_vendor_delay_report_with_duplicate_receipt_without_backorder(self):
+        """
+        PO 10 units x P
+        Receive 6 x P without backorder
+        Duplicate picking with remaining 4 x P
+        -> 100% received
+        """
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.partner
+        with po_form.order_line.new() as line:
+            line.product_id = self.product
+            line.product_qty = 10
+        po = po_form.save()
+        po.button_confirm()
+
+        receipt01 = po.picking_ids
+        receipt01.move_ids.quantity = 6
+        action = receipt01.button_validate()
+        Form(self.env[action['res_model']].with_context(action['context'])).save().process_cancel_backorder()
+        receipt02 = receipt01.copy()
+        receipt02.move_ids.write({
+            'product_uom_qty': 4,
+        })
+        receipt02.button_validate()
+        data = self.env['vendor.delay.report'].read_group(
+            [('partner_id', '=', self.partner.id)],
+            ['product_id', 'on_time_rate', 'qty_on_time', 'qty_total'],
+            ['product_id'],
+        )[0]
+        self.assertEqual(data['qty_total'], 10)
+        self.assertEqual(data['qty_on_time'], 10)
+        self.assertEqual(data['on_time_rate'], 100)


### PR DESCRIPTION
**Steps to reproduce:**

1- Install the purchase_stock module.
2- Create a new PO with a new vendor.
3- Add new one product in the purchase order line with quantity > 1.
4- Confirm the PO and go to the generated receipt.
5- Validate the receipt with less than the ordered quantity, by choosing no
   backorder.
6- Duplicate the receipt for the remaining quantity and validate it.
7- In vendor form view, the On-time Rate value shown in the smart button differs
   from the value in the graph.

**Issue:**
https://github.com/odoo/odoo/blob/e7da32fe67cfe78bc6da8bf5d36a7c584763e3bb/addons/purchase_stock/report/vendor_delay_report.py#L26-L42

- The On-time Rate shown in the smart button does not match the graph.

**Example:**

- PO Line ordered qty: 10  
- First receipt validated: 6 (no backorder)  
- Duplicated receipt validated: 4  
- In vendor form view inside On-time Rate Smart button
- Total quantity coming: 14 (incorrect)  
- Expected total qty for calculation: 10 (from PO line)  
- On-time delivery rate calculated: **71.43%**  
- Expected On-time delivery rate: **100%**

**Cause:**

- The report uses `product_qty` from the stock move.  
- When a receipt is duplicated and the demand quantity is manually set, 
`product_qty` is recomputed from this demand value.  
This leads to a mismatch between the PO line quantity and the aggregated stock 
move quantities.

**NOTE:**
In `test_02_vendor_delay_report_partially_cancelled_purchase_order`, added the line::
`purchase_order.order_line.flush_recordset()`

- Because we were taking the `partner_id` from the `Purchase Order line` is a stored related field.
- The computed value first lives in Odoo’s cache.
- It is not written to the database until a flush occurs.
- If we immediately call something like _read_group() (which queries the database directly), 
it won’t see the cached value — only what is persisted in the DB.

**Solution:**

- Use the purchase order line quantity instead of the stock move’s `product_qty` 
to ensure consistent and accurate On-time Rate calculation.

opw-4991367