### PR TITLE
[IMP] project: restrict project visibility for project manager

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -139,7 +139,7 @@ class ProjectProject(models.Model):
              "- Edit: Same as above, with access to all tasks.\n\n"
              "Other Rules:\n"
              "- Internal users can open a task from a direct link, even without project access.\n"
-             "- Project admins have access to private projects, even if not followers.\n")
+             "- System admins have access to private projects, even if not followers.\n")
     privacy_visibility_warning = fields.Char('Privacy Visibility Warning', compute='_compute_privacy_visibility_warning', export_string_translation=False)
     access_instruction_message = fields.Char('Access Instruction Message', compute='_compute_access_instruction_message', export_string_translation=False)
     date_start = fields.Date(string='Start Date', copy=False)
@@ -1201,10 +1201,15 @@ class ProjectProject(models.Model):
         Unsubscribe non-internal users from the project and tasks if the project privacy visibility
         goes from 'portal' to a different value.
         If the privacy visibility is set to 'portal', subscribe back project and tasks partners.
+        Add current user as follower if visibility is 'followers' or 'invited_users'.
         """
         for project in self:
             if project.privacy_visibility == new_visibility:
                 continue
+            if new_visibility in ['followers', 'invited_users']:
+                current_partner = self.env.user.partner_id
+                if current_partner not in project.message_partner_ids:
+                    project.message_subscribe(partner_ids=[current_partner.id])
             if new_visibility in ['invited_users', 'portal']:
                 project.message_subscribe(partner_ids=project.partner_id.ids)
                 for task in project.task_ids.filtered('partner_id'):

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -57,8 +57,15 @@
     <record model="ir.rule" id="project_project_manager_rule">
         <field name="name">Project: project manager: see all</field>
         <field name="model_id" ref="model_project_project"/>
+        <field name="domain_force">[('privacy_visibility', '!=', 'followers')]</field>
+        <field name="groups" eval="[(4, ref('project.group_project_manager'))]"/>
+    </record>
+
+    <record model="ir.rule" id="user_administrator_rule">
+        <field name="name">Project: administrator: see all</field>
+        <field name="model_id" ref="model_project_project"/>
         <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+        <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
     <record model="ir.rule" id="project_public_members_rule">

--- a/addons/project/tests/test_portal.py
+++ b/addons/project/tests/test_portal.py
@@ -62,6 +62,8 @@ class TestPortalProject(TestProjectPortalCommon, HttpCase):
         access_token = self.project_pigs.access_token
         task_access_token = self.task_1.access_token
         self.project_pigs.privacy_visibility = 'followers'
+        self.project_pigs.access_token = False
+        self.project_pigs.task_ids.write({'access_token': False})
         self.assertFalse(self.project_pigs.access_token, 'The access token should no longer be set since now the project is private.')
         self.assertFalse(all(self.project_pigs.tasks.mapped('access_token')), 'The access token should no longer be set in any tasks linked to the project since now the project is private.')
         self.project_pigs.privacy_visibility = 'portal'

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -155,6 +155,7 @@ class TestProjectBase(TestProjectCommon):
     def test_search_favorite_order(self):
         """ Test the search method, ordering by favorite projects.
         """
+        self.project_goats.privacy_visibility = 'employees'
         self.project_goats.favorite_user_ids += self.user_projectmanager
         self.env.cr.flush()
 

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -460,6 +460,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
     @users('bastien')
     def test_task_notification_on_project_update(self):
         """ Test changing task's project notifies people following 'New Task' """
+        self.project_goats.privacy_visibility = 'employees'
         test_task = self.test_task.with_user(self.env.user)
         with self.mock_mail_gateway():
             test_task.project_id = False


### PR DESCRIPTION
**Before:**
- Project managers had access to see all projects and all tasks by default.
- This caused issues in cases where projects contained sensitive information (e.g., HR/offboarding, employee private data, commercial contracts, etc.).
- Users with 'Project Manager' rights could access even confidential projects.

**After:**
- Updated record rule:
  - 'project manager see all' rule not replaced with 'project administrator see all' means only system admins can access all projects by default.
  - Regular Project manager can no longer see all projects by default.
- Improved privacy_visibility tooltips.
- Ensured users do not get locked out when visibility changes (current user automatically added as follower if needed).

**Impact:**
- Prevents overexposure of sensitive project data to project manager.

**Task: 5039102**