### PR TITLE
[FIX] core: Change `read_group` labels to 24-hour time representation

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2052,7 +2052,7 @@ class BaseModel(metaclass=MetaModel):
                 # Mixing both formats, e.g. 'MMM YYYY' would yield wrong results,
                 # such as 2006-01-01 being formatted as "January 2005" in some locales.
                 # Cfr: http://babel.pocoo.org/en/latest/dates.html#date-fields
-                'hour': 'hh:00 dd MMM',
+                'hour': 'HH:00 dd MMM',
                 'day': 'dd MMM yyyy', # yyyy = normal year
                 'week': "'W'w YYYY",  # w YYYY = ISO week-year
                 'month': 'MMMM yyyy',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Group by hour was introduced in [this commit](https://github.com/odoo/odoo/commit/cdf13bf70379600930649fa0cb11cb377901e39d). Although graph views don't yet support this feature, when users/developers use the `read_group` method with `create_date:hour` as an example, the expectation is that the labels returned should be formatted using the 24 hour format, not the 12 hour format. Changing `hh` to `HH` fixes this issue. Reference: https://babel.pocoo.org/en/latest/dates.html#time-fields

Current behavior before PR:

`read_group` with a datetime field by hour returns 12 hour formatted time labels.

Desired behavior after PR is merged:

`read_group` with a datetime field by hour returns 24 hour formatted time labels.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
