### PR TITLE
[FIX] pos_event: company name not saved

### DIFF
--- a/addons/pos_event/models/event_registration.py
+++ b/addons/pos_event/models/event_registration.py
@@ -16,7 +16,7 @@ class EventRegistration(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['id', 'event_id', 'event_ticket_id', 'pos_order_line_id', 'pos_order_id', 'phone', 'email', 'name',
-                'registration_answer_ids', 'registration_answer_choice_ids', 'write_date']
+                'company_name', 'registration_answer_ids', 'registration_answer_choice_ids', 'write_date']
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/pos_event/models/pos_session.py
+++ b/addons/pos_event/models/pos_session.py
@@ -19,3 +19,4 @@ class PosSession(models.Model):
             response['event.registration']['relations']['email']['compute'] = False
             response['event.registration']['relations']['phone']['compute'] = False
             response['event.registration']['relations']['name']['compute'] = False
+            response['event.registration']['relations']['company_name']['compute'] = False

--- a/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
@@ -99,8 +99,8 @@ patch(ProductScreen.prototype, {
                         userData.phone = answer;
                     } else if (question.question_type === "name") {
                         userData.name = answer;
-                    } else if (question.question_type === "company") {
-                        userData.company = answer;
+                    } else if (question.question_type === "company_name") {
+                        userData.company_name = answer;
                     }
                 }
 


### PR DESCRIPTION
Steps to reproduce:
1. Add a question to an event with type 'Company'.
2. Sell a ticket for that event in a POS, making sure to fill in the company question.
3. Validate the sale
4. In the backend, check the new event registration that was created.

EXPECTED: The company name you filled in is saved to the registration.
ACTUAL: The company name is blank.

There were three things that needed to be fixed in order for the company name to work:
1. Use `company_name` instead of `company` on the JS side
2. Add `company_name` to the list of loaded POS fields
3. Tell the POS that `company_name` is not computed (this was already being done for name, email, phone)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
