### PR TITLE
[FIX] account, mail: fix language for cc in invoice email

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -595,6 +595,7 @@ class AccountMoveSend(models.TransientModel):
 
             email_from = self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'email_from')
             model_description = move.with_context(lang=mail_lang).type_name
+            mail_params['force_email_lang'] = mail_lang
 
             self._send_mail(
                 move,

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3370,9 +3370,7 @@ class MailThread(models.AbstractModel):
           avoid fetching it and easing translation support;
         :param record force_email_company: <res.company> record used when rendering
           notification layout. Otherwise computed based on current record;
-        :param str force_email_lang: when no specific lang is found this is the
-          default lang to use notably to compute model name or translate access
-          buttons;
+        :param str force_email_lang: lang used to group the recipients;
         :param list subtitles: optional list set as template value "subtitles";
 
         :return: iterator based on recipients classified by lang, with their
@@ -3401,7 +3399,7 @@ class MailThread(models.AbstractModel):
         lang_to_recipients = {}
         for data in recipients_data:
             lang_to_recipients.setdefault(
-                data.get('lang') or force_email_lang or self.env.lang,
+                force_email_lang or data.get('lang') or self.env.lang,
                 [],
             ).append(data)
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and Contacts

- Go to "Settings / Translations / Languages"
- Activate another language (e.g. French)

- Create a contact with an email and French as language
- Create another contact with an email and English as language

- Go to "Settings / Technical / Email / Email Templates"
- Edit "Invoice: Sending" email template
- In "Email Configuration" tab, add the email of the English contact in "Cc" field

- Create an invoice for the French contact
- Confirm the invoice
- Send the invoice

**Issue:**
The invoice is sent by email to the customer and to the email configured as CC in the template.
Both emails are in French, but some terms in the email header for the CC contact are in his configured language.
For example, instead of "Voir Facture", it's written "View Facture". And instead of "$10 dû le 01/01/2025", it's written "$10 due 01/01/2025".

**Cause:**
The content of the email and the model description is translated in the language of the customer of the invoice.
However, when grouping the recipients of the email, they are grouped by their language, leading to a mix of languages for some recipients.

**Solution:**
In the method grouping the recipients by lang, there is a parameter named "force_email_lang" that is the lang used for the content of the email, but it is only used as a fallback when a recipient doesn't have a lang configured.
From the name of the parameter (i.e. force_email_lang), it should be use in priority if set.

opw-4904029




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
