### PR TITLE
[FIX] payment_redsys: timestamp reference

### DIFF
--- a/addons/payment_redsys/models/payment_transaction.py
+++ b/addons/payment_redsys/models/payment_transaction.py
@@ -45,9 +45,9 @@ class PaymentTransaction(models.Model):
                 provider_code, prefix=prefix, separator=separator, **kwargs
             )
 
-        # Generate the prefix as a part of the current datetime (up to the month). This leaves just
-        # enough room for the separator and the suffix in case of collisions.
-        prefix = fields.Datetime.now().strftime('%m%d%H%M%S')
+        # Generate the prefix as the timestamp of the current time (10 chars).
+        # This leaves just enough room for the separator and the suffix in case of collisions.
+        prefix = str(int(fields.Datetime.now().timestamp()))[-10:]
 
         return super()._compute_reference(provider_code, prefix=prefix, separator='S', **kwargs)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Redsys requires the reference to be unique and within 9 and 12 alphanumeric characters.
The previous approach of truncating now (datetime) up to the month (10 characters + 2 for handling collisions) would lead to an increase of collision risk year after year (as months repeat every year). 
Using the timestamp value of now allows us to save the year information within 10 characters. 

Related: https://github.com/odoo/odoo/pull/205135