### PR TITLE
[IMP] *: add robots.txt entry & noindex meta for auth routes

### DIFF
--- a/addons/marketing_card/views/website_templates.xml
+++ b/addons/marketing_card/views/website_templates.xml
@@ -1,7 +1,7 @@
 <odoo>
     <data>
         <template id="robots" inherit_id="website.robots">
-            <xpath expr="//t[@t-out='request.website.sudo().robots_txt']" position="before">
+            <xpath expr="//t[@id='robots_module_rules']" position="inside">
 <t t-translation="off">
 User-agent: *
 Allow: /cards/

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -323,19 +323,7 @@ class Website(Home):
         response.headers['Cache-Control'] = 'public, max-age=%s' % http.STATIC_CACHE_LONG
         return response
 
-    def sitemap_website_info(env, rule, qs):
-        website = env['website'].get_current_website()
-        if not (
-            website.is_view_active('website.website_info')
-            and website.is_view_active('website.show_website_info')
-        ):
-            # avoid 404 or blank page in sitemap
-            return False
-
-        if not qs or qs.lower() in '/website/info':
-            yield {'loc': '/website/info'}
-
-    @http.route('/website/info', type='http', auth="public", website=True, sitemap=sitemap_website_info, readonly=True, list_as_website_content=_lt("Website Information"))
+    @http.route('/website/info', type='http', auth="public", website=True, sitemap=False, readonly=True, list_as_website_content=_lt("Website Information"))
     def website_info(self, **kwargs):
         Module = request.env['ir.module.module'].sudo()
         apps = Module.search([('state', '=', 'installed'), ('application', '=', True)])

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -247,12 +247,6 @@ class WithContext(HttpCase):
         admin_uid = self.env.ref('base.user_admin').id
         website = self.env['website'].get_current_website()
 
-        robot = self.xmlrpc_object.execute(
-            dbname, admin_uid, 'admin',
-            'website', 'search_pages', [website.id], 'info'
-        )
-        self.assertIn({'loc': '/website/info'}, robot)
-
         pages = self.xmlrpc_object.execute(
             dbname, admin_uid, 'admin',
             'website', 'search_pages', [website.id], 'page'

--- a/addons/website/tests/test_redirect.py
+++ b/addons/website/tests/test_redirect.py
@@ -65,5 +65,4 @@ class TestWebsiteRedirect(TransactionCase):
             self.env['website.rewrite'].refresh_routes()
             pages = self.env.ref('website.default_website')._enumerate_pages()
             urls = [url['loc'] for url in pages]
-            self.assertIn('/website/info', urls)
             self.assertNotIn('/test', urls)

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -388,6 +388,14 @@
     </xpath>
 </template>
 
+<template id="auth_pages_meta_robots" inherit_id="web.login_layout" name="Auth Pages - No Index">
+    <xpath expr="t[@t-call]" position="before">
+        <t t-set="head">
+            <meta name="robots" content="noindex, nofollow"/>
+        </t>
+    </xpath>
+</template>
+
 <template id="custom_code_layout" name="Custom Code Layout" inherit_id="website.layout" priority="55">
     <xpath expr="//head" position="inside">
         <t t-out="website.custom_code_head"/>
@@ -2777,6 +2785,9 @@
 <!-- Error and special pages -->
 <template id="website_info" name="Odoo Information">
     <t t-call="website.layout">
+        <t t-set="head">
+            <meta name="robots" content="noindex, nofollow"/>
+        </t>
         <div id="wrap" class="o_website_info"/>
     </t>
 </template>
@@ -3037,7 +3048,7 @@ Sitemap: <t t-out="website.domain"/>/sitemap.xml
 </t>
 <t t-else="">
 Sitemap: <t t-out="url_root"/>sitemap.xml
-
+<t id="robots_module_rules"/>
 
 ##############
 #   custom   #

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -422,4 +422,14 @@ list of filtered posts (by date or tag).
 </feed>
 </template>
 
+<!-- Robots.txt -->
+<template id="robots" inherit_id="website.robots">
+    <xpath expr="//t[@id='robots_module_rules']" position="inside">
+<t t-translation="off">
+User-agent: *
+Disallow: /blog/*/feed
+</t>
+    </xpath>
+</template>
+
 </odoo>


### PR DESCRIPTION
> \* = website, website_blog

The blog's Atom feed (`/blog/*/feed`) is currently crawlable by default,
which can lead to search engines indexing it. This improvement helps
reduce crawl budget since indexing the Atom feed provides no direct
value to users.

Additionally, a robot noindex meta tag is now added to prevent search
engine indexing of authentication routes and website info route.

**Specifically:**
- Added a Disallow rule for the blog Atom feed in `robots.txt`.
- Added a noindex meta tag for the following routes when the website
  module is installed:
    - `/web/login`
    - `/web/signup`
    - `/website/info`
    - `/web/reset_password`
    - `/web/login_successful`
    - `/auth-timeout/check-identity`
    - `/web/login/totp`
    - `/mail_client_extension/auth`
    - `/mail_plugin/auth`
    - `/mail_client_extension/app_error`
- Removed sitemap entry for website info page (`/website/info`) as
  noindex meta tag is present.
- Introduced `robots_module_rules` hook in website `robots.txt` template
  to allow modules to easily add their own rules.

This ensures search engines ignore these URLs while preserving indexing
for other website pages.

task-[4894062](https://www.odoo.com/odoo/project/974/tasks/4894062)