### PR TITLE
[FIX] spreadsheet_dashboard: fix quick search for relational filter

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_search_bar/dashboard_search_bar.js
@@ -476,7 +476,7 @@ export class DashboardSearchBar extends Component {
                     const strings = filterValue?.strings || [];
                     newValue = {
                         strings: isILike ? [...strings, item.value] : [item.value],
-                        operator: isILike ? "ilike" : filterValue?.operator || "ilike",
+                        operator: isILike ? filterValue.operator : "ilike",
                     };
                 }
                 break;

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -561,6 +561,20 @@ describe("Quick search bar", () => {
         expect(filterValue).toEqual({ operator: "ilike", strings: ["phone"] });
     });
 
+    test("Can quick search a string in a relational filter if a record was already selected", async function () {
+        const filter = { ...productFilter, defaultValue: { operator: "in", ids: [37] } };
+        const spreadsheetData = { globalFilters: [filter] };
+        const serverData = getServerData(spreadsheetData);
+        const { model } = await createSpreadsheetDashboard({ serverData });
+
+        await contains(".o_searchview_input").edit("test");
+        expect(".o-dropdown-item.focus").toHaveText("Search Product for: test");
+        await press("Enter");
+
+        const filterValue = model.getters.getGlobalFilterValue(productFilter.id);
+        expect(filterValue).toEqual({ operator: "ilike", strings: ["test"] });
+    });
+
     test("Can quick search a specific record in a relational filter", async function () {
         const spreadsheetData = { globalFilters: [productFilter] };
         const serverData = getServerData(spreadsheetData);


### PR DESCRIPTION
If a relational filter was set to a specific record, it was not possible to use quick search to search for a string in the records.

Task: [5008483](https://www.odoo.com/odoo/2328/tasks/5008483)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
