### PR TITLE
[FIX] l10n_latam_check:  handle current journal when both operations exist.

### DIFF
--- a/addons/l10n_latam_check/models/l10n_latam_check.py
+++ b/addons/l10n_latam_check/models/l10n_latam_check.py
@@ -129,7 +129,7 @@ class l10nLatamAccountPaymentCheck(models.Model):
     def _get_last_operation(self):
         self.ensure_one()
         return (self.payment_id + self.operation_ids).filtered(
-                lambda x: x.state not in ['draft', 'canceled']).sorted(key=lambda payment: (payment.date, payment._origin.id))[-1:]
+                lambda x: x.state not in ['draft', 'canceled']).sorted(key=lambda payment: (payment.date, payment.write_date, payment._origin.id))[-1:]
 
     @api.depends('payment_id.state', 'operation_ids.state')
     def _compute_current_journal(self):


### PR DESCRIPTION
**Steps to reproduce:**

1. Install the modules: `accounting`, `l10n_ar`, and `l10n_latam_check`.
2. Create a third-party check journal:
   * Add payment methods: *New Third Party Checks* (inbound) and *Existing Third Party Checks* (outbound).
   * Configure outstanding accounts for both methods.
3. Create a vendor payment:
   * Use the third-party check journal.
   * Select the *Existing Third Party Checks* method.
   * Leave the check list empty.
   * Keep the payment in *Draft*.
4. Create a customer payment:
   * Use the same journal and select the *New Third Party Checks* method.
   * Add a new check under the *Checks* tab.
   * Post the payment.
5. Return to the draft vendor payment created in step 3:
   * Add the newly created check to it (via *Add a line*).
   * Post the payment.
6. Go to **Customers → Third Party Checks**.

**Observed behavior:**
- The check still shows a `current_journal_id` even though it has both inbound and outbound operations.
- As a result, the check incorrectly appears in the 'On Hand' filter.

**Root cause:**
- `_get_last_operation` was sorting operations by `date`.          
- In some scenarios or flows where multiple operations share the same `date`, the wrong operation could be selected as the "last one", leading `_compute_current_journal` to assign a journal incorrectly.

**Solution:**
- Sort operations by `write_date` to always pick the true last operation.
- This ensures `_compute_current_journal` correctly clears `current_journal_id` whenever both inbound and outbound operations exist.


opw-5012903
