### PR TITLE
[FIX] hr: prevent error on loading demo data

### DIFF
--- a/addons/hr/data/scenarios/hr_scenario.xml
+++ b/addons/hr/data/scenarios/hr_scenario.xml
@@ -133,7 +133,7 @@
             <field name="private_country_id" ref="base.us"/>
             <field name="private_phone">+1 555-555-5757</field>
             <field name="work_email">williams@mycompany.example.com</field>
-            <field name="department_id" ref="hr.dep_administration"/>
+            <field name="department_id" eval="ref('hr.dep_administration', raise_if_not_found=False)"/>
             <field name="job_id" ref="job_ceo"/>
             <field name="job_title">Chief Executive Officer</field>
             <field name="company_id" ref="base.main_company"/>


### PR DESCRIPTION
The system crash with error when user tries to load demo data of employees.

**Steps to produce:-**
- Install the `Attendances` module without demo data.
- Navigate to `Employees > Departments` and **delete** the `Administrative department`.
- **Remove** all employees.
- Go to `Attendances > Load Demo`.
- Observe the error.

**Error:-**
```py
ValueError: External ID not found in the system: hr.dep_administration

ParseError: while parsing /home/odoo/src/odoo/saas-18.4/addons/hr/data/scenarios/hr_scenario.xml:126, somewhere inside <record id='employee_mw' model='hr.employee' forcecreate='1'>
            <field name='active'>True</field>
            <field name='name'>Michael Williams</field>
            <field name='private_street'>349-943 Miania St.</field>
            <field name='certificate'>master</field>
            <field name='private_zip'>58198</field>
            <field name='private_city'>Williston</field>
            <field name='private_country_id' ref=base.us/>
            <field name='private_phone'>+1 555-555-5757</field>
            <field name='work_email'>williams@mycompany.example.com</field>
            <field name='department_id' ref='hr.dep_administration'/>
            <field name='job_id' ref='job_ceo'/>
            <field name='job_title'>Chief Executive Officer</field>
            <field name='company_id' ref='base.main_company'/>
            <field name='category_ids' eval='[Command.set([ref('emplo...
```

- The error occurs because the user deleted the  Administrative department, and then try to load data, that reference the deleted department.

- This commit resolves the error by providing a False value for the field if the employee department is missing.

**sentry-6856979884**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
