### PR TITLE
[FIX] website: form inputs without label are still sent

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -313,6 +313,14 @@ import wUtils from '@website/js/utils';
             }
 
             // Prepare form inputs
+            // Set a placeholder name to input fields without
+            // a label to allow FormData to function correctly
+            for (const [i, inputEl] of this.el
+                .querySelectorAll(".s_website_form_input:not([name]), [name=''].s_website_form_input")
+                .entries()) {
+                inputEl.setAttribute("name", "unknown_field_" + (i + 1));
+            };
+
             this.form_fields = this.$el.serializeArray();
             $.each(this.$el.find('input[type=file]:not([disabled])'), (outer_index, input) => {
                 $.each($(input).prop('files'), function (index, file) {

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -185,7 +185,7 @@ const FormEditor = options.Class.extend({
         if (!field.id) {
             field.id = weUtils.generateHTMLId();
         }
-        const params = { field: { ...field }, defaultName: escape(_t("Field")) };
+        const params = { field: { ...field }, defaultName: escape(field.string || _t("Field")) };
         if (["url", "email", "tel"].includes(field.type)) {
             params.field.inputType = field.type;
         }
@@ -1080,6 +1080,10 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
      * Set the name of the field on the label
      */
     setLabelText: function (previewMode, value, params) {
+        // If value is empty, use the original field label
+        if (!value.trim() && this.$target[0].dataset.translatedName) {
+            value = this.$target[0].dataset.translatedName;
+        }
         this.$target.find('.s_website_form_label_content').text(value);
         if (this._isFieldCustom()) {
             value = this._getQuotesEncodedName(value);


### PR DESCRIPTION
Before this commit, a form input without a label would not send its data when clicking send.

Steps to reproduce
- go to the website editor
- add a form
- choose any field
- delete the field label
- save and exit the editor
- now in the website, fill the form and click send => the fields without a name label are not sent

After this commit fields without a label get sent with a placeholder "unknown_field"

task-5062575
