### PR TITLE
[IMP] l10n_in: set default outstanding accounts on bank journals

### DIFF
--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_in
 from . import account_invoice
+from . import account_journal
 from . import account_move_line
 from . import account_payment
 from . import account_tax

--- a/addons/l10n_in/models/account_journal.py
+++ b/addons/l10n_in/models/account_journal.py
@@ -1,0 +1,30 @@
+from odoo import models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    def _update_payment_method_lines(self, payment_type):
+        bank_journals = self.filtered(lambda j: j.type == "bank" and j.company_id.chart_template == "in")
+        if not bank_journals:
+            return
+
+        if payment_type == 'inbound':
+            account_xmlid = "account_journal_payment_debit_account_id"
+        else:
+            account_xmlid = "account_journal_payment_credit_account_id"
+
+        lines_to_update = bank_journals[f"{payment_type}_payment_method_line_ids"].filtered(
+            lambda l: l.payment_method_id.code == 'manual'
+        )
+        for company, lines in lines_to_update.grouped('company_id').items():
+            if account := self.env['account.chart.template'].with_company(company).ref(account_xmlid, raise_if_not_found=False):
+                lines.payment_account_id = account
+
+    def _compute_inbound_payment_method_line_ids(self):
+        super()._compute_inbound_payment_method_line_ids()
+        self._update_payment_method_lines("inbound")
+
+    def _compute_outbound_payment_method_line_ids(self):
+        super()._compute_outbound_payment_method_line_ids()
+        self._update_payment_method_lines("outbound")

--- a/addons/l10n_in/models/template_in.py
+++ b/addons/l10n_in/models/template_in.py
@@ -108,3 +108,12 @@ class AccountChartTemplate(models.AbstractModel):
         if template_code == 'in':
             company = company or self.env.company
             company._update_l10n_in_is_gst_registered()
+
+            # The COA (Chart of Accounts) data is loaded after the initial compute methods are called.
+            # During initial journal setup, the payment methods and accounts may not exist yet,
+            # causing the payment method lines to not be properly configured.
+            # We call these helper methods again in _post_load_data to ensure all payment method lines
+            # are correctly assigned once all COA data is fully available.
+            bank_journals = company.bank_journal_ids
+            bank_journals._update_payment_method_lines("inbound")
+            bank_journals._update_payment_method_lines("outbound")


### PR DESCRIPTION
Before:
- By default, Odoo does not assign outstanding accounts (debit/credit) to bank journals. Users must configure them manually from within the journal.
- This often left setups incomplete, resulting in missing entries in the CoA.

After:
- For the Indian localisation, outstanding accounts are now automatically set on bank journals’ inbound and outbound manual payment methods.
- The payment accounts are applied by default during CoA loading and whenever payment method lines are recomputed, ensuring accounts remain consistent.

Explanation:
This improvement removes manual setup steps, and ensures a ready-to-use bank journal configuration with default outstanding accounts out of the box.

task-5055756