### PR TITLE
[IMP] web, html_builder: fix focus edit color combination button

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
@@ -91,6 +91,10 @@
         &:hover {
             color: $o-we-fg-lighter;
         }
+
+        &:not(:focus-visible) {
+            border: 1px solid transparent; // keep size stable on focus
+        }
     }
 
     // Gradients

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -59,7 +59,7 @@
                                 <span class="py-1 px-1 rounded-1 fs-6 btn btn-sm lh-1 btn btn-sm d-flex flex-column justify-content-center btn-secondary"><small>Button</small></span>
                             </div>
                         </button>
-                        <button t-on-click="() => this.props.editColorCombination(number)" class="o-hb-edit-color-combination o_colorpicker_ignore fa fa-pencil btn pe-1" title="Edit"/>
+                        <button t-on-click="() => this.props.editColorCombination(number)" class="o-hb-edit-color-combination o_colorpicker_ignore fa fa-pencil btn ms-1 px-1" title="Edit"/>
                     </div>
                 </t>
             </div>


### PR DESCRIPTION
Fix "edit color combination button" size shifting on focus by keeping a transparent border when not focused. This ensures the button width stays consistent and avoids a slight layout jump when the button is selected.