### PR TITLE
[FIX] sale,account: retrieve getCellTitle method's result

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -24,7 +24,7 @@ export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRend
         if (this.productColumns.includes(column.name)) {
             return;
         }
-        super.getCellTitle(column, record);
+        return super.getCellTitle(column, record);
     }
 
     getActiveColumns(list) {

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -27,7 +27,7 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
         if (column.name === 'product_id' || column.name === 'product_template_id') {
             return;
         }
-        super.getCellTitle(column, record);
+        return super.getCellTitle(column, record);
     }
 
     getActiveColumns(list) {


### PR DESCRIPTION
## Versions
18.0+

## Issue
No tooltip can be displayed on Sale Order Lines.

## Steps to reproduce
*Install Studio*
- Open any SO;
- Open Studio:
  - Click "Edit List view" on the Order Lines table;
  - Add a "Text" field in the columns;
  - Close Studio.
- Add a product line if none:
  - Write something in the new column added with Studio;
  - Hover that cell and see no tooltip appear

## Cause
https://github.com/odoo/odoo/blob/4daf4824a70ef679f65d5cbb15d71bc55c1e760e/addons/web/static/src/views/list/list_renderer.xml#L250 The template calls `getCellTitle` which returns a formatted text but has been overridden. These methods call the original `getCellTitle` method but don't return the formatted value.

opw-4921113