### PR TITLE
[FIX] hw_drivers: fix traceback in USB interface

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/USBInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/USBInterface_L.py
@@ -24,7 +24,10 @@ class USBInterface(Interface):
                         return False
 
         # Ignore serial adapters
-        return dev.product != "USB2.0-Ser!"
+        try:
+            return dev.product != "USB2.0-Ser!"
+        except ValueError:
+            return True
 
     def get_devices(self):
         """


### PR DESCRIPTION
Before this commit, if a USB device did not provide a valid product string, the USB interface would crash trying to access it.

After this commit, we wrap the access in a try/except to prevent the crash.

task-5060062

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
