### PR TITLE
[FIX] purchase_stock: fix vendor delay report in purchase

### DIFF
--- a/addons/purchase_stock/report/vendor_delay_report.py
+++ b/addons/purchase_stock/report/vendor_delay_report.py
@@ -45,7 +45,7 @@ FROM   stock_move m
          ON pt.id = p.product_tmpl_id
        JOIN uom_uom pt_uom
          ON pt_uom.id = pt.uom_id
-       JOIN product_category pc
+       LEFT JOIN product_category pc
          ON pc.id = pt.categ_id
        LEFT JOIN stock_move_line ml
          ON ml.move_id = m.id

--- a/addons/purchase_stock/tests/test_purchase_stock_report.py
+++ b/addons/purchase_stock/tests/test_purchase_stock_report.py
@@ -342,29 +342,40 @@ class TestPurchaseStockReports(TestReportsCommon):
 
     def test_vendor_delay_report_without_backorder(self):
         """
-        PO 10 units x P
-        Receive 6 x P without backorder
-        -> 60% received
+        PO with two lines:
+        - 10 units of product with category
+        - 10 units of product without category
+        Receive 6 units for each line without backorder
+        -> 60% received for each product.
+        The vendor delay report should include both products
+        even if one has no category.
         """
+        product_no_categ = self.env['product.product'].create({
+            'name': 'Product without category',
+        })
         po_form = Form(self.env['purchase.order'])
         po_form.partner_id = self.partner
         with po_form.order_line.new() as line:
             line.product_id = self.product
             line.product_qty = 10
+        with po_form.order_line.new() as line:
+            line.product_id = product_no_categ
+            line.product_qty = 10
         po = po_form.save()
         po.button_confirm()
 
-        receipt01 = po.picking_ids
-        receipt01_move = receipt01.move_ids
-        receipt01_move.quantity = 6
-        receipt01_move.picked = True
-        Form.from_action(self.env, receipt01.button_validate()).save().process_cancel_backorder()
+        receipt = po.picking_ids
+        receipt_moves = receipt.move_ids
+        receipt_moves.quantity = 6
+        receipt_moves.picked = True
+        Form.from_action(self.env, receipt.button_validate()).save().process_cancel_backorder()
 
         data = self.env['vendor.delay.report'].web_read_group(
             [('partner_id', '=', self.partner.id)],
             ['product_id'],
             ['on_time_rate:sum', 'qty_on_time:sum', 'qty_total:sum'],
-        )['groups'][0]
-        self.assertEqual(data['qty_on_time:sum'], 6)
-        self.assertEqual(data['qty_total:sum'], 10)
-        self.assertEqual(data['on_time_rate:sum'], 60)
+        )['groups']
+        self.assertEqual(
+            [(rec['qty_on_time:sum'], rec['qty_total:sum'], rec['on_time_rate:sum']) for rec in data],
+            [(6, 10, 60), (6, 10, 60)]
+        )


### PR DESCRIPTION
**Steps to reproduce:**

1-Install the purchase_stock module.
2-Create a Purchase Order with a new vendor.
3-In the Purchase Order line, add a product without a category. 
4-Confirm the order and validate the generated receipt. 
5-In the vendor form view, click the On-time Rate smart button → no graph is
 visible.

**Issue:**

https://github.com/odoo/odoo/blob/77b3956ed5635d79ae8dc19423140dc6a10098f1/addons/purchase_stock/report/vendor_delay_report.py#L46-L50

```
The On-time Rate graph is not displayed in the Vendor Delay report.
```

**Cause:**

- From version 18.2, `categ_id` was removed as a required field. The report query still uses an inner join on `categ_id`, which  excludes products without a category and prevents data from being generated.

- Commit which make `categ_id` non require  - https://github.com/odoo/odoo/pull/166323/commits/b039caecbeb04057fbccb1cc88d03a4946f88e8e

**Solution:**

- Replace the inner join with a left join so that products without a `categ_id` are also included in the report (with null values when the category is not set).

**opw** - 4991367

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
