### PR TITLE
[REF] web, *: remove export of stateToUrl and urlToState

### DIFF
--- a/addons/crm/static/src/core/common/crm_lead_model.js
+++ b/addons/crm/static/src/core/common/crm_lead_model.js
@@ -1,5 +1,5 @@
 import { fields, Record } from "@mail/core/common/record";
-import { stateToUrl } from "@web/core/browser/router";
+import { router } from "@web/core/browser/router";
 
 export class CrmLead extends Record {
     static id = "id";
@@ -11,7 +11,7 @@ export class CrmLead extends Record {
     name;
     href = fields.Attr("", {
         compute() {
-            return stateToUrl({ model: 'crm.lead', resId: this.id });
+            return router.stateToUrl({ model: 'crm.lead', resId: this.id });
         }
     });
 }

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -8,7 +8,7 @@ import {
 } from "@mail/utils/common/format";
 
 import { browser } from "@web/core/browser/browser";
-import { stateToUrl } from "@web/core/browser/router";
+import { router } from "@web/core/browser/router";
 import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
@@ -293,7 +293,7 @@ export class Message extends Record {
     }
 
     get resUrl() {
-        return url(stateToUrl({ model: this.thread.model, resId: this.thread.id }));
+        return url(router.stateToUrl({ model: this.thread.model, resId: this.thread.id }));
     }
 
     isTranslatable(thread) {

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -1,6 +1,6 @@
 import { htmlEscape, markup } from "@odoo/owl";
 
-import { stateToUrl } from "@web/core/browser/router";
+import { router } from "@web/core/browser/router";
 import { loadEmoji, loader } from "@web/core/emoji_picker/emoji_picker";
 import { normalize } from "@web/core/l10n/utils";
 import {
@@ -234,7 +234,7 @@ function generateMentionsLinks(
     for (const mention of mentions) {
         const link = document.createElement("a");
         setAttributes(link, {
-            href: stateToUrl({ model: mention.model, resId: mention.id }),
+            href: router.stateToUrl({ model: mention.model, resId: mention.id }),
             class: mention.class,
             "data-oe-id": mention.id,
             "data-oe-model": mention.model,

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
@@ -1,6 +1,6 @@
 import { Plugin } from "@html_editor/plugin";
 import { MentionList } from "@mail/core/web/mention_list";
-import { stateToUrl } from "@web/core/browser/router";
+import { router } from "@web/core/browser/router";
 import { renderToElement } from "@web/core/utils/render";
 import { url } from "@web/core/utils/urls";
 
@@ -24,7 +24,7 @@ export class MentionPlugin extends Plugin {
         const mentionBlock = renderToElement("mail.Wysiwyg.mentionLink", {
             option,
             href: url(
-                stateToUrl({
+                router.stateToUrl({
                     model: option.partner ? "res.partner" : "discuss.channel",
                     resId: option.partner ? option.partner.id : option.channel.id,
                 })

--- a/addons/web/static/src/core/browser/router.js
+++ b/addons/web/static/src/core/browser/router.js
@@ -123,7 +123,7 @@ export function startUrl() {
  * @param {{ [key: string]: any }} state
  * @returns
  */
-export function stateToUrl(state) {
+function stateToUrl(state) {
     let path = "";
     const pathKeysToOmit = [..._hiddenKeysFromUrl];
     const actionStack = (state.actionStack || [state]).map((a) => ({ ...a }));
@@ -158,7 +158,7 @@ export function stateToUrl(state) {
     return `/${start_url}${path}${search ? `?${search}` : ""}`;
 }
 
-export function urlToState(urlObj) {
+function urlToState(urlObj) {
     const { pathname, hash, search } = urlObj;
     const state = parseSearchQuery(search);
 

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -14,7 +14,7 @@ import { ReportAction } from "./reports/report_action";
 import { UPDATE_METHODS } from "@web/core/orm_service";
 import { CallbackRecorder } from "@web/search/action_hook";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
-import { PATH_KEYS, router as _router, stateToUrl } from "@web/core/browser/router";
+import { PATH_KEYS, router as _router } from "@web/core/browser/router";
 
 import {
     Component,
@@ -459,7 +459,7 @@ export function makeActionManager(env, router = _router) {
                     return controller.props?.type === "form";
                 },
                 get url() {
-                    return stateToUrl(controller.state);
+                    return router.stateToUrl(controller.state);
                 },
                 onSelected() {
                     restore(controller.jsId);
@@ -814,7 +814,7 @@ export function makeActionManager(env, router = _router) {
         // Store on the session the action for the new window
         browser.sessionStorage.setItem("current_action", action._originalAction || "{}");
         browser.sessionStorage.setItem("current_state", JSON.stringify(state));
-        _openURL(stateToUrl(state));
+        _openURL(router.stateToUrl(state));
         // restore the current action from the current window
         browser.sessionStorage.setItem("current_action", currentAction);
         browser.sessionStorage.setItem("current_state", currentState);
@@ -1413,7 +1413,10 @@ export function makeActionManager(env, router = _router) {
                 return _executeActURLAction(action, options);
             case "ir.actions.act_window":
                 if (action.target !== "new" && !options.newWindow) {
-                    const canProceed = await clearUncommittedChanges(env, pick(options, "forceLeave"));
+                    const canProceed = await clearUncommittedChanges(
+                        env,
+                        pick(options, "forceLeave")
+                    );
                     if (!canProceed) {
                         return new Promise(() => {});
                     }


### PR DESCRIPTION
Since [1], overriding the router’s state <-> URL conversion functions is supported. However, both functions were still exported, which could cause inconsistencies if code continued using the exported versions instead of the overridden ones.

This commit removes the exports, ensuring that the functions are always accessed through the router.

[1] https://github.com/odoo/odoo/commit/d278ab17698c0c4fbdf887b19ed7ccb9122ffb77

